### PR TITLE
feat(app): surface delegate child runtime contract in planning prompts

### DIFF
--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -113,6 +113,42 @@ pub struct DelegateToolConfig {
     pub child_tool_allowlist: Vec<String>,
     #[serde(default)]
     pub allow_shell_in_child: bool,
+    #[serde(default)]
+    pub child_runtime: DelegateChildRuntimeConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DelegateChildRuntimeConfig {
+    #[serde(default)]
+    pub web: DelegateChildWebRuntimeConfig,
+    #[serde(default)]
+    pub browser: DelegateChildBrowserRuntimeConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DelegateChildWebRuntimeConfig {
+    #[serde(default)]
+    pub allow_private_hosts: Option<bool>,
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+    #[serde(default)]
+    pub blocked_domains: Vec<String>,
+    #[serde(default)]
+    pub timeout_seconds: Option<u64>,
+    #[serde(default)]
+    pub max_bytes: Option<usize>,
+    #[serde(default)]
+    pub max_redirects: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DelegateChildBrowserRuntimeConfig {
+    #[serde(default)]
+    pub max_sessions: Option<usize>,
+    #[serde(default)]
+    pub max_links: Option<usize>,
+    #[serde(default)]
+    pub max_text_chars: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -260,6 +296,7 @@ impl Default for DelegateToolConfig {
             timeout_seconds: default_delegate_timeout_seconds(),
             child_tool_allowlist: default_delegate_child_tool_allowlist(),
             allow_shell_in_child: false,
+            child_runtime: DelegateChildRuntimeConfig::default(),
         }
     }
 }
@@ -360,6 +397,66 @@ impl ToolConfig {
         ) {
             issues.push(*issue);
         }
+        if let Some(max_sessions) = self.delegate.child_runtime.browser.max_sessions
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.browser.max_sessions",
+                max_sessions,
+                MIN_BROWSER_MAX_SESSIONS,
+                MAX_BROWSER_MAX_SESSIONS,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(max_links) = self.delegate.child_runtime.browser.max_links
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.browser.max_links",
+                max_links,
+                MIN_BROWSER_MAX_LINKS,
+                MAX_BROWSER_MAX_LINKS,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(max_text_chars) = self.delegate.child_runtime.browser.max_text_chars
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.browser.max_text_chars",
+                max_text_chars,
+                MIN_BROWSER_MAX_TEXT_CHARS,
+                MAX_BROWSER_MAX_TEXT_CHARS,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(max_bytes) = self.delegate.child_runtime.web.max_bytes
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.web.max_bytes",
+                max_bytes,
+                MIN_WEB_FETCH_MAX_BYTES,
+                MAX_WEB_FETCH_MAX_BYTES,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(timeout_seconds) = self.delegate.child_runtime.web.timeout_seconds
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.web.timeout_seconds",
+                timeout_seconds as usize,
+                MIN_WEB_FETCH_TIMEOUT_SECONDS,
+                MAX_WEB_FETCH_TIMEOUT_SECONDS,
+            )
+        {
+            issues.push(*issue);
+        }
+        if let Some(max_redirects) = self.delegate.child_runtime.web.max_redirects
+            && let Err(issue) = validate_numeric_range(
+                "tools.delegate.child_runtime.web.max_redirects",
+                max_redirects,
+                0,
+                MAX_WEB_FETCH_MAX_REDIRECTS,
+            )
+        {
+            issues.push(*issue);
+        }
         issues
     }
 }
@@ -385,6 +482,36 @@ impl WebToolConfig {
 
     pub fn normalized_blocked_domains(&self) -> Vec<String> {
         normalize_domain_entries(&self.blocked_domains)
+    }
+}
+
+impl DelegateChildWebRuntimeConfig {
+    pub fn normalized_allowed_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.allowed_domains)
+    }
+
+    pub fn normalized_blocked_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.blocked_domains)
+    }
+}
+
+impl DelegateChildRuntimeConfig {
+    pub fn runtime_narrowing(&self) -> crate::tools::runtime_config::ToolRuntimeNarrowing {
+        crate::tools::runtime_config::ToolRuntimeNarrowing {
+            web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
+                allow_private_hosts: self.web.allow_private_hosts,
+                allowed_domains: self.web.normalized_allowed_domains().into_iter().collect(),
+                blocked_domains: self.web.normalized_blocked_domains().into_iter().collect(),
+                timeout_seconds: self.web.timeout_seconds,
+                max_bytes: self.web.max_bytes,
+                max_redirects: self.web.max_redirects,
+            },
+            browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+                max_sessions: self.browser.max_sessions,
+                max_links: self.browser.max_links,
+                max_text_chars: self.browser.max_text_chars,
+            },
+        }
     }
 }
 
@@ -530,6 +657,19 @@ max_active_children = 4
 timeout_seconds = 90
 allow_shell_in_child = true
 child_tool_allowlist = ["file.read", "shell.exec"]
+
+[tools.delegate.child_runtime.web]
+allow_private_hosts = false
+allowed_domains = ["Docs.Example.com", "docs.example.com"]
+blocked_domains = ["internal.example", " INTERNAL.EXAMPLE "]
+timeout_seconds = 9
+max_bytes = 262144
+max_redirects = 1
+
+[tools.delegate.child_runtime.browser]
+max_sessions = 2
+max_links = 10
+max_text_chars = 1024
 "#;
         let parsed =
             toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
