### PR TITLE
docs: align dev contributor governance and intake

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,4 +4,4 @@ reviews:
     enabled: true
     base_branches:
       - main
-      - alpha-test
+      - dev

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a reproducible defect in LoongClaw's active alpha-test runtime.
+description: Report a reproducible defect in LoongClaw's active `dev` branch or latest stable release.
 title: "[Bug]: "
 labels:
   - bug
@@ -10,6 +10,8 @@ body:
       value: |
         Thanks for filing a bug report.
         Please keep the report evidence-based, redact secrets, and provide the shortest reproducible path you can.
+        If you are still figuring out whether this is a bug or a setup problem, GitHub Discussions
+        or the community channels are also fine places to ask first.
 
   - type: dropdown
     id: area
@@ -98,7 +100,7 @@ body:
     attributes:
       label: Version / commit
       description: Release tag or exact branch/commit tested.
-      placeholder: alpha-test@ec9ee5f or v0.3.2
+      placeholder: dev@<commit> or v0.3.2
     validations:
       required: true
 
@@ -154,7 +156,7 @@ body:
     attributes:
       label: Pre-flight checks
       options:
-        - label: I reproduced this on the latest `alpha-test` branch tip or the latest published release.
+        - label: I reproduced this on the latest `dev` branch tip or the latest published release.
           required: true
         - label: I redacted secrets, tokens, and private endpoints from everything I attached.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,13 +5,19 @@ contact_links:
     about: Report security issues privately.
   - name: Questions and troubleshooting
     url: https://github.com/loongclaw-ai/loongclaw/discussions
-    about: Use Discussions for Q&A, setup questions, and general troubleshooting.
-  - name: Community chat
+    about: Use Discussions for Q&A, setup questions, and general troubleshooting. Discord, Telegram, Feishu, and WeChat community spaces are also welcome support paths.
+  - name: Discord community
     url: https://discord.gg/7kSTX9mca
-    about: Join Discord for community help and operator discussion.
+    about: Join Discord for community help and day-to-day discussion. If you are already active in Telegram, Feishu, or WeChat community spaces, those are good places to ask too.
+  - name: Telegram community
+    url: https://t.me/loongclaw
+    about: Telegram is another active community space for support and contributor chat.
+  - name: Direct introduction
+    url: mailto:contact@loongclaw.ai
+    about: If you want to introduce yourself, talk about where you could help most, or ask where your strengths fit, email us directly.
   - name: Contribution guide
-    url: https://github.com/loongclaw-ai/loongclaw/blob/alpha-test/CONTRIBUTING.md
-    about: Read the active alpha-test contribution workflow before opening a PR.
+    url: https://github.com/loongclaw-ai/loongclaw/blob/dev/CONTRIBUTING.md
+    about: Read the active dev-branch contribution workflow before opening a PR.
   - name: GitHub collaboration reference
-    url: https://github.com/loongclaw-ai/loongclaw/blob/alpha-test/docs/references/github-collaboration.md
+    url: https://github.com/loongclaw-ai/loongclaw/blob/dev/docs/references/github-collaboration.md
     about: See labels, branch model, and intake/review rules for the active collaboration baseline.

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -8,7 +8,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this template for documentation drift, missing guidance, broken workflows, or confusing contributor instructions.
+        Use this template for documentation drift, missing guidance, broken workflows, confusing
+        contributor instructions, or release-process wording that no longer matches reality.
 
   - type: dropdown
     id: area
@@ -41,7 +42,7 @@ body:
     attributes:
       label: Summary
       description: What is wrong or missing?
-      placeholder: CONTRIBUTING.md tells contributors to branch from main even though alpha-test is the actual integration branch.
+      placeholder: CONTRIBUTING.md still points contributors at `main` even though `dev` is the active integration branch.
     validations:
       required: true
 
@@ -70,8 +71,11 @@ body:
       description: Link the relevant files, PRs, workflows, or screenshots if available.
       placeholder: |
         - CONTRIBUTING.md
-        - .github/workflows/enforce-alpha-test-to-main.yml
-        - recent PRs targeting alpha-test
+        - docs/references/github-collaboration.md
+        - .github/ISSUE_TEMPLATE/config.yml
+        - .github/workflows/enforce-dev-to-main.yml
+        - .github/workflows/release.yml
+        - recent PRs targeting dev
 
   - type: textarea
     id: impact

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -42,7 +42,7 @@ body:
     attributes:
       label: Problem statement
       description: What user or system problem are you trying to solve?
