### PR TITLE
feat: retire implicit noop audit constructor default

### DIFF
--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -29,7 +29,8 @@ async fn mvp_memory_adapter_routes_through_kernel() {
         ExecutionRoute, HarnessKind, LoongClawKernel, StaticPolicyEngine, VerticalPackManifest,
     };
 
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
 
     kernel.register_core_memory_adapter(MvpMemoryAdapter::new());
     kernel

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -8,7 +8,10 @@ use std::{
 };
 
 use crate::{
-    audit::{AuditEvent, AuditEventKind, AuditSink, ExecutionPlane, NoopAuditSink, PlaneTier},
+    audit::{
+        AuditEvent, AuditEventKind, AuditSink, ExecutionPlane, InMemoryAuditSink, NoopAuditSink,
+        PlaneTier,
+    },
     clock::{Clock, SystemClock},
     connector::{ConnectorExtensionAdapter, ConnectorPlane, CoreConnectorAdapter},
     contracts::{
@@ -84,8 +87,29 @@ pub struct Kernel<P: PolicyEngine> {
 }
 
 impl<P: PolicyEngine> LoongClawKernel<P> {
+    /// Safe convenience constructor for callers that do not need to customize
+    /// runtime components. This defaults to in-memory audit rather than silent
+    /// audit dropping.
     #[must_use]
     pub fn new(policy: P) -> Self {
+        Self::new_with_in_memory_audit(policy).0
+    }
+
+    /// Construct a kernel with the default system clock and an inspectable
+    /// in-memory audit sink.
+    #[must_use]
+    pub fn new_with_in_memory_audit(policy: P) -> (Self, Arc<InMemoryAuditSink>) {
+        let audit = Arc::new(InMemoryAuditSink::default());
+        let kernel = Self::with_runtime(policy, Arc::new(SystemClock), audit.clone());
+        (kernel, audit)
+    }
+
+    /// Construct a kernel that intentionally discards audit events.
+    ///
+    /// This is reserved for narrow fixture paths where callers explicitly do
+    /// not need audit assertions or evidence retention.
+    #[must_use]
+    pub fn new_without_audit(policy: P) -> Self {
         Self::with_runtime(policy, Arc::new(SystemClock), Arc::new(NoopAuditSink))
     }
 

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -105,6 +105,37 @@ fn fanout_audit_sink_records_to_all_children() {
 }
 
 #[test]
+fn explicit_in_memory_kernel_constructor_records_token_audit_events() {
+    let (mut kernel, audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
+    kernel
+        .register_pack(sample_pack())
+        .expect("pack should register");
+
+    kernel
+        .issue_token("sales-intel", "agent-in-memory", 120)
+        .expect("token should issue");
+
+    let events = audit.snapshot();
+    assert_eq!(events.len(), 1, "expected one token-issued audit event");
+    assert!(matches!(events[0].kind, AuditEventKind::TokenIssued { .. }));
+}
+
+#[test]
+fn explicit_no_audit_kernel_constructor_keeps_side_effect_free_fixture_path() {
+    let mut kernel = LoongClawKernel::new_without_audit(StaticPolicyEngine::default());
+    kernel
+        .register_pack(sample_pack())
+        .expect("pack should register");
+
+    let token = kernel
+        .issue_token("sales-intel", "agent-no-audit", 120)
+        .expect("token should issue without wiring an audit sink");
+
+    assert_eq!(token.agent_id, "agent-no-audit");
+}
+
+#[test]
 fn jsonl_audit_sink_surfaces_io_errors() {
     let path = fresh_audit_temp_path("jsonl-dir");
     fs::create_dir(&path).expect("directory fixture should create");
@@ -191,7 +222,8 @@ proptest! {
         let pack_capabilities = capability_set_from_mask(pack_mask);
         let required_capabilities = capability_set_from_mask(required_mask);
 
-        let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+        let (mut kernel, _audit) =
+            LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
         let mut pack = sample_pack();
         pack.granted_capabilities = pack_capabilities.clone();
         kernel

--- a/crates/kernel/tests/kernel_integration.rs
+++ b/crates/kernel/tests/kernel_integration.rs
@@ -7,7 +7,8 @@ use serde_json::json;
 
 #[tokio::test]
 async fn integration_kernel_executes_task() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel.register_pack(sample_pack()).unwrap();
     kernel.register_harness_adapter(MockEmbeddedPiHarness {
         seen_tasks: Mutex::new(Vec::new()),
@@ -30,7 +31,8 @@ async fn integration_kernel_executes_task() {
 
 #[tokio::test]
 async fn kernel_executes_task_and_connector_under_pack_policy() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -76,7 +78,8 @@ async fn kernel_executes_task_and_connector_under_pack_policy() {
 
 #[tokio::test]
 async fn kernel_rejects_token_missing_capability() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -109,7 +112,8 @@ async fn kernel_rejects_token_missing_capability() {
 
 #[tokio::test]
 async fn kernel_rejects_connector_not_whitelisted_by_pack() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -142,7 +146,8 @@ async fn kernel_rejects_connector_not_whitelisted_by_pack() {
 
 #[tokio::test]
 async fn layered_connector_core_executes_through_core_plane() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -171,7 +176,8 @@ async fn layered_connector_core_executes_through_core_plane() {
 
 #[tokio::test]
 async fn layered_connector_extension_composes_over_core_plane() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -202,7 +208,8 @@ async fn layered_connector_extension_composes_over_core_plane() {
 
 #[tokio::test]
 async fn layered_connector_plane_still_enforces_pack_whitelist() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -235,7 +242,8 @@ async fn layered_connector_plane_still_enforces_pack_whitelist() {
 
 #[tokio::test]
 async fn layered_connector_extension_requires_available_core_adapter() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -265,7 +273,8 @@ async fn layered_connector_extension_requires_available_core_adapter() {
 
 #[tokio::test]
 async fn layered_connector_default_core_adapter_can_be_overridden() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -296,7 +305,8 @@ async fn layered_connector_default_core_adapter_can_be_overridden() {
 
 #[test]
 fn layered_connector_rejects_unknown_default_adapter_override() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel.register_core_connector_adapter(MockCoreConnector);
 
     let error = kernel
@@ -311,7 +321,8 @@ fn layered_connector_rejects_unknown_default_adapter_override() {
 
 #[tokio::test]
 async fn kernel_auto_routes_by_harness_kind_when_adapter_is_not_pinned() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(acp_pack_without_explicit_adapter())
         .expect("pack should register");
@@ -342,7 +353,8 @@ async fn kernel_auto_routes_by_harness_kind_when_adapter_is_not_pinned() {
 
 #[tokio::test]
 async fn revoked_token_is_denied_by_policy_engine() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(sample_pack())
         .expect("pack should register");
@@ -569,7 +581,8 @@ fn record_audit_event_supports_provider_failover_summary() {
 
 #[tokio::test]
 async fn layered_runtime_tool_and_memory_paths_execute_via_core_and_extension() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(VerticalPackManifest {
             pack_id: "layered-dev".to_owned(),
@@ -827,7 +840,8 @@ async fn audit_sink_captures_runtime_tool_memory_and_connector_plane_events() {
 
 #[tokio::test]
 async fn policy_extension_chain_can_block_high_risk_capabilities() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel
         .register_pack(VerticalPackManifest {
             pack_id: "strict-env".to_owned(),
@@ -1209,7 +1223,8 @@ async fn task_supervisor_faults_on_kernel_error() {
 
 #[test]
 fn register_pack_creates_namespace() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel.register_pack(sample_pack()).unwrap();
 
     let ns = kernel.get_namespace("sales-intel");
@@ -1222,13 +1237,14 @@ fn register_pack_creates_namespace() {
 
 #[test]
 fn get_namespace_returns_none_for_unregistered_pack() {
-    let kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (kernel, _audit) = LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     assert!(kernel.get_namespace("nonexistent").is_none());
 }
 
 #[test]
 fn namespace_membrane_defaults_to_pack_id() {
-    let mut kernel = LoongClawKernel::new(StaticPolicyEngine::default());
+    let (mut kernel, _audit) =
+        LoongClawKernel::new_with_in_memory_audit(StaticPolicyEngine::default());
     kernel.register_pack(sample_pack()).unwrap();
 
     let ns = kernel.get_namespace("sales-intel").unwrap();
@@ -1237,7 +1253,8 @@ fn namespace_membrane_defaults_to_pack_id() {
 
 #[tokio::test]
 async fn kernel_is_usable_from_concurrent_tasks() {
-    let mut builder = KernelBuilder::new(StaticPolicyEngine::default());
+    let (mut builder, _audit) =
+        KernelBuilder::new_with_in_memory_audit(StaticPolicyEngine::default());
     builder
         .register_pack(sample_pack())
         .expect("pack should register");

--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -17,7 +17,7 @@ use crate::spec_runtime::{
 
 /// The spec/bootstrap layer is a harness-facing surface, so its default audit
 /// sink stays explicitly in-memory unless a caller wires a different sink.
-pub fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
+pub(crate) fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
     Arc::new(InMemoryAuditSink::default())
 }
 
@@ -106,31 +106,58 @@ fn configured_builder(
     audit: Option<Arc<dyn AuditSink>>,
     native_tool_executor: Option<crate::NativeToolExecutor>,
 ) -> RuntimeKernelBuilder<StaticPolicyEngine> {
-    let mut kernel = match (clock, audit) {
-        (Some(clock), Some(audit)) => {
-            RuntimeKernelBuilder::with_runtime(StaticPolicyEngine::default(), clock, audit)
+    configured_builder_with_default_audit(clock, audit, native_tool_executor).0
+}
+
+fn configured_builder_with_default_audit(
+    clock: Option<Arc<dyn Clock>>,
+    audit: Option<Arc<dyn AuditSink>>,
+    native_tool_executor: Option<crate::NativeToolExecutor>,
+) -> (
+    RuntimeKernelBuilder<StaticPolicyEngine>,
+    Option<Arc<InMemoryAuditSink>>,
+) {
+    let (mut kernel, fallback_audit) = match (clock, audit) {
+        (Some(clock), Some(audit)) => (
+            RuntimeKernelBuilder::with_runtime(StaticPolicyEngine::default(), clock, audit),
+            None,
+        ),
+        (Some(clock), None) => {
+            let audit = default_in_memory_audit_sink();
+            (
+                RuntimeKernelBuilder::with_runtime(
+                    StaticPolicyEngine::default(),
+                    clock,
+                    audit.clone() as Arc<dyn AuditSink>,
+                ),
+                Some(audit),
+            )
         }
-        (Some(clock), None) => RuntimeKernelBuilder::with_runtime(
-            StaticPolicyEngine::default(),
-            clock,
-            default_in_memory_audit_sink() as Arc<dyn AuditSink>,
+        (None, Some(audit)) => (
+            RuntimeKernelBuilder::with_runtime(
+                StaticPolicyEngine::default(),
+                Arc::new(SystemClock) as Arc<dyn Clock>,
+                audit,
+            ),
+            None,
         ),
-        (None, Some(audit)) => RuntimeKernelBuilder::with_runtime(
-            StaticPolicyEngine::default(),
-            Arc::new(SystemClock) as Arc<dyn Clock>,
-            audit,
-        ),
-        (None, None) => RuntimeKernelBuilder::with_runtime(
-            StaticPolicyEngine::default(),
-            Arc::new(SystemClock) as Arc<dyn Clock>,
-            default_in_memory_audit_sink() as Arc<dyn AuditSink>,
-        ),
+        (None, None) => {
+            let audit = default_in_memory_audit_sink();
+            (
+                RuntimeKernelBuilder::with_runtime(
+                    StaticPolicyEngine::default(),
+                    Arc::new(SystemClock) as Arc<dyn Clock>,
+                    audit.clone() as Arc<dyn AuditSink>,
+                ),
+                Some(audit),
+            )
+        }
     };
     register_builtin_adapters(&mut kernel, native_tool_executor);
     // The default pack manifest is hardcoded and always valid; ignore the
     // impossible error branch to avoid panicking in production.
     let _ = kernel.register_pack(default_pack_manifest());
-    kernel
+    (kernel, fallback_audit)
 }
 
 fn register_builtin_adapters(
@@ -217,19 +244,42 @@ mod tests {
     }
 
     #[test]
-    fn builder_explicit_in_memory_audit_records_events() {
-        let audit = default_in_memory_audit_sink();
-        let kernel = KernelBuilder::default()
-            .audit(audit.clone() as Arc<dyn AuditSink>)
-            .build();
+    fn builder_default_fallback_records_token_audit_events() {
+        let (kernel, audit) = configured_builder_with_default_audit(None, None, None);
+        let audit =
+            audit.expect("default builder should surface the fallback in-memory audit sink");
 
         kernel
             .issue_token(DEFAULT_PACK_ID, "spec-audit-builder", 60)
-            .expect("token issue should succeed with the named in-memory audit helper");
+            .expect("token issue should succeed with the default in-memory audit fallback");
 
         let events = audit.snapshot();
-        assert_eq!(events.len(), 1, "expected one token-issued audit event");
-        assert!(matches!(events[0].kind, AuditEventKind::TokenIssued { .. }));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.kind, AuditEventKind::TokenIssued { .. })),
+            "expected token issuance to be recorded by the fallback in-memory audit sink"
+        );
+    }
+
+    #[test]
+    fn builder_clock_only_fallback_records_token_audit_events() {
+        let clock = Arc::new(FixedClock::new(1_700_000_000));
+        let (kernel, audit) = configured_builder_with_default_audit(Some(clock), None, None);
+        let audit =
+            audit.expect("clock-only builder should surface the fallback in-memory audit sink");
+
+        kernel
+            .issue_token(DEFAULT_PACK_ID, "spec-audit-builder-clock-only", 60)
+            .expect("token issue should succeed with the clock-only in-memory audit fallback");
+
+        let events = audit.snapshot();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.kind, AuditEventKind::TokenIssued { .. })),
+            "expected token issuance to be recorded by the clock-only fallback in-memory audit sink"
+        );
     }
 
     #[test]

--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -15,10 +15,17 @@ use crate::spec_runtime::{
     WebhookConnector,
 };
 
+/// The spec/bootstrap layer is a harness-facing surface, so its default audit
+/// sink stays explicitly in-memory unless a caller wires a different sink.
+pub fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
+    Arc::new(InMemoryAuditSink::default())
+}
+
 /// Builder for constructing a fully configured `LoongClawKernel`.
 ///
-/// By default the builder uses `SystemClock` and `InMemoryAuditSink`.
-/// Override either with the corresponding setter before calling `build()`.
+/// By default the builder uses `SystemClock` and the spec layer's named
+/// in-memory audit helper. Override either with the corresponding setter before
+/// calling `build()`.
 #[derive(Default)]
 pub struct KernelBuilder {
     clock: Option<Arc<dyn Clock>>,
@@ -106,7 +113,7 @@ fn configured_builder(
         (Some(clock), None) => RuntimeKernelBuilder::with_runtime(
             StaticPolicyEngine::default(),
             clock,
-            Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+            default_in_memory_audit_sink() as Arc<dyn AuditSink>,
         ),
         (None, Some(audit)) => RuntimeKernelBuilder::with_runtime(
             StaticPolicyEngine::default(),
@@ -116,7 +123,7 @@ fn configured_builder(
         (None, None) => RuntimeKernelBuilder::with_runtime(
             StaticPolicyEngine::default(),
             Arc::new(SystemClock) as Arc<dyn Clock>,
-            Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+            default_in_memory_audit_sink() as Arc<dyn AuditSink>,
         ),
     };
     register_builtin_adapters(&mut kernel, native_tool_executor);
@@ -185,7 +192,7 @@ pub fn default_pack_manifest() -> VerticalPackManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kernel::{FixedClock, LoongClawKernel};
+    use kernel::{AuditEventKind, FixedClock, LoongClawKernel};
 
     #[test]
     fn builder_default_creates_kernel() {
@@ -207,6 +214,22 @@ mod tests {
             .issue_token(DEFAULT_PACK_ID, "test-agent", 60)
             .expect("token issue should succeed with custom clock/audit");
         assert!(!token.token_id.is_empty());
+    }
+
+    #[test]
+    fn builder_explicit_in_memory_audit_records_events() {
+        let audit = default_in_memory_audit_sink();
+        let kernel = KernelBuilder::default()
+            .audit(audit.clone() as Arc<dyn AuditSink>)
+            .build();
+
+        kernel
+            .issue_token(DEFAULT_PACK_ID, "spec-audit-builder", 60)
+            .expect("token issue should succeed with the named in-memory audit helper");
+
+        let events = audit.snapshot();
+        assert_eq!(events.len(), 1, "expected one token-issued audit event");
+        assert!(matches!(events[0].kind, AuditEventKind::TokenIssued { .. }));
     }
 
     #[test]

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -20,6 +20,7 @@ use kernel::{
 use serde_json::{Value, json};
 
 use crate::CliResult;
+use crate::kernel_bootstrap::default_in_memory_audit_sink;
 use crate::programmatic::execute_programmatic_tool_call;
 use crate::spec_runtime::*;
 
@@ -52,7 +53,7 @@ pub async fn execute_spec_with_native_tool_executor(
     native_tool_executor: Option<crate::NativeToolExecutor>,
 ) -> SpecRunReport {
     let mut pack = spec.pack.clone();
-    let audit_sink = Arc::new(InMemoryAuditSink::default());
+    let audit_sink = default_in_memory_audit_sink();
     let mut builder = crate::kernel_bootstrap::KernelBuilder::default()
         .clock(Arc::new(SystemClock) as Arc<dyn Clock>)
         .audit(audit_sink.clone());

--- a/crates/spec/tests/spec_execution.rs
+++ b/crates/spec/tests/spec_execution.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use kernel::Capability;
+use kernel::{AuditEventKind, Capability};
 use loongclaw_spec::test_support::make_runner_spec;
 use loongclaw_spec::{OperationSpec, execute_spec, spec_requires_native_tool_executor};
 use serde_json::json;
@@ -50,5 +50,49 @@ async fn execute_spec_blocks_native_tool_without_executor() {
             .as_deref()
             .expect("blocked reason should exist")
             .contains("native tool executor")
+    );
+}
+
+#[tokio::test]
+async fn execute_spec_returns_audit_snapshot_when_requested() {
+    let spec = make_runner_spec(OperationSpec::Task {
+        task_id: "spec-audit-task".to_owned(),
+        objective: "exercise spec audit snapshot capture".to_owned(),
+        required_capabilities: BTreeSet::new(),
+        payload: json!({"kind": "audit-contract-check"}),
+    });
+
+    let report = execute_spec(&spec, true).await;
+
+    let audit_events = report
+        .audit_events
+        .as_ref()
+        .expect("audit events should be present when explicitly requested");
+    assert!(
+        !audit_events.is_empty(),
+        "expected spec execution to retain at least one in-memory audit event"
+    );
+    assert!(
+        audit_events
+            .iter()
+            .any(|event| matches!(event.kind, AuditEventKind::TokenIssued { .. })),
+        "expected token issuance to be retained in the audit snapshot"
+    );
+}
+
+#[tokio::test]
+async fn execute_spec_suppresses_audit_snapshot_when_not_requested() {
+    let spec = make_runner_spec(OperationSpec::Task {
+        task_id: "spec-audit-task".to_owned(),
+        objective: "exercise spec audit snapshot suppression".to_owned(),
+        required_capabilities: BTreeSet::new(),
+        payload: json!({"kind": "audit-contract-check"}),
+    });
+
+    let report = execute_spec(&spec, false).await;
+
+    assert!(
+        report.audit_events.is_none(),
+        "audit snapshots should stay opt-in for spec execution reports"
     );
 }

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -31,7 +31,7 @@ optional `scripts/pre-commit` hook mirrors these cargo gates locally.
 ## Kernel Invariants
 
 1. **Token authorization is fail-closed** — if the policy engine cannot determine authorization (e.g., mutex poisoned), the operation is denied.
-2. **Audit events are never silently dropped** — production-shaped CLI chat, Telegram, and Feishu bootstraps default to `audit.mode = "fanout"`, which appends `~/.loongclaw/audit/events.jsonl` and can retain in-memory snapshots for local diagnostics. Test-only helpers may still use `InMemoryAuditSink`, and `NoopAuditSink` remains reserved for cases that explicitly do not need audit.
+2. **Audit events are never silently dropped** — production-shaped CLI chat, Telegram, and Feishu bootstraps default to `audit.mode = "fanout"`, which appends `~/.loongclaw/audit/events.jsonl` and can retain in-memory snapshots for local diagnostics. `LoongClawKernel::new()` now defaults to `InMemoryAuditSink`, and `NoopAuditSink` remains reserved for callers that explicitly opt into `new_without_audit(...)` or wire a noop sink themselves.
 3. **Pack registration is idempotent-safe** — duplicate pack IDs return `DuplicatePack` error, never silently overwrite.
 4. **Generation-based revocation is monotonic** — the revocation threshold only increases, never decreases.
 5. **TaskState transitions are irreversible from terminal states** — `Completed` and `Faulted` states cannot transition.

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -31,7 +31,7 @@ optional `scripts/pre-commit` hook mirrors these cargo gates locally.
 ## Kernel Invariants
 
 1. **Token authorization is fail-closed** — if the policy engine cannot determine authorization (e.g., mutex poisoned), the operation is denied.
-2. **Audit events are never silently dropped** — production-shaped CLI chat, Telegram, and Feishu bootstraps default to `audit.mode = "fanout"`, which appends `~/.loongclaw/audit/events.jsonl` and can retain in-memory snapshots for local diagnostics. `LoongClawKernel::new()` now defaults to `InMemoryAuditSink`, and `NoopAuditSink` remains reserved for callers that explicitly opt into `new_without_audit(...)` or wire a noop sink themselves.
+2. **Audit events are never silently dropped** — production-shaped CLI chat, Telegram, and Feishu bootstraps default to `audit.mode = "fanout"`, which appends `~/.loongclaw/audit/events.jsonl` and can retain in-memory snapshots for local diagnostics. `LoongClawKernel::new()` now defaults to `InMemoryAuditSink`, `spec` bootstrap/runner helpers intentionally use a named in-memory audit helper for side-effect-free snapshot reporting, and `NoopAuditSink` remains reserved for callers that explicitly opt into `new_without_audit(...)` or wire a noop sink themselves.
 3. **Pack registration is idempotent-safe** — duplicate pack IDs return `DuplicatePack` error, never silently overwrite.
 4. **Generation-based revocation is monotonic** — the revocation threshold only increases, never decreases.
 5. **TaskState transitions are irreversible from terminal states** — `Completed` and `Faulted` states cannot transition.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -61,8 +61,9 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - Operators can inspect recent entries with standard tooling such as
   `tail -n 20 ~/.loongclaw/audit/events.jsonl`
 - No HMAC chain for tamper evidence (TD-007)
-- Spec/demo helpers and explicit test seams may still opt into in-memory-only audit when
-  side-effect-free execution is required
+- `spec` bootstrap and spec-execution helpers intentionally default to a named in-memory audit
+  helper so side-effect-free harness/demo runs can still surface audit snapshots in `SpecRunReport`
+- Explicit no-audit behavior remains opt-in only and should stay reserved for narrow fixture seams
 
 ### Compile-Time Constraints
 

--- a/docs/plans/2026-03-18-retire-noop-audit-default-design.md
+++ b/docs/plans/2026-03-18-retire-noop-audit-default-design.md
@@ -1,0 +1,151 @@
+# Retire the Implicit Noop Audit Default Design
+
+Date: 2026-03-18
+Branch: `feat/279-retire-noop-audit-default`
+Scope: constructor-level kernel audit safety on `alpha-test`
+Linked issue: `#279`
+Status: proposed direction, pre-implementation design
+
+## Problem
+
+`alpha-test` now treats audit as a first-class kernel concern in the main runtime/bootstrap path, but
+the most convenient kernel constructor still undermines that story:
+
+1. `LoongClawKernel::new()` still wires `NoopAuditSink`.
+2. the local repository only calls `LoongClawKernel::new()` from tests today, which hid the risk
+   while the production bootstrap moved forward
+3. external or future internal callers can still reach for `new()` and silently drop security-
+   critical audit events unless they know to switch to `with_runtime(...)`
+
+This is a constructor-boundary truth gap. The repository docs already say silent audit drops are
+bugs, but the public default constructor still encodes the opposite behavior.
+
+## Root Cause
+
+`git log -S'NoopAuditSink' -- crates/kernel/src/kernel.rs` traces the default back to commit
+`7574d362` (`feat: bootstrap layered kernel, security governance, and roadmap`). At that point the
+kernel needed a side-effect-free constructor quickly, so `new()` took the shortest path and reused
+`NoopAuditSink`.
+
+That shortcut outlived the original context:
+
+1. audit retention now exists as a real architectural lane
+2. repository documentation has been updated to describe audit as non-optional for governed paths
+3. the constructor default never got revisited, so the safety model and the API default drifted
+
+The root problem is not missing documentation or missing durable retention anymore. The root
+problem is that the public default constructor still encodes a historical bootstrap shortcut.
+
+## Goals
+
+1. Make the default kernel constructor stop silently dropping audit events.
+2. Preserve additive API compatibility for callers that already use `LoongClawKernel::new()`.
+3. Keep an explicit no-audit path for narrow fixtures that intentionally do not need audit.
+4. Make repository-owned test callsites grep-able about their audit intent.
+5. Keep the change tightly scoped to constructor semantics and audit docs.
+
+## Non-Goals
+
+1. Do not redesign app/bootstrap durable audit retention.
+2. Do not add new storage backends, query APIs, or audit indexing.
+3. Do not change kernel event schemas or policy semantics.
+4. Do not break the existing public constructor signature.
+
+## Current State
+
+### What is already correct
+
+1. `AuditSink` is a small injectable seam.
+2. `InMemoryAuditSink` already exists and is adequate for tests and local assertions.
+3. production-shaped app bootstrap already assembles explicit audit sinks outside the kernel.
+
+### What is still wrong
+
+1. `LoongClawKernel::new()` silently selects `NoopAuditSink`.
+2. `KernelBuilder::new()` inherits the same default because it aliases `LoongClawKernel`.
+3. local tests mostly use `new()`, which keeps audit intent implicit inside the repository.
+
+## Approaches Considered
+
+### A. Keep `new()` as-is and only document the exception
+
+Pros:
+
+1. no code churn
+2. zero compatibility risk
+
+Cons:
+
+1. preserves the root footgun
+2. keeps the public API in conflict with the repository's security claims
+3. relies on contributor memory instead of mechanical defaults
+
+### B. Change `new()` to use `InMemoryAuditSink`, add an explicit no-audit constructor
+
+Pros:
+
+1. additive API change
+2. smallest behavioral fix that makes the default safe
+3. keeps side-effect-free fixtures available through an intentionally named escape hatch
+4. aligns the default constructor with current docs and runtime expectations
+
+Cons:
+
+1. changes constructor behavior for callers who implicitly relied on audit being discarded
+2. does not force every caller to choose a sink explicitly at compile time
+
+### C. Remove or change the `new()` signature so audit is always caller-provided
+
+Pros:
+
+1. strongest explicitness
+2. impossible to forget audit at the constructor boundary
+
+Cons:
+
+1. breaking API change against the repository's additive-compatibility rule
+2. larger migration surface than the actual risk warrants
+3. not necessary because the repo currently has only test callsites
+
+## Decision
+
+Implement Approach B.
+
+Specifically:
+
+1. change `LoongClawKernel::new()` to use `InMemoryAuditSink`
+2. add a deliberately named explicit no-audit constructor for narrow fixture use
+3. add an explicit in-memory helper that returns the sink handle for audit assertions
+4. migrate repository test callsites away from ambiguous `new()` where direct audit intent can be
+   made explicit with minimal churn
+
+This is the smallest fix that closes the constructor-level safety gap without breaking public API
+shape.
+
+## Why This Is Better Than a Heavier Refactor
+
+The tempting stricter design is to require every caller to pass an `Arc<dyn AuditSink>`. That would
+make audit choice explicit everywhere, but it is the wrong move for this slice:
+
+1. it violates the repository's additive-API rule
+2. it creates migration noise unrelated to the actual bug
+3. the real defect is the unsafe default, not the existence of a convenience constructor
+
+Using `InMemoryAuditSink` as the safe default keeps the default constructor honest while preserving
+the explicit `with_runtime(...)` seam for full control.
+
+## Validation Strategy
+
+1. Add regression coverage proving the default constructor lane is backed by in-memory audit.
+2. Add regression coverage for the explicit no-audit constructor.
+3. Update internal tests to use explicit constructor helpers where that improves audit intent.
+4. Reconcile reliability/core-belief docs with the actual constructor behavior.
+
+## Expected Outcome
+
+After this slice:
+
+1. the default kernel constructor no longer silently drops audit events
+2. `NoopAuditSink` remains available, but only behind an explicit constructor name
+3. repository-owned tests become clearer about whether they want in-memory audit or no audit
+4. the kernel audit story becomes internally consistent again

--- a/docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md
+++ b/docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md
@@ -1,0 +1,134 @@
+# Retire the Implicit Noop Audit Default Implementation Plan
+
+Goal: make the default kernel constructor safe by replacing the implicit `NoopAuditSink` default
+with in-memory audit, while preserving an explicit no-audit escape hatch and keeping the change
+additive.
+
+Architecture: keep `AuditSink` injection intact. Fix the bug at the constructor seam instead of
+reworking bootstrap layers. `LoongClawKernel::new()` becomes the safe convenience path,
+`with_runtime(...)` remains the fully explicit path, and a narrowly named no-audit helper makes
+intent grep-able.
+
+Tech stack: Rust, kernel/app tests, cargo fmt, cargo clippy, workspace tests, repo check scripts
+
+---
+
+### Task 1: Lock the constructor design
+
+**Files:**
+- Create: `docs/plans/2026-03-18-retire-noop-audit-default-design.md`
+- Create: `docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md`
+
+**Step 1: Confirm the root-cause seam**
+
+Run: `rg -n "NoopAuditSink|LoongClawKernel::new\\(" crates/kernel crates/app docs`
+Expected: the default constructor seam and current callsites are enumerated.
+
+**Step 2: Confirm the plan files exist**
+
+Run: `ls docs/plans/2026-03-18-retire-noop-audit-default-design.md docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md`
+Expected: both files exist.
+
+### Task 2: Add regression coverage before the implementation
+
+**Files:**
+- Modify: `crates/kernel/src/tests.rs`
+- Modify: `crates/kernel/tests/kernel_integration.rs`
+
+**Step 1: Add a failing default-constructor audit regression**
+
+Cover the safe default lane with a helper that makes the default in-memory audit observable, then
+assert token issuance records an audit event.
+
+**Step 2: Add a failing explicit no-audit regression**
+
+Add a test proving the intentionally named no-audit constructor still allows side-effect-free
+fixtures when callers opt into it explicitly.
+
+**Step 3: Run the targeted kernel tests and confirm RED**
+
+Run: `cargo test -p loongclaw-kernel default_constructor_audit explicit_no_audit -- --test-threads=1`
+Expected: FAIL before the constructor helpers exist.
+
+### Task 3: Implement the additive constructor changes
+
+**Files:**
+- Modify: `crates/kernel/src/kernel.rs`
+- Modify: `crates/kernel/src/lib.rs`
+- Modify: `crates/kernel/tests/kernel_integration.rs`
+- Modify: `crates/app/src/memory/tests.rs`
+
+**Step 1: Add explicit constructor helpers**
+
+Introduce:
+
+1. a safe in-memory constructor/helper for tests and default convenience
+2. a deliberately named no-audit constructor
+
+Keep `with_runtime(...)` unchanged.
+
+**Step 2: Retire the implicit noop default**
+
+Switch `LoongClawKernel::new()` to the safe default helper rather than `NoopAuditSink`.
+
+**Step 3: Migrate repository-owned ambiguous callsites**
+
+Replace local `LoongClawKernel::new()` uses with explicit helper calls where doing so improves
+audit intent without large churn.
+
+**Step 4: Re-export any new constructor-supporting types if needed**
+
+Only expose new items from `crates/kernel/src/lib.rs` if the implementation introduces reusable
+surface beyond existing exports.
+
+### Task 4: Reconcile docs
+
+**Files:**
+- Modify: `docs/RELIABILITY.md`
+- Modify: `docs/design-docs/core-beliefs.md` if wording needs precision
+
+**Step 1: Update reliability wording**
+
+Document that the default constructor now records to in-memory audit, while any silent-drop path
+must be explicit.
+
+**Step 2: Review doc scope**
+
+Run: `git diff -- docs/RELIABILITY.md docs/design-docs/core-beliefs.md`
+Expected: only constructor-semantics wording changes are present.
+
+### Task 5: Run full verification and prepare delivery
+
+**Files:**
+- Modify: `crates/kernel/src/kernel.rs`
+- Modify: `crates/kernel/src/tests.rs`
+- Modify: `crates/kernel/tests/kernel_integration.rs`
+- Modify: `crates/app/src/memory/tests.rs`
+- Modify: `docs/RELIABILITY.md`
+- Modify: `docs/design-docs/core-beliefs.md` if needed
+- Create: `docs/plans/2026-03-18-retire-noop-audit-default-design.md`
+- Create: `docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md`
+
+**Step 1: Run format and lint**
+
+Run: `cargo fmt --all -- --check`
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: PASS.
+
+**Step 2: Run workspace tests**
+
+Run: `cargo test --workspace -- --test-threads=1`
+Run: `cargo test --workspace --all-features -- --test-threads=1`
+Expected: PASS.
+
+**Step 3: Run repo guardrails**
+
+Run: `./scripts/check_architecture_boundaries.sh`
+Run: `./scripts/check_dep_graph.sh`
+Run: `./scripts/check-docs.sh`
+Expected: PASS.
+
+**Step 4: Review the final scoped diff**
+
+Run: `git diff -- crates/kernel/src/kernel.rs crates/kernel/src/tests.rs crates/kernel/tests/kernel_integration.rs crates/app/src/memory/tests.rs docs/RELIABILITY.md docs/design-docs/core-beliefs.md docs/plans/2026-03-18-retire-noop-audit-default-design.md docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md`
+Expected: only the constructor-audit slice is present.

--- a/docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md
+++ b/docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md
@@ -13,7 +13,7 @@ Tech stack: Rust, kernel/app tests, cargo fmt, cargo clippy, workspace tests, re
 
 ---
 
-### Task 1: Lock the constructor design
+## Task 1: Lock the constructor design
 
 **Files:**
 - Create: `docs/plans/2026-03-18-retire-noop-audit-default-design.md`
@@ -29,7 +29,7 @@ Expected: the default constructor seam and current callsites are enumerated.
 Run: `ls docs/plans/2026-03-18-retire-noop-audit-default-design.md docs/plans/2026-03-18-retire-noop-audit-default-implementation-plan.md`
 Expected: both files exist.
 
-### Task 2: Add regression coverage before the implementation
+## Task 2: Add regression coverage before the implementation
 
 **Files:**
 - Modify: `crates/kernel/src/tests.rs`
@@ -50,7 +50,7 @@ fixtures when callers opt into it explicitly.
 Run: `cargo test -p loongclaw-kernel default_constructor_audit explicit_no_audit -- --test-threads=1`
 Expected: FAIL before the constructor helpers exist.
 
-### Task 3: Implement the additive constructor changes
+## Task 3: Implement the additive constructor changes
 
 **Files:**
 - Modify: `crates/kernel/src/kernel.rs`
@@ -81,7 +81,7 @@ audit intent without large churn.
 Only expose new items from `crates/kernel/src/lib.rs` if the implementation introduces reusable
 surface beyond existing exports.
 
-### Task 4: Reconcile docs
+## Task 4: Reconcile docs
 
 **Files:**
 - Modify: `docs/RELIABILITY.md`
@@ -97,7 +97,7 @@ must be explicit.
 Run: `git diff -- docs/RELIABILITY.md docs/design-docs/core-beliefs.md`
 Expected: only constructor-semantics wording changes are present.
 
-### Task 5: Run full verification and prepare delivery
+## Task 5: Run full verification and prepare delivery
 
 **Files:**
 - Modify: `crates/kernel/src/kernel.rs`

--- a/docs/plans/2026-03-18-spec-audit-contract-convergence-design.md
+++ b/docs/plans/2026-03-18-spec-audit-contract-convergence-design.md
@@ -1,0 +1,140 @@
+# Spec Audit Contract Convergence Design
+
+## Problem
+
+`#279` retired the unsafe implicit `NoopAuditSink` default from `LoongClawKernel::new()`, and the
+app/runtime bootstrap path now has an explicit durable audit story. The remaining seam is `spec`:
+
+1. `crates/spec/src/kernel_bootstrap.rs` still defaults its bootstrap builder to
+   `InMemoryAuditSink` without naming that choice as a harness-specific contract.
+2. `crates/spec/src/spec_execution.rs` constructs its own `InMemoryAuditSink` inline instead of
+   reusing a shared spec-level audit decision.
+3. `docs/SECURITY.md` already permits spec/demo helpers to stay in-memory, but the code path has no
+   focused regression tests that prove this is an intentional harness default rather than an
+   accidental drift.
+
+The result is semantic ambiguity. Production-shaped app bootstraps are now explicit and durable by
+default, while the `spec` layer remains silently in-memory.
+
+## Goals
+
+1. Make the `spec` audit default explicit as a harness-only in-memory policy.
+2. Centralize `spec`'s in-memory audit construction so the contract lives in one place.
+3. Add regression tests that fail if `spec` stops exposing in-memory audit events for report
+   snapshots or if the bootstrap fallback stops being intentionally in-memory.
+4. Align security/reliability docs with the resulting contract.
+
+## Non-Goals
+
+1. Do not route `spec` through app `[audit]` runtime configuration.
+2. Do not introduce a new cross-layer audit profile abstraction.
+3. Do not change production CLI/Telegram/Feishu audit defaults in this slice.
+
+## Options Considered
+
+### A. Promote `spec` to production-shaped durable audit defaults
+
+This would thread app-style audit configuration into `spec` and make `spec` mirror runtime
+bootstraps.
+
+Why not now:
+- `spec` is intentionally detached from `app`.
+- Durable retention is an operator/runtime concern, while `spec` is still used as a harness/demo
+  path and for side-effect-free evaluation.
+- The change set would be much larger and would blur an architecture boundary just to remove a
+  smaller semantic ambiguity.
+
+### B. Keep `spec` in-memory but leave the current implicit defaults in place
+
+This is the smallest code delta, but it preserves the root problem: callers still have to infer
+intent from scattered `InMemoryAuditSink::default()` allocations and builder fallbacks.
+
+Why not:
+- It does not create a durable regression guard.
+- It keeps docs and code coupled only by tribal knowledge.
+
+### C. Keep `spec` in-memory and make that contract explicit
+
+Recommended.
+
+Concretely:
+- add a named helper in `crates/spec/src/kernel_bootstrap.rs` for the spec/harness in-memory audit
+  default
+- use that helper everywhere `spec` needs its default sink
+- document that `KernelBuilder`/`BootstrapBuilder` are harness bootstrap helpers whose implicit
+  fallback is intentionally in-memory
+- add tests that exercise real `spec` execution with `include_audit = true`
+
+Why this is the right cut:
+- minimal change set
+- no new hardcoding or policy duplication
+- keeps `spec` detached from `app`
+- mechanically protects the intended semantics
+
+## Proposed Design
+
+### 1. Introduce a named spec audit helper
+
+Add a small helper in `crates/spec/src/kernel_bootstrap.rs`:
+
+- `pub fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink>`
+
+This gives the harness default a single source of truth. The helper name carries the architectural
+meaning that raw `InMemoryAuditSink::default()` does not.
+
+### 2. Reuse the helper in both bootstrap and spec execution
+
+Replace direct inline `InMemoryAuditSink::default()` construction in:
+
+- `crates/spec/src/kernel_bootstrap.rs`
+- `crates/spec/src/spec_execution.rs`
+
+with the named helper.
+
+That keeps the fallback policy centralized and avoids semantic drift between builder bootstraps and
+the report-producing spec execution path.
+
+### 3. Add regression coverage at the behavior seam
+
+Add tests in:
+
+- `crates/spec/src/kernel_bootstrap.rs`
+- `crates/spec/tests/spec_execution.rs`
+
+Coverage:
+- the default spec audit helper records real kernel events
+- `execute_spec(..., include_audit = true)` returns captured audit events instead of `None`
+- `execute_spec(..., include_audit = false)` continues suppressing snapshots
+
+This gives us a behavior-level guard instead of only a comment-level contract.
+
+### 4. Tighten docs
+
+Update:
+
+- `docs/SECURITY.md`
+- `docs/RELIABILITY.md`
+
+to say that:
+- production-shaped app bootstraps default to durable audit modes
+- `spec`/demo/harness helpers intentionally default to in-memory audit for side-effect-free local
+  execution and snapshot reporting
+
+## Testing Strategy
+
+1. Write failing spec tests first for audit snapshot inclusion/suppression.
+2. Add a focused bootstrap test proving the named helper captures emitted audit events.
+3. Run targeted spec/kernel tests during iteration.
+4. Run full repo verification before declaring completion.
+
+## Risks
+
+1. Over-correcting by threading app audit configuration into `spec` would widen the slice and create
+   boundary drift.
+2. Only updating docs without behavior tests would recreate the same ambiguity later.
+
+## Recommendation
+
+Implement Option C. It is the smallest change that closes the actual gap: `spec` stays
+harness-oriented and in-memory by design, but that design becomes explicit, centralized, tested, and
+documented.

--- a/docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md
+++ b/docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md
@@ -1,0 +1,176 @@
+# Spec Audit Contract Convergence Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the `spec` layer's in-memory audit default explicit, centralized, and regression-tested without widening the `spec -> app` boundary.
+
+**Architecture:** Treat `spec` as a harness/demo bootstrap surface with an intentionally in-memory audit default. Centralize that choice behind a named helper, reuse it in builder and execution paths, and verify the behavior through end-to-end spec execution tests plus focused bootstrap tests.
+
+**Tech Stack:** Rust workspace, `cargo test`, spec/kernel crates, Markdown design/reliability/security docs.
+
+---
+
+### Task 1: Add the failing spec execution audit tests
+
+**Files:**
+- Modify: `crates/spec/tests/spec_execution.rs`
+
+**Step 1: Write the failing test**
+
+Add:
+- one async test asserting `execute_spec(&spec, true)` returns `Some(audit_events)` with at least one event
+- one async test asserting `execute_spec(&spec, false)` returns `None`
+
+Use a minimal `ToolCore` runner spec that succeeds through the normal spec path.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_returns_audit_snapshot_when_requested -- --exact`
+
+Expected: FAIL because the current behavior is not yet expressed through focused regression coverage.
+
+**Step 3: Write minimal implementation**
+
+Do not change production code yet. Only fix compile issues in the new tests if needed.
+
+**Step 4: Run test to verify it still fails for the intended reason**
+
+Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_returns_audit_snapshot_when_requested -- --exact`
+
+Expected: FAIL on the assertion, not due to unrelated compile errors.
+
+**Step 5: Commit**
+
+Do not commit yet. This slice will be committed after code + docs are green.
+
+### Task 2: Centralize the spec in-memory audit default
+
+**Files:**
+- Modify: `crates/spec/src/kernel_bootstrap.rs`
+- Modify: `crates/spec/src/spec_execution.rs`
+
+**Step 1: Add the named helper**
+
+Add a helper such as:
+
+```rust
+pub fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
+    Arc::new(InMemoryAuditSink::default())
+}
+```
+
+**Step 2: Route bootstrap fallback through the helper**
+
+Replace inline `Arc::new(InMemoryAuditSink::default())` fallback construction in
+`configured_builder(...)` with the helper.
+
+**Step 3: Route spec execution through the helper**
+
+Replace the inline `audit_sink` construction in `execute_spec_with_native_tool_executor(...)` with
+the helper so spec execution and spec bootstrap share one default.
+
+**Step 4: Run the focused spec test**
+
+Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_returns_audit_snapshot_when_requested -- --exact`
+
+Expected: PASS
+
+**Step 5: Run the suppression test**
+
+Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_suppresses_audit_snapshot_when_not_requested -- --exact`
+
+Expected: PASS
+
+### Task 3: Add a focused bootstrap regression test
+
+**Files:**
+- Modify: `crates/spec/src/kernel_bootstrap.rs`
+
+**Step 1: Write the failing test**
+
+Add a unit test that:
+- constructs the named spec audit helper
+- wires it into `KernelBuilder`
+- issues a token
+- asserts the in-memory audit snapshot is non-empty
+
+**Step 2: Run test to verify it fails or is missing**
+
+Run: `cargo test -p loongclaw-spec builder_explicit_in_memory_audit_records_events -- --exact`
+
+Expected: FAIL before the helper/test wiring is complete.
+
+**Step 3: Write minimal implementation**
+
+Use the new helper in the test and keep the production code limited to the centralization from Task 2.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-spec builder_explicit_in_memory_audit_records_events -- --exact`
+
+Expected: PASS
+
+### Task 4: Update the documentation contract
+
+**Files:**
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/RELIABILITY.md`
+- Create: `docs/plans/2026-03-18-spec-audit-contract-convergence-design.md`
+- Create: `docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md`
+
+**Step 1: Update security wording**
+
+Clarify that durable retention exists on production-shaped app bootstraps, while `spec`/demo
+helpers intentionally remain in-memory for side-effect-free execution and audit snapshot reporting.
+
+**Step 2: Update reliability wording**
+
+Clarify that the "never silently dropped" invariant means:
+- production paths default to durable or in-memory-backed audit as documented
+- explicit no-audit paths must remain opt-in only
+- `spec` defaults are intentionally in-memory and named as such
+
+**Step 3: Review for consistency**
+
+Run: `rg -n "No persistent audit sink|In-memory only|spec.*in-memory|fanout|new_without_audit" docs crates/spec`
+
+Expected: wording reflects the current contract with no stale contradiction.
+
+### Task 5: Run verification and prepare the final change set
+
+**Files:**
+- Modify: `crates/spec/src/kernel_bootstrap.rs`
+- Modify: `crates/spec/src/spec_execution.rs`
+- Modify: `crates/spec/tests/spec_execution.rs`
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/RELIABILITY.md`
+- Create: `docs/plans/2026-03-18-spec-audit-contract-convergence-design.md`
+- Create: `docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md`
+
+**Step 1: Run focused tests**
+
+Run:
+- `cargo test -p loongclaw-spec --test spec_execution`
+- `cargo test -p loongclaw-spec kernel_bootstrap --lib`
+
+Expected: PASS
+
+**Step 2: Run repo verification**
+
+Run:
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace -- --test-threads=1`
+- `cargo test --workspace --all-features -- --test-threads=1`
+- `./scripts/check_architecture_boundaries.sh`
+- `./scripts/check_dep_graph.sh`
+- `./scripts/check-docs.sh`
+
+Expected: PASS, except for known unrelated non-blocking release-artifact warnings if they remain unchanged.
+
+**Step 3: Review the final diff for scope**
+
+Run:
+- `git diff -- crates/spec/src/kernel_bootstrap.rs crates/spec/src/spec_execution.rs crates/spec/tests/spec_execution.rs docs/SECURITY.md docs/RELIABILITY.md docs/plans/2026-03-18-spec-audit-contract-convergence-design.md docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md`
+
+Expected: only the intended audit-contract convergence slice is present.

--- a/docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md
+++ b/docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add the failing spec execution audit tests
+## Task 1: Add the failing spec execution audit tests
 
 **Files:**
 - Modify: `crates/spec/tests/spec_execution.rs`
@@ -43,7 +43,7 @@ Expected: FAIL on the assertion, not due to unrelated compile errors.
 
 Do not commit yet. This slice will be committed after code + docs are green.
 
-### Task 2: Centralize the spec in-memory audit default
+## Task 2: Centralize the spec in-memory audit default
 
 **Files:**
 - Modify: `crates/spec/src/kernel_bootstrap.rs`
@@ -81,7 +81,7 @@ Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_suppresses
 
 Expected: PASS
 
-### Task 3: Add a focused bootstrap regression test
+## Task 3: Add a focused bootstrap regression test
 
 **Files:**
 - Modify: `crates/spec/src/kernel_bootstrap.rs`
@@ -110,7 +110,7 @@ Run: `cargo test -p loongclaw-spec builder_explicit_in_memory_audit_records_even
 
 Expected: PASS
 
-### Task 4: Update the documentation contract
+## Task 4: Update the documentation contract
 
 **Files:**
 - Modify: `docs/SECURITY.md`
@@ -136,7 +136,7 @@ Run: `rg -n "No persistent audit sink|In-memory only|spec.*in-memory|fanout|new_
 
 Expected: wording reflects the current contract with no stale contradiction.
 
-### Task 5: Run verification and prepare the final change set
+## Task 5: Run verification and prepare the final change set
 
 **Files:**
 - Modify: `crates/spec/src/kernel_bootstrap.rs`

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-18T00:35:37Z
+- Generated at: 2026-03-18T10:08:59Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -12,7 +12,7 @@
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 301 | 1000 | 699 | 8 | 20 | 12 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 312 | 650 | 338 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
 
@@ -40,7 +40,7 @@
 - [CI workflow](../../.github/workflows/ci.yml)
 
 <!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
-<!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
+<!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=301 functions=8 -->
 <!-- arch-hotspot key=memory_mod lines=312 functions=15 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: the default kernel constructor still wired `NoopAuditSink` implicitly, so repository-owned tests and side-effect-free local runs could miss observable audit behavior unless every caller remembered to opt into a real sink.
- Why it matters: the runtime and test surface should make audit behavior explicit and observable by default instead of silently discarding events through an implicit noop path.
- What changed: switched the default kernel constructor to in-memory audit, added explicit constructor helpers for in-memory and no-audit fixture paths, migrated repository-owned tests to the explicit in-memory helper, added regression coverage, and updated reliability/security docs plus design docs for the default-behavior change.
- What did not change (scope boundary): this does not add durable retention, change daemon CLI audit commands, or alter unrelated provider/runtime policy.

## Linked Issues

- Closes #279
- Related # n/a

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  this changes the default audit behavior of the kernel bootstrap path, so callers and tests that previously relied on implicit noop behavior must remain explicit and well covered.
- Rollout / guardrails:
  explicit in-memory and no-audit helpers were added for fixture paths, repository-owned tests were migrated, and regression coverage verifies the new default behavior.
- Rollback path:
  revert the default-constructor change to restore implicit noop audit behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo test --workspace -- --test-threads=1
- passed

cargo test --workspace --all-features -- --test-threads=1
- passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed

./scripts/check_architecture_boundaries.sh
- passed

./scripts/check_dep_graph.sh
- passed

./scripts/check-docs.sh
- passed
```

Before / after behavior:

- Before: the default kernel constructor implicitly wired `NoopAuditSink`, so callers that wanted observable audit behavior had to opt in explicitly.
- After: the default kernel constructor uses in-memory audit, while explicit helpers remain available for in-memory and no-audit fixture paths.

Regression coverage:

- repository-owned tests were moved onto the explicit in-memory helper where appropriate.
- kernel and spec tests assert the new default constructor behavior and the retained explicit no-audit path.

## User-visible / Operator-visible Changes

- kernel bootstraps now observe audit events in memory by default instead of implicitly dropping them through `NoopAuditSink`.

## Failure Recovery

- Fast rollback or disable path: revert this change to restore the previous implicit noop default.
- Observable failure symptoms reviewers should watch for: callers unexpectedly depending on missing audit events, tests still assuming the implicit noop path, or fixture paths no longer selecting the intended audit mode explicitly.

## Reviewer Focus

- `crates/kernel/src/kernel.rs` for the default-constructor behavior and explicit helper split.
- `crates/kernel/src/tests.rs`, `crates/kernel/tests/kernel_integration.rs`, and spec tests for regression coverage around the default audit path.
- `docs/RELIABILITY.md` and `docs/SECURITY.md` for the documented default-behavior change.
