### PR TITLE
Add runtime capability family index and readiness gate

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -411,7 +411,7 @@ pub enum Commands {
         #[command(subcommand)]
         command: runtime_experiment_cli::RuntimeExperimentCommands,
     },
-    /// Manage run-derived capability candidate records
+    /// Manage run-derived capability candidates, family readiness, and dry-run promotion plans
     RuntimeCapability {
         #[command(subcommand)]
         command: runtime_capability_cli::RuntimeCapabilityCommands,

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -10,7 +10,7 @@ use loongclaw_spec::CliResult;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -26,6 +26,8 @@ pub enum RuntimeCapabilityCommands {
     Review(RuntimeCapabilityReviewCommandOptions),
     /// Load and render one persisted capability-candidate artifact
     Show(RuntimeCapabilityShowCommandOptions),
+    /// Aggregate candidate artifacts into deterministic capability families and readiness states
+    Index(RuntimeCapabilityIndexCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -68,6 +70,14 @@ pub struct RuntimeCapabilityReviewCommandOptions {
 pub struct RuntimeCapabilityShowCommandOptions {
     #[arg(long)]
     pub candidate: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityIndexCommandOptions {
+    #[arg(long)]
+    pub root: String,
     #[arg(long, default_value_t = false)]
     pub json: bool,
 }
@@ -153,6 +163,82 @@ pub struct RuntimeCapabilityArtifactDocument {
     pub review: Option<RuntimeCapabilityReview>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityFamilyReadinessStatus {
+    Ready,
+    NotReady,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityFamilyReadinessCheckStatus {
+    Pass,
+    NeedsEvidence,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityFamilyReadinessCheck {
+    pub dimension: String,
+    pub status: RuntimeCapabilityFamilyReadinessCheckStatus,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityFamilyReadiness {
+    pub status: RuntimeCapabilityFamilyReadinessStatus,
+    pub checks: Vec<RuntimeCapabilityFamilyReadinessCheck>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityMetricRange {
+    pub min: f64,
+    pub max: f64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilitySourceDecisionRollup {
+    pub promoted: usize,
+    pub rejected: usize,
+    pub undecided: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityEvidenceDigest {
+    pub total_candidates: usize,
+    pub reviewed_candidates: usize,
+    pub undecided_candidates: usize,
+    pub accepted_candidates: usize,
+    pub rejected_candidates: usize,
+    pub distinct_source_run_count: usize,
+    pub distinct_experiment_count: usize,
+    pub latest_candidate_at: Option<String>,
+    pub latest_reviewed_at: Option<String>,
+    pub source_decisions: RuntimeCapabilitySourceDecisionRollup,
+    pub unique_warnings: Vec<String>,
+    pub metric_ranges: BTreeMap<String, RuntimeCapabilityMetricRange>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityFamilySummary {
+    pub family_id: String,
+    pub proposal: RuntimeCapabilityProposal,
+    pub candidate_ids: Vec<String>,
+    pub evidence: RuntimeCapabilityEvidenceDigest,
+    pub readiness: RuntimeCapabilityFamilyReadiness,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityIndexReport {
+    pub generated_at: String,
+    pub root: String,
+    pub total_candidate_count: usize,
+    pub family_count: usize,
+    pub families: Vec<RuntimeCapabilityFamilySummary>,
+}
+
 pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
     match command {
         RuntimeCapabilityCommands::Propose(options) => {
@@ -169,6 +255,11 @@ pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResu
             let as_json = options.json;
             let artifact = execute_runtime_capability_show_command(options)?;
             emit_runtime_capability_artifact(&artifact, as_json)
+        }
+        RuntimeCapabilityCommands::Index(options) => {
+            let as_json = options.json;
+            let report = execute_runtime_capability_index_command(options)?;
+            emit_runtime_capability_index_report(&report, as_json)
         }
     }
 }
@@ -256,6 +347,52 @@ pub fn execute_runtime_capability_show_command(
     load_runtime_capability_artifact(Path::new(&options.candidate))
 }
 
+pub fn execute_runtime_capability_index_command(
+    options: RuntimeCapabilityIndexCommandOptions,
+) -> CliResult<RuntimeCapabilityIndexReport> {
+    let root_path = Path::new(&options.root);
+    let root = canonicalize_existing_path(root_path)?;
+    let mut artifacts = Vec::new();
+    collect_runtime_capability_artifacts(root_path, &mut artifacts)?;
+
+    let total_candidate_count = artifacts.len();
+    let mut families_by_id = BTreeMap::<String, Vec<RuntimeCapabilityArtifactDocument>>::new();
+    for artifact in artifacts {
+        let family_id = compute_family_id(&artifact.proposal)?;
+        families_by_id.entry(family_id).or_default().push(artifact);
+    }
+
+    let mut families = Vec::new();
+    for (family_id, mut artifacts) in families_by_id {
+        sort_runtime_capability_artifacts(&mut artifacts);
+        let proposal = artifacts
+            .first()
+            .map(|artifact| artifact.proposal.clone())
+            .ok_or_else(|| "runtime capability family cannot be empty".to_owned())?;
+        let candidate_ids = artifacts
+            .iter()
+            .map(|artifact| artifact.candidate_id.clone())
+            .collect::<Vec<_>>();
+        let evidence = build_family_evidence_digest(&artifacts);
+        let readiness = evaluate_family_readiness(&artifacts, &evidence);
+        families.push(RuntimeCapabilityFamilySummary {
+            family_id,
+            proposal,
+            candidate_ids,
+            evidence,
+            readiness,
+        });
+    }
+
+    Ok(RuntimeCapabilityIndexReport {
+        generated_at: now_rfc3339()?,
+        root,
+        total_candidate_count,
+        family_count: families.len(),
+        families,
+    })
+}
+
 fn emit_runtime_capability_artifact(
     artifact: &RuntimeCapabilityArtifactDocument,
     as_json: bool,
@@ -268,6 +405,22 @@ fn emit_runtime_capability_artifact(
     }
 
     println!("{}", render_runtime_capability_text(artifact));
+    Ok(())
+}
+
+fn emit_runtime_capability_index_report(
+    report: &RuntimeCapabilityIndexReport,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(report).map_err(|error| {
+            format!("serialize runtime capability index report failed: {error}")
+        })?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_capability_index_text(report));
     Ok(())
 }
 
@@ -339,7 +492,374 @@ fn load_runtime_capability_artifact(path: &Path) -> CliResult<RuntimeCapabilityA
             RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION
         ));
     }
+    validate_runtime_capability_artifact_state(&artifact, path)?;
     Ok(artifact)
+}
+
+fn validate_runtime_capability_artifact_state(
+    artifact: &RuntimeCapabilityArtifactDocument,
+    path: &Path,
+) -> CliResult<()> {
+    match artifact.status {
+        RuntimeCapabilityStatus::Proposed => {
+            if artifact.reviewed_at.is_some()
+                || artifact.review.is_some()
+                || artifact.decision != RuntimeCapabilityDecision::Undecided
+            {
+                return Err(format!(
+                    "runtime capability artifact {} has inconsistent proposed state",
+                    path.display()
+                ));
+            }
+        }
+        RuntimeCapabilityStatus::Reviewed => {
+            if artifact.reviewed_at.is_none()
+                || artifact.review.is_none()
+                || artifact.decision == RuntimeCapabilityDecision::Undecided
+            {
+                return Err(format!(
+                    "runtime capability artifact {} has inconsistent reviewed state",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_runtime_capability_artifacts(
+    root: &Path,
+    artifacts: &mut Vec<RuntimeCapabilityArtifactDocument>,
+) -> CliResult<()> {
+    let mut entries = fs::read_dir(root)
+        .map_err(|error| {
+            format!(
+                "read runtime capability index root {} failed: {error}",
+                root.display()
+            )
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            format!(
+                "enumerate runtime capability index root {} failed: {error}",
+                root.display()
+            )
+        })?;
+    entries.sort_by_key(|entry| entry.path());
+
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_runtime_capability_artifacts(&path, artifacts)?;
+            continue;
+        }
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(artifact) = load_supported_runtime_capability_artifact(&path)? else {
+            continue;
+        };
+        artifacts.push(artifact);
+    }
+    Ok(())
+}
+
+fn load_supported_runtime_capability_artifact(
+    path: &Path,
+) -> CliResult<Option<RuntimeCapabilityArtifactDocument>> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read runtime capability index entry {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let value = serde_json::from_str::<serde_json::Value>(&raw).map_err(|error| {
+        format!(
+            "decode runtime capability index entry {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let Some(surface) = value
+        .get("schema")
+        .and_then(|schema| schema.get("surface"))
+        .and_then(serde_json::Value::as_str)
+    else {
+        return Ok(None);
+    };
+    if surface != "runtime_capability" {
+        return Ok(None);
+    }
+    load_runtime_capability_artifact(path).map(Some)
+}
+
+fn sort_runtime_capability_artifacts(artifacts: &mut [RuntimeCapabilityArtifactDocument]) {
+    artifacts.sort_by(|left, right| {
+        left.created_at
+            .cmp(&right.created_at)
+            .then_with(|| left.candidate_id.cmp(&right.candidate_id))
+    });
+}
+
+fn compute_family_id(proposal: &RuntimeCapabilityProposal) -> CliResult<String> {
+    let encoded = serde_json::to_vec(&json!({
+        "target": render_target(proposal.target),
+        "summary": proposal.summary,
+        "bounded_scope": proposal.bounded_scope,
+        "tags": proposal.tags,
+        "required_capabilities": proposal.required_capabilities,
+    }))
+    .map_err(|error| format!("serialize runtime capability family_id input failed: {error}"))?;
+    Ok(format!("{:x}", sha2::Sha256::digest(encoded)))
+}
+
+fn build_family_evidence_digest(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+) -> RuntimeCapabilityEvidenceDigest {
+    let reviewed_candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.status == RuntimeCapabilityStatus::Reviewed)
+        .count();
+    let undecided_candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Undecided)
+        .count();
+    let accepted_candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Accepted)
+        .count();
+    let rejected_candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Rejected)
+        .count();
+    let distinct_source_run_count = artifacts
+        .iter()
+        .map(|artifact| artifact.source_run.run_id.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    let distinct_experiment_count = artifacts
+        .iter()
+        .map(|artifact| artifact.source_run.experiment_id.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    let latest_candidate_at = artifacts
+        .iter()
+        .map(|artifact| artifact.created_at.as_str())
+        .max()
+        .map(str::to_owned);
+    let latest_reviewed_at = artifacts
+        .iter()
+        .filter_map(|artifact| artifact.reviewed_at.as_deref())
+        .max()
+        .map(str::to_owned);
+
+    let mut promoted = 0;
+    let mut rejected = 0;
+    let mut undecided = 0;
+    let mut unique_warnings = BTreeSet::new();
+    let mut metric_bounds = BTreeMap::<String, RuntimeCapabilityMetricRange>::new();
+
+    for artifact in artifacts {
+        match artifact.source_run.decision {
+            RuntimeExperimentDecision::Promoted => promoted += 1,
+            RuntimeExperimentDecision::Rejected => rejected += 1,
+            RuntimeExperimentDecision::Undecided => undecided += 1,
+        }
+
+        if artifact.decision == RuntimeCapabilityDecision::Accepted {
+            for warning in &artifact.source_run.warnings {
+                unique_warnings.insert(warning.clone());
+            }
+        }
+
+        for (metric, value) in &artifact.source_run.metrics {
+            let entry = metric_bounds.entry(metric.clone()).or_insert_with(|| {
+                RuntimeCapabilityMetricRange {
+                    min: *value,
+                    max: *value,
+                }
+            });
+            entry.min = entry.min.min(*value);
+            entry.max = entry.max.max(*value);
+        }
+    }
+
+    RuntimeCapabilityEvidenceDigest {
+        total_candidates: artifacts.len(),
+        reviewed_candidates,
+        undecided_candidates,
+        accepted_candidates,
+        rejected_candidates,
+        distinct_source_run_count,
+        distinct_experiment_count,
+        latest_candidate_at,
+        latest_reviewed_at,
+        source_decisions: RuntimeCapabilitySourceDecisionRollup {
+            promoted,
+            rejected,
+            undecided,
+        },
+        unique_warnings: unique_warnings.into_iter().collect(),
+        metric_ranges: metric_bounds,
+    }
+}
+
+fn evaluate_family_readiness(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadiness {
+    let review_consensus = evaluate_review_consensus(evidence);
+    let stability = evaluate_stability(evidence);
+    let accepted_source_integrity = evaluate_accepted_source_integrity(artifacts, evidence);
+    let warning_pressure = evaluate_warning_pressure(evidence);
+    let checks = vec![
+        review_consensus,
+        stability,
+        accepted_source_integrity,
+        warning_pressure,
+    ];
+    let status = if checks
+        .iter()
+        .any(|check| check.status == RuntimeCapabilityFamilyReadinessCheckStatus::Blocked)
+    {
+        RuntimeCapabilityFamilyReadinessStatus::Blocked
+    } else if checks
+        .iter()
+        .all(|check| check.status == RuntimeCapabilityFamilyReadinessCheckStatus::Pass)
+    {
+        RuntimeCapabilityFamilyReadinessStatus::Ready
+    } else {
+        RuntimeCapabilityFamilyReadinessStatus::NotReady
+    };
+    RuntimeCapabilityFamilyReadiness { status, checks }
+}
+
+fn evaluate_review_consensus(
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    let (status, summary) = if evidence.rejected_candidates > 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Blocked,
+            format!(
+                "{} candidate(s) in this family were explicitly rejected",
+                evidence.rejected_candidates
+            ),
+        )
+    } else if evidence.undecided_candidates > 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            format!(
+                "{} candidate(s) still require operator review",
+                evidence.undecided_candidates
+            ),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            "all candidate evidence is reviewed and accepted".to_owned(),
+        )
+    };
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "review_consensus".to_owned(),
+        status,
+        summary,
+    }
+}
+
+fn evaluate_stability(
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    let (status, summary) = if evidence.distinct_source_run_count >= 2 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            format!(
+                "family is supported by {} distinct source runs",
+                evidence.distinct_source_run_count
+            ),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            "family needs repeated evidence from at least two distinct source runs".to_owned(),
+        )
+    };
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "stability".to_owned(),
+        status,
+        summary,
+    }
+}
+
+fn evaluate_accepted_source_integrity(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    if evidence.accepted_candidates == 0 {
+        return RuntimeCapabilityFamilyReadinessCheck {
+            dimension: "accepted_source_integrity".to_owned(),
+            status: RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            summary: "family has no accepted candidates yet".to_owned(),
+        };
+    }
+
+    let invalid_sources = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Accepted)
+        .filter(|artifact| {
+            artifact.source_run.status != RuntimeExperimentStatus::Completed
+                || artifact.source_run.decision != RuntimeExperimentDecision::Promoted
+                || artifact.source_run.result_snapshot_id.is_none()
+        })
+        .count();
+
+    let (status, summary) = if invalid_sources > 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Blocked,
+            format!(
+                "{} accepted candidate(s) came from incomplete or non-promoted source runs",
+                invalid_sources
+            ),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            "accepted candidates all trace back to completed promoted runs".to_owned(),
+        )
+    };
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "accepted_source_integrity".to_owned(),
+        status,
+        summary,
+    }
+}
+
+fn evaluate_warning_pressure(
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    let (status, summary) = if evidence.accepted_candidates == 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            "warning pressure cannot be evaluated before the family has accepted evidence"
+                .to_owned(),
+        )
+    } else if evidence.unique_warnings.is_empty() {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            "accepted candidates carry no source warnings".to_owned(),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            format!(
+                "accepted evidence still carries warnings: {}",
+                evidence.unique_warnings.join(" | ")
+            ),
+        )
+    };
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "warning_pressure".to_owned(),
+        status,
+        summary,
+    }
 }
 
 fn now_rfc3339() -> CliResult<String> {
@@ -506,6 +1026,66 @@ pub fn render_runtime_capability_text(artifact: &RuntimeCapabilityArtifactDocume
     .join("\n")
 }
 
+pub fn render_runtime_capability_index_text(report: &RuntimeCapabilityIndexReport) -> String {
+    let mut lines = vec![
+        format!("root={}", report.root),
+        format!("family_count={}", report.family_count),
+        format!("total_candidate_count={}", report.total_candidate_count),
+    ];
+
+    for family in &report.families {
+        lines.push(String::new());
+        lines.push(format!("family_id={}", family.family_id));
+        lines.push(format!(
+            "readiness={}",
+            render_family_readiness_status(family.readiness.status)
+        ));
+        lines.push(format!("target={}", render_target(family.proposal.target)));
+        lines.push(format!("target_summary={}", family.proposal.summary));
+        lines.push(format!("bounded_scope={}", family.proposal.bounded_scope));
+        lines.push(format!(
+            "candidate_ids={}",
+            render_string_values(&family.candidate_ids)
+        ));
+        lines.push(format!(
+            "evidence_counts=total:{} reviewed:{} accepted:{} rejected:{} undecided:{}",
+            family.evidence.total_candidates,
+            family.evidence.reviewed_candidates,
+            family.evidence.accepted_candidates,
+            family.evidence.rejected_candidates,
+            family.evidence.undecided_candidates
+        ));
+        lines.push(format!(
+            "distinct_source_runs={}",
+            family.evidence.distinct_source_run_count
+        ));
+        lines.push(format!(
+            "distinct_experiments={}",
+            family.evidence.distinct_experiment_count
+        ));
+        lines.push(format!(
+            "metric_ranges={}",
+            render_metric_ranges(&family.evidence.metric_ranges)
+        ));
+        lines.push(format!(
+            "warnings={}",
+            render_string_values_with_separator(&family.evidence.unique_warnings, " | ")
+        ));
+        lines.push(format!(
+            "checks={}",
+            family
+                .readiness
+                .checks
+                .iter()
+                .map(render_family_readiness_check)
+                .collect::<Vec<_>>()
+                .join(" | ")
+        ));
+    }
+
+    lines.join("\n")
+}
+
 fn render_metrics(metrics: &std::collections::BTreeMap<String, f64>) -> String {
     if metrics.is_empty() {
         "-".to_owned()
@@ -532,6 +1112,27 @@ fn render_string_values_with_separator(values: &[String], separator: &str) -> St
     } else {
         values.join(separator)
     }
+}
+
+fn render_metric_ranges(ranges: &BTreeMap<String, RuntimeCapabilityMetricRange>) -> String {
+    if ranges.is_empty() {
+        "-".to_owned()
+    } else {
+        ranges
+            .iter()
+            .map(|(key, range)| format!("{key}:{}..{}", range.min, range.max))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+fn render_family_readiness_check(check: &RuntimeCapabilityFamilyReadinessCheck) -> String {
+    format!(
+        "{}:{}:{}",
+        check.dimension,
+        render_family_readiness_check_status(check.status),
+        check.summary
+    )
 }
 
 fn render_target(target: RuntimeCapabilityTarget) -> &'static str {
@@ -570,5 +1171,23 @@ fn render_experiment_decision(decision: RuntimeExperimentDecision) -> &'static s
         RuntimeExperimentDecision::Undecided => "undecided",
         RuntimeExperimentDecision::Promoted => "promoted",
         RuntimeExperimentDecision::Rejected => "rejected",
+    }
+}
+
+fn render_family_readiness_status(status: RuntimeCapabilityFamilyReadinessStatus) -> &'static str {
+    match status {
+        RuntimeCapabilityFamilyReadinessStatus::Ready => "ready",
+        RuntimeCapabilityFamilyReadinessStatus::NotReady => "not_ready",
+        RuntimeCapabilityFamilyReadinessStatus::Blocked => "blocked",
+    }
+}
+
+fn render_family_readiness_check_status(
+    status: RuntimeCapabilityFamilyReadinessCheckStatus,
+) -> &'static str {
+    match status {
+        RuntimeCapabilityFamilyReadinessCheckStatus::Pass => "pass",
+        RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence => "needs_evidence",
+        RuntimeCapabilityFamilyReadinessCheckStatus::Blocked => "blocked",
     }
 }

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -28,6 +28,8 @@ pub enum RuntimeCapabilityCommands {
     Show(RuntimeCapabilityShowCommandOptions),
     /// Aggregate candidate artifacts into deterministic capability families and readiness states
     Index(RuntimeCapabilityIndexCommandOptions),
+    /// Derive one dry-run promotion plan from one indexed capability family
+    Plan(RuntimeCapabilityPlanCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -78,6 +80,16 @@ pub struct RuntimeCapabilityShowCommandOptions {
 pub struct RuntimeCapabilityIndexCommandOptions {
     #[arg(long)]
     pub root: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityPlanCommandOptions {
+    #[arg(long)]
+    pub root: String,
+    #[arg(long)]
+    pub family_id: String,
     #[arg(long, default_value_t = false)]
     pub json: bool,
 }
@@ -239,6 +251,44 @@ pub struct RuntimeCapabilityIndexReport {
     pub families: Vec<RuntimeCapabilityFamilySummary>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityPromotionArtifactPlan {
+    pub target_kind: RuntimeCapabilityTarget,
+    pub artifact_kind: String,
+    pub artifact_id: String,
+    pub delivery_surface: String,
+    pub summary: String,
+    pub bounded_scope: String,
+    pub required_capabilities: Vec<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityPromotionProvenance {
+    pub candidate_ids: Vec<String>,
+    pub source_run_ids: Vec<String>,
+    pub experiment_ids: Vec<String>,
+    pub source_run_artifact_paths: Vec<String>,
+    pub latest_candidate_at: Option<String>,
+    pub latest_reviewed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityPromotionPlanReport {
+    pub generated_at: String,
+    pub root: String,
+    pub family_id: String,
+    pub promotable: bool,
+    pub proposal: RuntimeCapabilityProposal,
+    pub evidence: RuntimeCapabilityEvidenceDigest,
+    pub readiness: RuntimeCapabilityFamilyReadiness,
+    pub planned_artifact: RuntimeCapabilityPromotionArtifactPlan,
+    pub blockers: Vec<RuntimeCapabilityFamilyReadinessCheck>,
+    pub approval_checklist: Vec<String>,
+    pub rollback_hints: Vec<String>,
+    pub provenance: RuntimeCapabilityPromotionProvenance,
+}
+
 pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
     match command {
         RuntimeCapabilityCommands::Propose(options) => {
@@ -260,6 +310,11 @@ pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResu
             let as_json = options.json;
             let report = execute_runtime_capability_index_command(options)?;
             emit_runtime_capability_index_report(&report, as_json)
+        }
+        RuntimeCapabilityCommands::Plan(options) => {
+            let as_json = options.json;
+            let report = execute_runtime_capability_plan_command(options)?;
+            emit_runtime_capability_promotion_plan(&report, as_json)
         }
     }
 }
@@ -352,36 +407,14 @@ pub fn execute_runtime_capability_index_command(
 ) -> CliResult<RuntimeCapabilityIndexReport> {
     let root_path = Path::new(&options.root);
     let root = canonicalize_existing_path(root_path)?;
-    let mut artifacts = Vec::new();
-    collect_runtime_capability_artifacts(root_path, &mut artifacts)?;
-
-    let total_candidate_count = artifacts.len();
-    let mut families_by_id = BTreeMap::<String, Vec<RuntimeCapabilityArtifactDocument>>::new();
-    for artifact in artifacts {
-        let family_id = compute_family_id(&artifact.proposal)?;
-        families_by_id.entry(family_id).or_default().push(artifact);
-    }
+    let families_by_id = collect_runtime_capability_family_artifacts(root_path)?;
+    let total_candidate_count = families_by_id.values().map(Vec::len).sum();
 
     let mut families = Vec::new();
-    for (family_id, mut artifacts) in families_by_id {
-        sort_runtime_capability_artifacts(&mut artifacts);
-        let proposal = artifacts
-            .first()
-            .map(|artifact| artifact.proposal.clone())
-            .ok_or_else(|| "runtime capability family cannot be empty".to_owned())?;
-        let candidate_ids = artifacts
-            .iter()
-            .map(|artifact| artifact.candidate_id.clone())
-            .collect::<Vec<_>>();
-        let evidence = build_family_evidence_digest(&artifacts);
-        let readiness = evaluate_family_readiness(&artifacts, &evidence);
-        families.push(RuntimeCapabilityFamilySummary {
-            family_id,
-            proposal,
-            candidate_ids,
-            evidence,
-            readiness,
-        });
+    for (family_id, artifacts) in families_by_id {
+        families.push(build_runtime_capability_family_summary(
+            family_id, artifacts,
+        )?);
     }
 
     Ok(RuntimeCapabilityIndexReport {
@@ -390,6 +423,54 @@ pub fn execute_runtime_capability_index_command(
         total_candidate_count,
         family_count: families.len(),
         families,
+    })
+}
+
+pub fn execute_runtime_capability_plan_command(
+    options: RuntimeCapabilityPlanCommandOptions,
+) -> CliResult<RuntimeCapabilityPromotionPlanReport> {
+    let root_path = Path::new(&options.root);
+    let root = canonicalize_existing_path(root_path)?;
+    let families_by_id = collect_runtime_capability_family_artifacts(root_path)?;
+    let family_artifacts = families_by_id
+        .get(&options.family_id)
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "runtime capability family `{}` not found under {}",
+                options.family_id, root
+            )
+        })?;
+    let family = build_runtime_capability_family_summary(
+        options.family_id.clone(),
+        family_artifacts.clone(),
+    )?;
+    let planned_artifact =
+        build_runtime_capability_promotion_artifact(&family.family_id, &family.proposal);
+    let blockers = family
+        .readiness
+        .checks
+        .iter()
+        .filter(|check| check.status != RuntimeCapabilityFamilyReadinessCheckStatus::Pass)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(RuntimeCapabilityPromotionPlanReport {
+        generated_at: now_rfc3339()?,
+        root,
+        family_id: family.family_id.clone(),
+        promotable: family.readiness.status == RuntimeCapabilityFamilyReadinessStatus::Ready,
+        proposal: family.proposal.clone(),
+        evidence: family.evidence.clone(),
+        readiness: family.readiness.clone(),
+        planned_artifact: planned_artifact.clone(),
+        blockers,
+        approval_checklist: build_runtime_capability_approval_checklist(&planned_artifact),
+        rollback_hints: build_runtime_capability_rollback_hints(&planned_artifact),
+        provenance: build_runtime_capability_promotion_provenance(
+            &family_artifacts,
+            &family.evidence,
+        ),
     })
 }
 
@@ -421,6 +502,22 @@ fn emit_runtime_capability_index_report(
     }
 
     println!("{}", render_runtime_capability_index_text(report));
+    Ok(())
+}
+
+fn emit_runtime_capability_promotion_plan(
+    report: &RuntimeCapabilityPromotionPlanReport,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(report).map_err(|error| {
+            format!("serialize runtime capability promotion plan failed: {error}")
+        })?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_capability_promotion_plan_text(report));
     Ok(())
 }
 
@@ -564,6 +661,20 @@ fn collect_runtime_capability_artifacts(
     Ok(())
 }
 
+fn collect_runtime_capability_family_artifacts(
+    root: &Path,
+) -> CliResult<BTreeMap<String, Vec<RuntimeCapabilityArtifactDocument>>> {
+    let mut artifacts = Vec::new();
+    collect_runtime_capability_artifacts(root, &mut artifacts)?;
+
+    let mut families_by_id = BTreeMap::<String, Vec<RuntimeCapabilityArtifactDocument>>::new();
+    for artifact in artifacts {
+        let family_id = compute_family_id(&artifact.proposal)?;
+        families_by_id.entry(family_id).or_default().push(artifact);
+    }
+    Ok(families_by_id)
+}
+
 fn load_supported_runtime_capability_artifact(
     path: &Path,
 ) -> CliResult<Option<RuntimeCapabilityArtifactDocument>> {
@@ -598,6 +709,31 @@ fn sort_runtime_capability_artifacts(artifacts: &mut [RuntimeCapabilityArtifactD
             .cmp(&right.created_at)
             .then_with(|| left.candidate_id.cmp(&right.candidate_id))
     });
+}
+
+fn build_runtime_capability_family_summary(
+    family_id: String,
+    mut artifacts: Vec<RuntimeCapabilityArtifactDocument>,
+) -> CliResult<RuntimeCapabilityFamilySummary> {
+    sort_runtime_capability_artifacts(&mut artifacts);
+    let proposal = artifacts
+        .first()
+        .map(|artifact| artifact.proposal.clone())
+        .ok_or_else(|| "runtime capability family cannot be empty".to_owned())?;
+    let candidate_ids = artifacts
+        .iter()
+        .map(|artifact| artifact.candidate_id.clone())
+        .collect::<Vec<_>>();
+    let evidence = build_family_evidence_digest(&artifacts);
+    let readiness = evaluate_family_readiness(&artifacts, &evidence);
+
+    Ok(RuntimeCapabilityFamilySummary {
+        family_id,
+        proposal,
+        candidate_ids,
+        evidence,
+        readiness,
+    })
 }
 
 fn compute_family_id(proposal: &RuntimeCapabilityProposal) -> CliResult<String> {
@@ -1189,5 +1325,224 @@ fn render_family_readiness_check_status(
         RuntimeCapabilityFamilyReadinessCheckStatus::Pass => "pass",
         RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence => "needs_evidence",
         RuntimeCapabilityFamilyReadinessCheckStatus::Blocked => "blocked",
+    }
+}
+
+fn build_runtime_capability_promotion_artifact(
+    family_id: &str,
+    proposal: &RuntimeCapabilityProposal,
+) -> RuntimeCapabilityPromotionArtifactPlan {
+    let (artifact_kind, delivery_surface, id_prefix) =
+        runtime_capability_promotion_target_contract(proposal.target);
+    let artifact_id = format!(
+        "{id_prefix}-{}-{}",
+        slugify_runtime_capability_identifier(&proposal.summary),
+        family_id.chars().take(12).collect::<String>()
+    );
+
+    RuntimeCapabilityPromotionArtifactPlan {
+        target_kind: proposal.target,
+        artifact_kind: artifact_kind.to_owned(),
+        artifact_id,
+        delivery_surface: delivery_surface.to_owned(),
+        summary: proposal.summary.clone(),
+        bounded_scope: proposal.bounded_scope.clone(),
+        required_capabilities: proposal.required_capabilities.clone(),
+        tags: proposal.tags.clone(),
+    }
+}
+
+fn runtime_capability_promotion_target_contract(
+    target: RuntimeCapabilityTarget,
+) -> (&'static str, &'static str, &'static str) {
+    match target {
+        RuntimeCapabilityTarget::ManagedSkill => {
+            ("managed_skill_bundle", "managed_skills", "managed-skill")
+        }
+        RuntimeCapabilityTarget::ProgrammaticFlow => (
+            "programmatic_flow_spec",
+            "programmatic_flows",
+            "programmatic-flow",
+        ),
+        RuntimeCapabilityTarget::ProfileNoteAddendum => {
+            ("profile_note_addendum", "profile_note", "profile-note")
+        }
+    }
+}
+
+fn slugify_runtime_capability_identifier(raw: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_dash = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_was_dash = false;
+        } else if !last_was_dash {
+            slug.push('-');
+            last_was_dash = true;
+        }
+    }
+    let trimmed = slug.trim_matches('-').to_owned();
+    if trimmed.is_empty() {
+        "capability".to_owned()
+    } else {
+        trimmed
+    }
+}
+
+fn build_runtime_capability_approval_checklist(
+    planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
+) -> Vec<String> {
+    let mut checklist = vec![
+        "confirm summary and bounded scope still describe exactly one lower-layer artifact"
+            .to_owned(),
+        "confirm required capabilities remain least-privilege for the planned artifact".to_owned(),
+        "confirm provenance references still represent the intended behavior to codify".to_owned(),
+        format!(
+            "confirm the chosen delivery surface `{}` matches the target kind",
+            planned_artifact.delivery_surface
+        ),
+    ];
+    checklist.push(match planned_artifact.target_kind {
+        RuntimeCapabilityTarget::ManagedSkill => {
+            "confirm the behavior belongs in a reusable managed skill".to_owned()
+        }
+        RuntimeCapabilityTarget::ProgrammaticFlow => {
+            "confirm the behavior can be expressed as a deterministic programmatic flow".to_owned()
+        }
+        RuntimeCapabilityTarget::ProfileNoteAddendum => {
+            "confirm the behavior belongs in advisory profile guidance rather than executable logic"
+                .to_owned()
+        }
+    });
+    checklist
+}
+
+fn build_runtime_capability_rollback_hints(
+    planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
+) -> Vec<String> {
+    vec![
+        format!(
+            "capture the current `{}` state before applying artifact `{}`",
+            planned_artifact.delivery_surface, planned_artifact.artifact_id
+        ),
+        format!(
+            "remove or revert `{}` from `{}` if downstream validation fails",
+            planned_artifact.artifact_id, planned_artifact.delivery_surface
+        ),
+        "keep candidate ids and source-run references attached to the rollback record".to_owned(),
+    ]
+}
+
+fn build_runtime_capability_promotion_provenance(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityPromotionProvenance {
+    RuntimeCapabilityPromotionProvenance {
+        candidate_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.candidate_id.clone())
+            .collect(),
+        source_run_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.source_run.run_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        experiment_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.source_run.experiment_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        source_run_artifact_paths: artifacts
+            .iter()
+            .filter_map(|artifact| artifact.source_run.artifact_path.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        latest_candidate_at: evidence.latest_candidate_at.clone(),
+        latest_reviewed_at: evidence.latest_reviewed_at.clone(),
+    }
+}
+
+pub fn render_runtime_capability_promotion_plan_text(
+    report: &RuntimeCapabilityPromotionPlanReport,
+) -> String {
+    [
+        format!("family_id={}", report.family_id),
+        format!("promotable={}", report.promotable),
+        format!(
+            "readiness={}",
+            render_family_readiness_status(report.readiness.status)
+        ),
+        format!(
+            "target={}",
+            render_target(report.planned_artifact.target_kind)
+        ),
+        format!("artifact_kind={}", report.planned_artifact.artifact_kind),
+        format!("artifact_id={}", report.planned_artifact.artifact_id),
+        format!(
+            "delivery_surface={}",
+            report.planned_artifact.delivery_surface
+        ),
+        format!("target_summary={}", report.planned_artifact.summary),
+        format!("bounded_scope={}", report.planned_artifact.bounded_scope),
+        format!(
+            "required_capabilities={}",
+            render_string_values(&report.planned_artifact.required_capabilities)
+        ),
+        format!(
+            "tags={}",
+            render_string_values(&report.planned_artifact.tags)
+        ),
+        format!(
+            "blockers={}",
+            render_family_readiness_checks(&report.blockers)
+        ),
+        format!(
+            "checks={}",
+            render_family_readiness_checks(&report.readiness.checks)
+        ),
+        format!(
+            "approval_checklist={}",
+            render_string_values_with_separator(&report.approval_checklist, " | ")
+        ),
+        format!(
+            "rollback_hints={}",
+            render_string_values_with_separator(&report.rollback_hints, " | ")
+        ),
+        format!(
+            "provenance_candidate_ids={}",
+            render_string_values(&report.provenance.candidate_ids)
+        ),
+        format!(
+            "provenance_source_run_ids={}",
+            render_string_values(&report.provenance.source_run_ids)
+        ),
+        format!(
+            "provenance_experiment_ids={}",
+            render_string_values(&report.provenance.experiment_ids)
+        ),
+        format!(
+            "provenance_source_run_artifact_paths={}",
+            render_string_values_with_separator(
+                &report.provenance.source_run_artifact_paths,
+                " | "
+            )
+        ),
+    ]
+    .join("\n")
+}
+
+fn render_family_readiness_checks(checks: &[RuntimeCapabilityFamilyReadinessCheck]) -> String {
+    if checks.is_empty() {
+        "-".to_owned()
+    } else {
+        checks
+            .iter()
+            .map(render_family_readiness_check)
+            .collect::<Vec<_>>()
+            .join(" | ")
     }
 }

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -17,6 +17,8 @@ use std::{
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 pub const RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
+pub const RUNTIME_CAPABILITY_ARTIFACT_SURFACE: &str = "runtime_capability";
+pub const RUNTIME_CAPABILITY_ARTIFACT_PURPOSE: &str = "promotion_candidate_record";
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeCapabilityCommands {
@@ -348,8 +350,8 @@ pub fn execute_runtime_capability_propose_command(
     let artifact = RuntimeCapabilityArtifactDocument {
         schema: RuntimeCapabilityArtifactSchema {
             version: RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION,
-            surface: "runtime_capability".to_owned(),
-            purpose: "promotion_candidate_record".to_owned(),
+            surface: RUNTIME_CAPABILITY_ARTIFACT_SURFACE.to_owned(),
+            purpose: RUNTIME_CAPABILITY_ARTIFACT_PURPOSE.to_owned(),
         },
         candidate_id,
         created_at,
@@ -589,8 +591,32 @@ fn load_runtime_capability_artifact(path: &Path) -> CliResult<RuntimeCapabilityA
             RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION
         ));
     }
+    validate_runtime_capability_artifact_schema(&artifact, path)?;
     validate_runtime_capability_artifact_state(&artifact, path)?;
     Ok(artifact)
+}
+
+fn validate_runtime_capability_artifact_schema(
+    artifact: &RuntimeCapabilityArtifactDocument,
+    path: &Path,
+) -> CliResult<()> {
+    if artifact.schema.surface != RUNTIME_CAPABILITY_ARTIFACT_SURFACE {
+        return Err(format!(
+            "runtime capability artifact {} uses unsupported schema surface {}; expected {}",
+            path.display(),
+            artifact.schema.surface,
+            RUNTIME_CAPABILITY_ARTIFACT_SURFACE
+        ));
+    }
+    if artifact.schema.purpose != RUNTIME_CAPABILITY_ARTIFACT_PURPOSE {
+        return Err(format!(
+            "runtime capability artifact {} uses unsupported schema purpose {}; expected {}",
+            path.display(),
+            artifact.schema.purpose,
+            RUNTIME_CAPABILITY_ARTIFACT_PURPOSE
+        ));
+    }
+    Ok(())
 }
 
 fn validate_runtime_capability_artifact_state(
@@ -706,7 +732,7 @@ fn load_supported_runtime_capability_artifact(
     else {
         return Ok(None);
     };
-    if surface != "runtime_capability" {
+    if surface != RUNTIME_CAPABILITY_ARTIFACT_SURFACE {
         return Ok(None);
     }
     load_runtime_capability_artifact(path).map(Some)

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1438,24 +1438,27 @@ fn build_runtime_capability_promotion_provenance(
     artifacts: &[RuntimeCapabilityArtifactDocument],
     evidence: &RuntimeCapabilityEvidenceDigest,
 ) -> RuntimeCapabilityPromotionProvenance {
+    let mut ordered_artifacts = artifacts.to_vec();
+    sort_runtime_capability_artifacts(&mut ordered_artifacts);
+
     RuntimeCapabilityPromotionProvenance {
-        candidate_ids: artifacts
+        candidate_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.candidate_id.clone())
             .collect(),
-        source_run_ids: artifacts
+        source_run_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.source_run.run_id.clone())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect(),
-        experiment_ids: artifacts
+        experiment_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.source_run.experiment_id.clone())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect(),
-        source_run_artifact_paths: artifacts
+        source_run_artifact_paths: ordered_artifacts
             .iter()
             .filter_map(|artifact| artifact.source_run.artifact_path.clone())
             .collect::<BTreeSet<_>>()

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -646,7 +646,16 @@ fn collect_runtime_capability_artifacts(
 
     for entry in entries {
         let path = entry.path();
-        if path.is_dir() {
+        let entry_type = entry.file_type().map_err(|error| {
+            format!(
+                "inspect runtime capability index entry {} failed: {error}",
+                path.display()
+            )
+        })?;
+        if entry_type.is_symlink() {
+            continue;
+        }
+        if entry_type.is_dir() {
             collect_runtime_capability_artifacts(&path, artifacts)?;
             continue;
         }
@@ -737,12 +746,14 @@ fn build_runtime_capability_family_summary(
 }
 
 fn compute_family_id(proposal: &RuntimeCapabilityProposal) -> CliResult<String> {
+    let tags = normalize_repeated_values(&proposal.tags);
+    let required_capabilities = parse_required_capabilities(&proposal.required_capabilities)?;
     let encoded = serde_json::to_vec(&json!({
         "target": render_target(proposal.target),
-        "summary": proposal.summary,
-        "bounded_scope": proposal.bounded_scope,
-        "tags": proposal.tags,
-        "required_capabilities": proposal.required_capabilities,
+        "summary": proposal.summary.trim(),
+        "bounded_scope": proposal.bounded_scope.trim(),
+        "tags": tags,
+        "required_capabilities": required_capabilities,
     }))
     .map_err(|error| format!("serialize runtime capability family_id input failed: {error}"))?;
     Ok(format!("{:x}", sha2::Sha256::digest(encoded)))

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -584,7 +584,7 @@ fn runtime_experiment_cli_rejects_compare_recorded_snapshots_with_manual_paths()
 }
 
 #[test]
-fn runtime_capability_cli_parses_propose_review_and_show() {
+fn runtime_capability_cli_parses_propose_review_show_and_index() {
     let propose = Cli::try_parse_from([
         "loongclaw",
         "runtime-capability",
@@ -649,7 +649,8 @@ fn runtime_capability_cli_parses_propose_review_and_show() {
             other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
                 _,
             )
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -695,7 +696,8 @@ fn runtime_capability_cli_parses_propose_review_and_show() {
             other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
                 _,
             )
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -723,7 +725,35 @@ fn runtime_capability_cli_parses_propose_review_and_show() {
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
                 _,
-            )) => {
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let index = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "index",
+        "--root",
+        "/tmp/runtime-capability",
+        "--json",
+    ])
+    .expect("`runtime-capability index` should parse");
+
+    match index.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(options) => {
+                assert_eq!(options.root, "/tmp/runtime-capability");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -584,7 +584,7 @@ fn runtime_experiment_cli_rejects_compare_recorded_snapshots_with_manual_paths()
 }
 
 #[test]
-fn runtime_capability_cli_parses_propose_review_show_and_index() {
+fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
     let propose = Cli::try_parse_from([
         "loongclaw",
         "runtime-capability",
@@ -650,7 +650,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -697,7 +698,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -726,7 +728,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
                 _,
             )
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -753,7 +756,39 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let plan = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "plan",
+        "--root",
+        "/tmp/runtime-capability",
+        "--family-id",
+        "family-123",
+        "--json",
+    ])
+    .expect("`runtime-capability plan` should parse");
+
+    match plan.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(options) => {
+                assert_eq!(options.root, "/tmp/runtime-capability");
+                assert_eq!(options.family_id, "family-123");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -257,25 +257,47 @@ fn propose_runtime_capability_variant(
     loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument,
 ) {
     let candidate_path = root.join(format!("artifacts/runtime-capability-{slug}.json"));
-    let candidate =
-        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
-            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
-                run: run_path.display().to_string(),
-                output: candidate_path.display().to_string(),
-                target:
-                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
-                target_summary: "Codify browser preview onboarding as a reusable managed skill"
-                    .to_owned(),
-                bounded_scope: "Browser preview onboarding and companion readiness checks only"
-                    .to_owned(),
-                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
-                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
-                label: Some(format!("browser-preview-skill-candidate-{slug}")),
-                json: false,
-            },
-        )
-        .expect("runtime capability propose should succeed");
+    let candidate = propose_runtime_capability_variant_with_target(
+        root,
+        run_path,
+        slug,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
     (candidate_path, candidate)
+}
+
+fn propose_runtime_capability_variant_with_target(
+    root: &Path,
+    run_path: &Path,
+    slug: &str,
+    target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget,
+    target_summary: &str,
+    bounded_scope: &str,
+    required_capabilities: &[&str],
+    tags: &[&str],
+) -> loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument {
+    let candidate_path = root.join(format!("artifacts/runtime-capability-{slug}.json"));
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target,
+            target_summary: target_summary.to_owned(),
+            bounded_scope: bounded_scope.to_owned(),
+            required_capability: required_capabilities
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            tag: tags.iter().map(|value| (*value).to_owned()).collect(),
+            label: Some(format!("runtime-capability-{slug}")),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed")
 }
 
 fn review_runtime_capability_variant(
@@ -774,6 +796,360 @@ fn runtime_capability_index_marks_family_blocked_on_conflicting_reviews() {
                     == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Blocked
         }),
         "review consensus should block mixed accepted/rejected evidence"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-ready");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "ready-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "ready-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path = root.join("artifacts/runtime-capability-ready-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-ready-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "ready-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "ready-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "ready-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "ready-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(plan.promotable, "ready family should be promotable");
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Ready
+    );
+    assert_eq!(plan.planned_artifact.artifact_kind, "managed_skill_bundle");
+    assert_eq!(plan.planned_artifact.delivery_surface, "managed_skills");
+    assert!(
+        plan.planned_artifact
+            .artifact_id
+            .starts_with("managed-skill-"),
+        "artifact id should carry a managed-skill prefix"
+    );
+    assert!(
+        plan.planned_artifact
+            .artifact_id
+            .ends_with(&family.family_id[..12]),
+        "artifact id should be family-derived"
+    );
+    assert!(
+        plan.blockers.is_empty(),
+        "ready family should have no blockers"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("managed skill")),
+        "checklist should include the target-specific managed skill review item"
+    );
+    assert!(
+        plan.rollback_hints
+            .iter()
+            .any(|hint| hint.contains("managed_skills")),
+        "rollback hints should mention the managed skill delivery surface"
+    );
+    assert_eq!(plan.provenance.candidate_ids.len(), 2);
+    assert_eq!(plan.provenance.source_run_ids.len(), 2);
+    assert!(
+        plan.provenance.source_run_artifact_paths.contains(
+            &fs::canonicalize(&run_a_path)
+                .expect("canonicalize run a path")
+                .display()
+                .to_string()
+        )
+    );
+    assert!(
+        plan.provenance.source_run_artifact_paths.contains(
+            &fs::canonicalize(&run_b_path)
+                .expect("canonicalize run b path")
+                .display()
+                .to_string()
+        )
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_reports_missing_evidence_for_programmatic_flow_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-not-ready");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "flow",
+        -0.2,
+        &["manual verification only"],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_path = root.join("artifacts/runtime-capability-flow.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_path,
+        "flow",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProgrammaticFlow,
+        "Codify runtime compare summarization as a reusable flow",
+        "Runtime experiment compare report generation only",
+        &["invoke_tool", "memory_read"],
+        &["runtime", "compare"],
+    );
+    review_runtime_capability_variant(
+        &candidate_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "flow",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(
+        !plan.promotable,
+        "not-ready family should not be promotable"
+    );
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::NotReady
+    );
+    assert_eq!(
+        plan.planned_artifact.artifact_kind,
+        "programmatic_flow_spec"
+    );
+    assert_eq!(plan.planned_artifact.delivery_surface, "programmatic_flows");
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "stability"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "stability should surface as a missing-evidence blocker"
+    );
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "warning_pressure"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "warnings should surface as missing-evidence blockers"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("programmatic flow")),
+        "checklist should include the target-specific programmatic flow review item"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_reports_blocked_profile_note_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-blocked");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "note-a",
+        -0.1,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "note-b",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_a_path = root.join("artifacts/runtime-capability-note-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-note-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "note-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProfileNoteAddendum,
+        "Record browser preview operator guidance in profile memory",
+        "Browser preview operator guidance only",
+        &["memory_write"],
+        &["profile", "guidance"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "note-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProfileNoteAddendum,
+        "Record browser preview operator guidance in profile memory",
+        "Browser preview operator guidance only",
+        &["memory_write"],
+        &["profile", "guidance"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "note-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
+        "note-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(!plan.promotable, "blocked family should not be promotable");
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Blocked
+    );
+    assert_eq!(plan.planned_artifact.artifact_kind, "profile_note_addendum");
+    assert_eq!(plan.planned_artifact.delivery_surface, "profile_note");
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "review_consensus"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Blocked
+        }),
+        "blocked review consensus should surface as a hard-stop blocker"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("advisory profile guidance")),
+        "checklist should include the target-specific profile-note review item"
+    );
+    assert!(
+        plan.rollback_hints
+            .iter()
+            .any(|hint| hint.contains("profile_note")),
+        "rollback hints should mention the profile note delivery surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_rejects_unknown_family_id() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-missing-family");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    propose_runtime_capability_variant(&root, &run_path, "missing");
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: "missing-family".to_owned(),
+            json: false,
+        },
+    )
+    .expect_err("unknown family id should be rejected");
+
+    assert!(
+        error.contains("missing-family"),
+        "error should name the requested family id: {error}"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -396,6 +396,25 @@ fn rewrite_runtime_capability_proposal(
     .expect("persist runtime capability artifact");
 }
 
+fn rewrite_runtime_capability_schema(candidate_path: &Path, surface: &str, purpose: &str) {
+    let mut payload = serde_json::from_str::<Value>(
+        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
+    )
+    .expect("decode runtime capability artifact");
+    let schema = payload
+        .as_object_mut()
+        .and_then(|artifact| artifact.get_mut("schema"))
+        .and_then(Value::as_object_mut)
+        .expect("runtime capability artifact should include schema");
+    schema.insert("surface".to_owned(), Value::String(surface.to_owned()));
+    schema.insert("purpose".to_owned(), Value::String(purpose.to_owned()));
+    fs::write(
+        candidate_path,
+        serde_json::to_string_pretty(&payload).expect("encode runtime capability artifact"),
+    )
+    .expect("persist runtime capability artifact");
+}
+
 fn try_symlink_dir(original: &Path, link: &Path) -> bool {
     #[cfg(unix)]
     {
@@ -678,6 +697,97 @@ fn runtime_capability_show_rejects_inconsistent_review_state() {
     .expect_err("inconsistent review state should be rejected");
 
     assert!(error.contains("inconsistent"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_show_rejects_wrong_schema_purpose() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show-wrong-purpose");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+            target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                .to_owned(),
+            bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                .to_owned(),
+            required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+            tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+            label: Some("browser-preview-invalid-schema".to_owned()),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed");
+
+    rewrite_runtime_capability_schema(
+        &candidate_path,
+        "runtime_capability",
+        "promotion_plan_record",
+    );
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect_err("wrong-purpose artifacts should be rejected");
+
+    assert!(error.contains("unsupported schema"), "error: {error}");
+    assert!(error.contains("promotion_plan_record"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_show_rejects_wrong_schema_surface() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show-wrong-surface");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+            target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                .to_owned(),
+            bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                .to_owned(),
+            required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+            tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+            label: Some("browser-preview-invalid-schema".to_owned()),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed");
+
+    rewrite_runtime_capability_schema(
+        &candidate_path,
+        "runtime_capability_preview",
+        "promotion_candidate_record",
+    );
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect_err("wrong-surface artifacts should be rejected");
+
+    assert!(error.contains("unsupported schema"), "error: {error}");
+    assert!(
+        error.contains("runtime_capability_preview"),
+        "error: {error}"
+    );
 
     fs::remove_dir_all(&root).ok();
 }
@@ -1074,6 +1184,66 @@ fn runtime_capability_index_rejects_malformed_supported_artifact_during_scan() {
     assert!(
         error.contains("inconsistent reviewed state"),
         "error should surface the invalid review state: {error}"
+    );
+    assert!(
+        error.contains(&invalid_candidate_path.display().to_string()),
+        "error should identify the malformed artifact path: {error}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_rejects_wrong_schema_purpose_during_scan() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-wrong-purpose");
+    let config_path = write_runtime_capability_config(&root);
+    let (valid_run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "valid",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (invalid_run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "invalid",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (valid_candidate_path, _) =
+        propose_runtime_capability_variant(&root, &valid_run_path, "valid");
+    review_runtime_capability_variant(
+        &valid_candidate_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "valid",
+    );
+    let (invalid_candidate_path, _) =
+        propose_runtime_capability_variant(&root, &invalid_run_path, "invalid");
+    rewrite_runtime_capability_schema(
+        &invalid_candidate_path,
+        "runtime_capability",
+        "promotion_plan_record",
+    );
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            json: false,
+        },
+    )
+    .expect_err("wrong-purpose supported artifacts should abort index scans");
+
+    assert!(
+        error.contains("unsupported schema purpose"),
+        "error should surface the invalid schema purpose: {error}"
+    );
+    assert!(
+        error.contains("promotion_plan_record"),
+        "error should surface the invalid purpose value: {error}"
     );
     assert!(
         error.contains(&invalid_candidate_path.display().to_string()),

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -317,6 +317,23 @@ fn review_runtime_capability_variant(
     .expect("runtime capability review should succeed")
 }
 
+fn rewrite_runtime_capability_created_at(candidate_path: &Path, created_at: &str) {
+    let mut payload = serde_json::from_str::<Value>(
+        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
+    )
+    .expect("decode runtime capability artifact");
+    let created_at_value = payload
+        .as_object_mut()
+        .and_then(|artifact| artifact.get_mut("created_at"))
+        .expect("runtime capability artifact should include created_at");
+    *created_at_value = Value::String(created_at.to_owned());
+    fs::write(
+        candidate_path,
+        serde_json::to_string_pretty(&payload).expect("encode runtime capability artifact"),
+    )
+    .expect("rewrite runtime capability artifact");
+}
+
 #[test]
 fn runtime_capability_propose_persists_candidate_from_finished_run() {
     let root = unique_temp_dir("loongclaw-runtime-capability-propose");
@@ -1126,6 +1143,95 @@ fn runtime_capability_plan_reports_blocked_profile_note_family() {
             .iter()
             .any(|hint| hint.contains("profile_note")),
         "rollback hints should mention the profile note delivery surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_provenance_candidate_ids_follow_family_order() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-provenance-order");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_z_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "z-run",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "a-run",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_z_path = root.join("artifacts/runtime-capability-zzz-first.json");
+    let candidate_a_path = root.join("artifacts/runtime-capability-aaa-second.json");
+    let candidate_z = propose_runtime_capability_variant_with_target(
+        &root,
+        &run_z_path,
+        "zzz-first",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    let candidate_a = propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "aaa-second",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    rewrite_runtime_capability_created_at(&candidate_z_path, "2026-03-18T08:00:00Z");
+    rewrite_runtime_capability_created_at(&candidate_a_path, "2026-03-18T08:00:01Z");
+    review_runtime_capability_variant(
+        &candidate_z_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "zzz-first",
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "aaa-second",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert_eq!(
+        family.candidate_ids,
+        vec![candidate_z.candidate_id, candidate_a.candidate_id],
+        "family summary should use semantic candidate order"
+    );
+    assert_eq!(
+        plan.provenance.candidate_ids, family.candidate_ids,
+        "planner provenance should preserve the family candidate order"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -334,6 +334,19 @@ fn rewrite_runtime_capability_created_at(candidate_path: &Path, created_at: &str
     .expect("rewrite runtime capability artifact");
 }
 
+fn make_runtime_capability_review_state_inconsistent(candidate_path: &Path) {
+    let mut payload = serde_json::from_str::<Value>(
+        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
+    )
+    .expect("decode runtime capability artifact");
+    payload["status"] = Value::String("reviewed".to_owned());
+    fs::write(
+        candidate_path,
+        serde_json::to_string_pretty(&payload).expect("encode malformed capability candidate"),
+    )
+    .expect("persist malformed capability candidate");
+}
+
 #[test]
 fn runtime_capability_propose_persists_candidate_from_finished_run() {
     let root = unique_temp_dir("loongclaw-runtime-capability-propose");
@@ -589,16 +602,7 @@ fn runtime_capability_show_rejects_inconsistent_review_state() {
     )
     .expect("runtime capability propose should succeed");
 
-    let mut raw = serde_json::from_str::<Value>(
-        &fs::read_to_string(&candidate_path).expect("read persisted capability candidate"),
-    )
-    .expect("decode persisted capability candidate");
-    raw["status"] = Value::String("reviewed".to_owned());
-    fs::write(
-        &candidate_path,
-        serde_json::to_string_pretty(&raw).expect("encode malformed capability candidate"),
-    )
-    .expect("persist malformed capability candidate");
+    make_runtime_capability_review_state_inconsistent(&candidate_path);
 
     let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
         loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
@@ -819,6 +823,58 @@ fn runtime_capability_index_marks_family_blocked_on_conflicting_reviews() {
 }
 
 #[test]
+fn runtime_capability_index_rejects_malformed_supported_artifact_during_scan() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-malformed");
+    let config_path = write_runtime_capability_config(&root);
+    let (valid_run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "valid",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (invalid_run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "invalid",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (valid_candidate_path, _) =
+        propose_runtime_capability_variant(&root, &valid_run_path, "valid");
+    review_runtime_capability_variant(
+        &valid_candidate_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "valid",
+    );
+    let (invalid_candidate_path, _) =
+        propose_runtime_capability_variant(&root, &invalid_run_path, "invalid");
+    make_runtime_capability_review_state_inconsistent(&invalid_candidate_path);
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            json: false,
+        },
+    )
+    .expect_err("malformed supported artifacts should abort index scans");
+
+    assert!(
+        error.contains("inconsistent reviewed state"),
+        "error should surface the invalid review state: {error}"
+    );
+    assert!(
+        error.contains(&invalid_candidate_path.display().to_string()),
+        "error should identify the malformed artifact path: {error}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
     let root = unique_temp_dir("loongclaw-runtime-capability-plan-ready");
     let config_path = write_runtime_capability_config(&root);
@@ -947,6 +1003,87 @@ fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
                 .display()
                 .to_string()
         )
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_rejects_malformed_supported_artifact_during_scan() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-malformed");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "ready-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "ready-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_bad_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "bad",
+        -0.1,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) = propose_runtime_capability_variant(&root, &run_a_path, "ready-a");
+    let (candidate_b_path, _) = propose_runtime_capability_variant(&root, &run_b_path, "ready-b");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "ready-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "ready-b",
+    );
+
+    let family_id =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("index should succeed before introducing malformed artifacts")
+        .families
+        .first()
+        .expect("one capability family should be reported")
+        .family_id
+        .clone();
+
+    let (invalid_candidate_path, _) =
+        propose_runtime_capability_variant(&root, &run_bad_path, "bad");
+    make_runtime_capability_review_state_inconsistent(&invalid_candidate_path);
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id,
+            json: false,
+        },
+    )
+    .expect_err("malformed supported artifacts should abort plan scans");
+
+    assert!(
+        error.contains("inconsistent reviewed state"),
+        "error should surface the invalid review state: {error}"
+    );
+    assert!(
+        error.contains(&invalid_candidate_path.display().to_string()),
+        "error should identify the malformed artifact path: {error}"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -118,6 +118,30 @@ fn start_runtime_experiment(
     (run_path, run)
 }
 
+fn start_runtime_experiment_variant(
+    root: &Path,
+    snapshot_path: &Path,
+    slug: &str,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let run_path = root.join(format!("artifacts/runtime-experiment-{slug}.json"));
+    let run = loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_start_command(
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStartCommandOptions {
+            snapshot: snapshot_path.display().to_string(),
+            output: run_path.display().to_string(),
+            mutation_summary: format!("enable browser preview skill ({slug})"),
+            experiment_id: Some("exp-42".to_owned()),
+            label: Some(format!("browser-preview-{slug}")),
+            tag: vec!["browser".to_owned(), slug.to_owned()],
+            json: false,
+        },
+    )
+    .expect("runtime experiment start should succeed");
+    (run_path, run)
+}
+
 fn finish_runtime_experiment(
     root: &Path,
     config_path: &Path,
@@ -165,6 +189,110 @@ fn finish_runtime_experiment(
         )
         .expect("runtime experiment finish should succeed");
     (run_path, finished)
+}
+
+fn finish_runtime_experiment_variant(
+    root: &Path,
+    config_path: &Path,
+    slug: &str,
+    cost_delta: f64,
+    warnings: &[&str],
+    decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        &format!("artifacts/runtime-snapshot-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some(format!("baseline-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment_variant(root, &baseline_snapshot_path, slug);
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        &format!("artifacts/runtime-snapshot-result-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some(format!("candidate-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: format!("provider and tool policy updated ({slug})"),
+                metric: vec![
+                    "task_success=1".to_owned(),
+                    format!("cost_delta={cost_delta}"),
+                ],
+                warning: warnings.iter().map(|warning| (*warning).to_owned()).collect(),
+                decision,
+                status:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+    (run_path, finished)
+}
+
+fn propose_runtime_capability_variant(
+    root: &Path,
+    run_path: &Path,
+    slug: &str,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument,
+) {
+    let candidate_path = root.join(format!("artifacts/runtime-capability-{slug}.json"));
+    let candidate =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: Some(format!("browser-preview-skill-candidate-{slug}")),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+    (candidate_path, candidate)
+}
+
+fn review_runtime_capability_variant(
+    candidate_path: &Path,
+    decision: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision,
+    slug: &str,
+) -> loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument {
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_review_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            decision,
+            review_summary: format!("reviewed runtime capability candidate {slug}"),
+            warning: Vec::new(),
+            json: false,
+        },
+    )
+    .expect("runtime capability review should succeed")
 }
 
 #[test]
@@ -394,6 +522,259 @@ fn runtime_capability_show_round_trips_the_persisted_artifact() {
     .expect("show should round-trip the persisted artifact");
 
     assert_eq!(shown, proposed);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_show_rejects_inconsistent_review_state() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show-invalid-state");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+            target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                .to_owned(),
+            bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                .to_owned(),
+            required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+            tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+            label: Some("browser-preview-invalid-state".to_owned()),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed");
+
+    let mut raw = serde_json::from_str::<Value>(
+        &fs::read_to_string(&candidate_path).expect("read persisted capability candidate"),
+    )
+    .expect("decode persisted capability candidate");
+    raw["status"] = Value::String("reviewed".to_owned());
+    fs::write(
+        &candidate_path,
+        serde_json::to_string_pretty(&raw).expect("encode malformed capability candidate"),
+    )
+    .expect("persist malformed capability candidate");
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect_err("inconsistent review state should be rejected");
+
+    assert!(error.contains("inconsistent"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_groups_related_candidates_and_reports_ready_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-ready");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) = propose_runtime_capability_variant(&root, &run_a_path, "a");
+    let (candidate_b_path, _) = propose_runtime_capability_variant(&root, &run_b_path, "b");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "b",
+    );
+
+    fs::write(
+        root.join("artifacts/ignore-me.json"),
+        "{\"hello\":\"world\"}",
+    )
+    .expect("write unrelated json fixture");
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+
+    assert_eq!(report.total_candidate_count, 2);
+    assert_eq!(report.family_count, 1);
+
+    let family = report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    assert_eq!(
+        family.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Ready
+    );
+    assert_eq!(family.evidence.total_candidates, 2);
+    assert_eq!(family.evidence.accepted_candidates, 2);
+    assert_eq!(family.evidence.distinct_source_run_count, 2);
+    assert_eq!(
+        family
+            .evidence
+            .metric_ranges
+            .get("cost_delta")
+            .expect("cost delta range should exist")
+            .min,
+        -0.4
+    );
+    assert_eq!(
+        family
+            .evidence
+            .metric_ranges
+            .get("cost_delta")
+            .expect("cost delta range should exist")
+            .max,
+        -0.2
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_marks_family_not_ready_when_evidence_is_incomplete() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-not-ready");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "solo",
+        -0.2,
+        &["manual verification only"],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (candidate_path, _) = propose_runtime_capability_variant(&root, &run_path, "solo");
+    review_runtime_capability_variant(
+        &candidate_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "solo",
+    );
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+
+    let family = report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    assert_eq!(
+        family.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::NotReady
+    );
+    assert!(
+        family.readiness.checks.iter().any(|check| {
+            check.dimension == "stability"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "stability should require repeated evidence"
+    );
+    assert!(
+        family.readiness.checks.iter().any(|check| {
+            check.dimension == "warning_pressure"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "warnings should keep the family out of ready state"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_marks_family_blocked_on_conflicting_reviews() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-blocked");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "accept",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "reject",
+        -0.1,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) = propose_runtime_capability_variant(&root, &run_a_path, "accept");
+    let (candidate_b_path, _) = propose_runtime_capability_variant(&root, &run_b_path, "reject");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "accept",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
+        "reject",
+    );
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+
+    let family = report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    assert_eq!(
+        family.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Blocked
+    );
+    assert!(
+        family.readiness.checks.iter().any(|check| {
+            check.dimension == "review_consensus"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Blocked
+        }),
+        "review consensus should block mixed accepted/rejected evidence"
+    );
 
     fs::remove_dir_all(&root).ok();
 }

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -339,7 +339,11 @@ fn make_runtime_capability_review_state_inconsistent(candidate_path: &Path) {
         &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
     )
     .expect("decode runtime capability artifact");
-    payload["status"] = Value::String("reviewed".to_owned());
+    let status = payload
+        .as_object_mut()
+        .and_then(|artifact| artifact.get_mut("status"))
+        .expect("runtime capability artifact should include status");
+    *status = Value::String("reviewed".to_owned());
     fs::write(
         candidate_path,
         serde_json::to_string_pretty(&payload).expect("encode malformed capability candidate"),

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -351,6 +351,67 @@ fn make_runtime_capability_review_state_inconsistent(candidate_path: &Path) {
     .expect("persist malformed capability candidate");
 }
 
+fn rewrite_runtime_capability_proposal(
+    candidate_path: &Path,
+    summary: &str,
+    bounded_scope: &str,
+    required_capabilities: &[&str],
+    tags: &[&str],
+) {
+    let mut payload = serde_json::from_str::<Value>(
+        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
+    )
+    .expect("decode runtime capability artifact");
+    let proposal = payload
+        .as_object_mut()
+        .and_then(|artifact| artifact.get_mut("proposal"))
+        .and_then(Value::as_object_mut)
+        .expect("runtime capability artifact should include proposal");
+    proposal.insert("summary".to_owned(), Value::String(summary.to_owned()));
+    proposal.insert(
+        "bounded_scope".to_owned(),
+        Value::String(bounded_scope.to_owned()),
+    );
+    proposal.insert(
+        "required_capabilities".to_owned(),
+        Value::Array(
+            required_capabilities
+                .iter()
+                .map(|value| Value::String((*value).to_owned()))
+                .collect(),
+        ),
+    );
+    proposal.insert(
+        "tags".to_owned(),
+        Value::Array(
+            tags.iter()
+                .map(|value| Value::String((*value).to_owned()))
+                .collect(),
+        ),
+    );
+    fs::write(
+        candidate_path,
+        serde_json::to_string_pretty(&payload).expect("encode runtime capability artifact"),
+    )
+    .expect("persist runtime capability artifact");
+}
+
+fn try_symlink_dir(original: &Path, link: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(original, link).is_ok()
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(original, link).is_ok()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (original, link);
+        false
+    }
+}
+
 #[test]
 fn runtime_capability_propose_persists_candidate_from_finished_run() {
     let root = unique_temp_dir("loongclaw-runtime-capability-propose");
@@ -702,6 +763,150 @@ fn runtime_capability_index_groups_related_candidates_and_reports_ready_family()
             .expect("cost delta range should exist")
             .max,
         -0.2
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_ignores_symlinked_directories_during_scan() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-symlink");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) = propose_runtime_capability_variant(&root, &run_a_path, "a");
+    let (candidate_b_path, _) = propose_runtime_capability_variant(&root, &run_b_path, "b");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "b",
+    );
+
+    let external_root = unique_temp_dir("loongclaw-runtime-capability-index-symlink-external");
+    fs::create_dir_all(&external_root).expect("create external fixture root");
+    fs::write(
+        external_root.join("runtime-capability-bad.json"),
+        r#"{
+  "schema": {
+    "version": 1,
+    "surface": "runtime_capability",
+    "purpose": "promotion_candidate_record"
+  }
+}"#,
+    )
+    .expect("write malformed supported artifact");
+
+    let symlink_path = root.join("artifacts/external-scan");
+    if !try_symlink_dir(&external_root, &symlink_path) {
+        fs::remove_dir_all(&external_root).ok();
+        fs::remove_dir_all(&root).ok();
+        return;
+    }
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should skip symlinked directories");
+
+    assert_eq!(report.total_candidate_count, 2);
+    assert_eq!(report.family_count, 1);
+
+    fs::remove_dir_all(&external_root).ok();
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_normalizes_family_ids_for_equivalent_persisted_proposals() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-family-id-normalization");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "canonical-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "canonical-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) =
+        propose_runtime_capability_variant(&root, &run_a_path, "canonical-a");
+    let (candidate_b_path, _) =
+        propose_runtime_capability_variant(&root, &run_b_path, "canonical-b");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "canonical-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "canonical-b",
+    );
+
+    rewrite_runtime_capability_proposal(
+        &candidate_b_path,
+        "  Codify browser preview onboarding as a reusable managed skill  ",
+        "  Browser preview onboarding and companion readiness checks only  ",
+        &[" memory_read ", "invoke_tool"],
+        &[" onboarding ", "browser"],
+    );
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should normalize equivalent persisted proposals");
+
+    assert_eq!(report.total_candidate_count, 2);
+    assert_eq!(
+        report.family_count, 1,
+        "equivalent persisted proposals should stay in one family"
+    );
+    assert_eq!(
+        report
+            .families
+            .first()
+            .expect("one capability family should be reported")
+            .candidate_ids
+            .len(),
+        2
     );
 
     fs::remove_dir_all(&root).ok();

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -291,6 +291,7 @@ Delivered in current baseline:
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
   - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
   - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests, and evaluates readiness as `ready`, `not_ready`, or `blocked`
+  - `runtime-capability plan` resolves one indexed capability family into a deterministic dry-run promotion plan with artifact identity, blockers, approval checklist, rollback hints, and provenance
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -310,7 +311,7 @@ Remaining deliverables:
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
   - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
-  - add a dry-run promotion planner on top of the capability-family readiness output instead of jumping directly to automatic mutation
+  - keep the new dry-run promotion planner read-only and use it as the contract for any future promotion executor instead of jumping directly to automatic mutation
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
   - partial governed adapter skeleton now exists for richer page actions:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-17
+Last updated: 2026-03-19
 
 This roadmap is execution-focused. Every stage has:
 
@@ -290,6 +290,7 @@ Delivered in current baseline:
   - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
   - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
+  - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests, and evaluates readiness as `ready`, `not_ready`, or `blocked`
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -309,6 +310,7 @@ Remaining deliverables:
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
   - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
+  - add a dry-run promotion planner on top of the capability-family readiness output instead of jumping directly to automatic mutation
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
   - partial governed adapter skeleton now exists for richer page actions:

--- a/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md
+++ b/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md
@@ -1,0 +1,287 @@
+# Runtime Capability Index and Readiness Gate Design
+
+## Problem
+
+`runtime-capability` currently gives LoongClaw one governed record per finished
+experiment run:
+
+- one proposal
+- one explicit target type
+- one explicit operator review decision
+
+That closes the "should this single run become a reusable lower-layer artifact?"
+gap, but it still leaves the next governance gap open.
+
+Operators still cannot answer, in one deterministic view:
+
+- which candidate records are really the same underlying promotion intent?
+- how many independent runs now support that intent?
+- is the evidence strong enough to treat the intent as promotion-ready?
+- what compact digest should later automation use instead of reopening every
+  source run artifact?
+
+Without that middle layer, every future promotion flow would have to reason over
+ad-hoc sets of individual candidate files. That is expensive, noisy, and easy
+to get wrong.
+
+## Goal
+
+Add the next strictly read-only layer above individual capability candidates:
+
+1. aggregate compatible candidates into deterministic capability families
+2. summarize evidence into a compact, auditable digest
+3. evaluate readiness as `ready`, `not_ready`, or `blocked`
+4. keep the entire slice local-first, deterministic, and operator-readable
+5. avoid automatic promotion or mutation in this phase
+
+## Non-Goals
+
+- automatically generating or applying managed skills
+- automatically generating or applying programmatic flows
+- automatically mutating runtime config or profile notes
+- semantic clustering powered by an LLM or fuzzy matching
+- background queues, schedulers, or continuously running index daemons
+- changing `runtime-experiment` to become the source of truth for family state
+- introducing a promotion executor in the same change
+
+## Constraints
+
+- The source of truth remains the persisted `runtime-capability` candidate
+  artifacts.
+- The new layer must stay additive and keep existing candidate artifacts valid.
+- The grouping rule must be deterministic and explainable from stored fields.
+- Readiness must come from explicit evidence checks, not opaque heuristics.
+- The first slice should optimize for auditability and token savings over
+  autonomy.
+
+## Approaches Considered
+
+### Option A: Add an index command that derives families from proposal intent
+
+Scan candidate artifacts under one root, derive a stable family id from the
+normalized promotion-intent fields, and emit one read-only report.
+
+Pros:
+
+- additive and backward-compatible
+- keeps candidate artifacts unchanged
+- deterministic and easy to diff
+- minimal code surface
+
+Cons:
+
+- only exact promotion-intent matches aggregate together
+- does not repair older artifacts with inconsistent free-form wording
+
+### Option B: Add a new persisted family artifact and update candidates to point to it
+
+Introduce a new artifact type, persist one family record, and embed a stable
+family id into every candidate.
+
+Pros:
+
+- explicit family storage
+- faster later lookups
+
+Cons:
+
+- more schema churn immediately after the foundation landed
+- requires deciding write/update ownership for a new artifact type
+- adds mutation semantics to a slice that can stay read-only for now
+
+### Option C: Use semantic clustering to infer families automatically
+
+Let a model or fuzzy matcher group candidates with similar summaries and scopes.
+
+Pros:
+
+- groups near-duplicate wording together
+
+Cons:
+
+- opaque and unstable
+- hard to audit
+- introduces model dependence into a governance gate
+
+## Decision
+
+Choose Option A.
+
+The next slice should stay deterministic, read-only, and cheap. A capability
+family is defined as "the same normalized promotion intent":
+
+- same target type
+- same target summary
+- same bounded scope
+- same normalized tag set
+- same normalized required-capability set
+
+That intent fingerprint is strict by design. If an operator changes the intended
+promotion summary or scope, LoongClaw should treat that as a different family
+instead of silently merging it.
+
+## Proposed Surface
+
+### Command family
+
+Keep the existing commands and add one new read-only command:
+
+- `loongclaw runtime-capability propose`
+- `loongclaw runtime-capability review`
+- `loongclaw runtime-capability show`
+- `loongclaw runtime-capability index`
+
+### Index command
+
+```bash
+loongclaw runtime-capability index \
+  --root artifacts/runtime-capability \
+  [--json]
+```
+
+Behavior:
+
+- recursively scan `--root`
+- load JSON files that decode as supported `runtime-capability` artifacts
+- derive one stable family id from normalized proposal intent
+- group candidates by family id
+- build one compact evidence digest per family
+- evaluate readiness through explicit deterministic checks
+- render text or JSON without mutating any artifact
+
+## Family Model
+
+### Family id
+
+Compute `family_id` from a SHA-256 hash of:
+
+- `proposal.target`
+- `proposal.summary`
+- `proposal.bounded_scope`
+- normalized `proposal.tags`
+- normalized `proposal.required_capabilities`
+
+This intentionally excludes:
+
+- `candidate_id`
+- timestamps
+- source run ids
+- labels
+- operator review text
+
+The family key therefore represents promotion intent, not one specific piece of
+evidence.
+
+### Compact evidence digest
+
+Each family summary should expose compact evidence instead of replaying every
+source artifact:
+
+- candidate count
+- reviewed / undecided counts
+- accepted / rejected counts
+- distinct source run count
+- distinct experiment id count
+- latest candidate timestamp
+- latest review timestamp
+- source decision rollup
+- unique warnings observed across accepted candidates
+- per-metric min/max rollups
+
+This gives later automation a stable digest to reason over without reopening all
+candidate and experiment files.
+
+## Readiness Gate
+
+Readiness is derived from explicit check results. Each check reports:
+
+- dimension name
+- status: `pass`, `needs_evidence`, or `blocked`
+- summary
+
+Overall readiness is:
+
+- `blocked` if any check is `blocked`
+- `ready` if every check passes
+- `not_ready` otherwise
+
+### Checks
+
+#### 1. Review consensus
+
+- `pass`: every candidate in the family has been reviewed and accepted
+- `needs_evidence`: at least one candidate remains undecided and there are no
+  rejected candidates
+- `blocked`: any candidate in the family was rejected
+
+Rationale: promotion cannot be considered ready if the family already contains a
+negative operator decision or unresolved candidate evidence.
+
+#### 2. Stability
+
+- `pass`: the family contains evidence from at least two distinct source runs
+- `needs_evidence`: fewer than two distinct source runs exist
+
+Rationale: one successful run is promising; two independent runs is the minimum
+signal that the capability is repeatable rather than accidental.
+
+#### 3. Accepted-source integrity
+
+Evaluate only accepted candidates:
+
+- `pass`: every accepted candidate came from a `completed` run whose source run
+  decision was `promoted` and whose result snapshot id is present
+- `needs_evidence`: there are no accepted candidates yet
+- `blocked`: any accepted candidate violates those integrity conditions
+
+Rationale: accepted promotion evidence should not be built on aborted or
+incomplete runtime results.
+
+#### 4. Warning pressure
+
+- `pass`: accepted candidates carry no source warnings
+- `needs_evidence`: accepted candidates exist but still carry warnings
+
+Rationale: warnings are not automatically fatal, but they should prevent the
+family from being considered promotion-ready in the first slice.
+
+## Why This Is Simpler Than a Persisted Family Artifact
+
+The index report can be regenerated from candidate artifacts at any time.
+Nothing new needs to be synchronized, updated, or rolled back. That keeps the
+current change:
+
+- lightweight
+- deterministic
+- backward-compatible
+- easier to test
+
+If later stages need persisted promotion plans, they can consume the family
+report contract without forcing this slice to mutate disk state beyond existing
+candidate records.
+
+## Testing Strategy
+
+1. Extend CLI parsing coverage for `runtime-capability index`.
+2. Add integration coverage proving:
+   - same promotion intent across two candidate artifacts collapses into one
+     family
+   - the family becomes `ready` only after repeated accepted evidence
+   - a family becomes `not_ready` when evidence is incomplete
+   - a family becomes `blocked` when review decisions conflict
+   - non-capability JSON files under the root are ignored
+3. Re-run targeted daemon integration tests and direct integration binary
+   verification.
+
+## Recommendation
+
+Ship the capability-family index and readiness gate now, but keep it read-only.
+
+That gives LoongClaw the missing governed middle layer:
+
+- experiments answer "what changed?"
+- candidates answer "what lower-layer capability could exist?"
+- the family index answers "is there enough stable evidence to plan promotion?"
+
+Automatic promotion should remain a later, dry-run-only step built on top of
+this index contract instead of being entangled with it.

--- a/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md
+++ b/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md
@@ -142,7 +142,7 @@ loongclaw runtime-capability index \
 Behavior:
 
 - recursively scan `--root`
-- load JSON files that decode as supported `runtime-capability` artifacts
+- load JSON files that decode as supported `runtime-capability` artifacts, and abort with a file-specific error if a supported artifact fails schema or integrity validation
 - derive one stable family id from normalized proposal intent
 - group candidates by family id
 - build one compact evidence digest per family

--- a/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md
+++ b/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md
@@ -1,0 +1,181 @@
+# Runtime Capability Index and Readiness Gate Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a read-only `runtime-capability index` layer that groups candidate artifacts into deterministic capability families and evaluates readiness as `ready`, `not_ready`, or `blocked`.
+
+**Architecture:** Reuse the existing daemon-side artifact loading pattern from `runtime_capability_cli`, derive family identity from normalized proposal intent instead of creating a new persisted family artifact, and compute readiness from explicit evidence checks that stay fully deterministic and auditable.
+
+**Tech Stack:** Rust, `clap`, `serde`, daemon integration tests, Markdown docs
+
+---
+
+### Task 1: Write the design and planning artifacts
+
+**Files:**
+- Create: `docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md`
+- Create: `docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Describe the capability-family concept, the deterministic family fingerprint,
+the compact evidence digest, the readiness checks, the non-goals, and the
+testing strategy.
+
+**Step 2: Verify the design artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md`
+Expected: exit 0
+
+**Step 3: Write the implementation plan**
+
+Capture the exact file changes, tests, and verification steps below.
+
+**Step 4: Verify the plan artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md`
+Expected: exit 0
+
+### Task 2: Add failing CLI parsing coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Write the failing parse tests**
+
+Extend runtime-capability CLI parsing coverage so `index` parses:
+
+- `--root`
+- `--json`
+
+**Step 2: Run the targeted parsing test to verify RED**
+
+Run: `target/debug/deps/integration-be821edddb3e2519 --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_and_show --nocapture`
+Expected: FAIL because `index` is not parsed yet
+
+### Task 3: Add failing runtime-capability integration coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Write the failing index tests**
+
+Add integration tests covering:
+
+- one family aggregates two accepted candidates with the same promotion intent
+- the aggregated family reports compact evidence counts and metric ranges
+- one accepted candidate alone yields `not_ready`
+- a mix of accepted and rejected reviewed candidates yields `blocked`
+- non-capability files under the scan root are ignored
+
+**Step 2: Run the targeted runtime-capability tests to verify RED**
+
+Run: `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
+Expected: FAIL because the index surface does not exist yet
+
+### Task 4: Implement the new read-only index surface
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+
+**Step 1: Add the new command and option struct**
+
+Implement:
+
+- `RuntimeCapabilityCommands::Index`
+- `RuntimeCapabilityIndexCommandOptions`
+
+**Step 2: Add the family/report model**
+
+Implement:
+
+- family summary types
+- evidence digest types
+- readiness check types
+- readiness status enums
+
+**Step 3: Implement candidate discovery and grouping**
+
+Implement recursive root scanning, supported artifact loading, deterministic
+family-id derivation, and grouping by normalized proposal intent.
+
+**Step 4: Implement readiness evaluation**
+
+Implement the explicit check pipeline:
+
+- review consensus
+- stability
+- accepted-source integrity
+- warning pressure
+
+and derive overall readiness from those checks.
+
+**Step 5: Implement JSON/text rendering**
+
+Keep text output compact and review-first while exposing enough evidence to see
+why a family is `ready`, `not_ready`, or `blocked`.
+
+**Step 6: Run the targeted tests to verify GREEN**
+
+Run: `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
+Expected: PASS
+
+### Task 5: Update product docs and roadmap references
+
+**Files:**
+- Modify: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update the product spec**
+
+Document `runtime-capability index` as the aggregation/readiness layer above
+individual candidate records and below any future promotion planner.
+
+**Step 2: Update the roadmap**
+
+Describe the new index/readiness layer as the next governed self-evolution step
+after candidate records and before any dry-run promotion planning.
+
+**Step 3: Run doc spot checks**
+
+Run: `rg -n "runtime-capability|readiness|promotion" docs/product-specs/runtime-capability.md docs/ROADMAP.md`
+Expected: the new index/readiness references appear in the updated docs
+
+### Task 6: Verify and prepare clean delivery
+
+**Files:**
+- Review all touched files
+
+**Step 1: Run focused verification**
+
+Run:
+
+- `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
+- `target/debug/deps/integration-be821edddb3e2519 --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_and_show --nocapture`
+
+Expected: PASS
+
+**Step 2: Run repo-level verification as capacity allows**
+
+Run the strongest available checks that are not blocked by unrelated global
+cargo lock contention:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+
+If cargo lock contention persists, record the blocker and supplement with direct
+integration-binary verification for the touched daemon surface.
+
+**Step 3: Inspect the final diff**
+
+Run:
+
+- `git status --short`
+- `git diff --stat`
+- `git diff`
+
+Expected: only runtime-capability index/readiness code, tests, and directly
+related docs

--- a/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md
+++ b/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md
@@ -50,7 +50,7 @@ Extend runtime-capability CLI parsing coverage so `index` parses:
 
 **Step 2: Run the targeted parsing test to verify RED**
 
-Run: `target/debug/deps/integration-be821edddb3e2519 --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_and_show --nocapture`
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_cli_parses_propose_review_show_index_and_plan -- --nocapture`
 Expected: FAIL because `index` is not parsed yet
 
 ### Task 3: Add failing runtime-capability integration coverage
@@ -70,7 +70,7 @@ Add integration tests covering:
 
 **Step 2: Run the targeted runtime-capability tests to verify RED**
 
-Run: `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_ -- --nocapture`
 Expected: FAIL because the index surface does not exist yet
 
 ### Task 4: Implement the new read-only index surface
@@ -119,7 +119,7 @@ why a family is `ready`, `not_ready`, or `blocked`.
 
 **Step 6: Run the targeted tests to verify GREEN**
 
-Run: `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_ -- --nocapture`
 Expected: PASS
 
 ### Task 5: Update product docs and roadmap references
@@ -152,8 +152,8 @@ Expected: the new index/readiness references appear in the updated docs
 
 Run:
 
-- `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
-- `target/debug/deps/integration-be821edddb3e2519 --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_and_show --nocapture`
+- `cargo test -p loongclaw-daemon --test integration runtime_capability_ -- --nocapture`
+- `cargo test -p loongclaw-daemon --test integration runtime_capability_cli_parses_propose_review_show_index_and_plan -- --nocapture`
 
 Expected: PASS
 

--- a/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md
+++ b/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md
@@ -157,17 +157,18 @@ Run:
 
 Expected: PASS
 
-**Step 2: Run repo-level verification as capacity allows**
+**Step 2: Run repo-level verification**
 
-Run the strongest available checks that are not blocked by unrelated global
-cargo lock contention:
+Run the full CI-parity checks:
 
 - `cargo fmt --all -- --check`
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 - `cargo test --workspace`
+- `cargo test --workspace --all-features`
 
-If cargo lock contention persists, record the blocker and supplement with direct
-integration-binary verification for the touched daemon surface.
+If a wrapper-level cargo queue blocks these commands, rerun the same checks with
+a direct toolchain `cargo` binary and an isolated `CARGO_TARGET_DIR`; do not
+drop any CI-parity verification steps.
 
 **Step 3: Inspect the final diff**
 

--- a/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md
+++ b/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md
@@ -1,0 +1,337 @@
+# Runtime Capability Promotion Plan Dry-Run Design
+
+## Problem
+
+`runtime-capability` now gives LoongClaw two governed layers above finished
+runtime experiments:
+
+- one capability candidate per finished run
+- one deterministic family index with compact evidence and readiness
+
+That closes the "what reusable intent emerged?" and "is this family ready?"
+questions, but one operational gap still remains.
+
+Even when a family is indexed and evaluated, the operator still cannot answer in
+one deterministic view:
+
+- what exact lower-layer artifact should this family become?
+- what stable identifier should that artifact carry?
+- is the family actually promotable right now, or only plan-able?
+- what blockers still stop promotion?
+- what approval checklist and rollback notes should the eventual mutation step
+  follow?
+
+Without that dry-run layer, any later promotion executor would still need to
+re-open raw family summaries and improvise a plan at mutation time. That keeps
+the most safety-sensitive step underspecified.
+
+## Goal
+
+Add the smallest read-only promotion-planning layer above capability-family
+readiness:
+
+1. resolve one indexed family into one deterministic promotion plan
+2. describe the exact lower-layer artifact kind and stable identifier that would
+   be created
+3. expose whether the family is promotable now without mutating disk or runtime
+4. surface blockers, approval checklist items, rollback hints, and provenance in
+   one compact operator-readable report
+5. keep the entire slice local-first, deterministic, and auditable
+
+## Non-Goals
+
+- automatically generating or applying managed skills
+- automatically generating or applying programmatic flows
+- automatically mutating `profile_note` or runtime config
+- persisting a separate promotion-plan artifact
+- background daemons, queues, or schedulers
+- semantic ranking or LLM-based plan synthesis
+- solving multi-family prioritization in this slice
+
+## Constraints
+
+- The source of truth remains the persisted `runtime-capability` candidate
+  artifacts plus the derived family index view.
+- This slice must stay additive and read-only.
+- The plan contract must be deterministic from stored fields, not from external
+  state or model inference.
+- Planner output should be cheap enough that later automation can consume it
+  instead of replaying every candidate artifact.
+- The planner must still render a useful report for `not_ready` and `blocked`
+  families; failure to be promotable is data, not a command error.
+
+## Approaches Considered
+
+### Option A: Add a read-only `plan` command above `index`
+
+Compute the family index on demand, resolve one family by id, and derive a
+deterministic promotion-plan report.
+
+Pros:
+
+- additive and read-only
+- reuses the existing readiness/evidence contract
+- no new persisted state to synchronize
+- keeps later mutation layers honest by making the plan explicit first
+
+Cons:
+
+- requires re-scanning candidate artifacts for each planning request
+- still leaves actual mutation to a later slice
+
+### Option B: Persist a separate promotion-plan artifact
+
+Store one plan document on disk and update it whenever the family changes.
+
+Pros:
+
+- faster lookups later
+- explicit artifact path for every plan
+
+Cons:
+
+- adds a new write/update lifecycle immediately
+- forces ownership rules for stale plan invalidation
+- turns a read-only slice into another persistence surface
+
+### Option C: Jump directly to automatic promotion
+
+Let the system read a ready family and immediately generate the lower-layer
+artifact.
+
+Pros:
+
+- closest to the long-term autonomous loop
+
+Cons:
+
+- collapses planning and mutation into one step
+- reduces auditability exactly where safety matters most
+- introduces unnecessary slop debt before the plan contract is proven
+
+## Decision
+
+Choose Option A.
+
+The next governed self-evolution slice should make the would-be promotion
+explicit before anything is allowed to mutate state. The planner should consume
+the deterministic family view, preserve that same strictness, and add only the
+missing operator-facing details:
+
+- planned lower-layer artifact kind
+- stable artifact identifier
+- promotability boolean
+- blockers
+- approval checklist
+- rollback hints
+- provenance references
+
+## Proposed Surface
+
+### Command family
+
+Keep the existing commands and add one new read-only command:
+
+- `loongclaw runtime-capability propose`
+- `loongclaw runtime-capability review`
+- `loongclaw runtime-capability show`
+- `loongclaw runtime-capability index`
+- `loongclaw runtime-capability plan`
+
+### Plan command
+
+```bash
+loongclaw runtime-capability plan \
+  --root artifacts/runtime-capability \
+  --family-id <family-id> \
+  [--json]
+```
+
+Behavior:
+
+- recursively scan `--root` using the same supported-artifact rules as `index`
+- derive the same deterministic family summaries
+- select exactly one family by `family_id`
+- derive one deterministic promotion plan from that family
+- render text or JSON without mutating any artifact
+
+Command errors should be limited to:
+
+- unreadable root
+- malformed artifact load
+- missing family id
+
+`not_ready` and `blocked` families should still produce a plan report with
+`promotable=false`.
+
+## Promotion Plan Model
+
+### Report shape
+
+The plan report should contain:
+
+- `generated_at`
+- `root`
+- `family_id`
+- `promotable`
+- `proposal`
+- `evidence`
+- `readiness`
+- `planned_artifact`
+- `blockers`
+- `approval_checklist`
+- `rollback_hints`
+- `provenance`
+
+The planner should reuse the existing family proposal/evidence/readiness model
+instead of duplicating those semantics in a second schema.
+
+### Planned artifact
+
+Each plan resolves to one lower-layer artifact description:
+
+- `target_kind`
+- `artifact_kind`
+- `artifact_id`
+- `delivery_surface`
+- `summary`
+- `bounded_scope`
+- `required_capabilities`
+- `tags`
+
+`artifact_id` should be deterministic and human-scannable:
+
+- start with a target-specific prefix
+- append a slug derived from `proposal.summary`
+- suffix with a short prefix of `family_id` for collision resistance
+
+Example shapes:
+
+- `managed_skill` -> `artifact_kind=managed_skill_bundle`
+- `programmatic_flow` -> `artifact_kind=programmatic_flow_spec`
+- `profile_note_addendum` -> `artifact_kind=profile_note_addendum`
+
+The planner should not guess filesystem paths yet. The executor layer can choose
+the final write location later. This slice only promises the exact logical
+artifact identity and delivery lane.
+
+### Promotable
+
+`promotable` should be `true` only when the family's readiness status is
+`ready`.
+
+This keeps the rule obvious:
+
+- `ready` -> the family is promotable in principle
+- `not_ready` -> the family has missing evidence
+- `blocked` -> the family currently should not be promoted
+
+### Blockers
+
+`blockers` should be derived from readiness checks that are not `pass`.
+
+- `needs_evidence` checks become actionable missing-evidence blockers
+- `blocked` checks become hard-stop blockers
+
+This avoids inventing a second blocker engine.
+
+### Approval checklist
+
+The planner should emit a short deterministic checklist that the eventual
+mutation step must satisfy. The checklist should stay generic enough to cover
+all target kinds:
+
+- confirm the summary and bounded scope still describe exactly one lower-layer
+  artifact
+- confirm required capabilities remain least-privilege for that artifact
+- confirm provenance references still represent the intended behavior to codify
+- confirm the chosen delivery surface matches the target kind
+
+One extra target-specific item should be added:
+
+- `managed_skill`: confirm the behavior belongs in a reusable managed skill
+- `programmatic_flow`: confirm the behavior can be expressed as a deterministic
+  programmatic flow
+- `profile_note_addendum`: confirm the behavior belongs in advisory profile
+  guidance rather than executable logic
+
+### Rollback hints
+
+Rollback hints should stay high-signal and executor-neutral:
+
+- capture the current state of the target delivery surface before applying
+- remove or revert the promoted artifact by `artifact_id` if downstream
+  validation fails
+- keep the candidate ids and source-run references attached to the rollback
+  record so the revert stays auditable
+
+### Provenance
+
+The plan should carry the minimum references needed to audit where it came from:
+
+- candidate ids
+- source run ids
+- experiment ids
+- source run artifact paths when recorded on the candidate
+- latest candidate / review timestamps
+
+This is enough to trace the plan without reopening every file during normal
+review.
+
+## Text Output
+
+Text output should remain review-first and compact.
+
+Recommended order:
+
+1. family identity and promotability
+2. planned artifact description
+3. readiness/check summary
+4. blockers
+5. approval checklist
+6. rollback hints
+7. provenance references
+
+Example sketch:
+
+```text
+family_id=...
+promotable=true
+target=managed_skill
+artifact_kind=managed_skill_bundle
+artifact_id=managed-skill-browser-preview-onboarding-3f2a9c7d1b2e
+delivery_surface=managed_skills
+required_capabilities=invoke_tool,memory_read
+blockers=-
+checks=review_consensus:pass:... | stability:pass:...
+approval_checklist=confirm bounded scope | confirm least-privilege capabilities | ...
+rollback_hints=capture current managed_skills state | remove artifact_id on failure | ...
+provenance_candidate_ids=...
+provenance_source_run_ids=...
+```
+
+## Why This Is Simpler Than Persisted Plan State
+
+The planner can always be regenerated from candidate artifacts. That preserves
+the current self-evolution pyramid:
+
+- experiments create evidence
+- candidates capture promotion intent
+- family index summarizes readiness
+- promotion planner describes the would-be lower layer
+- a future executor can mutate only after all prior layers are explicit
+
+Nothing new needs to be synchronized or garbage-collected in this slice.
+
+## Testing Strategy
+
+1. Extend CLI parsing coverage for `runtime-capability plan`.
+2. Add failing integration tests for:
+   - planning a ready family
+   - planning a not-ready family and surfacing blockers
+   - planning a blocked family and surfacing blockers
+   - rejecting unknown family ids
+   - emitting target-specific artifact metadata and provenance references
+3. Implement the smallest plan derivation logic needed to satisfy those tests.
+4. Update product docs and roadmap so the runtime-capability ladder is described
+   as candidate -> index/readiness -> dry-run planner -> future executor.

--- a/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md
+++ b/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md
@@ -160,6 +160,7 @@ Command errors should be limited to:
 - unreadable root
 - malformed artifact load
 - missing family id
+- unknown family id
 
 `not_ready` and `blocked` families should still produce a plan report with
 `promotable=false`.

--- a/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md
+++ b/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md
@@ -1,0 +1,188 @@
+# Runtime Capability Promotion Plan Dry-Run Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a read-only `runtime-capability plan` layer that resolves one indexed capability family into a deterministic dry-run promotion plan without mutating runtime state.
+
+**Architecture:** Reuse the existing candidate loading and family-readiness logic in `runtime_capability_cli`, derive one promotion-plan report from one family summary, and keep the new surface strictly read-only so later mutation layers can consume an explicit plan contract instead of improvising promotion details.
+
+**Tech Stack:** Rust, `clap`, `serde`, daemon integration tests, Markdown docs
+
+---
+
+### Task 1: Write the design and planning artifacts
+
+**Files:**
+- Create: `docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md`
+- Create: `docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Describe the planner contract, the command surface, the planned-artifact model,
+the promotable rule, blockers, approval checklist, rollback hints, provenance,
+and why this slice stays read-only.
+
+**Step 2: Verify the design artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md`
+Expected: exit 0
+
+**Step 3: Write the implementation plan**
+
+Capture the exact file changes, tests, docs, and verification steps below.
+
+**Step 4: Verify the plan artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md`
+Expected: exit 0
+
+### Task 2: Add failing CLI parsing coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Write the failing parse test**
+
+Extend runtime-capability CLI parsing coverage so `plan` parses:
+
+- `--root`
+- `--family-id`
+- `--json`
+
+**Step 2: Run the targeted parsing test to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_cli_parses_propose_review_show_index_and_plan --test integration -- --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_show_index_and_plan --nocapture`
+Expected: FAIL because the `plan` subcommand does not exist yet
+
+### Task 3: Add failing runtime-capability planner integration coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Write the failing planner tests**
+
+Add integration tests covering:
+
+- planning a ready managed-skill family
+- planning a `not_ready` family and surfacing missing-evidence blockers
+- planning a `blocked` family and surfacing hard-stop blockers
+- rejecting an unknown `family_id`
+- exposing deterministic artifact metadata, approval checklist, rollback hints,
+  and provenance references
+
+**Step 2: Run the targeted runtime-capability tests to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_plan --test integration -- --nocapture`
+Expected: FAIL because the planner surface does not exist yet
+
+### Task 4: Implement the read-only planner surface
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/lib.rs`
+
+**Step 1: Add the new command and option struct**
+
+Implement:
+
+- `RuntimeCapabilityCommands::Plan`
+- `RuntimeCapabilityPlanCommandOptions`
+
+**Step 2: Add the promotion-plan report model**
+
+Implement:
+
+- promotion-plan report type
+- planned-artifact type
+- provenance type
+
+Reuse existing proposal, evidence, and readiness types instead of cloning that
+logic into a second schema.
+
+**Step 3: Implement family lookup and plan derivation**
+
+Implement:
+
+- family resolution by `family_id`
+- deterministic planned-artifact identity derivation
+- promotable boolean derived from readiness
+- blockers derived from non-pass readiness checks
+- approval checklist and rollback hints derived from target kind plus generic
+  governance rules
+- provenance extraction from indexed candidate evidence
+
+**Step 4: Implement JSON/text rendering**
+
+Keep text output compact and review-first while exposing:
+
+- promotability
+- target/artifact description
+- blockers
+- approval checklist
+- rollback hints
+- provenance references
+
+**Step 5: Run the targeted tests to verify GREEN**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_plan --test integration -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability_cli_parses_propose_review_show_index_and_plan --test integration -- --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_show_index_and_plan --nocapture`
+
+Expected: PASS
+
+### Task 5: Update product docs and roadmap references
+
+**Files:**
+- Modify: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update the product spec**
+
+Document `runtime-capability plan` as the dry-run planning layer above family
+readiness and below any future promotion executor.
+
+**Step 2: Update the roadmap**
+
+Describe the planner as the next shipped governed self-evolution step after the
+family index/readiness layer.
+
+**Step 3: Run doc spot checks**
+
+Run: `rg -n "runtime-capability|promotion planner|dry-run" docs/product-specs/runtime-capability.md docs/ROADMAP.md`
+Expected: the new planner references appear in the updated docs
+
+### Task 6: Verify and prepare clean delivery
+
+**Files:**
+- Review all touched files
+
+**Step 1: Run focused verification**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_ --test integration -- --nocapture`
+
+Expected: PASS
+
+**Step 2: Run repo-level verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 3: Inspect the final diff**
+
+Run:
+
+- `git status --short`
+- `git diff --stat`
+- `git diff`
+
+Expected: only runtime-capability planner code, tests, docs, and directly
+related GitHub delivery text are present

--- a/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md
+++ b/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Write the design and planning artifacts
+## Task 1: Write the design and planning artifacts
 
 **Files:**
 - Create: `docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md`
@@ -36,7 +36,7 @@ Capture the exact file changes, tests, docs, and verification steps below.
 Run: `test -f docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md`
 Expected: exit 0
 
-### Task 2: Add failing CLI parsing coverage
+## Task 2: Add failing CLI parsing coverage
 
 **Files:**
 - Modify: `crates/daemon/tests/integration/cli_tests.rs`
@@ -54,7 +54,7 @@ Extend runtime-capability CLI parsing coverage so `plan` parses:
 Run: `cargo test -p loongclaw-daemon runtime_capability_cli_parses_propose_review_show_index_and_plan --test integration -- --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_show_index_and_plan --nocapture`
 Expected: FAIL because the `plan` subcommand does not exist yet
 
-### Task 3: Add failing runtime-capability planner integration coverage
+## Task 3: Add failing runtime-capability planner integration coverage
 
 **Files:**
 - Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
@@ -75,7 +75,7 @@ Add integration tests covering:
 Run: `cargo test -p loongclaw-daemon runtime_capability_plan --test integration -- --nocapture`
 Expected: FAIL because the planner surface does not exist yet
 
-### Task 4: Implement the read-only planner surface
+## Task 4: Implement the read-only planner surface
 
 **Files:**
 - Modify: `crates/daemon/src/runtime_capability_cli.rs`
@@ -131,7 +131,7 @@ Run:
 
 Expected: PASS
 
-### Task 5: Update product docs and roadmap references
+## Task 5: Update product docs and roadmap references
 
 **Files:**
 - Modify: `docs/product-specs/runtime-capability.md`
@@ -152,7 +152,7 @@ family index/readiness layer.
 Run: `rg -n "runtime-capability|promotion planner|dry-run" docs/product-specs/runtime-capability.md docs/ROADMAP.md`
 Expected: the new planner references appear in the updated docs
 
-### Task 6: Verify and prepare clean delivery
+## Task 6: Verify and prepare clean delivery
 
 **Files:**
 - Review all touched files

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -9,7 +9,7 @@ experiment should be crystallized into a reusable lower-layer capability.
 ## Acceptance Criteria
 
 - [ ] LoongClaw exposes a `runtime-capability` command family with `propose`,
-      `review`, `show`, and `index` subcommands.
+      `review`, `show`, `index`, and `plan` subcommands.
 - [ ] `runtime-capability propose` creates a persisted capability-candidate
       artifact from one finished `runtime-experiment` run.
 - [ ] The candidate artifact records one explicit target type:
@@ -25,9 +25,14 @@ experiment should be crystallized into a reusable lower-layer capability.
       emits a compact evidence digest for each family.
 - [ ] Each capability family reports readiness as `ready`, `not_ready`, or
       `blocked` from explicit evidence checks rather than opaque heuristics.
+- [ ] `runtime-capability plan` resolves one indexed family into a dry-run
+      promotion plan that describes the target lower-layer artifact, stable
+      artifact id, blockers, approval checklist, rollback hints, and
+      provenance references without mutating runtime state.
 - [ ] Product docs describe `runtime-capability` as the governed review layer
-      above `runtime-experiment` and below any future dry-run promotion planner
-      or automated promotion loop.
+      above `runtime-experiment`, with `index`/readiness and `plan` forming the
+      dry-run planning ladder below any future promotion executor or automated
+      promotion loop.
 
 ## Out of Scope
 
@@ -36,4 +41,5 @@ experiment should be crystallized into a reusable lower-layer capability.
 - Automatically mutating `profile_note` or runtime config
 - Automatic promotion, rollback, or optimizer orchestration
 - Persisted capability-family state or background indexing daemons
+- Persisted promotion-plan artifacts or plan caches
 - Candidate queues, dashboards, or autonomous ranking systems

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -9,7 +9,7 @@ experiment should be crystallized into a reusable lower-layer capability.
 ## Acceptance Criteria
 
 - [ ] LoongClaw exposes a `runtime-capability` command family with `propose`,
-      `review`, and `show` subcommands.
+      `review`, `show`, and `index` subcommands.
 - [ ] `runtime-capability propose` creates a persisted capability-candidate
       artifact from one finished `runtime-experiment` run.
 - [ ] The candidate artifact records one explicit target type:
@@ -20,8 +20,14 @@ experiment should be crystallized into a reusable lower-layer capability.
       (`accepted` or `rejected`) plus one review summary and optional warnings.
 - [ ] `runtime-capability show` round-trips the persisted artifact as JSON and
       renders the review-critical fields first in text output.
+- [ ] `runtime-capability index` scans persisted candidate artifacts, groups
+      matching promotion intent into deterministic capability families, and
+      emits a compact evidence digest for each family.
+- [ ] Each capability family reports readiness as `ready`, `not_ready`, or
+      `blocked` from explicit evidence checks rather than opaque heuristics.
 - [ ] Product docs describe `runtime-capability` as the governed review layer
-      above `runtime-experiment` and below any future automated promotion loop.
+      above `runtime-experiment` and below any future dry-run promotion planner
+      or automated promotion loop.
 
 ## Out of Scope
 
@@ -29,4 +35,5 @@ experiment should be crystallized into a reusable lower-layer capability.
 - Automatically generating or applying programmatic flows
 - Automatically mutating `profile_note` or runtime config
 - Automatic promotion, rollback, or optimizer orchestration
+- Persisted capability-family state or background indexing daemons
 - Candidate queues, dashboards, or autonomous ranking systems


### PR DESCRIPTION
## Summary

- Problem: single `runtime-capability` candidate artifacts existed, but there was no read-only family index that grouped compatible candidates and evaluated family readiness explicitly.
- Why it matters: governed self-evolution needs a stable way to inspect families of candidates and understand whether they are ready, not ready, or blocked before any later promotion work.
- What changed: added `runtime-capability index --root <path> [--json]`, grouped compatible artifacts into deterministic capability families, emitted compact evidence digests, evaluated readiness through explicit checks, rejected malformed review-state combinations, and updated the product spec, roadmap, and planning docs.
- What did not change (scope boundary): this does not add a promotion executor or apply path, and it does not mutate candidate artifacts beyond read-only loading and validation.

## Linked Issues

- Closes #285
- Related # n/a

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  readiness classification becomes an explicit policy surface for runtime capability families, so malformed artifact handling and check semantics must stay deterministic and reviewable.
- Rollout / guardrails:
  the command is read-only, emits explicit check names, and the integration coverage exercises ready, not-ready, blocked, unrelated-json filtering, and malformed review-state rejection.
- Rollback path:
  revert the family-index command and readiness evaluation path to return to candidate-only inspection.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed

cargo test --workspace
- passed

cargo test --workspace --all-features
- passed
```

## User-visible / Operator-visible Changes

- `runtime-capability index` now groups compatible artifacts into deterministic families and reports family readiness with explicit evidence digests.

## Failure Recovery

- Fast rollback or disable path: revert the family-index command and readiness evaluation changes.
- Observable failure symptoms reviewers should watch for: malformed artifacts loading silently, readiness checks reporting unstable results for the same inputs, or family grouping drifting from normalized promotion intent.

## Reviewer Focus

- `crates/daemon/src/runtime_capability_cli.rs` for deterministic family grouping and readiness evaluation.
- `crates/daemon/tests/integration/runtime_capability_cli.rs` for ready, not-ready, blocked, unrelated-json, and malformed-artifact coverage.
- `docs/product-specs/runtime-capability.md` and roadmap/planning docs for the readiness contract.
