### PR TITLE
fix: preflight missing managed provider credentials for model discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ kind = "openai"
 api_key = "${PROVIDER_API_KEY}"
 ```
 
-Volcengine Coding Plan / ARK example:
+Volcengine / ARK example:
 
 ```bash
 export ARK_API_KEY=your-ark-api-key
@@ -253,6 +253,8 @@ api_key = "${ARK_API_KEY}"
 base_url = "https://ark.cn-beijing.volces.com"
 chat_completions_path = "/api/v3/chat/completions"
 ```
+
+Both `volcengine` and `volcengine_coding` use `api_key = "${ARK_API_KEY}"`. LoongClaw sends that value as `Authorization: Bearer <ARK_API_KEY>` on the OpenAI-compatible Volcengine path; AK/SK request signing is not used there.
 
 Feishu channel example:
 

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -1060,6 +1060,59 @@ impl ProviderConfig {
         }
     }
 
+    pub fn auth_hint_env_names(&self) -> Vec<String> {
+        let mut env_names = Vec::new();
+        push_inline_env_reference(&mut env_names, self.oauth_access_token.as_deref());
+        push_inline_env_reference(&mut env_names, self.api_key.as_deref());
+        for env_name in self.credential_env_names() {
+            push_unique_env_key(&mut env_names, Some(env_name.as_str()));
+        }
+        env_names
+    }
+
+    pub fn requires_explicit_auth_configuration(&self) -> bool {
+        !self.auth_hint_env_names().is_empty()
+    }
+
+    pub fn auth_guidance_hint(&self) -> Option<String> {
+        if self.kind.feature_family() == ProviderFeatureFamily::Volcengine {
+            let provider_label = if matches!(
+                self.kind,
+                ProviderKind::Byteplus | ProviderKind::ByteplusCoding
+            ) {
+                "BytePlus"
+            } else {
+                "Volcengine"
+            };
+            let env_name = self
+                .kind
+                .default_api_key_env()
+                .unwrap_or("PROVIDER_API_KEY");
+            Some(format!(
+                "LoongClaw's {provider_label} OpenAI-compatible path uses `provider.api_key` / `{env_name}` and sends `Authorization: Bearer <{env_name}>`; AK/SK request signing is not used on this path"
+            ))
+        } else {
+            None
+        }
+    }
+
+    pub fn missing_auth_configuration_message(&self) -> String {
+        let env_names = self.auth_hint_env_names();
+        let mut message = if env_names.is_empty() {
+            "provider credentials are missing; configure provider credentials or add supported auth headers".to_owned()
+        } else {
+            format!(
+                "provider credentials are missing; configure provider credentials or set {} in env",
+                env_names.join(", ")
+            )
+        };
+        if let Some(hint) = self.auth_guidance_hint() {
+            message.push(' ');
+            message.push_str(hint.as_str());
+        }
+        message
+    }
+
     pub fn transport_policy(&self) -> ProviderTransportPolicy {
         let request_endpoint = self.endpoint();
         let models_endpoint = self.models_endpoint();
@@ -3143,6 +3196,13 @@ fn push_unique_env_key(keys: &mut Vec<String>, maybe_key: Option<&str>) {
         return;
     }
     keys.push(trimmed.to_owned());
+}
+
+fn push_inline_env_reference(keys: &mut Vec<String>, maybe_secret: Option<&str>) {
+    let Some(secret) = non_empty(maybe_secret) else {
+        return;
+    };
+    push_unique_env_key(keys, parse_explicit_env_reference(secret));
 }
 
 fn non_empty(value: Option<&str>) -> Option<&str> {

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -1098,19 +1098,35 @@ impl ProviderConfig {
 
     pub fn missing_auth_configuration_message(&self) -> String {
         let env_names = self.auth_hint_env_names();
-        let mut message = if env_names.is_empty() {
-            "provider credentials are missing; configure provider credentials or add supported auth headers".to_owned()
-        } else {
-            format!(
-                "provider credentials are missing; configure provider credentials or set {} in env",
-                env_names.join(", ")
-            )
-        };
+        let mut configuration_paths = vec!["configure provider credentials".to_owned()];
+        if !env_names.is_empty() {
+            configuration_paths.push(format!("set {} in env", env_names.join(", ")));
+        }
+        if let Some(hint) = self.alternative_auth_configuration_hint() {
+            configuration_paths.push(hint);
+        }
+        let mut message = format!(
+            "provider credentials are missing; {}",
+            join_guidance_options(&configuration_paths)
+        );
         if let Some(hint) = self.auth_guidance_hint() {
             message.push(' ');
             message.push_str(hint.as_str());
         }
         message
+    }
+
+    fn alternative_auth_configuration_hint(&self) -> Option<String> {
+        if self.kind == ProviderKind::Bedrock {
+            Some(
+                "configure AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY with AWS_REGION or AWS_DEFAULT_REGION for SigV4"
+                    .to_owned(),
+            )
+        } else if self.kind == ProviderKind::Custom {
+            Some("add `Authorization` / `X-API-Key` in `provider.headers`".to_owned())
+        } else {
+            None
+        }
     }
 
     pub fn transport_policy(&self) -> ProviderTransportPolicy {
@@ -3203,6 +3219,24 @@ fn push_inline_env_reference(keys: &mut Vec<String>, maybe_secret: Option<&str>)
         return;
     };
     push_unique_env_key(keys, parse_explicit_env_reference(secret));
+}
+
+fn join_guidance_options(options: &[String]) -> String {
+    let Some((last, rest)) = options.split_last() else {
+        return String::new();
+    };
+
+    if let [first] = rest {
+        return format!("{first} or {last}");
+    }
+    if rest.is_empty() {
+        return last.clone();
+    }
+
+    let mut joined = rest.join(", ");
+    joined.push_str(", or ");
+    joined.push_str(last);
+    joined
 }
 
 fn non_empty(value: Option<&str>) -> Option<&str> {

--- a/crates/app/src/provider/catalog_executor.rs
+++ b/crates/app/src/provider/catalog_executor.rs
@@ -26,6 +26,29 @@ enum CatalogStatusOutcome {
     Fail,
 }
 
+fn render_catalog_status_failure_message(
+    provider: &ProviderConfig,
+    status_code: u16,
+    attempt: usize,
+    max_attempts: usize,
+    response_body: &serde_json::Value,
+) -> String {
+    let mut message = format!(
+        "provider model-list returned status {status_code} on attempt {attempt}/{max_attempts}: {response_body}"
+    );
+    if matches!(status_code, 401 | 403) {
+        if let Some(hint) = provider.auth_guidance_hint() {
+            message.push(' ');
+            message.push_str(hint.as_str());
+        }
+        if let Some(hint) = provider.region_endpoint_failure_hint() {
+            message.push(' ');
+            message.push_str(hint.as_str());
+        }
+    }
+    message
+}
+
 fn plan_catalog_status_outcome(
     attempt: usize,
     request_policy: &ProviderRequestPolicy,
@@ -121,9 +144,12 @@ pub(super) async fn fetch_available_models_with_policy(
                     CatalogStatusOutcome::Fail => {}
                 }
 
-                return Err(format!(
-                    "provider model-list returned status {status_code} on attempt {attempt}/{max_attempts}: {response_body}",
-                    max_attempts = runtime.request_policy.max_attempts
+                return Err(render_catalog_status_failure_message(
+                    runtime.provider,
+                    status_code,
+                    attempt,
+                    runtime.request_policy.max_attempts,
+                    &response_body,
                 ));
             }
             Err(transport::RequestExecutionError::Transport(error)) => {

--- a/crates/app/src/provider/catalog_query_runtime.rs
+++ b/crates/app/src/provider/catalog_query_runtime.rs
@@ -9,7 +9,8 @@ use super::profile_health_runtime::{
     mark_provider_profile_success, prioritize_provider_auth_profiles_by_health,
 };
 use super::provider_validation_runtime::{
-    validate_provider_configuration, validate_provider_feature_gate,
+    validate_provider_auth_readiness, validate_provider_configuration,
+    validate_provider_feature_gate,
 };
 
 pub(super) async fn fetch_available_models_with_profiles(
@@ -17,6 +18,7 @@ pub(super) async fn fetch_available_models_with_profiles(
 ) -> CliResult<Vec<String>> {
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
+    validate_provider_auth_readiness(config).await?;
     let auth_context = super::transport::resolve_request_auth_context(&config.provider).await?;
     let headers = super::transport::build_request_headers_without_provider_auth(&config.provider)?;
     let request_policy = policy::ProviderRequestPolicy::from_config(&config.provider);

--- a/crates/app/src/provider/provider_validation_runtime.rs
+++ b/crates/app/src/provider/provider_validation_runtime.rs
@@ -67,6 +67,18 @@ pub(super) fn validate_provider_configuration(config: &LoongClawConfig) -> CliRe
     Ok(())
 }
 
+pub(super) async fn validate_provider_auth_readiness(config: &LoongClawConfig) -> CliResult<()> {
+    if !config.provider.requires_explicit_auth_configuration() {
+        return Ok(());
+    }
+
+    if super::provider_auth_ready(config).await {
+        return Ok(());
+    }
+
+    Err(config.provider.missing_auth_configuration_message())
+}
+
 fn provider_uses_kimi_coding_endpoint(provider: &ProviderConfig) -> bool {
     is_kimi_coding_endpoint(provider.endpoint().as_str())
         || provider

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -96,11 +96,15 @@ fn render_status_failure_message(
     let mut message = format!(
         "provider returned status {status_code} for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}"
     );
-    if matches!(reason, ProviderFailoverReason::AuthRejected)
-        && let Some(hint) = provider.request_region_endpoint_failure_hint()
-    {
-        message.push(' ');
-        message.push_str(hint.as_str());
+    if matches!(reason, ProviderFailoverReason::AuthRejected) {
+        if let Some(hint) = provider.auth_guidance_hint() {
+            message.push(' ');
+            message.push_str(hint.as_str());
+        }
+        if let Some(hint) = provider.request_region_endpoint_failure_hint() {
+            message.push(' ');
+            message.push_str(hint.as_str());
+        }
     }
     message
 }

--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -15,7 +15,8 @@ use super::profile_health_runtime::{
 use super::profile_state_backend::ensure_provider_profile_state_backend;
 use super::provider_keyspace::build_model_candidate_cooldown_namespace;
 use super::provider_validation_runtime::{
-    validate_provider_configuration, validate_provider_feature_gate,
+    validate_provider_auth_readiness, validate_provider_configuration,
+    validate_provider_feature_gate,
 };
 
 pub(super) struct ProviderRequestSession {
@@ -36,6 +37,7 @@ pub(super) async fn prepare_provider_request_session(
 ) -> CliResult<ProviderRequestSession> {
     validate_provider_configuration(config)?;
     validate_provider_feature_gate(config)?;
+    validate_provider_auth_readiness(config).await?;
     ensure_provider_profile_state_backend(config);
 
     let endpoint = config.provider.endpoint();

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -19,6 +19,13 @@ use std::sync::{
 };
 use tokio::sync::{Barrier, Notify};
 
+const OPENAI_AUTH_ENV_KEYS: &[&str] = &[
+    "OPENAI_CODEX_OAUTH_TOKEN",
+    "OPENAI_OAUTH_ACCESS_TOKEN",
+    "OPENAI_API_KEY",
+];
+const VOLCENGINE_AUTH_ENV_KEYS: &[&str] = &["ARK_API_KEY"];
+
 fn build_provider_failover_test_kernel_context(
     agent_id: &str,
 ) -> (KernelContext, Arc<InMemoryAuditSink>) {
@@ -168,7 +175,7 @@ async fn fetch_available_models_rejects_missing_volcengine_credentials_before_ne
         requests
     });
 
-    let config = test_config(ProviderConfig {
+    let provider = ProviderConfig {
         kind: ProviderKind::Volcengine,
         base_url: format!("http://{addr}"),
         model: "auto".to_owned(),
@@ -177,7 +184,10 @@ async fn fetch_available_models_rejects_missing_volcengine_credentials_before_ne
         oauth_access_token: None,
         oauth_access_token_env: None,
         ..ProviderConfig::default()
-    });
+    };
+    let mut env = ScopedEnv::new();
+    clear_provider_auth_envs(&mut env, VOLCENGINE_AUTH_ENV_KEYS);
+    let config = test_config(provider);
 
     let error = fetch_available_models(&config)
         .await
@@ -204,23 +214,39 @@ async fn fetch_available_models_enriches_volcengine_auth_failures_with_ark_guida
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider listener");
     let addr = listener.local_addr().expect("local addr");
     let server = std::thread::spawn(move || {
+        listener
+            .set_nonblocking(true)
+            .expect("set listener nonblocking");
+        let deadline = Instant::now() + Duration::from_millis(250);
         let mut requests = Vec::new();
-        let (mut stream, _) = listener.accept().expect("accept local provider request");
-        let mut request_buf = [0_u8; 8192];
-        let len = stream.read(&mut request_buf).expect("read request");
-        let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
-        requests.push(request);
+        loop {
+            if Instant::now() >= deadline {
+                panic!("timed out waiting for local provider request");
+            }
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut request_buf = [0_u8; 8192];
+                    let len = stream.read(&mut request_buf).expect("read request");
+                    let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
+                    requests.push(request);
 
-        let body = r#"{"error":{"code":"AuthenticationError","message":"the API key or AK/SK in the request is missing or invalid","type":"Unauthorized"}}"#;
-        let response = format!(
-            "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        stream
-            .write_all(response.as_bytes())
-            .expect("write response");
-        requests
+                    let body = r#"{"error":{"code":"AuthenticationError","message":"the API key or AK/SK in the request is missing or invalid","type":"Unauthorized"}}"#;
+                    let response = format!(
+                        "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .expect("write response");
+                    return requests;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::yield_now();
+                }
+                Err(error) => panic!("accept local provider request: {error}"),
+            }
+        }
     });
 
     let config = test_config(ProviderConfig {
@@ -259,7 +285,7 @@ async fn fetch_available_models_enriches_volcengine_auth_failures_with_ark_guida
 
 #[tokio::test(flavor = "current_thread")]
 async fn request_turn_auto_model_rejects_missing_volcengine_credentials_before_transport() {
-    let config = test_config(ProviderConfig {
+    let provider = ProviderConfig {
         kind: ProviderKind::VolcengineCoding,
         base_url: "http://127.0.0.1:1".to_owned(),
         model: "auto".to_owned(),
@@ -268,7 +294,10 @@ async fn request_turn_auto_model_rejects_missing_volcengine_credentials_before_t
         oauth_access_token: None,
         oauth_access_token_env: None,
         ..ProviderConfig::default()
-    });
+    };
+    let mut env = ScopedEnv::new();
+    clear_provider_auth_envs(&mut env, VOLCENGINE_AUTH_ENV_KEYS);
+    let config = test_config(provider);
 
     let error = request_turn(
         &config,
@@ -299,11 +328,7 @@ async fn request_turn_auto_model_rejects_missing_volcengine_credentials_before_t
 
 #[tokio::test(flavor = "current_thread")]
 async fn fetch_available_models_rejects_missing_openai_credentials_before_transport() {
-    let mut env = ScopedEnv::new();
-    env.remove("OPENAI_CODEX_OAUTH_TOKEN");
-    env.remove("OPENAI_API_KEY");
-
-    let config = test_config(ProviderConfig {
+    let provider = ProviderConfig {
         kind: ProviderKind::Openai,
         base_url: "http://127.0.0.1:1".to_owned(),
         model: "auto".to_owned(),
@@ -312,7 +337,10 @@ async fn fetch_available_models_rejects_missing_openai_credentials_before_transp
         oauth_access_token: None,
         oauth_access_token_env: None,
         ..ProviderConfig::default()
-    });
+    };
+    let mut env = ScopedEnv::new();
+    clear_provider_auth_envs(&mut env, OPENAI_AUTH_ENV_KEYS);
+    let config = test_config(provider);
 
     let error = fetch_available_models(&config)
         .await
@@ -352,12 +380,47 @@ fn byteplus_auth_guidance_uses_byteplus_api_key_env() {
     assert!(hint.contains("Authorization: Bearer <BYTEPLUS_API_KEY>"));
 }
 
+#[test]
+fn custom_missing_auth_configuration_message_mentions_supported_headers() {
+    let provider = ProviderConfig {
+        kind: ProviderKind::Custom,
+        ..ProviderConfig::default()
+    };
+
+    let message = provider.missing_auth_configuration_message();
+
+    assert!(message.contains("CUSTOM_PROVIDER_API_KEY"));
+    assert!(message.contains("Authorization"));
+    assert!(message.contains("provider.headers"));
+}
+
+#[test]
+fn bedrock_missing_auth_configuration_message_mentions_sigv4_fallback() {
+    let provider = ProviderConfig {
+        kind: ProviderKind::Bedrock,
+        ..ProviderConfig::default()
+    };
+
+    let message = provider.missing_auth_configuration_message();
+
+    assert!(message.contains("AWS_BEARER_TOKEN_BEDROCK"));
+    assert!(message.contains("AWS_ACCESS_KEY_ID"));
+    assert!(message.contains("AWS_SECRET_ACCESS_KEY"));
+    assert!(message.contains("AWS_REGION"));
+}
+
 fn cleanup_sqlite_artifacts(path: &Path) {
     let _ = std::fs::remove_file(path);
     let wal = format!("{}-wal", path.display());
     let shm = format!("{}-shm", path.display());
     let _ = std::fs::remove_file(wal);
     let _ = std::fs::remove_file(shm);
+}
+
+fn clear_provider_auth_envs(env: &mut ScopedEnv, env_keys: &[&'static str]) {
+    for key in env_keys {
+        env.remove(key);
+    }
 }
 
 fn test_config(provider: ProviderConfig) -> LoongClawConfig {

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -132,6 +132,226 @@ async fn provider_auth_ready_accepts_bedrock_sigv4_credentials() {
     assert!(provider_auth_ready(&config).await);
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn fetch_available_models_rejects_missing_volcengine_credentials_before_network_request() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider listener");
+    let addr = listener.local_addr().expect("local addr");
+    let server = std::thread::spawn(move || {
+        listener
+            .set_nonblocking(true)
+            .expect("set listener nonblocking");
+        let deadline = Instant::now() + Duration::from_millis(250);
+        let mut requests = Vec::new();
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut request_buf = [0_u8; 8192];
+                    let len = stream.read(&mut request_buf).expect("read request");
+                    let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
+                    requests.push(request);
+                    let body = r#"{"error":{"message":"unexpected request"}}"#;
+                    let response = format!(
+                        "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .expect("write response");
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::yield_now();
+                }
+                Err(error) => panic!("accept local provider request: {error}"),
+            }
+        }
+        requests
+    });
+
+    let config = test_config(ProviderConfig {
+        kind: ProviderKind::Volcengine,
+        base_url: format!("http://{addr}"),
+        model: "auto".to_owned(),
+        api_key: None,
+        api_key_env: None,
+        oauth_access_token: None,
+        oauth_access_token_env: None,
+        ..ProviderConfig::default()
+    });
+
+    let error = fetch_available_models(&config)
+        .await
+        .expect_err("missing volcengine credentials should fail before any network request");
+
+    assert!(
+        error.contains("provider credentials are missing"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        error.contains("ARK_API_KEY"),
+        "missing-credential guidance should mention the Volcengine env binding: {error}"
+    );
+
+    let requests = server.join().expect("join local provider server");
+    assert!(
+        requests.is_empty(),
+        "missing managed credentials should not fall through to an anonymous model-list request: {requests:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn fetch_available_models_enriches_volcengine_auth_failures_with_ark_guidance() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider listener");
+    let addr = listener.local_addr().expect("local addr");
+    let server = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        let (mut stream, _) = listener.accept().expect("accept local provider request");
+        let mut request_buf = [0_u8; 8192];
+        let len = stream.read(&mut request_buf).expect("read request");
+        let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
+        requests.push(request);
+
+        let body = r#"{"error":{"code":"AuthenticationError","message":"the API key or AK/SK in the request is missing or invalid","type":"Unauthorized"}}"#;
+        let response = format!(
+            "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response");
+        requests
+    });
+
+    let config = test_config(ProviderConfig {
+        kind: ProviderKind::VolcengineCoding,
+        base_url: format!("http://{addr}"),
+        model: "auto".to_owned(),
+        api_key: Some("bad-ark-key".to_owned()),
+        api_key_env: None,
+        ..ProviderConfig::default()
+    });
+
+    let error = fetch_available_models(&config)
+        .await
+        .expect_err("volcengine auth failures should surface actionable guidance");
+
+    assert!(error.contains("status 401"), "unexpected error: {error}");
+    assert!(
+        error.contains("Authorization: Bearer <ARK_API_KEY>"),
+        "volcengine auth failures should explain the supported auth shape: {error}"
+    );
+    assert!(
+        error.contains("AK/SK request signing is not used"),
+        "volcengine auth failures should explain the unsupported auth path clearly: {error}"
+    );
+
+    let requests = server.join().expect("join local provider server");
+    assert!(
+        requests.iter().any(|request| {
+            let normalized = request.to_ascii_lowercase();
+            request.starts_with("GET /models ")
+                && normalized.contains("authorization: bearer bad-ark-key")
+        }),
+        "the catalog probe should still use the configured bearer secret when credentials exist: {requests:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn request_turn_auto_model_rejects_missing_volcengine_credentials_before_transport() {
+    let config = test_config(ProviderConfig {
+        kind: ProviderKind::VolcengineCoding,
+        base_url: "http://127.0.0.1:1".to_owned(),
+        model: "auto".to_owned(),
+        api_key: None,
+        api_key_env: None,
+        oauth_access_token: None,
+        oauth_access_token_env: None,
+        ..ProviderConfig::default()
+    });
+
+    let error = request_turn(
+        &config,
+        "session-provider-test",
+        "turn-provider-test",
+        &[json!({
+            "role": "user",
+            "content": "ping"
+        })],
+        ProviderRuntimeBinding::direct(),
+    )
+    .await
+    .expect_err("auto-model requests should fail on missing managed credentials before transport");
+
+    assert!(
+        error.contains("provider credentials are missing"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        error.contains("ARK_API_KEY"),
+        "missing-credential request errors should preserve the provider env hint: {error}"
+    );
+    assert!(
+        !error.contains("Connection refused"),
+        "missing managed credentials should fail before a transport attempt: {error}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn fetch_available_models_rejects_missing_openai_credentials_before_transport() {
+    let mut env = ScopedEnv::new();
+    env.remove("OPENAI_CODEX_OAUTH_TOKEN");
+    env.remove("OPENAI_API_KEY");
+
+    let config = test_config(ProviderConfig {
+        kind: ProviderKind::Openai,
+        base_url: "http://127.0.0.1:1".to_owned(),
+        model: "auto".to_owned(),
+        api_key: None,
+        api_key_env: None,
+        oauth_access_token: None,
+        oauth_access_token_env: None,
+        ..ProviderConfig::default()
+    });
+
+    let error = fetch_available_models(&config)
+        .await
+        .expect_err("missing OpenAI credentials should fail before transport");
+
+    assert!(
+        error.contains("provider credentials are missing"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        error.contains("OPENAI_CODEX_OAUTH_TOKEN"),
+        "openai guidance should preserve the oauth default hint: {error}"
+    );
+    assert!(
+        error.contains("OPENAI_API_KEY"),
+        "openai guidance should preserve the api key fallback hint: {error}"
+    );
+    assert!(
+        !error.contains("Connection refused"),
+        "missing managed credentials should fail before a transport attempt: {error}"
+    );
+}
+
+#[test]
+fn byteplus_auth_guidance_uses_byteplus_api_key_env() {
+    let provider = ProviderConfig {
+        kind: ProviderKind::ByteplusCoding,
+        ..ProviderConfig::default()
+    };
+
+    let hint = provider
+        .auth_guidance_hint()
+        .expect("byteplus coding should expose auth guidance");
+
+    assert!(hint.contains("BytePlus"));
+    assert!(hint.contains("BYTEPLUS_API_KEY"));
+    assert!(hint.contains("Authorization: Bearer <BYTEPLUS_API_KEY>"));
+}
+
 fn cleanup_sqlite_artifacts(path: &Path) {
     let _ = std::fs::remove_file(path);
     let wal = format!("{}-wal", path.display());

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -971,7 +971,7 @@ fn provider_credentials_doctor_check(
     }
 
     let hints = crate::onboard_cli::provider_credential_env_hints(&config.provider);
-    let detail = if hints.is_empty() {
+    let mut detail = if hints.is_empty() {
         "provider credentials are missing".to_owned()
     } else {
         format!(
@@ -979,6 +979,10 @@ fn provider_credentials_doctor_check(
             hints.join(", ")
         )
     };
+    if let Some(hint) = config.provider.auth_guidance_hint() {
+        detail.push(' ');
+        detail.push_str(hint.as_str());
+    }
     DoctorCheck {
         name: "provider credentials".to_owned(),
         level: DoctorCheckLevel::Warn,
@@ -2455,6 +2459,23 @@ mod tests {
                 == "Re-run diagnostics: loongclaw doctor --config '/tmp/loongclaw.toml'"),
             "doctor should tell the operator how to confirm the repair path: {next_steps:#?}"
         );
+    }
+
+    #[test]
+    fn provider_credentials_doctor_check_adds_volcengine_auth_guidance() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Volcengine;
+        config.provider.api_key = None;
+        config.provider.api_key_env = None;
+        config.provider.oauth_access_token = None;
+        config.provider.oauth_access_token_env = None;
+
+        let check = provider_credentials_doctor_check(&config, false);
+
+        assert_eq!(check.name, "provider credentials");
+        assert_eq!(check.level, DoctorCheckLevel::Warn);
+        assert!(check.detail.contains("ARK_API_KEY"));
+        assert!(check.detail.contains("Authorization: Bearer <ARK_API_KEY>"));
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2401,9 +2401,13 @@ pub fn provider_credential_check(config: &mvp::config::LoongClawConfig) -> Onboa
         };
     }
 
-    let detail = provider_credential_env_hint(provider)
+    let mut detail = provider_credential_env_hint(provider)
         .map(|env_name| format!("{env_name} is not set"))
         .unwrap_or_else(|| "provider credentials are not configured".to_owned());
+    if let Some(hint) = provider.auth_guidance_hint() {
+        detail.push(' ');
+        detail.push_str(hint.as_str());
+    }
     OnboardCheck {
         name: "provider credentials",
         level: OnboardCheckLevel::Warn,
@@ -6806,6 +6810,23 @@ mod tests {
             message.contains("provider.model"),
             "non-interactive onboarding should preserve the explicit remediation from the failing check: {message}"
         );
+    }
+
+    #[test]
+    fn provider_credential_check_adds_volcengine_auth_guidance_when_missing() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::VolcengineCoding;
+        config.provider.api_key = None;
+        config.provider.api_key_env = None;
+        config.provider.oauth_access_token = None;
+        config.provider.oauth_access_token_env = None;
+
+        let check = provider_credential_check(&config);
+
+        assert_eq!(check.name, "provider credentials");
+        assert_eq!(check.level, OnboardCheckLevel::Warn);
+        assert!(check.detail.contains("ARK_API_KEY"));
+        assert!(check.detail.contains("Authorization: Bearer <ARK_API_KEY>"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Problem:
  managed providers with missing credentials could still fall through into model discovery or auto-model request setup, which produced raw upstream `401` responses instead of a local configuration failure; this was especially confusing on the OpenAI-compatible Volcengine path.
- Why it matters:
  the current behavior looked like a transport/provider bug even when the real problem was missing local auth configuration, and the error text did not explain the supported auth shape for Volcengine / BytePlus family providers.
- What changed:
  added a shared auth-readiness preflight before model discovery and request-session setup for providers that require explicit auth configuration; enriched `401`/`403` failures with provider-aware auth guidance for the Volcengine family; extended doctor/onboard warnings to surface the same guidance; clarified the README; added regression coverage across Volcengine, OpenAI, and BytePlus-family paths.
- What did not change (scope boundary):
  this does not redesign provider auth transports, add AK/SK signing support, or change successful credential resolution paths.

## Linked Issues

- Closes #339
- Related #339

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo test -q missing_
- passed

cargo test -q auth_guidance
- passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed

cargo test --workspace --locked
- passed

cargo test --workspace --all-features --locked
- passed

git diff --check
- passed

git diff --cached --check
- passed
```

