### PR TITLE
fix(onboard): harden single-line prompt capture

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -18,7 +18,8 @@ const ONBOARD_CLEAR_INPUT_TOKEN: &str = ":clear";
 const ONBOARD_ESCAPE_CANCEL_HINT: &str = "- press Esc then Enter to cancel onboarding";
 const ONBOARD_SINGLE_LINE_INPUT_HINT: &str =
     "- terminal input is single line; extra pasted lines are ignored";
-const ONBOARD_PASTE_DRAIN_WINDOW: Duration = Duration::from_millis(20);
+const ONBOARD_PASTE_DRAIN_WINDOW_ENV: &str = "LOONGCLAW_ONBOARD_PASTE_DRAIN_WINDOW_MS";
+const DEFAULT_ONBOARD_PASTE_DRAIN_WINDOW: Duration = Duration::from_millis(75);
 const ONBOARD_LINE_READER_BUFFER_SIZE: usize = 64;
 
 #[derive(Debug, Clone)]
@@ -110,6 +111,7 @@ type StdioOnboardLineSender = mpsc::SyncSender<StdioOnboardLineMessage>;
 enum StdioOnboardLineReader {
     Background {
         receiver: Receiver<StdioOnboardLineMessage>,
+        paste_drain_window: Duration,
     },
     Direct {
         degraded_notice: Option<String>,
@@ -128,6 +130,15 @@ fn onboard_line_channel_with_capacity(
         "onboard line reader buffer must be non-zero"
     );
     mpsc::sync_channel(buffer_size)
+}
+
+fn onboard_paste_drain_window() -> Duration {
+    env::var(ONBOARD_PASTE_DRAIN_WINDOW_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|millis| *millis > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_ONBOARD_PASTE_DRAIN_WINDOW)
 }
 
 fn spawn_onboard_stdin_reader(sender: StdioOnboardLineSender) -> io::Result<()> {
@@ -166,7 +177,10 @@ fn format_onboard_line_reader_spawn_notice(error: &io::Error) -> String {
 
 impl StdioOnboardLineReader {
     fn background_from_receiver(receiver: Receiver<StdioOnboardLineMessage>) -> Self {
-        Self::Background { receiver }
+        Self::Background {
+            receiver,
+            paste_drain_window: onboard_paste_drain_window(),
+        }
     }
 
     fn try_spawn_background_receiver() -> io::Result<Receiver<StdioOnboardLineMessage>> {
@@ -204,7 +218,7 @@ impl OnboardPromptLineReader for StdioOnboardLineReader {
             eprintln!("{notice}");
         }
         match self {
-            Self::Background { receiver } => match receiver.recv() {
+            Self::Background { receiver, .. } => match receiver.recv() {
                 Ok(StdioOnboardLineMessage::Line(line)) => Ok(OnboardPromptRead::Line(line)),
                 Ok(StdioOnboardLineMessage::Eof) => Ok(OnboardPromptRead::Eof),
                 Ok(StdioOnboardLineMessage::Error(error)) => Err(error),
@@ -225,16 +239,15 @@ impl OnboardPromptLineReader for StdioOnboardLineReader {
 
     fn read_pending_line(&mut self) -> CliResult<Option<String>> {
         match self {
-            Self::Background { receiver } => {
-                match receiver.recv_timeout(ONBOARD_PASTE_DRAIN_WINDOW) {
-                    Ok(StdioOnboardLineMessage::Line(line)) => Ok(Some(line)),
-                    Ok(StdioOnboardLineMessage::Eof) => Ok(None),
-                    Ok(StdioOnboardLineMessage::Error(error)) => Err(error),
-                    Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => {
-                        Ok(None)
-                    }
-                }
-            }
+            Self::Background {
+                receiver,
+                paste_drain_window,
+            } => match receiver.recv_timeout(*paste_drain_window) {
+                Ok(StdioOnboardLineMessage::Line(line)) => Ok(Some(line)),
+                Ok(StdioOnboardLineMessage::Eof) => Ok(None),
+                Ok(StdioOnboardLineMessage::Error(error)) => Err(error),
+                Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => Ok(None),
+            },
             Self::Direct { .. } => Ok(None),
         }
     }
@@ -5851,6 +5864,40 @@ mod tests {
         }
     }
 
+    struct PasteDrainWindowEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        saved_value: Option<OsString>,
+    }
+
+    impl PasteDrainWindowEnvGuard {
+        fn set(value: Option<&str>) -> Self {
+            let lock = crate::test_support::lock_daemon_test_environment();
+            let saved_value = std::env::var_os(ONBOARD_PASTE_DRAIN_WINDOW_ENV);
+            match value {
+                Some(value) => set_browser_companion_env_var(ONBOARD_PASTE_DRAIN_WINDOW_ENV, value),
+                None => remove_browser_companion_env_var(ONBOARD_PASTE_DRAIN_WINDOW_ENV),
+            }
+            Self {
+                _lock: lock,
+                saved_value,
+            }
+        }
+    }
+
+    impl Drop for PasteDrainWindowEnvGuard {
+        fn drop(&mut self) {
+            match &self.saved_value {
+                Some(value) => {
+                    set_browser_companion_env_var(
+                        ONBOARD_PASTE_DRAIN_WINDOW_ENV,
+                        &value.to_string_lossy(),
+                    );
+                }
+                None => remove_browser_companion_env_var(ONBOARD_PASTE_DRAIN_WINDOW_ENV),
+            }
+        }
+    }
+
     impl Drop for BrowserCompanionEnvGuard {
         fn drop(&mut self) {
             let key = "LOONGCLAW_BROWSER_COMPANION_READY";
@@ -6734,6 +6781,33 @@ mod tests {
         assert_eq!(second.raw, "window-plus-summary\n");
         assert_eq!(second.dropped_line_count, 0);
         assert!(!second.reached_eof);
+    }
+
+    #[test]
+    fn onboard_paste_drain_window_prefers_valid_env_override() {
+        let _guard = PasteDrainWindowEnvGuard::set(Some("125"));
+
+        assert_eq!(onboard_paste_drain_window(), Duration::from_millis(125));
+    }
+
+    #[test]
+    fn onboard_paste_drain_window_falls_back_for_invalid_env_values() {
+        let _guard = PasteDrainWindowEnvGuard::set(Some("not-a-number"));
+
+        assert_eq!(
+            onboard_paste_drain_window(),
+            DEFAULT_ONBOARD_PASTE_DRAIN_WINDOW
+        );
+    }
+
+    #[test]
+    fn onboard_paste_drain_window_rejects_zero_millisecond_override() {
+        let _guard = PasteDrainWindowEnvGuard::set(Some("0"));
+
+        assert_eq!(
+            onboard_paste_drain_window(),
+            DEFAULT_ONBOARD_PASTE_DRAIN_WINDOW
+        );
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -19,6 +19,7 @@ const ONBOARD_ESCAPE_CANCEL_HINT: &str = "- press Esc then Enter to cancel onboa
 const ONBOARD_SINGLE_LINE_INPUT_HINT: &str =
     "- terminal input is single line; extra pasted lines are ignored";
 const ONBOARD_PASTE_DRAIN_WINDOW: Duration = Duration::from_millis(20);
+const ONBOARD_LINE_READER_BUFFER_SIZE: usize = 64;
 
 #[derive(Debug, Clone)]
 pub struct OnboardCommandOptions {
@@ -103,49 +104,105 @@ enum StdioOnboardLineMessage {
     Error(String),
 }
 
+type StdioOnboardLineSender = mpsc::SyncSender<StdioOnboardLineMessage>;
+
 #[derive(Debug)]
 enum StdioOnboardLineReader {
     Background {
         receiver: Receiver<StdioOnboardLineMessage>,
     },
-    Direct,
+    Direct {
+        degraded_notice: Option<String>,
+    },
+}
+
+fn onboard_line_channel() -> (StdioOnboardLineSender, Receiver<StdioOnboardLineMessage>) {
+    onboard_line_channel_with_capacity(ONBOARD_LINE_READER_BUFFER_SIZE)
+}
+
+fn onboard_line_channel_with_capacity(
+    buffer_size: usize,
+) -> (StdioOnboardLineSender, Receiver<StdioOnboardLineMessage>) {
+    assert!(
+        buffer_size > 0,
+        "onboard line reader buffer must be non-zero"
+    );
+    mpsc::sync_channel(buffer_size)
+}
+
+fn spawn_onboard_stdin_reader(sender: StdioOnboardLineSender) -> io::Result<()> {
+    thread::Builder::new()
+        .name("loongclaw-onboard-stdin".to_owned())
+        .spawn(move || {
+            loop {
+                let mut line = String::new();
+                match io::stdin().read_line(&mut line) {
+                    Ok(0) => {
+                        let _ = sender.send(StdioOnboardLineMessage::Eof);
+                        break;
+                    }
+                    Ok(_) => {
+                        if sender.send(StdioOnboardLineMessage::Line(line)).is_err() {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        let _ = sender.send(StdioOnboardLineMessage::Error(format!(
+                            "read stdin failed: {error}"
+                        )));
+                        break;
+                    }
+                }
+            }
+        })
+        .map(|_handle| ())
+}
+
+fn format_onboard_line_reader_spawn_notice(error: &io::Error) -> String {
+    format!(
+        "warning: failed to start onboarding stdin reader thread ({error}); single-line paste draining is disabled for this session"
+    )
+}
+
+impl StdioOnboardLineReader {
+    fn background_from_receiver(receiver: Receiver<StdioOnboardLineMessage>) -> Self {
+        Self::Background { receiver }
+    }
+
+    fn try_spawn_background_receiver() -> io::Result<Receiver<StdioOnboardLineMessage>> {
+        let (sender, receiver) = onboard_line_channel();
+        spawn_onboard_stdin_reader(sender)?;
+        Ok(receiver)
+    }
+
+    fn from_spawn_result(result: io::Result<Receiver<StdioOnboardLineMessage>>) -> Self {
+        match result {
+            Ok(receiver) => Self::background_from_receiver(receiver),
+            Err(error) => Self::Direct {
+                degraded_notice: Some(format_onboard_line_reader_spawn_notice(&error)),
+            },
+        }
+    }
+
+    fn take_degraded_notice(&mut self) -> Option<String> {
+        match self {
+            Self::Background { .. } => None,
+            Self::Direct { degraded_notice } => degraded_notice.take(),
+        }
+    }
 }
 
 impl Default for StdioOnboardLineReader {
     fn default() -> Self {
-        let (sender, receiver) = mpsc::channel();
-        match thread::Builder::new()
-            .name("loongclaw-onboard-stdin".to_owned())
-            .spawn(move || {
-                loop {
-                    let mut line = String::new();
-                    match io::stdin().read_line(&mut line) {
-                        Ok(0) => {
-                            let _ = sender.send(StdioOnboardLineMessage::Eof);
-                            break;
-                        }
-                        Ok(_) => {
-                            if sender.send(StdioOnboardLineMessage::Line(line)).is_err() {
-                                break;
-                            }
-                        }
-                        Err(error) => {
-                            let _ = sender.send(StdioOnboardLineMessage::Error(format!(
-                                "read stdin failed: {error}"
-                            )));
-                            break;
-                        }
-                    }
-                }
-            }) {
-            Ok(_handle) => Self::Background { receiver },
-            Err(_) => Self::Direct,
-        }
+        Self::from_spawn_result(Self::try_spawn_background_receiver())
     }
 }
 
 impl OnboardPromptLineReader for StdioOnboardLineReader {
     fn read_blocking_line(&mut self) -> CliResult<OnboardPromptRead> {
+        if let Some(notice) = self.take_degraded_notice() {
+            eprintln!("{notice}");
+        }
         match self {
             Self::Background { receiver } => match receiver.recv() {
                 Ok(StdioOnboardLineMessage::Line(line)) => Ok(OnboardPromptRead::Line(line)),
@@ -153,7 +210,7 @@ impl OnboardPromptLineReader for StdioOnboardLineReader {
                 Ok(StdioOnboardLineMessage::Error(error)) => Err(error),
                 Err(_) => Ok(OnboardPromptRead::Eof),
             },
-            Self::Direct => {
+            Self::Direct { .. } => {
                 let mut line = String::new();
                 let bytes_read = io::stdin()
                     .read_line(&mut line)
@@ -178,7 +235,7 @@ impl OnboardPromptLineReader for StdioOnboardLineReader {
                     }
                 }
             }
-            Self::Direct => Ok(None),
+            Self::Direct { .. } => Ok(None),
         }
     }
 }
@@ -5631,7 +5688,8 @@ mod tests {
     use super::*;
     use std::collections::VecDeque;
     use std::ffi::OsString;
-    use std::sync::MutexGuard;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, MutexGuard};
 
     struct TestOnboardUi {
         inputs: VecDeque<String>,
@@ -6676,6 +6734,73 @@ mod tests {
         assert_eq!(second.raw, "window-plus-summary\n");
         assert_eq!(second.dropped_line_count, 0);
         assert!(!second.reached_eof);
+    }
+
+    #[test]
+    fn onboard_line_channel_applies_backpressure_after_buffer_limit() {
+        let (sender, receiver) = onboard_line_channel_with_capacity(1);
+        let second_send_completed = Arc::new(AtomicBool::new(false));
+        let completed_flag = Arc::clone(&second_send_completed);
+        let producer = thread::spawn(move || {
+            sender
+                .send(StdioOnboardLineMessage::Line("system prompt\n".to_owned()))
+                .expect("send first line");
+            sender
+                .send(StdioOnboardLineMessage::Line(
+                    "follow-up paste\n".to_owned(),
+                ))
+                .expect("send second line after receiver drains");
+            completed_flag.store(true, Ordering::SeqCst);
+        });
+
+        for _ in 0..1_000 {
+            if second_send_completed.load(Ordering::SeqCst) {
+                break;
+            }
+            thread::yield_now();
+        }
+        assert!(
+            !second_send_completed.load(Ordering::SeqCst),
+            "bounded onboarding queue should apply backpressure once the first buffered line is occupied"
+        );
+
+        let mut reader = StdioOnboardLineReader::background_from_receiver(receiver);
+        let capture = read_single_line_prompt_capture(&mut reader)
+            .expect("capture should drain the queued follow-up line");
+        producer.join().expect("producer join");
+
+        assert_eq!(capture.raw, "system prompt\n");
+        assert_eq!(capture.dropped_line_count, 1);
+        assert!(!capture.reached_eof);
+        assert!(
+            second_send_completed.load(Ordering::SeqCst),
+            "receiver drain should unblock the producer once capacity is freed"
+        );
+    }
+
+    #[test]
+    fn stdio_onboard_line_reader_warns_once_when_background_spawn_fails() {
+        let mut reader = StdioOnboardLineReader::from_spawn_result(Err(io::Error::other(
+            "thread quota exhausted",
+        )));
+
+        assert!(
+            matches!(reader, StdioOnboardLineReader::Direct { .. }),
+            "spawn failure should fall back to direct reads instead of constructing a broken background reader"
+        );
+
+        let first_notice = reader
+            .take_degraded_notice()
+            .expect("spawn failure should surface a degraded-mode notice");
+        assert!(
+            first_notice.contains("single-line paste draining is disabled"),
+            "spawn failure notice should explain the lost hardening: {first_notice}"
+        );
+        assert_eq!(
+            reader.take_degraded_notice(),
+            None,
+            "degraded-mode notice should only be emitted once per session"
+        );
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2,6 +2,9 @@ use std::env;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread;
+use std::time::Duration;
 
 use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
@@ -13,6 +16,9 @@ const BACKUP_TIMESTAMP_FORMAT: &[FormatItem<'static>] =
     format_description!("[year][month][day]-[hour][minute][second]");
 const ONBOARD_CLEAR_INPUT_TOKEN: &str = ":clear";
 const ONBOARD_ESCAPE_CANCEL_HINT: &str = "- press Esc then Enter to cancel onboarding";
+const ONBOARD_SINGLE_LINE_INPUT_HINT: &str =
+    "- terminal input is single line; extra pasted lines are ignored";
+const ONBOARD_PASTE_DRAIN_WINDOW: Duration = Duration::from_millis(20);
 
 #[derive(Debug, Clone)]
 pub struct OnboardCommandOptions {
@@ -79,8 +85,150 @@ impl OnboardRuntimeContext {
     }
 }
 
+trait OnboardPromptLineReader {
+    fn read_blocking_line(&mut self) -> CliResult<OnboardPromptRead>;
+    fn read_pending_line(&mut self) -> CliResult<Option<String>>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum OnboardPromptRead {
+    Line(String),
+    Eof,
+}
+
+#[derive(Debug)]
+enum StdioOnboardLineMessage {
+    Line(String),
+    Eof,
+    Error(String),
+}
+
+#[derive(Debug)]
+enum StdioOnboardLineReader {
+    Background {
+        receiver: Receiver<StdioOnboardLineMessage>,
+    },
+    Direct,
+}
+
+impl Default for StdioOnboardLineReader {
+    fn default() -> Self {
+        let (sender, receiver) = mpsc::channel();
+        match thread::Builder::new()
+            .name("loongclaw-onboard-stdin".to_owned())
+            .spawn(move || {
+                loop {
+                    let mut line = String::new();
+                    match io::stdin().read_line(&mut line) {
+                        Ok(0) => {
+                            let _ = sender.send(StdioOnboardLineMessage::Eof);
+                            break;
+                        }
+                        Ok(_) => {
+                            if sender.send(StdioOnboardLineMessage::Line(line)).is_err() {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            let _ = sender.send(StdioOnboardLineMessage::Error(format!(
+                                "read stdin failed: {error}"
+                            )));
+                            break;
+                        }
+                    }
+                }
+            }) {
+            Ok(_handle) => Self::Background { receiver },
+            Err(_) => Self::Direct,
+        }
+    }
+}
+
+impl OnboardPromptLineReader for StdioOnboardLineReader {
+    fn read_blocking_line(&mut self) -> CliResult<OnboardPromptRead> {
+        match self {
+            Self::Background { receiver } => match receiver.recv() {
+                Ok(StdioOnboardLineMessage::Line(line)) => Ok(OnboardPromptRead::Line(line)),
+                Ok(StdioOnboardLineMessage::Eof) => Ok(OnboardPromptRead::Eof),
+                Ok(StdioOnboardLineMessage::Error(error)) => Err(error),
+                Err(_) => Ok(OnboardPromptRead::Eof),
+            },
+            Self::Direct => {
+                let mut line = String::new();
+                let bytes_read = io::stdin()
+                    .read_line(&mut line)
+                    .map_err(|error| format!("read stdin failed: {error}"))?;
+                if bytes_read == 0 {
+                    return Ok(OnboardPromptRead::Eof);
+                }
+                Ok(OnboardPromptRead::Line(line))
+            }
+        }
+    }
+
+    fn read_pending_line(&mut self) -> CliResult<Option<String>> {
+        match self {
+            Self::Background { receiver } => {
+                match receiver.recv_timeout(ONBOARD_PASTE_DRAIN_WINDOW) {
+                    Ok(StdioOnboardLineMessage::Line(line)) => Ok(Some(line)),
+                    Ok(StdioOnboardLineMessage::Eof) => Ok(None),
+                    Ok(StdioOnboardLineMessage::Error(error)) => Err(error),
+                    Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => {
+                        Ok(None)
+                    }
+                }
+            }
+            Self::Direct => Ok(None),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
-struct StdioOnboardUi;
+struct StdioOnboardUi {
+    line_reader: StdioOnboardLineReader,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct OnboardPromptCapture {
+    raw: String,
+    dropped_line_count: usize,
+    reached_eof: bool,
+}
+
+fn read_single_line_prompt_capture(
+    reader: &mut impl OnboardPromptLineReader,
+) -> CliResult<OnboardPromptCapture> {
+    let read = reader.read_blocking_line()?;
+    let mut dropped_line_count = 0;
+    let (raw, reached_eof) = match read {
+        OnboardPromptRead::Line(raw) => {
+            while reader.read_pending_line()?.is_some() {
+                dropped_line_count += 1;
+            }
+            (raw, false)
+        }
+        OnboardPromptRead::Eof => (String::new(), true),
+    };
+    Ok(OnboardPromptCapture {
+        raw,
+        dropped_line_count,
+        reached_eof,
+    })
+}
+
+fn print_dropped_paste_notice(label: &str, dropped_line_count: usize) {
+    if dropped_line_count == 0 {
+        return;
+    }
+    let noun = if dropped_line_count == 1 {
+        "line"
+    } else {
+        "lines"
+    };
+    println!(
+        "note: {label} accepts a single line; ignored {dropped_line_count} extra pasted {noun}"
+    );
+}
 
 impl OnboardUi for StdioOnboardUi {
     fn print_line(&mut self, line: &str) -> CliResult<()> {
@@ -93,12 +241,9 @@ impl OnboardUi for StdioOnboardUi {
         io::stdout()
             .flush()
             .map_err(|error| format!("flush stdout failed: {error}"))?;
-        let mut line = String::new();
-        io::stdin()
-            .read_line(&mut line)
-            .map_err(|error| format!("read stdin failed: {error}"))?;
-        drain_stdin();
-        let line = ensure_onboard_input_not_cancelled(line)?;
+        let capture = read_single_line_prompt_capture(&mut self.line_reader)?;
+        let line = ensure_onboard_input_not_cancelled(capture.raw)?;
+        print_dropped_paste_notice(label, capture.dropped_line_count);
         let trimmed = line.trim();
         if trimmed.is_empty() {
             return Ok(default.to_owned());
@@ -111,12 +256,9 @@ impl OnboardUi for StdioOnboardUi {
         io::stdout()
             .flush()
             .map_err(|error| format!("flush stdout failed: {error}"))?;
-        let mut line = String::new();
-        io::stdin()
-            .read_line(&mut line)
-            .map_err(|error| format!("read stdin failed: {error}"))?;
-        drain_stdin();
-        let line = ensure_onboard_input_not_cancelled(line)?;
+        let capture = read_single_line_prompt_capture(&mut self.line_reader)?;
+        let line = ensure_onboard_input_not_cancelled(capture.raw)?;
+        print_dropped_paste_notice(label, capture.dropped_line_count);
         Ok(line.trim().to_owned())
     }
 
@@ -126,12 +268,9 @@ impl OnboardUi for StdioOnboardUi {
         io::stdout()
             .flush()
             .map_err(|error| format!("flush stdout failed: {error}"))?;
-        let mut line = String::new();
-        io::stdin()
-            .read_line(&mut line)
-            .map_err(|error| format!("read stdin failed: {error}"))?;
-        drain_stdin();
-        let line = ensure_onboard_input_not_cancelled(line)?;
+        let capture = read_single_line_prompt_capture(&mut self.line_reader)?;
+        let line = ensure_onboard_input_not_cancelled(capture.raw)?;
+        print_dropped_paste_notice(message, capture.dropped_line_count);
         let value = line.trim().to_ascii_lowercase();
         if value.is_empty() {
             return Ok(default);
@@ -168,15 +307,12 @@ impl OnboardUi for StdioOnboardUi {
             io::stdout()
                 .flush()
                 .map_err(|error| format!("flush stdout failed: {error}"))?;
-            let mut input = String::new();
-            let bytes_read = io::stdin()
-                .read_line(&mut input)
-                .map_err(|error| format!("read stdin failed: {error}"))?;
-            drain_stdin();
-            if bytes_read == 0 {
+            let capture = read_single_line_prompt_capture(&mut self.line_reader)?;
+            print_dropped_paste_notice(label, capture.dropped_line_count);
+            if capture.reached_eof {
                 return resolve_select_one_eof(default);
             }
-            let input = ensure_onboard_input_not_cancelled(input)?;
+            let input = ensure_onboard_input_not_cancelled(capture.raw)?;
             let trimmed = input.trim();
             if trimmed.is_empty() {
                 if let Some(idx) = default {
@@ -221,53 +357,6 @@ fn resolve_select_one_eof(default: Option<usize>) -> CliResult<usize> {
         "onboarding cancelled: stdin closed while waiting for required selection".to_owned()
     })
 }
-
-/// Drain any buffered bytes from stdin so that multi-line pastes do not
-/// leak into subsequent prompts.
-///
-/// Drains both Rust's internal `BufReader` (used by `stdin().read_line()`)
-/// and the OS-level kernel buffer via non-blocking `libc::read`.
-#[cfg(unix)]
-#[allow(unsafe_code)]
-fn drain_stdin() {
-    use std::io::Read;
-    use std::os::unix::io::AsRawFd;
-
-    let stdin = std::io::stdin();
-    let fd = stdin.as_raw_fd();
-
-    // SAFETY: fcntl(F_GETFL) reads the file-descriptor flags for stdin,
-    // which is a well-defined POSIX operation with no memory concerns.
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    if flags < 0 {
-        return;
-    }
-    // SAFETY: fcntl(F_SETFL) temporarily sets stdin to non-blocking mode
-    // so we can drain without hanging. The original flags are restored below.
-    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
-        return;
-    }
-
-    // Drain Rust's internal BufReader via stdin().lock().
-    // This consumes bytes already buffered in userspace that libc::read cannot reach.
-    {
-        let mut handle = stdin.lock();
-        let mut discard = [0u8; 1024];
-        loop {
-            match handle.read(&mut discard) {
-                Ok(0) | Err(_) => break,
-                Ok(_) => continue,
-            }
-        }
-    }
-
-    // SAFETY: restoring the original file-descriptor flags is a well-defined
-    // POSIX operation with no memory concerns.
-    unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
-}
-
-#[cfg(not(unix))]
-fn drain_stdin() {}
 
 fn print_lines(ui: &mut impl OnboardUi, lines: impl IntoIterator<Item = String>) -> CliResult<()> {
     for line in lines {
@@ -650,7 +739,7 @@ pub type ChannelImportReadiness = crate::migration::ChannelImportReadiness;
 
 pub async fn run_onboard_cli(options: OnboardCommandOptions) -> CliResult<()> {
     let context = OnboardRuntimeContext::capture();
-    let mut ui = StdioOnboardUi;
+    let mut ui = StdioOnboardUi::default();
     run_onboard_cli_with_ui(options, &mut ui, &context).await
 }
 
@@ -4627,6 +4716,7 @@ fn render_system_prompt_selection_screen_lines_with_style(
             } else {
                 render_clear_input_hint_line("use the built-in behavior")
             },
+            ONBOARD_SINGLE_LINE_INPUT_HINT.to_owned(),
         ],
         color_enabled,
     )
@@ -4756,6 +4846,7 @@ fn render_prompt_addendum_selection_screen_lines_with_style(
         vec![
             "- blank keeps the current addendum".to_owned(),
             "- type '-' to clear it".to_owned(),
+            ONBOARD_SINGLE_LINE_INPUT_HINT.to_owned(),
         ],
         color_enabled,
     )
@@ -5620,6 +5711,36 @@ mod tests {
                     default.ok_or_else(|| "missing test input for required selection".to_owned())
                 }
             }
+        }
+    }
+
+    struct TestPromptLineReader {
+        blocking_reads: VecDeque<OnboardPromptRead>,
+        pending_lines: VecDeque<String>,
+    }
+
+    impl TestPromptLineReader {
+        fn new(
+            blocking_reads: impl IntoIterator<Item = OnboardPromptRead>,
+            pending_lines: impl IntoIterator<Item = impl Into<String>>,
+        ) -> Self {
+            Self {
+                blocking_reads: blocking_reads.into_iter().collect(),
+                pending_lines: pending_lines.into_iter().map(Into::into).collect(),
+            }
+        }
+    }
+
+    impl OnboardPromptLineReader for TestPromptLineReader {
+        fn read_blocking_line(&mut self) -> CliResult<OnboardPromptRead> {
+            Ok(self
+                .blocking_reads
+                .pop_front()
+                .unwrap_or(OnboardPromptRead::Eof))
+        }
+
+        fn read_pending_line(&mut self) -> CliResult<Option<String>> {
+            Ok(self.pending_lines.pop_front())
         }
     }
 
@@ -6532,6 +6653,59 @@ mod tests {
             .expect("required prompt should preserve stdio trimming semantics");
 
         assert_eq!(value, "minimax");
+    }
+
+    #[test]
+    fn single_line_prompt_capture_drains_follow_up_paste_before_next_prompt() {
+        let mut reader = TestPromptLineReader::new(
+            [
+                OnboardPromptRead::Line("You are helpful.\n".to_owned()),
+                OnboardPromptRead::Line("window-plus-summary\n".to_owned()),
+            ],
+            ["Always be concise.\n"],
+        );
+
+        let first = read_single_line_prompt_capture(&mut reader)
+            .expect("first prompt capture should succeed");
+        let second = read_single_line_prompt_capture(&mut reader)
+            .expect("second prompt capture should consume the next real prompt line");
+
+        assert_eq!(first.raw, "You are helpful.\n");
+        assert_eq!(first.dropped_line_count, 1);
+        assert!(!first.reached_eof);
+        assert_eq!(second.raw, "window-plus-summary\n");
+        assert_eq!(second.dropped_line_count, 0);
+        assert!(!second.reached_eof);
+    }
+
+    #[test]
+    fn prompt_addendum_screen_mentions_single_line_terminal_input() {
+        let lines = render_prompt_addendum_selection_screen_lines(
+            &mvp::config::LoongClawConfig::default(),
+            80,
+        );
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("single line") && line.contains("ignored")),
+            "prompt addendum screen should explain how terminal onboarding handles pasted multiline text: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn system_prompt_screen_mentions_single_line_terminal_input() {
+        let lines = render_system_prompt_selection_screen_lines(
+            &mvp::config::LoongClawConfig::default(),
+            80,
+        );
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("single line") && line.contains("ignored")),
+            "system prompt screen should explain how terminal onboarding handles pasted multiline text: {lines:#?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## summary

- replace the unix-specific prompt drain with queued single-line capture inside `StdioOnboardUi`
- drop follow-up pasted lines at the prompt boundary instead of letting them leak into later onboarding steps
- surface single-line guidance on the prompt addendum and system prompt screens

## root cause

`#260` stopped the immediate corruption path, but it still solved the symptom by draining stdin after `read_line()` with unix-specific fd handling. the deeper issue was that the stdio onboarding ui did not model prompt ownership for extra pasted lines. this follow-up moves that boundary into the ui itself.

## validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `LOONGCLAW_ARCH_STRICT=true bash scripts/check_architecture_boundaries.sh`
- `bash scripts/check_dep_graph.sh`
- `bash scripts/check-docs.sh` (passes with existing release-artifact warnings)
- `cargo deny check` (passes with existing duplicate-dependency and deny config warnings)

## notes

- `task verify` is not available in this environment because `task` is not installed
- `task check:conventions` remains blocked here because `~/.claude/skills/convention-engineering/scripts/main.go` is unavailable

## linked issues

- refs #247
- follow-up to #260


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced handling of multi-line pastes for single-line onboarding prompts to avoid accidental input.
  * Added on-screen hints informing users that input is single-line and extra pasted lines are ignored.
  * Emits a clear notice when extra pasted lines are dropped to prevent confusion.

* **Tests**
  * Added coverage for single-line prompt capture, paste-drain behavior, and presence of the single-line input hint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->