-      placeholder: Contributors cannot tell which branch or issue intake path is authoritative, so review and triage context arrives fragmented.
+      placeholder: Contributors cannot tell which work should land on `dev`, how stable promotions reach `main`, or when a release is expected.
     validations:
       required: true
 
@@ -51,7 +51,7 @@ body:
     attributes:
       label: Proposed solution
       description: Describe the preferred behavior, UX, API, or workflow.
-      placeholder: Add area-aware issue intake, lightweight path label automation, and explicit alpha-test contribution guidance.
+      placeholder: Add explicit `dev`-branch contribution guidance, narrow `dev -> main` promotion rules, and clearer release-readiness language.
     validations:
       required: true
 
@@ -75,9 +75,9 @@ body:
       label: Acceptance criteria
       description: What concrete outcomes would make this request complete?
       placeholder: |
-        - PRs get stable area labels automatically
-        - Bug reports capture runtime evidence consistently
-        - Contributor docs point external PRs at alpha-test
+        - Contributor docs point normal external PRs at `dev`
+        - Promotion PRs into `main` stay stabilization-focused
+        - Release guidance explains when a stable promotion becomes a tagged release
 
   - type: dropdown
     id: sensitivity

--- a/.github/workflows/enforce-dev-to-main.yml
+++ b/.github/workflows/enforce-dev-to-main.yml
@@ -1,4 +1,4 @@
-name: enforce-alpha-test-to-main
+name: enforce-dev-to-main
 
 on:
   pull_request_target:
@@ -11,24 +11,24 @@ on:
       - edited
 
 jobs:
