### PR TITLE
feat: converge spec audit contract on named in-memory default

### DIFF
--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -17,7 +17,7 @@ use crate::spec_runtime::{
 
 /// The spec/bootstrap layer is a harness-facing surface, so its default audit
 /// sink stays explicitly in-memory unless a caller wires a different sink.
-pub fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
+pub(crate) fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
     Arc::new(InMemoryAuditSink::default())
 }
 
@@ -106,31 +106,58 @@ fn configured_builder(
     audit: Option<Arc<dyn AuditSink>>,
     native_tool_executor: Option<crate::NativeToolExecutor>,
 ) -> RuntimeKernelBuilder<StaticPolicyEngine> {
-    let mut kernel = match (clock, audit) {
-        (Some(clock), Some(audit)) => {
-            RuntimeKernelBuilder::with_runtime(StaticPolicyEngine::default(), clock, audit)
+    configured_builder_with_default_audit(clock, audit, native_tool_executor).0
+}
+
+fn configured_builder_with_default_audit(
+    clock: Option<Arc<dyn Clock>>,
+    audit: Option<Arc<dyn AuditSink>>,
+    native_tool_executor: Option<crate::NativeToolExecutor>,
+) -> (
+    RuntimeKernelBuilder<StaticPolicyEngine>,
+    Option<Arc<InMemoryAuditSink>>,
+) {
+    let (mut kernel, fallback_audit) = match (clock, audit) {
+        (Some(clock), Some(audit)) => (
+            RuntimeKernelBuilder::with_runtime(StaticPolicyEngine::default(), clock, audit),
+            None,
+        ),
+        (Some(clock), None) => {
+            let audit = default_in_memory_audit_sink();
+            (
+                RuntimeKernelBuilder::with_runtime(
+                    StaticPolicyEngine::default(),
+                    clock,
+                    audit.clone() as Arc<dyn AuditSink>,
+                ),
+                Some(audit),
+            )
         }
-        (Some(clock), None) => RuntimeKernelBuilder::with_runtime(
-            StaticPolicyEngine::default(),
-            clock,
-            default_in_memory_audit_sink() as Arc<dyn AuditSink>,
+        (None, Some(audit)) => (
+            RuntimeKernelBuilder::with_runtime(
+                StaticPolicyEngine::default(),
+                Arc::new(SystemClock) as Arc<dyn Clock>,
+                audit,
+            ),
+            None,
         ),
-        (None, Some(audit)) => RuntimeKernelBuilder::with_runtime(
-            StaticPolicyEngine::default(),
-            Arc::new(SystemClock) as Arc<dyn Clock>,
-            audit,
-        ),
-        (None, None) => RuntimeKernelBuilder::with_runtime(
-            StaticPolicyEngine::default(),
-            Arc::new(SystemClock) as Arc<dyn Clock>,
-            default_in_memory_audit_sink() as Arc<dyn AuditSink>,
-        ),
+        (None, None) => {
+            let audit = default_in_memory_audit_sink();
+            (
+                RuntimeKernelBuilder::with_runtime(
+                    StaticPolicyEngine::default(),
+                    Arc::new(SystemClock) as Arc<dyn Clock>,
+                    audit.clone() as Arc<dyn AuditSink>,
+                ),
+                Some(audit),
+            )
+        }
     };
     register_builtin_adapters(&mut kernel, native_tool_executor);
     // The default pack manifest is hardcoded and always valid; ignore the
     // impossible error branch to avoid panicking in production.
     let _ = kernel.register_pack(default_pack_manifest());
-    kernel
+    (kernel, fallback_audit)
 }
 
 fn register_builtin_adapters(
@@ -217,19 +244,42 @@ mod tests {
     }
 
     #[test]
-    fn builder_explicit_in_memory_audit_records_events() {
-        let audit = default_in_memory_audit_sink();
-        let kernel = KernelBuilder::default()
-            .audit(audit.clone() as Arc<dyn AuditSink>)
-            .build();
+    fn builder_default_fallback_records_token_audit_events() {
+        let (kernel, audit) = configured_builder_with_default_audit(None, None, None);
+        let audit =
+            audit.expect("default builder should surface the fallback in-memory audit sink");
 
         kernel
             .issue_token(DEFAULT_PACK_ID, "spec-audit-builder", 60)
-            .expect("token issue should succeed with the named in-memory audit helper");
+            .expect("token issue should succeed with the default in-memory audit fallback");
 
         let events = audit.snapshot();
-        assert_eq!(events.len(), 1, "expected one token-issued audit event");
-        assert!(matches!(events[0].kind, AuditEventKind::TokenIssued { .. }));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.kind, AuditEventKind::TokenIssued { .. })),
+            "expected token issuance to be recorded by the fallback in-memory audit sink"
+        );
+    }
+
+    #[test]
+    fn builder_clock_only_fallback_records_token_audit_events() {
+        let clock = Arc::new(FixedClock::new(1_700_000_000));
+        let (kernel, audit) = configured_builder_with_default_audit(Some(clock), None, None);
+        let audit =
+            audit.expect("clock-only builder should surface the fallback in-memory audit sink");
+
+        kernel
+            .issue_token(DEFAULT_PACK_ID, "spec-audit-builder-clock-only", 60)
+            .expect("token issue should succeed with the clock-only in-memory audit fallback");
+
+        let events = audit.snapshot();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event.kind, AuditEventKind::TokenIssued { .. })),
+            "expected token issuance to be recorded by the clock-only fallback in-memory audit sink"
+        );
     }
 
     #[test]

