### PR TITLE
Add runtime capability candidate review CLI

### DIFF
--- a/crates/contracts/src/contracts.rs
+++ b/crates/contracts/src/contracts.rs
@@ -17,6 +17,37 @@ pub enum Capability {
     ObserveTelemetry,
 }
 
+impl Capability {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvokeTool => "invoke_tool",
+            Self::InvokeConnector => "invoke_connector",
+            Self::MemoryRead => "memory_read",
+            Self::MemoryWrite => "memory_write",
+            Self::FilesystemRead => "filesystem_read",
+            Self::FilesystemWrite => "filesystem_write",
+            Self::NetworkEgress => "network_egress",
+            Self::ScheduleTask => "schedule_task",
+            Self::ObserveTelemetry => "observe_telemetry",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+            "invoke_tool" => Some(Self::InvokeTool),
+            "invoke_connector" => Some(Self::InvokeConnector),
+            "memory_read" => Some(Self::MemoryRead),
+            "memory_write" => Some(Self::MemoryWrite),
+            "filesystem_read" => Some(Self::FilesystemRead),
+            "filesystem_write" => Some(Self::FilesystemWrite),
+            "network_egress" => Some(Self::NetworkEgress),
+            "schedule_task" => Some(Self::ScheduleTask),
+            "observe_telemetry" => Some(Self::ObserveTelemetry),
+            _ => None,
+        }
+    }
+}
+
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HarnessKind {
@@ -77,4 +108,44 @@ pub struct ConnectorCommand {
 pub struct ConnectorOutcome {
     pub status: String,
     pub payload: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Capability;
+
+    #[test]
+    fn capability_round_trips_through_canonical_names() {
+        let fixtures = [
+            (Capability::InvokeTool, "invoke_tool"),
+            (Capability::InvokeConnector, "invoke_connector"),
+            (Capability::MemoryRead, "memory_read"),
+            (Capability::MemoryWrite, "memory_write"),
+            (Capability::FilesystemRead, "filesystem_read"),
+            (Capability::FilesystemWrite, "filesystem_write"),
+            (Capability::NetworkEgress, "network_egress"),
+            (Capability::ScheduleTask, "schedule_task"),
+            (Capability::ObserveTelemetry, "observe_telemetry"),
+        ];
+
+        for (capability, expected_name) in fixtures {
+            assert_eq!(capability.as_str(), expected_name);
+            assert_eq!(Capability::parse(expected_name), Some(capability));
+            assert_eq!(
+                Capability::parse(&expected_name.to_ascii_uppercase()),
+                Some(capability)
+            );
+            assert_eq!(
+                Capability::parse(&expected_name.replace('_', "-")),
+                Some(capability)
+            );
+        }
+    }
+
+    #[test]
+    fn capability_parse_rejects_unknown_values() {
+        assert_eq!(Capability::parse("totally_unknown"), None);
+        assert_eq!(Capability::parse(""), None);
+        assert_eq!(Capability::parse("   "), None);
+    }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -50,6 +50,7 @@ pub mod next_actions;
 pub mod onboard_cli;
 pub mod onboard_presentation;
 pub mod provider_presentation;
+pub mod runtime_capability_cli;
 pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;
 pub mod skills_cli;
@@ -409,6 +410,11 @@ pub enum Commands {
     RuntimeExperiment {
         #[command(subcommand)]
         command: runtime_experiment_cli::RuntimeExperimentCommands,
+    },
+    /// Manage run-derived capability candidate records
+    RuntimeCapability {
+        #[command(subcommand)]
+        command: runtime_capability_cli::RuntimeCapabilityCommands,
     },
     /// List available conversation context engines and selected runtime engine
     ListContextEngines {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -211,6 +211,9 @@ async fn main() {
         Commands::RuntimeExperiment { command } => {
             runtime_experiment_cli::run_runtime_experiment_cli(command)
         }
+        Commands::RuntimeCapability { command } => {
+            runtime_capability_cli::run_runtime_capability_cli(command)
+        }
         Commands::ListContextEngines { config, json } => {
             run_list_context_engines_cli(config.as_deref(), json)
         }

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1,0 +1,586 @@
+use crate::runtime_experiment_cli::{
+    RuntimeExperimentArtifactDocument, RuntimeExperimentDecision,
+    RuntimeExperimentShowCommandOptions, RuntimeExperimentStatus,
+    execute_runtime_experiment_show_command,
+};
+use crate::sha2::{self, Digest};
+use clap::{Args, Subcommand, ValueEnum};
+use loongclaw_spec::CliResult;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+pub const RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeCapabilityCommands {
+    /// Create one capability-candidate artifact from one finished experiment run
+    Propose(RuntimeCapabilityProposeCommandOptions),
+    /// Record one explicit operator review decision for a capability candidate
+    Review(RuntimeCapabilityReviewCommandOptions),
+    /// Load and render one persisted capability-candidate artifact
+    Show(RuntimeCapabilityShowCommandOptions),
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityProposeCommandOptions {
+    #[arg(long)]
+    pub run: String,
+    #[arg(long)]
+    pub output: String,
+    #[arg(long, value_enum)]
+    pub target: RuntimeCapabilityTarget,
+    #[arg(long)]
+    pub target_summary: String,
+    #[arg(long)]
+    pub bounded_scope: String,
+    #[arg(long = "required-capability")]
+    pub required_capability: Vec<String>,
+    #[arg(long = "tag")]
+    pub tag: Vec<String>,
+    #[arg(long)]
+    pub label: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityReviewCommandOptions {
+    #[arg(long)]
+    pub candidate: String,
+    #[arg(long, value_enum)]
+    pub decision: RuntimeCapabilityReviewDecision,
+    #[arg(long)]
+    pub review_summary: String,
+    #[arg(long = "warning")]
+    pub warning: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityShowCommandOptions {
+    #[arg(long)]
+    pub candidate: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityTarget {
+    ManagedSkill,
+    ProgrammaticFlow,
+    ProfileNoteAddendum,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityStatus {
+    Proposed,
+    Reviewed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityDecision {
+    Undecided,
+    Accepted,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum RuntimeCapabilityReviewDecision {
+    Accepted,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityArtifactSchema {
+    pub version: u32,
+    pub surface: String,
+    pub purpose: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityProposal {
+    pub target: RuntimeCapabilityTarget,
+    pub summary: String,
+    pub bounded_scope: String,
+    pub tags: Vec<String>,
+    pub required_capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeCapabilitySourceRunSummary {
+    pub run_id: String,
+    pub experiment_id: String,
+    pub label: Option<String>,
+    pub status: RuntimeExperimentStatus,
+    pub decision: RuntimeExperimentDecision,
+    pub mutation_summary: String,
+    pub baseline_snapshot_id: String,
+    pub result_snapshot_id: Option<String>,
+    pub evaluation_summary: String,
+    pub metrics: std::collections::BTreeMap<String, f64>,
+    pub warnings: Vec<String>,
+    pub artifact_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityReview {
+    pub summary: String,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeCapabilityArtifactDocument {
+    pub schema: RuntimeCapabilityArtifactSchema,
+    pub candidate_id: String,
+    pub created_at: String,
+    pub reviewed_at: Option<String>,
+    pub label: Option<String>,
+    pub status: RuntimeCapabilityStatus,
+    pub decision: RuntimeCapabilityDecision,
+    pub proposal: RuntimeCapabilityProposal,
+    pub source_run: RuntimeCapabilitySourceRunSummary,
+    pub review: Option<RuntimeCapabilityReview>,
+}
+
+pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
+    match command {
+        RuntimeCapabilityCommands::Propose(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_capability_propose_command(options)?;
+            emit_runtime_capability_artifact(&artifact, as_json)
+        }
+        RuntimeCapabilityCommands::Review(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_capability_review_command(options)?;
+            emit_runtime_capability_artifact(&artifact, as_json)
+        }
+        RuntimeCapabilityCommands::Show(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_capability_show_command(options)?;
+            emit_runtime_capability_artifact(&artifact, as_json)
+        }
+    }
+}
+
+pub fn execute_runtime_capability_propose_command(
+    options: RuntimeCapabilityProposeCommandOptions,
+) -> CliResult<RuntimeCapabilityArtifactDocument> {
+    let run = execute_runtime_experiment_show_command(RuntimeExperimentShowCommandOptions {
+        run: options.run.clone(),
+        json: false,
+    })?;
+    validate_proposable_run(&run, &options.run)?;
+
+    let created_at = now_rfc3339()?;
+    let label = optional_arg(options.label.as_deref());
+    let summary = required_trimmed_arg("target_summary", &options.target_summary)?;
+    let bounded_scope = required_trimmed_arg("bounded_scope", &options.bounded_scope)?;
+    let tags = normalize_repeated_values(&options.tag);
+    let required_capabilities = parse_required_capabilities(&options.required_capability)?;
+    let source_run = build_source_run_summary(&run, Some(Path::new(&options.run)))?;
+    let candidate_id = compute_candidate_id(
+        &created_at,
+        label.as_deref(),
+        &source_run,
+        options.target,
+        &summary,
+        &bounded_scope,
+        &tags,
+        &required_capabilities,
+    )?;
+    let artifact = RuntimeCapabilityArtifactDocument {
+        schema: RuntimeCapabilityArtifactSchema {
+            version: RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION,
+            surface: "runtime_capability".to_owned(),
+            purpose: "promotion_candidate_record".to_owned(),
+        },
+        candidate_id,
+        created_at,
+        reviewed_at: None,
+        label,
+        status: RuntimeCapabilityStatus::Proposed,
+        decision: RuntimeCapabilityDecision::Undecided,
+        proposal: RuntimeCapabilityProposal {
+            target: options.target,
+            summary,
+            bounded_scope,
+            tags,
+            required_capabilities,
+        },
+        source_run,
+        review: None,
+    };
+    persist_runtime_capability_artifact(&options.output, &artifact)?;
+    Ok(artifact)
+}
+
+pub fn execute_runtime_capability_review_command(
+    options: RuntimeCapabilityReviewCommandOptions,
+) -> CliResult<RuntimeCapabilityArtifactDocument> {
+    let mut artifact = load_runtime_capability_artifact(Path::new(&options.candidate))?;
+    if artifact.status != RuntimeCapabilityStatus::Proposed {
+        return Err(format!(
+            "runtime capability candidate {} is already reviewed",
+            options.candidate
+        ));
+    }
+
+    artifact.reviewed_at = Some(now_rfc3339()?);
+    artifact.status = RuntimeCapabilityStatus::Reviewed;
+    artifact.decision = match options.decision {
+        RuntimeCapabilityReviewDecision::Accepted => RuntimeCapabilityDecision::Accepted,
+        RuntimeCapabilityReviewDecision::Rejected => RuntimeCapabilityDecision::Rejected,
+    };
+    artifact.review = Some(RuntimeCapabilityReview {
+        summary: required_trimmed_arg("review_summary", &options.review_summary)?,
+        warnings: normalize_repeated_values(&options.warning),
+    });
+    persist_runtime_capability_artifact(&options.candidate, &artifact)?;
+    Ok(artifact)
+}
+
+pub fn execute_runtime_capability_show_command(
+    options: RuntimeCapabilityShowCommandOptions,
+) -> CliResult<RuntimeCapabilityArtifactDocument> {
+    load_runtime_capability_artifact(Path::new(&options.candidate))
+}
+
+fn emit_runtime_capability_artifact(
+    artifact: &RuntimeCapabilityArtifactDocument,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(artifact)
+            .map_err(|error| format!("serialize runtime capability artifact failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_capability_text(artifact));
+    Ok(())
+}
+
+fn validate_proposable_run(
+    run: &RuntimeExperimentArtifactDocument,
+    run_path: &str,
+) -> CliResult<()> {
+    if run.status == RuntimeExperimentStatus::Planned {
+        return Err(format!(
+            "runtime capability propose requires a finished runtime experiment run; {} is still planned",
+            run_path
+        ));
+    }
+    if run.evaluation.is_none() {
+        return Err(format!(
+            "runtime capability propose requires evaluation data on source run {}",
+            run_path
+        ));
+    }
+    Ok(())
+}
+
+fn build_source_run_summary(
+    run: &RuntimeExperimentArtifactDocument,
+    artifact_path: Option<&Path>,
+) -> CliResult<RuntimeCapabilitySourceRunSummary> {
+    let evaluation = run
+        .evaluation
+        .as_ref()
+        .ok_or_else(|| "runtime capability source run is missing evaluation".to_owned())?;
+    Ok(RuntimeCapabilitySourceRunSummary {
+        run_id: run.run_id.clone(),
+        experiment_id: run.experiment_id.clone(),
+        label: run.label.clone(),
+        status: run.status,
+        decision: run.decision,
+        mutation_summary: run.mutation.summary.clone(),
+        baseline_snapshot_id: run.baseline_snapshot.snapshot_id.clone(),
+        result_snapshot_id: run
+            .result_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.snapshot_id.clone()),
+        evaluation_summary: evaluation.summary.clone(),
+        metrics: evaluation.metrics.clone(),
+        warnings: evaluation.warnings.clone(),
+        artifact_path: artifact_path.map(canonicalize_existing_path).transpose()?,
+    })
+}
+
+fn load_runtime_capability_artifact(path: &Path) -> CliResult<RuntimeCapabilityArtifactDocument> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read runtime capability artifact {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let artifact =
+        serde_json::from_str::<RuntimeCapabilityArtifactDocument>(&raw).map_err(|error| {
+            format!(
+                "decode runtime capability artifact {} failed: {error}",
+                path.display()
+            )
+        })?;
+    if artifact.schema.version != RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION {
+        return Err(format!(
+            "runtime capability artifact {} uses unsupported schema version {}; expected {}",
+            path.display(),
+            artifact.schema.version,
+            RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION
+        ));
+    }
+    Ok(artifact)
+}
+
+fn now_rfc3339() -> CliResult<String> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| format!("format runtime capability timestamp failed: {error}"))
+}
+
+fn optional_arg(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn required_trimmed_arg(name: &str, raw: &str) -> CliResult<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!("runtime capability {name} cannot be empty"));
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn normalize_repeated_values(values: &[String]) -> Vec<String> {
+    let mut normalized = values
+        .iter()
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn parse_required_capabilities(values: &[String]) -> CliResult<Vec<String>> {
+    let mut normalized = BTreeSet::new();
+    for raw in values {
+        let value = normalize_required_capability(raw)?;
+        normalized.insert(value);
+    }
+    Ok(normalized.into_iter().collect())
+}
+
+fn normalize_required_capability(raw: &str) -> CliResult<String> {
+    let normalized = raw.trim().replace('-', "_").to_ascii_lowercase();
+    let canonical = match normalized.as_str() {
+        "invoke_tool" => "invoke_tool",
+        "invoke_connector" => "invoke_connector",
+        "memory_read" => "memory_read",
+        "memory_write" => "memory_write",
+        "filesystem_read" => "filesystem_read",
+        "filesystem_write" => "filesystem_write",
+        "network_egress" => "network_egress",
+        "schedule_task" => "schedule_task",
+        "observe_telemetry" => "observe_telemetry",
+        _ => {
+            return Err(format!(
+                "runtime capability required capability `{}` is unknown",
+                raw.trim()
+            ));
+        }
+    };
+    Ok(canonical.to_owned())
+}
+
+fn compute_candidate_id(
+    created_at: &str,
+    label: Option<&str>,
+    source_run: &RuntimeCapabilitySourceRunSummary,
+    target: RuntimeCapabilityTarget,
+    summary: &str,
+    bounded_scope: &str,
+    tags: &[String],
+    required_capabilities: &[String],
+) -> CliResult<String> {
+    let encoded = serde_json::to_vec(&json!({
+        "created_at": created_at,
+        "label": label,
+        "source_run_id": source_run.run_id,
+        "target": render_target(target),
+        "summary": summary,
+        "bounded_scope": bounded_scope,
+        "tags": tags,
+        "required_capabilities": required_capabilities,
+    }))
+    .map_err(|error| format!("serialize runtime capability candidate_id input failed: {error}"))?;
+    Ok(format!("{:x}", sha2::Sha256::digest(encoded)))
+}
+
+fn persist_runtime_capability_artifact(
+    output: &str,
+    artifact: &RuntimeCapabilityArtifactDocument,
+) -> CliResult<()> {
+    let output_path = PathBuf::from(output);
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create runtime capability artifact directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let encoded = serde_json::to_string_pretty(artifact)
+        .map_err(|error| format!("serialize runtime capability artifact failed: {error}"))?;
+    fs::write(&output_path, encoded).map_err(|error| {
+        format!(
+            "write runtime capability artifact {} failed: {error}",
+            output_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn canonicalize_existing_path(path: &Path) -> CliResult<String> {
+    fs::canonicalize(path)
+        .map(|resolved| resolved.display().to_string())
+        .map_err(|error| {
+            format!(
+                "canonicalize artifact path {} failed: {error}",
+                path.display()
+            )
+        })
+}
+
+pub fn render_runtime_capability_text(artifact: &RuntimeCapabilityArtifactDocument) -> String {
+    [
+        format!("candidate_id={}", artifact.candidate_id),
+        format!("status={}", render_capability_status(artifact.status)),
+        format!("decision={}", render_capability_decision(artifact.decision)),
+        format!("target={}", render_target(artifact.proposal.target)),
+        format!("target_summary={}", artifact.proposal.summary),
+        format!("bounded_scope={}", artifact.proposal.bounded_scope),
+        format!(
+            "required_capabilities={}",
+            render_string_values(&artifact.proposal.required_capabilities)
+        ),
+        format!("tags={}", render_string_values(&artifact.proposal.tags)),
+        format!("source_run_id={}", artifact.source_run.run_id),
+        format!("source_experiment_id={}", artifact.source_run.experiment_id),
+        format!(
+            "source_run_status={}",
+            render_experiment_status(artifact.source_run.status)
+        ),
+        format!(
+            "source_run_decision={}",
+            render_experiment_decision(artifact.source_run.decision)
+        ),
+        format!(
+            "source_metrics={}",
+            render_metrics(&artifact.source_run.metrics)
+        ),
+        format!(
+            "source_warnings={}",
+            render_string_values_with_separator(&artifact.source_run.warnings, " | ")
+        ),
+        format!(
+            "review_summary={}",
+            artifact
+                .review
+                .as_ref()
+                .map(|review| review.summary.as_str())
+                .unwrap_or("-")
+        ),
+        format!(
+            "review_warnings={}",
+            artifact
+                .review
+                .as_ref()
+                .map(|review| render_string_values_with_separator(&review.warnings, " | "))
+                .unwrap_or_else(|| "-".to_owned())
+        ),
+    ]
+    .join("\n")
+}
+
+fn render_metrics(metrics: &std::collections::BTreeMap<String, f64>) -> String {
+    if metrics.is_empty() {
+        "-".to_owned()
+    } else {
+        metrics
+            .iter()
+            .map(|(key, value)| format!("{key}:{value}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+fn render_string_values(values: &[String]) -> String {
+    if values.is_empty() {
+        "-".to_owned()
+    } else {
+        values.join(",")
+    }
+}
+
+fn render_string_values_with_separator(values: &[String], separator: &str) -> String {
+    if values.is_empty() {
+        "-".to_owned()
+    } else {
+        values.join(separator)
+    }
+}
+
+fn render_target(target: RuntimeCapabilityTarget) -> &'static str {
+    match target {
+        RuntimeCapabilityTarget::ManagedSkill => "managed_skill",
+        RuntimeCapabilityTarget::ProgrammaticFlow => "programmatic_flow",
+        RuntimeCapabilityTarget::ProfileNoteAddendum => "profile_note_addendum",
+    }
+}
+
+fn render_capability_status(status: RuntimeCapabilityStatus) -> &'static str {
+    match status {
+        RuntimeCapabilityStatus::Proposed => "proposed",
+        RuntimeCapabilityStatus::Reviewed => "reviewed",
+    }
+}
+
+fn render_capability_decision(decision: RuntimeCapabilityDecision) -> &'static str {
+    match decision {
+        RuntimeCapabilityDecision::Undecided => "undecided",
+        RuntimeCapabilityDecision::Accepted => "accepted",
+        RuntimeCapabilityDecision::Rejected => "rejected",
+    }
+}
+
+fn render_experiment_status(status: RuntimeExperimentStatus) -> &'static str {
+    match status {
+        RuntimeExperimentStatus::Planned => "planned",
+        RuntimeExperimentStatus::Completed => "completed",
+        RuntimeExperimentStatus::Aborted => "aborted",
+    }
+}
+
+fn render_experiment_decision(decision: RuntimeExperimentDecision) -> &'static str {
+    match decision {
+        RuntimeExperimentDecision::Undecided => "undecided",
+        RuntimeExperimentDecision::Promoted => "promoted",
+        RuntimeExperimentDecision::Rejected => "rejected",
+    }
+}

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1,3 +1,4 @@
+use crate::Capability;
 use crate::runtime_experiment_cli::{
     RuntimeExperimentArtifactDocument, RuntimeExperimentDecision,
     RuntimeExperimentShowCommandOptions, RuntimeExperimentStatus,
@@ -362,7 +363,7 @@ fn required_trimmed_arg(name: &str, raw: &str) -> CliResult<String> {
 }
 
 fn normalize_repeated_values(values: &[String]) -> Vec<String> {
-    let mut normalized = values
+    values
         .iter()
         .map(String::as_str)
         .map(str::trim)
@@ -370,9 +371,7 @@ fn normalize_repeated_values(values: &[String]) -> Vec<String> {
         .map(str::to_owned)
         .collect::<BTreeSet<_>>()
         .into_iter()
-        .collect::<Vec<_>>();
-    normalized.sort();
-    normalized
+        .collect()
 }
 
 fn parse_required_capabilities(values: &[String]) -> CliResult<Vec<String>> {
@@ -385,25 +384,14 @@ fn parse_required_capabilities(values: &[String]) -> CliResult<Vec<String>> {
 }
 
 fn normalize_required_capability(raw: &str) -> CliResult<String> {
-    let normalized = raw.trim().replace('-', "_").to_ascii_lowercase();
-    let canonical = match normalized.as_str() {
-        "invoke_tool" => "invoke_tool",
-        "invoke_connector" => "invoke_connector",
-        "memory_read" => "memory_read",
-        "memory_write" => "memory_write",
-        "filesystem_read" => "filesystem_read",
-        "filesystem_write" => "filesystem_write",
-        "network_egress" => "network_egress",
-        "schedule_task" => "schedule_task",
-        "observe_telemetry" => "observe_telemetry",
-        _ => {
-            return Err(format!(
+    Capability::parse(raw)
+        .map(|capability| capability.as_str().to_owned())
+        .ok_or_else(|| {
+            format!(
                 "runtime capability required capability `{}` is unknown",
                 raw.trim()
-            ));
-        }
-    };
-    Ok(canonical.to_owned())
+            )
+        })
 }
 
 fn compute_candidate_id(

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -584,6 +584,154 @@ fn runtime_experiment_cli_rejects_compare_recorded_snapshots_with_manual_paths()
 }
 
 #[test]
+fn runtime_capability_cli_parses_propose_review_and_show() {
+    let propose = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "propose",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--output",
+        "/tmp/runtime-capability.json",
+        "--target",
+        "managed-skill",
+        "--target-summary",
+        "Codify browser preview onboarding as a reusable managed skill",
+        "--bounded-scope",
+        "Browser preview onboarding and companion readiness checks only",
+        "--required-capability",
+        "invoke_tool",
+        "--required-capability",
+        "memory_read",
+        "--tag",
+        "browser",
+        "--tag",
+        "onboarding",
+        "--label",
+        "browser-preview-skill-candidate",
+        "--json",
+    ])
+    .expect("`runtime-capability propose` should parse");
+
+    match propose.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                options,
+            ) => {
+                assert_eq!(options.run, "/tmp/runtime-experiment.json");
+                assert_eq!(options.output, "/tmp/runtime-capability.json");
+                assert_eq!(
+                    options.target,
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill
+                );
+                assert_eq!(
+                    options.target_summary,
+                    "Codify browser preview onboarding as a reusable managed skill"
+                );
+                assert_eq!(
+                    options.bounded_scope,
+                    "Browser preview onboarding and companion readiness checks only"
+                );
+                assert_eq!(
+                    options.required_capability,
+                    vec!["invoke_tool".to_owned(), "memory_read".to_owned()]
+                );
+                assert_eq!(
+                    options.tag,
+                    vec!["browser".to_owned(), "onboarding".to_owned()]
+                );
+                assert_eq!(
+                    options.label.as_deref(),
+                    Some("browser-preview-skill-candidate")
+                );
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let review = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "review",
+        "--candidate",
+        "/tmp/runtime-capability.json",
+        "--decision",
+        "accepted",
+        "--review-summary",
+        "Promotion target is bounded and evidence supports manual codification",
+        "--warning",
+        "still requires manual implementation",
+        "--json",
+    ])
+    .expect("`runtime-capability review` should parse");
+
+    match review.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
+                options,
+            ) => {
+                assert_eq!(options.candidate, "/tmp/runtime-capability.json");
+                assert_eq!(
+                    options.decision,
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted
+                );
+                assert_eq!(
+                    options.review_summary,
+                    "Promotion target is bounded and evidence supports manual codification"
+                );
+                assert_eq!(
+                    options.warning,
+                    vec!["still requires manual implementation".to_owned()]
+                );
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let show = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "show",
+        "--candidate",
+        "/tmp/runtime-capability.json",
+        "--json",
+    ])
+    .expect("`runtime-capability show` should parse");
+
+    match show.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(options) => {
+                assert_eq!(options.candidate, "/tmp/runtime-capability.json");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
+                _,
+            )) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn acp_event_summary_cli_rejects_zero_limit() {
     let error = run_acp_event_summary_cli(None, Some("session-a"), 0, false)
         .expect_err("zero limit must be rejected");

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -32,6 +32,7 @@ mod migrate_cli;
 mod migration;
 mod onboard_cli;
 mod programmatic;
+mod runtime_capability_cli;
 mod runtime_experiment_cli;
 mod runtime_restore_cli;
 mod runtime_snapshot_cli;

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -1,4 +1,3 @@
-#![allow(unsafe_code)]
 #![allow(
     clippy::disallowed_methods,
     clippy::multiple_unsafe_ops_per_block,

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -1,0 +1,400 @@
+#![allow(unsafe_code)]
+#![allow(
+    clippy::disallowed_methods,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks
+)]
+
+use super::*;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_runtime_capability_config(root: &Path) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.tools.file_root = Some(root.display().to_string());
+    config.tools.browser.enabled = true;
+    config.tools.web.enabled = true;
+    config.acp.enabled = true;
+    config.acp.dispatch.enabled = true;
+    config.acp.default_agent = Some("planner".to_owned());
+    config.acp.allowed_agents = vec!["planner".to_owned(), "codex".to_owned()];
+    config.providers.insert(
+        "openai-main".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: false,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "gpt-4.1-mini".to_owned(),
+                ..Default::default()
+            },
+        },
+    );
+    config.set_active_provider_profile(
+        "deepseek-lab",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Deepseek,
+                model: "deepseek-chat".to_owned(),
+                api_key: Some("demo-token".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+
+    let config_path = root.join("loongclaw.toml");
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    config_path
+}
+
+fn write_snapshot_artifact(
+    root: &Path,
+    config_path: &Path,
+    relative: &str,
+    metadata: loongclaw_daemon::RuntimeSnapshotArtifactMetadata,
+) -> (PathBuf, Value) {
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let payload =
+        loongclaw_daemon::build_runtime_snapshot_artifact_json_payload(&snapshot, &metadata)
+            .expect("build runtime snapshot artifact");
+    let artifact_path = root.join(relative);
+    if let Some(parent) = artifact_path.parent() {
+        fs::create_dir_all(parent).expect("create artifact directory");
+    }
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(&payload).expect("encode snapshot artifact"),
+    )
+    .expect("write snapshot artifact");
+    (artifact_path, payload)
+}
+
+fn snapshot_id_from_payload(payload: &Value) -> String {
+    payload
+        .get("lineage")
+        .and_then(|lineage| lineage.get("snapshot_id"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .expect("snapshot payload should include lineage.snapshot_id")
+}
+
+fn start_runtime_experiment(
+    root: &Path,
+    snapshot_path: &Path,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let run_path = root.join("artifacts/runtime-experiment.json");
+    let run = loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_start_command(
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStartCommandOptions {
+            snapshot: snapshot_path.display().to_string(),
+            output: run_path.display().to_string(),
+            mutation_summary: "enable browser preview skill".to_owned(),
+            experiment_id: Some("exp-42".to_owned()),
+            label: Some("browser-preview-a".to_owned()),
+            tag: vec!["browser".to_owned(), "preview".to_owned()],
+            json: false,
+        },
+    )
+    .expect("runtime experiment start should succeed");
+    (run_path, run)
+}
+
+fn finish_runtime_experiment(
+    root: &Path,
+    config_path: &Path,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(root, &baseline_snapshot_path);
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "provider and tool policy updated".to_owned(),
+                metric: vec!["task_success=1".to_owned(), "cost_delta=-0.2".to_owned()],
+                warning: vec!["manual verification only".to_owned()],
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+    (run_path, finished)
+}
+
+#[test]
+fn runtime_capability_propose_persists_candidate_from_finished_run() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, run) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    let candidate =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec![
+                    "invoke_tool".to_owned(),
+                    "memory_read".to_owned(),
+                    "invoke_tool".to_owned(),
+                ],
+                tag: vec![
+                    "browser".to_owned(),
+                    "onboarding".to_owned(),
+                    "browser".to_owned(),
+                ],
+                label: Some("browser-preview-skill-candidate".to_owned()),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    assert_eq!(
+        candidate.label.as_deref(),
+        Some("browser-preview-skill-candidate")
+    );
+    assert_eq!(
+        candidate.source_run.run_id, run.run_id,
+        "candidate should retain source run linkage"
+    );
+    assert_eq!(
+        candidate.proposal.required_capabilities,
+        vec!["invoke_tool".to_owned(), "memory_read".to_owned()]
+    );
+    assert_eq!(
+        candidate.proposal.tags,
+        vec!["browser".to_owned(), "onboarding".to_owned()]
+    );
+    assert!(
+        candidate_path.exists(),
+        "propose should persist the candidate artifact"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_rejects_planned_runs() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-planned");
+    let config_path = write_runtime_capability_config(&root);
+    let (snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(&root, &snapshot_path);
+
+    let error =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: root
+                    .join("artifacts/runtime-capability.json")
+                    .display()
+                    .to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned()],
+                tag: vec!["browser".to_owned()],
+                label: None,
+                json: false,
+            },
+        )
+        .expect_err("planned run should be rejected");
+
+    assert!(error.contains("finished"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_rejects_unknown_required_capability() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-capability");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+
+    let error =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: root
+                    .join("artifacts/runtime-capability.json")
+                    .display()
+                    .to_string(),
+                target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProgrammaticFlow,
+                target_summary: "Codify runtime comparison as a reusable flow".to_owned(),
+                bounded_scope: "Runtime experiment compare reports only".to_owned(),
+                required_capability: vec!["totally_unknown".to_owned()],
+                tag: vec!["runtime".to_owned()],
+                label: None,
+                json: false,
+            },
+        )
+        .expect_err("unknown capabilities should be rejected");
+
+    assert!(error.contains("totally_unknown"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_review_records_terminal_decision_once() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-review");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    let proposed =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: None,
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    let reviewed =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_review_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewCommandOptions {
+                candidate: candidate_path.display().to_string(),
+                decision: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+                review_summary:
+                    "Promotion target is bounded and evidence supports manual codification"
+                        .to_owned(),
+                warning: vec!["still requires manual implementation".to_owned()],
+                json: false,
+            },
+        )
+        .expect("runtime capability review should succeed");
+
+    assert_eq!(reviewed.candidate_id, proposed.candidate_id);
+    assert!(
+        reviewed.reviewed_at.is_some(),
+        "review should record a terminal timestamp"
+    );
+
+    let error =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_review_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewCommandOptions {
+                candidate: candidate_path.display().to_string(),
+                decision: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
+                review_summary: "second review should fail".to_owned(),
+                warning: Vec::new(),
+                json: false,
+            },
+        )
+        .expect_err("double review should fail");
+
+    assert!(error.contains("already reviewed"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_show_round_trips_the_persisted_artifact() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    let proposed =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProfileNoteAddendum,
+                target_summary: "Persist browser preview operator guidance".to_owned(),
+                bounded_scope: "Imported operator guidance only".to_owned(),
+                required_capability: vec!["memory_write".to_owned()],
+                tag: vec!["memory".to_owned(), "guidance".to_owned()],
+                label: Some("browser-preview-guidance".to_owned()),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    let shown = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect("show should round-trip the persisted artifact");
+
+    assert_eq!(shown, proposed);
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
@@ -377,6 +377,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_id_mismatch() {
 #   "metadata": {
 #     "bridge_kind":"process_stdio",
 #     "command":"python3",
+#     "process_timeout_ms":"15000",
 #     "args_json":"[\"-c\",\"import json,sys,time; sys.stdout.write(json.dumps({'method':'tools/call','id':'wrong-id','payload':{'ok':True}})+'\\\\n'); sys.stdout.flush(); time.sleep(0.05)\"]",
 #     "version":"1.0.0"
 #   }
@@ -488,6 +489,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_method_mismatch() {
 #   "metadata": {
 #     "bridge_kind":"process_stdio",
 #     "command":"python3",
+#     "process_timeout_ms":"15000",
 #     "args_json":"[\"-c\",\"import json,sys,time; sys.stdout.write(json.dumps({'method':'tools/list','id':'stdio-mismatch-method-provider:primary:invoke','payload':{'ok':True}})+'\\\\n'); sys.stdout.flush(); time.sleep(0.05)\"]",
 #     "version":"1.0.0"
 #   }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -289,6 +289,7 @@ Delivered in current baseline:
   - `runtime-snapshot` persists lineage-aware runtime checkpoint artifacts
   - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
+  - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -307,7 +308,7 @@ Remaining deliverables:
   - sustain tagged release publishing across macOS/Linux/Windows
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
-  - use the shipped snapshot/restore/experiment record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
+  - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
   - partial governed adapter skeleton now exists for richer page actions:

--- a/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md
+++ b/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md
@@ -1,0 +1,317 @@
+# Alpha-Test Runtime Capability Candidate Foundation Design
+
+## Problem
+
+`runtime-snapshot` and `runtime-experiment` now give LoongClaw a clean,
+operator-controlled record layer for:
+
+- one baseline runtime state
+- one candidate result state
+- one explicit experiment decision
+- one optional runtime-surface delta report
+
+That closes the "what changed?" gap, but it still leaves the next
+self-evolution gap open.
+
+After an experiment run is compared and accepted or rejected, the operator still
+has no first-class artifact that answers:
+
+- what reusable capability candidate did this run produce?
+- should the candidate become a `managed_skill`, a `programmatic_flow`, or a
+  `profile_note_addendum`?
+- what bounded scope and required capabilities should that candidate carry?
+- did an operator later accept or reject that capability candidate itself?
+
+Today those answers live in ad-hoc notes, issue comments, or operator memory.
+That is workable for one-off exploration, but it is not a durable foundation for
+governed self-evolution.
+
+## Goal
+
+Define the smallest LoongClaw-native `runtime-capability` record layer that:
+
+1. derives one capability candidate from one finished `runtime-experiment` run
+2. keeps the first slice local-first, deterministic, and operator-readable
+3. records the intended promotion target and bounded scope without mutating live
+   runtime state
+4. adds an explicit review gate above experiment results and below any future
+   automatic promotion system
+5. stays small enough to ship before any autonomous skill/script generation
+
+## Non-Goals
+
+- automatically generating or applying `managed_skill` artifacts
+- automatically generating or applying `programmatic_flow` definitions
+- mutating `profile_note` or runtime config during candidate creation/review
+- automatically deciding which target type to use
+- evaluating arbitrary shell commands or free-form plans inside this command
+- replacing `runtime-experiment` as the source of truth for experiment evidence
+- building a dashboard, queue, or optimizer loop in the first slice
+
+## Constraints
+
+- `runtime-experiment` remains the source of truth for experiment evidence and
+  runtime-state comparison.
+- The first artifact format must remain plain JSON, operator-readable, and easy
+  to diff in git or local storage.
+- The first command surface must not require live runtime mutation, daemon
+  writes, or background services.
+- Capability candidates must stay portable; embedded data should be summaries,
+  not full copied run payloads.
+- The target types should align with shipped LoongClaw concepts, not introduce a
+  new parallel taxonomy.
+
+## Approaches Considered
+
+### Option A: Extend `runtime-experiment` artifacts directly
+
+Add capability-target metadata and candidate review fields directly to the
+existing run artifact schema.
+
+Pros:
+
+- smallest apparent surface area
+- no new command family
+- direct linkage to the experiment record
+
+Cons:
+
+- mixes "experiment evidence" with "promotion candidate" concerns
+- makes the run artifact responsible for two different lifecycle stages
+- increases schema churn on the record layer that was intentionally kept small
+
+### Option B: Add a separate `runtime-capability` artifact and CLI
+
+Create a new `runtime-capability` command family with `propose`, `review`, and
+`show`, backed by a separate capability-candidate artifact derived from one
+finished run.
+
+Pros:
+
+- preserves the boundary between experiment evidence and promotion intent
+- creates the missing middle layer between run comparison and future automation
+- stays operator-controlled and local-first
+- keeps the first slice additive and easy to test
+
+Cons:
+
+- introduces another JSON artifact type to explain
+- duplicates a small subset of source run metadata for portability
+- does not yet perform any automatic promotion
+
+### Option C: Jump directly to automatic skill/script promotion
+
+Let the system translate selected experiment runs directly into reusable
+artifacts and apply them automatically.
+
+Pros:
+
+- closest to the long-term self-evolving runtime vision
+- highest headline value
+
+Cons:
+
+- couples generation, review, policy, mutation, and rollback too early
+- creates immediate safety and audit questions around incorrect promotion
+- risks slop debt before the candidate record contract is proven
+
+## Decision
+
+Choose Option B.
+
+`alpha-test` should first gain a separate capability-candidate artifact and CLI
+surface. That keeps `runtime-experiment` focused on "what happened in one run"
+while `runtime-capability` answers "what reusable capability candidate should be
+considered next."
+
+The first slice should remain record-oriented and explicit. It should not
+generate code, install skills, or mutate config.
+
+## Proposed Surface
+
+### Command family
+
+- `loongclaw runtime-capability propose`
+- `loongclaw runtime-capability review`
+- `loongclaw runtime-capability show`
+
+### Propose command
+
+Create one capability-candidate artifact from one finished experiment run.
+
+```bash
+loongclaw runtime-capability propose \
+  --run artifacts/runtime-experiment.json \
+  --output artifacts/runtime-capability.json \
+  --target managed_skill \
+  --target-summary "Codify browser preview onboarding as a reusable managed skill" \
+  --bounded-scope "Browser preview onboarding and companion readiness checks only" \
+  --required-capability invoke_tool \
+  --required-capability memory_read \
+  --tag browser \
+  --tag onboarding
+```
+
+Behavior:
+
+- load the source run artifact
+- require the run to be finished (`completed` or `aborted`), not `planned`
+- require the run to include an evaluation payload
+- persist a new capability-candidate artifact with:
+  - stable `candidate_id`
+  - source run summary
+  - explicit target type
+  - bounded scope
+  - normalized tags
+  - normalized required capabilities
+  - `proposed` / `undecided` starting state
+
+### Review command
+
+Attach one explicit operator review decision to a proposed capability candidate.
+
+```bash
+loongclaw runtime-capability review \
+  --candidate artifacts/runtime-capability.json \
+  --decision accepted \
+  --review-summary "Promotion target is bounded and evidence supports manual codification" \
+  --warning "still requires manual implementation"
+```
+
+Behavior:
+
+- load the existing candidate artifact
+- require the current candidate status to be `proposed`
+- record one terminal review decision (`accepted` or `rejected`)
+- record one review summary and optional warnings
+- persist the updated artifact in place
+
+### Show command
+
+Render one persisted capability-candidate artifact without mutation.
+
+```bash
+loongclaw runtime-capability show --candidate artifacts/runtime-capability.json [--json]
+```
+
+Text output should keep review-critical fields first:
+
+- `candidate_id`
+- `status`
+- `decision`
+- `target`
+- `target_summary`
+- `bounded_scope`
+- `source_run_id`
+- `source_run_decision`
+- `source_run_metrics`
+- `review_summary`
+
+## Proposed Artifact Model
+
+```json
+{
+  "schema": {
+    "version": 1,
+    "surface": "runtime_capability",
+    "purpose": "promotion_candidate_record"
+  },
+  "candidate_id": "candidate-...",
+  "created_at": "2026-03-17T08:00:00Z",
+  "reviewed_at": null,
+  "label": "browser-preview-skill-candidate",
+  "status": "proposed",
+  "decision": "undecided",
+  "proposal": {
+    "target": "managed_skill",
+    "summary": "Codify browser preview onboarding as a reusable managed skill",
+    "bounded_scope": "Browser preview onboarding and companion readiness checks only",
+    "tags": ["browser", "onboarding"],
+    "required_capabilities": ["invoke_tool", "memory_read"]
+  },
+  "source_run": {
+    "run_id": "run-...",
+    "experiment_id": "exp-42",
+    "label": "browser-preview-a",
+    "status": "completed",
+    "decision": "promoted",
+    "mutation_summary": "enable browser preview skill",
+    "baseline_snapshot_id": "snapshot-a",
+    "result_snapshot_id": "snapshot-b",
+    "evaluation_summary": "provider and tool policy updated",
+    "metrics": {
+      "cost_delta": -0.2,
+      "task_success": 1.0
+    },
+    "warnings": ["manual verification only"],
+    "artifact_path": "/abs/path/runtime-experiment.json"
+  },
+  "review": null
+}
+```
+
+### Key model choices
+
+- `source_run` stores a compact experiment summary so the candidate remains
+  readable even when the original run file is not open.
+- `artifact_path` remains optional traceability metadata; it is not the source
+  of truth.
+- `proposal.target` is intentionally limited to shipped LoongClaw terms:
+  `managed_skill`, `programmatic_flow`, and `profile_note_addendum`.
+- `required_capabilities` are normalized string identifiers so the artifact can
+  remain language-agnostic and diff-friendly.
+- `review` is absent until the operator performs an explicit review action.
+
+## Why Not Reuse Experiment Decisions Directly
+
+`runtime-experiment` answers whether one runtime mutation attempt looked good or
+bad. That is necessary evidence, but it is not the same as deciding how the
+result should be crystallized into a reusable capability.
+
+Keeping `runtime-capability` separate preserves this boundary:
+
+- experiment run = one evaluated runtime change
+- capability candidate = one proposed reusable codification of that change
+
+## Error Handling
+
+- missing run file -> hard error
+- unsupported run artifact schema version -> hard error
+- `propose` from a `planned` run -> hard error
+- `propose` from a run without evaluation -> hard error
+- empty `target_summary` or `bounded_scope` -> hard error
+- unknown required capability string -> hard error naming the offending value
+- `review` on an already reviewed candidate -> hard error
+- malformed candidate review summary -> hard error
+
+## Testing Strategy
+
+1. CLI parsing for `runtime-capability propose|review|show`
+2. propose flow persists a normalized candidate artifact from a finished run
+3. propose rejects unfinished runs
+4. propose rejects unknown capability strings
+5. review flow updates the candidate once and persists review data
+6. review rejects double review
+7. `show --json` round-trips the persisted artifact
+8. text rendering surfaces decision-critical fields first
+
+## Rollout
+
+1. Land the artifact schema and CLI surface.
+2. Update product docs and roadmap references so `runtime-capability` is
+   explained as the review gate above experiment runs and below future
+   automation.
+3. Keep actual skill/script/profile-note mutation out of scope until the record
+   contract is proven in real operator use.
+
+## Recommendation
+
+Implement `runtime-capability` as the next governed self-evolution slice for
+`alpha-test`.
+
+It adds the missing middle layer without compromising the existing safety model:
+
+- experiments stay about evidence
+- candidates stay about reusable intent
+- future automation can build on explicit records instead of ad-hoc operator
+  memory

--- a/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md
+++ b/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md
@@ -1,0 +1,224 @@
+# Runtime Capability Candidate Foundation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a minimal `runtime-capability` record layer that derives one reusable capability candidate from one finished `runtime-experiment` run and records one explicit operator review decision.
+
+**Architecture:** Reuse the existing daemon-side record-artifact pattern from `runtime_experiment_cli`, keep the new surface file-based and operator-controlled, and do not mutate live runtime config, managed skills, or profile notes. The new artifact stores a compact source-run summary plus proposal/review metadata so later automation has a stable contract.
+
+**Tech Stack:** Rust, `clap`, `serde`, daemon CLI integration tests, Markdown product docs
+
+---
+
+### Task 1: Write the design and planning artifacts
+
+**Files:**
+- Create: `docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md`
+- Create: `docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Describe the problem, goal, non-goals, command surface, artifact schema,
+testing strategy, and recommendation.
+
+**Step 2: Verify the design artifact exists**
+
+Run: `test -f docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md`
+Expected: exit 0
+
+**Step 3: Write the implementation plan**
+
+Capture the exact file changes, tests, commands, and verification steps below.
+
+**Step 4: Verify the plan artifact exists**
+
+Run: `test -f docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md`
+Expected: exit 0
+
+### Task 2: Add failing CLI parsing coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Write the failing parse tests**
+
+Add parse coverage for:
+
+- `runtime-capability propose`
+- `runtime-capability review`
+- `runtime-capability show`
+
+The tests should assert:
+
+- `--run`, `--output`, `--target`, `--target-summary`, `--bounded-scope`,
+  repeated `--required-capability`, repeated `--tag`, and `--json` parse into
+  the correct option struct for `propose`
+- `--candidate`, `--decision`, `--review-summary`, repeated `--warning`, and
+  `--json` parse into the correct option struct for `review`
+- `--candidate` and `--json` parse into the correct option struct for `show`
+
+**Step 2: Run the targeted parse tests to verify RED**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_cli_ -- --nocapture`
+Expected: FAIL because the command family and types do not exist yet
+
+### Task 3: Add failing runtime-capability integration tests
+
+**Files:**
+- Create if needed: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+- Modify if preferred by repo convention: `crates/daemon/tests/integration/runtime_experiment_cli.rs`
+
+**Step 1: Write the failing propose/show/review tests**
+
+Cover:
+
+- `propose` persists a capability-candidate artifact from a finished run
+- proposal tags and required capabilities are normalized and deduplicated
+- source run summary carries run id, experiment id, decision, mutation summary,
+  metrics, warnings, and optional artifact path
+- `propose` rejects a `planned` run
+- `propose` rejects an unknown capability string
+- `review` records one terminal decision and review summary
+- `review` rejects double review
+- `show` round-trips the persisted artifact
+
+**Step 2: Run the targeted integration tests to verify RED**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_ -- --nocapture`
+Expected: FAIL because the runtime-capability code path does not exist yet
+
+### Task 4: Implement the new daemon CLI surface
+
+**Files:**
+- Create: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+
+**Step 1: Add the new command family and option structs**
+
+Implement:
+
+- `RuntimeCapabilityCommands`
+- `RuntimeCapabilityProposeCommandOptions`
+- `RuntimeCapabilityReviewCommandOptions`
+- `RuntimeCapabilityShowCommandOptions`
+
+Also add the command family to top-level daemon CLI parsing and dispatch.
+
+**Step 2: Add the artifact structs and helpers**
+
+Implement:
+
+- schema, proposal, source-run summary, review, and artifact document structs
+- normalized target enum
+- normalized review-decision enum
+- helper functions for timestamps, text validation, repeated-value normalization,
+  capability parsing, artifact persistence, and text rendering
+
+**Step 3: Implement `propose` with minimal run-derived logic**
+
+`propose` should:
+
+- load a finished `runtime-experiment` artifact
+- reject unfinished runs or runs without evaluation
+- build a compact source-run summary
+- normalize tags and required capabilities
+- compute a stable `candidate_id`
+- persist the new artifact to the requested output path
+
+**Step 4: Implement `review` and `show`**
+
+`review` should:
+
+- load the candidate artifact
+- reject non-proposed candidates
+- persist `reviewed_at`, terminal decision, summary, and warnings
+
+`show` should:
+
+- load the artifact
+- print JSON or a stable text summary without mutation
+
+**Step 5: Run targeted daemon tests to verify GREEN**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_ runtime_experiment_cli_ -- --nocapture`
+Expected: PASS
+
+### Task 5: Update product docs and roadmap references
+
+**Files:**
+- Create: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/ROADMAP.md`
+- Modify if needed: `AGENTS.md`
+- Modify if needed: `CLAUDE.md`
+
+**Step 1: Add the product spec**
+
+Describe `runtime-capability` as the review layer above `runtime-experiment`
+and below future automation. Keep automatic mutation explicitly out of scope.
+
+**Step 2: Wire the product spec index**
+
+Add `Runtime Capability` to `docs/product-specs/index.md`.
+
+**Step 3: Update the roadmap**
+
+Mention the new capability-candidate record layer as a prerequisite for later
+skill-optimization loops or governed promotion work.
+
+**Step 4: Run doc spot checks**
+
+Run: `rg -n "runtime-capability|runtime capability|skill-optimization" docs/product-specs docs/ROADMAP.md`
+Expected: matches in the new/updated docs only
+
+### Task 6: Verify, isolate, and commit
+
+**Files:**
+- Review all touched files
+
+**Step 1: Run focused verification**
+
+Run:
+
+- `cargo test -p loongclaw-daemon --test integration runtime_capability_ runtime_experiment_cli_ -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability -- --nocapture`
+
+Expected: PASS
+
+**Step 2: Run repo-level CI-parity checks**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 3: Inspect the final diff**
+
+Run:
+
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`
+
+Expected: only runtime-capability and directly related doc/test changes
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md \
+  docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md \
+  docs/product-specs/runtime-capability.md \
+  docs/product-specs/index.md \
+  docs/ROADMAP.md \
+  crates/daemon/src/runtime_capability_cli.rs \
+  crates/daemon/src/lib.rs \
+  crates/daemon/src/main.rs \
+  crates/daemon/tests/integration/cli_tests.rs \
+  crates/daemon/tests/integration/runtime_capability_cli.rs
+git commit -m "feat(daemon): add runtime capability candidate records"
+```

--- a/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md
+++ b/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md
@@ -10,6 +10,8 @@
 
 ---
 
+## Implementation Tasks
+
 ### Task 1: Write the design and planning artifacts
 
 **Files:**

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -17,6 +17,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - [Channel Setup](channel-setup.md)
 - [Tool Surface](tool-surface.md)
 - [Runtime Experiment](runtime-experiment.md)
+- [Runtime Capability](runtime-capability.md)
 - [WebChat](webchat.md)
 - [Prompt And Personality](prompt-and-personality.md)
 - [Memory Profiles](memory-profiles.md)
@@ -25,6 +26,7 @@ Product specs describe **what** the product does from the user's perspective, no
 
 - `Installation`, `Onboarding`, `One-Shot Ask`, `Doctor`, `Browser Automation`, `Tool Surface`, and `Channel Setup` define the shipped first-run and support journey for the current MVP.
 - `Runtime Experiment` defines the shipped local experiment-record surface layered on top of runtime snapshot and restore artifacts.
+- `Runtime Capability` defines the shipped local capability-candidate review surface layered on top of runtime experiment artifacts.
 - `Browser Automation Companion` and `WebChat` are expectation-setting specs for the next user-facing surfaces. They should not be documented as generally available before the implementation exists.
 
 Template for new specs:

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -1,0 +1,32 @@
+# Runtime Capability
+
+## User Story
+
+As a LoongClaw operator, I want to derive one explicit capability candidate from
+one finished runtime experiment so that I can review how a successful or failed
+experiment should be crystallized into a reusable lower-layer capability.
+
+## Acceptance Criteria
+
+- [ ] LoongClaw exposes a `runtime-capability` command family with `propose`,
+      `review`, and `show` subcommands.
+- [ ] `runtime-capability propose` creates a persisted capability-candidate
+      artifact from one finished `runtime-experiment` run.
+- [ ] The candidate artifact records one explicit target type:
+      `managed_skill`, `programmatic_flow`, or `profile_note_addendum`.
+- [ ] The candidate artifact records one bounded scope, normalized tags, and
+      normalized required capabilities without mutating live runtime state.
+- [ ] `runtime-capability review` records one explicit operator decision
+      (`accepted` or `rejected`) plus one review summary and optional warnings.
+- [ ] `runtime-capability show` round-trips the persisted artifact as JSON and
+      renders the review-critical fields first in text output.
+- [ ] Product docs describe `runtime-capability` as the governed review layer
+      above `runtime-experiment` and below any future automated promotion loop.
+
+## Out of Scope
+
+- Automatically generating or applying managed skills
+- Automatically generating or applying programmatic flows
+- Automatically mutating `profile_note` or runtime config
+- Automatic promotion, rollback, or optimizer orchestration
+- Candidate queues, dashboards, or autonomous ranking systems


### PR DESCRIPTION
Closes #277

## Summary

This PR adds a governed `runtime-capability` review layer above `runtime-experiment` so operators can persist explicit promotion candidates without mutating live runtime state.

## What Changed

- add `runtime-capability propose|review|show` to the daemon CLI
- persist dedicated capability-candidate artifacts with target kind, bounded scope, normalized tags, normalized required capabilities, and source run evidence
- record explicit operator review decisions (`accepted` / `rejected`) and render review-critical fields first in text output
- add integration coverage for CLI parsing, proposal persistence, rejection paths, review finalization, and show round-trips
- document the new surface in product specs, roadmap notes, and design / implementation plan docs
- harden two process-stdio mismatch tests by giving them an explicit timeout budget so `--all-features` verification stays stable under full-suite load

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime-capability CLI (propose, review, show) to create, review, persist, and display capability candidates derived from finished runs.
  * Added canonical capability name parsing/formatting to improve handling of required capabilities.

* **Tests**
  * Added integration tests exercising propose/review/show flows and CLI parsing.

* **Documentation**
  * Added product spec, design and implementation plan, roadmap updates, and usage docs for runtime-capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