-  block-non-alpha-test-source:
-    if: ${{ github.event.pull_request.head.ref != 'alpha-test' }}
+  block-non-dev-source:
+    if: ${{ github.event.pull_request.head.ref != 'dev' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       issues: write
       contents: read
     steps:
-      - name: Close PR when source branch is not alpha-test
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+      - name: Close PR when source branch is not dev
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const pr = context.payload.pull_request;
             const body = [
-              "Only `alpha-test` can merge into `main` in this repository.",
+              "Only `dev` can merge into `main` in this repository.",
               "",
               `Current source branch: \`${pr.head.ref}\``,
-              "Please land your changes on `alpha-test` first, then open the promotion PR from `alpha-test` to `main`."
+              "Please land your changes on `dev` first, then open the promotion PR from `dev` to `main`."
             ].join("\\n");
 
             await github.rest.issues.createComment({
@@ -44,5 +44,4 @@ jobs:
               pull_number: pr.number,
               state: "closed"
             });
-
-            core.setFailed("Blocked: only alpha-test can merge into main.");
+            core.setFailed("Blocked: only dev can merge into main.");

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to LoongClaw
 
-Thanks for contributing. This guide defines the baseline workflow for external and internal contributors.
+Thanks for spending time on LoongClaw. This guide defines the baseline workflow for external and
+internal contributors. We care about clear ownership, thoughtful engineering, and kind
+collaboration.
 
 ## Prerequisites
 
@@ -68,13 +70,55 @@ If you are unsure which track applies, open an issue and ask maintainers for tri
 
 ## Branch Model
 
-- `alpha-test` is the active integration branch for normal OSS work.
-- `main` is the promotion branch and should only receive reviewed changes from `alpha-test`.
-- The repository default branch setting does not yet fully reflect this flow. Until that changes, treat the docs and workflow files on `alpha-test` as the authoritative contributor baseline.
+- `dev` is the active integration branch for day-to-day development.
+- Contributors should branch from `dev` and target `dev` with normal pull requests.
+- `main` is the stable promotion branch and should only receive reviewed changes from `dev`.
+- Maintainers aim to promote stable slices from `dev` into `main` on a regular cadence. Exact
+  timing depends on validation status, scope completion, and operational readiness.
+
+## Release Model
+
+- Tagged releases are published from stable promotion points rather than from arbitrary in-flight
+  commits.
+- Not every `dev -> main` promotion needs to become a public release.
+- Release readiness normally includes green CI, required validation, install flow sanity, and docs
+  or changelog updates for shipped user-facing changes.
 
 ## Where Do I Start?
 
 Use [Core Beliefs](docs/design-docs/core-beliefs.md) and [Layered Kernel Design](docs/design-docs/layered-kernel-design.md) for architecture principles and dependency boundaries.
+
+If you are unsure where your background fits, start with
+[Contribution Areas We Especially Welcome](docs/references/contribution-areas.md). We warmly
+welcome help across design, frontend work, hardware / robotics / embodied AI, systems engineering,
+cross-platform delivery, testing and operations, docs and i18n, and community care.
+
+## How to Join In
+
+- If you already know what you want to work on, open or join the relevant Issue and link your plan.
+- If you want to take on a large feature or architecture change, start with an Issue or Discussion
+  first so maintainers can help shape scope early.
+- If your strengths are design, docs, translation, QA, operations, support, or community work,
+  those are first-class contributions here, not second-tier work.
+- If you would rather start with a direct introduction, email
+  [contact@loongclaw.ai](mailto:contact@loongclaw.ai). A short note is enough. You do not need a
+  formal application.
+- If you are unsure where to begin, open a Discussion or send that introduction email and we will
+  help point you toward good starting areas.
+
+## A Short Introduction That Helps
+
+If you email us, it is especially helpful to include:
+
+- where you are based or what time zone you usually work in
+- your strongest skills or the kinds of problems you are best at
+- the area you would most like to own or help push forward
+- what you hope LoongClaw could become, or what part of the project excites you
+- roughly how much time or energy you expect to contribute
+- any links to GitHub, past work, writing, design, demos, or projects you want us to see
+
+That does not need to be long. A thoughtful, honest introduction is much more useful than a formal
+pitch.
 
 **Common contribution areas:**
 
@@ -133,10 +177,11 @@ cargo test --workspace --all-features
 ## Standard Workflow
 
 1. Fork the repository.
-2. Create a branch from `alpha-test`.
+2. Create a branch from `dev`.
 3. Make focused commits.
 4. Run required checks.
-5. Open a pull request against `alpha-test` using the PR template unless a maintainer explicitly asks for a promotion PR into `main`.
+5. Open a pull request against `dev` using the PR template unless a maintainer explicitly asks you
+   to help with a focused promotion PR from `dev` into `main`.
 6. Address review feedback and keep PR scope focused.
 
 ## Issue Intake
@@ -145,16 +190,44 @@ cargo test --workspace --all-features
 - Use the feature request form for new capabilities, behavior changes, or meaningful product/runtime improvements.
 - Use the documentation improvement form for contributor guide drift, missing references, or confusing review workflow docs.
 - Use GitHub Discussions for setup questions and general troubleshooting.
+- Use community channels such as Discord and Telegram. If you are already active in Feishu or
+  WeChat community spaces, those are also good places to ask.
+- If you want to introduce yourself directly or talk about where you could help most, email
+  [contact@loongclaw.ai](mailto:contact@loongclaw.ai).
 - Use the private security advisory flow for vulnerabilities instead of public issues.
 
-See [docs/references/github-collaboration.md](docs/references/github-collaboration.md) for the current label baseline, issue routing, and the default-branch visibility caveat for issue forms.
+See [docs/references/github-collaboration.md](docs/references/github-collaboration.md) for the
+current label baseline, issue routing, community paths, and review flow.
+
+## PRs We Are Unlikely to Merge
+
+The following pull requests are unlikely to be accepted unless maintainers have explicitly aligned
+on them in advance:
+
+1. AI-assisted changes that the author does not understand or cannot defend. We welcome AI tooling
+   as a force multiplier, but contributors are expected to understand every line they submit and to
+   take responsibility for its behavior, risks, and tradeoffs.
+2. Uncoordinated changes to core project identity or governance files. This includes brand assets,
+   licensing, pull request templates, `CODEOWNERS`, and similar repository-critical configuration.
+   These areas are maintained by the core team and may be closed without review if changed without
+   prior discussion.
+3. Large changes to core product architecture without prior maintainer discussion. If you want to
+   build a major feature or restructure key architecture, start with an Issue or Discussion, align
+   on the design, and wait for maintainer guidance before implementation.
+4. Ecosystem extensions outside the core product scope. Third-party plugins, external integrations,
+   and ecosystem-specific additions are usually better maintained in separate repositories instead
+   of being merged into the main repository.
 
 ## Commit and PR Expectations
 
 - Use clear, scoped commit messages.
 - Keep one logical change per PR when possible.
 - Link relevant issue IDs in PR description.
+- When a PR resolves a tracked issue, include an explicit closing clause such as `Closes #123` in
+  the PR body.
 - Include risk notes for Track B changes.
+- Promotion PRs from `dev` into `main` should stay narrow and focus on stabilization rather than
+  mixed feature development.
 
 ## Review Policy
 

--- a/crates/app/src/presentation.rs
+++ b/crates/app/src/presentation.rs
@@ -487,8 +487,7 @@ mod tests {
 
     #[test]
     fn presentation_version_line_is_traceable_for_dev_build() {
-        let build =
-            BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
+        let build = BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
 
         assert_eq!(build.render_version_line(), "v0.1.2 · dev · 1a2b3c4");
     }
@@ -566,8 +565,7 @@ mod tests {
 
     #[test]
     fn presentation_compact_brand_header_keeps_brand_and_version_on_one_line() {
-        let build =
-            BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
+        let build = BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
 
         let lines = render_compact_brand_header(80, &build, Some("choose model"));
 
@@ -578,8 +576,7 @@ mod tests {
 
     #[test]
     fn presentation_compact_brand_header_wraps_on_narrow_width() {
-        let build =
-            BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
+        let build = BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
 
         let lines = render_compact_brand_header(22, &build, Some("choose credential env"));
 
@@ -596,8 +593,7 @@ mod tests {
 
     #[test]
     fn presentation_brand_header_wraps_version_and_subtitle_on_narrow_width() {
-        let build =
-            BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
+        let build = BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
 
         let lines = render_brand_header(
             18,

--- a/crates/app/src/presentation.rs
+++ b/crates/app/src/presentation.rs
@@ -488,9 +488,9 @@ mod tests {
     #[test]
     fn presentation_version_line_is_traceable_for_dev_build() {
         let build =
-            BuildVersionInfo::new_for_test("0.1.2", Some("alpha-test"), Some("1a2b3c4"), false);
+            BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
 
-        assert_eq!(build.render_version_line(), "v0.1.2 · alpha-test · 1a2b3c4");
+        assert_eq!(build.render_version_line(), "v0.1.2 · dev · 1a2b3c4");
     }
 
     #[test]
@@ -567,19 +567,19 @@ mod tests {
     #[test]
     fn presentation_compact_brand_header_keeps_brand_and_version_on_one_line() {
         let build =
-            BuildVersionInfo::new_for_test("0.1.2", Some("alpha-test"), Some("1a2b3c4"), false);
+            BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
 
         let lines = render_compact_brand_header(80, &build, Some("choose model"));
 
         assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0].text, "LOONGCLAW  v0.1.2 · alpha-test · 1a2b3c4");
+        assert_eq!(lines[0].text, "LOONGCLAW  v0.1.2 · dev · 1a2b3c4");
         assert_eq!(lines[1].text, "choose model");
     }
 
     #[test]
     fn presentation_compact_brand_header_wraps_on_narrow_width() {
         let build =
-            BuildVersionInfo::new_for_test("0.1.2", Some("alpha-test"), Some("1a2b3c4"), false);
+            BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
 
         let lines = render_compact_brand_header(22, &build, Some("choose credential env"));
 
@@ -597,7 +597,7 @@ mod tests {
     #[test]
     fn presentation_brand_header_wraps_version_and_subtitle_on_narrow_width() {
         let build =
-            BuildVersionInfo::new_for_test("0.1.2", Some("alpha-test"), Some("1a2b3c4"), false);
+            BuildVersionInfo::new_for_test("0.1.2", Some("dev"), Some("1a2b3c4"), false);
 
         let lines = render_brand_header(
             18,

--- a/crates/app/tests/build_metadata.rs
+++ b/crates/app/tests/build_metadata.rs
@@ -10,7 +10,7 @@ fn non_release_build_prefers_git_branch_and_short_sha_when_not_overridden() {
         None,
         None,
         None,
-        Some("alpha-test"),
+        Some("dev"),
         Some("ec9ee5f0d57b9ef18110786407c3ccdb447bbcf7"),
     );
 
@@ -18,7 +18,7 @@ fn non_release_build_prefers_git_branch_and_short_sha_when_not_overridden() {
         metadata,
         BuildMetadata {
             release_build: false,
-            channel: Some("alpha-test".to_owned()),
+            channel: Some("dev".to_owned()),
             short_sha: Some("ec9ee5f".to_owned()),
         }
     );
@@ -30,7 +30,7 @@ fn explicit_compile_overrides_win_over_git_detection() {
         None,
         Some("custom-preview"),
         Some("1234567890abcdef"),
-        Some("alpha-test"),
+        Some("dev"),
         Some("ec9ee5f0d57b9ef18110786407c3ccdb447bbcf7"),
     );
 
@@ -70,9 +70,9 @@ fn git_rerun_hint_targets_handle_detached_head() {
 fn release_build_clears_non_release_trace_metadata() {
     let metadata = version_metadata::resolve_build_metadata(
         Some("1"),
-        Some("alpha-test"),
+        Some("dev"),
         Some("ec9ee5f0d57b9ef18110786407c3ccdb447bbcf7"),
-        Some("alpha-test"),
+        Some("dev"),
         Some("ec9ee5f0d57b9ef18110786407c3ccdb447bbcf7"),
     );
 

--- a/crates/daemon/tests/integration/migrate_cli.rs
+++ b/crates/daemon/tests/integration/migrate_cli.rs
@@ -13,6 +13,14 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
     std::env::temp_dir().join(format!("{prefix}-{nanos}"))
 }
 
+fn isolated_home_guard(prefix: &str) -> (PathBuf, MigrationEnvironmentGuard) {
+    let home = unique_temp_dir(prefix);
+    fs::create_dir_all(&home).expect("create isolated home");
+    let home_string = home.to_string_lossy().into_owned();
+    let guard = MigrationEnvironmentGuard::set(&[("HOME", Some(home_string.as_str()))]);
+    (home, guard)
+}
+
 fn write_file(root: &Path, relative: &str, content: &str) {
     let path = root.join(relative);
     if let Some(parent) = path.parent() {
@@ -57,6 +65,7 @@ fn parse_legacy_claw_source_accepts_supported_ids() {
 fn run_migrate_cli_writes_nativeized_config() {
     let legacy_root = unique_temp_dir("loongclaw-import-cli-legacy");
     let output_root = unique_temp_dir("loongclaw-import-cli-output");
+    let (home_root, _env_guard) = isolated_home_guard("loongclaw-import-cli-home");
     fs::create_dir_all(&legacy_root).expect("create legacy root");
     fs::create_dir_all(&output_root).expect("create output root");
 
@@ -113,12 +122,14 @@ fn run_migrate_cli_writes_nativeized_config() {
 
     fs::remove_dir_all(&legacy_root).ok();
     fs::remove_dir_all(&output_root).ok();
+    fs::remove_dir_all(&home_root).ok();
 }
 
 #[test]
 fn run_migrate_cli_plan_mode_returns_preview_without_writing() {
     let legacy_root = unique_temp_dir("loongclaw-import-cli-plan-legacy");
     let output_root = unique_temp_dir("loongclaw-import-cli-plan-output");
+    let (home_root, _env_guard) = isolated_home_guard("loongclaw-import-cli-plan-home");
     fs::create_dir_all(&legacy_root).expect("create legacy root");
     fs::create_dir_all(&output_root).expect("create output root");
 
@@ -151,12 +162,14 @@ fn run_migrate_cli_plan_mode_returns_preview_without_writing() {
 
     fs::remove_dir_all(&legacy_root).ok();
     fs::remove_dir_all(&output_root).ok();
+    fs::remove_dir_all(&home_root).ok();
 }
 
 #[test]
 fn run_migrate_cli_apply_selected_mode_writes_manifest_and_config() {
     let discovery_root = unique_temp_dir("loongclaw-import-cli-selected-discovery");
     let output_root = unique_temp_dir("loongclaw-import-cli-selected-output");
+    let (home_root, _env_guard) = isolated_home_guard("loongclaw-import-cli-selected-home");
     fs::create_dir_all(&discovery_root).expect("create discovery root");
     fs::create_dir_all(&output_root).expect("create output root");
 
@@ -204,12 +217,14 @@ fn run_migrate_cli_apply_selected_mode_writes_manifest_and_config() {
 
     fs::remove_dir_all(&discovery_root).ok();
     fs::remove_dir_all(&output_root).ok();
+    fs::remove_dir_all(&home_root).ok();
 }
 
 #[test]
 fn run_migrate_cli_apply_selected_mode_can_apply_external_skill_plan() {
     let discovery_root = unique_temp_dir("loongclaw-import-cli-external-skills-discovery");
     let output_root = unique_temp_dir("loongclaw-import-cli-external-skills-output");
+    let (home_root, _env_guard) = isolated_home_guard("loongclaw-import-cli-external-skills-home");
     fs::create_dir_all(&discovery_root).expect("create discovery root");
     fs::create_dir_all(&output_root).expect("create output root");
 
@@ -261,4 +276,5 @@ fn run_migrate_cli_apply_selected_mode_can_apply_external_skill_plan() {
 
     fs::remove_dir_all(&discovery_root).ok();
     fs::remove_dir_all(&output_root).ok();
+    fs::remove_dir_all(&home_root).ok();
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,7 @@ Build a layered Agentic OS kernel that is:
 
 ## Stage 0: Kernel Contract Freeze (Done)
 
-Status: complete  
+Status: complete
 Focus: create minimal but strong core boundaries.
 
 Delivered:
@@ -46,7 +46,7 @@ Exit criteria met:
 
 ## Stage 1: Baseline Security & Governance (In Progress)
 
-Status: in progress  
+Status: in progress
 Focus: medium-balanced defaults + hard stops for high-risk behavior.
 
 Delivered:
@@ -84,7 +84,7 @@ Exit criteria:
 
 ## Stage 2: Safe Hotplug Runtime (Next)
 
-Status: in progress  
+Status: in progress
 Focus: runtime-grade isolation for untrusted extension execution.
 
 Delivered in current baseline:
@@ -120,7 +120,7 @@ Acceptance criteria:
 
 ## Stage 3: Autonomous Integration Expansion (In Progress)
 
-Status: in progress  
+Status: in progress
 Focus: dynamic provider/channel integration without hardcoding.
 
 Delivered in current baseline:
@@ -196,7 +196,7 @@ Delivered in current baseline:
 - active `http_json` runtime execution lane (no longer plan-only):
   - timeout-controlled request execution
   - structured runtime evidence (`status_code`, `response_json`)
-- builtin-only memory-system foundation for `alpha-test`:
+- builtin-only memory-system foundation for `dev`:
   - typed memory-system metadata and registry seam
   - hydrated memory orchestration over LoongClaw-owned canonical history
   - operator diagnostics for selected system, capability set, and effective
@@ -223,7 +223,7 @@ Acceptance criteria:
 
 ## Stage 4: Community Plugin Supply Chain (Next)
 
-Status: planned  
+Status: planned
 Focus: open ecosystem without sacrificing trust boundaries.
 
 Planned deliverables:
@@ -244,7 +244,7 @@ Acceptance criteria:
 
 ## Stage 5: Vertical Pack Productization (Next)
 
-Status: planned  
+Status: planned
 Focus: 15-minute vertical customization workflow.
 
 Planned deliverables:
@@ -267,7 +267,7 @@ Acceptance criteria:
 
 ## Stage M: End-User MVP Product Layer (In Progress)
 
-Status: in progress  
+Status: in progress
 Focus: ship a low-friction daily-usable daemon entry for non-developers.
 
 Delivered in current baseline:
@@ -380,7 +380,7 @@ Approach: split `build_messages_for_session` into prompt construction + kernel-r
 
 Trade-off: improves audit coverage for memory reads, but requires splitting a tightly coupled function.
 
-Status (alpha-test): implemented.
+Status (`dev`): implemented.
 - Added `ConversationContextEngine` seam and default implementation.
 - `build_messages` now assembles through context engine and routes memory window reads via `kernel.execute_memory_core(..., Capability::MemoryRead, ...)` when kernel context is present.
 - Added registry/selection hooks (`register_context_engine`, `resolve_context_engine`, `LOONGCLAW_CONTEXT_ENGINE`) plus config-based selector (`[conversation].context_engine`) for future multi-engine evolution without invasive runtime refactors.
@@ -455,6 +455,6 @@ instead of preceding it.
 
 Execution package for this order:
 
-- `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-design.md`
-- `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-implementation-plan.md`
-- `docs/plans/2026-03-17-alpha-test-internal-runtime-hardening-github-backlog.md`
+- the 2026-03-17 internal runtime hardening design in `docs/plans/`
+- the 2026-03-17 internal runtime hardening implementation plan in `docs/plans/`
+- the 2026-03-17 internal runtime hardening GitHub backlog in `docs/plans/`

--- a/docs/design-docs/provider-runtime-roadmap.md
+++ b/docs/design-docs/provider-runtime-roadmap.md
@@ -3,7 +3,7 @@
 ## Scope and Baseline
 
 - OpenClaw reference: `openclaw/openclaw` `main@936607c` (fetched on 2026-03-11).
-- LoongClaw baseline: `loongclaw-ai/loongclaw` `alpha-test@cd39c7a`.
+- LoongClaw baseline: `loongclaw-ai/loongclaw` `dev@cd39c7a`.
 - Current working track: `feat/provider-runtime-abstraction` (this branch, unmerged changes).
 
 This document captures architecture comparison, implemented hardening, and a durable roadmap for provider runtime evolution.
@@ -18,7 +18,7 @@ This document captures architecture comparison, implemented hardening, and a dur
 
 ## Comparative Architecture Snapshot
 
-| Dimension | OpenClaw (`main`) | LoongClaw (`alpha-test`) | Current branch (`feat/provider-runtime-abstraction`) |
+| Dimension | OpenClaw (`main`) | LoongClaw (`dev`) | Current branch (`feat/provider-runtime-abstraction`) |
 | --- | --- | --- | --- |
 | Provider capability abstraction | Dedicated capability matrix (`provider-capabilities`) and provider-family toggles (OpenAI/Anthropic/default) | Minimal kind-based branching in runtime path | Still lightweight kind-based flow, but transport mode abstraction and payload adaptation are centralized |
 | Model catalog runtime | Shared async catalog loader with cache poisoning protection and synthetic forward-compat entries | Per-request direct model-list fetch in auto mode | Added bounded model-catalog cache + stale-if-error fallback + singleflight dedupe |

--- a/docs/references/github-collaboration.md
+++ b/docs/references/github-collaboration.md
@@ -1,13 +1,21 @@
 # GitHub Collaboration Reference
 
-This document defines the active GitHub collaboration baseline for the `alpha-test` branch.
+This document defines the active GitHub collaboration baseline for the `dev` branch.
 
 ## Active Branch Model
 
-- `alpha-test` is the active integration branch for day-to-day OSS work.
-- Contributors should branch from `alpha-test` and target `alpha-test` with normal pull requests.
-- `main` is the promotion branch. Only reviewed `alpha-test` changes should move into `main`.
-- The current default branch setting still lags this collaboration model. Until the default branch changes, or the same `.github/ISSUE_TEMPLATE` content is mirrored into `dev`, treat the docs and templates on `alpha-test` as the review source of truth.
+- `dev` is the active integration branch for day-to-day OSS work.
+- Contributors should branch from `dev` and target `dev` with normal pull requests.
+- `main` is the stable promotion branch. Only reviewed `dev` changes should move into `main`.
+- Promotion pull requests into `main` should come from `dev` and stay focused on stabilised work,
+  not mixed feature development.
+
+## Promotion and Release Rhythm
+
+- Maintainers aim to promote a stable slice from `dev` into `main` on a regular cadence.
+- Exact timing depends on validation status, scope completion, and operational readiness.
+- Releases are published from stable promotion points when the shipped slice is complete enough to
+  support a tagged release. Not every `dev -> main` promotion must become a public release.
 
 ## Intake Routes
 
@@ -16,7 +24,8 @@ This document defines the active GitHub collaboration baseline for the `alpha-te
 | Reproducible runtime defect | Bug report form | Captures severity, regression status, repro, runtime context, and evidence. |
 | New capability or behavior change | Feature request form | Captures problem statement, acceptance criteria, rollout notes, and scope boundaries. |
 | Missing, wrong, or confusing docs | Documentation improvement form | Captures branch-model drift, workflow gaps, and concrete doc references. |
-| Setup question or general troubleshooting | GitHub Discussions / Discord | Keeps support traffic out of the issue queue. |
+| Setup question or general troubleshooting | GitHub Discussions, Discord, Telegram, or the community spaces you already use such as Feishu and WeChat | Keeps support traffic out of the issue queue and lets people ask where they already participate. |
+| Direct contributor introduction or “where could I help?” conversation | [contact@loongclaw.ai](mailto:contact@loongclaw.ai) | Works well for async introductions, timezone context, and matching contributors to work that fits their strengths. |
 | Security vulnerability | Private security advisory | Avoids publishing sensitive details in public issues. |
 
 ## Managed Labels
@@ -83,16 +92,17 @@ The collaboration baseline continues to use the existing general labels for issu
 
 ## Pull Request Expectations
 
+- External contributors should normally target `dev`.
+- Promotion pull requests into `main` should come from `dev` and stay focused on stabilised work,
+  not mixed feature development.
 - Link the tracking issue in the PR body and include an explicit closing clause when the PR is meant to resolve it.
 - Keep the PR scoped to one logical change stream.
 - Fill in the PR template with changed areas, risk track, validation commands, and reviewer focus.
 - If the change is Track B, include rollout and rollback notes directly in the PR body.
 
-## Current Limitation
+## Default Branch Notes
 
-GitHub serves public issue forms from the default branch. At the moment, the repository default branch is not aligned with the active `alpha-test` contribution flow. That means the improved forms in `alpha-test` will not become public until one of these happens:
-
-1. The repository default branch is changed to `alpha-test`.
-2. The `.github/ISSUE_TEMPLATE` changes are mirrored into `dev`.
-
-Until then, this document and [CONTRIBUTING.md](../../CONTRIBUTING.md) are the authoritative guidance for contributors and maintainers reviewing `alpha-test`.
+GitHub serves public issue forms from the default branch. In this repository, the default branch is
+`dev`, which is also the active collaboration baseline. Keep contributor-facing templates, contact
+links, and references aligned on `dev` so public intake stays consistent with the actual review
+flow.

--- a/examples/spec/claw-import-hotplug.json
+++ b/examples/spec/claw-import-hotplug.json
@@ -13,7 +13,7 @@
     ],
     "metadata": {
       "owner": "loongclaw-ai",
-      "stage": "alpha-test"
+      "stage": "dev"
     }
   },
   "agent_id": "agent-migrate-legacy-claw",


### PR DESCRIPTION
## Summary

This PR aligns the current contributor-governance and intake surface with the live `dev` baseline.

Changes in this PR:
- deepen `CONTRIBUTING.md` with the `dev -> main` branch model, stable-promotion/release guidance, warmer contributor intake language, direct intro email guidance, and PRs we are unlikely to merge;
- update `docs/references/github-collaboration.md` to reflect `dev` as the active integration branch, `main` as the stable promotion branch, and the current community/contact routes;
- update public issue templates and contact links to point contributors at the active `dev` workflow and community spaces;
- rename and update the promotion guard workflow so only `dev -> main` promotion PRs are accepted;
- align current examples, tests, roadmap/references, and review-tooling config with `dev` as the live branch/channel name.

## Scope Notes

- Historical `docs/plans/` content is intentionally not mass-renamed in this pass.
- Active contributor-facing and automation-facing surfaces are aligned to `dev`.

Closes #326

## Validation

- `cargo test -p loongclaw-app presentation -- --nocapture`
- `cargo test -p loongclaw-app --test build_metadata -- --nocapture`
- `ruby -e 'require "yaml"; files=%w[.github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/docs_improvement.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/workflows/enforce-dev-to-main.yml .coderabbit.yaml]; files.each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- formatting scan across changed docs/templates/workflow/config files
- `rg -uu -n "alpha-test" -S --glob '!docs/plans/**' --glob '!target' --glob '!.git' --glob '!Cargo.lock'` returns no matches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced prior integration branch references with "dev" across contribution guides, collaboration docs, roadmap, issue/PR templates, examples; expanded release model, onboarding, review guidance, and added community channels (Discord, Telegram, Feishu, WeChat) plus direct-contact instructions.

* **Chores**
  * Updated repository policies, branch model, and enforcement workflows to target dev; adjusted promotion/release guidance and related CI messaging.

* **Tests**
  * Updated test data and expectations to use the dev branch label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->