### PR TITLE
Implement conversation turn middleware foundation

### DIFF
--- a/crates/app/src/config/conversation.rs
+++ b/crates/app/src/config/conversation.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 pub struct ConversationConfig {
     #[serde(default)]
     pub context_engine: Option<String>,
+    #[serde(default)]
+    pub turn_middlewares: Vec<String>,
     #[serde(default = "default_true")]
     pub compact_enabled: bool,
     #[serde(default)]
@@ -114,6 +116,7 @@ impl Default for ConversationConfig {
     fn default() -> Self {
         Self {
             context_engine: None,
+            turn_middlewares: Vec::new(),
             compact_enabled: default_true(),
             compact_min_messages: None,
             compact_trigger_estimated_tokens: None,
@@ -234,6 +237,21 @@ impl ConversationConfig {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(|value| value.to_ascii_lowercase())
+    }
+
+    pub fn turn_middleware_ids(&self) -> Vec<String> {
+        let mut seen = std::collections::BTreeSet::new();
+        let mut ids = Vec::new();
+
+        for raw in &self.turn_middlewares {
+            let normalized = raw.trim().to_ascii_lowercase();
+            if normalized.is_empty() || !seen.insert(normalized.clone()) {
+                continue;
+            }
+            ids.push(normalized);
+        }
+
+        ids
     }
 
     pub fn compact_min_messages(&self) -> Option<usize> {

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -2009,6 +2009,21 @@ context_engine = " Legacy "
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn conversation_turn_middlewares_field_parses_and_normalizes() {
+        let raw = r#"
+[conversation]
+turn_middlewares = [" Alpha ", "beta", "", "alpha"]
+"#;
+        let parsed =
+            toml::from_str::<LoongClawConfig>(raw).expect("parse conversation turn_middlewares");
+        assert_eq!(
+            parsed.conversation.turn_middleware_ids(),
+            vec!["alpha".to_owned(), "beta".to_owned()]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn memory_system_field_parses_and_normalizes() {
         let raw = r#"
 [memory]
@@ -2069,6 +2084,7 @@ compact_fail_open = false
     #[test]
     fn conversation_compaction_defaults_are_backward_compatible() {
         let config = ConversationConfig::default();
+        assert!(config.turn_middleware_ids().is_empty());
         assert!(config.compact_enabled);
         assert!(config.compaction_fail_open());
         assert_eq!(config.compact_trigger_estimated_tokens(), None);

--- a/crates/app/src/conversation/context_engine_registry.rs
+++ b/crates/app/src/conversation/context_engine_registry.rs
@@ -44,6 +44,12 @@ fn env_override() -> &'static Mutex<Option<Option<String>>> {
     CONTEXT_ENGINE_ENV_OVERRIDE.get_or_init(|| Mutex::new(None))
 }
 
+#[cfg(test)]
+pub(crate) fn conversation_selector_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 pub fn register_context_engine<F>(id: &str, factory: F) -> CliResult<()>
 where
     F: Fn() -> Box<dyn ConversationContextEngine> + Send + Sync + 'static,

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -17,6 +17,8 @@ mod turn_budget;
 mod turn_coordinator;
 pub mod turn_engine;
 mod turn_loop;
+mod turn_middleware;
+mod turn_middleware_registry;
 mod turn_shared;
 
 pub use analytics::{
@@ -50,8 +52,10 @@ pub use lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
 pub use runtime::{
     AsyncDelegateSpawnRequest, AsyncDelegateSpawner, ContextCompactionPolicySnapshot,
     ContextEngineRuntimeSnapshot, ContextEngineSelection, ContextEngineSelectionSource,
-    ConversationRuntime, DefaultConversationRuntime, SessionContext,
+    ConversationRuntime, DefaultConversationRuntime, SessionContext, TurnMiddlewareRuntimeSnapshot,
+    TurnMiddlewareSelection, TurnMiddlewareSelectionSource,
     collect_context_engine_runtime_snapshot, resolve_context_engine_selection,
+    resolve_turn_middleware_selection,
 };
 pub use runtime_binding::ConversationRuntimeBinding;
 pub use safe_lane_failure::{
@@ -82,6 +86,15 @@ pub use turn_engine::{
     ToolIntent, ToolOutcome, TurnEngine, TurnFailure, TurnFailureKind, TurnResult,
 };
 pub use turn_loop::ConversationTurnLoop;
+pub use turn_middleware::{
+    ConversationTurnMiddleware, TURN_MIDDLEWARE_API_VERSION, TurnMiddlewareCapability,
+    TurnMiddlewareMetadata,
+};
+pub use turn_middleware_registry::{
+    TURN_MIDDLEWARE_ENV, describe_turn_middlewares, list_turn_middleware_ids,
+    list_turn_middleware_metadata, register_turn_middleware, resolve_turn_middleware,
+    resolve_turn_middlewares, turn_middleware_ids_from_env,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderErrorMode {

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -87,13 +87,13 @@ pub use turn_engine::{
 };
 pub use turn_loop::ConversationTurnLoop;
 pub use turn_middleware::{
-    ConversationTurnMiddleware, TURN_MIDDLEWARE_API_VERSION, TurnMiddlewareCapability,
-    TurnMiddlewareMetadata,
+    ConversationTurnMiddleware, SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
+    TURN_MIDDLEWARE_API_VERSION, TurnMiddlewareCapability, TurnMiddlewareMetadata,
 };
 pub use turn_middleware_registry::{
-    TURN_MIDDLEWARE_ENV, describe_turn_middlewares, list_turn_middleware_ids,
-    list_turn_middleware_metadata, register_turn_middleware, resolve_turn_middleware,
-    resolve_turn_middlewares, turn_middleware_ids_from_env,
+    TURN_MIDDLEWARE_ENV, default_turn_middleware_ids, describe_turn_middlewares,
+    list_turn_middleware_ids, list_turn_middleware_metadata, register_turn_middleware,
+    resolve_turn_middleware, resolve_turn_middlewares, turn_middleware_ids_from_env,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -88,7 +88,8 @@ pub use turn_engine::{
 pub use turn_loop::ConversationTurnLoop;
 pub use turn_middleware::{
     ConversationTurnMiddleware, SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
-    TURN_MIDDLEWARE_API_VERSION, TurnMiddlewareCapability, TurnMiddlewareMetadata,
+    SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID, TURN_MIDDLEWARE_API_VERSION,
+    TurnMiddlewareCapability, TurnMiddlewareMetadata,
 };
 pub use turn_middleware_registry::{
     TURN_MIDDLEWARE_ENV, default_turn_middleware_ids, describe_turn_middlewares,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -26,10 +26,12 @@ use super::context_engine_registry::{
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::ProviderTurn;
-use super::turn_middleware::{ConversationTurnMiddleware, TurnMiddlewareMetadata};
+use super::turn_middleware::{
+    ConversationTurnMiddleware, SystemPromptAdditionTurnMiddleware, TurnMiddlewareMetadata,
+};
 use super::turn_middleware_registry::{
-    describe_turn_middlewares, list_turn_middleware_metadata, resolve_turn_middlewares,
-    turn_middleware_ids_from_env,
+    default_turn_middleware_ids, describe_turn_middlewares, list_turn_middleware_metadata,
+    resolve_turn_middlewares, turn_middleware_ids_from_env,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -302,26 +304,31 @@ pub fn resolve_context_engine_selection(config: &LoongClawConfig) -> ContextEngi
     }
 }
 
-pub fn resolve_turn_middleware_selection(config: &LoongClawConfig) -> TurnMiddlewareSelection {
-    if let Some(ids) = turn_middleware_ids_from_env() {
-        return TurnMiddlewareSelection {
-            ids,
+pub fn resolve_turn_middleware_selection(
+    config: &LoongClawConfig,
+) -> CliResult<TurnMiddlewareSelection> {
+    let mut ids = default_turn_middleware_ids()?;
+    if let Some(env_ids) = turn_middleware_ids_from_env() {
+        ids.extend(env_ids);
+        return Ok(TurnMiddlewareSelection {
+            ids: normalize_turn_middleware_ids(ids),
             source: TurnMiddlewareSelectionSource::Env,
-        };
+        });
     }
 
-    let ids = config.conversation.turn_middleware_ids();
-    if !ids.is_empty() {
-        return TurnMiddlewareSelection {
-            ids,
+    let configured_ids = config.conversation.turn_middleware_ids();
+    if !configured_ids.is_empty() {
+        ids.extend(configured_ids);
+        return Ok(TurnMiddlewareSelection {
+            ids: normalize_turn_middleware_ids(ids),
             source: TurnMiddlewareSelectionSource::Config,
-        };
+        });
     }
 
-    TurnMiddlewareSelection {
-        ids: Vec::new(),
+    Ok(TurnMiddlewareSelection {
+        ids: normalize_turn_middleware_ids(ids),
         source: TurnMiddlewareSelectionSource::Default,
-    }
+    })
 }
 
 pub fn collect_context_engine_runtime_snapshot(
@@ -330,7 +337,7 @@ pub fn collect_context_engine_runtime_snapshot(
     let selected = resolve_context_engine_selection(config);
     let selected_metadata = describe_context_engine(Some(selected.id.as_str()))?;
     let available = list_context_engine_metadata()?;
-    let turn_middleware_selection = resolve_turn_middleware_selection(config);
+    let turn_middleware_selection = resolve_turn_middleware_selection(config)?;
     let turn_middlewares = TurnMiddlewareRuntimeSnapshot {
         selected_metadata: describe_turn_middlewares(turn_middleware_selection.ids.as_slice())?,
         available: list_turn_middleware_metadata()?,
@@ -354,10 +361,7 @@ pub fn collect_context_engine_runtime_snapshot(
 
 impl Default for DefaultConversationRuntime<DefaultContextEngine> {
     fn default() -> Self {
-        Self {
-            context_engine: DefaultContextEngine,
-            turn_middlewares: Vec::new(),
-        }
+        Self::with_context_engine(DefaultContextEngine)
     }
 }
 
@@ -380,7 +384,7 @@ impl<E> DefaultConversationRuntime<E> {
     pub fn with_context_engine(context_engine: E) -> Self {
         Self {
             context_engine,
-            turn_middlewares: Vec::new(),
+            turn_middlewares: vec![Box::new(SystemPromptAdditionTurnMiddleware)],
         }
     }
 
@@ -525,15 +529,12 @@ where
 impl DefaultConversationRuntime<Box<dyn ConversationContextEngine>> {
     pub fn from_engine_id(engine_id: Option<&str>) -> CliResult<Self> {
         let context_engine = resolve_context_engine(engine_id)?;
-        Ok(Self {
-            context_engine,
-            turn_middlewares: Vec::new(),
-        })
+        Ok(Self::with_context_engine(context_engine))
     }
 
     pub fn from_config_or_env(config: &LoongClawConfig) -> CliResult<Self> {
         let selection = resolve_context_engine_selection(config);
-        let turn_middleware_selection = resolve_turn_middleware_selection(config);
+        let turn_middleware_selection = resolve_turn_middleware_selection(config)?;
         let context_engine = resolve_context_engine(Some(selection.id.as_str()))?;
         let turn_middlewares = resolve_turn_middlewares(turn_middleware_selection.ids.as_slice())?;
         Ok(Self {
@@ -836,7 +837,7 @@ where
         let delegate_runtime_contract = include_system_prompt
             .then(|| delegate_child_runtime_contract_prompt_summary(config, &session_context))
             .flatten();
-        let merged_system_prompt_addition = merge_system_prompt_additions(
+        assembled.system_prompt_addition = merge_system_prompt_additions(
             assembled.system_prompt_addition.as_deref(),
             delegate_runtime_contract.as_deref(),
         );
@@ -849,10 +850,6 @@ where
                 binding,
             )
             .await?;
-        apply_system_prompt_addition(
-            &mut assembled.messages,
-            merged_system_prompt_addition.as_deref(),
-        );
         if include_system_prompt {
             apply_tool_view_to_system_prompt_if_needed(
                 &mut assembled.messages,
@@ -1056,42 +1053,6 @@ fn merge_system_prompt_additions(existing: Option<&str>, extra: Option<&str>) ->
         (None, None) => None,
     }
 }
-
-fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: Option<&str>) {
-    let Some(addition) = addition
-        .map(str::trim)
-        .filter(|content| !content.is_empty())
-    else {
-        return;
-    };
-
-    for message in messages.iter_mut() {
-        let is_system = message.get("role").and_then(Value::as_str) == Some("system");
-        if !is_system {
-            continue;
-        }
-
-        if let Some(object) = message.as_object_mut() {
-            let merged_content = match object.get("content").and_then(Value::as_str) {
-                Some(existing) if !existing.trim().is_empty() => {
-                    format!("{addition}\n\n{}", existing.trim())
-                }
-                _ => addition.to_owned(),
-            };
-            object.insert("content".to_owned(), Value::String(merged_content));
-            return;
-        }
-    }
-
-    messages.insert(
-        0,
-        json!({
-            "role": "system",
-            "content": addition,
-        }),
-    );
-}
-
 fn apply_tool_view_to_system_prompt_if_needed(
     messages: &mut [Value],
     runtime_tool_view: &ToolView,
@@ -1133,6 +1094,17 @@ fn apply_tool_view_to_system_prompt(messages: &mut [Value], tool_view: &ToolView
         }
         return;
     }
+}
+
+fn normalize_turn_middleware_ids(ids: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::new();
+    for id in ids {
+        if seen.insert(id.clone()) {
+            normalized.push(id);
+        }
+    }
+    normalized
 }
 
 #[cfg(test)]

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -26,6 +26,11 @@ use super::context_engine_registry::{
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::ProviderTurn;
+use super::turn_middleware::{ConversationTurnMiddleware, TurnMiddlewareMetadata};
+use super::turn_middleware_registry::{
+    describe_turn_middlewares, list_turn_middleware_metadata, resolve_turn_middlewares,
+    turn_middleware_ids_from_env,
+};
 
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -203,6 +208,7 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
 
 pub struct DefaultConversationRuntime<E = DefaultContextEngine> {
     context_engine: E,
+    turn_middlewares: Vec<Box<dyn ConversationTurnMiddleware>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -222,10 +228,33 @@ impl ContextEngineSelectionSource {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnMiddlewareSelectionSource {
+    Env,
+    Config,
+    Default,
+}
+
+impl TurnMiddlewareSelectionSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TurnMiddlewareSelectionSource::Env => "env",
+            TurnMiddlewareSelectionSource::Config => "config",
+            TurnMiddlewareSelectionSource::Default => "default",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextEngineSelection {
     pub id: String,
     pub source: ContextEngineSelectionSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnMiddlewareSelection {
+    pub ids: Vec<String>,
+    pub source: TurnMiddlewareSelectionSource,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -241,7 +270,15 @@ pub struct ContextEngineRuntimeSnapshot {
     pub selected: ContextEngineSelection,
     pub selected_metadata: ContextEngineMetadata,
     pub available: Vec<ContextEngineMetadata>,
+    pub turn_middlewares: TurnMiddlewareRuntimeSnapshot,
     pub compaction: ContextCompactionPolicySnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnMiddlewareRuntimeSnapshot {
+    pub selected: TurnMiddlewareSelection,
+    pub selected_metadata: Vec<TurnMiddlewareMetadata>,
+    pub available: Vec<TurnMiddlewareMetadata>,
 }
 
 pub fn resolve_context_engine_selection(config: &LoongClawConfig) -> ContextEngineSelection {
@@ -265,12 +302,40 @@ pub fn resolve_context_engine_selection(config: &LoongClawConfig) -> ContextEngi
     }
 }
 
+pub fn resolve_turn_middleware_selection(config: &LoongClawConfig) -> TurnMiddlewareSelection {
+    if let Some(ids) = turn_middleware_ids_from_env() {
+        return TurnMiddlewareSelection {
+            ids,
+            source: TurnMiddlewareSelectionSource::Env,
+        };
+    }
+
+    let ids = config.conversation.turn_middleware_ids();
+    if !ids.is_empty() {
+        return TurnMiddlewareSelection {
+            ids,
+            source: TurnMiddlewareSelectionSource::Config,
+        };
+    }
+
+    TurnMiddlewareSelection {
+        ids: Vec::new(),
+        source: TurnMiddlewareSelectionSource::Default,
+    }
+}
+
 pub fn collect_context_engine_runtime_snapshot(
     config: &LoongClawConfig,
 ) -> CliResult<ContextEngineRuntimeSnapshot> {
     let selected = resolve_context_engine_selection(config);
     let selected_metadata = describe_context_engine(Some(selected.id.as_str()))?;
     let available = list_context_engine_metadata()?;
+    let turn_middleware_selection = resolve_turn_middleware_selection(config);
+    let turn_middlewares = TurnMiddlewareRuntimeSnapshot {
+        selected_metadata: describe_turn_middlewares(turn_middleware_selection.ids.as_slice())?,
+        available: list_turn_middleware_metadata()?,
+        selected: turn_middleware_selection,
+    };
     let compaction = ContextCompactionPolicySnapshot {
         enabled: config.conversation.compact_enabled,
         min_messages: config.conversation.compact_min_messages(),
@@ -282,6 +347,7 @@ pub fn collect_context_engine_runtime_snapshot(
         selected,
         selected_metadata,
         available,
+        turn_middlewares,
         compaction,
     })
 }
@@ -290,6 +356,7 @@ impl Default for DefaultConversationRuntime<DefaultContextEngine> {
     fn default() -> Self {
         Self {
             context_engine: DefaultContextEngine,
+            turn_middlewares: Vec::new(),
         }
     }
 }
@@ -298,11 +365,33 @@ impl DefaultConversationRuntime<DefaultContextEngine> {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub fn with_turn_middlewares(
+        turn_middlewares: Vec<Box<dyn ConversationTurnMiddleware>>,
+    ) -> Self {
+        Self {
+            context_engine: DefaultContextEngine,
+            turn_middlewares,
+        }
+    }
 }
 
 impl<E> DefaultConversationRuntime<E> {
     pub fn with_context_engine(context_engine: E) -> Self {
-        Self { context_engine }
+        Self {
+            context_engine,
+            turn_middlewares: Vec::new(),
+        }
+    }
+
+    pub fn with_context_engine_and_turn_middlewares(
+        context_engine: E,
+        turn_middlewares: Vec<Box<dyn ConversationTurnMiddleware>>,
+    ) -> Self {
+        Self {
+            context_engine,
+            turn_middlewares,
+        }
     }
 }
 
@@ -313,17 +402,144 @@ where
     pub fn context_engine_metadata(&self) -> ContextEngineMetadata {
         self.context_engine.metadata()
     }
+
+    pub fn turn_middleware_metadata(&self) -> Vec<TurnMiddlewareMetadata> {
+        self.turn_middlewares
+            .iter()
+            .map(|middleware| middleware.metadata())
+            .collect()
+    }
+
+    async fn run_turn_middlewares_bootstrap(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        for middleware in &self.turn_middlewares {
+            middleware.bootstrap(config, session_id, kernel_ctx).await?;
+        }
+        Ok(())
+    }
+
+    async fn run_turn_middlewares_ingest(
+        &self,
+        session_id: &str,
+        message: &Value,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        for middleware in &self.turn_middlewares {
+            middleware.ingest(session_id, message, kernel_ctx).await?;
+        }
+        Ok(())
+    }
+
+    async fn apply_turn_middlewares_to_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        mut assembled: AssembledConversationContext,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        for middleware in &self.turn_middlewares {
+            assembled = middleware
+                .transform_context(
+                    config,
+                    session_id,
+                    include_system_prompt,
+                    assembled,
+                    binding,
+                )
+                .await?;
+        }
+        Ok(assembled)
+    }
+
+    async fn run_turn_middlewares_after_turn(
+        &self,
+        session_id: &str,
+        user_input: &str,
+        assistant_reply: &str,
+        messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        for middleware in &self.turn_middlewares {
+            middleware
+                .after_turn(
+                    session_id,
+                    user_input,
+                    assistant_reply,
+                    messages,
+                    kernel_ctx,
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn run_turn_middlewares_compact_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        for middleware in &self.turn_middlewares {
+            middleware
+                .compact_context(config, session_id, messages, kernel_ctx)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn run_turn_middlewares_prepare_subagent_spawn(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        for middleware in &self.turn_middlewares {
+            middleware
+                .prepare_subagent_spawn(parent_session_id, subagent_session_id, kernel_ctx)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn run_turn_middlewares_on_subagent_ended(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        for middleware in &self.turn_middlewares {
+            middleware
+                .on_subagent_ended(parent_session_id, subagent_session_id, kernel_ctx)
+                .await?;
+        }
+        Ok(())
+    }
 }
 
 impl DefaultConversationRuntime<Box<dyn ConversationContextEngine>> {
     pub fn from_engine_id(engine_id: Option<&str>) -> CliResult<Self> {
         let context_engine = resolve_context_engine(engine_id)?;
-        Ok(Self { context_engine })
+        Ok(Self {
+            context_engine,
+            turn_middlewares: Vec::new(),
+        })
     }
 
     pub fn from_config_or_env(config: &LoongClawConfig) -> CliResult<Self> {
         let selection = resolve_context_engine_selection(config);
-        Self::from_engine_id(Some(selection.id.as_str()))
+        let turn_middleware_selection = resolve_turn_middleware_selection(config);
+        let context_engine = resolve_context_engine(Some(selection.id.as_str()))?;
+        let turn_middlewares = resolve_turn_middlewares(turn_middleware_selection.ids.as_slice())?;
+        Ok(Self {
+            context_engine,
+            turn_middlewares,
+        })
     }
 }
 
@@ -581,9 +797,13 @@ where
         session_id: &str,
         kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineBootstrapResult> {
-        self.context_engine
+        let result = self
+            .context_engine
             .bootstrap(config, session_id, kernel_ctx)
-            .await
+            .await?;
+        self.run_turn_middlewares_bootstrap(config, session_id, kernel_ctx)
+            .await?;
+        Ok(result)
     }
 
     async fn ingest(
@@ -592,9 +812,13 @@ where
         message: &Value,
         kernel_ctx: &KernelContext,
     ) -> CliResult<ContextEngineIngestResult> {
-        self.context_engine
+        let result = self
+            .context_engine
             .ingest(session_id, message, kernel_ctx)
-            .await
+            .await?;
+        self.run_turn_middlewares_ingest(session_id, message, kernel_ctx)
+            .await?;
+        Ok(result)
     }
 
     async fn build_context(
@@ -616,6 +840,15 @@ where
             assembled.system_prompt_addition.as_deref(),
             delegate_runtime_contract.as_deref(),
         );
+        assembled = self
+            .apply_turn_middlewares_to_context(
+                config,
+                session_id,
+                include_system_prompt,
+                assembled,
+                binding,
+            )
+            .await?;
         apply_system_prompt_addition(
             &mut assembled.messages,
             merged_system_prompt_addition.as_deref(),
@@ -731,7 +964,15 @@ where
                 messages,
                 kernel_ctx,
             )
-            .await
+            .await?;
+        self.run_turn_middlewares_after_turn(
+            session_id,
+            user_input,
+            assistant_reply,
+            messages,
+            kernel_ctx,
+        )
+        .await
     }
 
     async fn compact_context(
@@ -743,6 +984,8 @@ where
     ) -> CliResult<()> {
         self.context_engine
             .compact_context(config, session_id, messages, kernel_ctx)
+            .await?;
+        self.run_turn_middlewares_compact_context(config, session_id, messages, kernel_ctx)
             .await
     }
 
@@ -754,7 +997,13 @@ where
     ) -> CliResult<()> {
         self.context_engine
             .prepare_subagent_spawn(parent_session_id, subagent_session_id, kernel_ctx)
-            .await
+            .await?;
+        self.run_turn_middlewares_prepare_subagent_spawn(
+            parent_session_id,
+            subagent_session_id,
+            kernel_ctx,
+        )
+        .await
     }
 
     async fn on_subagent_ended(
@@ -765,7 +1014,13 @@ where
     ) -> CliResult<()> {
         self.context_engine
             .on_subagent_ended(parent_session_id, subagent_session_id, kernel_ctx)
-            .await
+            .await?;
+        self.run_turn_middlewares_on_subagent_ended(
+            parent_session_id,
+            subagent_session_id,
+            kernel_ctx,
+        )
+        .await
     }
 }
 

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -27,8 +27,7 @@ use super::runtime_binding::ConversationRuntimeBinding;
 use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::ProviderTurn;
 use super::turn_middleware::{
-    ConversationTurnMiddleware, SystemPromptAdditionTurnMiddleware,
-    SystemPromptToolViewTurnMiddleware, TurnMiddlewareMetadata,
+    ConversationTurnMiddleware, TurnMiddlewareMetadata, builtin_turn_middlewares,
 };
 use super::turn_middleware_registry::{
     default_turn_middleware_ids, describe_turn_middlewares, list_turn_middleware_metadata,
@@ -374,10 +373,7 @@ impl DefaultConversationRuntime<DefaultContextEngine> {
     pub fn with_turn_middlewares(
         turn_middlewares: Vec<Box<dyn ConversationTurnMiddleware>>,
     ) -> Self {
-        Self {
-            context_engine: DefaultContextEngine,
-            turn_middlewares,
-        }
+        Self::with_context_engine_and_turn_middlewares(DefaultContextEngine, turn_middlewares)
     }
 }
 
@@ -385,10 +381,7 @@ impl<E> DefaultConversationRuntime<E> {
     pub fn with_context_engine(context_engine: E) -> Self {
         Self {
             context_engine,
-            turn_middlewares: vec![
-                Box::new(SystemPromptAdditionTurnMiddleware),
-                Box::new(SystemPromptToolViewTurnMiddleware),
-            ],
+            turn_middlewares: builtin_turn_middlewares(),
         }
     }
 
@@ -396,9 +389,11 @@ impl<E> DefaultConversationRuntime<E> {
         context_engine: E,
         turn_middlewares: Vec<Box<dyn ConversationTurnMiddleware>>,
     ) -> Self {
+        let mut combined_turn_middlewares = builtin_turn_middlewares();
+        combined_turn_middlewares.extend(turn_middlewares);
         Self {
             context_engine,
-            turn_middlewares,
+            turn_middlewares: combined_turn_middlewares,
         }
     }
 }

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use loongclaw_contracts::Capability;
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use crate::CliResult;
 use crate::KernelContext;
@@ -27,7 +27,8 @@ use super::runtime_binding::ConversationRuntimeBinding;
 use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::ProviderTurn;
 use super::turn_middleware::{
-    ConversationTurnMiddleware, SystemPromptAdditionTurnMiddleware, TurnMiddlewareMetadata,
+    ConversationTurnMiddleware, SystemPromptAdditionTurnMiddleware,
+    SystemPromptToolViewTurnMiddleware, TurnMiddlewareMetadata,
 };
 use super::turn_middleware_registry::{
     default_turn_middleware_ids, describe_turn_middlewares, list_turn_middleware_metadata,
@@ -384,7 +385,10 @@ impl<E> DefaultConversationRuntime<E> {
     pub fn with_context_engine(context_engine: E) -> Self {
         Self {
             context_engine,
-            turn_middlewares: vec![Box::new(SystemPromptAdditionTurnMiddleware)],
+            turn_middlewares: vec![
+                Box::new(SystemPromptAdditionTurnMiddleware),
+                Box::new(SystemPromptToolViewTurnMiddleware),
+            ],
         }
     }
 
@@ -403,6 +407,43 @@ impl<E> DefaultConversationRuntime<E>
 where
     E: ConversationContextEngine,
 {
+    async fn build_context_for_tool_view(
+        &self,
+        config: &LoongClawConfig,
+        session_context: &SessionContext,
+        include_system_prompt: bool,
+        requested_tool_view: &ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        let runtime_tool_view = crate::tools::runtime_tool_view_from_loongclaw_config(config);
+        let mut assembled = self
+            .context_engine
+            .assemble_context(
+                config,
+                session_context.session_id.as_str(),
+                include_system_prompt,
+                binding,
+            )
+            .await?;
+        let delegate_runtime_contract = include_system_prompt
+            .then(|| delegate_child_runtime_contract_prompt_summary(config, session_context))
+            .flatten();
+        assembled.system_prompt_addition = merge_system_prompt_additions(
+            assembled.system_prompt_addition.as_deref(),
+            delegate_runtime_contract.as_deref(),
+        );
+        self.apply_turn_middlewares_to_context(
+            config,
+            session_context.session_id.as_str(),
+            include_system_prompt,
+            assembled,
+            &runtime_tool_view,
+            requested_tool_view,
+            binding,
+        )
+        .await
+    }
+
     pub fn context_engine_metadata(&self) -> ContextEngineMetadata {
         self.context_engine.metadata()
     }
@@ -444,6 +485,8 @@ where
         session_id: &str,
         include_system_prompt: bool,
         mut assembled: AssembledConversationContext,
+        runtime_tool_view: &ToolView,
+        requested_tool_view: &ToolView,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         for middleware in &self.turn_middlewares {
@@ -453,6 +496,8 @@ where
                     session_id,
                     include_system_prompt,
                     assembled,
+                    runtime_tool_view,
+                    requested_tool_view,
                     binding,
                 )
                 .await?;
@@ -830,34 +875,14 @@ where
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         let session_context = self.session_context(config, session_id, binding)?;
-        let mut assembled = self
-            .context_engine
-            .assemble_context(config, session_id, include_system_prompt, binding)
-            .await?;
-        let delegate_runtime_contract = include_system_prompt
-            .then(|| delegate_child_runtime_contract_prompt_summary(config, &session_context))
-            .flatten();
-        assembled.system_prompt_addition = merge_system_prompt_additions(
-            assembled.system_prompt_addition.as_deref(),
-            delegate_runtime_contract.as_deref(),
-        );
-        assembled = self
-            .apply_turn_middlewares_to_context(
-                config,
-                session_id,
-                include_system_prompt,
-                assembled,
-                binding,
-            )
-            .await?;
-        if include_system_prompt {
-            apply_tool_view_to_system_prompt_if_needed(
-                &mut assembled.messages,
-                &crate::tools::runtime_tool_view_from_loongclaw_config(config),
-                &session_context.tool_view,
-            );
-        }
-        Ok(assembled)
+        self.build_context_for_tool_view(
+            config,
+            &session_context,
+            include_system_prompt,
+            &session_context.tool_view,
+            binding,
+        )
+        .await
     }
 
     async fn build_messages(
@@ -868,16 +893,16 @@ where
         tool_view: &ToolView,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
-        self.build_context(config, session_id, include_system_prompt, binding)
-            .await
-            .map(|mut assembled| {
-                apply_tool_view_to_system_prompt_if_needed(
-                    &mut assembled.messages,
-                    &crate::tools::runtime_tool_view_from_loongclaw_config(config),
-                    tool_view,
-                );
-                assembled.messages
-            })
+        let session_context = self.session_context(config, session_id, binding)?;
+        self.build_context_for_tool_view(
+            config,
+            &session_context,
+            include_system_prompt,
+            tool_view,
+            binding,
+        )
+        .await
+        .map(|assembled| assembled.messages)
     }
 
     async fn request_completion(
@@ -1053,49 +1078,6 @@ fn merge_system_prompt_additions(existing: Option<&str>, extra: Option<&str>) ->
         (None, None) => None,
     }
 }
-fn apply_tool_view_to_system_prompt_if_needed(
-    messages: &mut [Value],
-    runtime_tool_view: &ToolView,
-    requested_tool_view: &ToolView,
-) {
-    if requested_tool_view != runtime_tool_view {
-        apply_tool_view_to_system_prompt(messages, requested_tool_view);
-    }
-}
-
-fn apply_tool_view_to_system_prompt(messages: &mut [Value], tool_view: &ToolView) {
-    for message in messages.iter_mut() {
-        let is_system = message.get("role").and_then(Value::as_str) == Some("system");
-        if !is_system {
-            continue;
-        }
-
-        let Some(content) = message
-            .get("content")
-            .and_then(Value::as_str)
-            .map(str::to_owned)
-        else {
-            continue;
-        };
-        let Some(snapshot_start) = content.find("[available_tools]") else {
-            continue;
-        };
-        let snapshot = crate::tools::capability_snapshot_for_view(tool_view);
-
-        let prefix = content[..snapshot_start].trim_end();
-        let rewritten = if prefix.is_empty() {
-            snapshot
-        } else {
-            format!("{prefix}\n\n{snapshot}")
-        };
-
-        if let Some(object) = message.as_object_mut() {
-            object.insert("content".to_owned(), Value::String(rewritten));
-        }
-        return;
-    }
-}
-
 fn normalize_turn_middleware_ids(ids: Vec<String>) -> Vec<String> {
     let mut seen = BTreeSet::new();
     let mut normalized = Vec::new();

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1511,6 +1511,138 @@ fn default_runtime_exposes_context_engine_metadata() {
 }
 
 #[tokio::test]
+async fn default_runtime_applies_turn_middlewares_in_declared_order() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let runtime = DefaultConversationRuntime::with_context_engine_and_turn_middlewares(
+        StubContextEngine,
+        vec![
+            Box::new(RecordingTransformTurnMiddleware::new(
+                "append-middle-b",
+                "middleware-b",
+                calls.clone(),
+            )),
+            Box::new(RecordingTransformTurnMiddleware::new(
+                "append-middle-a",
+                "middleware-a",
+                calls.clone(),
+            )),
+        ],
+    );
+    let binding = ConversationRuntimeBinding::direct();
+    let assembled = runtime
+        .build_context(
+            &test_config(),
+            "session-turn-middleware-order",
+            true,
+            binding,
+        )
+        .await
+        .expect("build context through turn middleware chain");
+
+    let contents = assembled
+        .messages
+        .iter()
+        .map(|message| {
+            message["content"]
+                .as_str()
+                .expect("message content should remain a string")
+                .to_owned()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        contents,
+        vec![
+            "stub-context-engine".to_owned(),
+            "middleware-b".to_owned(),
+            "middleware-a".to_owned(),
+        ]
+    );
+    assert_eq!(
+        calls.lock().expect("turn middleware calls lock").clone(),
+        vec![
+            "transform:append-middle-b:session-turn-middleware-order".to_owned(),
+            "transform:append-middle-a:session-turn-middleware-order".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn resolve_turn_middleware_selection_includes_builtin_defaults_when_unset() {
+    let _env_lock = turn_middleware_env_lock().lock().expect("env lock");
+    super::turn_middleware_registry::clear_turn_middleware_env_override();
+
+    let selection = resolve_turn_middleware_selection(&test_config())
+        .expect("resolve turn middleware selection");
+    assert_eq!(
+        selection.ids,
+        vec![SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID.to_owned()]
+    );
+    assert_eq!(selection.source, TurnMiddlewareSelectionSource::Default);
+}
+
+#[test]
+fn default_runtime_with_context_engine_exposes_builtin_turn_middleware_metadata() {
+    let runtime = DefaultConversationRuntime::with_context_engine(StubSystemPromptAdditionEngine);
+    assert_eq!(
+        runtime
+            .turn_middleware_metadata()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<Vec<_>>(),
+        vec![SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID]
+    );
+}
+
+#[test]
+fn collect_context_engine_runtime_snapshot_reports_turn_middleware_selection() {
+    let _env_lock = turn_middleware_env_lock().lock().expect("env lock");
+    register_turn_middleware("snapshot-turn-a", || {
+        Box::new(NoopTurnMiddleware::new("snapshot-turn-a"))
+    })
+    .expect("register turn middleware");
+    let _scoped_env = ScopedEnvVar::set(TURN_MIDDLEWARE_ENV, "");
+    let mut config = test_config();
+    config.conversation.turn_middlewares = vec!["snapshot-turn-a".to_owned()];
+
+    let snapshot = collect_context_engine_runtime_snapshot(&config)
+        .expect("collect context engine runtime snapshot");
+    assert_eq!(
+        snapshot.turn_middlewares.selected.ids,
+        vec![
+            SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID.to_owned(),
+            "snapshot-turn-a".to_owned()
+        ]
+    );
+    assert_eq!(
+        snapshot.turn_middlewares.selected.source,
+        TurnMiddlewareSelectionSource::Config
+    );
+    assert_eq!(
+        snapshot
+            .turn_middlewares
+            .selected_metadata
+            .iter()
+            .map(|metadata| metadata.id)
+            .collect::<Vec<_>>(),
+        vec![SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID, "snapshot-turn-a"]
+    );
+    assert!(
+        snapshot
+            .turn_middlewares
+            .available
+            .iter()
+            .any(|metadata| metadata.id == SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID)
+    );
+    assert!(
+        snapshot
+            .turn_middlewares
+            .available
+            .iter()
+            .any(|metadata| metadata.id == "snapshot-turn-a")
+    );
+}
+
+#[tokio::test]
 async fn default_runtime_build_messages_respects_restricted_tool_view() {
     let runtime = DefaultConversationRuntime::default();
     let view = crate::tools::ToolView::from_tool_names(["file.read"]);

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -583,25 +583,57 @@ fn context_engine_env_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+fn turn_middleware_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+enum ScopedEnvPrevious {
+    ContextEngine(Option<String>),
+    TurnMiddleware(Option<String>),
+}
+
 struct ScopedEnvVar {
-    previous: Option<Option<String>>,
+    previous: ScopedEnvPrevious,
 }
 
 impl ScopedEnvVar {
     fn set(key: &'static str, value: &str) -> Self {
-        assert_eq!(key, CONTEXT_ENGINE_ENV, "unexpected scoped env key");
-        let previous = Some(super::context_engine_registry::context_engine_id_from_env());
-        super::context_engine_registry::set_context_engine_env_override(Some(value));
+        let previous = match key {
+            CONTEXT_ENGINE_ENV => {
+                let previous = super::context_engine_registry::context_engine_id_from_env();
+                super::context_engine_registry::set_context_engine_env_override(Some(value));
+                ScopedEnvPrevious::ContextEngine(previous)
+            }
+            TURN_MIDDLEWARE_ENV => {
+                let previous = super::turn_middleware_registry::turn_middleware_ids_from_env()
+                    .map(|ids| ids.join(","));
+                super::turn_middleware_registry::set_turn_middleware_env_override(Some(value));
+                ScopedEnvPrevious::TurnMiddleware(previous)
+            }
+            _ => panic!("unexpected scoped env key: {key}"),
+        };
         Self { previous }
     }
 }
 
 impl Drop for ScopedEnvVar {
     fn drop(&mut self) {
-        if let Some(previous) = self.previous.as_ref() {
-            super::context_engine_registry::set_context_engine_env_override(previous.as_deref());
-        } else {
-            super::context_engine_registry::clear_context_engine_env_override();
+        match &self.previous {
+            ScopedEnvPrevious::ContextEngine(previous) => match previous {
+                Some(previous) => super::context_engine_registry::set_context_engine_env_override(
+                    Some(previous.as_str()),
+                ),
+                None => super::context_engine_registry::clear_context_engine_env_override(),
+            },
+            ScopedEnvPrevious::TurnMiddleware(previous) => match previous {
+                Some(previous) => {
+                    super::turn_middleware_registry::set_turn_middleware_env_override(Some(
+                        previous.as_str(),
+                    ))
+                }
+                None => super::turn_middleware_registry::clear_turn_middleware_env_override(),
+            },
         }
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -579,13 +579,19 @@ impl ConversationContextEngine for RecordingLifecycleContextEngine {
 }
 
 fn context_engine_env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
+    super::context_engine_registry::conversation_selector_env_lock()
 }
 
 fn turn_middleware_env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
+    super::context_engine_registry::conversation_selector_env_lock()
+}
+
+#[test]
+fn turn_middleware_env_lock_reuses_context_engine_env_lock() {
+    assert!(std::ptr::eq(
+        context_engine_env_lock(),
+        turn_middleware_env_lock()
+    ));
 }
 
 enum ScopedEnvPrevious {
@@ -1667,7 +1673,7 @@ async fn default_runtime_applies_turn_middlewares_in_declared_order() {
 #[test]
 fn resolve_turn_middleware_selection_includes_builtin_defaults_when_unset() {
     let _env_lock = turn_middleware_env_lock().lock().expect("env lock");
-    super::turn_middleware_registry::clear_turn_middleware_env_override();
+    let _scoped_env = ScopedEnvVar::set(TURN_MIDDLEWARE_ENV, "");
 
     let selection = resolve_turn_middleware_selection(&test_config())
         .expect("resolve turn middleware selection");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -74,6 +74,14 @@ enum FakeTurnResponse {
 }
 
 struct TraitDefaultToolViewRuntime;
+struct NoopTurnMiddleware {
+    id: &'static str,
+}
+struct RecordingTransformTurnMiddleware {
+    id: &'static str,
+    injected_content: &'static str,
+    calls: Arc<Mutex<Vec<String>>>,
+}
 
 #[async_trait]
 impl ConversationRuntime for TraitDefaultToolViewRuntime {
@@ -431,6 +439,64 @@ impl ConversationContextEngine for StubSystemPromptAdditionEngine {
     }
 }
 
+impl NoopTurnMiddleware {
+    fn new(id: &'static str) -> Self {
+        Self { id }
+    }
+}
+
+#[async_trait]
+impl ConversationTurnMiddleware for NoopTurnMiddleware {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+}
+
+impl RecordingTransformTurnMiddleware {
+    fn new(
+        id: &'static str,
+        injected_content: &'static str,
+        calls: Arc<Mutex<Vec<String>>>,
+    ) -> Self {
+        Self {
+            id,
+            injected_content,
+            calls,
+        }
+    }
+}
+
+#[async_trait]
+impl ConversationTurnMiddleware for RecordingTransformTurnMiddleware {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+
+    fn metadata(&self) -> TurnMiddlewareMetadata {
+        TurnMiddlewareMetadata::new(self.id(), [TurnMiddlewareCapability::ContextTransform])
+    }
+
+    async fn transform_context(
+        &self,
+        _config: &LoongClawConfig,
+        session_id: &str,
+        _include_system_prompt: bool,
+        mut assembled: AssembledConversationContext,
+        _runtime_tool_view: &crate::tools::ToolView,
+        _requested_tool_view: &crate::tools::ToolView,
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        self.calls
+            .lock()
+            .expect("transform middleware calls lock")
+            .push(format!("transform:{}:{session_id}", self.id));
+        assembled.messages.push(json!({
+            "role": "assistant",
+            "content": self.injected_content,
+        }));
+        Ok(assembled)
+    }
+}
 #[async_trait]
 impl ConversationContextEngine for RecordingLifecycleContextEngine {
     fn id(&self) -> &'static str {
@@ -1575,7 +1641,10 @@ fn resolve_turn_middleware_selection_includes_builtin_defaults_when_unset() {
         .expect("resolve turn middleware selection");
     assert_eq!(
         selection.ids,
-        vec![SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID.to_owned()]
+        vec![
+            SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID.to_owned(),
+            SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID.to_owned(),
+        ]
     );
     assert_eq!(selection.source, TurnMiddlewareSelectionSource::Default);
 }
@@ -1589,7 +1658,10 @@ fn default_runtime_with_context_engine_exposes_builtin_turn_middleware_metadata(
             .into_iter()
             .map(|metadata| metadata.id)
             .collect::<Vec<_>>(),
-        vec![SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID]
+        vec![
+            SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
+            SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID,
+        ]
     );
 }
 
@@ -1610,6 +1682,7 @@ fn collect_context_engine_runtime_snapshot_reports_turn_middleware_selection() {
         snapshot.turn_middlewares.selected.ids,
         vec![
             SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID.to_owned(),
+            SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID.to_owned(),
             "snapshot-turn-a".to_owned()
         ]
     );
@@ -1624,7 +1697,11 @@ fn collect_context_engine_runtime_snapshot_reports_turn_middleware_selection() {
             .iter()
             .map(|metadata| metadata.id)
             .collect::<Vec<_>>(),
-        vec![SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID, "snapshot-turn-a"]
+        vec![
+            SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
+            SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID,
+            "snapshot-turn-a",
+        ]
     );
     assert!(
         snapshot
@@ -1632,6 +1709,13 @@ fn collect_context_engine_runtime_snapshot_reports_turn_middleware_selection() {
             .available
             .iter()
             .any(|metadata| metadata.id == SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID)
+    );
+    assert!(
+        snapshot
+            .turn_middlewares
+            .available
+            .iter()
+            .any(|metadata| metadata.id == SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID)
     );
     assert!(
         snapshot

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1671,6 +1671,26 @@ async fn default_runtime_applies_turn_middlewares_in_declared_order() {
 }
 
 #[test]
+fn with_context_engine_and_turn_middlewares_retains_builtin_defaults_before_custom_chain() {
+    let runtime = DefaultConversationRuntime::with_context_engine_and_turn_middlewares(
+        StubContextEngine,
+        vec![Box::new(NoopTurnMiddleware::new("custom-turn-middleware"))],
+    );
+    assert_eq!(
+        runtime
+            .turn_middleware_metadata()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<Vec<_>>(),
+        vec![
+            SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
+            SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID,
+            "custom-turn-middleware",
+        ]
+    );
+}
+
+#[test]
 fn resolve_turn_middleware_selection_includes_builtin_defaults_when_unset() {
     let _env_lock = turn_middleware_env_lock().lock().expect("env lock");
     let _scoped_env = ScopedEnvVar::set(TURN_MIDDLEWARE_ENV, "");

--- a/crates/app/src/conversation/turn_middleware.rs
+++ b/crates/app/src/conversation/turn_middleware.rs
@@ -1,0 +1,246 @@
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::config::LoongClawConfig;
+use crate::{CliResult, KernelContext};
+
+use super::context_engine::AssembledConversationContext;
+use super::runtime_binding::ConversationRuntimeBinding;
+
+pub const TURN_MIDDLEWARE_API_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TurnMiddlewareCapability {
+    ContextTransform,
+    SessionBootstrap,
+    MessageIngestion,
+    AfterTurn,
+    ContextCompaction,
+    SubagentLifecycle,
+}
+
+impl TurnMiddlewareCapability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TurnMiddlewareCapability::ContextTransform => "context_transform",
+            TurnMiddlewareCapability::SessionBootstrap => "session_bootstrap",
+            TurnMiddlewareCapability::MessageIngestion => "message_ingestion",
+            TurnMiddlewareCapability::AfterTurn => "after_turn",
+            TurnMiddlewareCapability::ContextCompaction => "context_compaction",
+            TurnMiddlewareCapability::SubagentLifecycle => "subagent_lifecycle",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnMiddlewareMetadata {
+    pub id: &'static str,
+    pub api_version: u16,
+    pub capabilities: BTreeSet<TurnMiddlewareCapability>,
+}
+
+impl TurnMiddlewareMetadata {
+    pub fn new(
+        id: &'static str,
+        capabilities: impl IntoIterator<Item = TurnMiddlewareCapability>,
+    ) -> Self {
+        Self {
+            id,
+            api_version: TURN_MIDDLEWARE_API_VERSION,
+            capabilities: capabilities.into_iter().collect(),
+        }
+    }
+
+    pub fn capability_names(&self) -> Vec<&'static str> {
+        self.capabilities
+            .iter()
+            .copied()
+            .map(TurnMiddlewareCapability::as_str)
+            .collect()
+    }
+}
+
+#[async_trait]
+pub trait ConversationTurnMiddleware: Send + Sync {
+    fn id(&self) -> &'static str;
+
+    fn metadata(&self) -> TurnMiddlewareMetadata {
+        TurnMiddlewareMetadata::new(self.id(), [])
+    }
+
+    async fn bootstrap(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+
+    async fn ingest(
+        &self,
+        _session_id: &str,
+        _message: &Value,
+        _kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+
+    async fn transform_context(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _include_system_prompt: bool,
+        assembled: AssembledConversationContext,
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        Ok(assembled)
+    }
+
+    async fn after_turn(
+        &self,
+        _session_id: &str,
+        _user_input: &str,
+        _assistant_reply: &str,
+        _messages: &[Value],
+        _kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+
+    async fn compact_context(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _messages: &[Value],
+        _kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+
+    async fn prepare_subagent_spawn(
+        &self,
+        _parent_session_id: &str,
+        _subagent_session_id: &str,
+        _kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+
+    async fn on_subagent_ended(
+        &self,
+        _parent_session_id: &str,
+        _subagent_session_id: &str,
+        _kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<T> ConversationTurnMiddleware for Box<T>
+where
+    T: ConversationTurnMiddleware + ?Sized,
+{
+    fn id(&self) -> &'static str {
+        self.as_ref().id()
+    }
+
+    fn metadata(&self) -> TurnMiddlewareMetadata {
+        self.as_ref().metadata()
+    }
+
+    async fn bootstrap(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.as_ref()
+            .bootstrap(config, session_id, kernel_ctx)
+            .await
+    }
+
+    async fn ingest(
+        &self,
+        session_id: &str,
+        message: &Value,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.as_ref().ingest(session_id, message, kernel_ctx).await
+    }
+
+    async fn transform_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        assembled: AssembledConversationContext,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        self.as_ref()
+            .transform_context(
+                config,
+                session_id,
+                include_system_prompt,
+                assembled,
+                binding,
+            )
+            .await
+    }
+
+    async fn after_turn(
+        &self,
+        session_id: &str,
+        user_input: &str,
+        assistant_reply: &str,
+        messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.as_ref()
+            .after_turn(
+                session_id,
+                user_input,
+                assistant_reply,
+                messages,
+                kernel_ctx,
+            )
+            .await
+    }
+
+    async fn compact_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.as_ref()
+            .compact_context(config, session_id, messages, kernel_ctx)
+            .await
+    }
+
+    async fn prepare_subagent_spawn(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.as_ref()
+            .prepare_subagent_spawn(parent_session_id, subagent_session_id, kernel_ctx)
+            .await
+    }
+
+    async fn on_subagent_ended(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.as_ref()
+            .on_subagent_ended(parent_session_id, subagent_session_id, kernel_ctx)
+            .await
+    }
+}

--- a/crates/app/src/conversation/turn_middleware.rs
+++ b/crates/app/src/conversation/turn_middleware.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use async_trait::async_trait;
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::config::LoongClawConfig;
 use crate::{CliResult, KernelContext};
@@ -10,6 +10,7 @@ use super::context_engine::AssembledConversationContext;
 use super::runtime_binding::ConversationRuntimeBinding;
 
 pub const TURN_MIDDLEWARE_API_VERSION: u16 = 1;
+pub const SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID: &str = "system-prompt-addition";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TurnMiddlewareCapability {
@@ -61,6 +62,9 @@ impl TurnMiddlewareMetadata {
             .collect()
     }
 }
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemPromptAdditionTurnMiddleware;
 
 #[async_trait]
 pub trait ConversationTurnMiddleware: Send + Sync {
@@ -137,6 +141,67 @@ pub trait ConversationTurnMiddleware: Send + Sync {
     ) -> CliResult<()> {
         Ok(())
     }
+}
+
+#[async_trait]
+impl ConversationTurnMiddleware for SystemPromptAdditionTurnMiddleware {
+    fn id(&self) -> &'static str {
+        SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID
+    }
+
+    fn metadata(&self) -> TurnMiddlewareMetadata {
+        TurnMiddlewareMetadata::new(self.id(), [TurnMiddlewareCapability::ContextTransform])
+    }
+
+    async fn transform_context(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        _include_system_prompt: bool,
+        mut assembled: AssembledConversationContext,
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        apply_system_prompt_addition(
+            &mut assembled.messages,
+            assembled.system_prompt_addition.as_deref(),
+        );
+        Ok(assembled)
+    }
+}
+
+pub(crate) fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: Option<&str>) {
+    let Some(addition) = addition
+        .map(str::trim)
+        .filter(|content| !content.is_empty())
+    else {
+        return;
+    };
+
+    for message in messages.iter_mut() {
+        let is_system = message.get("role").and_then(Value::as_str) == Some("system");
+        if !is_system {
+            continue;
+        }
+
+        if let Some(object) = message.as_object_mut() {
+            let merged_content = match object.get("content").and_then(Value::as_str) {
+                Some(existing) if !existing.trim().is_empty() => {
+                    format!("{addition}\n\n{}", existing.trim())
+                }
+                _ => addition.to_owned(),
+            };
+            object.insert("content".to_owned(), Value::String(merged_content));
+            return;
+        }
+    }
+
+    messages.insert(
+        0,
+        json!({
+            "role": "system",
+            "content": addition,
+        }),
+    );
 }
 
 #[async_trait]

--- a/crates/app/src/conversation/turn_middleware.rs
+++ b/crates/app/src/conversation/turn_middleware.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use crate::config::LoongClawConfig;
+use crate::tools::ToolView;
 use crate::{CliResult, KernelContext};
 
 use super::context_engine::AssembledConversationContext;
@@ -11,6 +12,7 @@ use super::runtime_binding::ConversationRuntimeBinding;
 
 pub const TURN_MIDDLEWARE_API_VERSION: u16 = 1;
 pub const SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID: &str = "system-prompt-addition";
+pub const SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID: &str = "system-prompt-tool-view";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TurnMiddlewareCapability {
@@ -66,6 +68,9 @@ impl TurnMiddlewareMetadata {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SystemPromptAdditionTurnMiddleware;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemPromptToolViewTurnMiddleware;
+
 #[async_trait]
 pub trait ConversationTurnMiddleware: Send + Sync {
     fn id(&self) -> &'static str;
@@ -98,6 +103,8 @@ pub trait ConversationTurnMiddleware: Send + Sync {
         _session_id: &str,
         _include_system_prompt: bool,
         assembled: AssembledConversationContext,
+        _runtime_tool_view: &ToolView,
+        _requested_tool_view: &ToolView,
         _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         Ok(assembled)
@@ -159,12 +166,41 @@ impl ConversationTurnMiddleware for SystemPromptAdditionTurnMiddleware {
         _session_id: &str,
         _include_system_prompt: bool,
         mut assembled: AssembledConversationContext,
+        _runtime_tool_view: &ToolView,
+        _requested_tool_view: &ToolView,
         _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         apply_system_prompt_addition(
             &mut assembled.messages,
             assembled.system_prompt_addition.as_deref(),
         );
+        Ok(assembled)
+    }
+}
+
+#[async_trait]
+impl ConversationTurnMiddleware for SystemPromptToolViewTurnMiddleware {
+    fn id(&self) -> &'static str {
+        SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID
+    }
+
+    fn metadata(&self) -> TurnMiddlewareMetadata {
+        TurnMiddlewareMetadata::new(self.id(), [TurnMiddlewareCapability::ContextTransform])
+    }
+
+    async fn transform_context(
+        &self,
+        _config: &LoongClawConfig,
+        _session_id: &str,
+        include_system_prompt: bool,
+        mut assembled: AssembledConversationContext,
+        runtime_tool_view: &ToolView,
+        requested_tool_view: &ToolView,
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        if include_system_prompt && requested_tool_view != runtime_tool_view {
+            apply_tool_view_to_system_prompt(&mut assembled.messages, requested_tool_view);
+        }
         Ok(assembled)
     }
 }
@@ -202,6 +238,39 @@ pub(crate) fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: 
             "content": addition,
         }),
     );
+}
+
+fn apply_tool_view_to_system_prompt(messages: &mut [Value], tool_view: &ToolView) {
+    for message in messages.iter_mut() {
+        let is_system = message.get("role").and_then(Value::as_str) == Some("system");
+        if !is_system {
+            continue;
+        }
+
+        let Some(content) = message
+            .get("content")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+        else {
+            continue;
+        };
+        let Some(snapshot_start) = content.find("[available_tools]") else {
+            continue;
+        };
+        let snapshot = crate::tools::capability_snapshot_for_view(tool_view);
+
+        let prefix = content[..snapshot_start].trim_end();
+        let rewritten = if prefix.is_empty() {
+            snapshot
+        } else {
+            format!("{prefix}\n\n{snapshot}")
+        };
+
+        if let Some(object) = message.as_object_mut() {
+            object.insert("content".to_owned(), Value::String(rewritten));
+        }
+        return;
+    }
 }
 
 #[async_trait]
@@ -243,6 +312,8 @@ where
         session_id: &str,
         include_system_prompt: bool,
         assembled: AssembledConversationContext,
+        runtime_tool_view: &ToolView,
+        requested_tool_view: &ToolView,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         self.as_ref()
@@ -251,6 +322,8 @@ where
                 session_id,
                 include_system_prompt,
                 assembled,
+                runtime_tool_view,
+                requested_tool_view,
                 binding,
             )
             .await

--- a/crates/app/src/conversation/turn_middleware.rs
+++ b/crates/app/src/conversation/turn_middleware.rs
@@ -14,6 +14,14 @@ pub const TURN_MIDDLEWARE_API_VERSION: u16 = 1;
 pub const SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID: &str = "system-prompt-addition";
 pub const SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID: &str = "system-prompt-tool-view";
 
+pub(crate) type BuiltInTurnMiddlewareFactory = fn() -> Box<dyn ConversationTurnMiddleware>;
+
+#[derive(Clone, Copy)]
+pub(crate) struct BuiltInTurnMiddlewareSpec {
+    pub id: &'static str,
+    pub factory: BuiltInTurnMiddlewareFactory,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TurnMiddlewareCapability {
     ContextTransform,
@@ -70,6 +78,32 @@ pub struct SystemPromptAdditionTurnMiddleware;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SystemPromptToolViewTurnMiddleware;
+
+fn build_system_prompt_addition_turn_middleware() -> Box<dyn ConversationTurnMiddleware> {
+    Box::new(SystemPromptAdditionTurnMiddleware)
+}
+
+fn build_system_prompt_tool_view_turn_middleware() -> Box<dyn ConversationTurnMiddleware> {
+    Box::new(SystemPromptToolViewTurnMiddleware)
+}
+
+pub(crate) const BUILTIN_TURN_MIDDLEWARES: &[BuiltInTurnMiddlewareSpec] = &[
+    BuiltInTurnMiddlewareSpec {
+        id: SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
+        factory: build_system_prompt_addition_turn_middleware,
+    },
+    BuiltInTurnMiddlewareSpec {
+        id: SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID,
+        factory: build_system_prompt_tool_view_turn_middleware,
+    },
+];
+
+pub(crate) fn builtin_turn_middlewares() -> Vec<Box<dyn ConversationTurnMiddleware>> {
+    BUILTIN_TURN_MIDDLEWARES
+        .iter()
+        .map(|spec| (spec.factory)())
+        .collect()
+}
 
 #[async_trait]
 pub trait ConversationTurnMiddleware: Send + Sync {

--- a/crates/app/src/conversation/turn_middleware_registry.rs
+++ b/crates/app/src/conversation/turn_middleware_registry.rs
@@ -1,0 +1,244 @@
+use std::collections::{BTreeMap, BTreeSet};
+#[cfg(test)]
+use std::sync::Mutex;
+use std::sync::{Arc, OnceLock, RwLock};
+
+use crate::CliResult;
+
+use super::turn_middleware::{ConversationTurnMiddleware, TurnMiddlewareMetadata};
+
+pub const TURN_MIDDLEWARE_ENV: &str = "LOONGCLAW_TURN_MIDDLEWARES";
+
+type TurnMiddlewareFactory = Arc<dyn Fn() -> Box<dyn ConversationTurnMiddleware> + Send + Sync>;
+
+static TURN_MIDDLEWARE_REGISTRY: OnceLock<RwLock<BTreeMap<String, TurnMiddlewareFactory>>> =
+    OnceLock::new();
+#[cfg(test)]
+static TURN_MIDDLEWARE_ENV_OVERRIDE: OnceLock<Mutex<Option<Option<String>>>> = OnceLock::new();
+
+fn registry() -> &'static RwLock<BTreeMap<String, TurnMiddlewareFactory>> {
+    TURN_MIDDLEWARE_REGISTRY.get_or_init(|| RwLock::new(BTreeMap::new()))
+}
+
+fn normalize_middleware_id(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase()
+}
+
+fn normalize_middleware_ids<'a, I>(raw_ids: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut seen = BTreeSet::new();
+    let mut ids = Vec::new();
+
+    for raw in raw_ids {
+        let normalized = normalize_middleware_id(raw);
+        if normalized.is_empty() || !seen.insert(normalized.clone()) {
+            continue;
+        }
+        ids.push(normalized);
+    }
+
+    ids
+}
+
+#[cfg(test)]
+fn env_override() -> &'static Mutex<Option<Option<String>>> {
+    TURN_MIDDLEWARE_ENV_OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+pub fn register_turn_middleware<F>(id: &str, factory: F) -> CliResult<()>
+where
+    F: Fn() -> Box<dyn ConversationTurnMiddleware> + Send + Sync + 'static,
+{
+    let normalized = normalize_middleware_id(id);
+    if normalized.is_empty() {
+        return Err("turn middleware id must not be empty".to_owned());
+    }
+
+    let middleware = factory();
+    let middleware_id = normalize_middleware_id(middleware.id());
+    let metadata_id = normalize_middleware_id(middleware.metadata().id);
+    if normalized != middleware_id || normalized != metadata_id {
+        return Err(format!(
+            "registered turn middleware id `{normalized}` must match middleware.id `{}` and metadata.id `{}`",
+            middleware.id(),
+            middleware.metadata().id
+        ));
+    }
+
+    let mut guard = registry()
+        .write()
+        .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
+    guard.insert(normalized, Arc::new(factory));
+    Ok(())
+}
+
+pub fn list_turn_middleware_ids() -> CliResult<Vec<String>> {
+    let guard = registry()
+        .read()
+        .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
+    Ok(guard.keys().cloned().collect())
+}
+
+pub fn list_turn_middleware_metadata() -> CliResult<Vec<TurnMiddlewareMetadata>> {
+    let guard = registry()
+        .read()
+        .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
+    let mut metadata = guard
+        .values()
+        .map(|factory| factory().metadata())
+        .collect::<Vec<_>>();
+    metadata.sort_by_key(|entry| entry.id);
+    Ok(metadata)
+}
+
+pub fn resolve_turn_middleware(id: &str) -> CliResult<Box<dyn ConversationTurnMiddleware>> {
+    let normalized = normalize_middleware_id(id);
+    if normalized.is_empty() {
+        return Err("turn middleware id must not be empty".to_owned());
+    }
+
+    let guard = registry()
+        .read()
+        .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
+    let Some(factory) = guard.get(&normalized).cloned() else {
+        let available = guard.keys().cloned().collect::<Vec<_>>().join(", ");
+        return Err(format!(
+            "turn middleware `{normalized}` is not registered (available: {available})"
+        ));
+    };
+    Ok(factory())
+}
+
+pub fn resolve_turn_middlewares(
+    ids: &[String],
+) -> CliResult<Vec<Box<dyn ConversationTurnMiddleware>>> {
+    ids.iter()
+        .map(|id| resolve_turn_middleware(id.as_str()))
+        .collect()
+}
+
+pub fn describe_turn_middlewares(ids: &[String]) -> CliResult<Vec<TurnMiddlewareMetadata>> {
+    ids.iter()
+        .map(|id| resolve_turn_middleware(id.as_str()).map(|middleware| middleware.metadata()))
+        .collect()
+}
+
+pub fn turn_middleware_ids_from_env() -> Option<Vec<String>> {
+    #[cfg(test)]
+    {
+        if let Some(override_value) = env_override().lock().ok().and_then(|guard| guard.clone()) {
+            return override_value.and_then(|raw| {
+                let normalized = normalize_middleware_ids(raw.split(','));
+                (!normalized.is_empty()).then_some(normalized)
+            });
+        }
+    }
+
+    std::env::var(TURN_MIDDLEWARE_ENV).ok().and_then(|value| {
+        let normalized = normalize_middleware_ids(value.split(','));
+        (!normalized.is_empty()).then_some(normalized)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn set_turn_middleware_env_override(value: Option<&str>) {
+    if let Ok(mut guard) = env_override().lock() {
+        *guard = Some(value.map(str::to_owned));
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn clear_turn_middleware_env_override() {
+    if let Ok(mut guard) = env_override().lock() {
+        *guard = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use crate::config::LoongClawConfig;
+
+    use super::super::context_engine::AssembledConversationContext;
+    use super::super::runtime_binding::ConversationRuntimeBinding;
+    use super::super::turn_middleware::TurnMiddlewareCapability;
+    use super::*;
+
+    struct TestRegistryTurnMiddleware;
+
+    #[async_trait]
+    impl ConversationTurnMiddleware for TestRegistryTurnMiddleware {
+        fn id(&self) -> &'static str {
+            "registry-turn-middleware"
+        }
+
+        fn metadata(&self) -> TurnMiddlewareMetadata {
+            TurnMiddlewareMetadata::new(self.id(), [TurnMiddlewareCapability::ContextTransform])
+        }
+
+        async fn transform_context(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _include_system_prompt: bool,
+            assembled: AssembledConversationContext,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<AssembledConversationContext> {
+            Ok(assembled)
+        }
+    }
+
+    #[test]
+    fn registry_can_register_and_resolve_custom_turn_middleware() {
+        register_turn_middleware("registry-turn-middleware", || {
+            Box::new(TestRegistryTurnMiddleware)
+        })
+        .expect("register custom middleware");
+        let middleware =
+            resolve_turn_middleware("registry-turn-middleware").expect("resolve custom middleware");
+        assert_eq!(middleware.id(), "registry-turn-middleware");
+    }
+
+    #[test]
+    fn resolve_turn_middleware_returns_error_for_unknown_id() {
+        let error = match resolve_turn_middleware("not-registered") {
+            Ok(middleware) => panic!(
+                "expected unknown turn middleware to fail, got {}",
+                middleware.id()
+            ),
+            Err(error) => error,
+        };
+        assert!(error.contains("not registered"), "error: {error}");
+    }
+
+    #[test]
+    fn list_turn_middleware_metadata_exposes_capabilities() {
+        register_turn_middleware("registry-turn-middleware", || {
+            Box::new(TestRegistryTurnMiddleware)
+        })
+        .expect("register turn middleware");
+
+        let metadata = list_turn_middleware_metadata().expect("list turn middleware metadata");
+        let entry = metadata
+            .iter()
+            .find(|entry| entry.id == "registry-turn-middleware")
+            .expect("registry turn middleware metadata");
+        assert_eq!(entry.api_version, 1);
+        assert!(
+            entry
+                .capabilities
+                .contains(&TurnMiddlewareCapability::ContextTransform)
+        );
+    }
+
+    #[test]
+    fn turn_middleware_ids_from_env_normalizes_and_deduplicates() {
+        set_turn_middleware_env_override(Some(" Alpha , beta ,, alpha "));
+        let ids = turn_middleware_ids_from_env().expect("turn middleware ids from env");
+        assert_eq!(ids, vec!["alpha".to_owned(), "beta".to_owned()]);
+        clear_turn_middleware_env_override();
+    }
+}

--- a/crates/app/src/conversation/turn_middleware_registry.rs
+++ b/crates/app/src/conversation/turn_middleware_registry.rs
@@ -5,19 +5,53 @@ use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::CliResult;
 
-use super::turn_middleware::{ConversationTurnMiddleware, TurnMiddlewareMetadata};
+use super::turn_middleware::{
+    ConversationTurnMiddleware, SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
+    SystemPromptAdditionTurnMiddleware, TurnMiddlewareMetadata,
+};
 
 pub const TURN_MIDDLEWARE_ENV: &str = "LOONGCLAW_TURN_MIDDLEWARES";
 
 type TurnMiddlewareFactory = Arc<dyn Fn() -> Box<dyn ConversationTurnMiddleware> + Send + Sync>;
 
-static TURN_MIDDLEWARE_REGISTRY: OnceLock<RwLock<BTreeMap<String, TurnMiddlewareFactory>>> =
+#[derive(Clone)]
+struct TurnMiddlewareRegistration {
+    factory: TurnMiddlewareFactory,
+    default_enabled: bool,
+}
+
+impl TurnMiddlewareRegistration {
+    fn builtin(factory: TurnMiddlewareFactory) -> Self {
+        Self {
+            factory,
+            default_enabled: true,
+        }
+    }
+
+    fn custom(factory: TurnMiddlewareFactory) -> Self {
+        Self {
+            factory,
+            default_enabled: false,
+        }
+    }
+}
+
+static TURN_MIDDLEWARE_REGISTRY: OnceLock<RwLock<BTreeMap<String, TurnMiddlewareRegistration>>> =
     OnceLock::new();
 #[cfg(test)]
 static TURN_MIDDLEWARE_ENV_OVERRIDE: OnceLock<Mutex<Option<Option<String>>>> = OnceLock::new();
 
-fn registry() -> &'static RwLock<BTreeMap<String, TurnMiddlewareFactory>> {
-    TURN_MIDDLEWARE_REGISTRY.get_or_init(|| RwLock::new(BTreeMap::new()))
+fn registry() -> &'static RwLock<BTreeMap<String, TurnMiddlewareRegistration>> {
+    TURN_MIDDLEWARE_REGISTRY.get_or_init(|| {
+        let mut map: BTreeMap<String, TurnMiddlewareRegistration> = BTreeMap::new();
+        map.insert(
+            SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID.to_owned(),
+            TurnMiddlewareRegistration::builtin(Arc::new(|| {
+                Box::new(SystemPromptAdditionTurnMiddleware)
+            })),
+        );
+        RwLock::new(map)
+    })
 }
 
 fn normalize_middleware_id(raw: &str) -> String {
@@ -70,7 +104,15 @@ where
     let mut guard = registry()
         .write()
         .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
-    guard.insert(normalized, Arc::new(factory));
+    if guard.contains_key(&normalized) {
+        return Err(format!(
+            "turn middleware `{normalized}` is already registered"
+        ));
+    }
+    guard.insert(
+        normalized,
+        TurnMiddlewareRegistration::custom(Arc::new(factory)),
+    );
     Ok(())
 }
 
@@ -87,10 +129,20 @@ pub fn list_turn_middleware_metadata() -> CliResult<Vec<TurnMiddlewareMetadata>>
         .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
     let mut metadata = guard
         .values()
-        .map(|factory| factory().metadata())
+        .map(|registration| (registration.factory)().metadata())
         .collect::<Vec<_>>();
     metadata.sort_by_key(|entry| entry.id);
     Ok(metadata)
+}
+
+pub fn default_turn_middleware_ids() -> CliResult<Vec<String>> {
+    let guard = registry()
+        .read()
+        .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
+    Ok(guard
+        .iter()
+        .filter_map(|(id, registration)| registration.default_enabled.then_some(id.clone()))
+        .collect())
 }
 
 pub fn resolve_turn_middleware(id: &str) -> CliResult<Box<dyn ConversationTurnMiddleware>> {
@@ -102,13 +154,13 @@ pub fn resolve_turn_middleware(id: &str) -> CliResult<Box<dyn ConversationTurnMi
     let guard = registry()
         .read()
         .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
-    let Some(factory) = guard.get(&normalized).cloned() else {
+    let Some(registration) = guard.get(&normalized).cloned() else {
         let available = guard.keys().cloned().collect::<Vec<_>>().join(", ");
         return Err(format!(
             "turn middleware `{normalized}` is not registered (available: {available})"
         ));
     };
-    Ok(factory())
+    Ok((registration.factory)())
 }
 
 pub fn resolve_turn_middlewares(
@@ -160,46 +212,41 @@ pub(crate) fn clear_turn_middleware_env_override() {
 mod tests {
     use async_trait::async_trait;
 
-    use crate::config::LoongClawConfig;
-
-    use super::super::context_engine::AssembledConversationContext;
-    use super::super::runtime_binding::ConversationRuntimeBinding;
-    use super::super::turn_middleware::TurnMiddlewareCapability;
+    use super::super::turn_middleware::SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID;
     use super::*;
 
-    struct TestRegistryTurnMiddleware;
+    struct StaticIdTurnMiddleware {
+        id: &'static str,
+    }
 
     #[async_trait]
-    impl ConversationTurnMiddleware for TestRegistryTurnMiddleware {
+    impl ConversationTurnMiddleware for StaticIdTurnMiddleware {
         fn id(&self) -> &'static str {
-            "registry-turn-middleware"
-        }
-
-        fn metadata(&self) -> TurnMiddlewareMetadata {
-            TurnMiddlewareMetadata::new(self.id(), [TurnMiddlewareCapability::ContextTransform])
-        }
-
-        async fn transform_context(
-            &self,
-            _config: &LoongClawConfig,
-            _session_id: &str,
-            _include_system_prompt: bool,
-            assembled: AssembledConversationContext,
-            _binding: ConversationRuntimeBinding<'_>,
-        ) -> CliResult<AssembledConversationContext> {
-            Ok(assembled)
+            self.id
         }
     }
 
     #[test]
+    fn list_turn_middleware_ids_includes_builtin_defaults() {
+        let ids = list_turn_middleware_ids().expect("list ids");
+        assert!(
+            ids.iter()
+                .any(|id| id == SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID),
+            "system prompt addition middleware should be registered by default"
+        );
+    }
+
+    #[test]
     fn registry_can_register_and_resolve_custom_turn_middleware() {
-        register_turn_middleware("registry-turn-middleware", || {
-            Box::new(TestRegistryTurnMiddleware)
+        register_turn_middleware("registry-turn-middleware-custom", || {
+            Box::new(StaticIdTurnMiddleware {
+                id: "registry-turn-middleware-custom",
+            })
         })
         .expect("register custom middleware");
-        let middleware =
-            resolve_turn_middleware("registry-turn-middleware").expect("resolve custom middleware");
-        assert_eq!(middleware.id(), "registry-turn-middleware");
+        let middleware = resolve_turn_middleware("registry-turn-middleware-custom")
+            .expect("resolve custom middleware");
+        assert_eq!(middleware.id(), "registry-turn-middleware-custom");
     }
 
     #[test]
@@ -216,21 +263,40 @@ mod tests {
 
     #[test]
     fn list_turn_middleware_metadata_exposes_capabilities() {
-        register_turn_middleware("registry-turn-middleware", || {
-            Box::new(TestRegistryTurnMiddleware)
+        register_turn_middleware("registry-turn-middleware-capability", || {
+            Box::new(StaticIdTurnMiddleware {
+                id: "registry-turn-middleware-capability",
+            })
         })
         .expect("register turn middleware");
 
         let metadata = list_turn_middleware_metadata().expect("list turn middleware metadata");
         let entry = metadata
             .iter()
-            .find(|entry| entry.id == "registry-turn-middleware")
+            .find(|entry| entry.id == "registry-turn-middleware-capability")
             .expect("registry turn middleware metadata");
         assert_eq!(entry.api_version, 1);
+        assert!(entry.capabilities.is_empty());
+    }
+
+    #[test]
+    fn register_turn_middleware_rejects_duplicate_id() {
+        register_turn_middleware("registry-turn-middleware-duplicate", || {
+            Box::new(StaticIdTurnMiddleware {
+                id: "registry-turn-middleware-duplicate",
+            })
+        })
+        .expect("register duplicate test middleware");
+
+        let error = register_turn_middleware("registry-turn-middleware-duplicate", || {
+            Box::new(StaticIdTurnMiddleware {
+                id: "registry-turn-middleware-duplicate",
+            })
+        })
+        .expect_err("duplicate registration should fail");
         assert!(
-            entry
-                .capabilities
-                .contains(&TurnMiddlewareCapability::ContextTransform)
+            error.contains("already registered"),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/app/src/conversation/turn_middleware_registry.rs
+++ b/crates/app/src/conversation/turn_middleware_registry.rs
@@ -131,12 +131,18 @@ pub fn list_turn_middleware_ids() -> CliResult<Vec<String>> {
 }
 
 pub fn list_turn_middleware_metadata() -> CliResult<Vec<TurnMiddlewareMetadata>> {
-    let guard = registry()
-        .read()
-        .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
-    let mut metadata = guard
-        .values()
-        .map(|registration| (registration.factory)().metadata())
+    let factories = {
+        let guard = registry()
+            .read()
+            .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
+        guard
+            .values()
+            .map(|registration| registration.factory.clone())
+            .collect::<Vec<_>>()
+    };
+    let mut metadata = factories
+        .into_iter()
+        .map(|factory| factory().metadata())
         .collect::<Vec<_>>();
     metadata.sort_by_key(|entry| entry.id);
     Ok(metadata)
@@ -158,14 +164,17 @@ pub fn resolve_turn_middleware(id: &str) -> CliResult<Box<dyn ConversationTurnMi
         return Err("turn middleware id must not be empty".to_owned());
     }
 
-    let guard = registry()
-        .read()
-        .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
-    let Some(registration) = guard.get(&normalized).cloned() else {
-        let available = guard.keys().cloned().collect::<Vec<_>>().join(", ");
-        return Err(format!(
-            "turn middleware `{normalized}` is not registered (available: {available})"
-        ));
+    let registration = {
+        let guard = registry()
+            .read()
+            .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
+        let Some(registration) = guard.get(&normalized).cloned() else {
+            let available = guard.keys().cloned().collect::<Vec<_>>().join(", ");
+            return Err(format!(
+                "turn middleware `{normalized}` is not registered (available: {available})"
+            ));
+        };
+        registration
     };
     Ok((registration.factory)())
 }
@@ -216,7 +225,35 @@ pub(crate) fn clear_turn_middleware_env_override() {
 }
 
 #[cfg(test)]
+struct ScopedTurnMiddlewareEnvOverride {
+    previous: Option<Option<String>>,
+}
+
+#[cfg(test)]
+impl ScopedTurnMiddlewareEnvOverride {
+    fn set(value: Option<&str>) -> Self {
+        let mut guard = env_override()
+            .lock()
+            .expect("turn middleware env override lock");
+        let previous = guard.clone();
+        *guard = Some(value.map(str::to_owned));
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ScopedTurnMiddlewareEnvOverride {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = env_override().lock() {
+            *guard = self.previous.clone();
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use async_trait::async_trait;
 
     use super::super::turn_middleware::{
@@ -315,10 +352,60 @@ mod tests {
     }
 
     #[test]
+    fn list_turn_middleware_metadata_runs_factories_outside_registry_lock() {
+        let factory_ran_outside_registry_lock = Arc::new(AtomicBool::new(false));
+        let observed = factory_ran_outside_registry_lock.clone();
+        register_turn_middleware("registry-turn-middleware-metadata-lock-scope", move || {
+            observed.store(registry().try_write().is_ok(), Ordering::SeqCst);
+            Box::new(StaticIdTurnMiddleware {
+                id: "registry-turn-middleware-metadata-lock-scope",
+            })
+        })
+        .expect("register turn middleware");
+
+        let metadata = list_turn_middleware_metadata().expect("list turn middleware metadata");
+        assert!(
+            metadata
+                .iter()
+                .any(|entry| entry.id == "registry-turn-middleware-metadata-lock-scope")
+        );
+        assert!(
+            factory_ran_outside_registry_lock.load(Ordering::SeqCst),
+            "metadata factory should not run while the registry read lock is held"
+        );
+    }
+
+    #[test]
+    fn resolve_turn_middleware_runs_factory_outside_registry_lock() {
+        let factory_ran_outside_registry_lock = Arc::new(AtomicBool::new(false));
+        let observed = factory_ran_outside_registry_lock.clone();
+        register_turn_middleware("registry-turn-middleware-resolve-lock-scope", move || {
+            observed.store(registry().try_write().is_ok(), Ordering::SeqCst);
+            Box::new(StaticIdTurnMiddleware {
+                id: "registry-turn-middleware-resolve-lock-scope",
+            })
+        })
+        .expect("register turn middleware");
+
+        let middleware = resolve_turn_middleware("registry-turn-middleware-resolve-lock-scope")
+            .expect("resolve turn middleware");
+        assert_eq!(
+            middleware.id(),
+            "registry-turn-middleware-resolve-lock-scope"
+        );
+        assert!(
+            factory_ran_outside_registry_lock.load(Ordering::SeqCst),
+            "middleware factory should not run while the registry read lock is held"
+        );
+    }
+
+    #[test]
     fn turn_middleware_ids_from_env_normalizes_and_deduplicates() {
-        set_turn_middleware_env_override(Some(" Alpha , beta ,, alpha "));
+        let _env_lock = super::super::context_engine_registry::conversation_selector_env_lock()
+            .lock()
+            .expect("env lock");
+        let _scoped_env = ScopedTurnMiddlewareEnvOverride::set(Some(" Alpha , beta ,, alpha "));
         let ids = turn_middleware_ids_from_env().expect("turn middleware ids from env");
         assert_eq!(ids, vec!["alpha".to_owned(), "beta".to_owned()]);
-        clear_turn_middleware_env_override();
     }
 }

--- a/crates/app/src/conversation/turn_middleware_registry.rs
+++ b/crates/app/src/conversation/turn_middleware_registry.rs
@@ -7,7 +7,8 @@ use crate::CliResult;
 
 use super::turn_middleware::{
     ConversationTurnMiddleware, SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
-    SystemPromptAdditionTurnMiddleware, TurnMiddlewareMetadata,
+    SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID, SystemPromptAdditionTurnMiddleware,
+    SystemPromptToolViewTurnMiddleware, TurnMiddlewareMetadata,
 };
 
 pub const TURN_MIDDLEWARE_ENV: &str = "LOONGCLAW_TURN_MIDDLEWARES";
@@ -48,6 +49,12 @@ fn registry() -> &'static RwLock<BTreeMap<String, TurnMiddlewareRegistration>> {
             SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID.to_owned(),
             TurnMiddlewareRegistration::builtin(Arc::new(|| {
                 Box::new(SystemPromptAdditionTurnMiddleware)
+            })),
+        );
+        map.insert(
+            SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID.to_owned(),
+            TurnMiddlewareRegistration::builtin(Arc::new(|| {
+                Box::new(SystemPromptToolViewTurnMiddleware)
             })),
         );
         RwLock::new(map)
@@ -212,7 +219,9 @@ pub(crate) fn clear_turn_middleware_env_override() {
 mod tests {
     use async_trait::async_trait;
 
-    use super::super::turn_middleware::SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID;
+    use super::super::turn_middleware::{
+        SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID, SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID,
+    };
     use super::*;
 
     struct StaticIdTurnMiddleware {
@@ -233,6 +242,11 @@ mod tests {
             ids.iter()
                 .any(|id| id == SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID),
             "system prompt addition middleware should be registered by default"
+        );
+        assert!(
+            ids.iter()
+                .any(|id| id == SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID),
+            "system prompt tool-view middleware should be registered by default"
         );
     }
 

--- a/crates/app/src/conversation/turn_middleware_registry.rs
+++ b/crates/app/src/conversation/turn_middleware_registry.rs
@@ -6,9 +6,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use crate::CliResult;
 
 use super::turn_middleware::{
-    ConversationTurnMiddleware, SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID,
-    SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID, SystemPromptAdditionTurnMiddleware,
-    SystemPromptToolViewTurnMiddleware, TurnMiddlewareMetadata,
+    BUILTIN_TURN_MIDDLEWARES, ConversationTurnMiddleware, TurnMiddlewareMetadata,
 };
 
 pub const TURN_MIDDLEWARE_ENV: &str = "LOONGCLAW_TURN_MIDDLEWARES";
@@ -45,18 +43,13 @@ static TURN_MIDDLEWARE_ENV_OVERRIDE: OnceLock<Mutex<Option<Option<String>>>> = O
 fn registry() -> &'static RwLock<BTreeMap<String, TurnMiddlewareRegistration>> {
     TURN_MIDDLEWARE_REGISTRY.get_or_init(|| {
         let mut map: BTreeMap<String, TurnMiddlewareRegistration> = BTreeMap::new();
-        map.insert(
-            SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID.to_owned(),
-            TurnMiddlewareRegistration::builtin(Arc::new(|| {
-                Box::new(SystemPromptAdditionTurnMiddleware)
-            })),
-        );
-        map.insert(
-            SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID.to_owned(),
-            TurnMiddlewareRegistration::builtin(Arc::new(|| {
-                Box::new(SystemPromptToolViewTurnMiddleware)
-            })),
-        );
+        for spec in BUILTIN_TURN_MIDDLEWARES {
+            let factory: TurnMiddlewareFactory = Arc::new(spec.factory);
+            map.insert(
+                spec.id.to_owned(),
+                TurnMiddlewareRegistration::builtin(factory),
+            );
+        }
         RwLock::new(map)
     })
 }
@@ -95,6 +88,17 @@ where
     let normalized = normalize_middleware_id(id);
     if normalized.is_empty() {
         return Err("turn middleware id must not be empty".to_owned());
+    }
+
+    {
+        let guard = registry()
+            .read()
+            .map_err(|_error| "turn middleware registry lock poisoned".to_owned())?;
+        if guard.contains_key(&normalized) {
+            return Err(format!(
+                "turn middleware `{normalized}` is already registered"
+            ));
+        }
     }
 
     let middleware = factory();
@@ -252,7 +256,7 @@ impl Drop for ScopedTurnMiddlewareEnvOverride {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use async_trait::async_trait;
 
@@ -348,6 +352,36 @@ mod tests {
         assert!(
             error.contains("already registered"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn register_turn_middleware_duplicate_id_does_not_invoke_factory() {
+        register_turn_middleware("registry-turn-middleware-duplicate-fast-fail", || {
+            Box::new(StaticIdTurnMiddleware {
+                id: "registry-turn-middleware-duplicate-fast-fail",
+            })
+        })
+        .expect("register duplicate fast-fail test middleware");
+
+        let duplicate_factory_calls = Arc::new(AtomicUsize::new(0));
+        let observed = duplicate_factory_calls.clone();
+        let error =
+            register_turn_middleware("registry-turn-middleware-duplicate-fast-fail", move || {
+                observed.fetch_add(1, Ordering::SeqCst);
+                Box::new(StaticIdTurnMiddleware {
+                    id: "registry-turn-middleware-duplicate-fast-fail",
+                })
+            })
+            .expect_err("duplicate registration should fast-fail before invoking the factory");
+        assert!(
+            error.contains("already registered"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            duplicate_factory_calls.load(Ordering::SeqCst),
+            0,
+            "duplicate registration should not invoke the replacement factory"
         );
     }
 


### PR DESCRIPTION
## Summary

- Problem: per-turn conversation lifecycle hooks were hardwired into the runtime flow, so there was no ordered middleware foundation for cross-cutting turn behavior.
- Why it matters: extensible turn processing needs a stable hook model for bootstrap, ingestion, context transformation, after-turn compaction, and delegate child lifecycle events.
- What changed: added ordered conversation turn middleware traits, config-backed registry resolution, runtime selection plumbing, lifecycle hook execution around the major conversation seams, and regression coverage for ordering, runtime snapshots, and delegate lifecycle notifications.
- What did not change (scope boundary): this does not add a marketplace or external plugin transport for middleware, and it does not change provider routing semantics.

## Linked Issues

- Closes #312
- Related # n/a

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  this inserts a new ordered middleware layer across core conversation lifecycle seams, so ordering and hook boundaries must stay deterministic.
- Rollout / guardrails:
  middleware resolution stays explicit and ordered, and regression coverage exercises ordering, lifecycle execution, and runtime snapshot reporting.
- Rollback path:
  revert the middleware registry and hook wiring to restore the previous hardwired lifecycle flow.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- passed

cargo test --workspace --locked
- passed

cargo test --workspace --all-features --locked
- passed

LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
- passed

scripts/check_dep_graph.sh
- passed

scripts/check-docs.sh
- passed

diff CLAUDE.md AGENTS.md
- passed
```

## User-visible / Operator-visible Changes

- conversation runtimes can now resolve ordered turn middleware and run middleware hooks around bootstrap, ingestion, context transformation, after-turn compaction, and delegate child lifecycle events.

## Failure Recovery

- Fast rollback or disable path: revert the middleware foundation to restore the previous lifecycle flow.
- Observable failure symptoms reviewers should watch for: middleware ordering drift, missing lifecycle callbacks, duplicated hook execution, or runtime snapshot reporting diverging from the active middleware set.

## Reviewer Focus

- `crates/app/src/conversation/turn_middleware.rs` and `crates/app/src/conversation/turn_middleware_registry.rs` for the hook contract and ordered resolution behavior.
- `crates/app/src/conversation/runtime.rs` for lifecycle insertion points.
- `crates/app/src/conversation/tests.rs` for ordering, runtime snapshot, and delegate lifecycle regression coverage.