@@ -558,6 +698,52 @@ child_tool_allowlist = ["file.read", "shell.exec"]
         assert_eq!(
             parsed.tools.delegate.child_tool_allowlist,
             vec!["file.read".to_owned(), "shell.exec".to_owned()]
+        );
+        assert_eq!(
+            parsed
+                .tools
+                .delegate
+                .child_runtime
+                .web
+                .normalized_allowed_domains(),
+            vec!["docs.example.com".to_owned()]
+        );
+        assert_eq!(
+            parsed
+                .tools
+                .delegate
+                .child_runtime
+                .web
+                .normalized_blocked_domains(),
+            vec!["internal.example".to_owned()]
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.web.allow_private_hosts,
+            Some(false)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.web.timeout_seconds,
+            Some(9)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.web.max_bytes,
+            Some(262144)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.web.max_redirects,
+            Some(1)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.browser.max_sessions,
+            Some(2)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.browser.max_links,
+            Some(10)
+        );
+        assert_eq!(
+            parsed.tools.delegate.child_runtime.browser.max_text_chars,
+            Some(1024)
         );
     }
 

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -105,6 +105,8 @@ pub struct DelegateToolConfig {
     pub enabled: bool,
     #[serde(default = "default_delegate_max_depth")]
     pub max_depth: usize,
+    #[serde(default = "default_delegate_max_active_children")]
+    pub max_active_children: usize,
     #[serde(default = "default_delegate_timeout_seconds")]
     pub timeout_seconds: u64,
     #[serde(default = "default_delegate_child_tool_allowlist")]
@@ -254,6 +256,7 @@ impl Default for DelegateToolConfig {
         Self {
             enabled: default_enabled(),
             max_depth: default_delegate_max_depth(),
+            max_active_children: default_delegate_max_active_children(),
             timeout_seconds: default_delegate_timeout_seconds(),
             child_tool_allowlist: default_delegate_child_tool_allowlist(),
             allow_shell_in_child: false,
@@ -401,6 +404,10 @@ const fn default_delegate_max_depth() -> usize {
     1
 }
 
+const fn default_delegate_max_active_children() -> usize {
+    5
+}
+
 const fn default_delegate_timeout_seconds() -> u64 {
     60
 }
@@ -472,6 +479,7 @@ mod tests {
         assert!(!config.messages.enabled);
         assert!(config.delegate.enabled);
         assert_eq!(config.delegate.max_depth, 1);
+        assert_eq!(config.delegate.max_active_children, 5);
         assert_eq!(config.delegate.timeout_seconds, 60);
         assert_eq!(
             config.delegate.child_tool_allowlist,
@@ -518,6 +526,7 @@ enabled = true
 [tools.delegate]
 enabled = false
 max_depth = 2
+max_active_children = 4
 timeout_seconds = 90
 allow_shell_in_child = true
 child_tool_allowlist = ["file.read", "shell.exec"]
@@ -543,6 +552,7 @@ child_tool_allowlist = ["file.read", "shell.exec"]
         assert!(parsed.tools.messages.enabled);
         assert!(!parsed.tools.delegate.enabled);
         assert_eq!(parsed.tools.delegate.max_depth, 2);
+        assert_eq!(parsed.tools.delegate.max_active_children, 4);
         assert_eq!(parsed.tools.delegate.timeout_seconds, 90);
         assert!(parsed.tools.delegate.allow_shell_in_child);
         assert_eq!(

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -12,6 +12,7 @@ mod runtime_binding;
 mod safe_lane_failure;
 mod session_address;
 mod session_history;
+mod subagent;
 mod turn_budget;
 mod turn_coordinator;
 pub mod turn_engine;
@@ -60,6 +61,9 @@ pub use safe_lane_failure::{
 pub use session_address::ConversationSessionAddress;
 pub use session_history::load_discovery_first_event_summary;
 pub use session_history::{load_safe_lane_event_summary, load_turn_checkpoint_event_summary};
+pub use subagent::{
+    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
+};
 pub use turn_budget::SafeLaneFailureRouteReason;
 pub use turn_coordinator::ConversationTurnCoordinator;
 pub(crate) use turn_coordinator::{TurnCheckpointDiagnostics, TurnCheckpointRecoveryAssessment};

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -7,6 +7,7 @@ use serde_json::{Value, json};
 
 use crate::CliResult;
 use crate::KernelContext;
+use crate::tools::runtime_config::ToolRuntimeNarrowing;
 use crate::tools::{
     ToolView, delegate_child_tool_view_for_config,
     delegate_child_tool_view_for_config_with_delegate,
@@ -38,6 +39,7 @@ pub struct SessionContext {
     pub session_id: String,
     pub parent_session_id: Option<String>,
     pub tool_view: ToolView,
+    pub runtime_narrowing: Option<ToolRuntimeNarrowing>,
 }
 
 impl SessionContext {
@@ -46,6 +48,7 @@ impl SessionContext {
             session_id: normalize_session_id(session_id.into()),
             parent_session_id: None,
             tool_view,
+            runtime_narrowing: None,
         }
     }
 
@@ -58,7 +61,16 @@ impl SessionContext {
             session_id: normalize_session_id(session_id.into()),
             parent_session_id: Some(normalize_session_id(parent_session_id.into())),
             tool_view,
+            runtime_narrowing: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_runtime_narrowing(mut self, runtime_narrowing: ToolRuntimeNarrowing) -> Self {
+        if !runtime_narrowing.is_empty() {
+            self.runtime_narrowing = Some(runtime_narrowing);
+        }
+        self
     }
 }
 
@@ -69,6 +81,27 @@ fn normalize_session_id(session_id: String) -> String {
     } else {
         trimmed.to_owned()
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_delegate_runtime_narrowing(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<ToolRuntimeNarrowing>, String> {
+    let events = repo.list_delegate_lifecycle_events(session_id)?;
+    let execution = events.into_iter().rev().find_map(|event| {
+        matches!(
+            event.event_kind.as_str(),
+            "delegate_queued" | "delegate_started"
+        )
+        .then(|| {
+            super::subagent::ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
+        })
+        .flatten()
+    });
+    Ok(execution.and_then(|execution| {
+        (!execution.runtime_narrowing.is_empty()).then_some(execution.runtime_narrowing)
+    }))
 }
 
 #[derive(Clone)]
@@ -440,22 +473,26 @@ where
                     .map_err(|error| format!("load session context failed: {error}"))?
                 {
                     if let Some(parent_session_id) = session.parent_session_id {
+                        let runtime_narrowing = load_delegate_runtime_narrowing(&repo, session_id)?;
                         return Ok(SessionContext::child(
                             session.session_id,
                             parent_session_id,
                             tool_view,
-                        ));
+                        )
+                        .with_runtime_narrowing(runtime_narrowing.unwrap_or_default()));
                     }
                 } else if let Some(summary) = repo
                     .load_session_summary_with_legacy_fallback(session_id)
                     .map_err(|error| format!("load legacy session context failed: {error}"))?
                     && let Some(parent_session_id) = summary.parent_session_id
                 {
+                    let runtime_narrowing = load_delegate_runtime_narrowing(&repo, session_id)?;
                     return Ok(SessionContext::child(
                         summary.session_id,
                         parent_session_id,
                         tool_view,
-                    ));
+                    )
+                    .with_runtime_narrowing(runtime_narrowing.unwrap_or_default()));
                 }
             }
         }

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -589,9 +589,16 @@ where
             .context_engine
             .assemble_context(config, session_id, include_system_prompt, binding)
             .await?;
+        let delegate_runtime_contract = include_system_prompt
+            .then(|| delegate_child_runtime_contract_prompt_summary(&session_context))
+            .flatten();
+        let merged_system_prompt_addition = merge_system_prompt_additions(
+            assembled.system_prompt_addition.as_deref(),
+            delegate_runtime_contract.as_deref(),
+        );
         apply_system_prompt_addition(
             &mut assembled.messages,
-            assembled.system_prompt_addition.as_deref(),
+            merged_system_prompt_addition.as_deref(),
         );
         if include_system_prompt {
             apply_tool_view_to_system_prompt_if_needed(
@@ -749,6 +756,26 @@ where
             .on_subagent_ended(parent_session_id, subagent_session_id, kernel_ctx)
             .await
     }
+}
+
+fn delegate_child_runtime_contract_prompt_summary(
+    session_context: &SessionContext,
+) -> Option<String> {
+    session_context.parent_session_id.as_ref()?;
+    session_context
+        .runtime_narrowing
+        .as_ref()?
+        .delegate_child_prompt_summary()
+}
+
+fn merge_system_prompt_additions(existing: Option<&str>, extra: Option<&str>) -> Option<String> {
+    let merged = [existing, extra]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .filter(|content| !content.is_empty())
+        .collect::<Vec<_>>();
+    (!merged.is_empty()).then(|| merged.join("\n\n"))
 }
 
 fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: Option<&str>) {

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -23,6 +23,7 @@ use super::context_engine_registry::{
     list_context_engine_metadata, resolve_context_engine,
 };
 use super::runtime_binding::ConversationRuntimeBinding;
+use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::ProviderTurn;
 
 #[cfg(feature = "memory-sqlite")]
@@ -76,6 +77,7 @@ pub struct AsyncDelegateSpawnRequest {
     pub parent_session_id: String,
     pub task: String,
     pub label: Option<String>,
+    pub execution: ConstrainedSubagentExecution,
     pub timeout_seconds: u64,
     pub kernel_context: Option<KernelContext>,
 }
@@ -115,11 +117,9 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
                 last_error: None,
                 event_kind: "delegate_started".to_owned(),
                 actor_session_id: Some(request.parent_session_id.clone()),
-                event_payload_json: json!({
-                    "task": request.task.clone(),
-                    "label": request.label.clone(),
-                    "timeout_seconds": request.timeout_seconds,
-                }),
+                event_payload_json: request
+                    .execution
+                    .spawn_payload(&request.task, request.label.as_deref()),
             },
         )?;
         if started.is_none() {
@@ -137,6 +137,7 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
             &request.parent_session_id,
             request.label,
             &request.task,
+            request.execution,
             request.timeout_seconds,
             ConversationRuntimeBinding::from_optional_kernel_context(
                 request.kernel_context.as_ref(),

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use crate::tools::runtime_config::ToolRuntimeNarrowing;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConstrainedSubagentMode {
@@ -27,6 +29,8 @@ pub struct ConstrainedSubagentExecution {
     pub timeout_seconds: u64,
     pub allow_shell_in_child: bool,
     pub child_tool_allowlist: Vec<String>,
+    #[serde(default, skip_serializing_if = "ToolRuntimeNarrowing::is_empty")]
+    pub runtime_narrowing: ToolRuntimeNarrowing,
     pub kernel_bound: bool,
 }
 
@@ -95,6 +99,7 @@ mod tests {
             timeout_seconds: 60,
             allow_shell_in_child: false,
             child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            runtime_narrowing: ToolRuntimeNarrowing::default(),
             kernel_bound: true,
         };
 

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstrainedSubagentMode {
+    Inline,
+    Async,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstrainedSubagentTerminalReason {
+    Completed,
+    Failed,
+    TimedOut,
+    SpawnFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstrainedSubagentExecution {
+    pub mode: ConstrainedSubagentMode,
+    pub depth: usize,
+    pub max_depth: usize,
+    pub active_children: usize,
+    pub max_active_children: usize,
+    pub timeout_seconds: u64,
+    pub allow_shell_in_child: bool,
+    pub child_tool_allowlist: Vec<String>,
+    pub kernel_bound: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstrainedSubagentSpawnEventPayload {
+    pub task: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub execution: ConstrainedSubagentExecution,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstrainedSubagentTerminalEventPayload {
+    pub terminal_reason: ConstrainedSubagentTerminalReason,
+    pub execution: ConstrainedSubagentExecution,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl ConstrainedSubagentExecution {
+    pub fn spawn_payload(&self, task: &str, label: Option<&str>) -> Value {
+        json!(ConstrainedSubagentSpawnEventPayload {
+            task: task.to_owned(),
+            label: label.map(ToOwned::to_owned),
+            execution: self.clone(),
+        })
+    }
+
+    pub fn terminal_payload(
+        &self,
+        terminal_reason: ConstrainedSubagentTerminalReason,
+        duration_ms: u64,
+        turn_count: Option<usize>,
+        error: Option<&str>,
+    ) -> Value {
+        json!(ConstrainedSubagentTerminalEventPayload {
+            terminal_reason,
+            execution: self.clone(),
+            duration_ms,
+            turn_count,
+            error: error.map(ToOwned::to_owned),
+        })
+    }
+
+    pub fn from_event_payload(payload: &Value) -> Option<Self> {
+        let execution = payload.get("execution")?.clone();
+        serde_json::from_value(execution).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constrained_subagent_execution_round_trips_event_payload() {
+        let execution = ConstrainedSubagentExecution {
+            mode: ConstrainedSubagentMode::Async,
+            depth: 1,
+            max_depth: 2,
+            active_children: 0,
+            max_active_children: 3,
+            timeout_seconds: 60,
+            allow_shell_in_child: false,
+            child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            kernel_bound: true,
+        };
+
+        let payload = execution.spawn_payload("research", Some("child"));
+        assert_eq!(
+            ConstrainedSubagentExecution::from_event_payload(&payload),
+            Some(execution)
+        );
+    }
+}

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1258,6 +1258,80 @@ fn test_kernel_context_with_memory(
     }
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn sample_delegate_runtime_narrowing() -> crate::tools::runtime_config::ToolRuntimeNarrowing {
+    crate::tools::runtime_config::ToolRuntimeNarrowing {
+        browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+            max_sessions: Some(1),
+            max_links: Some(8),
+            max_text_chars: Some(512),
+        },
+        web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
+            allow_private_hosts: Some(false),
+            allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+            blocked_domains: BTreeSet::from(["deny.example.com".to_owned()]),
+            timeout_seconds: Some(5),
+            max_bytes: Some(4_096),
+            max_redirects: Some(2),
+        },
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn seed_delegate_child_session_with_runtime_narrowing(
+    config: &mut LoongClawConfig,
+    suffix: &str,
+    runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing,
+) -> String {
+    let sqlite_path = unique_memory_sqlite_path(&format!("delegate-runtime-contract-{suffix}"));
+    config.memory.sqlite_path = sqlite_path;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let root_session_id = format!("root-session-{suffix}");
+    let child_session_id = format!("child-session-{suffix}");
+
+    repo.create_session(NewSessionRecord {
+        session_id: root_session_id.clone(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(NewSessionRecord {
+        session_id: child_session_id.clone(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some(root_session_id.clone()),
+        label: Some("Child".to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: child_session_id.clone(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some(root_session_id),
+        payload_json: json!({
+            "task": "fetch docs",
+            "label": "Child",
+            "execution": {
+                "mode": "inline",
+                "depth": 1,
+                "max_depth": 2,
+                "active_children": 0,
+                "max_active_children": 3,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["web.fetch"],
+                "kernel_bound": true,
+                "runtime_narrowing": runtime_narrowing,
+            }
+        }),
+    })
+    .expect("append delegate_started event");
+
+    child_session_id
+}
+
 fn provider_tool_intent(
     tool_name: &str,
     args_json: Value,
@@ -1618,6 +1692,97 @@ async fn default_runtime_build_context_applies_system_prompt_addition() {
     assert_eq!(
         merged, "runtime-policy-addition\n\nbase-system-prompt",
         "system prompt addition should be prepended"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_merges_delegate_runtime_contract_with_system_prompt_addition()
+ {
+    let mut config = test_config();
+    let child_session_id = seed_delegate_child_session_with_runtime_narrowing(
+        &mut config,
+        "system-prompt-contract",
+        sample_delegate_runtime_narrowing(),
+    );
+    let runtime = DefaultConversationRuntime::with_context_engine(StubSystemPromptAdditionEngine);
+    let binding = crate::conversation::ConversationRuntimeBinding::direct();
+
+    let assembled = runtime
+        .build_context(&config, &child_session_id, true, binding)
+        .await
+        .expect("build context with delegate runtime contract");
+
+    let merged = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should stay string");
+    assert!(
+        merged.contains("runtime-policy-addition"),
+        "expected existing addition to remain in merged prompt, got: {merged}"
+    );
+    assert!(
+        merged.contains("[delegate_child_runtime_contract]"),
+        "expected delegate runtime contract marker, got: {merged}"
+    );
+    assert!(merged.contains("Plan within these child-session runtime limits:"));
+    assert!(merged.contains("- web.fetch private hosts: denied"));
+    assert!(merged.contains("- web.fetch allowed domains: docs.example.com"));
+    assert!(merged.contains("- web.fetch blocked domains: deny.example.com"));
+    assert!(merged.contains("- web.fetch timeout seconds: 5"));
+    assert!(merged.contains("- web.fetch max bytes: 4096"));
+    assert!(merged.contains("- web.fetch max redirects: 2"));
+    assert!(merged.contains("- browser max sessions: 1"));
+    assert!(merged.contains("- browser max links: 8"));
+    assert!(merged.contains("- browser max text chars: 512"));
+    assert!(merged.ends_with("base-system-prompt"));
+    assert!(
+        merged.find("runtime-policy-addition") < merged.find("[delegate_child_runtime_contract]"),
+        "expected the existing system prompt addition to remain ahead of the child contract block, got: {merged}"
+    );
+}
+
+#[tokio::test]
+async fn default_runtime_build_context_does_not_add_delegate_runtime_contract_for_root_session() {
+    let runtime = DefaultConversationRuntime::default();
+    let binding = crate::conversation::ConversationRuntimeBinding::direct();
+
+    let assembled = runtime
+        .build_context(&test_config(), "root-session-no-contract", true, binding)
+        .await
+        .expect("build context for root session");
+
+    let system_content = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should stay string");
+    assert!(
+        !system_content.contains("[delegate_child_runtime_contract]"),
+        "root system prompt should not include the child runtime contract block: {system_content}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_skips_delegate_runtime_contract_for_empty_child_narrowing() {
+    let mut config = test_config();
+    let child_session_id = seed_delegate_child_session_with_runtime_narrowing(
+        &mut config,
+        "empty-child-narrowing",
+        crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
+    );
+    let runtime = DefaultConversationRuntime::default();
+    let binding = crate::conversation::ConversationRuntimeBinding::direct();
+
+    let assembled = runtime
+        .build_context(&config, &child_session_id, true, binding)
+        .await
+        .expect("build context for child session");
+
+    let system_content = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should stay string");
+    assert!(
+        !system_content.contains("[delegate_child_runtime_contract]"),
+        "empty child narrowing should not inject a contract block: {system_content}"
     );
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -60,6 +60,9 @@ struct FakeRuntime {
     turn_calls: Mutex<usize>,
     after_turn_calls: Mutex<Vec<(String, String, String, usize)>>,
     compact_calls: Mutex<Vec<(String, usize)>>,
+    prepare_subagent_spawn_result: Result<(), String>,
+    on_subagent_ended_result: Result<(), String>,
+    subagent_lifecycle_calls: Mutex<Vec<String>>,
 }
 
 enum FakeTurnResponse {
@@ -198,6 +201,7 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
             &request.parent_session_id,
             request.label,
             &request.task,
+            request.execution,
             request.timeout_seconds,
             ConversationRuntimeBinding::from_optional_kernel_context(
                 request.kernel_context.as_ref(),
@@ -572,6 +576,9 @@ impl FakeRuntime {
             turn_calls: Mutex::new(0),
             after_turn_calls: Mutex::new(Vec::new()),
             compact_calls: Mutex::new(Vec::new()),
+            prepare_subagent_spawn_result: Ok(()),
+            on_subagent_ended_result: Ok(()),
+            subagent_lifecycle_calls: Mutex::new(Vec::new()),
         }
     }
 
@@ -603,6 +610,11 @@ impl FakeRuntime {
 
     fn with_compact_result(mut self, result: Result<(), String>) -> Self {
         self.compact_result = result;
+        self
+    }
+
+    fn with_prepare_subagent_spawn_result(mut self, result: Result<(), String>) -> Self {
+        self.prepare_subagent_spawn_result = result;
         self
     }
 
@@ -1159,6 +1171,36 @@ impl ConversationRuntime for FakeRuntime {
             .expect("compact lock")
             .push((session_id.to_owned(), messages.len()));
         self.compact_result.clone()
+    }
+
+    async fn prepare_subagent_spawn(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+        _kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.subagent_lifecycle_calls
+            .lock()
+            .expect("subagent lifecycle calls lock")
+            .push(format!(
+                "prepare_subagent_spawn:{parent_session_id}:{subagent_session_id}"
+            ));
+        self.prepare_subagent_spawn_result.clone()
+    }
+
+    async fn on_subagent_ended(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+        _kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.subagent_lifecycle_calls
+            .lock()
+            .expect("subagent lifecycle calls lock")
+            .push(format!(
+                "on_subagent_ended:{parent_session_id}:{subagent_session_id}"
+            ));
+        self.on_subagent_ended_result.clone()
     }
 }
 
@@ -11457,6 +11499,179 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate", "kernel-lifecycle")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Delegating.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "delegate",
+                    json!({
+                        "task": "child task",
+                        "label": "research-subtask"
+                    }),
+                    "root-session",
+                    "turn-delegate-parent",
+                    "call-delegate-parent",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-kernel-lifecycle");
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("delegate handle turn success");
+
+    assert!(
+        reply.contains("\"tool\":\"delegate\""),
+        "expected raw delegate tool output, got: {reply}"
+    );
+
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
+    assert_eq!(
+        child.state,
+        crate::session::repository::SessionState::Completed
+    );
+
+    assert_eq!(
+        runtime
+            .subagent_lifecycle_calls
+            .lock()
+            .expect("subagent lifecycle calls lock")
+            .clone(),
+        vec![
+            format!("prepare_subagent_spawn:root-session:{}", child.session_id),
+            format!("on_subagent_ended:root-session:{}", child.session_id),
+        ]
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_delegate_rejects_spawn_when_prepare_subagent_spawn_fails() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate", "prepare-failure")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Delegating.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "delegate",
+                json!({
+                    "task": "child task",
+                    "label": "research-subtask"
+                }),
+                "root-session",
+                "turn-delegate-parent",
+                "call-delegate-parent",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_prepare_subagent_spawn_result(Err("synthetic_prepare_subagent_spawn_failure".to_owned()))
+    .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-prepare-failure");
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("delegate handle turn reply");
+
+    assert!(
+        reply.contains("synthetic_prepare_subagent_spawn_failure"),
+        "expected prepare_subagent_spawn failure in reply, got: {reply}"
+    );
+    assert_eq!(
+        repo.list_sessions().expect("list sessions").len(),
+        1,
+        "failed prepare_subagent_spawn should not create a child session"
+    );
+
+    let calls = runtime
+        .subagent_lifecycle_calls
+        .lock()
+        .expect("subagent lifecycle calls lock")
+        .clone();
+    assert_eq!(calls.len(), 1);
+    assert!(
+        calls[0].starts_with("prepare_subagent_spawn:root-session:delegate:"),
+        "unexpected lifecycle calls: {calls:?}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_approve_once() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
@@ -11986,6 +12201,97 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
             .expect("async delegate requests lock")
             .len(),
         0
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_delegate_async_rejects_when_active_child_limit_is_exhausted() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-async", "active-child-limit")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.delegate.max_active_children = 1;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session-existing".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Existing".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create existing child session");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Delegating async.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
+                    "task": "child async task",
+                    "label": "async-child"
+                }),
+                "root-session",
+                "turn-delegate-async-parent",
+                "call-delegate-async-parent",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_async_delegate_spawner(spawner.clone())
+    .with_durable_memory_config(memory_config.clone());
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("delegate_async reply");
+
+    assert!(
+        reply.contains("delegate_active_children_exceeded"),
+        "expected active-child limit rejection, got: {reply}"
+    );
+    assert_eq!(
+        repo.list_visible_sessions("root-session")
+            .expect("list visible sessions")
+            .into_iter()
+            .filter(|session| session.parent_session_id.as_deref() == Some("root-session"))
+            .count(),
+        1,
+        "active-child limit rejection should not create another child session"
+    );
+    assert_eq!(
+        spawner
+            .requests
+            .lock()
+            .expect("async delegate requests lock")
+            .len(),
+        0,
+        "active-child limit rejection should happen before dispatching the async spawner"
     );
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
 use loongclaw_contracts::{
-    Capability, ExecutionRoute, HarnessKind, MemoryPlaneError, ToolCoreRequest,
+    Capability, ExecutionRoute, HarnessKind, MemoryPlaneError, ToolCoreOutcome, ToolCoreRequest,
 };
 use loongclaw_kernel::{
     CoreMemoryAdapter, FixedClock, InMemoryAuditSink, LoongClawKernel, MemoryCoreOutcome,
@@ -31,6 +31,8 @@ use crate::acp::{
 use crate::memory::MEMORY_OP_WINDOW;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{NewSessionRecord, SessionKind, SessionRepository, SessionState};
 
 struct FakeRuntime {
     seed_messages: Vec<Value>,
@@ -11073,6 +11075,285 @@ async fn handle_turn_with_runtime_passes_restricted_tool_view_into_provider_requ
             .as_slice(),
         &[child_view]
     );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_kernel_payload() {
+    struct EchoToolAdapter;
+
+    #[async_trait::async_trait]
+    impl loongclaw_kernel::CoreToolAdapter for EchoToolAdapter {
+        fn name(&self) -> &str {
+            "echo-tools"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, loongclaw_contracts::ToolPlaneError> {
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool": request.tool_name,
+                    "payload": request.payload,
+                }),
+            })
+        }
+    }
+
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-runtime", "payload-context")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.delegate.child_tool_allowlist = vec!["web.fetch".to_owned()];
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: SessionState::Running,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "fetch docs",
+            "label": "Child",
+            "execution": {
+                "mode": "inline",
+                "depth": 1,
+                "max_depth": 2,
+                "active_children": 0,
+                "max_active_children": 3,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["web.fetch"],
+                "kernel_bound": true,
+                "runtime_narrowing": {
+                    "web_fetch": {
+                        "allowed_domains": ["docs.example.com"],
+                        "allow_private_hosts": false
+                    },
+                    "browser": {
+                        "max_sessions": 1,
+                        "max_links": 8,
+                        "max_text_chars": 512
+                    }
+                }
+            }
+        }),
+    })
+    .expect("append delegate_started event");
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_context = runtime
+        .session_context(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("load child session context");
+    assert_eq!(
+        session_context
+            .runtime_narrowing
+            .as_ref()
+            .and_then(|narrowing| { narrowing.web_fetch.allowed_domains.iter().next().cloned() }),
+        Some("docs.example.com".to_owned())
+    );
+
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(EchoToolAdapter);
+    kernel
+        .set_default_core_tool_adapter("echo-tools")
+        .expect("set default tool adapter");
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+    let kernel_ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![provider_tool_intent(
+            "web.fetch",
+            json!({
+                "url": "https://outside.invalid/docs"
+            }),
+            "child-session",
+            "turn-child-runtime",
+            "call-child-runtime",
+        )],
+        raw_meta: Value::Null,
+    };
+
+    let result = TurnEngine::new(5)
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &DefaultAppToolDispatcher::runtime(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::FinalText(text) => {
+            let line = text.lines().next().expect("tool result line should exist");
+            let payload = line
+                .strip_prefix("[ok] ")
+                .expect("tool result line should keep [ok] prefix");
+            let envelope: Value =
+                serde_json::from_str(payload).expect("tool result envelope should be json");
+            let payload_summary = envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should be text");
+            assert!(
+                payload_summary.contains("\"runtime_narrowing\""),
+                "expected runtime_narrowing in payload summary, got: {payload_summary}"
+            );
+            assert!(
+                payload_summary.contains("docs.example.com"),
+                "expected narrowed domain in payload summary, got: {payload_summary}"
+            );
+            assert!(
+                payload_summary.contains("\"max_sessions\":1"),
+                "expected browser max_sessions narrowing in payload summary, got: {payload_summary}"
+            );
+        }
+        other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected final text tool output, got: {other:?}")
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_context_preserves_child_runtime_narrowing_after_many_later_events() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-runtime", "history-retention")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: SessionState::Running,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "fetch docs",
+            "label": "Child",
+            "execution": {
+                "mode": "inline",
+                "depth": 1,
+                "max_depth": 2,
+                "active_children": 0,
+                "max_active_children": 3,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["web.fetch"],
+                "kernel_bound": true,
+                "runtime_narrowing": {
+                    "web_fetch": {
+                        "allowed_domains": ["docs.example.com"],
+                        "allow_private_hosts": false
+                    },
+                    "browser": {
+                        "max_sessions": 1
+                    }
+                }
+            }
+        }),
+    })
+    .expect("append delegate_started event");
+
+    for index in 0..24 {
+        repo.append_event(crate::session::repository::NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: format!("child_progress_{index}"),
+            actor_session_id: Some("child-session".to_owned()),
+            payload_json: json!({
+                "index": index,
+            }),
+        })
+        .expect("append later child event");
+    }
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_context = runtime
+        .session_context(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("load child session context");
+
+    let runtime_narrowing = session_context
+        .runtime_narrowing
+        .expect("child runtime narrowing should survive later events");
+    assert_eq!(
+        runtime_narrowing.web_fetch.allowed_domains,
+        BTreeSet::from(["docs.example.com".to_owned()])
+    );
+    assert_eq!(runtime_narrowing.browser.max_sessions, Some(1));
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4296,6 +4296,7 @@ fn constrained_subagent_execution_for_delegate(
         timeout_seconds,
         allow_shell_in_child: config.tools.delegate.allow_shell_in_child,
         child_tool_allowlist: config.tools.delegate.child_tool_allowlist.clone(),
+        runtime_narrowing: config.tools.delegate.child_runtime.runtime_narrowing(),
         kernel_bound: binding.is_kernel_bound(),
     })
 }
@@ -6376,6 +6377,7 @@ mod tests {
             timeout_seconds: 60,
             allow_shell_in_child: false,
             child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
             kernel_bound: false,
         };
         repo.create_session(NewSessionRecord {
@@ -6487,6 +6489,7 @@ mod tests {
             timeout_seconds: 60,
             allow_shell_in_child: false,
             child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
             kernel_bound: false,
         };
         repo.create_session(NewSessionRecord {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -68,6 +68,10 @@ use super::session_history::{
     AssistantHistoryLoadErrorCode, load_assistant_contents_from_session_window_detailed,
     load_latest_turn_checkpoint_entry, load_turn_checkpoint_history_snapshot,
 };
+#[cfg(feature = "memory-sqlite")]
+use super::subagent::{
+    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
+};
 use super::turn_budget::{
     EscalatingAttemptBudget, SafeLaneBackpressureBudget, SafeLaneContinuationBudgetDecision,
     SafeLaneFailureRouteReason, SafeLaneReplanBudget,
@@ -3781,14 +3785,21 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
     let child_session_id = crate::tools::delegate::next_delegate_session_id();
     let child_label = delegate_request.label.clone();
     let repo = SessionRepository::new(&MemoryRuntimeConfig::from_memory_config(&config.memory))?;
-    let current_depth = repo.session_lineage_depth(&session_context.session_id)?;
-    let next_child_depth = current_depth.saturating_add(1);
-    if next_child_depth > config.tools.delegate.max_depth {
-        return Err(format!(
-            "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
-            config.tools.delegate.max_depth
-        ));
-    }
+    let execution = constrained_subagent_execution_for_delegate(
+        config,
+        &repo,
+        session_context,
+        binding,
+        ConstrainedSubagentMode::Inline,
+        delegate_request.timeout_seconds,
+    )?;
+    prepare_subagent_spawn_if_kernel_bound(
+        runtime,
+        &session_context.session_id,
+        &child_session_id,
+        binding,
+    )
+    .await?;
 
     repo.create_session_with_event(CreateSessionWithEventRequest {
         session: NewSessionRecord {
@@ -3800,11 +3811,7 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
         },
         event_kind: "delegate_started".to_owned(),
         actor_session_id: Some(session_context.session_id.clone()),
-        event_payload_json: json!({
-            "task": delegate_request.task.clone(),
-            "label": child_label.clone(),
-            "timeout_seconds": delegate_request.timeout_seconds,
-        }),
+        event_payload_json: execution.spawn_payload(&delegate_request.task, child_label.as_deref()),
     })?;
 
     run_started_delegate_child_turn_with_runtime(
@@ -3814,6 +3821,7 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
         &session_context.session_id,
         child_label,
         &delegate_request.task,
+        execution,
         delegate_request.timeout_seconds,
         binding,
     )
@@ -3845,14 +3853,21 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
     let child_label = delegate_request.label.clone();
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
-    let current_depth = repo.session_lineage_depth(&session_context.session_id)?;
-    let next_child_depth = current_depth.saturating_add(1);
-    if next_child_depth > config.tools.delegate.max_depth {
-        return Err(format!(
-            "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
-            config.tools.delegate.max_depth
-        ));
-    }
+    let execution = constrained_subagent_execution_for_delegate(
+        config,
+        &repo,
+        session_context,
+        binding,
+        ConstrainedSubagentMode::Async,
+        delegate_request.timeout_seconds,
+    )?;
+    prepare_subagent_spawn_if_kernel_bound(
+        runtime,
+        &session_context.session_id,
+        &child_session_id,
+        binding,
+    )
+    .await?;
 
     repo.create_session_with_event(CreateSessionWithEventRequest {
         session: NewSessionRecord {
@@ -3864,11 +3879,7 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
         },
         event_kind: "delegate_queued".to_owned(),
         actor_session_id: Some(session_context.session_id.clone()),
-        event_payload_json: json!({
-            "task": delegate_request.task,
-            "label": child_label,
-            "timeout_seconds": delegate_request.timeout_seconds,
-        }),
+        event_payload_json: execution.spawn_payload(&delegate_request.task, child_label.as_deref()),
     })?;
 
     spawn_async_delegate_detached(
@@ -3880,6 +3891,7 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
             parent_session_id: session_context.session_id.clone(),
             task: delegate_request.task,
             label: child_label,
+            execution,
             timeout_seconds: delegate_request.timeout_seconds,
             kernel_context: binding.kernel_context().cloned(),
         },
@@ -3924,6 +3936,7 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
     parent_session_id: &str,
     child_label: Option<String>,
     user_input: &str,
+    execution: ConstrainedSubagentExecution,
     timeout_seconds: u64,
     binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
@@ -3965,14 +3978,23 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     last_error: None,
                     event_kind: "delegate_completed".to_owned(),
                     actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: json!({
-                        "turn_count": turn_count,
-                        "duration_ms": duration_ms,
-                    }),
+                    event_payload_json: execution.terminal_payload(
+                        ConstrainedSubagentTerminalReason::Completed,
+                        duration_ms,
+                        Some(turn_count),
+                        None,
+                    ),
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
                 },
             )?;
+            notify_subagent_ended_if_kernel_bound(
+                runtime,
+                parent_session_id,
+                child_session_id,
+                binding,
+            )
+            .await?;
             Ok(outcome)
         }
         Ok(Ok(Err(error))) => {
@@ -3990,14 +4012,23 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     last_error: Some(error.clone()),
                     event_kind: "delegate_failed".to_owned(),
                     actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: json!({
-                        "error": error,
-                        "duration_ms": duration_ms,
-                    }),
+                    event_payload_json: execution.terminal_payload(
+                        ConstrainedSubagentTerminalReason::Failed,
+                        duration_ms,
+                        None,
+                        Some(error.as_str()),
+                    ),
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
                 },
             )?;
+            notify_subagent_ended_if_kernel_bound(
+                runtime,
+                parent_session_id,
+                child_session_id,
+                binding,
+            )
+            .await?;
             Ok(outcome)
         }
         Ok(Err(panic_payload)) => {
@@ -4016,14 +4047,23 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     last_error: Some(panic_error.clone()),
                     event_kind: "delegate_failed".to_owned(),
                     actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: json!({
-                        "error": panic_error,
-                        "duration_ms": duration_ms,
-                    }),
+                    event_payload_json: execution.terminal_payload(
+                        ConstrainedSubagentTerminalReason::Failed,
+                        duration_ms,
+                        None,
+                        Some(panic_error.as_str()),
+                    ),
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
                 },
             )?;
+            notify_subagent_ended_if_kernel_bound(
+                runtime,
+                parent_session_id,
+                child_session_id,
+                binding,
+            )
+            .await?;
             Ok(outcome)
         }
         Err(_) => {
@@ -4041,14 +4081,23 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                     last_error: Some(timeout_error.clone()),
                     event_kind: "delegate_timed_out".to_owned(),
                     actor_session_id: Some(parent_session_id.to_owned()),
-                    event_payload_json: json!({
-                        "error": timeout_error,
-                        "duration_ms": duration_ms,
-                    }),
+                    event_payload_json: execution.terminal_payload(
+                        ConstrainedSubagentTerminalReason::TimedOut,
+                        duration_ms,
+                        None,
+                        Some(timeout_error.as_str()),
+                    ),
                     outcome_status: outcome.status.clone(),
                     outcome_payload_json: outcome.payload.clone(),
                 },
             )?;
+            notify_subagent_ended_if_kernel_bound(
+                runtime,
+                parent_session_id,
+                child_session_id,
+                binding,
+            )
+            .await?;
             Ok(outcome)
         }
     }
@@ -4060,6 +4109,7 @@ fn finalize_async_delegate_spawn_failure(
     child_session_id: &str,
     parent_session_id: &str,
     label: Option<String>,
+    execution: &ConstrainedSubagentExecution,
     error: String,
 ) -> Result<(), String> {
     let repo = SessionRepository::new(memory_config)?;
@@ -4074,9 +4124,12 @@ fn finalize_async_delegate_spawn_failure(
         last_error: Some(error.clone()),
         event_kind: "delegate_spawn_failed".to_owned(),
         actor_session_id: Some(parent_session_id.to_owned()),
-        event_payload_json: json!({
-            "error": error,
-        }),
+        event_payload_json: execution.terminal_payload(
+            ConstrainedSubagentTerminalReason::SpawnFailed,
+            0,
+            None,
+            Some(error.as_str()),
+        ),
         outcome_status: outcome.status,
         outcome_payload_json: outcome.payload,
     };
@@ -4095,6 +4148,7 @@ fn finalize_async_delegate_spawn_failure_with_recovery(
     child_session_id: &str,
     parent_session_id: &str,
     label: Option<String>,
+    execution: &ConstrainedSubagentExecution,
     error: String,
 ) -> Result<(), String> {
     let recovery_label = label.clone();
@@ -4103,6 +4157,7 @@ fn finalize_async_delegate_spawn_failure_with_recovery(
         child_session_id,
         parent_session_id,
         label,
+        execution,
         error.clone(),
     ) {
         Ok(()) => Ok(()),
@@ -4183,6 +4238,7 @@ fn spawn_async_delegate_detached(
     let child_session_id = request.child_session_id.clone();
     let parent_session_id = request.parent_session_id.clone();
     let label = request.label.clone();
+    let execution = request.execution.clone();
     runtime_handle.spawn(async move {
         let spawn_failure = match AssertUnwindSafe(spawner.spawn(request))
             .catch_unwind()
@@ -4198,10 +4254,80 @@ fn spawn_async_delegate_detached(
                 &child_session_id,
                 &parent_session_id,
                 label,
+                &execution,
                 error,
             );
         }
     });
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn constrained_subagent_execution_for_delegate(
+    config: &LoongClawConfig,
+    repo: &SessionRepository,
+    session_context: &SessionContext,
+    binding: ConversationRuntimeBinding<'_>,
+    mode: ConstrainedSubagentMode,
+    timeout_seconds: u64,
+) -> Result<ConstrainedSubagentExecution, String> {
+    let current_depth = repo.session_lineage_depth(&session_context.session_id)?;
+    let next_child_depth = current_depth.saturating_add(1);
+    if next_child_depth > config.tools.delegate.max_depth {
+        return Err(format!(
+            "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
+            config.tools.delegate.max_depth
+        ));
+    }
+
+    let active_children = repo.count_active_direct_children(&session_context.session_id)?;
+    if active_children >= config.tools.delegate.max_active_children {
+        return Err(format!(
+            "delegate_active_children_exceeded: active child count {active_children} reaches configured max_active_children {}",
+            config.tools.delegate.max_active_children
+        ));
+    }
+
+    Ok(ConstrainedSubagentExecution {
+        mode,
+        depth: next_child_depth,
+        max_depth: config.tools.delegate.max_depth,
+        active_children,
+        max_active_children: config.tools.delegate.max_active_children,
+        timeout_seconds,
+        allow_shell_in_child: config.tools.delegate.allow_shell_in_child,
+        child_tool_allowlist: config.tools.delegate.child_tool_allowlist.clone(),
+        kernel_bound: binding.is_kernel_bound(),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn prepare_subagent_spawn_if_kernel_bound<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    parent_session_id: &str,
+    child_session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<(), String> {
+    let Some(kernel_ctx) = binding.kernel_context() else {
+        return Ok(());
+    };
+    runtime
+        .prepare_subagent_spawn(parent_session_id, child_session_id, kernel_ctx)
+        .await
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn notify_subagent_ended_if_kernel_bound<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    parent_session_id: &str,
+    child_session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<(), String> {
+    let Some(kernel_ctx) = binding.kernel_context() else {
+        return Ok(());
+    };
+    runtime
+        .on_subagent_ended(parent_session_id, child_session_id, kernel_ctx)
+        .await
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -6241,6 +6367,17 @@ mod tests {
     fn finalize_async_delegate_spawn_failure_does_not_overwrite_recovered_failure() {
         let memory_config = sqlite_memory_config("recovered-ready-child");
         let repo = SessionRepository::new(&memory_config).expect("session repository");
+        let execution = ConstrainedSubagentExecution {
+            mode: ConstrainedSubagentMode::Async,
+            depth: 1,
+            max_depth: 1,
+            active_children: 0,
+            max_active_children: 1,
+            timeout_seconds: 60,
+            allow_shell_in_child: false,
+            child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            kernel_bound: false,
+        };
         repo.create_session(NewSessionRecord {
             session_id: "root-session".to_owned(),
             kind: SessionKind::Root,
@@ -6267,6 +6404,7 @@ mod tests {
             "child-session",
             "root-session",
             Some("Child".to_owned()),
+            &execution,
             "spawn unavailable".to_owned(),
         )
         .expect("stale queued spawn failure finalizer should no-op");
@@ -6340,6 +6478,17 @@ mod tests {
     fn finalize_async_delegate_spawn_failure_with_recovery_errors_when_child_session_missing() {
         let memory_config = sqlite_memory_config("missing-ready-child");
         let repo = SessionRepository::new(&memory_config).expect("session repository");
+        let execution = ConstrainedSubagentExecution {
+            mode: ConstrainedSubagentMode::Async,
+            depth: 1,
+            max_depth: 1,
+            active_children: 0,
+            max_active_children: 1,
+            timeout_seconds: 60,
+            allow_shell_in_child: false,
+            child_tool_allowlist: vec!["file.read".to_owned(), "file.write".to_owned()],
+            kernel_bound: false,
+        };
         repo.create_session(NewSessionRecord {
             session_id: "root-session".to_owned(),
             kind: SessionKind::Root,
@@ -6354,6 +6503,7 @@ mod tests {
             "child-session",
             "root-session",
             Some("Child".to_owned()),
+            &execution,
             "spawn unavailable".to_owned(),
         )
         .expect_err("missing child session should not bypass spawn failure recovery");

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -646,11 +646,13 @@ pub(crate) fn render_kernel_error_reason(error: &KernelError) -> String {
 fn augment_tool_payload_for_kernel(
     canonical_tool_name: &str,
     payload: serde_json::Value,
-    session_id: &str,
+    session_context: &SessionContext,
 ) -> serde_json::Value {
+    let payload = inject_runtime_narrowing_context(payload, session_context);
+
     // Direct browser tool calls: inject scope at the top level.
     if browser_scope_injection_required(canonical_tool_name) {
-        return inject_browser_scope_field(payload, session_id);
+        return inject_browser_scope_field(payload, &session_context.session_id);
     }
 
     // tool.invoke wrapping a browser tool: inject scope into the nested arguments.
@@ -664,13 +666,43 @@ fn augment_tool_payload_for_kernel(
         if let Some(arguments) = outer.remove("arguments") {
             outer.insert(
                 "arguments".to_owned(),
-                inject_browser_scope_field(arguments, session_id),
+                inject_browser_scope_field(arguments, &session_context.session_id),
             );
         }
         return serde_json::Value::Object(outer);
     }
 
     payload
+}
+
+fn inject_runtime_narrowing_context(
+    payload: serde_json::Value,
+    session_context: &SessionContext,
+) -> serde_json::Value {
+    let Some(runtime_narrowing) = session_context.runtime_narrowing.as_ref() else {
+        return payload;
+    };
+    if runtime_narrowing.is_empty() {
+        return payload;
+    }
+
+    let serde_json::Value::Object(mut object) = payload else {
+        return payload;
+    };
+    let mut internal = object
+        .remove(crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    internal.insert(
+        crate::tools::LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY.to_owned(),
+        serde_json::to_value(runtime_narrowing)
+            .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new())),
+    );
+    object.insert(
+        crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+        serde_json::Value::Object(internal),
+    );
+    serde_json::Value::Object(object)
 }
 
 fn browser_scope_injection_required(tool_name: &str) -> bool {
@@ -1114,7 +1146,7 @@ impl TurnEngine {
             let augmented_payload = augment_tool_payload_for_kernel(
                 resolved_tool.canonical_name,
                 injected.payload,
-                &session_context.session_id,
+                session_context,
             );
             let request = ToolCoreRequest {
                 tool_name: resolved_tool.canonical_name.to_owned(),
@@ -1961,7 +1993,11 @@ mod tests {
             Some("turn-browser-companion-start"),
         );
 
-        let augmented = augment_tool_payload_for_kernel(&tool_name, payload, "root-session");
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::ToolView::from_tool_names(std::iter::empty::<&str>()),
+        );
+        let augmented = augment_tool_payload_for_kernel(&tool_name, payload, &session_context);
 
         assert_eq!(augmented["tool_id"], "browser.companion.session.start");
         assert_eq!(

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -804,6 +804,23 @@ impl SessionRepository {
         Ok(depth)
     }
 
+    pub fn count_active_direct_children(&self, parent_session_id: &str) -> Result<usize, String> {
+        let parent_session_id = normalize_required_text(parent_session_id, "parent_session_id")?;
+        let conn = self.open_connection()?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM sessions
+                 WHERE parent_session_id = ?1
+                   AND state IN ('ready', 'running')",
+                params![parent_session_id],
+                |row| row.get(0),
+            )
+            .map_err(|error| format!("count active direct child sessions failed: {error}"))?;
+        usize::try_from(count)
+            .map_err(|error| format!("active direct child count overflowed usize: {error}"))
+    }
+
     pub fn lineage_root_session_id(&self, session_id: &str) -> Result<Option<String>, String> {
         let session_id = normalize_required_text(session_id, "session_id")?;
         let mut seen = BTreeSet::new();

--- a/crates/app/src/tools/browser.rs
+++ b/crates/app/src/tools/browser.rs
@@ -694,6 +694,7 @@ mod tests {
             web_fetch: super::super::runtime_config::WebFetchRuntimePolicy {
                 enabled: true,
                 allow_private_hosts: true,
+                enforce_allowed_domains: false,
                 allowed_domains: std::collections::BTreeSet::new(),
                 blocked_domains: std::collections::BTreeSet::new(),
                 timeout_seconds: 5,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2842,6 +2842,46 @@ mod tests {
 
     #[cfg(feature = "tool-webfetch")]
     #[test]
+    fn web_fetch_denies_disjoint_allowlists_when_runtime_narrowing_intersection_is_empty() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-web-fetch-runtime-narrowing-disjoint-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let mut config = test_tool_runtime_config(root.clone());
+        config
+            .web_fetch
+            .allowed_domains
+            .insert("api.example.com".to_owned());
+        let error = execute_tool_core_with_test_context(
+            ToolCoreRequest {
+                tool_name: "web.fetch".to_owned(),
+                payload: json!({
+                    "url": "https://outside.invalid/docs",
+                    "_loongclaw": {
+                        "runtime_narrowing": {
+                            "web_fetch": {
+                                "allowed_domains": ["docs.example.com"]
+                            }
+                        }
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("disjoint allowlists should deny before host resolution");
+
+        assert!(
+            error.contains("not in allowed_domains"),
+            "expected empty-intersection allowlist denial, got: {error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    #[test]
     fn web_fetch_rejects_forged_runtime_narrowing_from_untrusted_payload() {
         let root = std::env::temp_dir().join(format!(
             "loongclaw-web-fetch-runtime-narrowing-forged-{}",

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -64,6 +64,7 @@ pub const BROWSER_COMPANION_COMMAND: &str = bundled_skills::BROWSER_COMPANION_CO
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: &str = "visible_tool_ids";
+pub(crate) const LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY: &str = "runtime_narrowing";
 
 pub fn normalize_external_skills_domain_rule(raw: &str) -> Result<String, String> {
     external_skills::normalize_domain_rule(raw)
@@ -595,11 +596,28 @@ pub fn execute_tool_core_with_config(
         tool_name: canonical_name.to_owned(),
         payload: request.payload,
     };
+    let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)
+        .map(|narrowing| config.narrowed(&narrowing));
+    let config = effective_config.as_ref().unwrap_or(config);
     match canonical_name {
         "tool.search" => execute_tool_search_tool_with_config(request, config),
         "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
         _ => execute_discoverable_tool_core_with_config(request, config),
     }
+}
+
+fn trusted_runtime_narrowing_from_payload(
+    payload: &Value,
+) -> Option<runtime_config::ToolRuntimeNarrowing> {
+    if !trusted_internal_tool_payload_enabled() {
+        return None;
+    }
+
+    payload
+        .get(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+        .and_then(|body| body.get(LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY))
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
 }
 
 fn execute_discoverable_tool_core_with_config(
@@ -2775,6 +2793,80 @@ mod tests {
             &config,
         )
         .expect_err("untrusted tool search should reject reserved internal visibility context");
+
+        assert!(
+            error.contains("payload._loongclaw is reserved for trusted internal tool context"),
+            "error={error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    #[test]
+    fn web_fetch_respects_runtime_narrowing_from_trusted_internal_payload() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-web-fetch-runtime-narrowing-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let mut config = test_tool_runtime_config(root.clone());
+        config.web_fetch.timeout_seconds = 1;
+        let error = execute_tool_core_with_test_context(
+            ToolCoreRequest {
+                tool_name: "web.fetch".to_owned(),
+                payload: json!({
+                    "url": "https://example.com/docs",
+                    "_loongclaw": {
+                        "runtime_narrowing": {
+                            "web_fetch": {
+                                "allowed_domains": ["docs.example.com"],
+                                "allow_private_hosts": false
+                            }
+                        }
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("runtime-narrowed child web.fetch should be denied before network access");
+
+        assert!(
+            error.contains("not in allowed_domains"),
+            "expected narrowed domain denial, got: {error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    #[test]
+    fn web_fetch_rejects_forged_runtime_narrowing_from_untrusted_payload() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-web-fetch-runtime-narrowing-forged-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "web.fetch".to_owned(),
+                payload: json!({
+                    "url": "https://example.com/docs",
+                    "_loongclaw": {
+                        "runtime_narrowing": {
+                            "web_fetch": {
+                                "allowed_domains": ["docs.example.com"]
+                            }
+                        }
+                    }
+                }),
+            },
+            &config,
+        )
+        .expect_err("untrusted runtime narrowing should be rejected");
 
         assert!(
             error.contains("payload._loongclaw is reserved for trusted internal tool context"),

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -68,6 +68,73 @@ impl ToolRuntimeNarrowing {
     pub fn is_empty(&self) -> bool {
         self.browser.is_empty() && self.web_fetch.is_empty()
     }
+
+    #[must_use]
+    pub fn delegate_child_prompt_summary(&self) -> Option<String> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let mut lines = vec![
+            "[delegate_child_runtime_contract]".to_owned(),
+            "Plan within these child-session runtime limits:".to_owned(),
+        ];
+
+        if let Some(allow_private_hosts) = self.web_fetch.allow_private_hosts {
+            lines.push(format!(
+                "- web.fetch private hosts: {}",
+                if allow_private_hosts {
+                    "allowed"
+                } else {
+                    "denied"
+                }
+            ));
+        }
+        if !self.web_fetch.allowed_domains.is_empty() {
+            lines.push(format!(
+                "- web.fetch allowed domains: {}",
+                self.web_fetch
+                    .allowed_domains
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if !self.web_fetch.blocked_domains.is_empty() {
+            lines.push(format!(
+                "- web.fetch blocked domains: {}",
+                self.web_fetch
+                    .blocked_domains
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if let Some(timeout_seconds) = self.web_fetch.timeout_seconds {
+            lines.push(format!("- web.fetch timeout seconds: {timeout_seconds}"));
+        }
+        if let Some(max_bytes) = self.web_fetch.max_bytes {
+            lines.push(format!("- web.fetch max bytes: {max_bytes}"));
+        }
+        if let Some(max_redirects) = self.web_fetch.max_redirects {
+            lines.push(format!("- web.fetch max redirects: {max_redirects}"));
+        }
+
+        if let Some(max_sessions) = self.browser.max_sessions {
+            lines.push(format!("- browser max sessions: {max_sessions}"));
+        }
+        if let Some(max_links) = self.browser.max_links {
+            lines.push(format!("- browser max links: {max_links}"));
+        }
+        if let Some(max_text_chars) = self.browser.max_text_chars {
+            lines.push(format!("- browser max text chars: {max_text_chars}"));
+        }
+
+        lines.push("Treat these as enforced limits for this child session.".to_owned());
+        Some(lines.join("\n"))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1264,6 +1331,53 @@ mod tests {
         assert!(
             effective.web_fetch.allowed_domains.is_empty(),
             "disjoint allowlists should preserve an enforced empty intersection"
+        );
+    }
+
+    #[test]
+    fn delegate_child_prompt_summary_returns_none_when_narrowing_is_empty() {
+        assert_eq!(
+            ToolRuntimeNarrowing::default().delegate_child_prompt_summary(),
+            None
+        );
+    }
+
+    #[test]
+    fn delegate_child_prompt_summary_is_stable_and_sparse() {
+        let narrowing = ToolRuntimeNarrowing {
+            browser: BrowserRuntimeNarrowing {
+                max_sessions: Some(1),
+                max_links: Some(8),
+                max_text_chars: Some(512),
+            },
+            web_fetch: WebFetchRuntimeNarrowing {
+                allow_private_hosts: Some(false),
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["deny.example.com".to_owned()]),
+                timeout_seconds: Some(5),
+                max_bytes: Some(4_096),
+                max_redirects: Some(2),
+            },
+        };
+
+        let summary = narrowing
+            .delegate_child_prompt_summary()
+            .expect("delegate child prompt summary");
+
+        assert_eq!(
+            summary,
+            "[delegate_child_runtime_contract]\n\
+Plan within these child-session runtime limits:\n\
+- web.fetch private hosts: denied\n\
+- web.fetch allowed domains: docs.example.com\n\
+- web.fetch blocked domains: deny.example.com\n\
+- web.fetch timeout seconds: 5\n\
+- web.fetch max bytes: 4096\n\
+- web.fetch max redirects: 2\n\
+- browser max sessions: 1\n\
+- browser max links: 8\n\
+- browser max text chars: 512\n\
+Treat these as enforced limits for this child session."
         );
     }
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -144,6 +144,7 @@ impl BrowserCompanionRuntimePolicy {
 pub struct WebFetchRuntimePolicy {
     pub enabled: bool,
     pub allow_private_hosts: bool,
+    pub enforce_allowed_domains: bool,
     pub allowed_domains: BTreeSet<String>,
     pub blocked_domains: BTreeSet<String>,
     pub timeout_seconds: u64,
@@ -156,6 +157,7 @@ impl Default for WebFetchRuntimePolicy {
         Self {
             enabled: true,
             allow_private_hosts: false,
+            enforce_allowed_domains: false,
             allowed_domains: BTreeSet::new(),
             blocked_domains: BTreeSet::new(),
             timeout_seconds: crate::config::DEFAULT_WEB_FETCH_TIMEOUT_SECONDS,
@@ -240,6 +242,8 @@ impl Default for ToolRuntimeConfig {
 
 impl ToolRuntimeConfig {
     pub fn from_loongclaw_config(config: &LoongClawConfig, config_path: Option<&Path>) -> Self {
+        let web_fetch_allowed_domains = config.tools.web.normalized_allowed_domains();
+        let web_fetch_enforce_allowed_domains = !web_fetch_allowed_domains.is_empty();
         Self {
             file_root: Some(config.tools.resolved_file_root()),
             shell_allow: config
@@ -275,12 +279,8 @@ impl ToolRuntimeConfig {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: config.tools.web.enabled,
                 allow_private_hosts: config.tools.web.allow_private_hosts,
-                allowed_domains: config
-                    .tools
-                    .web
-                    .normalized_allowed_domains()
-                    .into_iter()
-                    .collect(),
+                enforce_allowed_domains: web_fetch_enforce_allowed_domains,
+                allowed_domains: web_fetch_allowed_domains.into_iter().collect(),
                 blocked_domains: config
                     .tools
                     .web
@@ -387,6 +387,7 @@ impl ToolRuntimeConfig {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: web_fetch_enabled,
                 allow_private_hosts: web_fetch_allow_private_hosts,
+                enforce_allowed_domains: !web_fetch_allowed_domains.is_empty(),
                 allowed_domains: web_fetch_allowed_domains,
                 blocked_domains: web_fetch_blocked_domains,
                 timeout_seconds: web_fetch_timeout_seconds,
@@ -440,6 +441,7 @@ impl ToolRuntimeConfig {
         };
 
         if !narrowing.web_fetch.allowed_domains.is_empty() {
+            narrowed.web_fetch.enforce_allowed_domains = true;
             narrowed.web_fetch.allowed_domains = if narrowed.web_fetch.allowed_domains.is_empty() {
                 narrowing.web_fetch.allowed_domains.clone()
             } else {
@@ -763,6 +765,7 @@ mod tests {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: false,
                 allow_private_hosts: true,
+                enforce_allowed_domains: true,
                 allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
                 blocked_domains: BTreeSet::from(["internal.example".to_owned()]),
                 timeout_seconds: 9,
@@ -1115,6 +1118,7 @@ mod tests {
         let policy = WebFetchRuntimePolicy {
             enabled: false,
             allow_private_hosts: true,
+            enforce_allowed_domains: true,
             allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
             blocked_domains: BTreeSet::from(["internal.example".to_owned()]),
             timeout_seconds: 9,
@@ -1124,6 +1128,7 @@ mod tests {
 
         assert!(!policy.enabled);
         assert!(policy.allow_private_hosts);
+        assert!(policy.enforce_allowed_domains);
         assert!(policy.allowed_domains.contains("docs.example.com"));
         assert!(policy.blocked_domains.contains("internal.example"));
         assert_eq!(policy.timeout_seconds, 9);
@@ -1143,6 +1148,7 @@ mod tests {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: true,
                 allow_private_hosts: true,
+                enforce_allowed_domains: true,
                 allowed_domains: BTreeSet::from([
                     "docs.example.com".to_owned(),
                     "api.example.com".to_owned(),
@@ -1180,6 +1186,7 @@ mod tests {
             effective.web_fetch.allowed_domains,
             BTreeSet::from(["docs.example.com".to_owned()])
         );
+        assert!(effective.web_fetch.enforce_allowed_domains);
         assert_eq!(
             effective.web_fetch.blocked_domains,
             BTreeSet::from([
@@ -1198,6 +1205,7 @@ mod tests {
             web_fetch: WebFetchRuntimePolicy {
                 enabled: true,
                 allow_private_hosts: false,
+                enforce_allowed_domains: false,
                 allowed_domains: BTreeSet::new(),
                 blocked_domains: BTreeSet::new(),
                 timeout_seconds: 15,
@@ -1223,6 +1231,39 @@ mod tests {
         assert_eq!(
             effective.web_fetch.allowed_domains,
             BTreeSet::from(["docs.example.com".to_owned()])
+        );
+        assert!(effective.web_fetch.enforce_allowed_domains);
+    }
+
+    #[test]
+    fn tool_runtime_config_narrowed_fail_closes_disjoint_allowlists() {
+        let base = ToolRuntimeConfig {
+            web_fetch: WebFetchRuntimePolicy {
+                enabled: true,
+                allow_private_hosts: false,
+                enforce_allowed_domains: true,
+                allowed_domains: BTreeSet::from(["api.example.com".to_owned()]),
+                blocked_domains: BTreeSet::new(),
+                timeout_seconds: 15,
+                max_bytes: 8_192,
+                max_redirects: 4,
+            },
+            ..ToolRuntimeConfig::default()
+        };
+        let narrowing = ToolRuntimeNarrowing {
+            web_fetch: WebFetchRuntimeNarrowing {
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                ..WebFetchRuntimeNarrowing::default()
+            },
+            ..ToolRuntimeNarrowing::default()
+        };
+
+        let effective = base.narrowed(&narrowing);
+
+        assert!(effective.web_fetch.enforce_allowed_domains);
+        assert!(
+            effective.web_fetch.allowed_domains.is_empty(),
+            "disjoint allowlists should preserve an enforced empty intersection"
         );
     }
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -3,10 +3,72 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use serde::{Deserialize, Serialize};
+
 use super::shell_policy_ext::ShellPolicyDefault;
 use crate::config::LoongClawConfig;
 #[cfg(feature = "feishu-integration")]
 use crate::config::{FeishuChannelConfig, FeishuIntegrationConfig};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct BrowserRuntimeNarrowing {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_sessions: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_links: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_text_chars: Option<usize>,
+}
+
+impl BrowserRuntimeNarrowing {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.max_sessions.is_none() && self.max_links.is_none() && self.max_text_chars.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebFetchRuntimeNarrowing {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_private_hosts: Option<bool>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub allowed_domains: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub blocked_domains: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_redirects: Option<usize>,
+}
+
+impl WebFetchRuntimeNarrowing {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.allow_private_hosts.is_none()
+            && self.allowed_domains.is_empty()
+            && self.blocked_domains.is_empty()
+            && self.timeout_seconds.is_none()
+            && self.max_bytes.is_none()
+            && self.max_redirects.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ToolRuntimeNarrowing {
+    #[serde(default)]
+    pub browser: BrowserRuntimeNarrowing,
+    #[serde(default)]
+    pub web_fetch: WebFetchRuntimeNarrowing,
+}
+
+impl ToolRuntimeNarrowing {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.browser.is_empty() && self.web_fetch.is_empty()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalSkillsRuntimePolicy {
@@ -350,6 +412,64 @@ impl ToolRuntimeConfig {
             self.feishu = FeishuToolRuntimeConfig::from_env();
         }
         self
+    }
+
+    #[must_use]
+    pub fn narrowed(&self, narrowing: &ToolRuntimeNarrowing) -> Self {
+        if narrowing.is_empty() {
+            return self.clone();
+        }
+
+        let mut narrowed = self.clone();
+
+        if let Some(max_sessions) = narrowing.browser.max_sessions {
+            narrowed.browser.max_sessions = narrowed.browser.max_sessions.min(max_sessions.max(1));
+        }
+        if let Some(max_links) = narrowing.browser.max_links {
+            narrowed.browser.max_links = narrowed.browser.max_links.min(max_links.max(1));
+        }
+        if let Some(max_text_chars) = narrowing.browser.max_text_chars {
+            narrowed.browser.max_text_chars =
+                narrowed.browser.max_text_chars.min(max_text_chars.max(1));
+        }
+
+        narrowed.web_fetch.allow_private_hosts = match narrowing.web_fetch.allow_private_hosts {
+            Some(false) => false,
+            Some(true) => narrowed.web_fetch.allow_private_hosts,
+            None => narrowed.web_fetch.allow_private_hosts,
+        };
+
+        if !narrowing.web_fetch.allowed_domains.is_empty() {
+            narrowed.web_fetch.allowed_domains = if narrowed.web_fetch.allowed_domains.is_empty() {
+                narrowing.web_fetch.allowed_domains.clone()
+            } else {
+                narrowed
+                    .web_fetch
+                    .allowed_domains
+                    .intersection(&narrowing.web_fetch.allowed_domains)
+                    .cloned()
+                    .collect()
+            };
+        }
+        narrowed
+            .web_fetch
+            .blocked_domains
+            .extend(narrowing.web_fetch.blocked_domains.iter().cloned());
+
+        if let Some(timeout_seconds) = narrowing.web_fetch.timeout_seconds {
+            narrowed.web_fetch.timeout_seconds = narrowed
+                .web_fetch
+                .timeout_seconds
+                .min(timeout_seconds.max(1));
+        }
+        if let Some(max_bytes) = narrowing.web_fetch.max_bytes {
+            narrowed.web_fetch.max_bytes = narrowed.web_fetch.max_bytes.min(max_bytes.max(1));
+        }
+        if let Some(max_redirects) = narrowing.web_fetch.max_redirects {
+            narrowed.web_fetch.max_redirects = narrowed.web_fetch.max_redirects.min(max_redirects);
+        }
+
+        narrowed
     }
 }
 
@@ -1009,6 +1129,101 @@ mod tests {
         assert_eq!(policy.timeout_seconds, 9);
         assert_eq!(policy.max_bytes, 262_144);
         assert_eq!(policy.max_redirects, 1);
+    }
+
+    #[test]
+    fn tool_runtime_config_narrowed_intersects_web_domains_and_clamps_browser_limits() {
+        let base = ToolRuntimeConfig {
+            browser: BrowserRuntimePolicy {
+                enabled: true,
+                max_sessions: 4,
+                max_links: 12,
+                max_text_chars: 2_048,
+            },
+            web_fetch: WebFetchRuntimePolicy {
+                enabled: true,
+                allow_private_hosts: true,
+                allowed_domains: BTreeSet::from([
+                    "docs.example.com".to_owned(),
+                    "api.example.com".to_owned(),
+                ]),
+                blocked_domains: BTreeSet::from(["blocked.example.com".to_owned()]),
+                timeout_seconds: 15,
+                max_bytes: 8_192,
+                max_redirects: 4,
+            },
+            ..ToolRuntimeConfig::default()
+        };
+        let narrowing = ToolRuntimeNarrowing {
+            browser: BrowserRuntimeNarrowing {
+                max_sessions: Some(1),
+                max_links: Some(6),
+                max_text_chars: Some(512),
+            },
+            web_fetch: WebFetchRuntimeNarrowing {
+                allow_private_hosts: Some(false),
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["deny.example.com".to_owned()]),
+                timeout_seconds: Some(5),
+                max_bytes: Some(4_096),
+                max_redirects: Some(2),
+            },
+        };
+
+        let effective = base.narrowed(&narrowing);
+
+        assert_eq!(effective.browser.max_sessions, 1);
+        assert_eq!(effective.browser.max_links, 6);
+        assert_eq!(effective.browser.max_text_chars, 512);
+        assert!(!effective.web_fetch.allow_private_hosts);
+        assert_eq!(
+            effective.web_fetch.allowed_domains,
+            BTreeSet::from(["docs.example.com".to_owned()])
+        );
+        assert_eq!(
+            effective.web_fetch.blocked_domains,
+            BTreeSet::from([
+                "blocked.example.com".to_owned(),
+                "deny.example.com".to_owned(),
+            ])
+        );
+        assert_eq!(effective.web_fetch.timeout_seconds, 5);
+        assert_eq!(effective.web_fetch.max_bytes, 4_096);
+        assert_eq!(effective.web_fetch.max_redirects, 2);
+    }
+
+    #[test]
+    fn tool_runtime_config_narrowed_uses_child_allowlist_when_parent_has_none() {
+        let base = ToolRuntimeConfig {
+            web_fetch: WebFetchRuntimePolicy {
+                enabled: true,
+                allow_private_hosts: false,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
+                timeout_seconds: 15,
+                max_bytes: 8_192,
+                max_redirects: 4,
+            },
+            ..ToolRuntimeConfig::default()
+        };
+        let narrowing = ToolRuntimeNarrowing {
+            web_fetch: WebFetchRuntimeNarrowing {
+                allow_private_hosts: None,
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                blocked_domains: BTreeSet::new(),
+                timeout_seconds: None,
+                max_bytes: None,
+                max_redirects: None,
+            },
+            ..ToolRuntimeNarrowing::default()
+        };
+
+        let effective = base.narrowed(&narrowing);
+
+        assert_eq!(
+            effective.web_fetch.allowed_domains,
+            BTreeSet::from(["docs.example.com".to_owned()])
+        );
     }
 
     #[cfg(feature = "feishu-integration")]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -4556,7 +4556,16 @@ mod tests {
                     "timeout_seconds": 60,
                     "allow_shell_in_child": false,
                     "child_tool_allowlist": ["file.read", "file.write"],
-                    "kernel_bound": false
+                    "kernel_bound": false,
+                    "runtime_narrowing": {
+                        "web_fetch": {
+                            "allowed_domains": ["docs.example.com"],
+                            "allow_private_hosts": false
+                        },
+                        "browser": {
+                            "max_sessions": 1
+                        }
+                    }
                 }
             }),
         })
@@ -4618,6 +4627,18 @@ mod tests {
         assert_eq!(
             outcome.payload["delegate_lifecycle"]["execution"]["kernel_bound"],
             false
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["runtime_narrowing"]["web_fetch"]["allowed_domains"],
+            json!(["docs.example.com"])
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["runtime_narrowing"]["web_fetch"]["allow_private_hosts"],
+            false
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["runtime_narrowing"]["browser"]["max_sessions"],
+            1
         );
     }
 

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -10,6 +10,8 @@ use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{Value, json};
 
 use crate::config::{SessionVisibility, ToolConfig};
+#[cfg(feature = "memory-sqlite")]
+use crate::conversation::ConstrainedSubagentExecution;
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
@@ -73,6 +75,7 @@ struct SessionDelegateLifecycleRecord {
     queued_at: Option<i64>,
     started_at: Option<i64>,
     timeout_seconds: Option<u64>,
+    execution: Option<ConstrainedSubagentExecution>,
     staleness: Option<SessionDelegateStalenessRecord>,
     cancellation: Option<SessionDelegateCancellationRecord>,
 }
@@ -1951,22 +1954,39 @@ fn session_delegate_lifecycle_at(
     let mut started_at = None;
     let mut queued_timeout_seconds = None;
     let mut started_timeout_seconds = None;
+    let mut execution = None;
     let mut cancellation = None;
     for event in recent_events {
         match event.event_kind.as_str() {
             "delegate_queued" => {
                 queued_at = Some(event.ts);
+                execution = execution.or_else(|| {
+                    ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
+                });
                 queued_timeout_seconds = event
                     .payload_json
                     .get("timeout_seconds")
-                    .and_then(Value::as_u64);
+                    .and_then(Value::as_u64)
+                    .or_else(|| {
+                        execution
+                            .as_ref()
+                            .map(|execution| execution.timeout_seconds)
+                    });
             }
             "delegate_started" => {
                 started_at = Some(event.ts);
+                execution = execution.or_else(|| {
+                    ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
+                });
                 started_timeout_seconds = event
                     .payload_json
                     .get("timeout_seconds")
-                    .and_then(Value::as_u64);
+                    .and_then(Value::as_u64)
+                    .or_else(|| {
+                        execution
+                            .as_ref()
+                            .map(|execution| execution.timeout_seconds)
+                    });
             }
             DELEGATE_CANCEL_REQUESTED_EVENT_KIND => {
                 let reason = event
@@ -2034,6 +2054,7 @@ fn session_delegate_lifecycle_at(
         queued_at,
         started_at,
         timeout_seconds,
+        execution,
         staleness,
         cancellation: if session.state == SessionState::Running {
             cancellation
@@ -2077,6 +2098,7 @@ fn session_delegate_lifecycle_json(lifecycle: SessionDelegateLifecycleRecord) ->
         "queued_at": lifecycle.queued_at,
         "started_at": lifecycle.started_at,
         "timeout_seconds": lifecycle.timeout_seconds,
+        "execution": lifecycle.execution,
         "staleness": lifecycle.staleness.map(session_delegate_staleness_json),
         "cancellation": lifecycle
             .cancellation
@@ -4524,7 +4546,18 @@ mod tests {
             payload_json: json!({
                 "task": "research",
                 "label": "Child",
-                "timeout_seconds": 60
+                "timeout_seconds": 60,
+                "execution": {
+                    "mode": "async",
+                    "depth": 1,
+                    "max_depth": 2,
+                    "active_children": 0,
+                    "max_active_children": 3,
+                    "timeout_seconds": 60,
+                    "allow_shell_in_child": false,
+                    "child_tool_allowlist": ["file.read", "file.write"],
+                    "kernel_bound": false
+                }
             }),
         })
         .expect("append queued event");
@@ -4554,6 +4587,38 @@ mod tests {
         );
         assert!(outcome.payload["delegate_lifecycle"]["queued_at"].is_number());
         assert!(outcome.payload["delegate_lifecycle"]["started_at"].is_null());
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["mode"],
+            "async"
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["depth"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["max_depth"],
+            2
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["active_children"],
+            0
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["max_active_children"],
+            3
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["allow_shell_in_child"],
+            false
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["child_tool_allowlist"],
+            json!(["file.read", "file.write"])
+        );
+        assert_eq!(
+            outcome.payload["delegate_lifecycle"]["execution"]["kernel_bound"],
+            false
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/web_fetch.rs
+++ b/crates/app/src/tools/web_fetch.rs
@@ -368,7 +368,7 @@ pub(crate) fn validate_web_target(
             "{surface_name} blocked host `{host}` because it matches blocked domain rule `{rule}`"
         ));
     }
-    if !policy.allowed_domains.is_empty()
+    if policy.enforce_allowed_domains
         && first_matching_domain_rule(&host, &policy.allowed_domains).is_none()
     {
         return Err(format!(
@@ -925,6 +925,20 @@ mod tests {
             validate_web_target(&url, &policy, "web.fetch").expect("localhost should be allowed");
 
         assert_eq!(host, "localhost");
+    }
+
+    #[test]
+    fn validate_web_target_denies_when_allowlist_is_enforced_but_empty() {
+        let policy = super::super::runtime_config::WebFetchRuntimePolicy {
+            enforce_allowed_domains: true,
+            ..super::super::runtime_config::WebFetchRuntimePolicy::default()
+        };
+        let url = reqwest::Url::parse("https://example.com").expect("url");
+
+        let error =
+            validate_web_target(&url, &policy, "web.fetch").expect_err("empty enforced allowlist");
+
+        assert!(error.contains("not in allowed_domains"), "error={error}");
     }
 
     #[test]

--- a/crates/app/src/tools/web_fetch.rs
+++ b/crates/app/src/tools/web_fetch.rs
@@ -765,6 +765,7 @@ mod tests {
     #[test]
     fn web_fetch_enforces_allow_and_block_domain_rules() {
         let mut allowlist_config = super::super::runtime_config::ToolRuntimeConfig::default();
+        allowlist_config.web_fetch.enforce_allowed_domains = true;
         allowlist_config
             .web_fetch
             .allowed_domains

--- a/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
@@ -376,8 +376,8 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_id_mismatch() {
 #   "capabilities": ["InvokeConnector"],
 #   "metadata": {
 #     "bridge_kind":"process_stdio",
-#     "command":"python3",
-#     "args_json":"[\"-c\",\"import json,sys,time; sys.stdout.write(json.dumps({'method':'tools/call','id':'wrong-id','payload':{'ok':True}})+'\\\\n'); sys.stdout.flush(); time.sleep(0.05)\"]",
+#     "command":"printf",
+#     "args_json":"[\"{\\\"method\\\":\\\"tools/call\\\",\\\"id\\\":\\\"wrong-id\\\",\\\"payload\\\":{\\\"ok\\\":true}}\\n\"]",
 #     "version":"1.0.0"
 #   }
 # }
@@ -418,7 +418,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_id_mismatch() {
             expected_sha256: None,
             execute_process_stdio: true,
             execute_http_json: false,
-            allowed_process_commands: vec!["python3".to_owned()],
+            allowed_process_commands: vec!["printf".to_owned()],
             enforce_execution_success: false,
             security_scan: None,
         }),
@@ -487,8 +487,8 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_method_mismatch() {
 #   "capabilities": ["InvokeConnector"],
 #   "metadata": {
 #     "bridge_kind":"process_stdio",
-#     "command":"python3",
-#     "args_json":"[\"-c\",\"import json,sys,time; sys.stdout.write(json.dumps({'method':'tools/list','id':'stdio-mismatch-method-provider:primary:invoke','payload':{'ok':True}})+'\\\\n'); sys.stdout.flush(); time.sleep(0.05)\"]",
+#     "command":"printf",
+#     "args_json":"[\"{\\\"method\\\":\\\"tools/list\\\",\\\"id\\\":\\\"stdio-mismatch-method-provider:primary:invoke\\\",\\\"payload\\\":{\\\"ok\\\":true}}\\n\"]",
 #     "version":"1.0.0"
 #   }
 # }
@@ -529,7 +529,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_method_mismatch() {
             expected_sha256: None,
             execute_process_stdio: true,
             execute_http_json: false,
-            allowed_process_commands: vec!["python3".to_owned()],
+            allowed_process_commands: vec!["printf".to_owned()],
             enforce_execution_success: false,
             security_scan: None,
         }),

--- a/docs/plans/2026-03-17-constrained-delegate-subagent-design.md
+++ b/docs/plans/2026-03-17-constrained-delegate-subagent-design.md
@@ -1,0 +1,187 @@
+# Constrained Delegate Subagent Design
+
+**Problem**
+
+`alpha-test` already has the beginnings of delegated child-session execution:
+
+- `delegate` and `delegate_async` create child sessions and persist lifecycle events
+- the conversation runtime exposes `prepare_subagent_spawn(...)` and `on_subagent_ended(...)`
+- session inspection can infer queued/running delegate lifecycle from persisted events
+
+But those pieces do not yet compose into a coherent constrained subagent primitive.
+
+Today the production delegate path still behaves like an ad hoc child-session launcher:
+
+- context-engine subagent hooks are never called from the real delegate execution path
+- lifecycle payloads are free-form JSON fragments with no typed execution envelope
+- there is a depth limit but no concurrent active-child limit
+- session inspection can only reconstruct a partial lifecycle view from sparse event fields
+
+That leaves a gap between LoongClaw's reserved kernel/context seams and an actually governed delegate runtime.
+
+**Goal**
+
+Advance `delegate` and `delegate_async` from "persisted child-session launch" toward a first-class constrained subagent primitive without widening this slice into a full OpenClaw-style subagent subsystem.
+
+The bounded target for this slice is:
+
+1. Wire the existing runtime/context-engine subagent lifecycle hooks into the real delegate path.
+2. Replace ad hoc lifecycle payload fragments with a typed constrained-subagent execution envelope and terminal taxonomy.
+3. Add a direct-child concurrency guard so one parent session cannot fan out unbounded active delegates.
+4. Surface the new envelope in `session_status` / delegate lifecycle inspection.
+
+**Non-Goals**
+
+- Do not add a new ACP control-plane surface for delegate children in this slice.
+- Do not redesign session visibility, orphan recovery, or delivery hooks.
+- Do not add general descendant-tree scheduling or cross-parent global delegate quotas.
+- Do not widen delegate into an arbitrary custom-agent registry.
+
+**Constraints**
+
+- Keep the existing `delegate` / `delegate_async` tool names and request schema stable.
+- Preserve the current child-tool allowlist model and shell gating model.
+- Preserve the current session persistence model built on `sessions`, `session_events`, and `session_terminal_outcomes`.
+- Keep the implementation additive and local to the conversation/session/tooling seam.
+
+**Root Cause**
+
+The root problem is not that delegate lacks more knobs. The root problem is that the current runtime has no explicit contract object for "a constrained subagent execution" even though multiple subsystems already need one:
+
+- the conversation runtime needs a stable spawn/end lifecycle shape
+- the context engine needs a governed seam for kernel-bound child sessions
+- the session inspection tooling needs more than a timeout number to explain what constraints governed the child
+
+Because the contract is missing, the current code duplicates just enough JSON to make the happy path work and silently leaves the reserved lifecycle hooks unused.
+
+**Approaches Considered**
+
+1. Keep the current event payloads and only add hook calls.
+   Rejected because it would fix one symptom while leaving the execution contract implicit. Session inspection would still need to reverse-engineer child constraints from loosely shaped payloads.
+
+2. Build a full OpenClaw-style subagent runtime with its own registry, outcomes, queue lane, announce chain, and orphan recovery semantics.
+   Rejected for this slice because it is too large for the actual gap on `alpha-test`. The current repository already has child-session persistence and recovery. The missing value is governance clarity, not a second orchestration subsystem.
+
+3. Introduce a typed constrained-subagent envelope at the existing delegate seam, wire lifecycle hooks, and add a direct-child active limit.
+   Recommended because it addresses the architectural gap with the smallest durable change set and keeps the implementation aligned with current LoongClaw structure.
+
+**Chosen Design**
+
+Add a small typed contract module in the conversation layer to describe constrained delegate execution.
+
+The contract will include:
+
+- execution mode: `inline` or `async`
+- parent/child lineage depth snapshot:
+  - `depth`
+  - `max_depth`
+- direct active-child budget snapshot:
+  - `active_children`
+  - `max_active_children`
+- execution constraints:
+  - `timeout_seconds`
+  - `allow_shell_in_child`
+  - `child_tool_allowlist`
+- terminal reason taxonomy:
+  - `completed`
+  - `failed`
+  - `timed_out`
+  - `spawn_failed`
+
+This envelope will be serialized into delegate lifecycle events instead of the current hand-built partial payloads.
+
+**Config Change**
+
+Add `tools.delegate.max_active_children` with a conservative default.
+
+This is intentionally a direct-child limit, not a descendant-tree limit. Direct children are the parent-controlled concurrency surface at the current delegate seam. Descendant-tree budgeting can be added later if the design expands into a broader scheduler.
+
+**Runtime Behavior**
+
+For both `delegate` and `delegate_async`:
+
+1. Parse the delegate request.
+2. Resolve the parent's current lineage depth.
+3. Count the parent's active direct child sessions (`ready` + `running`).
+4. Enforce:
+   - `next_depth <= max_depth`
+   - `active_children < max_active_children`
+5. Build a constrained-subagent envelope.
+6. If the parent turn is kernel-bound, call `runtime.prepare_subagent_spawn(...)` before creating the child session.
+7. Persist child creation / transition events with the typed envelope embedded.
+
+For terminal completion paths:
+
+- persist terminal state and terminal outcome as before
+- include typed terminal reason metadata in the terminal event payload
+- if the child ran under a kernel-bound parent binding, call `runtime.on_subagent_ended(...)` after terminal persistence
+
+**Hook Failure Policy**
+
+`prepare_subagent_spawn(...)` is fail-closed.
+
+Rationale:
+- it runs before child session creation
+- a failure means the context engine could not prepare the governed subagent seam
+- failing before child creation avoids half-created child sessions
+
+`on_subagent_ended(...)` is also treated as part of the governed lifecycle contract for synchronous delegate execution.
+
+Rationale:
+- for kernel-bound execution, a child is not fully reconciled until the context engine has observed completion
+- returning a visible error is preferable to silently pretending the governed lifecycle fully succeeded
+
+For async children the end hook still runs in the spawned task path. This slice does not add a separate async hook-failure replay channel; it keeps the bounded scope focused on wiring the lifecycle seam and exposing typed execution metadata. If later evidence shows async post-terminal hook failures need their own persisted recovery event, that should be a follow-up slice.
+
+**Session Inspection Changes**
+
+`session_status` and related delegate lifecycle inspection will stop relying only on:
+
+- inferred queued/started timestamps
+- timeout numbers
+
+and will additionally surface the constrained-subagent envelope, so inspection can answer:
+
+- was this child inline or async?
+- what depth budget governed it?
+- how many active siblings existed when it was launched?
+- what child-tool constraints applied?
+
+This should be sourced from the earliest available lifecycle event carrying the typed envelope, rather than recomputing it later from mutable config.
+
+**Why This Is The Smallest Durable Slice**
+
+This change intentionally does not attempt to normalize LoongClaw into OpenClaw's complete subagent system. OpenClaw's design includes dedicated session lanes, orphan recovery machinery, delivery hooks, and registry-level governance. LoongClaw already has a narrower but functional child-session substrate.
+
+The minimum architectural debt payoff here is:
+
+- make the existing reserved lifecycle seam real
+- give delegate execution a first-class contract object
+- cap parent fan-out at runtime instead of only at nesting depth
+
+That yields durable structure without adding a second orchestration model beside the one the repo already uses.
+
+**Testing Strategy**
+
+Add failing tests first for:
+
+- kernel-bound `delegate` calling `prepare_subagent_spawn(...)` before child execution
+- terminal child completion calling `on_subagent_ended(...)`
+- direct (non-kernel) delegate execution still working without lifecycle hooks
+- `delegate_async` refusing new children when direct active-child budget is exhausted
+- `session_status` exposing the typed constrained-subagent envelope from delegate lifecycle events
+- deterministic rejection when spawn preparation fails before child session creation
+
+Then verify adjacent delegate/session regressions and full repository validation.
+
+**Risk Assessment**
+
+The highest risk is not functional breakage. It is semantic drift between:
+
+- the new typed envelope
+- the session-inspection view
+- the actual runtime constraints
+
+That risk is controlled by using one shared typed contract and by persisting the runtime snapshot into lifecycle events at creation/transition time.
+
+The second risk is accidentally widening the scope into a new general subagent framework. This design deliberately avoids that by staying on the current delegate/session seam.

--- a/docs/plans/2026-03-17-constrained-delegate-subagent-implementation-plan.md
+++ b/docs/plans/2026-03-17-constrained-delegate-subagent-implementation-plan.md
@@ -1,0 +1,154 @@
+# Constrained Delegate Subagent Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn `delegate` / `delegate_async` into a bounded constrained-subagent primitive by wiring runtime lifecycle hooks, introducing a typed execution envelope, enforcing a direct active-child limit, and exposing the new metadata through session inspection.
+
+**Architecture:** Keep the existing child-session persistence model and tool surface. Add a shared constrained-subagent contract in the conversation layer, persist that contract into delegate lifecycle events, enforce `max_active_children` at spawn time, and reuse the persisted envelope in `session_status`.
+
+**Tech Stack:** Rust, serde/serde_json, conversation runtime + coordinator, sqlite-backed `SessionRepository`, session inspection tooling, existing delegate tests in `crates/app/src/conversation/tests.rs` and `crates/app/src/tools/session.rs`.
+
+---
+
+### Task 1: Add failing tests for the missing lifecycle contract
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Add a failing kernel-bound inline delegate lifecycle test**
+
+Add a test proving that a kernel-bound `delegate` turn calls:
+
+- `prepare_subagent_spawn(parent, child)` before the child turn runs
+- `on_subagent_ended(parent, child)` after terminal completion
+
+Verify both the recorded context-engine calls and the persisted child session shape.
+
+**Step 2: Add a failing spawn-preparation failure test**
+
+Add a test proving that if `prepare_subagent_spawn(...)` fails:
+
+- the delegate tool returns an error
+- no child session row is created
+- no queued/started delegate lifecycle events are written
+
+**Step 3: Add a failing direct-child concurrency test**
+
+Add a test proving that a parent with `max_active_children` already-active direct children cannot launch another `delegate_async` child.
+
+The failure should be deterministic and should not create a new child session.
+
+**Step 4: Add a failing session inspection test**
+
+Add a test proving `session_status` exposes the persisted constrained-subagent envelope from delegate lifecycle events, including:
+
+- `mode`
+- `depth`
+- `max_depth`
+- `active_children`
+- `max_active_children`
+- `timeout_seconds`
+- `allow_shell_in_child`
+- child tool allowlist metadata
+
+**Step 5: Run one focused red test**
+
+Run:
+
+`cargo test -p loongclaw-app handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks -- --exact --nocapture`
+
+Expected: FAIL because the production delegate path currently never invokes the runtime lifecycle hooks.
+
+### Task 2: Implement the constrained-subagent contract and runtime wiring
+
+**Files:**
+- Add: `crates/app/src/conversation/subagent.rs`
+- Modify: `crates/app/src/conversation/mod.rs`
+- Modify: `crates/app/src/config/tools.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Add the shared constrained-subagent types**
+
+Create typed serde-backed structs/enums for:
+
+- execution mode
+- constraint envelope
+- terminal reason
+
+Keep the shape narrow and local to delegate execution.
+
+**Step 2: Add the config knob and repository helper**
+
+Add `tools.delegate.max_active_children` with a default.
+
+Add a repository helper that counts active direct child sessions for a parent in `ready` or `running` state.
+
+**Step 3: Wire inline and async delegate spawn through the new envelope**
+
+Update `execute_delegate_tool(...)` and `execute_delegate_async_tool(...)` to:
+
+- compute depth and active-child counts
+- enforce both limits
+- build the constrained-subagent envelope
+- call `prepare_subagent_spawn(...)` for kernel-bound parents before child creation
+- persist the envelope in `delegate_started` / `delegate_queued` payloads
+
+**Step 4: Persist typed terminal reason metadata**
+
+Update delegate terminal completion/failure/timeout and async spawn-failure paths so terminal events carry a typed reason payload instead of only free-form strings.
+
+**Step 5: Reuse the persisted envelope in session inspection**
+
+Update `session_status` / delegate lifecycle extraction to parse the constrained-subagent envelope from delegate lifecycle events and surface it in the inspection JSON.
+
+### Task 3: Verify the slice and prepare GitHub delivery
+
+**Files:**
+- Modify: `docs/plans/2026-03-17-constrained-delegate-subagent-design.md`
+- Modify: `docs/plans/2026-03-17-constrained-delegate-subagent-implementation-plan.md`
+
+**Step 1: Run focused tests**
+
+Run:
+
+- `cargo test -p loongclaw-app handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks -- --exact --nocapture`
+- `cargo test -p loongclaw-app handle_turn_with_runtime_delegate_rejects_spawn_when_prepare_subagent_spawn_fails -- --exact --nocapture`
+- `cargo test -p loongclaw-app handle_turn_with_runtime_delegate_async_rejects_when_active_child_limit_is_exhausted -- --exact --nocapture`
+- `cargo test -p loongclaw-app session_status_exposes_constrained_delegate_envelope -- --exact --nocapture`
+
+Expected: PASS
+
+**Step 2: Run adjacent regressions**
+
+Run:
+
+- `cargo test -p loongclaw-app handle_turn_with_runtime_executes_delegate -- --nocapture`
+- `cargo test -p loongclaw-app handle_turn_with_runtime_executes_delegate_async -- --nocapture`
+- `cargo test -p loongclaw-app session_status_ -- --nocapture`
+
+Expected: PASS
+
+**Step 3: Run repository-grade verification**
+
+Run:
+
+- `cargo fmt --all`
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 4: Prepare GitHub delivery**
+
+Reuse issue `#222` and update it with:
+
+- why LoongClaw needed a typed constrained-subagent contract at the delegate seam
+- why this slice adds `max_active_children` in addition to `max_depth`
+- what remains intentionally out of scope relative to a full OpenClaw-style subagent runtime
+
+Open a PR against `alpha-test` with `Closes #222` only if the implemented slice fully satisfies the issue scope. Otherwise use `Related #222` and describe the remaining follow-up explicitly.

--- a/docs/plans/2026-03-18-delegate-runtime-contract-visibility-v1-design.md
+++ b/docs/plans/2026-03-18-delegate-runtime-contract-visibility-v1-design.md
@@ -1,0 +1,175 @@
+# Delegate Runtime Contract Visibility V1 Design
+
+**Problem**
+
+`#280` and `#281` made delegate-child runtime narrowing real at execution time for kernel-bound
+core tools, but the child planning surface still does not explain that effective contract clearly to
+the model before it plans.
+
+Today LoongClaw can already persist and enforce a child runtime posture through:
+
+- the constrained delegate execution envelope
+- child-session lifecycle events
+- `SessionContext.runtime_narrowing`
+- trusted internal `_loongclaw.runtime_narrowing`
+- `ToolRuntimeConfig::narrowed(...)`
+
+That closes the execution-time correctness gap, but it still leaves a planning-time visibility gap:
+
+- the child can only discover some limits after a tool call fails
+- the model may plan as if the root web/browser posture still applies
+- operators do not get a prompt-level statement of the contract that is already being enforced
+
+This slice addresses that narrower usability gap without widening the runtime-policy surface.
+
+**Goal**
+
+Surface the effective delegate child runtime contract directly in child planning prompts so the model
+can plan against the same web/browser posture that the runtime will enforce.
+
+The target behavior is:
+
+1. Child sessions with non-empty persisted `runtime_narrowing` receive a stable prompt summary.
+2. Root sessions and unrestricted sessions remain unchanged.
+3. The prompt summary reflects the same narrowing semantics already enforced for:
+   - `web.fetch`
+   - `browser.*`
+4. No new planning channel or schema mutation is introduced.
+
+**Non-Goals**
+
+- Do not change actual runtime enforcement semantics.
+- Do not mutate provider tool schemas based on session-specific policy.
+- Do not add a new planning metadata envelope or side channel.
+- Do not expand the contract to shell, filesystem, or external-skills policy in this slice.
+- Do not redesign provider request assembly.
+
+**Root Cause**
+
+The real defect is not missing enforcement. That was the previous slice.
+
+The remaining defect is that the model does not see the effective child runtime contract early enough
+in the prompt assembly path. The existing runtime narrowing is available on `SessionContext`, but the
+system prompt builder does not project it into planning-visible text.
+
+As a result, the child can still reason from a broader imagined capability surface and only learn the
+real limits through execution failure.
+
+**Approaches Considered**
+
+1. Add child-specific text to provider tool definitions.
+   Rejected because tool definitions are effectively static provider-facing schema. Injecting
+   per-session runtime posture there would blur the boundary between static tool metadata and dynamic
+   execution policy.
+
+2. Add a separate internal planning metadata channel.
+   Rejected because it introduces a second mechanism when the existing system prompt rewrite path is
+   already sufficient for this slice.
+
+3. Reuse the existing system prompt rewrite path and append a child-only runtime contract summary.
+   Recommended because it is the smallest correct change:
+   - the child contract is already available on `SessionContext`
+   - the system prompt is already session-scoped
+   - the change stays local to prompt assembly
+   - no provider schema or execution pipeline changes are needed
+
+**Chosen Design**
+
+Add a stable formatter on `ToolRuntimeNarrowing` that produces a deterministic system-prompt block.
+
+The block will be injected only when all of the following are true:
+
+- the session is a child session
+- `SessionContext.runtime_narrowing` is present
+- the narrowing is not empty
+- system-prompt inclusion is enabled
+
+The block should be explicit that these are hard runtime limits for the child session, not generic
+guidance.
+
+Recommended shape:
+
+```text
+[delegate_child_runtime_contract]
+Plan within these child-session runtime limits:
+- web.fetch private hosts: denied
+- web.fetch allowed domains: docs.example.com
+- web.fetch blocked domains: deny.example.com
+- web.fetch timeout seconds: 5
+- web.fetch max bytes: 4096
+- web.fetch max redirects: 2
+- browser max sessions: 1
+- browser max links: 8
+- browser max text chars: 512
+Treat these as enforced limits for this child session.
+```
+
+Only fields present in the narrowing contract should appear. Empty sections should be omitted. The
+marker and ordering must be deterministic for stable prompting and testing.
+
+**Injection Path**
+
+Use `DefaultConversationRuntime::build_context(...)` as the injection seam.
+
+Why this seam is correct:
+
+- it already resolves `SessionContext`
+- it already rewrites the effective system prompt
+- it is the narrowest session-scoped prompt assembly path
+- it avoids duplicating logic in lower provider request builders that do not naturally own child
+  runtime context
+
+Implementation outline:
+
+1. Resolve child `SessionContext`.
+2. Derive `delegate_runtime_contract_prompt_summary()` from `runtime_narrowing`.
+3. Merge that summary with any existing `system_prompt_addition`.
+4. Reuse `apply_system_prompt_addition(...)` to prepend the merged addition to the system prompt.
+
+This keeps the change additive and localized.
+
+**Why Not Use `apply_tool_view_to_system_prompt(...)`**
+
+`apply_tool_view_to_system_prompt(...)` is aimed at projecting tool visibility, not runtime policy.
+It rewrites the capability snapshot section, while the delegate runtime contract is better modeled as
+separate planning guidance that accompanies the system prompt rather than replacing the snapshot.
+
+Using the system-prompt addition path keeps tool visibility and runtime-policy visibility as distinct
+concerns.
+
+**Testing Strategy**
+
+Write failing tests first for:
+
+- child build-context prompt includes the runtime contract marker and concrete narrowed values
+- root build-context prompt does not include the child contract marker
+- child sessions with empty narrowing do not inject the block
+- the formatter emits stable ordered lines for web/browser narrowing fields
+
+Then run the focused conversation/runtime and runtime-config tests before broader repository
+verification.
+
+**Risk Assessment**
+
+The main risk is semantic drift between:
+
+- the narrowing contract used for enforcement
+- the prompt summary shown to the model
+
+This is controlled by formatting directly from the typed `ToolRuntimeNarrowing` struct rather than
+reconstructing the prompt contract from unrelated config or free-form strings.
+
+The second risk is accidental prompt noise. This is controlled by:
+
+- child-only gating
+- non-empty narrowing gating
+- field omission for unset values
+- deterministic compact formatting
+
+**Why This Slice Is Worth Doing**
+
+The previous slice solved correctness at execution time. This slice improves correctness at planning
+time using the same contract.
+
+That means fewer avoidable failed tool calls, clearer operator expectations, and tighter alignment
+between what the child can plan and what it can actually execute.

--- a/docs/plans/2026-03-18-delegate-runtime-contract-visibility-v1-implementation-plan.md
+++ b/docs/plans/2026-03-18-delegate-runtime-contract-visibility-v1-implementation-plan.md
@@ -1,0 +1,113 @@
+# Delegate Runtime Contract Visibility V1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Surface the effective delegate child runtime contract in child planning prompts without changing provider tool schema or runtime enforcement behavior.
+
+**Architecture:** Format a deterministic prompt block directly from `ToolRuntimeNarrowing`, then inject it through the existing system-prompt addition path inside `DefaultConversationRuntime::build_context(...)` only for child sessions with non-empty persisted runtime narrowing.
+
+**Tech Stack:** Rust, serde-backed runtime narrowing structs, conversation runtime prompt assembly, memory-backed session lifecycle loading, existing conversation/runtime and runtime-config tests.
+
+---
+
+### Task 1: Add failing tests for prompt contract visibility
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/tools/runtime_config.rs`
+
+**Step 1: Add a failing child-session prompt test**
+
+Add a `memory-sqlite` conversation test that persists a child session with delegate
+`runtime_narrowing`, calls `DefaultConversationRuntime::build_context(...)`, and asserts the system
+prompt contains the delegate runtime contract marker plus narrowed web/browser values.
+
+**Step 2: Add a failing root-session negative control**
+
+Add a conversation test proving a root session prompt does not include the delegate runtime contract
+marker.
+
+**Step 3: Add a failing empty-narrowing negative control**
+
+Add a child-session conversation test where the persisted runtime narrowing is empty and verify no
+contract block is injected.
+
+**Step 4: Add a failing formatter test**
+
+Add a `ToolRuntimeNarrowing` unit test proving the formatted prompt block is deterministic and only
+contains configured narrowing fields.
+
+**Step 5: Run the focused red tests**
+
+Run only the new conversation/runtime and runtime-config tests and confirm they fail for the missing
+prompt-summary behavior before implementing production code.
+
+### Task 2: Implement the prompt-summary formatter
+
+**Files:**
+- Modify: `crates/app/src/tools/runtime_config.rs`
+
+**Step 1: Add a stable formatter helper**
+
+Add a method on `ToolRuntimeNarrowing` that returns `None` for empty narrowing and otherwise returns
+a deterministic prompt block string.
+
+**Step 2: Keep formatting aligned with enforcement semantics**
+
+Emit only fields that are actually narrowed:
+
+- `web.fetch allow_private_hosts`
+- `web.fetch allowed_domains`
+- `web.fetch blocked_domains`
+- `web.fetch timeout_seconds`
+- `web.fetch max_bytes`
+- `web.fetch max_redirects`
+- `browser max_sessions`
+- `browser max_links`
+- `browser max_text_chars`
+
+**Step 3: Preserve deterministic output**
+
+Use fixed line ordering and sorted set iteration so tests and prompt behavior stay stable.
+
+### Task 3: Inject the child contract through existing prompt rewrite logic
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+
+**Step 1: Add a helper to derive the child prompt addition**
+
+Create a small helper that reads `SessionContext.runtime_narrowing` and returns the formatted prompt
+summary only for child sessions.
+
+**Step 2: Merge additions instead of replacing them**
+
+Combine any context-engine `system_prompt_addition` with the delegate runtime contract block so the
+existing addition behavior remains intact.
+
+**Step 3: Reuse `apply_system_prompt_addition(...)`**
+
+Keep the system prompt injection path unchanged apart from feeding it the merged addition text.
+
+### Task 4: Verify locally and prepare GitHub delivery
+
+**Files:**
+- Modify: GitHub issue / PR artifacts after code lands
+
+**Step 1: Run focused tests**
+
+Run the newly added conversation/runtime and runtime-config tests.
+
+**Step 2: Run repository verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+**Step 3: Prepare stacked delivery**
+
+Commit only this slice, push `feat/delegate-runtime-contract-visibility-v1`, and open a stacked PR
+against the current delegate-runtime branch with `Closes #282` in the PR body.

--- a/docs/plans/2026-03-18-delegate-runtime-envelope-v2-design.md
+++ b/docs/plans/2026-03-18-delegate-runtime-envelope-v2-design.md
@@ -1,0 +1,238 @@
+# Delegate Runtime Envelope V2 Design
+
+**Problem**
+
+`feat/constrained-subagent-v1` made delegate children explicit enough to be inspectable:
+
+- child sessions now persist a typed constrained-subagent execution envelope
+- depth and active-child limits are enforced at spawn time
+- session inspection can explain the launch contract after the fact
+
+But the execution envelope still stops at the session boundary.
+
+Today a child session can have a narrower visible tool surface while still executing core tools with
+the process-global runtime policy because kernel-bound tool execution ultimately routes through:
+
+- `TurnEngine::execute_tool_intent_via_kernel(...)`
+- `KernelContext`
+- `MvpToolAdapter::new()`
+- `execute_tool_core(...)`
+- `get_tool_runtime_config()`
+
+That means LoongClaw can currently create a child that *looks* constrained in:
+
+- `tool_view`
+- provider-visible tool definitions
+- `session_status`
+
+while still letting `web.fetch` / `browser.*` run with the parent process runtime posture.
+
+This is the next real architectural gap after the first constrained-subagent slice.
+
+**Goal**
+
+Add a second bounded slice that makes delegate child runtime posture real for kernel-bound core tool
+execution without introducing a separate subagent runtime or kernel control plane.
+
+The target for this slice is:
+
+1. Define a typed child runtime-narrowing contract for delegate executions.
+2. Persist that contract inside the existing constrained-subagent execution envelope.
+3. Carry the contract into trusted internal tool context during child-session tool execution.
+4. Narrow actual core-tool runtime config at execution time for child sessions.
+5. Cover the first meaningful policy surfaces:
+   - `web.fetch` domain/private-host posture and transport limits
+   - `browser.*` session/text/link limits
+
+**Non-Goals**
+
+- Do not add a new global subagent scheduler, queue, or registry.
+- Do not redesign ACP routing or introduce a subagent-specific kernel pack model.
+- Do not solve context-budget shaping in this slice.
+- Do not widen the child runtime contract to every tool class at once.
+- Do not bypass kernel execution for child tools.
+
+**Root Cause**
+
+The first constrained-subagent slice made child launches explicit, but the effective runtime policy
+for core tools is still resolved at the wrong layer.
+
+The root problem is not missing allowlist fields. The root problem is that the actual kernel-bound
+tool execution path has no session-scoped runtime-policy carrier. The system currently narrows:
+
+- what a child can *see*
+- what a child session reports about itself
+
+but it does not narrow:
+
+- what runtime config `execute_tool_core_with_config(...)` sees once a kernel-bound child tool call
+  actually executes
+
+So the missing contract is not “more delegate knobs”. The missing contract is “how a child
+session’s runtime posture survives the trip into trusted core-tool execution”.
+
+**External Reference**
+
+OpenClaw and Codex both treat subagents as more than prompt forks:
+
+- OpenClaw emphasizes bounded depth, explicit lifecycle, and child-session governance.
+- Codex emphasizes isolated execution environments and async child-session continuity.
+
+LoongClaw is not ready for their full orchestration surface yet, but it does need one key property
+they both rely on: child execution constraints must remain true at actual execution time, not only
+at planning time.
+
+That makes runtime-envelope propagation the right next slice.
+
+**Approaches Considered**
+
+1. Only widen `ToolView` / `child_tool_allowlist`.
+   Rejected because it preserves the current false boundary: visibility would narrow, but
+   `execute_tool_core(...)` would still run under the global runtime config.
+
+2. Create a child-specific `KernelContext` with its own tool adapter and policy extensions.
+   Rejected for this slice because it would force a broader redesign of kernel bootstrap,
+   audit/plumbing continuity, and per-child adapter registration. It solves the problem, but at the
+   wrong cost right now.
+
+3. Store child runtime narrowing in trusted internal tool context and derive an effective runtime
+   config inside core-tool execution.
+   Recommended because it:
+   - keeps kernel execution intact
+   - avoids mutable global runtime state
+   - reuses the existing reserved `_loongclaw` trusted payload seam
+   - lets one typed contract drive persistence, inspection, and actual execution
+
+**Chosen Design**
+
+Add a typed runtime-narrowing contract under the existing constrained-subagent execution envelope.
+
+The contract will include:
+
+- `web_fetch`
+  - `allow_private_hosts: Option<bool>`
+  - `allowed_domains`
+  - `blocked_domains`
+  - `timeout_seconds: Option<u64>`
+  - `max_bytes: Option<usize>`
+  - `max_redirects: Option<usize>`
+- `browser`
+  - `max_sessions: Option<usize>`
+  - `max_links: Option<usize>`
+  - `max_text_chars: Option<usize>`
+
+The contract is a *narrowing* shape, not a second full runtime config.
+
+Semantics:
+
+- booleans can only stay the same or become more restrictive
+- numeric limits clamp downward
+- blocked-domain sets union with parent policy
+- allow-domain sets intersect with parent allowlists when both are present
+- an empty child allow-domain list means “no additional allowlist narrowing”
+
+This keeps the slice monotonic: child posture can only stay within or below the parent runtime
+policy.
+
+**Configuration Shape**
+
+Add a nested delegate child runtime policy section under `tools.delegate`:
+
+- `tools.delegate.child_runtime.web`
+- `tools.delegate.child_runtime.browser`
+
+This keeps runtime narrowing local to delegate execution instead of leaking a subagent-specific
+schema across unrelated tool config.
+
+Examples of intended use:
+
+- limit child browser concurrency to one session even if root allows more
+- allow child web access only to a documentation domain
+- force child web requests to stay off private hosts even when the root runtime allows them
+
+**Execution Path**
+
+For a child session:
+
+1. `execute_delegate_tool(...)` or `execute_delegate_async_tool(...)` builds the persisted
+   `ConstrainedSubagentExecution`, including `runtime_narrowing`.
+2. `ConversationRuntime::session_context(...)` resolves the child’s persisted execution envelope and
+   exposes the narrowing contract on `SessionContext`.
+3. `TurnEngine` injects trusted internal tool context for child core-tool calls.
+4. `execute_tool_core_with_config(...)` reads the trusted internal runtime narrowing and derives an
+   effective `ToolRuntimeConfig`.
+5. `web.fetch`, `browser.*`, and tool-search runtime filtering execute against the narrowed config.
+
+This keeps one execution contract flowing through:
+
+- persisted lifecycle events
+- in-memory session context
+- trusted core-tool payload context
+- actual executor runtime config
+
+**Why Trusted Internal Tool Context**
+
+LoongClaw already reserves `_loongclaw` for trusted internal payload context and rejects untrusted
+callers that try to forge it.
+
+Using that seam is the smallest durable option because:
+
+- it is already the right place for execution-only metadata
+- it avoids broadening public tool schemas
+- it composes with `tool.invoke`
+- it keeps session-specific runtime posture off global singleton state
+
+**Session Inspection Changes**
+
+`session_status` already surfaces the constrained-subagent envelope. This slice extends that
+envelope with `runtime_narrowing` so the inspection view answers:
+
+- which web/browser runtime posture governed the child
+- whether the child was stricter than the root runtime
+- whether the child was prevented from private-host access or broad domain access
+
+Inspection must continue to read the persisted snapshot rather than recomputing from current config.
+
+**Why This Is Smaller Than A Child Kernel Context**
+
+The tempting alternative is a per-child kernel instance or per-child adapter selection. That would
+be architecturally larger because it would force LoongClaw to answer, in one slice:
+
+- how audit sink continuity works across child kernels
+- how policy extensions are cloned or re-bound
+- how async child execution transports kernel state
+- how nested children compose multiple kernel instances
+
+LoongClaw does not need those answers yet to make child runtime posture real. It only needs a
+session-scoped execution contract that survives to actual core-tool execution.
+
+**Testing Strategy**
+
+Add failing tests first for:
+
+- child `session_status` exposing persisted runtime narrowing
+- child kernel-bound `web.fetch` being denied by narrowed domain/private-host policy even when the
+  base runtime is broader
+- child kernel-bound `browser.open` / `browser.extract` obeying narrowed browser limits
+- untrusted payloads being unable to forge runtime narrowing
+- runtime narrowing never widening parent policy
+
+Then run adjacent delegate/session/tool regressions and full repository verification.
+
+**Risk Assessment**
+
+The main risk is semantic drift between:
+
+- persisted runtime narrowing
+- injected trusted payload context
+- effective runtime config merging logic
+
+That risk is controlled by:
+
+- using one typed narrowing contract
+- keeping the merge logic centralized in `ToolRuntimeConfig`
+- testing both persisted inspection and actual tool execution
+
+The other risk is overfitting the contract to one tool. This design avoids that by targeting the
+shared runtime-policy layer (`ToolRuntimeConfig`) instead of adding one-off checks inside delegate
+or provider code.

--- a/docs/plans/2026-03-18-delegate-runtime-envelope-v2-implementation-plan.md
+++ b/docs/plans/2026-03-18-delegate-runtime-envelope-v2-implementation-plan.md
@@ -1,0 +1,146 @@
+# Delegate Runtime Envelope V2 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make delegate child runtime posture real by persisting a typed child runtime-narrowing contract and applying it to actual kernel-bound core-tool execution for `web.fetch` and `browser.*`.
+
+**Architecture:** Reuse the existing constrained-subagent execution envelope. Add typed runtime-narrowing config under `tools.delegate.child_runtime`, attach it to `SessionContext`, inject it through trusted `_loongclaw` payload context, and derive an effective `ToolRuntimeConfig` inside `execute_tool_core_with_config(...)`.
+
+**Tech Stack:** Rust, serde/serde_json, `ToolRuntimeConfig`, conversation runtime/session context, delegate lifecycle persistence, kernel-bound turn execution, existing delegate/session/tool tests.
+
+---
+
+### Task 1: Add red tests for runtime-narrowed child execution
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Add a failing session inspection test**
+
+Add a test proving `session_status` exposes persisted child `runtime_narrowing` under the
+constrained delegate lifecycle metadata.
+
+**Step 2: Add a failing child web policy test**
+
+Add a kernel-bound delegate test where the base runtime allows a broader web surface, but the child
+runtime narrowing allows only a stricter host set or denies private hosts. Verify the child tool
+execution fails with the narrowed policy.
+
+**Step 3: Add a failing child browser limit test**
+
+Add a test proving a child session uses narrowed browser limits, for example a one-session cap or a
+lower link/text ceiling than the parent runtime.
+
+**Step 4: Add a failing trusted-payload forgery test**
+
+Add a test proving untrusted callers cannot inject `_loongclaw.runtime_narrowing` into core-tool
+payloads to self-escalate or spoof child posture.
+
+**Step 5: Run one focused red test**
+
+Run a focused delegate-runtime test and confirm it fails for the expected reason before any
+production changes.
+
+### Task 2: Implement the typed runtime-narrowing contract
+
+**Files:**
+- Modify: `crates/app/src/config/tools.rs`
+- Modify: `crates/app/src/tools/runtime_config.rs`
+- Modify: `crates/app/src/conversation/subagent.rs`
+
+**Step 1: Add delegate child runtime config types**
+
+Add nested config types under `tools.delegate.child_runtime` for:
+
+- `web`
+- `browser`
+
+Use optional numeric/boolean fields where inheritance must remain distinguishable from explicit
+narrowing.
+
+**Step 2: Add runtime-narrowing runtime types**
+
+Add typed narrowing structs to `tools/runtime_config.rs` and implement the parent-to-child merge
+logic there.
+
+The merge must be monotonic:
+
+- numeric values clamp downward
+- blocked domains union
+- allow domains intersect when both sides restrict
+- private-host access can only stay allowed when both parent and child allow it
+
+**Step 3: Extend the constrained subagent execution envelope**
+
+Persist the runtime-narrowing snapshot on `ConstrainedSubagentExecution`.
+
+### Task 3: Carry child runtime narrowing into actual core-tool execution
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+- Modify: `crates/app/src/tools/mod.rs`
+
+**Step 1: Extend `SessionContext`**
+
+Add optional child runtime narrowing to `SessionContext` and load it from the child session’s
+persisted delegate lifecycle event.
+
+**Step 2: Inject trusted internal runtime context**
+
+Update the tool-payload augmentation path so child core-tool calls inject trusted internal
+runtime-narrowing context alongside existing internal execution metadata.
+
+**Step 3: Apply the effective runtime config**
+
+Update `execute_tool_core_with_config(...)` to derive an effective runtime config from:
+
+- the base runtime config
+- trusted internal child runtime narrowing, when present
+
+Keep untrusted `_loongclaw` rejection behavior intact.
+
+### Task 4: Reuse the persisted contract in inspection and docs
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+- Modify: `docs/plans/2026-03-18-delegate-runtime-envelope-v2-design.md`
+- Modify: `docs/plans/2026-03-18-delegate-runtime-envelope-v2-implementation-plan.md`
+
+**Step 1: Surface `runtime_narrowing` in session inspection**
+
+Update `session_status` / delegate lifecycle extraction to expose the persisted narrowing snapshot.
+
+**Step 2: Keep design/plan docs aligned**
+
+Adjust the design or plan if testing reveals a smaller safe seam than the initial draft.
+
+### Task 5: Verify and ship
+
+**Files:**
+- Modify: GitHub issue / PR artifacts after code lands
+
+**Step 1: Run focused tests**
+
+Run the new delegate-runtime and inspection tests exactly.
+
+**Step 2: Run adjacent regressions**
+
+Run delegate, session-status, browser, and web-fetch regression coverage that exercises the touched
+paths.
+
+**Step 3: Run repository verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+**Step 4: Prepare GitHub delivery**
+
+Open or reuse a follow-up issue for delegate runtime-envelope v2, assign the operator, and open a
+stacked PR that references `#275` and links the new issue explicitly.


### PR DESCRIPTION
## Summary

- Problem:
  Delegate child sessions already execute under a narrowed runtime posture, but the child planning prompt still does not surface that effective contract.
- Why it matters:
  The model can plan against a broader imagined web/browser posture and only discover the real limits after tool execution fails.
- What changed:
  - Added `ToolRuntimeNarrowing::delegate_child_prompt_summary()` to render a stable, sparse child-runtime contract summary from the existing typed narrowing data.
  - Merged that child-only contract block into the existing system-prompt addition path so existing prompt additions remain intact.
  - Added regression coverage proving child prompts include the effective contract, root prompts stay unchanged, and empty child narrowing does not inject noise.
  - Replaced the process-stdio mismatch fixtures with deterministic `printf` JSON-line responses so full-suite verification no longer depends on interpreter startup timing.
- What did not change (scope boundary):
  - No runtime enforcement semantics changed.
  - No provider schema or function-definition mutation was introduced.
  - No new planning metadata channel was added.
  - No filesystem, shell, or external-skills narrowing visibility was added in this slice.

## Linked Issues

- Closes #282
- Related #281
- Related #280
- Related #222

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This change alters how constrained child-session policy is surfaced during planning. It should remain child-only, non-duplicative, and aligned with the already-enforced narrowing contract.
- Rollout / guardrails:
  Land on top of the constrained-subagent stack, keep injection gated to child sessions with non-empty persisted `runtime_narrowing`, and keep the summary derived from existing typed narrowing data instead of a parallel prompt-only source.
- Rollback path:
  Revert the prompt-summary merge in conversation runtime while preserving the underlying runtime narrowing and enforcement path.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] Not applicable: this slice does not change config/env fallback, limits, or defaults outside child prompt visibility
- [x] Not applicable: added tests do not introduce new process-global env mutation

Commands and evidence:

```text
cargo fmt --all -- --check
  Passed.

cargo clippy --workspace --all-targets --all-features -- -D warnings
  Passed.

cargo test --workspace --locked
  Passed.

cargo test --workspace --all-features --locked
  Passed.

LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
  Passed.

./scripts/check_dep_graph.sh
  Passed.

diff -u CLAUDE.md AGENTS.md
  Passed with no diff.

./scripts/check-docs.sh
  Passed with existing non-blocking release-artifact warnings only.

cargo deny check advisories bans licenses sources
  Passed with existing duplicate-crate / unmatched-allowance warnings only.

Not run:
  check:conventions
    Local prerequisite is missing: ~/.claude/skills/convention-engineering/scripts/main.go
```

## User-visible / Operator-visible Changes

- Delegate child planning prompts now include an explicit child-runtime contract block when persisted `runtime_narrowing` is non-empty, so the model can plan within the actual `web.fetch` and `browser.*` limits before execution.
- Root sessions and unrestricted child sessions do not receive that contract block.

## Failure Recovery

- Fast rollback or disable path:
  Revert the child-contract prompt merge in `crates/app/src/conversation/runtime.rs` and keep the existing runtime narrowing enforcement untouched.
- Observable failure symptoms reviewers should watch for:
  Root-session prompts unexpectedly containing the child contract block, duplicate/empty contract sections, or prompt summaries drifting away from the enforced runtime narrowing semantics.

## Reviewer Focus

- `crates/app/src/conversation/runtime.rs`: verify the child-only merge path preserves existing `system_prompt_addition` behavior and never injects the child contract into root sessions.
- `crates/app/src/tools/runtime_config.rs`: verify the rendered summary stays stable, sparse, and aligned with the currently enforced `web.fetch` and `browser.*` narrowing fields.
- `crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs`: verify the deterministic `printf` fixtures preserve the id/method mismatch semantics rather than masking real bridge failures.