--- a/crates/spec/src/kernel_bootstrap.rs
+++ b/crates/spec/src/kernel_bootstrap.rs
@@ -15,10 +15,17 @@ use crate::spec_runtime::{
     WebhookConnector,
 };
 
+/// The spec/bootstrap layer is a harness-facing surface, so its default audit
+/// sink stays explicitly in-memory unless a caller wires a different sink.
+pub fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
+    Arc::new(InMemoryAuditSink::default())
+}
+
 /// Builder for constructing a fully configured `LoongClawKernel`.
 ///
-/// By default the builder uses `SystemClock` and `InMemoryAuditSink`.
-/// Override either with the corresponding setter before calling `build()`.
+/// By default the builder uses `SystemClock` and the spec layer's named
+/// in-memory audit helper. Override either with the corresponding setter before
+/// calling `build()`.
 #[derive(Default)]
 pub struct KernelBuilder {
     clock: Option<Arc<dyn Clock>>,
@@ -106,7 +113,7 @@ fn configured_builder(
         (Some(clock), None) => RuntimeKernelBuilder::with_runtime(
             StaticPolicyEngine::default(),
             clock,
-            Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+            default_in_memory_audit_sink() as Arc<dyn AuditSink>,
         ),
         (None, Some(audit)) => RuntimeKernelBuilder::with_runtime(
             StaticPolicyEngine::default(),
@@ -116,7 +123,7 @@ fn configured_builder(
         (None, None) => RuntimeKernelBuilder::with_runtime(
             StaticPolicyEngine::default(),
             Arc::new(SystemClock) as Arc<dyn Clock>,
-            Arc::new(InMemoryAuditSink::default()) as Arc<dyn AuditSink>,
+            default_in_memory_audit_sink() as Arc<dyn AuditSink>,
         ),
     };
     register_builtin_adapters(&mut kernel, native_tool_executor);
@@ -185,7 +192,7 @@ pub fn default_pack_manifest() -> VerticalPackManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kernel::{FixedClock, LoongClawKernel};
+    use kernel::{AuditEventKind, FixedClock, LoongClawKernel};
 
     #[test]
     fn builder_default_creates_kernel() {
@@ -207,6 +214,22 @@ mod tests {
             .issue_token(DEFAULT_PACK_ID, "test-agent", 60)
             .expect("token issue should succeed with custom clock/audit");
         assert!(!token.token_id.is_empty());
+    }
+
+    #[test]
+    fn builder_explicit_in_memory_audit_records_events() {
+        let audit = default_in_memory_audit_sink();
+        let kernel = KernelBuilder::default()
+            .audit(audit.clone() as Arc<dyn AuditSink>)
+            .build();
+
+        kernel
+            .issue_token(DEFAULT_PACK_ID, "spec-audit-builder", 60)
+            .expect("token issue should succeed with the named in-memory audit helper");
+
+        let events = audit.snapshot();
+        assert_eq!(events.len(), 1, "expected one token-issued audit event");
+        assert!(matches!(events[0].kind, AuditEventKind::TokenIssued { .. }));
     }
 
     #[test]

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -20,6 +20,7 @@ use kernel::{
 use serde_json::{Value, json};
 
 use crate::CliResult;
+use crate::kernel_bootstrap::default_in_memory_audit_sink;
 use crate::programmatic::execute_programmatic_tool_call;
 use crate::spec_runtime::*;
 
@@ -52,7 +53,7 @@ pub async fn execute_spec_with_native_tool_executor(
     native_tool_executor: Option<crate::NativeToolExecutor>,
 ) -> SpecRunReport {
     let mut pack = spec.pack.clone();
-    let audit_sink = Arc::new(InMemoryAuditSink::default());
+    let audit_sink = default_in_memory_audit_sink();
     let mut builder = crate::kernel_bootstrap::KernelBuilder::default()
         .clock(Arc::new(SystemClock) as Arc<dyn Clock>)
         .audit(audit_sink.clone());

--- a/crates/spec/tests/spec_execution.rs
+++ b/crates/spec/tests/spec_execution.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use kernel::Capability;
+use kernel::{AuditEventKind, Capability};
 use loongclaw_spec::test_support::make_runner_spec;
 use loongclaw_spec::{OperationSpec, execute_spec, spec_requires_native_tool_executor};
 use serde_json::json;
@@ -50,5 +50,49 @@ async fn execute_spec_blocks_native_tool_without_executor() {
             .as_deref()
             .expect("blocked reason should exist")
             .contains("native tool executor")
+    );
+}
+
+#[tokio::test]
+async fn execute_spec_returns_audit_snapshot_when_requested() {
+    let spec = make_runner_spec(OperationSpec::Task {
+        task_id: "spec-audit-task".to_owned(),
+        objective: "exercise spec audit snapshot capture".to_owned(),
+        required_capabilities: BTreeSet::new(),
+        payload: json!({"kind": "audit-contract-check"}),
+    });
+
+    let report = execute_spec(&spec, true).await;
+
+    let audit_events = report
+        .audit_events
+        .as_ref()
+        .expect("audit events should be present when explicitly requested");
+    assert!(
+        !audit_events.is_empty(),
+        "expected spec execution to retain at least one in-memory audit event"
+    );
+    assert!(
+        audit_events
+            .iter()
+            .any(|event| matches!(event.kind, AuditEventKind::TokenIssued { .. })),
+        "expected token issuance to be retained in the audit snapshot"
+    );
+}
+
+#[tokio::test]
+async fn execute_spec_suppresses_audit_snapshot_when_not_requested() {
+    let spec = make_runner_spec(OperationSpec::Task {
+        task_id: "spec-audit-task".to_owned(),
+        objective: "exercise spec audit snapshot suppression".to_owned(),
+        required_capabilities: BTreeSet::new(),
+        payload: json!({"kind": "audit-contract-check"}),
+    });
+
+    let report = execute_spec(&spec, false).await;
+
+    assert!(
+        report.audit_events.is_none(),
+        "audit snapshots should stay opt-in for spec execution reports"
     );
 }

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -30,7 +30,7 @@ Enforced by: CI (`verify` workflow). The optional `scripts/pre-commit` hook mirr
 ## Kernel Invariants
 
 1. **Token authorization is fail-closed** — if the policy engine cannot determine authorization (e.g., mutex poisoned), the operation is denied.
-2. **Audit events are never silently dropped** — production-shaped CLI chat, Telegram, and Feishu bootstraps default to `audit.mode = "fanout"`, which appends `~/.loongclaw/audit/events.jsonl` and can retain in-memory snapshots for local diagnostics. `LoongClawKernel::new()` now defaults to `InMemoryAuditSink`, and `NoopAuditSink` remains reserved for callers that explicitly opt into `new_without_audit(...)` or wire a noop sink themselves.
+2. **Audit events are never silently dropped** — production-shaped CLI chat, Telegram, and Feishu bootstraps default to `audit.mode = "fanout"`, which appends `~/.loongclaw/audit/events.jsonl` and can retain in-memory snapshots for local diagnostics. `LoongClawKernel::new()` now defaults to `InMemoryAuditSink`, `spec` bootstrap/runner helpers intentionally use a named in-memory audit helper for side-effect-free snapshot reporting, and `NoopAuditSink` remains reserved for callers that explicitly opt into `new_without_audit(...)` or wire a noop sink themselves.
 3. **Pack registration is idempotent-safe** — duplicate pack IDs return `DuplicatePack` error, never silently overwrite.
 4. **Generation-based revocation is monotonic** — the revocation threshold only increases, never decreases.
 5. **TaskState transitions are irreversible from terminal states** — `Completed` and `Faulted` states cannot transition.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -61,8 +61,9 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - Operators can inspect recent entries with standard tooling such as
   `tail -n 20 ~/.loongclaw/audit/events.jsonl`
 - No HMAC chain for tamper evidence (TD-007)
-- Spec/demo helpers and explicit test seams may still opt into in-memory-only audit when
-  side-effect-free execution is required
+- `spec` bootstrap and spec-execution helpers intentionally default to a named in-memory audit
+  helper so side-effect-free harness/demo runs can still surface audit snapshots in `SpecRunReport`
+- Explicit no-audit behavior remains opt-in only and should stay reserved for narrow fixture seams
 
 ### Compile-Time Constraints
 

--- a/docs/plans/2026-03-18-spec-audit-contract-convergence-design.md
+++ b/docs/plans/2026-03-18-spec-audit-contract-convergence-design.md
@@ -1,0 +1,140 @@
+# Spec Audit Contract Convergence Design
+
+## Problem
+
+`#279` retired the unsafe implicit `NoopAuditSink` default from `LoongClawKernel::new()`, and the
+app/runtime bootstrap path now has an explicit durable audit story. The remaining seam is `spec`:
+
+1. `crates/spec/src/kernel_bootstrap.rs` still defaults its bootstrap builder to
+   `InMemoryAuditSink` without naming that choice as a harness-specific contract.
+2. `crates/spec/src/spec_execution.rs` constructs its own `InMemoryAuditSink` inline instead of
+   reusing a shared spec-level audit decision.
+3. `docs/SECURITY.md` already permits spec/demo helpers to stay in-memory, but the code path has no
+   focused regression tests that prove this is an intentional harness default rather than an
+   accidental drift.
+
+The result is semantic ambiguity. Production-shaped app bootstraps are now explicit and durable by
+default, while the `spec` layer remains silently in-memory.
+
+## Goals
+
+1. Make the `spec` audit default explicit as a harness-only in-memory policy.
+2. Centralize `spec`'s in-memory audit construction so the contract lives in one place.
+3. Add regression tests that fail if `spec` stops exposing in-memory audit events for report
+   snapshots or if the bootstrap fallback stops being intentionally in-memory.
+4. Align security/reliability docs with the resulting contract.
+
+## Non-Goals
+
+1. Do not route `spec` through app `[audit]` runtime configuration.
+2. Do not introduce a new cross-layer audit profile abstraction.
+3. Do not change production CLI/Telegram/Feishu audit defaults in this slice.
+
+## Options Considered
+
+### A. Promote `spec` to production-shaped durable audit defaults
+
+This would thread app-style audit configuration into `spec` and make `spec` mirror runtime
+bootstraps.
+
+Why not now:
+- `spec` is intentionally detached from `app`.
+- Durable retention is an operator/runtime concern, while `spec` is still used as a harness/demo
+  path and for side-effect-free evaluation.
+- The change set would be much larger and would blur an architecture boundary just to remove a
+  smaller semantic ambiguity.
+
+### B. Keep `spec` in-memory but leave the current implicit defaults in place
+
+This is the smallest code delta, but it preserves the root problem: callers still have to infer
+intent from scattered `InMemoryAuditSink::default()` allocations and builder fallbacks.
+
+Why not:
+- It does not create a durable regression guard.
+- It keeps docs and code coupled only by tribal knowledge.
+
+### C. Keep `spec` in-memory and make that contract explicit
+
+Recommended.
+
+Concretely:
+- add a named helper in `crates/spec/src/kernel_bootstrap.rs` for the spec/harness in-memory audit
+  default
+- use that helper everywhere `spec` needs its default sink
+- document that `KernelBuilder`/`BootstrapBuilder` are harness bootstrap helpers whose implicit
+  fallback is intentionally in-memory
+- add tests that exercise real `spec` execution with `include_audit = true`
+
+Why this is the right cut:
+- minimal change set
+- no new hardcoding or policy duplication
+- keeps `spec` detached from `app`
+- mechanically protects the intended semantics
+
+## Proposed Design
+
+### 1. Introduce a named spec audit helper
+
+Add a small helper in `crates/spec/src/kernel_bootstrap.rs`:
+
+- `pub fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink>`
+
+This gives the harness default a single source of truth. The helper name carries the architectural
+meaning that raw `InMemoryAuditSink::default()` does not.
+
+### 2. Reuse the helper in both bootstrap and spec execution
+
+Replace direct inline `InMemoryAuditSink::default()` construction in:
+
+- `crates/spec/src/kernel_bootstrap.rs`
+- `crates/spec/src/spec_execution.rs`
+
+with the named helper.
+
+That keeps the fallback policy centralized and avoids semantic drift between builder bootstraps and
+the report-producing spec execution path.
+
+### 3. Add regression coverage at the behavior seam
+
+Add tests in:
+
+- `crates/spec/src/kernel_bootstrap.rs`
+- `crates/spec/tests/spec_execution.rs`
+
+Coverage:
+- the default spec audit helper records real kernel events
+- `execute_spec(..., include_audit = true)` returns captured audit events instead of `None`
+- `execute_spec(..., include_audit = false)` continues suppressing snapshots
+
+This gives us a behavior-level guard instead of only a comment-level contract.
+
+### 4. Tighten docs
+
+Update:
+
+- `docs/SECURITY.md`
+- `docs/RELIABILITY.md`
+
+to say that:
+- production-shaped app bootstraps default to durable audit modes
+- `spec`/demo/harness helpers intentionally default to in-memory audit for side-effect-free local
+  execution and snapshot reporting
+
+## Testing Strategy
+
+1. Write failing spec tests first for audit snapshot inclusion/suppression.
+2. Add a focused bootstrap test proving the named helper captures emitted audit events.
+3. Run targeted spec/kernel tests during iteration.
+4. Run full repo verification before declaring completion.
+
+## Risks
+
+1. Over-correcting by threading app audit configuration into `spec` would widen the slice and create
+   boundary drift.
+2. Only updating docs without behavior tests would recreate the same ambiguity later.
+
+## Recommendation
+
+Implement Option C. It is the smallest change that closes the actual gap: `spec` stays
+harness-oriented and in-memory by design, but that design becomes explicit, centralized, tested, and
+documented.

--- a/docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md
+++ b/docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md
@@ -1,0 +1,176 @@
+# Spec Audit Contract Convergence Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the `spec` layer's in-memory audit default explicit, centralized, and regression-tested without widening the `spec -> app` boundary.
+
+**Architecture:** Treat `spec` as a harness/demo bootstrap surface with an intentionally in-memory audit default. Centralize that choice behind a named helper, reuse it in builder and execution paths, and verify the behavior through end-to-end spec execution tests plus focused bootstrap tests.
+
+**Tech Stack:** Rust workspace, `cargo test`, spec/kernel crates, Markdown design/reliability/security docs.
+
+---
+
+### Task 1: Add the failing spec execution audit tests
+
+**Files:**
+- Modify: `crates/spec/tests/spec_execution.rs`
+
+**Step 1: Write the failing test**
+
+Add:
+- one async test asserting `execute_spec(&spec, true)` returns `Some(audit_events)` with at least one event
+- one async test asserting `execute_spec(&spec, false)` returns `None`
+
+Use a minimal `ToolCore` runner spec that succeeds through the normal spec path.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_returns_audit_snapshot_when_requested -- --exact`
+
+Expected: FAIL because the current behavior is not yet expressed through focused regression coverage.
+
+**Step 3: Write minimal implementation**
+
+Do not change production code yet. Only fix compile issues in the new tests if needed.
+
+**Step 4: Run test to verify it still fails for the intended reason**
+
+Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_returns_audit_snapshot_when_requested -- --exact`
+
+Expected: FAIL on the assertion, not due to unrelated compile errors.
+
+**Step 5: Commit**
+
+Do not commit yet. This slice will be committed after code + docs are green.
+
+### Task 2: Centralize the spec in-memory audit default
+
+**Files:**
+- Modify: `crates/spec/src/kernel_bootstrap.rs`
+- Modify: `crates/spec/src/spec_execution.rs`
+
+**Step 1: Add the named helper**
+
+Add a helper such as:
+
+```rust
+pub fn default_in_memory_audit_sink() -> Arc<InMemoryAuditSink> {
+    Arc::new(InMemoryAuditSink::default())
+}
+```
+
+**Step 2: Route bootstrap fallback through the helper**
+
+Replace inline `Arc::new(InMemoryAuditSink::default())` fallback construction in
+`configured_builder(...)` with the helper.
+
+**Step 3: Route spec execution through the helper**
+
+Replace the inline `audit_sink` construction in `execute_spec_with_native_tool_executor(...)` with
+the helper so spec execution and spec bootstrap share one default.
+
+**Step 4: Run the focused spec test**
+
+Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_returns_audit_snapshot_when_requested -- --exact`
+
+Expected: PASS
+
+**Step 5: Run the suppression test**
+
+Run: `cargo test -p loongclaw-spec --test spec_execution execute_spec_suppresses_audit_snapshot_when_not_requested -- --exact`
+
+Expected: PASS
+
+### Task 3: Add a focused bootstrap regression test
+
+**Files:**
+- Modify: `crates/spec/src/kernel_bootstrap.rs`
+
+**Step 1: Write the failing test**
+
+Add a unit test that:
+- constructs the named spec audit helper
+- wires it into `KernelBuilder`
+- issues a token
+- asserts the in-memory audit snapshot is non-empty
+
+**Step 2: Run test to verify it fails or is missing**
+
+Run: `cargo test -p loongclaw-spec builder_explicit_in_memory_audit_records_events -- --exact`
+
+Expected: FAIL before the helper/test wiring is complete.
+
+**Step 3: Write minimal implementation**
+
+Use the new helper in the test and keep the production code limited to the centralization from Task 2.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p loongclaw-spec builder_explicit_in_memory_audit_records_events -- --exact`
+
+Expected: PASS
+
+### Task 4: Update the documentation contract
+
+**Files:**
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/RELIABILITY.md`
+- Create: `docs/plans/2026-03-18-spec-audit-contract-convergence-design.md`
+- Create: `docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md`
+
+**Step 1: Update security wording**
+
+Clarify that durable retention exists on production-shaped app bootstraps, while `spec`/demo
+helpers intentionally remain in-memory for side-effect-free execution and audit snapshot reporting.
+
+**Step 2: Update reliability wording**
+
+Clarify that the "never silently dropped" invariant means:
+- production paths default to durable or in-memory-backed audit as documented
+- explicit no-audit paths must remain opt-in only
+- `spec` defaults are intentionally in-memory and named as such
+
+**Step 3: Review for consistency**
+
+Run: `rg -n "No persistent audit sink|In-memory only|spec.*in-memory|fanout|new_without_audit" docs crates/spec`
+
+Expected: wording reflects the current contract with no stale contradiction.
+
+### Task 5: Run verification and prepare the final change set
+
+**Files:**
+- Modify: `crates/spec/src/kernel_bootstrap.rs`
+- Modify: `crates/spec/src/spec_execution.rs`
+- Modify: `crates/spec/tests/spec_execution.rs`
+- Modify: `docs/SECURITY.md`
+- Modify: `docs/RELIABILITY.md`
+- Create: `docs/plans/2026-03-18-spec-audit-contract-convergence-design.md`
+- Create: `docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md`
+
+**Step 1: Run focused tests**
+
+Run:
+- `cargo test -p loongclaw-spec --test spec_execution`
+- `cargo test -p loongclaw-spec kernel_bootstrap --lib`
+
+Expected: PASS
+
+**Step 2: Run repo verification**
+
+Run:
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace -- --test-threads=1`
+- `cargo test --workspace --all-features -- --test-threads=1`
+- `./scripts/check_architecture_boundaries.sh`
+- `./scripts/check_dep_graph.sh`
+- `./scripts/check-docs.sh`
+
+Expected: PASS, except for known unrelated non-blocking release-artifact warnings if they remain unchanged.
+
+**Step 3: Review the final diff for scope**
+
+Run:
+- `git diff -- crates/spec/src/kernel_bootstrap.rs crates/spec/src/spec_execution.rs crates/spec/tests/spec_execution.rs docs/SECURITY.md docs/RELIABILITY.md docs/plans/2026-03-18-spec-audit-contract-convergence-design.md docs/plans/2026-03-18-spec-audit-contract-convergence-implementation-plan.md`
+
+Expected: only the intended audit-contract convergence slice is present.

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-17T08:38:17Z
+- Generated at: 2026-03-18T10:08:59Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -12,7 +12,7 @@
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1478 | 3700 | 2222 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 301 | 1000 | 699 | 8 | 20 | 12 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 312 | 650 | 338 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
 
@@ -39,7 +39,7 @@
 - [CI workflow](../../.github/workflows/ci.yml)
 
 <!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
-<!-- arch-hotspot key=spec_execution lines=1478 functions=23 -->
+<!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=301 functions=8 -->
 <!-- arch-hotspot key=memory_mod lines=312 functions=15 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- add a named spec/bootstrap helper for the default in-memory audit sink
- route spec bootstrap fallback and spec execution through that helper
- add regression coverage for `include_audit = true|false` and a focused bootstrap audit test
- tighten security/reliability docs around the production durable vs. spec in-memory audit split

## Why

`#279` fixed the unsafe implicit noop audit default at the kernel constructor level, but the `spec` layer still left its in-memory audit semantics implicit. This change keeps `spec` harness-shaped and side-effect-free while making that audit contract explicit, centralized, and regression-tested.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo test --workspace --all-features -- --test-threads=1`
- `./scripts/check_architecture_boundaries.sh`
- `./scripts/check_dep_graph.sh`
- `./scripts/check-docs.sh`

## Notes

- This PR is intentionally stacked on `#284`; after `#284` lands it can be retargeted to `alpha-test`.

Closes #335