Additional validation notes:
- verified the root-cause path with focused regressions covering missing managed credentials before transport, Volcengine `401` guidance, BytePlus-family auth hints, and a non-Volcengine managed provider path (`openai`)
- this change touches env-backed auth resolution only; successful configured provider flows are unchanged because the preflight delegates to the existing `provider_auth_ready(...)` resolution path
- tests that manipulate env state use the existing scoped env helpers already present in the suite, so process-global env is restored inside the test harness

## User-visible / Operator-visible Changes

- missing managed credentials now fail early with a local configuration error instead of falling through to anonymous provider requests
- Volcengine / Volcengine Coding / BytePlus family auth failures now explain that this path expects `provider.api_key` / env-backed bearer auth, not AK/SK signing
- doctor and onboarding checks now surface the same actionable guidance

## Failure Recovery

- Fast rollback or disable path:
  revert commit `4eff0029` to restore the previous provider auth validation behavior
- Observable failure symptoms reviewers should watch for:
  unexpected early credential-missing errors on provider profiles that intentionally rely on supported custom auth headers or Bedrock SigV4 fallback

## Reviewer Focus

- confirm the shared preflight is scoped to providers that actually require explicit auth configuration and does not block supported alternative auth paths
- review the Volcengine-family guidance wording and the added regressions in `crates/app/src/provider/tests.rs`
- review the doctor/onboard messaging so operator-facing guidance stays aligned with runtime behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-specific authentication guidance now appears in credential validation, request failures, and onboarding/doctor checks.
  * Early credential readiness checks run before network requests or session setup.

* **Bug Fixes**
  * Error messages improved to include clear env-var hints and actionable auth guidance (e.g., bearer auth shape) for relevant providers.

* **Documentation**
  * Updated Volcengine/ARK provider docs to clarify API key usage and header expectations.

* **Tests**
  * Added broad auth-validation tests covering catalog probes, requests, and provider-specific guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->