### PR TITLE
docs: finalize v0.1.0-alpha.1 release reports

### DIFF
--- a/docs/releases/v0.1.0-alpha.1-announcement.md
+++ b/docs/releases/v0.1.0-alpha.1-announcement.md
@@ -1,0 +1,45 @@
+# Release v0.1.0-alpha.1 Announcement
+
+LoongClaw v0.1.0-alpha.1 is published from `dev` with verified release assets.
+
+## Highlights
+- Introduced the fresh `0.1.0-alpha.1` prerelease line for LoongClaw as a secure Rust foundation for vertical AI agents.
+- Preserved the baseline CLI path around guided onboarding, ask or chat flows, doctor repair, and multi-surface delivery for early team evaluation.
+- Reset canonical release history on `dev` to the new prerelease baseline after invalidating the earlier tracked `0.1.x` release line.
+- Made release governance prerelease-aware and seeded contributor notes from the current source snapshot instead of inheriting the invalidated prior tag range.
+
+## Contributors
+- Chum Yin
+- dependabot[bot]
+- dianzuan
+- fettpl
+- keynezzz
+- killf
+- little_penguin66
+- threeice
+- ThreeIce & 泽崎凪
+- xj
+- xj
+- YunfanGoForIt
+
+## Downloads
+- [Release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.1)
+- [install.ps1](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/install.ps1)
+- [install.sh](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/install.sh)
+- [loongclaw-v0.1.0-alpha.1-aarch64-apple-darwin.tar.gz](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-aarch64-apple-darwin.tar.gz)
+- [loongclaw-v0.1.0-alpha.1-aarch64-apple-darwin.tar.gz.sha256](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-aarch64-apple-darwin.tar.gz.sha256)
+- [loongclaw-v0.1.0-alpha.1-x86_64-apple-darwin.tar.gz](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-apple-darwin.tar.gz)
+- [loongclaw-v0.1.0-alpha.1-x86_64-apple-darwin.tar.gz.sha256](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-apple-darwin.tar.gz.sha256)
+- [loongclaw-v0.1.0-alpha.1-x86_64-pc-windows-msvc.zip](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-pc-windows-msvc.zip)
+- [loongclaw-v0.1.0-alpha.1-x86_64-pc-windows-msvc.zip.sha256](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-pc-windows-msvc.zip.sha256)
+- [loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz)
+- [loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz.sha256](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz.sha256)
+
+## Links
+- [Canonical release report](./v0.1.0-alpha.1.md)
+- [Changelog entry](../../CHANGELOG.md)
+- [Release workflow run](https://github.com/loongclaw-ai/loongclaw/actions/runs/23234267067)
+- [GitHub release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.1)
+- Generated at: `2026-03-18T08:07:33Z`
+- Trace ID: `f3a5a6f1`
+- Trace path: `.docs/traces/20260318T080731Z-post-release-v0.1.0-alpha.1-f3a5a6f1`

--- a/docs/releases/v0.1.0-alpha.1.md
+++ b/docs/releases/v0.1.0-alpha.1.md
@@ -1,61 +1,79 @@
 # Release v0.1.0-alpha.1
 
 ## Summary
-- Generated at: 2026-03-17T00:00:00Z
+- Generated at: 2026-03-18T08:07:33Z
 - Release status: published (draft=false, prerelease=true)
 - Target commitish: `dev`
-- Artifact count: 1
-- Trace ID: `preflight01`
-- Trace path: `.docs/traces/20260317T000000Z-post-release-v0.1.0-alpha.1-preflight01`
+- Artifact count: 10
+- Trace ID: `f3a5a6f1`
+- Trace path: `.docs/traces/20260318T080731Z-post-release-v0.1.0-alpha.1-f3a5a6f1`
 
 ## Highlights
-- Introduced the fresh `v0.1.0-alpha.1` prerelease line for LoongClaw as a secure Rust foundation for vertical AI agents.
-- Kept the baseline focused on guided onboarding, governed runtime boundaries, and multi-surface delivery paths described in the README.
-- Contributor note: this fresh prerelease seeds contributor credits from the current source snapshot instead of the invalidated prior release line.
+- Introduced the fresh `0.1.0-alpha.1` prerelease line for LoongClaw as a secure Rust foundation for vertical AI agents.
+- Preserved the baseline CLI path around guided onboarding, ask or chat flows, doctor repair, and multi-surface delivery for early team evaluation.
+- Reset canonical release history on `dev` to the new prerelease baseline after invalidating the earlier tracked `0.1.x` release line.
+- Made release governance prerelease-aware and seeded contributor notes from the current source snapshot instead of inheriting the invalidated prior tag range.
 
 ## Contributors
-- Chummy
-- xj
-- threeice
+- Chum Yin
+- dependabot[bot]
+- dianzuan
 - fettpl
+- keynezzz
+- killf
 - little_penguin66
+- threeice
+- ThreeIce & 泽崎凪
+- xj
+- xj
+- YunfanGoForIt
 
 ## Process
-- Date: 2026-03-17T00:00:00Z
-- Owner: release-gate preflight scaffold
-- Scope summary: reset `dev` to the fresh `v0.1.0-alpha.1` prerelease baseline and replace the invalid prior tracked release line.
-- Gates run: `task verify`, release-doc bootstrap, and strict doc governance.
-- Refactor budget item: aligned prerelease publishing, release-doc validation, and workflow metadata under a single contract.
+- Date: 2026-03-18T08:07:33Z
+- Owner: release-gate automation
+- Scope summary: published v0.1.0-alpha.1 from `dev` after release workflow verification.
+- Gates run: GitHub `release.yml`, asset presence verification, and release document generation.
+- Refactor budget item: no explicit refactor-budget paydown was supplied to the automation flow.
+- Automated post-release verification completed via `release-gate post-release`.
+- Selected workflow run: https://github.com/loongclaw-ai/loongclaw/actions/runs/23234267067 (run id `23234267067`).
 
 ## Artifacts
 | Asset | Size (bytes) | SHA256 | Download |
 |---|---:|---|---|
-| `loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz` | 1 | `prepublish-placeholder` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz) |
+| `install.ps1` | 7362 | `be485775b42475445861d4433951ea689421a3252748a30c12d557a1272234b1` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/install.ps1) |
+| `install.sh` | 10355 | `6cab16979c11f8c5c6bf9d1c18df97a7883cce44371ad6ceb754a69a47cc04b8` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/install.sh) |
+| `loongclaw-v0.1.0-alpha.1-aarch64-apple-darwin.tar.gz` | 11748723 | `bcf6829174ccc3a3fca33ff27721ebfb8a1b68bcf28d492e3ed75f6888eeb331` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-aarch64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-alpha.1-aarch64-apple-darwin.tar.gz.sha256` | 119 | `f6ec161eb7b5333bed4325979f6845771a0ba5119fad5b467613a6db96444a04` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-aarch64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-alpha.1-x86_64-apple-darwin.tar.gz` | 13351665 | `63dc6a14610dc5bec8d2e72e8adb10ca3fc77d4302746d94acc20b7930d906e9` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-alpha.1-x86_64-apple-darwin.tar.gz.sha256` | 118 | `0ac816c668b2de9f8195222af621f20099e75c739cd48ba07c52b71702632080` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-alpha.1-x86_64-pc-windows-msvc.zip` | 12520703 | `493d35436dfaaf0c34b5ba9826ad26aca431b0c828b4f94783834084c650a419` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-pc-windows-msvc.zip) |
+| `loongclaw-v0.1.0-alpha.1-x86_64-pc-windows-msvc.zip.sha256` | 119 | `3d3b2bb89405866e641a86d63864eec4259a2cf24d308562abd34634bd16ef44` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-pc-windows-msvc.zip.sha256) |
+| `loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz` | 13748081 | `d7032c746858567de7a0385f7daa7db9de49a20c5776bfd617d40cc04b129012` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz) |
+| `loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz.sha256` | 123 | `c653b0088c6a17764248903cce0adb7af489a6d8ee6e597b75384f8f1904b7ac` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.1/loongclaw-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz.sha256) |
 
 ## Verification
 | Check | Result | Evidence |
 |---|---|---|
