### PR TITLE
feat(app): narrow delegate child runtime policy

### DIFF
--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -113,6 +113,42 @@ pub struct DelegateToolConfig {
     pub child_tool_allowlist: Vec<String>,
     #[serde(default)]
     pub allow_shell_in_child: bool,
+    #[serde(default)]
+    pub child_runtime: DelegateChildRuntimeConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DelegateChildRuntimeConfig {
+    #[serde(default)]
+    pub web: DelegateChildWebRuntimeConfig,
+    #[serde(default)]
+    pub browser: DelegateChildBrowserRuntimeConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DelegateChildWebRuntimeConfig {
+    #[serde(default)]
+    pub allow_private_hosts: Option<bool>,
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+    #[serde(default)]
+    pub blocked_domains: Vec<String>,
+    #[serde(default)]
+    pub timeout_seconds: Option<u64>,
+    #[serde(default)]
+    pub max_bytes: Option<usize>,
+    #[serde(default)]
+    pub max_redirects: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DelegateChildBrowserRuntimeConfig {
+    #[serde(default)]
+    pub max_sessions: Option<usize>,
+    #[serde(default)]
+    pub max_links: Option<usize>,
+    #[serde(default)]
+    pub max_text_chars: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -260,6 +296,7 @@ impl Default for DelegateToolConfig {
             timeout_seconds: default_delegate_timeout_seconds(),
             child_tool_allowlist: default_delegate_child_tool_allowlist(),
             allow_shell_in_child: false,
+            child_runtime: DelegateChildRuntimeConfig::default(),
         }
     }
 }
@@ -360,6 +397,66 @@ impl ToolConfig {
         ) {
             issues.push(*issue);
         }
+        if let Some(max_sessions) = self.delegate.child_runtime.browser.max_sessions
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.browser.max_sessions",
+                max_sessions,
+                MIN_BROWSER_MAX_SESSIONS,
+                MAX_BROWSER_MAX_SESSIONS,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(max_links) = self.delegate.child_runtime.browser.max_links
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.browser.max_links",
+                max_links,
+                MIN_BROWSER_MAX_LINKS,
+                MAX_BROWSER_MAX_LINKS,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(max_text_chars) = self.delegate.child_runtime.browser.max_text_chars
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.browser.max_text_chars",
+                max_text_chars,
+                MIN_BROWSER_MAX_TEXT_CHARS,
+                MAX_BROWSER_MAX_TEXT_CHARS,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(max_bytes) = self.delegate.child_runtime.web.max_bytes
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.web.max_bytes",
+                max_bytes,
+                MIN_WEB_FETCH_MAX_BYTES,
+                MAX_WEB_FETCH_MAX_BYTES,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(timeout_seconds) = self.delegate.child_runtime.web.timeout_seconds
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.web.timeout_seconds",
+                timeout_seconds as usize,
+                MIN_WEB_FETCH_TIMEOUT_SECONDS,
+                MAX_WEB_FETCH_TIMEOUT_SECONDS,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(max_redirects) = self.delegate.child_runtime.web.max_redirects
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.web.max_redirects",
+                max_redirects,
+                0,
+                MAX_WEB_FETCH_MAX_REDIRECTS,
+            )
+        {
+            issues.push(*issue);
+        }
         issues
     }
 }
@@ -385,6 +482,36 @@ impl WebToolConfig {
 
     pub fn normalized_blocked_domains(&self) -> Vec<String> {
         normalize_domain_entries(&self.blocked_domains)
+    }
+}
+
+impl DelegateChildWebRuntimeConfig {
+    pub fn normalized_allowed_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.allowed_domains)
+    }
+
+    pub fn normalized_blocked_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.blocked_domains)
+    }
+}
+
+impl DelegateChildRuntimeConfig {
+    pub fn runtime_narrowing(&self) -> crate::tools::runtime_config::ToolRuntimeNarrowing {
+        crate::tools::runtime_config::ToolRuntimeNarrowing {
+            web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
+                allow_private_hosts: self.web.allow_private_hosts,
+                allowed_domains: self.web.normalized_allowed_domains().into_iter().collect(),
+                blocked_domains: self.web.normalized_blocked_domains().into_iter().collect(),
+                timeout_seconds: self.web.timeout_seconds,
+                max_bytes: self.web.max_bytes,
+                max_redirects: self.web.max_redirects,
+            },
+            browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+                max_sessions: self.browser.max_sessions,
+                max_links: self.browser.max_links,
+                max_text_chars: self.browser.max_text_chars,
+            },
+        }
     }
 }
 
@@ -530,6 +657,19 @@ max_active_children = 4
 timeout_seconds = 90
 allow_shell_in_child = true
 child_tool_allowlist = ["file.read", "shell.exec"]
+
+[tools.delegate.child_runtime.web]
+allow_private_hosts = false
+allowed_domains = ["Docs.Example.com", "docs.example.com"]
+blocked_domains = ["internal.example", " INTERNAL.EXAMPLE "]
+timeout_seconds = 9
+max_bytes = 262144
+max_redirects = 1
+
+[tools.delegate.child_runtime.browser]
+max_sessions = 2
+max_links = 10
+max_text_chars = 1024
 "#;
         let parsed =
             toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
@@ -558,6 +698,52 @@ child_tool_allowlist = ["file.read", "shell.exec"]
         assert_eq!(
             parsed.tools.delegate.child_tool_allowlist,
             vec!["file.read".to_owned(), "shell.exec".to_owned()]
+        );
+        assert_eq!(
+            parsed
+                .tools
+                .delegate
+                .child_runtime
+                .web
+                .normalized_allowed_domains(),
+            vec!["docs.example.com".to_owned()]
+        );
+        assert_eq!(
+            parsed
+                .tools
+                .delegate
+                .child_runtime
+                .web
+                .normalized_blocked_domains(),
+            vec!["internal.example".to_owned()]
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.web.allow_private_hosts,
+            Some(false)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.web.timeout_seconds,
+            Some(9)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.web.max_bytes,
+            Some(262144)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.web.max_redirects,
+            Some(1)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.browser.max_sessions,
+            Some(2)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.browser.max_links,
+            Some(10)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.browser.max_text_chars,
+            Some(1024)
         );
     }
 

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -7,6 +7,7 @@ use serde_json::{Value, json};
 
 use crate::CliResult;
 use crate::KernelContext;
