### PR TITLE
feat: add runtime capability promotion planner

### DIFF
--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1450,24 +1450,27 @@ fn build_runtime_capability_promotion_provenance(
     artifacts: &[RuntimeCapabilityArtifactDocument],
     evidence: &RuntimeCapabilityEvidenceDigest,
 ) -> RuntimeCapabilityPromotionProvenance {
+    let mut ordered_artifacts = artifacts.to_vec();
+    sort_runtime_capability_artifacts(&mut ordered_artifacts);
+
     RuntimeCapabilityPromotionProvenance {
-        candidate_ids: artifacts
+        candidate_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.candidate_id.clone())
             .collect(),
-        source_run_ids: artifacts
+        source_run_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.source_run.run_id.clone())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect(),
-        experiment_ids: artifacts
+        experiment_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.source_run.experiment_id.clone())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect(),
-        source_run_artifact_paths: artifacts
+        source_run_artifact_paths: ordered_artifacts
             .iter()
             .filter_map(|artifact| artifact.source_run.artifact_path.clone())
             .collect::<BTreeSet<_>>()

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -27,6 +27,8 @@ pub enum RuntimeCapabilityCommands {
     Show(RuntimeCapabilityShowCommandOptions),
     /// Aggregate candidate artifacts into deterministic capability families and readiness states
     Index(RuntimeCapabilityIndexCommandOptions),
+    /// Derive one dry-run promotion plan from one indexed capability family
+    Plan(RuntimeCapabilityPlanCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -77,6 +79,16 @@ pub struct RuntimeCapabilityShowCommandOptions {
 pub struct RuntimeCapabilityIndexCommandOptions {
     #[arg(long)]
     pub root: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityPlanCommandOptions {
+    #[arg(long)]
+    pub root: String,
+    #[arg(long)]
+    pub family_id: String,
     #[arg(long, default_value_t = false)]
     pub json: bool,
 }
@@ -238,6 +250,44 @@ pub struct RuntimeCapabilityIndexReport {
     pub families: Vec<RuntimeCapabilityFamilySummary>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityPromotionArtifactPlan {
+    pub target_kind: RuntimeCapabilityTarget,
+    pub artifact_kind: String,
+    pub artifact_id: String,
+    pub delivery_surface: String,
+    pub summary: String,
+    pub bounded_scope: String,
+    pub required_capabilities: Vec<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityPromotionProvenance {
+    pub candidate_ids: Vec<String>,
+    pub source_run_ids: Vec<String>,
+    pub experiment_ids: Vec<String>,
+    pub source_run_artifact_paths: Vec<String>,
+    pub latest_candidate_at: Option<String>,
+    pub latest_reviewed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityPromotionPlanReport {
+    pub generated_at: String,
+    pub root: String,
+    pub family_id: String,
+    pub promotable: bool,
+    pub proposal: RuntimeCapabilityProposal,
+    pub evidence: RuntimeCapabilityEvidenceDigest,
+    pub readiness: RuntimeCapabilityFamilyReadiness,
+    pub planned_artifact: RuntimeCapabilityPromotionArtifactPlan,
+    pub blockers: Vec<RuntimeCapabilityFamilyReadinessCheck>,
+    pub approval_checklist: Vec<String>,
+    pub rollback_hints: Vec<String>,
+    pub provenance: RuntimeCapabilityPromotionProvenance,
+}
+
 pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
     match command {
         RuntimeCapabilityCommands::Propose(options) => {
@@ -259,6 +309,11 @@ pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResu
             let as_json = options.json;
             let report = execute_runtime_capability_index_command(options)?;
             emit_runtime_capability_index_report(&report, as_json)
+        }
+        RuntimeCapabilityCommands::Plan(options) => {
+            let as_json = options.json;
+            let report = execute_runtime_capability_plan_command(options)?;
+            emit_runtime_capability_promotion_plan(&report, as_json)
         }
     }
 }
@@ -351,36 +406,14 @@ pub fn execute_runtime_capability_index_command(
 ) -> CliResult<RuntimeCapabilityIndexReport> {
     let root_path = Path::new(&options.root);
     let root = canonicalize_existing_path(root_path)?;
-    let mut artifacts = Vec::new();
-    collect_runtime_capability_artifacts(root_path, &mut artifacts)?;
-
-    let total_candidate_count = artifacts.len();
-    let mut families_by_id = BTreeMap::<String, Vec<RuntimeCapabilityArtifactDocument>>::new();
-    for artifact in artifacts {
-        let family_id = compute_family_id(&artifact.proposal)?;
-        families_by_id.entry(family_id).or_default().push(artifact);
-    }
+    let families_by_id = collect_runtime_capability_family_artifacts(root_path)?;
+    let total_candidate_count = families_by_id.values().map(Vec::len).sum();
 
     let mut families = Vec::new();
-    for (family_id, mut artifacts) in families_by_id {
-        sort_runtime_capability_artifacts(&mut artifacts);
-        let proposal = artifacts
-            .first()
-            .map(|artifact| artifact.proposal.clone())
-            .ok_or_else(|| "runtime capability family cannot be empty".to_owned())?;
-        let candidate_ids = artifacts
-            .iter()
-            .map(|artifact| artifact.candidate_id.clone())
-            .collect::<Vec<_>>();
-        let evidence = build_family_evidence_digest(&artifacts);
-        let readiness = evaluate_family_readiness(&artifacts, &evidence);
-        families.push(RuntimeCapabilityFamilySummary {
-            family_id,
-            proposal,
-            candidate_ids,
-            evidence,
-            readiness,
-        });
+    for (family_id, artifacts) in families_by_id {
+        families.push(build_runtime_capability_family_summary(
+            family_id, artifacts,
+        )?);
     }
 
     Ok(RuntimeCapabilityIndexReport {
@@ -389,6 +422,54 @@ pub fn execute_runtime_capability_index_command(
         total_candidate_count,
         family_count: families.len(),
         families,
+    })
+}
+
+pub fn execute_runtime_capability_plan_command(
+    options: RuntimeCapabilityPlanCommandOptions,
+) -> CliResult<RuntimeCapabilityPromotionPlanReport> {
+    let root_path = Path::new(&options.root);
+    let root = canonicalize_existing_path(root_path)?;
+    let families_by_id = collect_runtime_capability_family_artifacts(root_path)?;
+    let family_artifacts = families_by_id
+        .get(&options.family_id)
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "runtime capability family `{}` not found under {}",
+                options.family_id, root
+            )
+        })?;
+    let family = build_runtime_capability_family_summary(
+        options.family_id.clone(),
+        family_artifacts.clone(),
+    )?;
+    let planned_artifact =
+        build_runtime_capability_promotion_artifact(&family.family_id, &family.proposal);
+    let blockers = family
+        .readiness
+        .checks
+        .iter()
+        .filter(|check| check.status != RuntimeCapabilityFamilyReadinessCheckStatus::Pass)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(RuntimeCapabilityPromotionPlanReport {
+        generated_at: now_rfc3339()?,
+        root,
+        family_id: family.family_id.clone(),
+        promotable: family.readiness.status == RuntimeCapabilityFamilyReadinessStatus::Ready,
+        proposal: family.proposal.clone(),
+        evidence: family.evidence.clone(),
+        readiness: family.readiness.clone(),
+        planned_artifact: planned_artifact.clone(),
+        blockers,
+        approval_checklist: build_runtime_capability_approval_checklist(&planned_artifact),
+        rollback_hints: build_runtime_capability_rollback_hints(&planned_artifact),
+        provenance: build_runtime_capability_promotion_provenance(
+            &family_artifacts,
+            &family.evidence,
+        ),
     })
 }
 
@@ -420,6 +501,22 @@ fn emit_runtime_capability_index_report(
     }
 
     println!("{}", render_runtime_capability_index_text(report));
+    Ok(())
+}
+
+fn emit_runtime_capability_promotion_plan(
+    report: &RuntimeCapabilityPromotionPlanReport,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(report).map_err(|error| {
+            format!("serialize runtime capability promotion plan failed: {error}")
+        })?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_capability_promotion_plan_text(report));
     Ok(())
 }
 
@@ -563,6 +660,20 @@ fn collect_runtime_capability_artifacts(
     Ok(())
 }
 
+fn collect_runtime_capability_family_artifacts(
+    root: &Path,
+) -> CliResult<BTreeMap<String, Vec<RuntimeCapabilityArtifactDocument>>> {
+    let mut artifacts = Vec::new();
+    collect_runtime_capability_artifacts(root, &mut artifacts)?;
+
+    let mut families_by_id = BTreeMap::<String, Vec<RuntimeCapabilityArtifactDocument>>::new();
+    for artifact in artifacts {
+        let family_id = compute_family_id(&artifact.proposal)?;
+        families_by_id.entry(family_id).or_default().push(artifact);
+    }
+    Ok(families_by_id)
+}
+
 fn load_supported_runtime_capability_artifact(
     path: &Path,
 ) -> CliResult<Option<RuntimeCapabilityArtifactDocument>> {
@@ -597,6 +708,31 @@ fn sort_runtime_capability_artifacts(artifacts: &mut [RuntimeCapabilityArtifactD
             .cmp(&right.created_at)
             .then_with(|| left.candidate_id.cmp(&right.candidate_id))
     });
+}
+
+fn build_runtime_capability_family_summary(
+    family_id: String,
+    mut artifacts: Vec<RuntimeCapabilityArtifactDocument>,
+) -> CliResult<RuntimeCapabilityFamilySummary> {
+    sort_runtime_capability_artifacts(&mut artifacts);
+    let proposal = artifacts
+        .first()
+        .map(|artifact| artifact.proposal.clone())
+        .ok_or_else(|| "runtime capability family cannot be empty".to_owned())?;
+    let candidate_ids = artifacts
+        .iter()
+        .map(|artifact| artifact.candidate_id.clone())
+        .collect::<Vec<_>>();
+    let evidence = build_family_evidence_digest(&artifacts);
+    let readiness = evaluate_family_readiness(&artifacts, &evidence);
+
+    Ok(RuntimeCapabilityFamilySummary {
+        family_id,
+        proposal,
+        candidate_ids,
+        evidence,
+        readiness,
+    })
 }
 
 fn compute_family_id(proposal: &RuntimeCapabilityProposal) -> CliResult<String> {
@@ -1201,5 +1337,224 @@ fn render_family_readiness_check_status(
         RuntimeCapabilityFamilyReadinessCheckStatus::Pass => "pass",
         RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence => "needs_evidence",
         RuntimeCapabilityFamilyReadinessCheckStatus::Blocked => "blocked",
+    }
+}
+
+fn build_runtime_capability_promotion_artifact(
+    family_id: &str,
+    proposal: &RuntimeCapabilityProposal,
+) -> RuntimeCapabilityPromotionArtifactPlan {
+    let (artifact_kind, delivery_surface, id_prefix) =
+        runtime_capability_promotion_target_contract(proposal.target);
+    let artifact_id = format!(
+        "{id_prefix}-{}-{}",
+        slugify_runtime_capability_identifier(&proposal.summary),
+        family_id.chars().take(12).collect::<String>()
+    );
+
+    RuntimeCapabilityPromotionArtifactPlan {
+        target_kind: proposal.target,
+        artifact_kind: artifact_kind.to_owned(),
+        artifact_id,
+        delivery_surface: delivery_surface.to_owned(),
+        summary: proposal.summary.clone(),
+        bounded_scope: proposal.bounded_scope.clone(),
+        required_capabilities: proposal.required_capabilities.clone(),
+        tags: proposal.tags.clone(),
+    }
+}
+
+fn runtime_capability_promotion_target_contract(
+    target: RuntimeCapabilityTarget,
+) -> (&'static str, &'static str, &'static str) {
+    match target {
+        RuntimeCapabilityTarget::ManagedSkill => {
+            ("managed_skill_bundle", "managed_skills", "managed-skill")
+        }
+        RuntimeCapabilityTarget::ProgrammaticFlow => (
+            "programmatic_flow_spec",
+            "programmatic_flows",
+            "programmatic-flow",
+        ),
+        RuntimeCapabilityTarget::ProfileNoteAddendum => {
+            ("profile_note_addendum", "profile_note", "profile-note")
+        }
+    }
+}
+
+fn slugify_runtime_capability_identifier(raw: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_dash = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_was_dash = false;
+        } else if !last_was_dash {
+            slug.push('-');
+            last_was_dash = true;
+        }
+    }
+    let trimmed = slug.trim_matches('-').to_owned();
+    if trimmed.is_empty() {
+        "capability".to_owned()
+    } else {
+        trimmed
+    }
+}
+
+fn build_runtime_capability_approval_checklist(
+    planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
+) -> Vec<String> {
+    let mut checklist = vec![
+        "confirm summary and bounded scope still describe exactly one lower-layer artifact"
+            .to_owned(),
+        "confirm required capabilities remain least-privilege for the planned artifact".to_owned(),
+        "confirm provenance references still represent the intended behavior to codify".to_owned(),
+        format!(
+            "confirm the chosen delivery surface `{}` matches the target kind",
+            planned_artifact.delivery_surface
+        ),
+    ];
+    checklist.push(match planned_artifact.target_kind {
+        RuntimeCapabilityTarget::ManagedSkill => {
+            "confirm the behavior belongs in a reusable managed skill".to_owned()
+        }
+        RuntimeCapabilityTarget::ProgrammaticFlow => {
+            "confirm the behavior can be expressed as a deterministic programmatic flow".to_owned()
+        }
+        RuntimeCapabilityTarget::ProfileNoteAddendum => {
+            "confirm the behavior belongs in advisory profile guidance rather than executable logic"
+                .to_owned()
+        }
+    });
+    checklist
+}
+
+fn build_runtime_capability_rollback_hints(
+    planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
+) -> Vec<String> {
+    vec![
+        format!(
+            "capture the current `{}` state before applying artifact `{}`",
+            planned_artifact.delivery_surface, planned_artifact.artifact_id
+        ),
+        format!(
+            "remove or revert `{}` from `{}` if downstream validation fails",
+            planned_artifact.artifact_id, planned_artifact.delivery_surface
+        ),
+        "keep candidate ids and source-run references attached to the rollback record".to_owned(),
+    ]
+}
+
+fn build_runtime_capability_promotion_provenance(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityPromotionProvenance {
+    RuntimeCapabilityPromotionProvenance {
+        candidate_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.candidate_id.clone())
+            .collect(),
+        source_run_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.source_run.run_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        experiment_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.source_run.experiment_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        source_run_artifact_paths: artifacts
+            .iter()
+            .filter_map(|artifact| artifact.source_run.artifact_path.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        latest_candidate_at: evidence.latest_candidate_at.clone(),
+        latest_reviewed_at: evidence.latest_reviewed_at.clone(),
+    }
+}
+
+pub fn render_runtime_capability_promotion_plan_text(
+    report: &RuntimeCapabilityPromotionPlanReport,
+) -> String {
+    [
+        format!("family_id={}", report.family_id),
+        format!("promotable={}", report.promotable),
+        format!(
+            "readiness={}",
+            render_family_readiness_status(report.readiness.status)
+        ),
+        format!(
+            "target={}",
+            render_target(report.planned_artifact.target_kind)
+        ),
+        format!("artifact_kind={}", report.planned_artifact.artifact_kind),
+        format!("artifact_id={}", report.planned_artifact.artifact_id),
+        format!(
+            "delivery_surface={}",
+            report.planned_artifact.delivery_surface
+        ),
+        format!("target_summary={}", report.planned_artifact.summary),
+        format!("bounded_scope={}", report.planned_artifact.bounded_scope),
+        format!(
+            "required_capabilities={}",
+            render_string_values(&report.planned_artifact.required_capabilities)
+        ),
+        format!(
+            "tags={}",
+            render_string_values(&report.planned_artifact.tags)
+        ),
+        format!(
+            "blockers={}",
+            render_family_readiness_checks(&report.blockers)
+        ),
+        format!(
+            "checks={}",
+            render_family_readiness_checks(&report.readiness.checks)
+        ),
+        format!(
+            "approval_checklist={}",
+            render_string_values_with_separator(&report.approval_checklist, " | ")
+        ),
+        format!(
+            "rollback_hints={}",
+            render_string_values_with_separator(&report.rollback_hints, " | ")
+        ),
+        format!(
+            "provenance_candidate_ids={}",
+            render_string_values(&report.provenance.candidate_ids)
+        ),
+        format!(
+            "provenance_source_run_ids={}",
+            render_string_values(&report.provenance.source_run_ids)
+        ),
+        format!(
+            "provenance_experiment_ids={}",
+            render_string_values(&report.provenance.experiment_ids)
+        ),
+        format!(
+            "provenance_source_run_artifact_paths={}",
+            render_string_values_with_separator(
+                &report.provenance.source_run_artifact_paths,
+                " | "
+            )
+        ),
+    ]
+    .join("\n")
+}
+
+fn render_family_readiness_checks(checks: &[RuntimeCapabilityFamilyReadinessCheck]) -> String {
+    if checks.is_empty() {
+        "-".to_owned()
+    } else {
+        checks
+            .iter()
+            .map(render_family_readiness_check)
+            .collect::<Vec<_>>()
+            .join(" | ")
     }
 }

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -584,7 +584,7 @@ fn runtime_experiment_cli_rejects_compare_recorded_snapshots_with_manual_paths()
 }
 
 #[test]
-fn runtime_capability_cli_parses_propose_review_show_and_index() {
+fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
     let propose = Cli::try_parse_from([
         "loongclaw",
         "runtime-capability",
@@ -650,7 +650,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -697,7 +698,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -726,7 +728,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
                 _,
             )
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -753,7 +756,39 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let plan = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "plan",
+        "--root",
+        "/tmp/runtime-capability",
+        "--family-id",
+        "family-123",
+        "--json",
+    ])
+    .expect("`runtime-capability plan` should parse");
+
+    match plan.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(options) => {
+                assert_eq!(options.root, "/tmp/runtime-capability");
+                assert_eq!(options.family_id, "family-123");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -258,25 +258,47 @@ fn propose_runtime_capability_variant(
     loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument,
 ) {
     let candidate_path = root.join(format!("artifacts/runtime-capability-{slug}.json"));
-    let candidate =
-        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
-            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
-                run: run_path.display().to_string(),
-                output: candidate_path.display().to_string(),
-                target:
-                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
-                target_summary: "Codify browser preview onboarding as a reusable managed skill"
-                    .to_owned(),
-                bounded_scope: "Browser preview onboarding and companion readiness checks only"
-                    .to_owned(),
-                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
-                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
-                label: Some(format!("browser-preview-skill-candidate-{slug}")),
-                json: false,
-            },
-        )
-        .expect("runtime capability propose should succeed");
+    let candidate = propose_runtime_capability_variant_with_target(
+        root,
+        run_path,
+        slug,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
     (candidate_path, candidate)
+}
+
+fn propose_runtime_capability_variant_with_target(
+    root: &Path,
+    run_path: &Path,
+    slug: &str,
+    target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget,
+    target_summary: &str,
+    bounded_scope: &str,
+    required_capabilities: &[&str],
+    tags: &[&str],
+) -> loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument {
+    let candidate_path = root.join(format!("artifacts/runtime-capability-{slug}.json"));
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target,
+            target_summary: target_summary.to_owned(),
+            bounded_scope: bounded_scope.to_owned(),
+            required_capability: required_capabilities
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            tag: tags.iter().map(|value| (*value).to_owned()).collect(),
+            label: Some(format!("runtime-capability-{slug}")),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed")
 }
 
 fn review_runtime_capability_variant(
@@ -775,6 +797,360 @@ fn runtime_capability_index_marks_family_blocked_on_conflicting_reviews() {
                     == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Blocked
         }),
         "review consensus should block mixed accepted/rejected evidence"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-ready");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "ready-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "ready-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path = root.join("artifacts/runtime-capability-ready-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-ready-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "ready-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "ready-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "ready-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "ready-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(plan.promotable, "ready family should be promotable");
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Ready
+    );
+    assert_eq!(plan.planned_artifact.artifact_kind, "managed_skill_bundle");
+    assert_eq!(plan.planned_artifact.delivery_surface, "managed_skills");
+    assert!(
+        plan.planned_artifact
+            .artifact_id
+            .starts_with("managed-skill-"),
+        "artifact id should carry a managed-skill prefix"
+    );
+    assert!(
+        plan.planned_artifact
+            .artifact_id
+            .ends_with(&family.family_id[..12]),
+        "artifact id should be family-derived"
+    );
+    assert!(
+        plan.blockers.is_empty(),
+        "ready family should have no blockers"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("managed skill")),
+        "checklist should include the target-specific managed skill review item"
+    );
+    assert!(
+        plan.rollback_hints
+            .iter()
+            .any(|hint| hint.contains("managed_skills")),
+        "rollback hints should mention the managed skill delivery surface"
+    );
+    assert_eq!(plan.provenance.candidate_ids.len(), 2);
+    assert_eq!(plan.provenance.source_run_ids.len(), 2);
+    assert!(
+        plan.provenance.source_run_artifact_paths.contains(
+            &fs::canonicalize(&run_a_path)
+                .expect("canonicalize run a path")
+                .display()
+                .to_string()
+        )
+    );
+    assert!(
+        plan.provenance.source_run_artifact_paths.contains(
+            &fs::canonicalize(&run_b_path)
+                .expect("canonicalize run b path")
+                .display()
+                .to_string()
+        )
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_reports_missing_evidence_for_programmatic_flow_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-not-ready");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "flow",
+        -0.2,
+        &["manual verification only"],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_path = root.join("artifacts/runtime-capability-flow.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_path,
+        "flow",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProgrammaticFlow,
+        "Codify runtime compare summarization as a reusable flow",
+        "Runtime experiment compare report generation only",
+        &["invoke_tool", "memory_read"],
+        &["runtime", "compare"],
+    );
+    review_runtime_capability_variant(
+        &candidate_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "flow",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(
+        !plan.promotable,
+        "not-ready family should not be promotable"
+    );
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::NotReady
+    );
+    assert_eq!(
+        plan.planned_artifact.artifact_kind,
+        "programmatic_flow_spec"
+    );
+    assert_eq!(plan.planned_artifact.delivery_surface, "programmatic_flows");
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "stability"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "stability should surface as a missing-evidence blocker"
+    );
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "warning_pressure"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "warnings should surface as missing-evidence blockers"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("programmatic flow")),
+        "checklist should include the target-specific programmatic flow review item"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_reports_blocked_profile_note_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-blocked");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "note-a",
+        -0.1,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "note-b",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_a_path = root.join("artifacts/runtime-capability-note-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-note-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "note-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProfileNoteAddendum,
+        "Record browser preview operator guidance in profile memory",
+        "Browser preview operator guidance only",
+        &["memory_write"],
+        &["profile", "guidance"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "note-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProfileNoteAddendum,
+        "Record browser preview operator guidance in profile memory",
+        "Browser preview operator guidance only",
+        &["memory_write"],
+        &["profile", "guidance"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "note-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
+        "note-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(!plan.promotable, "blocked family should not be promotable");
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Blocked
+    );
+    assert_eq!(plan.planned_artifact.artifact_kind, "profile_note_addendum");
+    assert_eq!(plan.planned_artifact.delivery_surface, "profile_note");
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "review_consensus"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Blocked
+        }),
+        "blocked review consensus should surface as a hard-stop blocker"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("advisory profile guidance")),
+        "checklist should include the target-specific profile-note review item"
+    );
+    assert!(
+        plan.rollback_hints
+            .iter()
+            .any(|hint| hint.contains("profile_note")),
+        "rollback hints should mention the profile note delivery surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_rejects_unknown_family_id() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-missing-family");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    propose_runtime_capability_variant(&root, &run_path, "missing");
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: "missing-family".to_owned(),
+            json: false,
+        },
+    )
+    .expect_err("unknown family id should be rejected");
+
+    assert!(
+        error.contains("missing-family"),
+        "error should name the requested family id: {error}"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -318,6 +318,23 @@ fn review_runtime_capability_variant(
     .expect("runtime capability review should succeed")
 }
 
+fn rewrite_runtime_capability_created_at(candidate_path: &Path, created_at: &str) {
+    let mut payload = serde_json::from_str::<Value>(
+        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
+    )
+    .expect("decode runtime capability artifact");
+    let created_at_value = payload
+        .as_object_mut()
+        .and_then(|artifact| artifact.get_mut("created_at"))
+        .expect("runtime capability artifact should include created_at");
+    *created_at_value = Value::String(created_at.to_owned());
+    fs::write(
+        candidate_path,
+        serde_json::to_string_pretty(&payload).expect("encode runtime capability artifact"),
+    )
+    .expect("rewrite runtime capability artifact");
+}
+
 #[test]
 fn runtime_capability_propose_persists_candidate_from_finished_run() {
     let root = unique_temp_dir("loongclaw-runtime-capability-propose");
@@ -1127,6 +1144,95 @@ fn runtime_capability_plan_reports_blocked_profile_note_family() {
             .iter()
             .any(|hint| hint.contains("profile_note")),
         "rollback hints should mention the profile note delivery surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_provenance_candidate_ids_follow_family_order() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-provenance-order");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_z_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "z-run",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "a-run",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_z_path = root.join("artifacts/runtime-capability-zzz-first.json");
+    let candidate_a_path = root.join("artifacts/runtime-capability-aaa-second.json");
+    let candidate_z = propose_runtime_capability_variant_with_target(
+        &root,
+        &run_z_path,
+        "zzz-first",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    let candidate_a = propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "aaa-second",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    rewrite_runtime_capability_created_at(&candidate_z_path, "2026-03-18T08:00:00Z");
+    rewrite_runtime_capability_created_at(&candidate_a_path, "2026-03-18T08:00:01Z");
+    review_runtime_capability_variant(
+        &candidate_z_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "zzz-first",
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "aaa-second",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert_eq!(
+        family.candidate_ids,
+        vec![candidate_z.candidate_id, candidate_a.candidate_id],
+        "family summary should use semantic candidate order"
+    );
+    assert_eq!(
+        plan.provenance.candidate_ids, family.candidate_ids,
+        "planner provenance should preserve the family candidate order"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -291,6 +291,7 @@ Delivered in current baseline:
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
   - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
   - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests, and evaluates readiness as `ready`, `not_ready`, or `blocked`
+  - `runtime-capability plan` resolves one indexed capability family into a deterministic dry-run promotion plan with artifact identity, blockers, approval checklist, rollback hints, and provenance
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -310,7 +311,7 @@ Remaining deliverables:
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
   - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
-  - add a dry-run promotion planner on top of the capability-family readiness output instead of jumping directly to automatic mutation
+  - keep the new dry-run promotion planner read-only and use it as the contract for any future promotion executor instead of jumping directly to automatic mutation
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
   - partial governed adapter skeleton now exists for richer page actions:

--- a/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md
+++ b/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md
@@ -1,0 +1,337 @@
+# Runtime Capability Promotion Plan Dry-Run Design
+
+## Problem
+
+`runtime-capability` now gives LoongClaw two governed layers above finished
+runtime experiments:
+
+- one capability candidate per finished run
+- one deterministic family index with compact evidence and readiness
+
+That closes the "what reusable intent emerged?" and "is this family ready?"
+questions, but one operational gap still remains.
+
+Even when a family is indexed and evaluated, the operator still cannot answer in
+one deterministic view:
+
+- what exact lower-layer artifact should this family become?
+- what stable identifier should that artifact carry?
+- is the family actually promotable right now, or only plan-able?
+- what blockers still stop promotion?
+- what approval checklist and rollback notes should the eventual mutation step
+  follow?
+
+Without that dry-run layer, any later promotion executor would still need to
+re-open raw family summaries and improvise a plan at mutation time. That keeps
+the most safety-sensitive step underspecified.
+
+## Goal
+
+Add the smallest read-only promotion-planning layer above capability-family
+readiness:
+
+1. resolve one indexed family into one deterministic promotion plan
+2. describe the exact lower-layer artifact kind and stable identifier that would
+   be created
+3. expose whether the family is promotable now without mutating disk or runtime
+4. surface blockers, approval checklist items, rollback hints, and provenance in
+   one compact operator-readable report
+5. keep the entire slice local-first, deterministic, and auditable
+
+## Non-Goals
+
+- automatically generating or applying managed skills
+- automatically generating or applying programmatic flows
+- automatically mutating `profile_note` or runtime config
+- persisting a separate promotion-plan artifact
+- background daemons, queues, or schedulers
+- semantic ranking or LLM-based plan synthesis
+- solving multi-family prioritization in this slice
+
+## Constraints
+
+- The source of truth remains the persisted `runtime-capability` candidate
+  artifacts plus the derived family index view.
+- This slice must stay additive and read-only.
+- The plan contract must be deterministic from stored fields, not from external
+  state or model inference.
+- Planner output should be cheap enough that later automation can consume it
+  instead of replaying every candidate artifact.
+- The planner must still render a useful report for `not_ready` and `blocked`
+  families; failure to be promotable is data, not a command error.
+
+## Approaches Considered
+
+### Option A: Add a read-only `plan` command above `index`
+
+Compute the family index on demand, resolve one family by id, and derive a
+deterministic promotion-plan report.
+
+Pros:
+
+- additive and read-only
+- reuses the existing readiness/evidence contract
+- no new persisted state to synchronize
+- keeps later mutation layers honest by making the plan explicit first
+
+Cons:
+
+- requires re-scanning candidate artifacts for each planning request
+- still leaves actual mutation to a later slice
+
+### Option B: Persist a separate promotion-plan artifact
+
+Store one plan document on disk and update it whenever the family changes.
+
+Pros:
+
+- faster lookups later
+- explicit artifact path for every plan
+
+Cons:
+
+- adds a new write/update lifecycle immediately
+- forces ownership rules for stale plan invalidation
+- turns a read-only slice into another persistence surface
+
+### Option C: Jump directly to automatic promotion
+
+Let the system read a ready family and immediately generate the lower-layer
+artifact.
+
+Pros:
+
+- closest to the long-term autonomous loop
+
+Cons:
+
+- collapses planning and mutation into one step
+- reduces auditability exactly where safety matters most
+- introduces unnecessary slop debt before the plan contract is proven
+
+## Decision
+
+Choose Option A.
+
+The next governed self-evolution slice should make the would-be promotion
+explicit before anything is allowed to mutate state. The planner should consume
+the deterministic family view, preserve that same strictness, and add only the
+missing operator-facing details:
+
+- planned lower-layer artifact kind
+- stable artifact identifier
+- promotability boolean
+- blockers
+- approval checklist
+- rollback hints
+- provenance references
+
+## Proposed Surface
+
+### Command family
+
+Keep the existing commands and add one new read-only command:
+
+- `loongclaw runtime-capability propose`
+- `loongclaw runtime-capability review`
+- `loongclaw runtime-capability show`
+- `loongclaw runtime-capability index`
+- `loongclaw runtime-capability plan`
+
+### Plan command
+
+```bash
+loongclaw runtime-capability plan \
+  --root artifacts/runtime-capability \
+  --family-id <family-id> \
+  [--json]
+```
+
+Behavior:
+
+- recursively scan `--root` using the same supported-artifact rules as `index`
+- derive the same deterministic family summaries
+- select exactly one family by `family_id`
+- derive one deterministic promotion plan from that family
+- render text or JSON without mutating any artifact
+
+Command errors should be limited to:
+
+- unreadable root
+- malformed artifact load
+- missing family id
+
+`not_ready` and `blocked` families should still produce a plan report with
+`promotable=false`.
+
+## Promotion Plan Model
+
+### Report shape
+
+The plan report should contain:
+
+- `generated_at`
+- `root`
+- `family_id`
+- `promotable`
+- `proposal`
+- `evidence`
+- `readiness`
+- `planned_artifact`
+- `blockers`
+- `approval_checklist`
+- `rollback_hints`
+- `provenance`
+
+The planner should reuse the existing family proposal/evidence/readiness model
+instead of duplicating those semantics in a second schema.
+
+### Planned artifact
+
+Each plan resolves to one lower-layer artifact description:
+
+- `target_kind`
+- `artifact_kind`
+- `artifact_id`
+- `delivery_surface`
+- `summary`
+- `bounded_scope`
+- `required_capabilities`
+- `tags`
+
+`artifact_id` should be deterministic and human-scannable:
+
+- start with a target-specific prefix
+- append a slug derived from `proposal.summary`
+- suffix with a short prefix of `family_id` for collision resistance
+
+Example shapes:
+
+- `managed_skill` -> `artifact_kind=managed_skill_bundle`
+- `programmatic_flow` -> `artifact_kind=programmatic_flow_spec`
+- `profile_note_addendum` -> `artifact_kind=profile_note_addendum`
+
+The planner should not guess filesystem paths yet. The executor layer can choose
+the final write location later. This slice only promises the exact logical
+artifact identity and delivery lane.
+
+### Promotable
+
+`promotable` should be `true` only when the family's readiness status is
+`ready`.
+
+This keeps the rule obvious:
+
+- `ready` -> the family is promotable in principle
+- `not_ready` -> the family has missing evidence
+- `blocked` -> the family currently should not be promoted
+
+### Blockers
+
+`blockers` should be derived from readiness checks that are not `pass`.
+
+- `needs_evidence` checks become actionable missing-evidence blockers
+- `blocked` checks become hard-stop blockers
+
+This avoids inventing a second blocker engine.
+
+### Approval checklist
+
+The planner should emit a short deterministic checklist that the eventual
+mutation step must satisfy. The checklist should stay generic enough to cover
+all target kinds:
+
+- confirm the summary and bounded scope still describe exactly one lower-layer
+  artifact
+- confirm required capabilities remain least-privilege for that artifact
+- confirm provenance references still represent the intended behavior to codify
+- confirm the chosen delivery surface matches the target kind
+
+One extra target-specific item should be added:
+
+- `managed_skill`: confirm the behavior belongs in a reusable managed skill
+- `programmatic_flow`: confirm the behavior can be expressed as a deterministic
+  programmatic flow
+- `profile_note_addendum`: confirm the behavior belongs in advisory profile
+  guidance rather than executable logic
+
+### Rollback hints
+
+Rollback hints should stay high-signal and executor-neutral:
+
+- capture the current state of the target delivery surface before applying
+- remove or revert the promoted artifact by `artifact_id` if downstream
+  validation fails
+- keep the candidate ids and source-run references attached to the rollback
+  record so the revert stays auditable
+
+### Provenance
+
+The plan should carry the minimum references needed to audit where it came from:
+
+- candidate ids
+- source run ids
+- experiment ids
+- source run artifact paths when recorded on the candidate
+- latest candidate / review timestamps
+
+This is enough to trace the plan without reopening every file during normal
+review.
+
+## Text Output
+
+Text output should remain review-first and compact.
+
+Recommended order:
+
+1. family identity and promotability
+2. planned artifact description
+3. readiness/check summary
+4. blockers
+5. approval checklist
+6. rollback hints
+7. provenance references
+
+Example sketch:
+
+```text
+family_id=...
+promotable=true
+target=managed_skill
+artifact_kind=managed_skill_bundle
+artifact_id=managed-skill-browser-preview-onboarding-3f2a9c7d1b2e
+delivery_surface=managed_skills
+required_capabilities=invoke_tool,memory_read
+blockers=-
+checks=review_consensus:pass:... | stability:pass:...
+approval_checklist=confirm bounded scope | confirm least-privilege capabilities | ...
+rollback_hints=capture current managed_skills state | remove artifact_id on failure | ...
+provenance_candidate_ids=...
+provenance_source_run_ids=...
+```
+
+## Why This Is Simpler Than Persisted Plan State
+
+The planner can always be regenerated from candidate artifacts. That preserves
+the current self-evolution pyramid:
+
+- experiments create evidence
+- candidates capture promotion intent
+- family index summarizes readiness
+- promotion planner describes the would-be lower layer
+- a future executor can mutate only after all prior layers are explicit
+
+Nothing new needs to be synchronized or garbage-collected in this slice.
+
+## Testing Strategy
+
+1. Extend CLI parsing coverage for `runtime-capability plan`.
+2. Add failing integration tests for:
+   - planning a ready family
+   - planning a not-ready family and surfacing blockers
+   - planning a blocked family and surfacing blockers
+   - rejecting unknown family ids
+   - emitting target-specific artifact metadata and provenance references
+3. Implement the smallest plan derivation logic needed to satisfy those tests.
+4. Update product docs and roadmap so the runtime-capability ladder is described
+   as candidate -> index/readiness -> dry-run planner -> future executor.

--- a/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md
+++ b/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md
@@ -1,0 +1,188 @@
+# Runtime Capability Promotion Plan Dry-Run Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a read-only `runtime-capability plan` layer that resolves one indexed capability family into a deterministic dry-run promotion plan without mutating runtime state.
+
+**Architecture:** Reuse the existing candidate loading and family-readiness logic in `runtime_capability_cli`, derive one promotion-plan report from one family summary, and keep the new surface strictly read-only so later mutation layers can consume an explicit plan contract instead of improvising promotion details.
+
+**Tech Stack:** Rust, `clap`, `serde`, daemon integration tests, Markdown docs
+
+---
+
+### Task 1: Write the design and planning artifacts
+
+**Files:**
+- Create: `docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md`
+- Create: `docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Describe the planner contract, the command surface, the planned-artifact model,
+the promotable rule, blockers, approval checklist, rollback hints, provenance,
+and why this slice stays read-only.
+
+**Step 2: Verify the design artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md`
+Expected: exit 0
+
+**Step 3: Write the implementation plan**
+
+Capture the exact file changes, tests, docs, and verification steps below.
+
+**Step 4: Verify the plan artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md`
+Expected: exit 0
+
+### Task 2: Add failing CLI parsing coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Write the failing parse test**
+
+Extend runtime-capability CLI parsing coverage so `plan` parses:
+
+- `--root`
+- `--family-id`
+- `--json`
+
+**Step 2: Run the targeted parsing test to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_cli_parses_propose_review_show_index_and_plan --test integration -- --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_show_index_and_plan --nocapture`
+Expected: FAIL because the `plan` subcommand does not exist yet
+
+### Task 3: Add failing runtime-capability planner integration coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Write the failing planner tests**
+
+Add integration tests covering:
+
+- planning a ready managed-skill family
+- planning a `not_ready` family and surfacing missing-evidence blockers
+- planning a `blocked` family and surfacing hard-stop blockers
+- rejecting an unknown `family_id`
+- exposing deterministic artifact metadata, approval checklist, rollback hints,
+  and provenance references
+
+**Step 2: Run the targeted runtime-capability tests to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_plan --test integration -- --nocapture`
+Expected: FAIL because the planner surface does not exist yet
+
+### Task 4: Implement the read-only planner surface
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/lib.rs`
+
+**Step 1: Add the new command and option struct**
+
+Implement:
+
+- `RuntimeCapabilityCommands::Plan`
+- `RuntimeCapabilityPlanCommandOptions`
+
+**Step 2: Add the promotion-plan report model**
+
+Implement:
+
+- promotion-plan report type
+- planned-artifact type
+- provenance type
+
+Reuse existing proposal, evidence, and readiness types instead of cloning that
+logic into a second schema.
+
+**Step 3: Implement family lookup and plan derivation**
+
+Implement:
+
+- family resolution by `family_id`
+- deterministic planned-artifact identity derivation
+- promotable boolean derived from readiness
+- blockers derived from non-pass readiness checks
+- approval checklist and rollback hints derived from target kind plus generic
+  governance rules
+- provenance extraction from indexed candidate evidence
+
+**Step 4: Implement JSON/text rendering**
+
+Keep text output compact and review-first while exposing:
+
+- promotability
+- target/artifact description
+- blockers
+- approval checklist
+- rollback hints
+- provenance references
+
+**Step 5: Run the targeted tests to verify GREEN**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_plan --test integration -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability_cli_parses_propose_review_show_index_and_plan --test integration -- --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_show_index_and_plan --nocapture`
+
+Expected: PASS
+
+### Task 5: Update product docs and roadmap references
+
+**Files:**
+- Modify: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update the product spec**
+
+Document `runtime-capability plan` as the dry-run planning layer above family
+readiness and below any future promotion executor.
+
+**Step 2: Update the roadmap**
+
+Describe the planner as the next shipped governed self-evolution step after the
+family index/readiness layer.
+
+**Step 3: Run doc spot checks**
+
+Run: `rg -n "runtime-capability|promotion planner|dry-run" docs/product-specs/runtime-capability.md docs/ROADMAP.md`
+Expected: the new planner references appear in the updated docs
+
+### Task 6: Verify and prepare clean delivery
+
+**Files:**
+- Review all touched files
+
+**Step 1: Run focused verification**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_ --test integration -- --nocapture`
+
+Expected: PASS
+
+**Step 2: Run repo-level verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 3: Inspect the final diff**
+
+Run:
+
+- `git status --short`
+- `git diff --stat`
+- `git diff`
+
+Expected: only runtime-capability planner code, tests, docs, and directly
+related GitHub delivery text are present

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -9,7 +9,7 @@ experiment should be crystallized into a reusable lower-layer capability.
 ## Acceptance Criteria
 
 - [ ] LoongClaw exposes a `runtime-capability` command family with `propose`,
-      `review`, `show`, and `index` subcommands.
+      `review`, `show`, `index`, and `plan` subcommands.
 - [ ] `runtime-capability propose` creates a persisted capability-candidate
       artifact from one finished `runtime-experiment` run.
 - [ ] The candidate artifact records one explicit target type:
@@ -25,9 +25,14 @@ experiment should be crystallized into a reusable lower-layer capability.
       emits a compact evidence digest for each family.
 - [ ] Each capability family reports readiness as `ready`, `not_ready`, or
       `blocked` from explicit evidence checks rather than opaque heuristics.
+- [ ] `runtime-capability plan` resolves one indexed family into a dry-run
+      promotion plan that describes the target lower-layer artifact, stable
+      artifact id, blockers, approval checklist, rollback hints, and
+      provenance references without mutating runtime state.
 - [ ] Product docs describe `runtime-capability` as the governed review layer
-      above `runtime-experiment` and below any future dry-run promotion planner
-      or automated promotion loop.
+      above `runtime-experiment`, with `index`/readiness and `plan` forming the
+      dry-run planning ladder below any future promotion executor or automated
+      promotion loop.
 
 ## Out of Scope
 
@@ -36,4 +41,5 @@ experiment should be crystallized into a reusable lower-layer capability.
 - Automatically mutating `profile_note` or runtime config
 - Automatic promotion, rollback, or optimizer orchestration
 - Persisted capability-family state or background indexing daemons
+- Persisted promotion-plan artifacts or plan caches
 - Candidate queues, dashboards, or autonomous ranking systems


### PR DESCRIPTION
Closes #329

## Summary

This PR adds the next read-only self-evolution layer above capability-family readiness: a dry-run `runtime-capability plan` command that turns a family into a deterministic lower-layer promotion plan without mutating runtime state.

## What Changed

- add `runtime-capability plan --family-id <id> [--json]`
- derive lower-layer promotion targets from indexed family metadata for managed skills, programmatic flows, and profile note addenda
- emit deterministic artifact identity, target path metadata, provenance, blockers, approval checklist, and rollback hints in the planner output
- reject unknown family ids and block planning when readiness checks are not green
- extend CLI and integration coverage for parse behavior, ready/not-ready/blocked planning, and unknown-family rejection
- document the planner slice in the runtime-capability product spec, roadmap, and design/implementation notes

## Scope Boundary

- no runtime mutation or automatic promotion
- no persisted promotion-plan artifacts
- no background loops, heuristic clustering, or LLM-driven planning

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`

## Reviewer Focus

- planner output contract and deterministic artifact identity in `crates/daemon/src/runtime_capability_cli.rs`
- readiness-to-blocker mapping and promotion safety guidance in the same planner path
- CLI and integration coverage in `crates/daemon/tests/integration/cli_tests.rs` and `crates/daemon/tests/integration/runtime_capability_cli.rs`