### PR TITLE
add feishu websocket serve mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ dependencies = [
  "loongclaw-bench",
  "loongclaw-kernel",
  "loongclaw-spec",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2442,8 +2442,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2548,7 +2548,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2597,12 +2597,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,8 +1985,8 @@ dependencies = [
  "http-body 1.0.1",
  "loongclaw-contracts",
  "loongclaw-kernel",
- "regex",
  "prost",
+ "regex",
  "reqwest",
  "rusqlite",
  "scraper",
@@ -3442,7 +3442,11 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -3598,6 +3602,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,7 +756,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1057,6 +1063,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -1974,6 +1986,7 @@ dependencies = [
  "loongclaw-contracts",
  "loongclaw-kernel",
  "regex",
+ "prost",
  "reqwest",
  "rusqlite",
  "scraper",
@@ -1984,6 +1997,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "toml",
  "wait-timeout",
 ]
@@ -2009,7 +2023,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2047,7 +2061,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2058,7 +2072,7 @@ dependencies = [
  "async-trait",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2438,6 +2452,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,7 +2533,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2517,7 +2554,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2738,7 +2775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3255,11 +3292,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3375,6 +3432,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -3515,6 +3584,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"
@@ -3895,7 +3982,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror",
+ "thiserror 2.0.18",
  "wasmparser 0.244.0",
  "wasmtime-environ",
  "wasmtime-internal-core",

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ chat_completions_path = "/api/v3/chat/completions"
 
 Both `volcengine` and `volcengine_coding` use `api_key = "${ARK_API_KEY}"`. LoongClaw sends that value as `Authorization: Bearer <ARK_API_KEY>` on the OpenAI-compatible Volcengine path; AK/SK request signing is not used there.
 
-Feishu channel example:
+Feishu channel example (webhook mode):
 
 ```bash
 export FEISHU_APP_ID=cli_your_app_id
@@ -310,7 +310,28 @@ allowed_chat_ids = ["oc_your_chat_id"]
 loongclaw feishu-serve --config ~/.loongclaw/config.toml
 ```
 
-By default, LoongClaw reads `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_VERIFICATION_TOKEN`, and `FEISHU_ENCRYPT_KEY`. If you are targeting Lark instead of Feishu, add `domain = "lark"`.
+LoongClaw defaults to `mode = "webhook"` and reads `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_VERIFICATION_TOKEN`, and `FEISHU_ENCRYPT_KEY`.
+
+Feishu channel example (websocket mode):
+
+```bash
+export FEISHU_APP_ID=cli_your_app_id
+export FEISHU_APP_SECRET=your_app_secret
+```
+
+```toml
+[feishu]
+enabled = true
+mode = "websocket"
+receive_id_type = "chat_id"
+allowed_chat_ids = ["oc_your_chat_id"]
+```
+
+```bash
+loongclaw feishu-serve --config ~/.loongclaw/config.toml
+```
+
+Webhook secrets are not required in websocket mode. If you are targeting Lark instead of Feishu, add `domain = "lark"`.
 
 Matrix channel example:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -235,7 +235,7 @@ base_url = "https://ark.cn-beijing.volces.com"
 chat_completions_path = "/api/v3/chat/completions"
 ```
 
-飞书通道示例：
+飞书通道示例（webhook 模式）：
 
 ```bash
 export FEISHU_APP_ID=cli_your_app_id
@@ -257,7 +257,28 @@ allowed_chat_ids = ["oc_your_chat_id"]
 loongclaw feishu-serve --config ~/.loongclaw/config.toml
 ```
 
-默认会读取 `FEISHU_APP_ID`、`FEISHU_APP_SECRET`、`FEISHU_VERIFICATION_TOKEN` 和 `FEISHU_ENCRYPT_KEY`。如果你接的是 Lark，可以再加上 `domain = "lark"`。
+默认是 `mode = "webhook"`，会读取 `FEISHU_APP_ID`、`FEISHU_APP_SECRET`、`FEISHU_VERIFICATION_TOKEN` 和 `FEISHU_ENCRYPT_KEY`。
+
+飞书通道示例（websocket 模式）：
+
+```bash
+export FEISHU_APP_ID=cli_your_app_id
+export FEISHU_APP_SECRET=your_app_secret
+```
+
+```toml
+[feishu]
+enabled = true
+mode = "websocket"
+receive_id_type = "chat_id"
+allowed_chat_ids = ["oc_your_chat_id"]
+```
+
+```bash
+loongclaw feishu-serve --config ~/.loongclaw/config.toml
+```
+
+websocket 模式不需要 webhook secret。如果你接的是 Lark，可以再加上 `domain = "lark"`。
 
 工具策略需要明确配置：
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 default = ["channel-cli", "channel-telegram", "channel-feishu", "channel-matrix", "config-toml", "memory-sqlite", "feishu-integration", "tool-shell", "tool-file", "tool-browser", "tool-webfetch", "tool-websearch", "provider-openai", "provider-anthropic", "provider-bedrock", "provider-volcengine"]
 channel-cli = []
 channel-telegram = []
-channel-feishu = ["dep:axum", "dep:aes", "dep:cbc", "feishu-integration"]
+channel-feishu = ["dep:axum", "dep:aes", "dep:cbc", "dep:prost", "dep:tokio-tungstenite", "feishu-integration"]
 channel-matrix = []
 provider-openai = []
 provider-anthropic = []
@@ -53,6 +53,8 @@ aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
 wait-timeout = "0.2"
 regex = { workspace = true, optional = true }
+prost = { version = "0.13", optional = true }
+tokio-tungstenite = { version = "0.24", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -54,7 +54,7 @@ cbc = { version = "0.1", optional = true }
 wait-timeout = "0.2"
 regex = { workspace = true, optional = true }
 prost = { version = "0.13", optional = true }
-tokio-tungstenite = { version = "0.24", optional = true }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -197,7 +197,7 @@ impl ChannelAdapter for FeishuAdapter {
     }
 
     async fn receive_batch(&mut self) -> CliResult<Vec<ChannelInboundMessage>> {
-        Err("feishu inbound is served via webhook mode (`feishu-serve`)".to_owned())
+        Err("feishu inbound is served via `feishu-serve` (webhook or websocket mode)".to_owned())
     }
 
     async fn send_message(

--- a/crates/app/src/channel/feishu/mod.rs
+++ b/crates/app/src/channel/feishu/mod.rs
@@ -16,6 +16,7 @@ use crate::config::{
 mod adapter;
 mod payload;
 mod webhook;
+mod websocket;
 
 use adapter::FeishuAdapter;
 use payload::normalize_webhook_path;
@@ -74,6 +75,19 @@ pub(super) async fn run_feishu_channel(
     kernel_ctx: KernelContext,
     runtime: Arc<ChannelOperationRuntimeTracker>,
 ) -> CliResult<()> {
+    if resolved.mode == crate::config::FeishuChannelServeMode::Websocket {
+        return websocket::run_feishu_websocket_channel(
+            config,
+            resolved,
+            resolved_path,
+            selected_by_default,
+            default_account_source,
+            kernel_ctx,
+            runtime,
+        )
+        .await;
+    }
+
     let mut adapter = FeishuAdapter::new(resolved)?;
     adapter.refresh_tenant_token().await?;
 

--- a/crates/app/src/channel/feishu/payload/inbound.rs
+++ b/crates/app/src/channel/feishu/payload/inbound.rs
@@ -31,20 +31,74 @@ const FEISHU_STRUCTURED_ONLY_MESSAGE_TYPES: &[&str] = &[
     "general_calendar",
 ];
 
-pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::channel::feishu) enum FeishuTransportAuth<'a> {
+    Webhook {
+        verification_token: Option<&'a str>,
+        encrypt_key: Option<&'a str>,
+    },
+    Websocket,
+}
+
+impl<'a> FeishuTransportAuth<'a> {
+    pub(in crate::channel::feishu) fn webhook(
+        verification_token: Option<&'a str>,
+        encrypt_key: Option<&'a str>,
+    ) -> Self {
+        Self::Webhook {
+            verification_token,
+            encrypt_key,
+        }
+    }
+
+    pub(in crate::channel::feishu) fn websocket() -> Self {
+        Self::Websocket
+    }
+
+    fn verification_token(self) -> Option<&'a str> {
+        match self {
+            Self::Webhook {
+                verification_token, ..
+            } => verification_token,
+            Self::Websocket => None,
+        }
+    }
+
+    fn encrypt_key(self) -> Option<&'a str> {
+        match self {
+            Self::Webhook { encrypt_key, .. } => encrypt_key,
+            Self::Websocket => None,
+        }
+    }
+
+    fn should_verify_token(self) -> bool {
+        matches!(self, Self::Webhook { .. })
+    }
+
+    fn should_decrypt(self) -> bool {
+        matches!(self, Self::Webhook { .. })
+    }
+}
+
+pub(in crate::channel::feishu) fn parse_feishu_inbound_payload(
     payload: &Value,
-    verification_token: Option<&str>,
-    encrypt_key: Option<&str>,
+    transport_auth: FeishuTransportAuth<'_>,
     allowed_chat_ids: &BTreeSet<String>,
     ignore_bot_messages: bool,
     configured_account_id: &str,
     account_id: &str,
 ) -> CliResult<FeishuWebhookAction> {
-    let decrypted_payload = decrypt_payload_if_needed(payload, encrypt_key)?;
+    let decrypted_payload = if transport_auth.should_decrypt() {
+        decrypt_payload_if_needed(payload, transport_auth.encrypt_key())?
+    } else {
+        None
+    };
     let payload = decrypted_payload.as_ref().unwrap_or(payload);
 
     if payload.get("type").and_then(Value::as_str) == Some("url_verification") {
-        verify_feishu_token(payload, verification_token)?;
+        if transport_auth.should_verify_token() {
+            verify_feishu_token(payload, transport_auth.verification_token())?;
+        }
         let challenge = payload
             .get("challenge")
             .and_then(Value::as_str)
@@ -62,7 +116,9 @@ pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
         .and_then(Value::as_str)
         .unwrap_or_default();
     if event_type == "card.action.trigger" {
-        verify_feishu_token(payload, verification_token)?;
+        if transport_auth.should_verify_token() {
+            verify_feishu_token(payload, transport_auth.verification_token())?;
+        }
         return parse_feishu_card_callback_v2(
             payload,
             allowed_chat_ids,
@@ -71,7 +127,9 @@ pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
         );
     }
     if event_type == "card.action.trigger_v1" || looks_like_feishu_legacy_card_callback(payload) {
-        verify_feishu_token(payload, verification_token)?;
+        if transport_auth.should_verify_token() {
+            verify_feishu_token(payload, transport_auth.verification_token())?;
+        }
         return parse_feishu_card_callback_v1(
             payload,
             allowed_chat_ids,
@@ -83,7 +141,9 @@ pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
         return Ok(FeishuWebhookAction::Ignore);
     }
 
-    verify_feishu_token(payload, verification_token)?;
+    if transport_auth.should_verify_token() {
+        verify_feishu_token(payload, transport_auth.verification_token())?;
+    }
 
     let event = payload
         .get("event")
@@ -178,6 +238,25 @@ pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
         text,
         resources,
     }))
+}
+
+pub(in crate::channel::feishu) fn parse_feishu_webhook_payload(
+    payload: &Value,
+    verification_token: Option<&str>,
+    encrypt_key: Option<&str>,
+    allowed_chat_ids: &BTreeSet<String>,
+    ignore_bot_messages: bool,
+    configured_account_id: &str,
+    account_id: &str,
+) -> CliResult<FeishuWebhookAction> {
+    parse_feishu_inbound_payload(
+        payload,
+        FeishuTransportAuth::webhook(verification_token, encrypt_key),
+        allowed_chat_ids,
+        ignore_bot_messages,
+        configured_account_id,
+        account_id,
+    )
 }
 
 pub(in crate::channel::feishu) fn normalize_webhook_path(path: &str) -> String {

--- a/crates/app/src/channel/feishu/payload/mod.rs
+++ b/crates/app/src/channel/feishu/payload/mod.rs
@@ -3,7 +3,10 @@ mod inbound;
 mod outbound;
 mod types;
 
-pub(super) use inbound::{normalize_webhook_path, parse_feishu_webhook_payload};
+pub(super) use inbound::{
+    FeishuTransportAuth, normalize_webhook_path, parse_feishu_inbound_payload,
+    parse_feishu_webhook_payload,
+};
 #[cfg(test)]
 pub(super) use outbound::build_feishu_send_payload;
 #[allow(unused_imports)]

--- a/crates/app/src/channel/feishu/payload/tests.rs
+++ b/crates/app/src/channel/feishu/payload/tests.rs
@@ -159,6 +159,50 @@ fn feishu_message_event_parses_text_payload() {
 }
 
 #[test]
+fn feishu_websocket_message_event_parses_without_verification_token() {
+    let payload = json!({
+        "header": {
+            "event_id": "evt_ws_1",
+            "event_type": "im.message.receive_v1"
+        },
+        "event": {
+            "sender": {
+                "sender_type": "user",
+                "sender_id": {
+                    "open_id": "ou_sender_ws_1"
+                }
+            },
+            "message": {
+                "chat_id": "oc_123",
+                "message_id": "om_ws_123",
+                "message_type": "text",
+                "content": "{\"text\":\"hello from websocket\"}"
+            }
+        }
+    });
+
+    let allowlist = BTreeSet::from([String::from("oc_123")]);
+    let action = parse_feishu_inbound_payload(
+        &payload,
+        FeishuTransportAuth::websocket(),
+        &allowlist,
+        true,
+        "work",
+        "feishu_cli_a1b2c3",
+    )
+    .expect("parse websocket feishu event");
+
+    let event = expect_inbound(action);
+    assert_eq!(event.event_id, "evt_ws_1");
+    assert_eq!(event.text, "hello from websocket");
+    assert_eq!(event.session.configured_account_id.as_deref(), Some("work"));
+    assert_eq!(
+        event.reply_target,
+        ChannelOutboundTarget::feishu_message_reply("om_ws_123")
+    );
+}
+
+#[test]
 fn feishu_message_event_uses_thread_id_and_sender_open_id_when_present() {
     let payload = json!({
         "token": "token-123",

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -575,13 +575,14 @@ async fn handle_feishu_inbound_event(
     state: &FeishuWebhookState,
     event: super::payload::FeishuInboundEvent,
 ) -> Result<FeishuParsedActionResponse, (StatusCode, String)> {
+    state.runtime.mark_run_start().await.map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("channel runtime start failed: {error}"),
+        )
+    })?;
+
     let result = async {
-        state.runtime.mark_run_start().await.map_err(|error| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("channel runtime start failed: {error}"),
-            )
-        })?;
         let channel_message = ChannelInboundMessage {
             session: event.session,
             reply_target: event.reply_target,
@@ -638,15 +639,12 @@ async fn handle_feishu_inbound_event(
         ))
     }
     .await;
-    let runtime_end_result = state.runtime.mark_run_end().await;
-    match (result, runtime_end_result) {
-        (Ok(reply), Ok(())) => Ok(reply),
-        (Err(error), _) => Err(error),
-        (Ok(_), Err(error)) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("channel runtime end failed: {error}"),
-        )),
+
+    if let Err(error) = state.runtime.mark_run_end().await {
+        log_feishu_inbound_warning("runtime end failed", &error);
     }
+
+    result
 }
 
 fn parse_feishu_structured_callback_response(text: &str) -> Option<FeishuCallbackResponse> {
@@ -798,6 +796,13 @@ fn log_feishu_callback_warning(context: &str, error: &str) {
     }
 }
 
+fn log_feishu_inbound_warning(context: &str, error: &str) {
+    #[allow(clippy::print_stderr)]
+    {
+        eprintln!("warning: feishu inbound {context}: {error}");
+    }
+}
+
 fn map_feishu_parse_error(error: String) -> (StatusCode, String) {
     if let Some(message) = error.strip_prefix("unauthorized:") {
         return (StatusCode::UNAUTHORIZED, message.trim().to_owned());
@@ -875,6 +880,7 @@ fn read_header_required<'a>(
 mod tests {
     use super::*;
     use crate::channel::ChannelPlatform;
+    use crate::channel::runtime_state::start_channel_operation_runtime_tracker_for_test;
     use crate::config::{LoongClawConfig, ProviderConfig};
     use crate::context::{DEFAULT_TOKEN_TTL_S, KernelContext, bootstrap_test_kernel_context};
     use crate::tools::runtime_config::ToolRuntimeConfig;
@@ -1086,6 +1092,34 @@ mod tests {
                                 }
                             })),
                         )
+                    }
+                }
+            }),
+        );
+        spawn_mock_server(router).await
+    }
+
+    async fn spawn_mock_provider_delayed_success_server(
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+        delay: std::time::Duration,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let state = MockServerState { requests };
+        let router = Router::new().route(
+            "/v1/chat/completions",
+            post({
+                let state = state.clone();
+                move |request| {
+                    let state = state.clone();
+                    async move {
+                        record_request(State(state), request).await;
+                        tokio::time::sleep(delay).await;
+                        Json(json!({
+                            "choices": [{
+                                "message": {
+                                    "content": "structured inbound ack"
+                                }
+                            }]
+                        }))
                     }
                 }
             }),
@@ -1662,6 +1696,107 @@ mod tests {
                 .body
                 .contains("\\\"text\\\":\\\"structured inbound ack\\\""),
             "reply body should include provider text"
+        );
+
+        provider_server.abort();
+        feishu_server.abort();
+    }
+
+    #[tokio::test]
+    async fn feishu_webhook_inbound_reply_stays_successful_when_runtime_end_write_fails() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let (provider_base_url, provider_server) = spawn_mock_provider_delayed_success_server(
+            provider_requests.clone(),
+            std::time::Duration::from_millis(50),
+        )
+        .await;
+        let (feishu_base_url, feishu_server) =
+            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_runtime_end").await;
+
+        let config = test_webhook_config(&provider_base_url, &feishu_base_url);
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve feishu account");
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before webhook test");
+        let kernel_ctx = bootstrap_test_kernel_context(
+            "feishu-webhook-runtime-end-failure",
+            DEFAULT_TOKEN_TTL_S,
+        )
+        .expect("bootstrap kernel context");
+        let runtime_dir = temp_webhook_test_dir("runtime-end-failure");
+        std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+        let runtime = Arc::new(
+            start_channel_operation_runtime_tracker_for_test(
+                &runtime_dir,
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+                424242,
+            )
+            .await
+            .expect("start test runtime tracker"),
+        );
+        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+
+        let runtime_dir_for_delete = runtime_dir.clone();
+        let runtime_delete = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            std::fs::remove_dir_all(&runtime_dir_for_delete).expect("remove runtime dir");
+            std::fs::write(&runtime_dir_for_delete, "blocked")
+                .expect("replace runtime dir with file");
+        });
+
+        let payload = json!({
+            "token": "verify-token",
+            "header": {
+                "event_id": "evt_runtime_end_failure",
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "sender": {
+                    "sender_type": "user",
+                    "sender_id": {
+                        "open_id": "ou_sender_runtime_end"
+                    }
+                },
+                "message": {
+                    "chat_id": "oc_demo",
+                    "message_id": "om_runtime_end_1",
+                    "message_type": "text",
+                    "content": "{\"text\":\"runtime end failure should stay acknowledged\"}"
+                }
+            }
+        });
+        let raw_body = serde_json::to_string(&payload).expect("serialize payload");
+        let headers = signed_headers(&raw_body, "encrypt-key");
+        let response = handle_feishu_webhook_payload(
+            state,
+            &headers,
+            raw_body.as_str(),
+            serde_json::from_str(raw_body.as_str()).expect("payload value"),
+        )
+        .await
+        .expect("reply should stay successful even if runtime end bookkeeping fails");
+
+        runtime_delete.await.expect("join runtime file deletion");
+
+        assert_eq!(response.body(), &json!({"code": 0, "msg": "ok"}));
+
+        let provider_requests = provider_requests.lock().await.clone();
+        assert_eq!(provider_requests.len(), 1);
+
+        let feishu_requests = feishu_requests.lock().await.clone();
+        assert_eq!(feishu_requests.len(), 2);
+        assert_eq!(
+            feishu_requests[1].path,
+            "/open-apis/im/v1/messages/om_runtime_end_1/reply"
         );
 
         provider_server.abort();

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -20,6 +20,7 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
+use crate::CliResult;
 use crate::KernelContext;
 use crate::channel::{
     ChannelAdapter, ChannelInboundMessage, ChannelOutboundMessage, ChannelOutboundTarget,
@@ -107,6 +108,27 @@ impl FeishuWebhookState {
             runtime,
         }
     }
+
+    pub(super) fn parse_websocket_payload(
+        &self,
+        payload: &Value,
+    ) -> CliResult<FeishuWebhookAction> {
+        super::payload::parse_feishu_inbound_payload(
+            payload,
+            super::payload::FeishuTransportAuth::websocket(),
+            &self.allowed_chat_ids,
+            self.ignore_bot_messages,
+            self.configured_account_id.as_str(),
+            self.account_id.as_str(),
+        )
+    }
+
+    pub(super) fn dispatch_deferred_updates(
+        &self,
+        updates: Vec<crate::tools::DeferredFeishuCardUpdate>,
+    ) {
+        dispatch_deferred_feishu_card_updates(self.config.clone(), updates);
+    }
 }
 
 struct RecentIdCache {
@@ -166,6 +188,13 @@ struct FeishuStructuredCallbackToast {
 }
 
 #[derive(Debug)]
+pub(super) struct FeishuParsedActionResponse {
+    pub(super) body: Value,
+    pub(super) websocket_body: Option<Value>,
+    pub(super) deferred_updates: Vec<crate::tools::DeferredFeishuCardUpdate>,
+}
+
+#[derive(Debug)]
 struct FeishuWebhookSuccessResponse {
     body: Value,
     post_response_dispatch: Option<FeishuWebhookPostResponseDispatch>,
@@ -211,10 +240,15 @@ impl FeishuCallbackResponse {
 }
 
 impl FeishuWebhookSuccessResponse {
-    fn immediate(body: Value) -> Self {
+    fn from_parsed_response(response: FeishuParsedActionResponse, config: LoongClawConfig) -> Self {
         Self {
-            body,
-            post_response_dispatch: None,
+            body: response.body,
+            post_response_dispatch: (!response.deferred_updates.is_empty()).then_some(
+                FeishuWebhookPostResponseDispatch {
+                    config,
+                    deferred_updates: response.deferred_updates,
+                },
+            ),
         }
     }
 
@@ -222,20 +256,25 @@ impl FeishuWebhookSuccessResponse {
     fn body(&self) -> &Value {
         &self.body
     }
+}
+
+impl FeishuParsedActionResponse {
+    fn immediate(body: Value) -> Self {
+        Self {
+            body,
+            websocket_body: None,
+            deferred_updates: Vec::new(),
+        }
+    }
 
     fn with_deferred_card_updates(
         body: Value,
-        config: LoongClawConfig,
         deferred_updates: Vec<crate::tools::DeferredFeishuCardUpdate>,
     ) -> Self {
         Self {
+            websocket_body: Some(body.clone()),
             body,
-            post_response_dispatch: (!deferred_updates.is_empty()).then_some(
-                FeishuWebhookPostResponseDispatch {
-                    config,
-                    deferred_updates,
-                },
-            ),
+            deferred_updates,
         }
     }
 }
@@ -426,11 +465,22 @@ async fn handle_feishu_webhook_payload(
     )
     .map_err(map_feishu_parse_error)?;
 
+    let response = handle_feishu_parsed_action(&state, parsed).await?;
+    Ok(FeishuWebhookSuccessResponse::from_parsed_response(
+        response,
+        state.config.clone(),
+    ))
+}
+
+pub(super) async fn handle_feishu_parsed_action(
+    state: &FeishuWebhookState,
+    parsed: FeishuWebhookAction,
+) -> Result<FeishuParsedActionResponse, (StatusCode, String)> {
     match parsed {
         FeishuWebhookAction::UrlVerification { challenge } => Ok(
-            FeishuWebhookSuccessResponse::immediate(json!({ "challenge": challenge })),
+            FeishuParsedActionResponse::immediate(json!({ "challenge": challenge })),
         ),
-        FeishuWebhookAction::Ignore => Ok(FeishuWebhookSuccessResponse::immediate(
+        FeishuWebhookAction::Ignore => Ok(FeishuParsedActionResponse::immediate(
             json!({"code": 0, "msg": "ignored"}),
         )),
         FeishuWebhookAction::CardCallback(event) => {
@@ -440,14 +490,14 @@ async fn handle_feishu_webhook_payload(
                     dedupe.begin_processing(&event.event_id),
                     RecentIdReservation::Accepted
                 ) {
-                    return Ok(FeishuWebhookSuccessResponse::immediate(
+                    return Ok(FeishuParsedActionResponse::immediate(
                         FeishuCallbackResponse::Noop.as_json(),
                     ));
                 }
             }
 
             let event_id = event.event_id.clone();
-            let response = handle_feishu_card_callback_event(&state, &event).await;
+            let response = handle_feishu_card_callback_event(state, &event).await;
 
             {
                 let mut dedupe = state.seen_events.lock().await;
@@ -463,85 +513,14 @@ async fn handle_feishu_webhook_payload(
                     dedupe.begin_processing(&event.event_id),
                     RecentIdReservation::Accepted
                 ) {
-                    return Ok(FeishuWebhookSuccessResponse::immediate(
+                    return Ok(FeishuParsedActionResponse::immediate(
                         json!({"code": 0, "msg": "duplicate_event"}),
                     ));
                 }
             }
 
             let event_id = event.event_id.clone();
-            let result = async {
-                state.runtime.mark_run_start().await.map_err(|error| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("channel runtime start failed: {error}"),
-                    )
-                })?;
-                let channel_message = ChannelInboundMessage {
-                    session: event.session,
-                    reply_target: event.reply_target,
-                    text: event.text,
-                    delivery: crate::channel::ChannelDelivery {
-                        ack_cursor: None,
-                        source_message_id: Some(event.message_id),
-                        sender_principal_key: event.principal.as_ref().map(|value| value.storage_key()),
-                        thread_root_id: event.root_id,
-                        parent_message_id: event.parent_id,
-                        resources: event.resources,
-                        feishu_callback: None,
-                    },
-                };
-                let reply = process_inbound_with_provider(
-                    &state.config,
-                    state.resolved_path.as_deref(),
-                    &channel_message,
-                    Some(state.kernel_ctx.as_ref()),
-                )
-                .await
-                .map_err(|error| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("provider processing failed: {error}"),
-                    )
-                })?;
-                let reply_target = channel_message.reply_target.clone();
-                let outbound = ChannelOutboundMessage::Text(reply);
-
-                let mut adapter = state.adapter.lock().await;
-                if let Err(first_error) = adapter.send_message(&reply_target, &outbound).await {
-                    adapter.refresh_tenant_token().await.map_err(|error| {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            format!(
-                                "feishu token refresh failed after send error `{first_error}`: {error}"
-                            ),
-                        )
-                    })?;
-                    adapter
-                        .send_message(&reply_target, &outbound)
-                        .await
-                        .map_err(|error| {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("feishu reply failed after token refresh: {error}"),
-                        )
-                    })?;
-                }
-
-                Ok(FeishuWebhookSuccessResponse::immediate(
-                    json!({"code": 0, "msg": "ok"}),
-                ))
-            }
-            .await;
-            let runtime_end_result = state.runtime.mark_run_end().await;
-            let result = match (result, runtime_end_result) {
-                (Ok(reply), Ok(())) => Ok(reply),
-                (Err(error), _) => Err(error),
-                (Ok(_), Err(error)) => Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("channel runtime end failed: {error}"),
-                )),
-            };
+            let result = handle_feishu_inbound_event(state, event).await;
 
             {
                 let mut dedupe = state.seen_events.lock().await;
@@ -560,10 +539,10 @@ async fn handle_feishu_webhook_payload(
 async fn handle_feishu_card_callback_event(
     state: &FeishuWebhookState,
     event: &FeishuCardCallbackEvent,
-) -> FeishuWebhookSuccessResponse {
+) -> FeishuParsedActionResponse {
     if let Err(error) = state.runtime.mark_run_start().await {
         log_feishu_callback_warning("runtime start failed", &error);
-        return FeishuWebhookSuccessResponse::immediate(FeishuCallbackResponse::Noop.as_json());
+        return FeishuParsedActionResponse::immediate(FeishuCallbackResponse::Noop.as_json());
     }
 
     let inbound = build_feishu_card_callback_inbound_message(event);
@@ -589,11 +568,85 @@ async fn handle_feishu_card_callback_event(
         log_feishu_callback_warning("runtime end failed", &error);
     }
 
-    FeishuWebhookSuccessResponse::with_deferred_card_updates(
-        callback_response,
-        state.config.clone(),
-        deferred_updates,
-    )
+    FeishuParsedActionResponse::with_deferred_card_updates(callback_response, deferred_updates)
+}
+
+async fn handle_feishu_inbound_event(
+    state: &FeishuWebhookState,
+    event: super::payload::FeishuInboundEvent,
+) -> Result<FeishuParsedActionResponse, (StatusCode, String)> {
+    let result = async {
+        state.runtime.mark_run_start().await.map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("channel runtime start failed: {error}"),
+            )
+        })?;
+        let channel_message = ChannelInboundMessage {
+            session: event.session,
+            reply_target: event.reply_target,
+            text: event.text,
+            delivery: crate::channel::ChannelDelivery {
+                ack_cursor: None,
+                source_message_id: Some(event.message_id),
+                sender_principal_key: event.principal.as_ref().map(|value| value.storage_key()),
+                thread_root_id: event.root_id,
+                parent_message_id: event.parent_id,
+                resources: event.resources,
+                feishu_callback: None,
+            },
+        };
+        let reply = process_inbound_with_provider(
+            &state.config,
+            state.resolved_path.as_deref(),
+            &channel_message,
+            Some(state.kernel_ctx.as_ref()),
+        )
+        .await
+        .map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("provider processing failed: {error}"),
+            )
+        })?;
+        let reply_target = channel_message.reply_target.clone();
+        let outbound = ChannelOutboundMessage::Text(reply);
+
+        let mut adapter = state.adapter.lock().await;
+        if let Err(first_error) = adapter.send_message(&reply_target, &outbound).await {
+            adapter.refresh_tenant_token().await.map_err(|error| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "feishu token refresh failed after send error `{first_error}`: {error}"
+                    ),
+                )
+            })?;
+            adapter
+                .send_message(&reply_target, &outbound)
+                .await
+                .map_err(|error| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("feishu reply failed after token refresh: {error}"),
+                    )
+                })?;
+        }
+
+        Ok(FeishuParsedActionResponse::immediate(
+            json!({"code": 0, "msg": "ok"}),
+        ))
+    }
+    .await;
+    let runtime_end_result = state.runtime.mark_run_end().await;
+    match (result, runtime_end_result) {
+        (Ok(reply), Ok(())) => Ok(reply),
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("channel runtime end failed: {error}"),
+        )),
+    }
 }
 
 fn parse_feishu_structured_callback_response(text: &str) -> Option<FeishuCallbackResponse> {

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -1,0 +1,803 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::http::StatusCode;
+use base64::Engine;
+use futures_util::{SinkExt, StreamExt};
+use prost::Message as ProstMessage;
+use serde::Serialize;
+use serde_json::Value;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::CliResult;
+use crate::KernelContext;
+use crate::channel::runtime_state::ChannelOperationRuntimeTracker;
+use crate::config::{
+    ChannelDefaultAccountSelectionSource, LoongClawConfig, ResolvedFeishuChannelConfig,
+};
+use crate::feishu::{FeishuClient, FeishuWsEndpointClientConfig};
+
+use super::adapter::FeishuAdapter;
+use super::webhook::{FeishuParsedActionResponse, FeishuWebhookState, handle_feishu_parsed_action};
+
+const HEADER_BIZ_RT: &str = "biz_rt";
+const HEADER_MESSAGE_ID: &str = "message_id";
+const HEADER_SEQ: &str = "seq";
+const HEADER_SUM: &str = "sum";
+const HEADER_TYPE: &str = "type";
+const MESSAGE_TYPE_PING: &str = "ping";
+const MESSAGE_TYPE_PONG: &str = "pong";
+const FRAME_TYPE_CONTROL: i32 = 0;
+const FRAME_TYPE_DATA: i32 = 1;
+const DEFAULT_WS_RECONNECT_INTERVAL_S: u64 = 120;
+const DEFAULT_WS_PING_INTERVAL_S: u64 = 120;
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct FeishuWsHeader {
+    #[prost(string, tag = "1")]
+    key: String,
+    #[prost(string, tag = "2")]
+    value: String,
+}
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct FeishuWsFrame {
+    #[prost(uint64, tag = "1")]
+    seq_id: u64,
+    #[prost(uint64, tag = "2")]
+    log_id: u64,
+    #[prost(int32, tag = "3")]
+    service: i32,
+    #[prost(int32, tag = "4")]
+    method: i32,
+    #[prost(message, repeated, tag = "5")]
+    headers: Vec<FeishuWsHeader>,
+    #[prost(string, tag = "6")]
+    payload_encoding: String,
+    #[prost(string, tag = "7")]
+    payload_type: String,
+    #[prost(bytes, tag = "8")]
+    payload: Vec<u8>,
+    #[prost(string, tag = "9")]
+    log_id_new: String,
+}
+
+#[derive(Debug, Default)]
+struct FeishuWsFragments {
+    messages: BTreeMap<String, FeishuWsFragmentSet>,
+}
+
+#[derive(Debug)]
+struct FeishuWsFragmentSet {
+    created_at: Instant,
+    total: usize,
+    parts: Vec<Option<Vec<u8>>>,
+}
+
+#[derive(Serialize)]
+struct FeishuWsResponseEnvelope {
+    code: u16,
+    headers: BTreeMap<String, String>,
+    data: Option<String>,
+}
+
+impl FeishuWsFrame {
+    fn header_value(&self, key: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find_map(|header| (header.key == key).then_some(header.value.as_str()))
+    }
+
+    fn header_value_usize(&self, key: &str) -> Option<usize> {
+        self.header_value(key)?.parse::<usize>().ok()
+    }
+
+    fn set_header(&mut self, key: &str, value: impl Into<String>) {
+        let value = value.into();
+        if let Some(header) = self.headers.iter_mut().find(|header| header.key == key) {
+            header.value = value;
+            return;
+        }
+        self.headers.push(FeishuWsHeader {
+            key: key.to_owned(),
+            value,
+        });
+    }
+}
+
+impl FeishuWsFragments {
+    fn combine(
+        &mut self,
+        message_id: &str,
+        total: usize,
+        seq: usize,
+        payload: Vec<u8>,
+    ) -> Option<Vec<u8>> {
+        self.retain_recent();
+        if total <= 1 {
+            return Some(payload);
+        }
+        if message_id.trim().is_empty() || seq >= total {
+            return Some(payload);
+        }
+
+        let entry = self
+            .messages
+            .entry(message_id.to_owned())
+            .or_insert_with(|| FeishuWsFragmentSet {
+                created_at: Instant::now(),
+                total,
+                parts: vec![None; total],
+            });
+        if entry.total != total {
+            *entry = FeishuWsFragmentSet {
+                created_at: Instant::now(),
+                total,
+                parts: vec![None; total],
+            };
+        }
+        if let Some(part) = entry.parts.get_mut(seq) {
+            *part = Some(payload);
+        } else {
+            return Some(payload);
+        }
+        if entry.parts.iter().any(Option::is_none) {
+            return None;
+        }
+
+        let mut combined = Vec::new();
+        for part in entry.parts.iter().flatten() {
+            combined.extend_from_slice(part);
+        }
+        self.messages.remove(message_id);
+        Some(combined)
+    }
+
+    fn retain_recent(&mut self) {
+        let ttl = Duration::from_secs(10);
+        self.messages
+            .retain(|_, set| set.created_at.elapsed() <= ttl);
+    }
+}
+
+pub(super) async fn run_feishu_websocket_channel(
+    config: &LoongClawConfig,
+    resolved: &ResolvedFeishuChannelConfig,
+    resolved_path: &Path,
+    selected_by_default: bool,
+    default_account_source: ChannelDefaultAccountSelectionSource,
+    kernel_ctx: KernelContext,
+    runtime: Arc<ChannelOperationRuntimeTracker>,
+) -> CliResult<()> {
+    let mut adapter = FeishuAdapter::new(resolved)?;
+    adapter.refresh_tenant_token().await?;
+    let state = FeishuWebhookState::new_with_resolved_path(
+        config.clone(),
+        resolved_path.to_path_buf(),
+        resolved,
+        adapter,
+        kernel_ctx,
+        runtime,
+    );
+    let client = FeishuClient::from_configs(resolved, &config.feishu_integration)?;
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!(
+            "feishu channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, mode=websocket)",
+            resolved_path.display(),
+            resolved.configured_account_id,
+            resolved.account.label,
+            selected_by_default,
+            default_account_source.as_str()
+        );
+    }
+
+    loop {
+        let endpoint = client.get_websocket_endpoint().await?;
+        let ws_config = endpoint.client_config.unwrap_or_default();
+        let reconnect_interval = Duration::from_secs(
+            ws_config
+                .reconnect_interval_s
+                .unwrap_or(DEFAULT_WS_RECONNECT_INTERVAL_S)
+                .max(1),
+        );
+
+        if let Err(error) = run_feishu_websocket_session(&state, &endpoint.url, &ws_config).await {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("warning: feishu websocket session ended: {error}");
+            }
+        }
+
+        tokio::time::sleep(reconnect_interval).await;
+    }
+}
+
+async fn run_feishu_websocket_session(
+    state: &FeishuWebhookState,
+    url: &str,
+    ws_config: &FeishuWsEndpointClientConfig,
+) -> CliResult<()> {
+    let parsed_url = reqwest::Url::parse(url)
+        .map_err(|error| format!("parse Feishu websocket URL failed: {error}"))?;
+    let service_id = parsed_url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "service_id").then_some(value))
+        .ok_or_else(|| "Feishu websocket URL missing service_id".to_owned())?
+        .parse::<i32>()
+        .map_err(|error| format!("parse Feishu websocket service_id failed: {error}"))?;
+    let ping_interval_s = ws_config
+        .ping_interval_s
+        .unwrap_or(DEFAULT_WS_PING_INTERVAL_S)
+        .max(1);
+
+    let (mut stream, _) = connect_async(parsed_url.as_str())
+        .await
+        .map_err(|error| format!("connect Feishu websocket failed: {error}"))?;
+    let mut ping_interval = tokio::time::interval(Duration::from_secs(ping_interval_s));
+    ping_interval.tick().await;
+    let mut fragments = FeishuWsFragments::default();
+
+    loop {
+        tokio::select! {
+            _ = ping_interval.tick() => {
+                let ping_frame = FeishuWsFrame {
+                    seq_id: 0,
+                    log_id: 0,
+                    service: service_id,
+                    method: FRAME_TYPE_CONTROL,
+                    headers: vec![FeishuWsHeader {
+                        key: HEADER_TYPE.to_owned(),
+                        value: MESSAGE_TYPE_PING.to_owned(),
+                    }],
+                    payload_encoding: String::new(),
+                    payload_type: String::new(),
+                    payload: Vec::new(),
+                    log_id_new: String::new(),
+                };
+                let mut bytes = Vec::new();
+                ping_frame
+                    .encode(&mut bytes)
+                    .map_err(|error| format!("encode Feishu websocket ping frame failed: {error}"))?;
+                stream
+                    .send(Message::Binary(bytes))
+                    .await
+                    .map_err(|error| format!("send Feishu websocket ping failed: {error}"))?;
+            }
+            maybe_message = stream.next() => {
+                let message = match maybe_message {
+                    Some(Ok(message)) => message,
+                    Some(Err(error)) => {
+                        return Err(format!("read Feishu websocket frame failed: {error}"));
+                    }
+                    None => return Err("Feishu websocket closed by remote peer".to_owned()),
+                };
+
+                match message {
+                    Message::Binary(bytes) => {
+                        let mut frame = FeishuWsFrame::decode(bytes.as_ref())
+                            .map_err(|error| format!("decode Feishu websocket frame failed: {error}"))?;
+                        if frame.method == FRAME_TYPE_CONTROL {
+                            if frame.header_value(HEADER_TYPE) == Some(MESSAGE_TYPE_PONG)
+                                && !frame.payload.is_empty()
+                                && let Ok(config) = serde_json::from_slice::<FeishuWsEndpointClientConfig>(&frame.payload)
+                                && let Some(next_ping_interval_s) = config.ping_interval_s
+                            {
+                                let interval = next_ping_interval_s.max(1);
+                                ping_interval = tokio::time::interval(Duration::from_secs(interval));
+                                ping_interval.tick().await;
+                            }
+                            continue;
+                        }
+                        if frame.method != FRAME_TYPE_DATA {
+                            continue;
+                        }
+
+                        let total = frame.header_value_usize(HEADER_SUM).unwrap_or(1);
+                        let seq = frame.header_value_usize(HEADER_SEQ).unwrap_or(0);
+                        let message_id = frame.header_value(HEADER_MESSAGE_ID).unwrap_or_default().to_owned();
+                        let Some(payload_bytes) = fragments.combine(&message_id, total, seq, frame.payload.clone()) else {
+                            continue;
+                        };
+
+                        let started_at = Instant::now();
+                        let payload = serde_json::from_slice::<Value>(&payload_bytes).map_err(|error| {
+                            format!("decode Feishu websocket event payload failed: {error}")
+                        })?;
+                        let response: FeishuWsOutboundResponse = match state.parse_websocket_payload(&payload) {
+                            Ok(parsed) => match handle_feishu_parsed_action(state, parsed).await {
+                                Ok(response) => build_ws_success_response(response, started_at.elapsed()),
+                                Err((status, message)) => build_ws_error_response(status, started_at.elapsed(), message),
+                            },
+                            Err(error) => build_ws_error_response(map_parse_error_status(&error), started_at.elapsed(), error),
+                        };
+                        let response_bytes = encode_ws_response_frame(&mut frame, &response)?;
+                        let deferred_updates = response.deferred_updates;
+                        stream
+                            .send(Message::Binary(response_bytes))
+                            .await
+                            .map_err(|error| format!("send Feishu websocket response failed: {error}"))?;
+                        state.dispatch_deferred_updates(deferred_updates);
+                    }
+                    Message::Close(_) => return Err("Feishu websocket closed by remote peer".to_owned()),
+                    Message::Ping(_) | Message::Pong(_) | Message::Text(_) | Message::Frame(_) => {}
+                }
+            }
+        }
+    }
+}
+
+fn build_ws_success_response(
+    response: FeishuParsedActionResponse,
+    elapsed: Duration,
+) -> FeishuWsOutboundResponse {
+    FeishuWsOutboundResponse {
+        status: StatusCode::OK,
+        body: response.websocket_body,
+        deferred_updates: response.deferred_updates,
+        biz_rt_ms: elapsed.as_millis() as u64,
+    }
+}
+
+fn build_ws_error_response(
+    status: StatusCode,
+    elapsed: Duration,
+    _message: String,
+) -> FeishuWsOutboundResponse {
+    FeishuWsOutboundResponse {
+        status,
+        body: None,
+        deferred_updates: Vec::new(),
+        biz_rt_ms: elapsed.as_millis() as u64,
+    }
+}
+
+struct FeishuWsOutboundResponse {
+    status: StatusCode,
+    body: Option<Value>,
+    deferred_updates: Vec<crate::tools::DeferredFeishuCardUpdate>,
+    biz_rt_ms: u64,
+}
+
+fn encode_ws_response_frame(
+    frame: &mut FeishuWsFrame,
+    response: &FeishuWsOutboundResponse,
+) -> CliResult<Vec<u8>> {
+    let payload = FeishuWsResponseEnvelope {
+        code: response.status.as_u16(),
+        headers: BTreeMap::new(),
+        data: response
+            .body
+            .as_ref()
+            .map(|body| {
+                serde_json::to_vec(&body)
+                    .map(|bytes| base64::engine::general_purpose::STANDARD.encode(bytes))
+            })
+            .transpose()
+            .map_err(|error| format!("serialize Feishu websocket callback body failed: {error}"))?,
+    };
+    frame.set_header(HEADER_BIZ_RT, response.biz_rt_ms.to_string());
+    frame.payload = serde_json::to_vec(&payload)
+        .map_err(|error| format!("serialize Feishu websocket response payload failed: {error}"))?;
+    let mut bytes = Vec::new();
+    frame
+        .encode(&mut bytes)
+        .map_err(|error| format!("encode Feishu websocket response frame failed: {error}"))?;
+    Ok(bytes)
+}
+
+fn map_parse_error_status(error: &str) -> StatusCode {
+    if error.starts_with("unauthorized:") {
+        return StatusCode::UNAUTHORIZED;
+    }
+    StatusCode::BAD_REQUEST
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use axum::{
+        Json, Router,
+        body::to_bytes,
+        extract::{Request, State},
+        routing::post,
+    };
+    use futures_util::{SinkExt, StreamExt};
+    use serde_json::{Value, json};
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex;
+    use tokio_tungstenite::accept_async;
+
+    use super::*;
+    use crate::channel::ChannelPlatform;
+    use crate::config::{FeishuChannelServeMode, LoongClawConfig, ProviderConfig};
+    use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_test_kernel_context};
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct MockRequest {
+        path: String,
+        authorization: Option<String>,
+        body: String,
+    }
+
+    #[derive(Clone, Default)]
+    struct MockServerState {
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+    }
+
+    fn temp_websocket_test_dir(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "loongclaw-feishu-websocket-{label}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ))
+    }
+
+    async fn spawn_mock_http_server(router: Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock http server");
+        let address = listener.local_addr().expect("mock http server addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("serve mock http server");
+        });
+        (format!("http://{address}"), handle)
+    }
+
+    async fn record_request(State(state): State<MockServerState>, request: Request) {
+        let (parts, body) = request.into_parts();
+        let body = to_bytes(body, usize::MAX)
+            .await
+            .expect("read mock request body");
+        state.requests.lock().await.push(MockRequest {
+            path: parts.uri.path().to_owned(),
+            authorization: parts
+                .headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned),
+            body: String::from_utf8(body.to_vec()).expect("mock request body utf8"),
+        });
+    }
+
+    async fn spawn_mock_provider_server(
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let state = MockServerState { requests };
+        let router = Router::new().route(
+            "/v1/chat/completions",
+            post({
+                let state = state.clone();
+                move |request| {
+                    let state = state.clone();
+                    async move {
+                        record_request(State(state), request).await;
+                        Json(json!({
+                            "choices": [{
+                                "message": {
+                                    "content": "structured inbound ack"
+                                }
+                            }]
+                        }))
+                    }
+                }
+            }),
+        );
+        spawn_mock_http_server(router).await
+    }
+
+    async fn spawn_mock_feishu_api_server(
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+        reply_message_id: &'static str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let state = MockServerState { requests };
+        let router = Router::new()
+            .route(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "tenant_access_token": "t-token-websocket"
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/im/v1/messages/{message_id}/reply",
+                post({
+                    let state = state.clone();
+                    move |axum::extract::Path(message_id): axum::extract::Path<String>, request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "message_id": reply_message_id,
+                                    "root_id": message_id
+                                }
+                            }))
+                        }
+                    }
+                }),
+            );
+        spawn_mock_http_server(router).await
+    }
+
+    fn test_websocket_config(provider_base_url: &str, feishu_base_url: &str) -> LoongClawConfig {
+        let temp_dir = temp_websocket_test_dir("runtime");
+        std::fs::create_dir_all(&temp_dir).expect("create websocket temp dir");
+
+        let mut config = LoongClawConfig {
+            provider: ProviderConfig {
+                base_url: provider_base_url.to_owned(),
+                api_key: Some("test-provider-key".to_owned()),
+                model: "test-model".to_owned(),
+                ..ProviderConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+        config.memory.sqlite_path = temp_dir.join("memory.sqlite3").display().to_string();
+        config.feishu.enabled = true;
+        config.feishu.account_id = Some("feishu_main".to_owned());
+        config.feishu.app_id = Some("cli_a1b2c3".to_owned());
+        config.feishu.app_secret = Some("secret-123".to_owned());
+        config.feishu.base_url = Some(feishu_base_url.to_owned());
+        config.feishu.mode = FeishuChannelServeMode::Websocket;
+        config.feishu.receive_id_type = "chat_id".to_owned();
+        config.feishu.allowed_chat_ids = vec!["oc_demo".to_owned()];
+        config.feishu.verification_token = None;
+        config.feishu.encrypt_key = None;
+        config
+    }
+
+    async fn spawn_mock_ws_server(
+        payload: Value,
+    ) -> (String, tokio::task::JoinHandle<CliResult<FeishuWsFrame>>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock websocket server");
+        let address = listener.local_addr().expect("mock websocket server addr");
+        let handle = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.map_err(|error| error.to_string())?;
+            let mut stream = accept_async(socket)
+                .await
+                .map_err(|error| format!("accept websocket failed: {error}"))?;
+            let request_frame = FeishuWsFrame {
+                seq_id: 1,
+                log_id: 1,
+                service: 42,
+                method: FRAME_TYPE_DATA,
+                headers: vec![
+                    FeishuWsHeader {
+                        key: HEADER_MESSAGE_ID.to_owned(),
+                        value: "evt_ws_inbound_1".to_owned(),
+                    },
+                    FeishuWsHeader {
+                        key: HEADER_SEQ.to_owned(),
+                        value: "0".to_owned(),
+                    },
+                    FeishuWsHeader {
+                        key: HEADER_SUM.to_owned(),
+                        value: "1".to_owned(),
+                    },
+                ],
+                payload_encoding: "json".to_owned(),
+                payload_type: "event".to_owned(),
+                payload: serde_json::to_vec(&payload)
+                    .map_err(|error| format!("encode websocket payload failed: {error}"))?,
+                log_id_new: String::new(),
+            };
+            let mut bytes = Vec::new();
+            request_frame
+                .encode(&mut bytes)
+                .map_err(|error| format!("encode websocket frame failed: {error}"))?;
+            stream
+                .send(Message::Binary(bytes))
+                .await
+                .map_err(|error| format!("send websocket frame failed: {error}"))?;
+
+            loop {
+                let message = stream
+                    .next()
+                    .await
+                    .ok_or_else(|| "websocket client disconnected before replying".to_owned())?
+                    .map_err(|error| format!("read websocket reply failed: {error}"))?;
+                match message {
+                    Message::Binary(bytes) => {
+                        let response = FeishuWsFrame::decode(bytes.as_ref()).map_err(|error| {
+                            format!("decode websocket reply frame failed: {error}")
+                        })?;
+                        stream
+                            .close(None)
+                            .await
+                            .map_err(|error| format!("close websocket server failed: {error}"))?;
+                        return Ok(response);
+                    }
+                    Message::Ping(_) | Message::Pong(_) | Message::Text(_) | Message::Frame(_) => {}
+                    Message::Close(_) => {
+                        return Err("websocket client closed before sending a reply".to_owned());
+                    }
+                }
+            }
+        });
+        (format!("ws://{address}/events?service_id=42"), handle)
+    }
+
+    #[test]
+    fn encode_ws_response_frame_base64_encodes_callback_body() {
+        let mut frame = FeishuWsFrame {
+            seq_id: 7,
+            log_id: 11,
+            service: 42,
+            method: FRAME_TYPE_DATA,
+            headers: vec![],
+            payload_encoding: "json".to_owned(),
+            payload_type: "event".to_owned(),
+            payload: Vec::new(),
+            log_id_new: String::new(),
+        };
+        let response = FeishuWsOutboundResponse {
+            status: StatusCode::OK,
+            body: Some(json!({
+                "toast": {
+                    "type": "success",
+                    "content": "approved"
+                }
+            })),
+            deferred_updates: Vec::new(),
+            biz_rt_ms: 12,
+        };
+
+        let encoded = encode_ws_response_frame(&mut frame, &response).expect("encode response");
+        let decoded = FeishuWsFrame::decode(encoded.as_slice()).expect("decode response frame");
+        let envelope = serde_json::from_slice::<Value>(&decoded.payload).expect("response json");
+
+        assert_eq!(envelope["code"], json!(200));
+        assert_eq!(decoded.header_value(HEADER_BIZ_RT), Some("12"));
+        let data = envelope["data"].as_str().expect("base64 callback body");
+        let body = base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .expect("decode base64 callback body");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).expect("decoded callback body json"),
+            json!({
+                "toast": {
+                    "type": "success",
+                    "content": "approved"
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn feishu_websocket_session_reaches_provider_and_replies() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let (provider_base_url, provider_server) =
+            spawn_mock_provider_server(provider_requests.clone()).await;
+        let (feishu_base_url, feishu_server) =
+            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_ws_1").await;
+
+        let config = test_websocket_config(&provider_base_url, &feishu_base_url);
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve websocket feishu account");
+        assert_eq!(resolved.mode, FeishuChannelServeMode::Websocket);
+
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before websocket test");
+        let kernel_ctx =
+            bootstrap_test_kernel_context("feishu-websocket-test", DEFAULT_TOKEN_TTL_S)
+                .expect("bootstrap kernel context");
+        let runtime = Arc::new(
+            ChannelOperationRuntimeTracker::start(
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+            )
+            .await
+            .expect("start runtime tracker"),
+        );
+        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+
+        let payload = json!({
+            "header": {
+                "event_id": "evt_ws_inbound_1",
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "sender": {
+                    "sender_type": "user",
+                    "sender_id": {
+                        "open_id": "ou_sender_ws_1"
+                    }
+                },
+                "message": {
+                    "chat_id": "oc_demo",
+                    "message_id": "om_inbound_ws_1",
+                    "message_type": "text",
+                    "content": "{\"text\":\"hello over websocket\"}"
+                }
+            }
+        });
+        let (url, ws_server) = spawn_mock_ws_server(payload).await;
+
+        let session_error = run_feishu_websocket_session(
+            &state,
+            url.as_str(),
+            &FeishuWsEndpointClientConfig {
+                ping_interval_s: Some(30),
+                ..FeishuWsEndpointClientConfig::default()
+            },
+        )
+        .await
+        .expect_err("session should end after the mock server closes");
+        assert!(
+            session_error.contains("closed by remote peer"),
+            "unexpected websocket session result: {session_error}"
+        );
+
+        let response_frame = ws_server
+            .await
+            .expect("join websocket server")
+            .expect("capture websocket response frame");
+        let response_envelope =
+            serde_json::from_slice::<Value>(&response_frame.payload).expect("response envelope");
+        assert_eq!(response_envelope["code"], json!(200));
+        assert!(response_envelope["data"].is_null());
+        assert!(
+            response_frame.header_value(HEADER_BIZ_RT).is_some(),
+            "response should include Feishu biz_rt timing"
+        );
+
+        let provider_requests = provider_requests.lock().await.clone();
+        assert_eq!(provider_requests.len(), 1);
+        assert_eq!(provider_requests[0].path, "/v1/chat/completions");
+        assert!(
+            provider_requests[0].body.contains("hello over websocket"),
+            "provider request should include the websocket inbound message"
+        );
+
+        let feishu_requests = feishu_requests.lock().await.clone();
+        assert_eq!(feishu_requests.len(), 2);
+        assert_eq!(
+            feishu_requests[1].path,
+            "/open-apis/im/v1/messages/om_inbound_ws_1/reply"
+        );
+        assert_eq!(
+            feishu_requests[1].authorization.as_deref(),
+            Some("Bearer t-token-websocket")
+        );
+        assert!(
+            feishu_requests[1]
+                .body
+                .contains("\\\"text\\\":\\\"structured inbound ack\\\""),
+            "websocket flow should still send the provider reply back through Feishu"
+        );
+
+        provider_server.abort();
+        feishu_server.abort();
+    }
+}

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -141,6 +141,7 @@ impl FeishuWsFragments {
         }
         if let Some(part) = entry.parts.get_mut(seq) {
             *part = Some(payload);
+            entry.created_at = Instant::now();
         } else {
             return Some(payload);
         }
@@ -197,7 +198,17 @@ pub(super) async fn run_feishu_websocket_channel(
     }
 
     loop {
-        let endpoint = client.get_websocket_endpoint().await?;
+        let endpoint = match client.get_websocket_endpoint().await {
+            Ok(endpoint) => endpoint,
+            Err(error) => {
+                #[allow(clippy::print_stderr)]
+                {
+                    eprintln!("warning: feishu websocket endpoint discovery failed: {error}");
+                }
+                tokio::time::sleep(Duration::from_secs(DEFAULT_WS_RECONNECT_INTERVAL_S)).await;
+                continue;
+            }
+        };
         let ws_config = endpoint.client_config.unwrap_or_default();
         let reconnect_interval = Duration::from_secs(
             ws_config
@@ -559,7 +570,7 @@ mod tests {
         config.feishu.app_id = Some("cli_a1b2c3".to_owned());
         config.feishu.app_secret = Some("secret-123".to_owned());
         config.feishu.base_url = Some(feishu_base_url.to_owned());
-        config.feishu.mode = FeishuChannelServeMode::Websocket;
+        config.feishu.mode = Some(FeishuChannelServeMode::Websocket);
         config.feishu.receive_id_type = "chat_id".to_owned();
         config.feishu.allowed_chat_ids = vec!["oc_demo".to_owned()];
         config.feishu.verification_token = None;
@@ -683,6 +694,52 @@ mod tests {
                     "content": "approved"
                 }
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn feishu_websocket_fragments_refresh_ttl_when_new_chunks_arrive() {
+        let mut fragments = FeishuWsFragments::default();
+        assert_eq!(
+            fragments.combine("evt_ws_fragments", 3, 0, b"hel".to_vec()),
+            None
+        );
+
+        fragments
+            .messages
+            .get_mut("evt_ws_fragments")
+            .expect("fragment entry after first chunk")
+            .created_at = Instant::now() - Duration::from_millis(9_900);
+
+        assert_eq!(
+            fragments.combine("evt_ws_fragments", 3, 1, b"lo ".to_vec()),
+            None
+        );
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert_eq!(
+            fragments.combine("evt_ws_fragments", 3, 2, b"ws".to_vec()),
+            Some(b"hello ws".to_vec()),
+            "recent fragment progress should keep the in-flight assembly alive"
+        );
+    }
+
+    #[tokio::test]
+    async fn feishu_websocket_wss_urls_do_not_fail_due_to_missing_tls_support() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind disposable tcp listener");
+        let address = listener.local_addr().expect("disposable listener addr");
+        drop(listener);
+
+        let error = connect_async(format!("wss://{address}/events?service_id=42"))
+            .await
+            .expect_err("closed port should reject the wss connection");
+
+        assert!(
+            !error.to_string().contains("TLS support not compiled in"),
+            "wss support must be compiled in for Feishu websocket mode: {error}"
         );
     }
 

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use crate::config::{
     ChannelDefaultAccountSelectionSource, FEISHU_APP_ID_ENV, FEISHU_APP_SECRET_ENV,
-    FEISHU_ENCRYPT_KEY_ENV, FEISHU_VERIFICATION_TOKEN_ENV, LoongClawConfig,
+    FEISHU_ENCRYPT_KEY_ENV, FEISHU_VERIFICATION_TOKEN_ENV, FeishuChannelServeMode, LoongClawConfig,
     MATRIX_ACCESS_TOKEN_ENV, ResolvedFeishuChannelConfig, ResolvedMatrixChannelConfig,
     ResolvedTelegramChannelConfig, TELEGRAM_BOT_TOKEN_ENV,
 };
@@ -451,7 +451,7 @@ const FEISHU_SEND_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
 
 const FEISHU_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     id: CHANNEL_OPERATION_SERVE_ID,
-    label: "webhook reply server",
+    label: "inbound reply service",
     command: "feishu-serve",
     availability: ChannelCatalogOperationAvailability::Implemented,
     tracks_runtime: true,
@@ -511,10 +511,18 @@ const FEISHU_ALLOWED_CHAT_IDS_REQUIREMENT: ChannelCatalogOperationRequirement =
         env_pointer_paths: &[],
         default_env_var: None,
     };
+const FEISHU_MODE_REQUIREMENT: ChannelCatalogOperationRequirement =
+    ChannelCatalogOperationRequirement {
+        id: "mode",
+        label: "serve mode",
+        config_paths: &["feishu.mode", "feishu.accounts.<account>.mode"],
+        env_pointer_paths: &[],
+        default_env_var: None,
+    };
 const FEISHU_VERIFICATION_TOKEN_REQUIREMENT: ChannelCatalogOperationRequirement =
     ChannelCatalogOperationRequirement {
         id: "verification_token",
-        label: "verification token",
+        label: "verification token (webhook mode only)",
         config_paths: &[
             "feishu.verification_token",
             "feishu.accounts.<account>.verification_token",
@@ -528,7 +536,7 @@ const FEISHU_VERIFICATION_TOKEN_REQUIREMENT: ChannelCatalogOperationRequirement 
 const FEISHU_ENCRYPT_KEY_REQUIREMENT: ChannelCatalogOperationRequirement =
     ChannelCatalogOperationRequirement {
         id: "encrypt_key",
-        label: "encrypt key",
+        label: "encrypt key (webhook mode only)",
         config_paths: &[
             "feishu.encrypt_key",
             "feishu.accounts.<account>.encrypt_key",
@@ -548,6 +556,7 @@ const FEISHU_SERVE_REQUIREMENTS: &[ChannelCatalogOperationRequirement] = &[
     FEISHU_ENABLED_REQUIREMENT,
     FEISHU_APP_ID_REQUIREMENT,
     FEISHU_APP_SECRET_REQUIREMENT,
+    FEISHU_MODE_REQUIREMENT,
     FEISHU_ALLOWED_CHAT_IDS_REQUIREMENT,
     FEISHU_VERIFICATION_TOKEN_REQUIREMENT,
     FEISHU_ENCRYPT_KEY_REQUIREMENT,
@@ -559,11 +568,11 @@ const FEISHU_SEND_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorChec
 }];
 const FEISHU_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[
     ChannelDoctorCheckSpec {
-        name: "feishu webhook verification",
+        name: "feishu inbound transport",
         trigger: ChannelDoctorCheckTrigger::OperationHealth,
     },
     ChannelDoctorCheckSpec {
-        name: "feishu webhook runtime",
+        name: "feishu serve runtime",
         trigger: ChannelDoctorCheckTrigger::ReadyRuntime,
     },
 ];
@@ -586,7 +595,7 @@ const FEISHU_CAPABILITIES: &[ChannelCapability] = &[
 ];
 const FEISHU_ONBOARDING_DESCRIPTOR: ChannelOnboardingDescriptor = ChannelOnboardingDescriptor {
     strategy: ChannelOnboardingStrategy::ManualConfig,
-    setup_hint: "configure feishu or lark app credentials and webhook secrets in loongclaw.toml under feishu or feishu.accounts.<account>",
+    setup_hint: "configure feishu or lark app credentials, allowed chat ids, and either webhook secrets or mode = \"websocket\" in loongclaw.toml under feishu or feishu.accounts.<account>",
     status_command: "loongclaw doctor",
     repair_command: Some("loongclaw doctor --fix"),
 };
@@ -834,7 +843,7 @@ const CHANNEL_REGISTRY: &[ChannelRegistryDescriptor] = &[
         capabilities: FEISHU_CAPABILITIES,
         label: "Feishu/Lark",
         aliases: &["lark"],
-        transport: "feishu_openapi_webhook",
+        transport: "feishu_openapi_webhook_or_websocket",
         onboarding: FEISHU_ONBOARDING_DESCRIPTOR,
         operations: FEISHU_OPERATIONS,
     },
@@ -1387,11 +1396,13 @@ fn build_feishu_snapshot_for_account(
     {
         serve_issues.push("allowed_chat_ids is empty".to_owned());
     }
-    if resolved.verification_token().is_none() {
-        serve_issues.push("verification_token is missing".to_owned());
-    }
-    if resolved.encrypt_key().is_none() {
-        serve_issues.push("encrypt_key is missing".to_owned());
+    if resolved.mode == FeishuChannelServeMode::Webhook {
+        if resolved.verification_token().is_none() {
+            serve_issues.push("verification_token is missing".to_owned());
+        }
+        if resolved.encrypt_key().is_none() {
+            serve_issues.push("encrypt_key is missing".to_owned());
+        }
     }
 
     let send_operation = if !compiled {
@@ -1449,10 +1460,13 @@ fn build_feishu_snapshot_for_account(
         format!("configured_account={}", resolved.configured_account_label),
         format!("account_id={}", resolved.account.id),
         format!("account={}", resolved.account.label),
+        format!("mode={}", resolved.mode.as_str()),
         format!("receive_id_type={}", resolved.receive_id_type),
-        format!("webhook_bind={}", resolved.webhook_bind),
-        format!("webhook_path={}", resolved.webhook_path),
     ];
+    if resolved.mode == FeishuChannelServeMode::Webhook {
+        notes.push(format!("webhook_bind={}", resolved.webhook_bind));
+        notes.push(format!("webhook_path={}", resolved.webhook_path));
+    }
     if !resolved.acp.bootstrap_mcp_servers.is_empty() {
         notes.push(format!(
             "acp_bootstrap_mcp_servers={}",
@@ -2074,7 +2088,7 @@ mod tests {
                 .iter()
                 .map(|check| check.name)
                 .collect::<Vec<_>>(),
-            vec!["feishu webhook verification", "feishu webhook runtime"]
+            vec!["feishu inbound transport", "feishu serve runtime"]
         );
 
         let discord_send =
@@ -2198,11 +2212,11 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 (
-                    "feishu webhook verification",
+                    "feishu inbound transport",
                     ChannelDoctorCheckTrigger::OperationHealth,
                 ),
                 (
-                    "feishu webhook runtime",
+                    "feishu serve runtime",
                     ChannelDoctorCheckTrigger::ReadyRuntime,
                 ),
             ]
@@ -2429,17 +2443,18 @@ mod tests {
                 "enabled",
                 "app_id",
                 "app_secret",
+                "mode",
                 "allowed_chat_ids",
                 "verification_token",
                 "encrypt_key",
             ]
         );
         assert_eq!(
-            feishu.operations[1].requirements[4].default_env_var,
+            feishu.operations[1].requirements[5].default_env_var,
             Some("FEISHU_VERIFICATION_TOKEN")
         );
         assert_eq!(
-            feishu.operations[1].requirements[5].default_env_var,
+            feishu.operations[1].requirements[6].default_env_var,
             Some("FEISHU_ENCRYPT_KEY")
         );
 
@@ -2867,6 +2882,57 @@ mod tests {
         assert!(
             serve.issues.iter().any(|issue| issue.contains("user_id")),
             "serve issues should require user_id when ignore_self_messages is enabled"
+        );
+    }
+
+    #[test]
+    fn feishu_websocket_status_uses_websocket_requirements() {
+        let mut config = LoongClawConfig::default();
+        config.feishu.enabled = true;
+        config.feishu.app_id = Some("app-id".to_owned());
+        config.feishu.app_secret = Some("app-secret".to_owned());
+        config.feishu.mode = crate::config::FeishuChannelServeMode::Websocket;
+        config.feishu.allowed_chat_ids = vec!["oc_123".to_owned()];
+
+        let snapshots = channel_status_snapshots(&config);
+        let feishu = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "feishu")
+            .expect("feishu snapshot");
+        let serve = feishu.operation("serve").expect("feishu serve operation");
+
+        assert_eq!(serve.health, ChannelOperationHealth::Ready);
+        assert!(
+            serve
+                .issues
+                .iter()
+                .all(|issue| !issue.contains("verification_token")),
+            "websocket mode must not require a webhook verification token"
+        );
+        assert!(
+            serve
+                .issues
+                .iter()
+                .all(|issue| !issue.contains("encrypt_key")),
+            "websocket mode must not require a webhook encrypt key"
+        );
+        assert!(
+            feishu.notes.iter().any(|note| note == "mode=websocket"),
+            "status notes should surface the configured feishu serve mode"
+        );
+        assert!(
+            feishu
+                .notes
+                .iter()
+                .all(|note| !note.starts_with("webhook_bind=")),
+            "websocket mode notes should not imply a webhook bind address is active"
+        );
+        assert!(
+            feishu
+                .notes
+                .iter()
+                .all(|note| !note.starts_with("webhook_path=")),
+            "websocket mode notes should not imply a webhook callback path is active"
         );
     }
 

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -2891,7 +2891,7 @@ mod tests {
         config.feishu.enabled = true;
         config.feishu.app_id = Some("app-id".to_owned());
         config.feishu.app_secret = Some("app-secret".to_owned());
-        config.feishu.mode = crate::config::FeishuChannelServeMode::Websocket;
+        config.feishu.mode = Some(crate::config::FeishuChannelServeMode::Websocket);
         config.feishu.allowed_chat_ids = vec!["oc_123".to_owned()];
 
         let snapshots = channel_status_snapshots(&config);

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -378,6 +378,8 @@ pub struct FeishuAccountConfig {
     #[serde(default)]
     pub base_url: Option<String>,
     #[serde(default)]
+    pub mode: Option<FeishuChannelServeMode>,
+    #[serde(default)]
     pub receive_id_type: Option<String>,
     #[serde(default)]
     pub webhook_bind: Option<String>,
@@ -399,6 +401,23 @@ pub struct FeishuAccountConfig {
     pub acp: Option<ChannelAcpConfig>,
 }
 
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FeishuChannelServeMode {
+    #[default]
+    Webhook,
+    Websocket,
+}
+
+impl FeishuChannelServeMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Webhook => "webhook",
+            Self::Websocket => "websocket",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedFeishuChannelConfig {
     pub configured_account_id: String,
@@ -411,6 +430,7 @@ pub struct ResolvedFeishuChannelConfig {
     pub app_secret_env: Option<String>,
     pub domain: FeishuDomain,
     pub base_url: Option<String>,
+    pub mode: FeishuChannelServeMode,
     pub receive_id_type: String,
     pub webhook_bind: String,
     pub webhook_path: String,
@@ -530,6 +550,8 @@ pub struct FeishuChannelConfig {
     pub domain: FeishuDomain,
     #[serde(default)]
     pub base_url: Option<String>,
+    #[serde(default)]
+    pub mode: FeishuChannelServeMode,
     #[serde(default = "default_feishu_receive_id_type")]
     pub receive_id_type: String,
     #[serde(default = "default_feishu_webhook_bind")]
@@ -840,6 +862,7 @@ impl Default for FeishuChannelConfig {
             app_secret_env: Some(FEISHU_APP_SECRET_ENV.to_owned()),
             domain: FeishuDomain::Feishu,
             base_url: None,
+            mode: FeishuChannelServeMode::Webhook,
             receive_id_type: default_feishu_receive_id_type(),
             webhook_bind: default_feishu_webhook_bind(),
             webhook_path: default_feishu_webhook_path(),
@@ -1027,6 +1050,9 @@ impl FeishuChannelConfig {
             base_url: account_override
                 .and_then(|account| account.base_url.clone())
                 .or_else(|| self.base_url.clone()),
+            mode: account_override
+                .and_then(|account| account.mode)
+                .unwrap_or(self.mode),
             receive_id_type: account_override
                 .and_then(|account| account.receive_id_type.clone())
                 .unwrap_or_else(|| self.receive_id_type.clone()),
@@ -1073,6 +1099,7 @@ impl FeishuChannelConfig {
             app_secret_env: merged.app_secret_env,
             domain: merged.domain,
             base_url: merged.base_url,
+            mode: merged.mode,
             receive_id_type: merged.receive_id_type,
             webhook_bind: merged.webhook_bind,
             webhook_path: merged.webhook_path,
@@ -2102,6 +2129,7 @@ mod tests {
     fn feishu_multi_account_resolution_merges_base_and_account_overrides() {
         let config: FeishuChannelConfig = serde_json::from_value(json!({
             "enabled": true,
+            "mode": "webhook",
             "app_id_env": "BASE_FEISHU_APP_ID",
             "app_secret_env": "BASE_FEISHU_APP_SECRET",
             "verification_token_env": "BASE_FEISHU_VERIFY",
@@ -2160,6 +2188,7 @@ mod tests {
             Some(std::path::PathBuf::from("/workspace/lark-prod"))
         );
         assert_eq!(resolved.receive_id_type, "chat_id");
+        assert_eq!(resolved.mode, FeishuChannelServeMode::Webhook);
         assert_eq!(resolved.resolved_base_url(), "https://open.larksuite.com");
 
         let disabled = config
@@ -2176,6 +2205,48 @@ mod tests {
             disabled.acp.resolved_working_directory(),
             Some(std::path::PathBuf::from("/workspace/base"))
         );
+    }
+
+    #[test]
+    fn feishu_mode_defaults_to_webhook_when_not_configured() {
+        let config: FeishuChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "app_id": "cli_a1b2c3",
+            "app_secret": "secret"
+        }))
+        .expect("deserialize feishu config");
+
+        let resolved = config
+            .resolve_account(None)
+            .expect("resolve default feishu account");
+
+        assert_eq!(resolved.mode, FeishuChannelServeMode::Webhook);
+    }
+
+    #[test]
+    fn feishu_multi_account_resolution_allows_websocket_mode_override() {
+        let config: FeishuChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "mode": "webhook",
+            "app_id": "cli_base",
+            "app_secret": "base-secret",
+            "allowed_chat_ids": ["oc_base"],
+            "accounts": {
+                "Long Connection": {
+                    "mode": "websocket",
+                    "app_id": "cli_ws",
+                    "app_secret": "ws-secret"
+                }
+            }
+        }))
+        .expect("deserialize feishu config");
+
+        let resolved = config
+            .resolve_account(Some("Long Connection"))
+            .expect("resolve websocket feishu account");
+
+        assert_eq!(resolved.mode, FeishuChannelServeMode::Websocket);
+        assert_eq!(resolved.allowed_chat_ids, vec!["oc_base".to_owned()]);
     }
 
     #[test]

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -551,7 +551,7 @@ pub struct FeishuChannelConfig {
     #[serde(default)]
     pub base_url: Option<String>,
     #[serde(default)]
-    pub mode: FeishuChannelServeMode,
+    pub mode: Option<FeishuChannelServeMode>,
     #[serde(default = "default_feishu_receive_id_type")]
     pub receive_id_type: String,
     #[serde(default = "default_feishu_webhook_bind")]
@@ -862,7 +862,7 @@ impl Default for FeishuChannelConfig {
             app_secret_env: Some(FEISHU_APP_SECRET_ENV.to_owned()),
             domain: FeishuDomain::Feishu,
             base_url: None,
-            mode: FeishuChannelServeMode::Webhook,
+            mode: None,
             receive_id_type: default_feishu_receive_id_type(),
             webhook_bind: default_feishu_webhook_bind(),
             webhook_path: default_feishu_webhook_path(),
@@ -1052,7 +1052,7 @@ impl FeishuChannelConfig {
                 .or_else(|| self.base_url.clone()),
             mode: account_override
                 .and_then(|account| account.mode)
-                .unwrap_or(self.mode),
+                .or(self.mode),
             receive_id_type: account_override
                 .and_then(|account| account.receive_id_type.clone())
                 .unwrap_or_else(|| self.receive_id_type.clone()),
@@ -1099,7 +1099,7 @@ impl FeishuChannelConfig {
             app_secret_env: merged.app_secret_env,
             domain: merged.domain,
             base_url: merged.base_url,
-            mode: merged.mode,
+            mode: merged.mode.unwrap_or_default(),
             receive_id_type: merged.receive_id_type,
             webhook_bind: merged.webhook_bind,
             webhook_path: merged.webhook_path,

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -14,10 +14,10 @@ pub use audit::{AuditConfig, AuditMode};
 pub use channels::{
     ChannelAcpConfig, ChannelDefaultAccountSelection, ChannelDefaultAccountSelectionSource,
     ChannelDescriptor, ChannelResolvedAccountRoute, ChannelRuntimeKind, CliChannelConfig,
-    FeishuAccountConfig, FeishuChannelConfig, FeishuDomain, MatrixAccountConfig,
-    MatrixChannelConfig, ResolvedFeishuChannelConfig, ResolvedMatrixChannelConfig,
-    ResolvedTelegramChannelConfig, TelegramAccountConfig, TelegramChannelConfig,
-    channel_descriptor, service_channel_descriptors,
+    FeishuAccountConfig, FeishuChannelConfig, FeishuChannelServeMode, FeishuDomain,
+    MatrixAccountConfig, MatrixChannelConfig, ResolvedFeishuChannelConfig,
+    ResolvedMatrixChannelConfig, ResolvedTelegramChannelConfig, TelegramAccountConfig,
+    TelegramChannelConfig, channel_descriptor, service_channel_descriptors,
 };
 #[allow(unused_imports)]
 pub(crate) use channels::{

--- a/crates/app/src/feishu/client.rs
+++ b/crates/app/src/feishu/client.rs
@@ -206,48 +206,84 @@ impl FeishuClient {
         }
 
         let url = self.build_open_api_url("/callback/ws/endpoint")?;
-        let response = self
-            .http
-            .post(url)
-            .header("locale", "zh")
-            .json(&json!({
-                "AppID": self.app_id(),
-                "AppSecret": self.app_secret(),
-            }))
-            .send()
-            .await
-            .map_err(|error| format!("request Feishu websocket endpoint failed: {error}"))?;
-        let status = response.status();
-        let body = response.text().await.map_err(|error| {
-            format!("read Feishu websocket endpoint response body failed: {error}")
-        })?;
-        if !status.is_success() {
-            return Err(format!(
-                "request Feishu websocket endpoint failed with status {}: {}",
-                status.as_u16(),
-                body
-            ));
+        let max_attempts = self.retry_policy.max_attempts.max(1);
+
+        for attempt in 1..=max_attempts {
+            match self
+                .http
+                .post(url.clone())
+                .header("locale", "zh")
+                .json(&json!({
+                    "AppID": self.app_id(),
+                    "AppSecret": self.app_secret(),
+                }))
+                .send()
+                .await
+            {
+                Ok(response) => {
+                    let status = response.status();
+                    let headers = response.headers().clone();
+                    let body = match response.text().await {
+                        Ok(body) => body,
+                        Err(error) => {
+                            if attempt < max_attempts {
+                                sleep(self.retry_policy.backoff_for_retry(attempt)).await;
+                                continue;
+                            }
+                            return Err(format!(
+                                "read Feishu websocket endpoint response body failed: {error}"
+                            ));
+                        }
+                    };
+                    if !status.is_success() {
+                        if attempt < max_attempts && is_retryable_json_failure(status, None) {
+                            sleep(retry_delay_for_attempt(
+                                &self.retry_policy,
+                                &headers,
+                                attempt,
+                            ))
+                            .await;
+                            continue;
+                        }
+                        return Err(format!(
+                            "request Feishu websocket endpoint failed with status {}: {}",
+                            status.as_u16(),
+                            body
+                        ));
+                    }
+
+                    let envelope: FeishuWsEndpointEnvelope =
+                        serde_json::from_str(&body).map_err(|error| {
+                            format!("decode Feishu websocket endpoint response failed: {error}")
+                        })?;
+                    if envelope.code != 0 {
+                        return Err(format!(
+                            "request Feishu websocket endpoint failed with code {}: {}",
+                            envelope.code, envelope.msg
+                        ));
+                    }
+
+                    let endpoint = envelope.data.ok_or_else(|| {
+                        "Feishu websocket endpoint response missing data".to_owned()
+                    })?;
+                    let endpoint_url = endpoint.url.trim();
+                    if endpoint_url.is_empty() {
+                        return Err("Feishu websocket endpoint response missing URL".to_owned());
+                    }
+
+                    return Ok(endpoint);
+                }
+                Err(error) => {
+                    if attempt < max_attempts && (error.is_timeout() || error.is_connect()) {
+                        sleep(self.retry_policy.backoff_for_retry(attempt)).await;
+                        continue;
+                    }
+                    return Err(format!("request Feishu websocket endpoint failed: {error}"));
+                }
+            }
         }
 
-        let envelope: FeishuWsEndpointEnvelope = serde_json::from_str(&body).map_err(|error| {
-            format!("decode Feishu websocket endpoint response failed: {error}")
-        })?;
-        if envelope.code != 0 {
-            return Err(format!(
-                "request Feishu websocket endpoint failed with code {}: {}",
-                envelope.code, envelope.msg
-            ));
-        }
-
-        let endpoint = envelope
-            .data
-            .ok_or_else(|| "Feishu websocket endpoint response missing data".to_owned())?;
-        let url = endpoint.url.trim();
-        if url.is_empty() {
-            return Err("Feishu websocket endpoint response missing URL".to_owned());
-        }
-
-        Ok(endpoint)
+        Err("feishu websocket endpoint retry loop exhausted without returning a result".to_owned())
     }
 
     pub async fn exchange_authorization_code(
@@ -1042,6 +1078,109 @@ mod tests {
         assert_eq!(
             payload.content_disposition.as_deref(),
             Some("attachment; filename=\"spec-sheet.pdf\"")
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn get_websocket_endpoint_retries_transient_server_error_then_succeeds() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let router = Router::new().route(
+            "/callback/ws/endpoint",
+            post({
+                let attempts = attempts.clone();
+                move || {
+                    let attempts = attempts.clone();
+                    async move {
+                        let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            return Response::builder()
+                                .status(StatusCode::SERVICE_UNAVAILABLE)
+                                .header("retry-after", "0")
+                                .body(Body::from("temporary outage"))
+                                .expect("build retry response");
+                        }
+
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header("content-type", "application/json")
+                            .body(Body::from(
+                                serde_json::json!({
+                                    "code": 0,
+                                    "msg": "ok",
+                                    "data": {
+                                        "URL": "wss://example.feishu.cn/ws?service_id=42",
+                                        "ClientConfig": {
+                                            "ReconnectInterval": 7
+                                        }
+                                    }
+                                })
+                                .to_string(),
+                            ))
+                            .expect("build websocket endpoint response")
+                    }
+                }
+            }),
+        );
+        let (base_url, server) = spawn_mock_feishu_server(router).await;
+        let mut client = FeishuClient::new(base_url, "cli_xxx", "secret_xxx", 20).expect("client");
+        client.retry_policy.max_attempts = 2;
+        client.retry_policy.initial_backoff_ms = 0;
+        client.retry_policy.max_backoff_ms = 0;
+
+        let endpoint = client
+            .get_websocket_endpoint()
+            .await
+            .expect("transient websocket endpoint failures should retry and recover");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(endpoint.url, "wss://example.feishu.cn/ws?service_id=42");
+        assert_eq!(
+            endpoint
+                .client_config
+                .expect("client config after endpoint recovery")
+                .reconnect_interval_s,
+            Some(7)
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn get_websocket_endpoint_does_not_retry_non_retryable_feishu_error() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let router = Router::new().route(
+            "/callback/ws/endpoint",
+            post({
+                let attempts = attempts.clone();
+                move || {
+                    let attempts = attempts.clone();
+                    async move {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        Json(serde_json::json!({
+                            "code": 20001,
+                            "msg": "invalid app credentials"
+                        }))
+                    }
+                }
+            }),
+        );
+        let (base_url, server) = spawn_mock_feishu_server(router).await;
+        let mut client = FeishuClient::new(base_url, "cli_xxx", "secret_xxx", 20).expect("client");
+        client.retry_policy.max_attempts = 2;
+        client.retry_policy.initial_backoff_ms = 0;
+        client.retry_policy.max_backoff_ms = 0;
+
+        let error = client
+            .get_websocket_endpoint()
+            .await
+            .expect_err("fatal websocket endpoint errors should surface immediately");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            error,
+            "request Feishu websocket endpoint failed with code 20001: invalid app credentials"
         );
 
         server.abort();

--- a/crates/app/src/feishu/client.rs
+++ b/crates/app/src/feishu/client.rs
@@ -72,6 +72,26 @@ pub struct FeishuUserInfo {
     pub tenant_key: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct FeishuWsEndpointClientConfig {
+    #[serde(rename = "ReconnectCount", default)]
+    pub reconnect_count: Option<u64>,
+    #[serde(rename = "ReconnectInterval", default)]
+    pub reconnect_interval_s: Option<u64>,
+    #[serde(rename = "ReconnectNonce", default)]
+    pub reconnect_nonce_s: Option<u64>,
+    #[serde(rename = "PingInterval", default)]
+    pub ping_interval_s: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeishuWsEndpoint {
+    #[serde(rename = "URL")]
+    pub url: String,
+    #[serde(rename = "ClientConfig", default)]
+    pub client_config: Option<FeishuWsEndpointClientConfig>,
+}
+
 impl FeishuClient {
     pub fn new(
         base_url: impl Into<String>,
@@ -175,6 +195,59 @@ impl FeishuClient {
             }
         }
         Ok(url)
+    }
+
+    pub async fn get_websocket_endpoint(&self) -> CliResult<FeishuWsEndpoint> {
+        #[derive(Debug, Deserialize)]
+        struct FeishuWsEndpointEnvelope {
+            code: i64,
+            msg: String,
+            data: Option<FeishuWsEndpoint>,
+        }
+
+        let url = self.build_open_api_url("/callback/ws/endpoint")?;
+        let response = self
+            .http
+            .post(url)
+            .header("locale", "zh")
+            .json(&json!({
+                "AppID": self.app_id(),
+                "AppSecret": self.app_secret(),
+            }))
+            .send()
+            .await
+            .map_err(|error| format!("request Feishu websocket endpoint failed: {error}"))?;
+        let status = response.status();
+        let body = response.text().await.map_err(|error| {
+            format!("read Feishu websocket endpoint response body failed: {error}")
+        })?;
+        if !status.is_success() {
+            return Err(format!(
+                "request Feishu websocket endpoint failed with status {}: {}",
+                status.as_u16(),
+                body
+            ));
+        }
+
+        let envelope: FeishuWsEndpointEnvelope = serde_json::from_str(&body).map_err(|error| {
+            format!("decode Feishu websocket endpoint response failed: {error}")
+        })?;
+        if envelope.code != 0 {
+            return Err(format!(
+                "request Feishu websocket endpoint failed with code {}: {}",
+                envelope.code, envelope.msg
+            ));
+        }
+
+        let endpoint = envelope
+            .data
+            .ok_or_else(|| "Feishu websocket endpoint response missing data".to_owned())?;
+        let url = endpoint.url.trim();
+        if url.is_empty() {
+            return Err("Feishu websocket endpoint response missing URL".to_owned());
+        }
+
+        Ok(endpoint)
     }
 
     pub async fn exchange_authorization_code(

--- a/crates/app/src/feishu/mod.rs
+++ b/crates/app/src/feishu/mod.rs
@@ -14,7 +14,10 @@ pub use auth::{
     parse_token_exchange_response, summarize_doc_write_scope_status,
     summarize_message_write_scope_status,
 };
-pub use client::{FeishuClient, FeishuUserInfo, parse_user_info_response};
+pub use client::{
+    FeishuClient, FeishuUserInfo, FeishuWsEndpoint, FeishuWsEndpointClientConfig,
+    parse_user_info_response,
+};
 pub use error::FeishuApiError;
 pub use outbound::{
     FeishuOperatorOutboundMessageInput, parse_post_json_argument,

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -948,8 +948,8 @@ fn doctor_check_spec(channel_id: &str, operation_id: &str) -> Option<DoctorChann
             runtime_name: None,
         }),
         ("feishu", "serve") => Some(DoctorChannelCheckSpec {
-            config_name: "feishu webhook verification",
-            runtime_name: Some("feishu webhook runtime"),
+            config_name: "feishu inbound transport",
+            runtime_name: Some("feishu serve runtime"),
         }),
         ("matrix", "send") => Some(DoctorChannelCheckSpec {
             config_name: "matrix channel",
@@ -1843,6 +1843,10 @@ mod tests {
             "ready matrix serve surfaces should emit runtime checks in live doctor output: {checks:#?}"
         );
         assert!(
+            names.contains(&"feishu channel") && names.contains(&"feishu inbound transport"),
+            "feishu send/serve surfaces should appear in live doctor output: {checks:#?}"
+        );
+        assert!(
             checks
                 .iter()
                 .any(|check| check.name == "matrix room sync"
@@ -2433,14 +2437,14 @@ mod tests {
                 mvp::config::ChannelDefaultAccountSelectionSource::RuntimeIdentity,
             label: "Feishu/Lark",
             aliases: vec!["lark"],
-            transport: "feishu_openapi_webhook",
+            transport: "feishu_openapi_webhook_or_websocket",
             compiled: true,
             enabled: true,
             api_base_url: Some("https://open.feishu.cn".to_owned()),
             notes: Vec::new(),
             operations: vec![ChannelOperationStatus {
                 id: "serve",
-                label: "webhook reply server",
+                label: "inbound reply service",
                 command: "feishu-serve",
                 health: ChannelOperationHealth::Ready,
                 detail: "ready".to_owned(),
@@ -2466,7 +2470,7 @@ mod tests {
 
         assert!(
             checks.iter().any(|check| {
-                check.name == "feishu webhook runtime"
+                check.name == "feishu serve runtime"
                     && check.level == DoctorCheckLevel::Fail
                     && check.detail.contains("stale")
                     && check.detail.contains("pid=4242")
@@ -2540,7 +2544,7 @@ mod tests {
                 mvp::config::ChannelDefaultAccountSelectionSource::ExplicitDefault,
             label: "Feishu/Lark",
             aliases: vec!["lark"],
-            transport: "feishu_openapi_webhook",
+            transport: "feishu_openapi_webhook_or_websocket",
             compiled: true,
             enabled: true,
             api_base_url: Some("https://open.feishu.cn".to_owned()),
@@ -2555,7 +2559,7 @@ mod tests {
             ],
             operations: vec![ChannelOperationStatus {
                 id: "serve",
-                label: "webhook reply server",
+                label: "inbound reply service",
                 command: "feishu-serve",
                 health: ChannelOperationHealth::Ready,
                 detail: "ready".to_owned(),

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -53,7 +53,7 @@ pub enum FeishuCommand {
     Send(FeishuSendArgs),
     /// Reply to one Feishu message or thread with text, post, image, file, or card content
     Reply(FeishuReplyArgs),
-    /// Run Feishu webhook serve mode
+    /// Run Feishu serve mode (webhook or websocket)
     Serve(FeishuServeArgs),
 }
 

--- a/crates/daemon/src/migration/channels/feishu.rs
+++ b/crates/daemon/src/migration/channels/feishu.rs
@@ -29,6 +29,7 @@ pub(super) fn collect_preview(
         || config.feishu.app_id_env != default_feishu.app_id_env
         || config.feishu.app_secret_env != default_feishu.app_secret_env
         || config.feishu.base_url != default_feishu.base_url
+        || config.feishu.mode != default_feishu.mode
         || config.feishu.receive_id_type != default_feishu.receive_id_type
         || config.feishu.webhook_bind != default_feishu.webhook_bind
         || config.feishu.webhook_path != default_feishu.webhook_path
@@ -108,14 +109,7 @@ pub(super) fn collect_preflight_checks(
     config: &mvp::config::LoongClawConfig,
 ) -> Vec<ChannelPreflightCheck> {
     let credential_state = readiness_state(config);
-    let verification_token = crate::doctor_cli::resolve_secret_value(
-        config.feishu.verification_token.as_deref(),
-        config.feishu.verification_token_env.as_deref(),
-    );
-    let encrypt_key = crate::doctor_cli::resolve_secret_value(
-        config.feishu.encrypt_key.as_deref(),
-        config.feishu.encrypt_key_env.as_deref(),
-    );
+    let (transport_level, transport_detail) = inbound_transport_check(config);
 
     vec![
         ChannelPreflightCheck {
@@ -132,17 +126,9 @@ pub(super) fn collect_preflight_checks(
             },
         },
         ChannelPreflightCheck {
-            name: "feishu webhook verification",
-            level: if verification_token.is_some() || encrypt_key.is_some() {
-                ChannelCheckLevel::Pass
-            } else {
-                ChannelCheckLevel::Warn
-            },
-            detail: if verification_token.is_some() || encrypt_key.is_some() {
-                "verification token or encrypt key is configured".to_owned()
-            } else {
-                "verification token and encrypt key are both missing".to_owned()
-            },
+            name: "feishu inbound transport",
+            level: transport_level,
+            detail: transport_detail,
         },
     ]
 }
@@ -151,14 +137,7 @@ pub(super) fn collect_doctor_checks(
     config: &mvp::config::LoongClawConfig,
 ) -> Vec<ChannelDoctorCheck> {
     let credential_state = readiness_state(config);
-    let verification_token = crate::doctor_cli::resolve_secret_value(
-        config.feishu.verification_token.as_deref(),
-        config.feishu.verification_token_env.as_deref(),
-    );
-    let encrypt_key = crate::doctor_cli::resolve_secret_value(
-        config.feishu.encrypt_key.as_deref(),
-        config.feishu.encrypt_key_env.as_deref(),
-    );
+    let (transport_level, transport_detail) = inbound_transport_check(config);
 
     vec![
         ChannelDoctorCheck {
@@ -175,17 +154,9 @@ pub(super) fn collect_doctor_checks(
             },
         },
         ChannelDoctorCheck {
-            name: "feishu webhook verification",
-            level: if verification_token.is_some() || encrypt_key.is_some() {
-                ChannelCheckLevel::Pass
-            } else {
-                ChannelCheckLevel::Warn
-            },
-            detail: if verification_token.is_some() || encrypt_key.is_some() {
-                "verification token or encrypt key is configured".to_owned()
-            } else {
-                "verification token and encrypt key are both missing".to_owned()
-            },
+            name: "feishu inbound transport",
+            level: transport_level,
+            detail: transport_detail,
         },
     ]
 }
@@ -251,6 +222,10 @@ fn merge_feishu_config(
         target.base_url = source.base_url.clone();
         changed = true;
     }
+    if target.mode == default.mode && source.mode != default.mode {
+        target.mode = source.mode;
+        changed = true;
+    }
     if target.receive_id_type == default.receive_id_type
         && source.receive_id_type != default.receive_id_type
     {
@@ -299,4 +274,34 @@ fn merge_feishu_config(
 
 fn descriptor() -> &'static mvp::config::ChannelDescriptor {
     mvp::config::channel_descriptor(ID).unwrap_or(&FALLBACK_DESCRIPTOR)
+}
+
+fn inbound_transport_check(config: &mvp::config::LoongClawConfig) -> (ChannelCheckLevel, String) {
+    if config.feishu.mode == mvp::config::FeishuChannelServeMode::Websocket {
+        return (
+            ChannelCheckLevel::Pass,
+            "websocket mode configured; webhook secrets are not required".to_owned(),
+        );
+    }
+
+    let verification_token = crate::doctor_cli::resolve_secret_value(
+        config.feishu.verification_token.as_deref(),
+        config.feishu.verification_token_env.as_deref(),
+    );
+    let encrypt_key = crate::doctor_cli::resolve_secret_value(
+        config.feishu.encrypt_key.as_deref(),
+        config.feishu.encrypt_key_env.as_deref(),
+    );
+    if verification_token.is_some() || encrypt_key.is_some() {
+        (
+            ChannelCheckLevel::Pass,
+            "webhook verification token or encrypt key is configured".to_owned(),
+        )
+    } else {
+        (
+            ChannelCheckLevel::Warn,
+            "webhook mode is configured but verification_token and encrypt_key are both missing"
+                .to_owned(),
+        )
+    }
 }

--- a/crates/daemon/src/migration/channels/feishu.rs
+++ b/crates/daemon/src/migration/channels/feishu.rs
@@ -29,7 +29,7 @@ pub(super) fn collect_preview(
         || config.feishu.app_id_env != default_feishu.app_id_env
         || config.feishu.app_secret_env != default_feishu.app_secret_env
         || config.feishu.base_url != default_feishu.base_url
-        || config.feishu.mode != default_feishu.mode
+        || config.feishu.mode.is_some()
         || config.feishu.receive_id_type != default_feishu.receive_id_type
         || config.feishu.webhook_bind != default_feishu.webhook_bind
         || config.feishu.webhook_path != default_feishu.webhook_path
@@ -176,18 +176,20 @@ pub(super) fn apply_default_env_bindings(config: &mut mvp::config::LoongClawConf
         "set feishu.app_secret_env",
         &mut fixes,
     );
-    ensure_default_env_binding(
-        &mut config.feishu.verification_token_env,
-        default.verification_token_env.as_deref(),
-        "set feishu.verification_token_env",
-        &mut fixes,
-    );
-    ensure_default_env_binding(
-        &mut config.feishu.encrypt_key_env,
-        default.encrypt_key_env.as_deref(),
-        "set feishu.encrypt_key_env",
-        &mut fixes,
-    );
+    if config.feishu.mode.unwrap_or_default() != mvp::config::FeishuChannelServeMode::Websocket {
+        ensure_default_env_binding(
+            &mut config.feishu.verification_token_env,
+            default.verification_token_env.as_deref(),
+            "set feishu.verification_token_env",
+            &mut fixes,
+        );
+        ensure_default_env_binding(
+            &mut config.feishu.encrypt_key_env,
+            default.encrypt_key_env.as_deref(),
+            "set feishu.encrypt_key_env",
+            &mut fixes,
+        );
+    }
     fixes
 }
 
@@ -222,7 +224,7 @@ fn merge_feishu_config(
         target.base_url = source.base_url.clone();
         changed = true;
     }
-    if target.mode == default.mode && source.mode != default.mode {
+    if target.mode.is_none() && source.mode.is_some() {
         target.mode = source.mode;
         changed = true;
     }
@@ -277,7 +279,7 @@ fn descriptor() -> &'static mvp::config::ChannelDescriptor {
 }
 
 fn inbound_transport_check(config: &mvp::config::LoongClawConfig) -> (ChannelCheckLevel, String) {
-    if config.feishu.mode == mvp::config::FeishuChannelServeMode::Websocket {
+    if config.feishu.mode.unwrap_or_default() == mvp::config::FeishuChannelServeMode::Websocket {
         return (
             ChannelCheckLevel::Pass,
             "websocket mode configured; webhook secrets are not required".to_owned(),
@@ -303,5 +305,87 @@ fn inbound_transport_check(config: &mvp::config::LoongClawConfig) -> (ChannelChe
             "webhook mode is configured but verification_token and encrypt_key are both missing"
                 .to_owned(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_config(raw: &str) -> mvp::config::LoongClawConfig {
+        toml::from_str(raw).expect("deserialize loongclaw config")
+    }
+
+    #[test]
+    fn merge_preserves_explicit_top_level_webhook_mode() {
+        let mut target = parse_config(
+            r#"
+            [feishu]
+            mode = "webhook"
+            "#,
+        );
+        let source = parse_config(
+            r#"
+            [feishu]
+            mode = "websocket"
+            "#,
+        );
+
+        assert!(
+            !apply(&mut target, &source),
+            "an explicit top-level webhook selection should leave the merged config unchanged"
+        );
+        assert_eq!(
+            target
+                .feishu
+                .resolve_account(None)
+                .expect("resolve merged feishu config")
+                .mode,
+            mvp::config::FeishuChannelServeMode::Webhook,
+            "an explicit top-level webhook selection must not be replaced by a later websocket source"
+        );
+    }
+
+    #[test]
+    fn websocket_mode_skips_default_webhook_secret_bindings() {
+        let mut config = parse_config(
+            r#"
+            [feishu]
+            mode = "websocket"
+            "#,
+        );
+        config.feishu.app_id_env = None;
+        config.feishu.app_secret_env = None;
+        config.feishu.verification_token_env = None;
+        config.feishu.encrypt_key_env = None;
+
+        let fixes = apply_default_env_bindings(&mut config);
+
+        assert!(
+            fixes
+                .iter()
+                .any(|fix| fix.starts_with("set feishu.app_id_env=")),
+            "websocket mode still needs default app_id env guidance"
+        );
+        assert!(
+            fixes
+                .iter()
+                .any(|fix| fix.starts_with("set feishu.app_secret_env=")),
+            "websocket mode still needs default app_secret env guidance"
+        );
+        assert!(
+            fixes
+                .iter()
+                .all(|fix| !fix.starts_with("set feishu.verification_token_env=")),
+            "websocket mode must not auto-fill webhook verification secrets"
+        );
+        assert!(
+            fixes
+                .iter()
+                .all(|fix| !fix.starts_with("set feishu.encrypt_key_env=")),
+            "websocket mode must not auto-fill webhook encrypt secrets"
+        );
+        assert!(config.feishu.verification_token_env.is_none());
+        assert!(config.feishu.encrypt_key_env.is_none());
     }
 }

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -868,10 +868,10 @@ fn channel_registry_collects_preflight_checks_for_enabled_channels() {
     );
     assert!(
         checks.iter().any(|check| {
-            check.name == "feishu webhook verification"
+            check.name == "feishu inbound transport"
                 && check.level == loongclaw_daemon::migration::channels::ChannelCheckLevel::Pass
         }),
-        "registry preflight should include feishu webhook verification readiness: {checks:#?}"
+        "registry preflight should include feishu inbound transport readiness: {checks:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -360,7 +360,7 @@ fn render_channel_surfaces_text_reports_aliases_and_operation_health() {
         channel_send_command("feishu")
     )));
     assert!(rendered.contains(&format!(
-        "op serve ({}) misconfigured: allowed_chat_ids is empty; verification_token is missing; encrypt_key is missing target_kinds=message_reply requirements=enabled,app_id,app_secret,allowed_chat_ids,verification_token,encrypt_key",
+        "op serve ({}) misconfigured: allowed_chat_ids is empty; verification_token is missing; encrypt_key is missing target_kinds=message_reply requirements=enabled,app_id,app_secret,mode,allowed_chat_ids,verification_token,encrypt_key",
         channel_serve_command("feishu")
     )));
     assert!(rendered.contains("running=false"));
@@ -595,6 +595,7 @@ fn build_channels_cli_json_payload_includes_operation_requirement_metadata() {
                     "enabled",
                     "app_id",
                     "app_secret",
+                    "mode",
                     "allowed_chat_ids",
                     "verification_token",
                     "encrypt_key",

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -1815,10 +1815,10 @@ fn channel_preflight_checks_report_enabled_channels() {
     );
     assert!(
         checks.iter().any(|check| {
-            check.name == "feishu webhook verification"
+            check.name == "feishu inbound transport"
                 && check.level == loongclaw_daemon::onboard_cli::OnboardCheckLevel::Pass
         }),
-        "feishu verification should pass when a verification token is configured: {checks:#?}"
+        "feishu inbound transport should pass when a supported transport is configured: {checks:#?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Problem:
  feishu-serve only supported webhook delivery, so issue #274 could not run Feishu/Lark inbound traffic over the official websocket persistent-connection mode.
- Why it matters:
  teams that rely on persistent connections could not onboard Feishu without forking the runtime or rewriting transport handling outside LoongClaw.
- What changed:
  added `feishu.mode` with webhook/websocket resolution, implemented websocket endpoint discovery and session handling for `feishu-serve`, shared webhook and websocket payload processing through one parsed-action path, made registry/doctor/migration surfaces mode-aware, and documented websocket setup in both READMEs.
- What did not change (scope boundary):
  webhook mode behavior, Feishu outbound reply semantics, and existing card-callback handling remain in place; this PR does not change unrelated channel runtimes.

## Linked Issues

- Closes #274
- Related: none

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  websocket frame handling is new Feishu transport runtime code, and the serve-mode contract now has webhook-vs-websocket conditional requirements.
- Rollout / guardrails:
  webhook remains the default mode; websocket is opt-in via `feishu.mode = "websocket"`; registry, doctor, onboarding, and docs now surface the active mode explicitly.
- Rollback path:
  switch the affected account back to `mode = "webhook"`, or revert commit `9778f77` if the websocket runtime needs to be backed out entirely.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo test -p loongclaw-app channel::registry::
cargo test -p loongclaw-app channel::feishu::
cargo test -p loongclaw-daemon doctor_cli::tests::channel_doctor_checks_report_enabled_channels_from_registry -- --exact
cargo test -p loongclaw-daemon integration::migration::channel_registry_collects_preflight_checks_for_enabled_channels -- --exact
cargo test -p loongclaw-daemon integration::onboard_cli::channel_preflight_checks_report_enabled_channels -- --exact
cargo test --workspace --locked
cargo test --workspace --all-features --locked
cargo clippy --workspace --all-targets --all-features -- -D warnings

All commands passed on the final branch state. Added explicit regression coverage for websocket payload parsing, websocket session reply flow, and websocket-aware channel registry readiness.

One unrelated daemon integration test (`integration::spec_runtime_bridge::process_stdio::execute_spec_process_stdio_bridge_fails_on_response_id_mismatch`) flaked once during the first `cargo test --workspace --locked` run, then passed on an exact rerun and on the final full locked workspace rerun. The failure did not touch the Feishu code paths changed in this PR.
```

## User-visible / Operator-visible Changes

- `feishu-serve` now supports `feishu.mode = "websocket"` in addition to the existing webhook mode.
- Channel inventory, doctor checks, onboarding migration checks, and CLI/docs now describe the active Feishu serve mode instead of assuming webhook-only requirements.

## Failure Recovery

- Fast rollback or disable path:
  set `feishu.mode = "webhook"` for the affected account and keep the existing webhook secrets, or revert commit `9778f77`.
- Observable failure symptoms reviewers should watch for:
  websocket endpoint acquisition failures, repeated websocket reconnect loops, or channel doctor output that still reports webhook-only requirements for websocket accounts.

## Reviewer Focus

- Review `crates/app/src/channel/feishu/websocket.rs` for frame assembly, ack payloads, and reconnect behavior.
- Review `crates/app/src/channel/feishu/webhook.rs` shared parsed-action flow to confirm webhook and websocket now share the same root-cause handling without diverging reply semantics.
- Review `crates/app/src/channel/registry.rs` and `crates/daemon/src/migration/channels/feishu.rs` for mode-aware readiness and onboarding behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Feishu WebSocket channel mode alongside webhook; defaults remain webhook.
  * App can fetch and use Feishu websocket endpoints with automatic reconnect/ping behavior.

* **Documentation**
  * README (EN/ZH) updated with websocket-mode examples, env vars, config snippets, and serve command usage.
  * CLI help updated to describe serve mode supporting webhook or websocket.

* **Bug Fixes / UX**
  * Improved onboarding, readiness checks, and diagnostics to reflect mode-specific requirements.

* **Tests**
  * Added tests and integrations covering websocket flows, parsing, and mode-dependent checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->