+use crate::tools::runtime_config::ToolRuntimeNarrowing;
 use crate::tools::{
     ToolView, delegate_child_tool_view_for_config,
     delegate_child_tool_view_for_config_with_delegate,
@@ -38,6 +39,7 @@ pub struct SessionContext {
     pub session_id: String,
     pub parent_session_id: Option<String>,
     pub tool_view: ToolView,
+    pub runtime_narrowing: Option<ToolRuntimeNarrowing>,
 }
 
 impl SessionContext {
@@ -46,6 +48,7 @@ impl SessionContext {
             session_id: normalize_session_id(session_id.into()),
             parent_session_id: None,
             tool_view,
+            runtime_narrowing: None,
         }
     }
 
@@ -58,7 +61,16 @@ impl SessionContext {
             session_id: normalize_session_id(session_id.into()),
             parent_session_id: Some(normalize_session_id(parent_session_id.into())),
             tool_view,
+            runtime_narrowing: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_runtime_narrowing(mut self, runtime_narrowing: ToolRuntimeNarrowing) -> Self {
+        if !runtime_narrowing.is_empty() {
+            self.runtime_narrowing = Some(runtime_narrowing);
+        }
+        self
     }
 }
 
@@ -69,6 +81,27 @@ fn normalize_session_id(session_id: String) -> String {
     } else {
         trimmed.to_owned()
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_delegate_runtime_narrowing(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<ToolRuntimeNarrowing>, String> {
+    let events = repo.list_delegate_lifecycle_events(session_id)?;
+    let execution = events.into_iter().rev().find_map(|event| {
+        matches!(
+            event.event_kind.as_str(),
+            "delegate_queued" | "delegate_started"
+        )
+        .then(|| {
+            super::subagent::ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
+        })
+        .flatten()
+    });
+    Ok(execution.and_then(|execution| {
+        (!execution.runtime_narrowing.is_empty()).then_some(execution.runtime_narrowing)
+    }))
 }
 
 #[derive(Clone)]
@@ -440,22 +473,26 @@ where
                     .map_err(|error| format!("load session context failed: {error}"))?
                 {
                     if let Some(parent_session_id) = session.parent_session_id {
+                        let runtime_narrowing = load_delegate_runtime_narrowing(&repo, session_id)?;
                         return Ok(SessionContext::child(
                             session.session_id,
                             parent_session_id,
                             tool_view,
-                        ));
+                        )
+                        .with_runtime_narrowing(runtime_narrowing.unwrap_or_default()));
                     }
                 } else if let Some(summary) = repo
                     .load_session_summary_with_legacy_fallback(session_id)
                     .map_err(|error| format!("load legacy session context failed: {error}"))?
                     && let Some(parent_session_id) = summary.parent_session_id
                 {
+                    let runtime_narrowing = load_delegate_runtime_narrowing(&repo, session_id)?;
                     return Ok(SessionContext::child(
                         summary.session_id,
                         parent_session_id,
                         tool_view,
-                    ));
+                    )
+                    .with_runtime_narrowing(runtime_narrowing.unwrap_or_default()));
                 }
             }
         }

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use crate::tools::runtime_config::ToolRuntimeNarrowing;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConstrainedSubagentMode {
@@ -27,6 +29,8 @@ pub struct ConstrainedSubagentExecution {
     pub timeout_seconds: u64,
     pub allow_shell_in_child: bool,
     pub child_tool_allowlist: Vec<String>,
+    #[serde(default, skip_serializing_if = "ToolRuntimeNarrowing::is_empty")]
+    pub runtime_narrowing: ToolRuntimeNarrowing,
     pub kernel_bound: bool,
 }
 
@@ -95,6 +99,7 @@ mod tests {
             timeout_seconds: 60,
             allow_shell_in_child: false,
             child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            runtime_narrowing: ToolRuntimeNarrowing::default(),
             kernel_bound: true,
         };
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
 use loongclaw_contracts::{
-    Capability, ExecutionRoute, HarnessKind, MemoryPlaneError, ToolCoreRequest,
+    Capability, ExecutionRoute, HarnessKind, MemoryPlaneError, ToolCoreOutcome, ToolCoreRequest,
 };
 use loongclaw_kernel::{
     CoreMemoryAdapter, FixedClock, InMemoryAuditSink, LoongClawKernel, MemoryCoreOutcome,
@@ -31,6 +31,8 @@ use crate::acp::{
 use crate::memory::MEMORY_OP_WINDOW;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{NewSessionRecord, SessionKind, SessionRepository, SessionState};
 
 struct FakeRuntime {
     seed_messages: Vec<Value>,
@@ -11073,6 +11075,285 @@ async fn handle_turn_with_runtime_passes_restricted_tool_view_into_provider_requ
             .as_slice(),
         &[child_view]
     );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_kernel_payload() {
+    struct EchoToolAdapter;
+
+    #[async_trait::async_trait]
+    impl loongclaw_kernel::CoreToolAdapter for EchoToolAdapter {
+        fn name(&self) -> &str {
+            "echo-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, loongclaw_contracts::ToolPlaneError> {
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool": request.tool_name,
+                    "payload": request.payload,
+                }),
+            })
+        }
+    }
+
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-runtime", "payload-context")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.delegate.child_tool_allowlist = vec!["web.fetch".to_owned()];
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: SessionState::Running,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "fetch docs",
+            "label": "Child",
+            "execution": {
+                "mode": "inline",
+                "depth": 1,
+                "max_depth": 2,
+                "active_children": 0,
+                "max_active_children": 3,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["web.fetch"],
+                "kernel_bound": true,
+                "runtime_narrowing": {
+                    "web_fetch": {
+                        "allowed_domains": ["docs.example.com"],
+                        "allow_private_hosts": false
+                    },
+                    "browser": {
+                        "max_sessions": 1,
+                        "max_links": 8,
+                        "max_text_chars": 512
+                    }
+                }
+            }
+        }),
+    })
+    .expect("append delegate_started event");
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_context = runtime
+        .session_context(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("load child session context");
+    assert_eq!(
+        session_context
+            .runtime_narrowing
+            .as_ref()
+            .and_then(|narrowing| { narrowing.web_fetch.allowed_domains.iter().next().cloned() }),
+        Some("docs.example.com".to_owned())
+    );
+
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(EchoToolAdapter);
+    kernel
+        .set_default_core_tool_adapter("echo-tools")
+        .expect("set default tool adapter");
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let kernel_ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![provider_tool_intent(
+            "web.fetch",
+            json!({
+                "url": "https://outside.invalid/docs"
+            }),
+            "child-session",
+            "turn-child-runtime",
+            "call-child-runtime",
+        )],
+        raw_meta: Value::Null,
+    };
+
+    let result = TurnEngine::new(5)
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &DefaultAppToolDispatcher::runtime(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            let line = text.lines().next().expect("tool result line should exist");
+            let payload = line
+                .strip_prefix("[ok] ")
+                .expect("tool result line should keep [ok] prefix");
+            let envelope: Value =
+                serde_json::from_str(payload).expect("tool result envelope should be json");
+            let payload_summary = envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should be text");
+            assert!(
+                payload_summary.contains("\"runtime_narrowing\""),
+                "expected runtime_narrowing in payload summary, got: {payload_summary}"
+            );
+            assert!(
+                payload_summary.contains("docs.example.com"),
+                "expected narrowed domain in payload summary, got: {payload_summary}"
+            );
+            assert!(
+                payload_summary.contains("\"max_sessions\":1"),
+                "expected browser max_sessions narrowing in payload summary, got: {payload_summary}"
+            );
+        }
+        other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected final text tool output, got: {other:?}")
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_context_preserves_child_runtime_narrowing_after_many_later_events() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-runtime", "history-retention")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: SessionState::Running,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "fetch docs",
+            "label": "Child",
+            "execution": {
+                "mode": "inline",
+                "depth": 1,
+                "max_depth": 2,
+                "active_children": 0,
+                "max_active_children": 3,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["web.fetch"],
+                "kernel_bound": true,
+                "runtime_narrowing": {
+                    "web_fetch": {
+                        "allowed_domains": ["docs.example.com"],
+                        "allow_private_hosts": false
+                    },
+                    "browser": {
+                        "max_sessions": 1
+                    }
+                }
+            }
+        }),
+    })
+    .expect("append delegate_started event");
+
+    for index in 0..24 {
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: format!("child_progress_{index}"),
+            actor_session_id: Some("child-session".to_owned()),
+            payload_json: json!({
+                "index": index,
+            }),
+        })
+        .expect("append later child event");
+    }
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_context = runtime
+        .session_context(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("load child session context");
+
+    let runtime_narrowing = session_context
+        .runtime_narrowing
+        .expect("child runtime narrowing should survive later events");
+    assert_eq!(
+        runtime_narrowing.web_fetch.allowed_domains,
+        BTreeSet::from(["docs.example.com".to_owned()])
+    );
+    assert_eq!(runtime_narrowing.browser.max_sessions, Some(1));
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4296,6 +4296,7 @@ fn constrained_subagent_execution_for_delegate(
         timeout_seconds,
         allow_shell_in_child: config.tools.delegate.allow_shell_in_child,
         child_tool_allowlist: config.tools.delegate.child_tool_allowlist.clone(),
+        runtime_narrowing: config.tools.delegate.child_runtime.runtime_narrowing(),
         kernel_bound: binding.is_kernel_bound(),
     })
 }
@@ -6376,6 +6377,7 @@ mod tests {
             timeout_seconds: 60,
             allow_shell_in_child: false,
             child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
             kernel_bound: false,
         };
         repo.create_session(NewSessionRecord {
@@ -6487,6 +6489,7 @@ mod tests {
             timeout_seconds: 60,
             allow_shell_in_child: false,
             child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
             kernel_bound: false,
         };
         repo.create_session(NewSessionRecord {

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -646,11 +646,13 @@ pub(crate) fn render_kernel_error_reason(error: &KernelError) -> String {
 fn augment_tool_payload_for_kernel(
     canonical_tool_name: &str,
     payload: serde_json::Value,
-    session_id: &str,
+    session_context: &SessionContext,
 ) -> serde_json::Value {
+    let payload = inject_runtime_narrowing_context(payload, session_context);
+
     // Direct browser tool calls: inject scope at the top level.
     if browser_scope_injection_required(canonical_tool_name) {
-        return inject_browser_scope_field(payload, session_id);
+        return inject_browser_scope_field(payload, &session_context.session_id);
     }
 
     // tool.invoke wrapping a browser tool: inject scope into the nested arguments.
@@ -664,13 +666,43 @@ fn augment_tool_payload_for_kernel(
         if let Some(arguments) = outer.remove("arguments") {
             outer.insert(
                 "arguments".to_owned(),
-                inject_browser_scope_field(arguments, session_id),
+                inject_browser_scope_field(arguments, &session_context.session_id),
             );
         }
         return serde_json::Value::Object(outer);
     }
 
     payload
+}
+
+fn inject_runtime_narrowing_context(
+    payload: serde_json::Value,
+    session_context: &SessionContext,
+) -> serde_json::Value {
+    let Some(runtime_narrowing) = session_context.runtime_narrowing.as_ref() else {
+        return payload;
+    };
+    if runtime_narrowing.is_empty() {
+        return payload;
+    }
+
+    let serde_json::Value::Object(mut object) = payload else {
+        return payload;
+    };
+    let mut internal = object
+        .remove(crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    internal.insert(
+        crate::tools::LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY.to_owned(),
+        serde_json::to_value(runtime_narrowing)
+            .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new())),
+    );
+    object.insert(
+        crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+        serde_json::Value::Object(internal),
+    );
+    serde_json::Value::Object(object)
 }
 
 fn browser_scope_injection_required(tool_name: &str) -> bool {
@@ -1114,7 +1146,7 @@ impl TurnEngine {
             let augmented_payload = augment_tool_payload_for_kernel(
                 resolved_tool.canonical_name,
                 injected.payload,
-                &session_context.session_id,
+                session_context,
             );
             let request = ToolCoreRequest {
                 tool_name: resolved_tool.canonical_name.to_owned(),
@@ -1961,7 +1993,11 @@ mod tests {
             Some("turn-browser-companion-start"),
         );
 
-        let augmented = augment_tool_payload_for_kernel(&tool_name, payload, "root-session");
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::ToolView::from_tool_names(std::iter::empty::<&str>()),
+        );
+        let augmented = augment_tool_payload_for_kernel(&tool_name, payload, &session_context);
 
         assert_eq!(augmented["tool_id"], "browser.companion.session.start");
         assert_eq!(

--- a/crates/app/src/tools/browser.rs
+++ b/crates/app/src/tools/browser.rs
@@ -694,6 +694,7 @@ mod tests {
             web_fetch: super::super::runtime_config::WebFetchRuntimePolicy {
                 enabled: true,
                 allow_private_hosts: true,
+                enforce_allowed_domains: false,
                 allowed_domains: std::collections::BTreeSet::new(),
                 blocked_domains: std::collections::BTreeSet::new(),
                 timeout_seconds: 5,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2842,6 +2842,46 @@ mod tests {
 
     #[cfg(feature = "tool-webfetch")]
     #[test]
+    fn web_fetch_denies_disjoint_allowlists_when_runtime_narrowing_intersection_is_empty() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-web-fetch-runtime-narrowing-disjoint-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let mut config = test_tool_runtime_config(root.clone());
+        config
+            .web_fetch
+            .allowed_domains
+            .insert("api.example.com".to_owned());
+        let error = execute_tool_core_with_test_context(
+            ToolCoreRequest {
+                tool_name: "web.fetch".to_owned(),
+                payload: json!({
+                    "url": "https://outside.invalid/docs",
+                    "_loongclaw": {
+                        "runtime_narrowing": {
+                            "web_fetch": {
+                                "allowed_domains": ["docs.example.com"]
+                            }
+                        }
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("disjoint allowlists should deny before host resolution");
+
+        assert!(
+            error.contains("not in allowed_domains"),
+            "expected empty-intersection allowlist denial, got: {error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    #[test]
     fn web_fetch_rejects_forged_runtime_narrowing_from_untrusted_payload() {
         let root = std::env::temp_dir().join(format!(
             "loongclaw-web-fetch-runtime-narrowing-forged-{}",

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -64,6 +64,7 @@ pub const BROWSER_COMPANION_COMMAND: &str = bundled_skills::BROWSER_COMPANION_CO
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: &str = "visible_tool_ids";
+pub(crate) const LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY: &str = "runtime_narrowing";
 
 pub fn normalize_external_skills_domain_rule(raw: &str) -> Result<String, String> {
     external_skills::normalize_domain_rule(raw)
@@ -595,11 +596,28 @@ pub fn execute_tool_core_with_config(
         tool_name: canonical_name.to_owned(),
         payload: request.payload,
     };
+    let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)
+        .map(|narrowing| config.narrowed(&narrowing));
+    let config = effective_config.as_ref().unwrap_or(config);
     match canonical_name {
         "tool.search" => execute_tool_search_tool_with_config(request, config),
         "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
         _ => execute_discoverable_tool_core_with_config(request, config),
     }
+}
+
+fn trusted_runtime_narrowing_from_payload(
+    payload: &Value,
+) -> Option<runtime_config::ToolRuntimeNarrowing> {
+    if !trusted_internal_tool_payload_enabled() {
+        return None;
+    }
+
+    payload
+        .get(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+        .and_then(|body| body.get(LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY))
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
 }
 
 fn execute_discoverable_tool_core_with_config(
@@ -2775,6 +2793,80 @@ mod tests {
             &config,
         )
         .expect_err("untrusted tool search should reject reserved internal visibility context");
+
+        assert!(
+            error.contains("payload._loongclaw is reserved for trusted internal tool context"),
+            "error={error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    #[test]
+    fn web_fetch_respects_runtime_narrowing_from_trusted_internal_payload() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-web-fetch-runtime-narrowing-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let mut config = test_tool_runtime_config(root.clone());
+        config.web_fetch.timeout_seconds = 1;
+        let error = execute_tool_core_with_test_context(
+            ToolCoreRequest {
+                tool_name: "web.fetch".to_owned(),
+                payload: json!({
+                    "url": "https://example.com/docs",
+                    "_loongclaw": {
+                        "runtime_narrowing": {
+                            "web_fetch": {
+                                "allowed_domains": ["docs.example.com"],
+                                "allow_private_hosts": false
+                            }
+                        }
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("runtime-narrowed child web.fetch should be denied before network access");
+
+        assert!(
+            error.contains("not in allowed_domains"),
+            "expected narrowed domain denial, got: {error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    #[test]
+    fn web_fetch_rejects_forged_runtime_narrowing_from_untrusted_payload() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-web-fetch-runtime-narrowing-forged-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "web.fetch".to_owned(),
+                payload: json!({
+                    "url": "https://example.com/docs",
+                    "_loongclaw": {
+                        "runtime_narrowing": {
+                            "web_fetch": {
+                                "allowed_domains": ["docs.example.com"]
+                            }
+                        }
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("untrusted runtime narrowing should be rejected");
 
         assert!(
             error.contains("payload._loongclaw is reserved for trusted internal tool context"),

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -144,6 +144,7 @@ impl BrowserCompanionRuntimePolicy {
 pub struct WebFetchRuntimePolicy {
     pub enabled: bool,
     pub allow_private_hosts: bool,
+    pub enforce_allowed_domains: bool,
     pub allowed_domains: BTreeSet<String>,
     pub blocked_domains: BTreeSet<String>,
     pub timeout_seconds: u64,
@@ -156,6 +157,7 @@ impl Default for WebFetchRuntimePolicy {
         Self {
             enabled: true,
             allow_private_hosts: false,
+            enforce_allowed_domains: false,
             allowed_domains: BTreeSet::new(),
             blocked_domains: BTreeSet::new(),
             timeout_seconds: crate::config::DEFAULT_WEB_FETCH_TIMEOUT_SECONDS,
@@ -240,6 +242,8 @@ impl Default for ToolRuntimeConfig {
 
 impl ToolRuntimeConfig {
     pub fn from_loongclaw_config(config: &LoongClawConfig, config_path: Option<&Path>) -> Self {
+        let web_fetch_allowed_domains = config.tools.web.normalized_allowed_domains();
+        let web_fetch_enforce_allowed_domains = !web_fetch_allowed_domains.is_empty();
         Self {
             file_root: Some(config.tools.resolved_file_root()),
             shell_allow: config
@@ -275,12 +279,8 @@ impl ToolRuntimeConfig {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: config.tools.web.enabled,
                 allow_private_hosts: config.tools.web.allow_private_hosts,
-                allowed_domains: config
-                    .tools
-                    .web
-                    .normalized_allowed_domains()
-                    .into_iter()
-                    .collect(),
+                enforce_allowed_domains: web_fetch_enforce_allowed_domains,
+                allowed_domains: web_fetch_allowed_domains.into_iter().collect(),
                 blocked_domains: config
                     .tools
                     .web
@@ -387,6 +387,7 @@ impl ToolRuntimeConfig {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: web_fetch_enabled,
                 allow_private_hosts: web_fetch_allow_private_hosts,
+                enforce_allowed_domains: !web_fetch_allowed_domains.is_empty(),
                 allowed_domains: web_fetch_allowed_domains,
                 blocked_domains: web_fetch_blocked_domains,
                 timeout_seconds: web_fetch_timeout_seconds,
@@ -440,6 +441,7 @@ impl ToolRuntimeConfig {
         };
 
         if !narrowing.web_fetch.allowed_domains.is_empty() {
+            narrowed.web_fetch.enforce_allowed_domains = true;
             narrowed.web_fetch.allowed_domains = if narrowed.web_fetch.allowed_domains.is_empty() {
                 narrowing.web_fetch.allowed_domains.clone()
             } else {
@@ -763,6 +765,7 @@ mod tests {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: false,
                 allow_private_hosts: true,
+                enforce_allowed_domains: true,
                 allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
                 blocked_domains: BTreeSet::from(["internal.example".to_owned()]),
                 timeout_seconds: 9,
@@ -1115,6 +1118,7 @@ mod tests {
         let policy = WebFetchRuntimePolicy {
             enabled: false,
             allow_private_hosts: true,
+            enforce_allowed_domains: true,
             allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
             blocked_domains: BTreeSet::from(["internal.example".to_owned()]),
             timeout_seconds: 9,
@@ -1124,6 +1128,7 @@ mod tests {
 
         assert!(!policy.enabled);
         assert!(policy.allow_private_hosts);
+        assert!(policy.enforce_allowed_domains);
         assert!(policy.allowed_domains.contains("docs.example.com"));
         assert!(policy.blocked_domains.contains("internal.example"));
         assert_eq!(policy.timeout_seconds, 9);
@@ -1143,6 +1148,7 @@ mod tests {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: true,
                 allow_private_hosts: true,
+                enforce_allowed_domains: true,
                 allowed_domains: BTreeSet::from([
                     "docs.example.com".to_owned(),
                     "api.example.com".to_owned(),
@@ -1180,6 +1186,7 @@ mod tests {
             effective.web_fetch.allowed_domains,
             BTreeSet::from(["docs.example.com".to_owned()])
         );
+        assert!(effective.web_fetch.enforce_allowed_domains);
         assert_eq!(
             effective.web_fetch.blocked_domains,
             BTreeSet::from([
@@ -1198,6 +1205,7 @@ mod tests {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: true,
                 allow_private_hosts: false,
+                enforce_allowed_domains: false,
                 allowed_domains: BTreeSet::new(),
                 blocked_domains: BTreeSet::new(),
                 timeout_seconds: 15,
@@ -1223,6 +1231,39 @@ mod tests {
         assert_eq!(
             effective.web_fetch.allowed_domains,
             BTreeSet::from(["docs.example.com".to_owned()])
+        );
+        assert!(effective.web_fetch.enforce_allowed_domains);
+    }
+
+    #[test]
+    fn tool_runtime_config_narrowed_fail_closes_disjoint_allowlists() {
+        let base = ToolRuntimeConfig {
+            web_fetch: WebFetchRuntimePolicy {
+                enabled: true,
+                allow_private_hosts: false,
+                enforce_allowed_domains: true,
+                allowed_domains: BTreeSet::from(["api.example.com".to_owned()]),
+                blocked_domains: BTreeSet::new(),
+                timeout_seconds: 15,
+                max_bytes: 8_192,
+                max_redirects: 4,
+            },
+            ..ToolRuntimeConfig::default()
+        };
+        let narrowing = ToolRuntimeNarrowing {
+            web_fetch: WebFetchRuntimeNarrowing {
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                ..WebFetchRuntimeNarrowing::default()
+            },
+            ..ToolRuntimeNarrowing::default()
+        };
+
+        let effective = base.narrowed(&narrowing);
+
+        assert!(effective.web_fetch.enforce_allowed_domains);
+        assert!(
+            effective.web_fetch.allowed_domains.is_empty(),
+            "disjoint allowlists should preserve an enforced empty intersection"
         );
     }
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -3,10 +3,72 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use serde::{Deserialize, Serialize};
+
 use super::shell_policy_ext::ShellPolicyDefault;
 use crate::config::LoongClawConfig;
 #[cfg(feature = "feishu-integration")]
 use crate::config::{FeishuChannelConfig, FeishuIntegrationConfig};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct BrowserRuntimeNarrowing {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_sessions: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_links: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_text_chars: Option<usize>,
+}
+
+impl BrowserRuntimeNarrowing {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.max_sessions.is_none() && self.max_links.is_none() && self.max_text_chars.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebFetchRuntimeNarrowing {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_private_hosts: Option<bool>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub allowed_domains: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub blocked_domains: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_redirects: Option<usize>,
+}
+
+impl WebFetchRuntimeNarrowing {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.allow_private_hosts.is_none()
+            && self.allowed_domains.is_empty()
+            && self.blocked_domains.is_empty()
+            && self.timeout_seconds.is_none()
+            && self.max_bytes.is_none()
+            && self.max_redirects.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ToolRuntimeNarrowing {
+    #[serde(default)]
+    pub browser: BrowserRuntimeNarrowing,
+    #[serde(default)]
+    pub web_fetch: WebFetchRuntimeNarrowing,
+}
+
+impl ToolRuntimeNarrowing {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.browser.is_empty() && self.web_fetch.is_empty()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalSkillsRuntimePolicy {
@@ -350,6 +412,64 @@ impl ToolRuntimeConfig {
             self.feishu = FeishuToolRuntimeConfig::from_env();
         }
         self
+    }
+
+    #[must_use]
+    pub fn narrowed(&self, narrowing: &ToolRuntimeNarrowing) -> Self {
+        if narrowing.is_empty() {
+            return self.clone();
+        }
+
+        let mut narrowed = self.clone();
+
+        if let Some(max_sessions) = narrowing.browser.max_sessions {
+            narrowed.browser.max_sessions = narrowed.browser.max_sessions.min(max_sessions.max(1));
+        }
+        if let Some(max_links) = narrowing.browser.max_links {
+            narrowed.browser.max_links = narrowed.browser.max_links.min(max_links.max(1));
+        }
+        if let Some(max_text_chars) = narrowing.browser.max_text_chars {
+            narrowed.browser.max_text_chars =
+                narrowed.browser.max_text_chars.min(max_text_chars.max(1));
+        }
+
+        narrowed.web_fetch.allow_private_hosts = match narrowing.web_fetch.allow_private_hosts {
+            Some(false) => false,
+            Some(true) => narrowed.web_fetch.allow_private_hosts,
+            None => narrowed.web_fetch.allow_private_hosts,
+        };
+
+        if !narrowing.web_fetch.allowed_domains.is_empty() {
+            narrowed.web_fetch.allowed_domains = if narrowed.web_fetch.allowed_domains.is_empty() {
+                narrowing.web_fetch.allowed_domains.clone()
+            } else {
+                narrowed
+                    .web_fetch
+                    .allowed_domains
+                    .intersection(&narrowing.web_fetch.allowed_domains)
+                    .cloned()
+                    .collect()
+            };
+        }
+        narrowed
+            .web_fetch
+            .blocked_domains
+            .extend(narrowing.web_fetch.blocked_domains.iter().cloned());
+
+        if let Some(timeout_seconds) = narrowing.web_fetch.timeout_seconds {
+            narrowed.web_fetch.timeout_seconds = narrowed
+                .web_fetch
+                .timeout_seconds
+                .min(timeout_seconds.max(1));
+        }
+        if let Some(max_bytes) = narrowing.web_fetch.max_bytes {
+            narrowed.web_fetch.max_bytes = narrowed.web_fetch.max_bytes.min(max_bytes.max(1));
+        }
+        if let Some(max_redirects) = narrowing.web_fetch.max_redirects {
+            narrowed.web_fetch.max_redirects = narrowed.web_fetch.max_redirects.min(max_redirects);
+        }
+
+        narrowed
     }
 }
 
@@ -1009,6 +1129,101 @@ mod tests {
         assert_eq!(policy.timeout_seconds, 9);
         assert_eq!(policy.max_bytes, 262_144);
         assert_eq!(policy.max_redirects, 1);
+    }
+
+    #[test]
+    fn tool_runtime_config_narrowed_intersects_web_domains_and_clamps_browser_limits() {
+        let base = ToolRuntimeConfig {
+            browser: BrowserRuntimePolicy {
+                enabled: true,
+                max_sessions: 4,
+                max_links: 12,
+                max_text_chars: 2_048,
+            },
+            web_fetch: WebFetchRuntimePolicy {
+                enabled: true,
+                allow_private_hosts: true,
+                allowed_domains: BTreeSet::from([
+                    "docs.example.com".to_owned(),
+                    "api.example.com".to_owned(),
+                ]),
+                blocked_domains: BTreeSet::from(["blocked.example.com".to_owned()]),
+                timeout_seconds: 15,
+                max_bytes: 8_192,
+                max_redirects: 4,
+            },
+            ..ToolRuntimeConfig::default()
+        };
+        let narrowing = ToolRuntimeNarrowing {
+            browser: BrowserRuntimeNarrowing {
+                max_sessions: Some(1),
+                max_links: Some(6),
+                max_text_chars: Some(512),
+            },
+            web_fetch: WebFetchRuntimeNarrowing {
+                allow_private_hosts: Some(false),
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["deny.example.com".to_owned()]),
+                timeout_seconds: Some(5),
+                max_bytes: Some(4_096),
+                max_redirects: Some(2),
+            },
+        };
+
+        let effective = base.narrowed(&narrowing);
+
+        assert_eq!(effective.browser.max_sessions, 1);
+        assert_eq!(effective.browser.max_links, 6);
+        assert_eq!(effective.browser.max_text_chars, 512);
+        assert!(!effective.web_fetch.allow_private_hosts);
+        assert_eq!(
+            effective.web_fetch.allowed_domains,
+            BTreeSet::from(["docs.example.com".to_owned()])
+        );
+        assert_eq!(
+            effective.web_fetch.blocked_domains,
+            BTreeSet::from([
+                "blocked.example.com".to_owned(),
+                "deny.example.com".to_owned(),
+            ])
+        );
+        assert_eq!(effective.web_fetch.timeout_seconds, 5);
+        assert_eq!(effective.web_fetch.max_bytes, 4_096);
+        assert_eq!(effective.web_fetch.max_redirects, 2);
+    }
+
+    #[test]
+    fn tool_runtime_config_narrowed_uses_child_allowlist_when_parent_has_none() {
+        let base = ToolRuntimeConfig {
+            web_fetch: WebFetchRuntimePolicy {
+                enabled: true,
+                allow_private_hosts: false,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+                timeout_seconds: 15,
+                max_bytes: 8_192,
+                max_redirects: 4,
+            },
+            ..ToolRuntimeConfig::default()
+        };
+        let narrowing = ToolRuntimeNarrowing {
+            web_fetch: WebFetchRuntimeNarrowing {
+                allow_private_hosts: None,
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                blocked_domains: BTreeSet::new(),
+                timeout_seconds: None,
+                max_bytes: None,
+                max_redirects: None,
+            },
+            ..ToolRuntimeNarrowing::default()
+        };
+
+        let effective = base.narrowed(&narrowing);
+
+        assert_eq!(
+            effective.web_fetch.allowed_domains,
+            BTreeSet::from(["docs.example.com".to_owned()])
+        );
     }
 
     #[cfg(feature = "feishu-integration")]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -4556,7 +4556,16 @@ mod tests {
                     "timeout_seconds": 60,
                     "allow_shell_in_child": false,
                     "child_tool_allowlist": ["file.read", "file.write"],
-                    "kernel_bound": false
+                    "kernel_bound": false,
+                    "runtime_narrowing": {
+                        "web_fetch": {
+                            "allowed_domains": ["docs.example.com"],
+                            "allow_private_hosts": false
+                        },
+                        "browser": {
+                            "max_sessions": 1
+                        }
+                    }
                 }
             }),
         })
@@ -4618,6 +4627,18 @@ mod tests {
         assert_eq!(
             outcome.payload["delegate_lifecycle"]["execution"]["kernel_bound"],
             false
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["runtime_narrowing"]["web_fetch"]["allowed_domains"],
+            json!(["docs.example.com"])
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["runtime_narrowing"]["web_fetch"]["allow_private_hosts"],
+            false
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["runtime_narrowing"]["browser"]["max_sessions"],
+            1
         );
     }
 

--- a/crates/app/src/tools/web_fetch.rs
+++ b/crates/app/src/tools/web_fetch.rs
@@ -368,7 +368,7 @@ pub(crate) fn validate_web_target(
             "{surface_name} blocked host `{host}` because it matches blocked domain rule `{rule}`"
         ));
     }
-    if !policy.allowed_domains.is_empty()
+    if policy.enforce_allowed_domains
         && first_matching_domain_rule(&host, &policy.allowed_domains).is_none()
     {
         return Err(format!(
@@ -925,6 +925,20 @@ mod tests {
             validate_web_target(&url, &policy, "web.fetch").expect("localhost should be allowed");
 
         assert_eq!(host, "localhost");
+    }
+
+    #[test]
+    fn validate_web_target_denies_when_allowlist_is_enforced_but_empty() {
+        let policy = super::super::runtime_config::WebFetchRuntimePolicy {
+            enforce_allowed_domains: true,
+            ..super::super::runtime_config::WebFetchRuntimePolicy::default()
+        };
+        let url = reqwest::Url::parse("https://example.com").expect("url");
+
+        let error =
+            validate_web_target(&url, &policy, "web.fetch").expect_err("empty enforced allowlist");
+
+        assert!(error.contains("not in allowed_domains"), "error={error}");
     }
 
     #[test]

--- a/crates/app/src/tools/web_fetch.rs
+++ b/crates/app/src/tools/web_fetch.rs
@@ -765,6 +765,7 @@ mod tests {
     #[test]
     fn web_fetch_enforces_allow_and_block_domain_rules() {
         let mut allowlist_config = super::super::runtime_config::ToolRuntimeConfig::default();
+        allowlist_config.web_fetch.enforce_allowed_domains = true;
         allowlist_config
             .web_fetch
             .allowed_domains

--- a/docs/plans/2026-03-18-delegate-runtime-envelope-v2-design.md
+++ b/docs/plans/2026-03-18-delegate-runtime-envelope-v2-design.md
@@ -1,0 +1,238 @@
+# Delegate Runtime Envelope V2 Design
+
+**Problem**
+
+`feat/constrained-subagent-v1` made delegate children explicit enough to be inspectable:
+
+- child sessions now persist a typed constrained-subagent execution envelope
+- depth and active-child limits are enforced at spawn time
+- session inspection can explain the launch contract after the fact
+
+But the execution envelope still stops at the session boundary.
+
+Today a child session can have a narrower visible tool surface while still executing core tools with
+the process-global runtime policy because kernel-bound tool execution ultimately routes through:
+
+- `TurnEngine::execute_tool_intent_via_kernel(...)`
+- `KernelContext`
+- `MvpToolAdapter::new()`
+- `execute_tool_core(...)`
+- `get_tool_runtime_config()`
+
+That means LoongClaw can currently create a child that *looks* constrained in:
+
+- `tool_view`
+- provider-visible tool definitions
+- `session_status`
+
+while still letting `web.fetch` / `browser.*` run with the parent process runtime posture.
+
+This is the next real architectural gap after the first constrained-subagent slice.
+
+**Goal**
+
+Add a second bounded slice that makes delegate child runtime posture real for kernel-bound core tool
+execution without introducing a separate subagent runtime or kernel control plane.
+
+The target for this slice is:
+
+1. Define a typed child runtime-narrowing contract for delegate executions.
+2. Persist that contract inside the existing constrained-subagent execution envelope.
+3. Carry the contract into trusted internal tool context during child-session tool execution.
+4. Narrow actual core-tool runtime config at execution time for child sessions.
+5. Cover the first meaningful policy surfaces:
+   - `web.fetch` domain/private-host posture and transport limits
+   - `browser.*` session/text/link limits
+
+**Non-Goals**
+
+- Do not add a new global subagent scheduler, queue, or registry.
+- Do not redesign ACP routing or introduce a subagent-specific kernel pack model.
+- Do not solve context-budget shaping in this slice.
+- Do not widen the child runtime contract to every tool class at once.
+- Do not bypass kernel execution for child tools.
+
+**Root Cause**
+
+The first constrained-subagent slice made child launches explicit, but the effective runtime policy
+for core tools is still resolved at the wrong layer.
+
+The root problem is not missing allowlist fields. The root problem is that the actual kernel-bound
+tool execution path has no session-scoped runtime-policy carrier. The system currently narrows:
+
+- what a child can *see*
+- what a child session reports about itself
+
+but it does not narrow:
+
+- what runtime config `execute_tool_core_with_config(...)` sees once a kernel-bound child tool call
+  actually executes
+
+So the missing contract is not “more delegate knobs”. The missing contract is “how a child
+session’s runtime posture survives the trip into trusted core-tool execution”.
+
+**External Reference**
+
+OpenClaw and Codex both treat subagents as more than prompt forks:
+
+- OpenClaw emphasizes bounded depth, explicit lifecycle, and child-session governance.
+- Codex emphasizes isolated execution environments and async child-session continuity.
+
+LoongClaw is not ready for their full orchestration surface yet, but it does need one key property
+they both rely on: child execution constraints must remain true at actual execution time, not only
+at planning time.
+
+That makes runtime-envelope propagation the right next slice.
+
+**Approaches Considered**
+
+1. Only widen `ToolView` / `child_tool_allowlist`.
+   Rejected because it preserves the current false boundary: visibility would narrow, but
+   `execute_tool_core(...)` would still run under the global runtime config.
+
+2. Create a child-specific `KernelContext` with its own tool adapter and policy extensions.
+   Rejected for this slice because it would force a broader redesign of kernel bootstrap,
+   audit/plumbing continuity, and per-child adapter registration. It solves the problem, but at the
+   wrong cost right now.
+
+3. Store child runtime narrowing in trusted internal tool context and derive an effective runtime
+   config inside core-tool execution.
+   Recommended because it:
+   - keeps kernel execution intact
+   - avoids mutable global runtime state
+   - reuses the existing reserved `_loongclaw` trusted payload seam
+   - lets one typed contract drive persistence, inspection, and actual execution
+
+**Chosen Design**
+
+Add a typed runtime-narrowing contract under the existing constrained-subagent execution envelope.
+
+The contract will include:
+
+- `web_fetch`
+  - `allow_private_hosts: Option<bool>`
+  - `allowed_domains`
+  - `blocked_domains`
+  - `timeout_seconds: Option<u64>`
+  - `max_bytes: Option<usize>`
+  - `max_redirects: Option<usize>`
+- `browser`
+  - `max_sessions: Option<usize>`
+  - `max_links: Option<usize>`
+  - `max_text_chars: Option<usize>`
+
+The contract is a *narrowing* shape, not a second full runtime config.
+
+Semantics:
+
+- booleans can only stay the same or become more restrictive
+- numeric limits clamp downward
+- blocked-domain sets union with parent policy
+- allow-domain sets intersect with parent allowlists when both are present
+- an empty child allow-domain list means “no additional allowlist narrowing”
+
+This keeps the slice monotonic: child posture can only stay within or below the parent runtime
+policy.
+
+**Configuration Shape**
+
+Add a nested delegate child runtime policy section under `tools.delegate`:
+
+- `tools.delegate.child_runtime.web`
+- `tools.delegate.child_runtime.browser`
+
+This keeps runtime narrowing local to delegate execution instead of leaking a subagent-specific
+schema across unrelated tool config.
+
+Examples of intended use:
+
+- limit child browser concurrency to one session even if root allows more
+- allow child web access only to a documentation domain
+- force child web requests to stay off private hosts even when the root runtime allows them
+
+**Execution Path**
+
+For a child session:
+
+1. `execute_delegate_tool(...)` or `execute_delegate_async_tool(...)` builds the persisted
+   `ConstrainedSubagentExecution`, including `runtime_narrowing`.
+2. `ConversationRuntime::session_context(...)` resolves the child’s persisted execution envelope and
+   exposes the narrowing contract on `SessionContext`.
+3. `TurnEngine` injects trusted internal tool context for child core-tool calls.
+4. `execute_tool_core_with_config(...)` reads the trusted internal runtime narrowing and derives an
+   effective `ToolRuntimeConfig`.
+5. `web.fetch`, `browser.*`, and tool-search runtime filtering execute against the narrowed config.
+
+This keeps one execution contract flowing through:
+
+- persisted lifecycle events
+- in-memory session context
+- trusted core-tool payload context
+- actual executor runtime config
+
+**Why Trusted Internal Tool Context**
+
+LoongClaw already reserves `_loongclaw` for trusted internal payload context and rejects untrusted
+callers that try to forge it.
+
+Using that seam is the smallest durable option because:
+
+- it is already the right place for execution-only metadata
+- it avoids broadening public tool schemas
+- it composes with `tool.invoke`
+- it keeps session-specific runtime posture off global singleton state
+
+**Session Inspection Changes**
+
+`session_status` already surfaces the constrained-subagent envelope. This slice extends that
+envelope with `runtime_narrowing` so the inspection view answers:
+
+- which web/browser runtime posture governed the child
+- whether the child was stricter than the root runtime
+- whether the child was prevented from private-host access or broad domain access
+
+Inspection must continue to read the persisted snapshot rather than recomputing from current config.
+
+**Why This Is Smaller Than A Child Kernel Context**
+
+The tempting alternative is a per-child kernel instance or per-child adapter selection. That would
+be architecturally larger because it would force LoongClaw to answer, in one slice:
+
+- how audit sink continuity works across child kernels
+- how policy extensions are cloned or re-bound
+- how async child execution transports kernel state
+- how nested children compose multiple kernel instances
+
+LoongClaw does not need those answers yet to make child runtime posture real. It only needs a
+session-scoped execution contract that survives to actual core-tool execution.
+
+**Testing Strategy**
+
+Add failing tests first for:
+
+- child `session_status` exposing persisted runtime narrowing
+- child kernel-bound `web.fetch` being denied by narrowed domain/private-host policy even when the
+  base runtime is broader
+- child kernel-bound `browser.open` / `browser.extract` obeying narrowed browser limits
+- untrusted payloads being unable to forge runtime narrowing
+- runtime narrowing never widening parent policy
+
+Then run adjacent delegate/session/tool regressions and full repository verification.
+
+**Risk Assessment**
+
+The main risk is semantic drift between:
+
+- persisted runtime narrowing
+- injected trusted payload context
+- effective runtime config merging logic
+
+That risk is controlled by:
+
+- using one typed narrowing contract
+- keeping the merge logic centralized in `ToolRuntimeConfig`
+- testing both persisted inspection and actual tool execution
+
+The other risk is overfitting the contract to one tool. This design avoids that by targeting the
+shared runtime-policy layer (`ToolRuntimeConfig`) instead of adding one-off checks inside delegate
+or provider code.

--- a/docs/plans/2026-03-18-delegate-runtime-envelope-v2-implementation-plan.md
+++ b/docs/plans/2026-03-18-delegate-runtime-envelope-v2-implementation-plan.md
@@ -1,0 +1,146 @@
+# Delegate Runtime Envelope V2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make delegate child runtime posture real by persisting a typed child runtime-narrowing contract and applying it to actual kernel-bound core-tool execution for `web.fetch` and `browser.*`.
+
+**Architecture:** Reuse the existing constrained-subagent execution envelope. Add typed runtime-narrowing config under `tools.delegate.child_runtime`, attach it to `SessionContext`, inject it through trusted `_loongclaw` payload context, and derive an effective `ToolRuntimeConfig` inside `execute_tool_core_with_config(...)`.
+
+**Tech Stack:** Rust, serde/serde_json, `ToolRuntimeConfig`, conversation runtime/session context, delegate lifecycle persistence, kernel-bound turn execution, existing delegate/session/tool tests.
+
+---
+
+### Task 1: Add red tests for runtime-narrowed child execution
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Add a failing session inspection test**
+
+Add a test proving `session_status` exposes persisted child `runtime_narrowing` under the
+constrained delegate lifecycle metadata.
+
+**Step 2: Add a failing child web policy test**
+
+Add a kernel-bound delegate test where the base runtime allows a broader web surface, but the child
+runtime narrowing allows only a stricter host set or denies private hosts. Verify the child tool
+execution fails with the narrowed policy.
+
+**Step 3: Add a failing child browser limit test**
+
+Add a test proving a child session uses narrowed browser limits, for example a one-session cap or a
+lower link/text ceiling than the parent runtime.
+
+**Step 4: Add a failing trusted-payload forgery test**
+
+Add a test proving untrusted callers cannot inject `_loongclaw.runtime_narrowing` into core-tool
+payloads to self-escalate or spoof child posture.
+
+**Step 5: Run one focused red test**
+
+Run a focused delegate-runtime test and confirm it fails for the expected reason before any
+production changes.
+
+### Task 2: Implement the typed runtime-narrowing contract
+
+**Files:**
+- Modify: `crates/app/src/config/tools.rs`
+- Modify: `crates/app/src/tools/runtime_config.rs`
+- Modify: `crates/app/src/conversation/subagent.rs`
+
+**Step 1: Add delegate child runtime config types**
+
+Add nested config types under `tools.delegate.child_runtime` for:
+
+- `web`
+- `browser`
+
+Use optional numeric/boolean fields where inheritance must remain distinguishable from explicit
+narrowing.
+
+**Step 2: Add runtime-narrowing runtime types**
+
+Add typed narrowing structs to `tools/runtime_config.rs` and implement the parent-to-child merge
+logic there.
+
+The merge must be monotonic:
+
+- numeric values clamp downward
+- blocked domains union
+- allow domains intersect when both sides restrict
+- private-host access can only stay allowed when both parent and child allow it
+
+**Step 3: Extend the constrained subagent execution envelope**
+
+Persist the runtime-narrowing snapshot on `ConstrainedSubagentExecution`.
+
+### Task 3: Carry child runtime narrowing into actual core-tool execution
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Extend `SessionContext`**
+
+Add optional child runtime narrowing to `SessionContext` and load it from the child session’s
+persisted delegate lifecycle event.
+
+**Step 2: Inject trusted internal runtime context**
+
+Update the tool-payload augmentation path so child core-tool calls inject trusted internal
+runtime-narrowing context alongside existing internal execution metadata.
+
+**Step 3: Apply the effective runtime config**
+
+Update `execute_tool_core_with_config(...)` to derive an effective runtime config from:
+
+- the base runtime config
+- trusted internal child runtime narrowing, when present
+
+Keep untrusted `_loongclaw` rejection behavior intact.
+
+### Task 4: Reuse the persisted contract in inspection and docs
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `docs/plans/2026-03-18-delegate-runtime-envelope-v2-design.md`
+- Modify: `docs/plans/2026-03-18-delegate-runtime-envelope-v2-implementation-plan.md`
+
+**Step 1: Surface `runtime_narrowing` in session inspection**
+
+Update `session_status` / delegate lifecycle extraction to expose the persisted narrowing snapshot.
+
+**Step 2: Keep design/plan docs aligned**
+
+Adjust the design or plan if testing reveals a smaller safe seam than the initial draft.
+
+### Task 5: Verify and ship
+
+**Files:**
+- Modify: GitHub issue / PR artifacts after code lands
+
+**Step 1: Run focused tests**
+
+Run the new delegate-runtime and inspection tests exactly.
+
+**Step 2: Run adjacent regressions**
+
+Run delegate, session-status, browser, and web-fetch regression coverage that exercises the touched
+paths.
+
+**Step 3: Run repository verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+**Step 4: Prepare GitHub delivery**
+
+Open or reuse a follow-up issue for delegate runtime-envelope v2, assign the operator, and open a
+stacked PR that references `#275` and links the new issue explicitly.


### PR DESCRIPTION
## Summary

- Problem:
  Delegate child sessions could expose a narrower tool surface while still executing kernel-bound core tools with the broader parent runtime policy.
- Why it matters:
  That mismatch weakens the constrained-subagent contract and leaves child `web.fetch` / `browser.*` execution broader than the child session boundary suggests.
- What changed:
  - added typed `tools.delegate.child_runtime` config for web and browser narrowing
  - persisted `runtime_narrowing` inside constrained subagent execution envelopes
  - loaded child runtime narrowing into `SessionContext`
  - injected narrowing through trusted `_loongclaw.runtime_narrowing` only for child-session execution
  - applied narrowing at the tool-core runtime merge point before dispatch
  - added regression coverage for config parsing, narrowing semantics, trusted payload enforcement, kernel payload injection, session status visibility, and noisy-history retention
  - fixed a lifecycle lookup bug by reading delegate lifecycle events instead of a small generic recent-event window, so child runtime narrowing remains durable after later child-session events
- What did not change (scope boundary):
  - no second kernel control plane or child-specific kernel instance
  - no ACP scheduler or registry redesign
  - no context-budget shaping in this slice
  - no widening of child capabilities beyond runtime narrowing

## Linked Issues

- Closes #280
- Related #275 (stacked base branch)
- Related #222

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  - child delegate execution now uses narrower effective runtime limits at actual tool execution time
  - merge semantics for allowlists, blocklists, private-host posture, and numeric clamps must remain monotonic and non-broadening
  - lifecycle lookup now depends on delegate anchor events rather than a recent generic event window
- Rollout / guardrails:
  - the path is a no-op when `tools.delegate.child_runtime` is unset
  - narrowing is applied only from trusted internal context during child-session execution
  - regression tests cover forged payload rejection and noisy child-session history retention
- Rollback path:
  - revert this PR, or temporarily stop attaching/applying child `runtime_narrowing` while keeping the envelope field optional for compatibility

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
diff CLAUDE.md AGENTS.md
scripts/check-docs.sh
cargo deny check advisories bans licenses sources

Focused regression coverage:
- cargo test -p loongclaw-app --all-features runtime_narrowing -- --nocapture
- cargo test -p loongclaw-app --all-features session_status_includes_delegate_lifecycle_for_queued_child -- --nocapture

Result summary:
- fmt, clippy, workspace tests, and all-features workspace tests passed
- architecture boundary, dependency graph, harness mirror, docs, and cargo-deny checks passed
- docs validation reported the repository's existing non-blocking release-artifact warnings only
- the convention check from the Taskfile could not run here because its external convention-engineering helper is not installed in this environment
```

## User-visible / Operator-visible Changes

- Delegate child sessions can now enforce narrower effective `web.fetch` and `browser.*` runtime limits than the parent runtime defaults.
- Session inspection and actual child execution posture now stay aligned, including after later child-session history becomes noisy.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR, or remove `tools.delegate.child_runtime` configuration to return to the previous no-op behavior.
- Observable failure symptoms reviewers should watch for:
  child `web.fetch` calls denied by the effective child allow/block policy, child browser calls hitting lower session/link/text ceilings, or missing `runtime_narrowing` in delegate lifecycle inspection.

## Reviewer Focus

- `crates/app/src/tools/runtime_config.rs`: confirm narrowing semantics are strictly non-broadening.
- `crates/app/src/conversation/runtime.rs`: confirm delegate lifecycle lookup keeps child runtime narrowing durable across noisy histories.
- `crates/app/src/tools/mod.rs` and `crates/app/src/conversation/turn_engine.rs`: confirm only trusted internal context can carry runtime narrowing into tool execution.