-| Release metadata matches the fresh prerelease scaffold | PASS | [changelog entry](../../CHANGELOG.md) |
-| Strict release-doc governance passes after bootstrap | PASS | [release docs convention](./README.md) |
-| GitHub prerelease publish remains pending until tag execution | PENDING | [release workflow definition](../../.github/workflows/release.yml) |
+| Release workflow completed successfully | PASS | [workflow run](https://github.com/loongclaw-ai/loongclaw/actions/runs/23234267067) |
+| GitHub release is not draft | PASS | [release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.1) |
+| Expected cross-platform assets are present | PASS | 10 assets validated |
 
 ## Refactor Budget
-- Hotspot metric paid down: release governance drift between prerelease docs, workflow metadata, and local strict checks.
-- Evidence: prerelease scaffold, local bootstrap output, and strict doc verification.
-- If no paydown shipped, rationale: this fresh baseline is focused on restoring a clean release contract before public artifacts exist.
+- Hotspot metric paid down: none recorded by the automated release flow.
+- Evidence: release workflow run `23234267067` and generated release artifacts for `v0.1.0-alpha.1`.
+- If no paydown shipped, rationale: this release was automated from existing repository metadata without an attached refactor-budget payload.
 
 ## Known Issues
-- GitHub prerelease assets are not published yet; `release-gate post-release` will rewrite this scaffold from the published release state.
+- None observed during automated post-release verification.
 
 ## Rollback
-- Remove the prerelease tag before publish and regenerate local release artifacts if metadata drifts during preflight.
-- If publish creates incorrect assets, mark the GitHub prerelease as draft, replace the assets, and rerun release automation for the same tag.
+- If a bad artifact is detected, mark the release as draft, remove broken assets, and re-run `release.yml` for the same tag.
+- If the tag itself is invalid, create a replacement patch release and document supersession in `CHANGELOG.md`.
 
 ## Detail Links
-- [Project README](../../README.md)
+- [Release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.1)
+- [Release workflow run](https://github.com/loongclaw-ai/loongclaw/actions/runs/23234267067)
 - [Changelog entry](../../CHANGELOG.md)
-- [Release docs convention](./README.md)
 - [Release workflow definition](../../.github/workflows/release.yml)
-- [Planned GitHub release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.1)
-- Trace directory: `.docs/traces/20260317T000000Z-post-release-v0.1.0-alpha.1-preflight01`
+- Trace directory: `.docs/traces/20260318T080731Z-post-release-v0.1.0-alpha.1-f3a5a6f1`
 - Local debug log: `.docs/releases/v0.1.0-alpha.1-debug.md`


### PR DESCRIPTION
## Summary
- replace the prerelease scaffold with the published v0.1.0-alpha.1 canonical report
- add the generated release announcement doc
- keep the release docs aligned with the published prerelease assets and trace metadata

## Verification
- LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh