### PR TITLE
fix(channel): prune inactive runtime owners before restart recovery

### DIFF
--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -843,12 +843,20 @@ fn ensure_channel_operation_runtime_slot_available_in_dir(
     runtime_dir: &std::path::Path,
     spec: ChannelServeRuntimeSpec<'_>,
 ) -> CliResult<()> {
+    let now = channel_runtime_now_ms();
+    runtime_state::prune_inactive_channel_operation_runtime_files_for_account_from_dir(
+        runtime_dir,
+        spec.platform,
+        spec.operation_id,
+        Some(spec.account_id),
+        now,
+    )?;
     let Some(runtime) = runtime_state::load_channel_operation_runtime_for_account_from_dir(
         runtime_dir,
         spec.platform,
         spec.operation_id,
         spec.account_id,
-        channel_runtime_now_ms(),
+        now,
     ) else {
         return Ok(());
     };
@@ -2397,6 +2405,71 @@ mod tests {
         )
         .expect("runtime should remain readable after takeover");
         assert_eq!(runtime.pid, Some(9191));
+        assert_eq!(runtime.instance_count, 1);
+        assert_eq!(runtime.running_instances, 0);
+        assert_eq!(runtime.stale_instances, 0);
+        let entries = std::fs::read_dir(runtime_dir.as_path())
+            .expect("list runtime dir after stale takeover")
+            .map(|entry| {
+                entry
+                    .expect("runtime entry after stale takeover")
+                    .file_name()
+                    .into_string()
+                    .expect("utf-8 runtime file name after stale takeover")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[cfg(any(feature = "channel-telegram", feature = "channel-feishu"))]
+    #[tokio::test]
+    async fn with_channel_serve_runtime_rejects_active_legacy_owner_after_inactive_account_prune() {
+        let runtime_dir = temp_runtime_dir("serve-runtime-legacy-owner");
+        let now = now_ms_for_test();
+        runtime_state::write_runtime_state_for_test_with_account_and_pid(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            7001,
+            false,
+            false,
+            0,
+            Some(now.saturating_sub(5_000)),
+            Some(now.saturating_sub(5_000)),
+            Some(7001),
+        )
+        .expect("seed inactive account-scoped runtime state");
+        runtime_state::write_runtime_state_for_test_with_pid(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            8118,
+            true,
+            true,
+            1,
+            Some(now),
+            Some(now),
+            Some(8118),
+        )
+        .expect("seed active legacy runtime state");
+
+        let error = with_channel_serve_runtime_in_dir(
+            runtime_dir.as_path(),
+            9191,
+            ChannelServeRuntimeSpec {
+                platform: ChannelPlatform::Telegram,
+                operation_id: CHANNEL_OPERATION_SERVE_ID,
+                account_id: "bot_123456",
+                account_label: "bot:123456",
+            },
+            |_runtime| async move { Ok::<_, String>("ok".to_owned()) },
+        )
+        .await
+        .expect_err("active legacy owner should still block startup");
+
+        assert!(error.contains("already has an active serve runtime"));
+        assert!(error.contains("8118"));
     }
 
     #[cfg(feature = "channel-telegram")]

--- a/crates/app/src/channel/runtime_state.rs
+++ b/crates/app/src/channel/runtime_state.rs
@@ -146,6 +146,14 @@ impl ChannelOperationRuntimeTracker {
         heartbeat_ms: u64,
         process_id: u32,
     ) -> CliResult<Self> {
+        let now = now_ms();
+        prune_inactive_channel_operation_runtime_files_for_account_from_dir(
+            runtime_dir,
+            platform,
+            operation_id,
+            account_id,
+            now,
+        )?;
         let path = channel_operation_runtime_path(
             runtime_dir,
             platform,
@@ -158,7 +166,7 @@ impl ChannelOperationRuntimeTracker {
             busy: false,
             active_runs: 0,
             last_run_activity_at: None,
-            last_heartbeat_at: Some(now_ms()),
+            last_heartbeat_at: Some(now),
             pid: Some(process_id),
             account_id: normalize_optional_account_value(account_id),
             account_label: normalize_optional_account_value(account_label),
@@ -355,6 +363,85 @@ fn load_channel_operation_runtime_for_optional_account_from_dir(
     summarize_runtime_candidates(candidates)
 }
 
+pub(crate) fn prune_inactive_channel_operation_runtime_files_for_account_from_dir(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+    now_ms: u64,
+) -> CliResult<()> {
+    prune_inactive_channel_operation_runtime_files_for_optional_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        account_id,
+        now_ms,
+    )?;
+    if account_id.is_some() {
+        prune_inactive_channel_operation_runtime_files_for_optional_account_from_dir(
+            runtime_dir,
+            platform,
+            operation_id,
+            None,
+            now_ms,
+        )?;
+    }
+    Ok(())
+}
+
+fn prune_inactive_channel_operation_runtime_files_for_optional_account_from_dir(
+    runtime_dir: &Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: Option<&str>,
+    now_ms: u64,
+) -> CliResult<()> {
+    let prefix = channel_operation_runtime_file_prefix(platform, operation_id, account_id);
+    let entries = match fs::read_dir(runtime_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "read channel runtime state directory failed for {}: {error}",
+                runtime_dir.display()
+            ));
+        }
+    };
+
+    for entry in entries {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if !matches_channel_operation_runtime_file(file_name.as_ref(), &prefix) {
+            continue;
+        }
+        let path = entry.path();
+        if !runtime_state_path_is_inactive(path.as_path(), now_ms) {
+            continue;
+        }
+        match fs::remove_file(path.as_path()) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "remove inactive channel runtime state failed for {}: {error}",
+                    path.display()
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn default_channel_runtime_state_dir() -> PathBuf {
     default_loongclaw_home().join("channel-runtime")
 }
@@ -401,6 +488,12 @@ fn read_runtime_state(path: &Path, now_ms: u64) -> Option<ChannelOperationRuntim
     let raw = fs::read_to_string(path).ok()?;
     let state = serde_json::from_str::<PersistedChannelOperationRuntime>(&raw).ok()?;
     Some(state.to_runtime_view(now_ms))
+}
+
+fn runtime_state_path_is_inactive(path: &Path, now_ms: u64) -> bool {
+    read_runtime_state(path, now_ms)
+        .map(|runtime| !runtime.running)
+        .unwrap_or(false)
 }
 
 fn select_preferred_runtime(
@@ -628,6 +721,149 @@ mod tests {
         .to_string_lossy()
         .into_owned();
         assert!(entries.contains(&expected_entry));
+    }
+
+    #[tokio::test]
+    async fn runtime_tracker_prunes_inactive_pid_files_before_restart() {
+        let runtime_dir = temp_runtime_dir("tracker-restart-cleanup");
+        let first = ChannelOperationRuntimeTracker::start_in_dir_with_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            20,
+            4242,
+        )
+        .await
+        .expect("start first runtime tracker");
+        first
+            .shutdown()
+            .await
+            .expect("shutdown first runtime tracker");
+
+        let second = ChannelOperationRuntimeTracker::start_in_dir_with_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            20,
+            5252,
+        )
+        .await
+        .expect("restart runtime tracker");
+
+        let runtime = load_channel_operation_runtime_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            now_ms(),
+        )
+        .expect("load restarted runtime state");
+
+        assert!(runtime.running);
+        assert_eq!(runtime.pid, Some(5252));
+        assert_eq!(runtime.instance_count, 1);
+        assert_eq!(runtime.running_instances, 1);
+        assert_eq!(runtime.stale_instances, 0);
+
+        let entries = fs::read_dir(&runtime_dir)
+            .expect("list runtime dir after restart")
+            .map(|entry| {
+                entry
+                    .expect("runtime entry after restart")
+                    .file_name()
+                    .into_string()
+                    .expect("utf-8 file name after restart")
+            })
+            .collect::<Vec<_>>();
+        let expected_entry = channel_operation_runtime_path(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            None,
+            Some(5252),
+        )
+        .file_name()
+        .expect("restarted runtime path file name")
+        .to_string_lossy()
+        .into_owned();
+        assert_eq!(entries, vec![expected_entry]);
+
+        second
+            .shutdown()
+            .await
+            .expect("shutdown restarted runtime tracker");
+    }
+
+    #[tokio::test]
+    async fn account_runtime_tracker_prunes_inactive_legacy_file_before_start() {
+        let runtime_dir = temp_runtime_dir("account-tracker-legacy-cleanup");
+        let now = now_ms();
+        write_runtime_state_for_test(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            false,
+            false,
+            0,
+            Some(now.saturating_sub(5_000)),
+            Some(now.saturating_sub(5_000)),
+            Some(4141),
+        )
+        .expect("write inactive legacy runtime state");
+
+        let tracker = ChannelOperationRuntimeTracker::start_in_dir_with_account_and_pid(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            "bot_123456",
+            &test_account_label("bot_123456"),
+            20,
+            5252,
+        )
+        .await
+        .expect("start account-scoped runtime tracker");
+
+        let runtime = load_channel_operation_runtime_for_account_from_dir(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            "bot_123456",
+            now_ms(),
+        )
+        .expect("load account-scoped runtime state");
+
+        assert!(runtime.running);
+        assert_eq!(runtime.pid, Some(5252));
+        assert_eq!(runtime.instance_count, 1);
+        assert_eq!(runtime.running_instances, 1);
+        assert_eq!(runtime.stale_instances, 0);
+
+        let entries = fs::read_dir(&runtime_dir)
+            .expect("list runtime dir after account startup")
+            .map(|entry| {
+                entry
+                    .expect("runtime entry after account startup")
+                    .file_name()
+                    .into_string()
+                    .expect("utf-8 file name after account startup")
+            })
+            .collect::<Vec<_>>();
+        let expected_entry = channel_operation_runtime_path(
+            &runtime_dir,
+            ChannelPlatform::Telegram,
+            CHANNEL_OPERATION_SERVE_ID,
+            Some("bot_123456"),
+            Some(5252),
+        )
+        .file_name()
+        .expect("account runtime path file name")
+        .to_string_lossy()
+        .into_owned();
+        assert_eq!(entries, vec![expected_entry]);
+
+        tracker
+            .shutdown()
+            .await
+            .expect("shutdown account-scoped runtime tracker");
     }
 
     #[test]

--- a/docs/plans/2026-03-11-channel-serve-ownership-phase-13.md
+++ b/docs/plans/2026-03-11-channel-serve-ownership-phase-13.md
@@ -5,8 +5,9 @@
 **Goal:** Prevent duplicate active `serve` workers for the same channel account.
 
 **Architecture:** Reuse account-scoped runtime-state summaries before tracker
-startup and block `with_channel_serve_runtime(...)` when an active owner already
-holds the serve slot. Permit startup when prior state is stale.
+startup, prune inactive pid-scoped owner files during restart/takeover recovery,
+and block `with_channel_serve_runtime(...)` when an active owner already holds
+the serve slot. Permit startup when prior state is stale.
 
 **Tech Stack:** Rust, tokio, serde
 


### PR DESCRIPTION
## Summary

- Problem:
  inactive pid-scoped channel runtime owner files could survive restart or stale-owner takeover on `alpha-test`, which drifted operator-visible runtime truth and left legacy fallback cleanup incomplete.
- Why it matters:
  `channels` and `doctor` can only stay trustworthy if serve ownership recovery removes inactive residue before deciding who owns the slot.
- What changed:
  prune inactive runtime owner files before serve-slot checks and tracker startup; account-scoped startup also prunes inactive legacy fallback files; ignore `NotFound` during prune removal so concurrent cleanup stays idempotent; add regression tests for restart recovery, stale takeover cleanup, legacy fallback cleanup, active legacy-owner blocking, and the delayed-update Feishu callback race that exposed the cleanup edge.
- What did not change (scope boundary):
  this does not add new daemon / status / service / cron / heartbeat / gateway surfaces; that broader operator-runtime work stays in `#217`.

## Linked Issues

- Closes #218
- Related #217

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  runtime ownership recovery now prunes inactive owner files earlier; the main seam is concurrent startup/shutdown around shared runtime-state files.
- Rollout / guardrails:
  the change only touches inactive runtime files, keeps active-owner blocking unchanged, and is covered by restart/takeover/legacy-owner regression tests plus a Feishu delayed-update callback race repro.
- Rollback path:
  revert this commit to restore the previous startup/ownership behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check

env CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=<branch-target-dir>/target-issue-218-lite cargo test -p loongclaw-app --jobs 1 --no-default-features --features channel-cli,channel-telegram,channel-feishu,config-toml,memory-sqlite,feishu-integration runtime_tracker_prunes_inactive_pid_files_before_restart -- --nocapture

env CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=<branch-target-dir>/target-issue-218-lite cargo test -p loongclaw-app --jobs 1 --no-default-features --features channel-cli,channel-telegram,channel-feishu,config-toml,memory-sqlite,feishu-integration account_runtime_tracker_prunes_inactive_legacy_file_before_start -- --nocapture

env CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=<branch-target-dir>/target-issue-218-lite cargo test -p loongclaw-app --jobs 1 --no-default-features --features channel-cli,channel-telegram,channel-feishu,config-toml,memory-sqlite,feishu-integration with_channel_serve_runtime_allows_takeover_when_previous_instance_is_stale -- --nocapture

env CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=<branch-target-dir>/target-issue-218-lite cargo test -p loongclaw-app --jobs 1 --no-default-features --features channel-cli,channel-telegram,channel-feishu,config-toml,memory-sqlite,feishu-integration with_channel_serve_runtime_rejects_active_legacy_owner_after_inactive_account_prune -- --nocapture

env CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 CARGO_TARGET_DIR=<branch-target-dir>/target-issue-218-lite cargo test -p loongclaw-app --jobs 1 --no-default-features --features channel-cli,channel-telegram,channel-feishu,config-toml,memory-sqlite,feishu-integration,provider-openai feishu_webhook_card_callback_delayed_update_ -- --nocapture

all targeted runtime recovery regressions passed.

broader `cargo test -p loongclaw-app --jobs 1 --no-default-features --features channel-cli,channel-telegram,channel-feishu,config-toml,memory-sqlite,feishu-integration` and `cargo test -p loongclaw-app --jobs 1 --no-default-features --features channel-cli,channel-telegram,channel-feishu,config-toml,memory-sqlite,feishu-integration channel::` probes were also run to look for collateral breakage. they surfaced unrelated existing failures in provider-gated suites outside this change, and one real concurrent cleanup race in the Feishu delayed-update path that is fixed in this patch.
```

## User-visible / Operator-visible Changes

- restart and stale-owner recovery no longer leave inactive channel runtime owner files behind, so runtime counts and ownership truth stay aligned after recovery.

## Failure Recovery

- Fast rollback or disable path:
  revert this commit.
- Observable failure symptoms reviewers should watch for:
  duplicate/stale owner counts persisting after restart, or duplicate serve startup blocked by an owner that is already inactive.

## Reviewer Focus

- check the cleanup ordering in `crates/app/src/channel/runtime_state.rs` and `crates/app/src/channel/mod.rs`, especially the account-scoped legacy fallback prune and the idempotent `NotFound` handling for concurrent cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cleanup of inactive runtime files during startup and ownership transitions.
  * Enhanced stale ownership takeover detection with better recovery handling.

* **Tests**
  * Added tests for stale takeover behavior and inactive account scenarios.

* **Documentation**
  * Updated architecture documentation for channel serve ownership process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->