### PR TITLE
ci: align the dev-main-release promotion lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           bash -n scripts/bootstrap_release_local_artifacts.sh
           bash -n scripts/test_release_artifact_lib.sh
           bash -n scripts/test_bootstrap_release_local_artifacts.sh
+          bash -n scripts/test_promotion_guard_workflows.sh
           bash -n scripts/check-docs.sh
           bash -n scripts/check_dep_graph.sh
           bash -n scripts/stress_daemon_tests.sh
@@ -62,6 +63,7 @@ jobs:
           bash scripts/test_install_sh.sh
           bash scripts/test_release_artifact_lib.sh
           bash scripts/test_bootstrap_release_local_artifacts.sh
+          bash scripts/test_promotion_guard_workflows.sh
           bash scripts/test_stress_daemon_tests.sh
 
       - name: Fresh architecture drift report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,17 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - dev
+      - main
+      - release
+      - 'release/**'
   push:
     branches:
+      - dev
       - main
+      - release
+      - 'release/**'
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -150,3 +158,41 @@ jobs:
 
       - name: Docs build
         run: cargo doc --workspace --no-deps
+
+  build:
+    name: build
+    if: ${{ always() }}
+    needs:
+      - governance
+      - rust-quality
+      - rust-test-default
+      - rust-test-all-features
+      - docs-build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require successful upstream jobs
+        env:
+          GOVERNANCE_RESULT: ${{ needs.governance.result }}
+          RUST_QUALITY_RESULT: ${{ needs.rust-quality.result }}
+          RUST_TEST_DEFAULT_RESULT: ${{ needs.rust-test-default.result }}
+          RUST_TEST_ALL_FEATURES_RESULT: ${{ needs.rust-test-all-features.result }}
+          DOCS_BUILD_RESULT: ${{ needs.docs-build.result }}
+        run: |
+          set -euo pipefail
+
+          check_result() {
+            local name="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error title=${name} result::Expected success, got ${result}"
+              exit 1
+            fi
+          }
+
+          check_result governance "$GOVERNANCE_RESULT"
+          check_result rust-quality "$RUST_QUALITY_RESULT"
+          check_result rust-test-default "$RUST_TEST_DEFAULT_RESULT"
+          check_result rust-test-all-features "$RUST_TEST_ALL_FEATURES_RESULT"
+          check_result docs-build "$DOCS_BUILD_RESULT"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,16 @@ name: CodeQL
 on:
   push:
     branches:
+      - dev
       - main
+      - release
+      - 'release/**'
   pull_request:
+    branches:
+      - dev
+      - main
+      - release
+      - 'release/**'
   schedule:
     - cron: "0 5 * * 1"
 

--- a/.github/workflows/enforce-dev-to-main.yml
+++ b/.github/workflows/enforce-dev-to-main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   block-non-dev-source:
-    if: ${{ github.event.pull_request.head.ref != 'dev' }}
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.head.ref != 'dev' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -25,9 +25,9 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const body = [
-              "Only `dev` can merge into `main` in this repository.",
+              "Only the same-repository `dev` branch can merge into `main` in this repository.",
               "",
-              `Current source branch: \`${pr.head.ref}\``,
+              `Current source branch: \`${pr.head.repo.full_name}:${pr.head.ref}\``,
               "Please land your changes on `dev` first, then open the promotion PR from `dev` to `main`."
             ].join("\\n");
 

--- a/.github/workflows/enforce-main-to-release.yml
+++ b/.github/workflows/enforce-main-to-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   block-non-main-source:
-    if: ${{ github.event.pull_request.head.ref != 'main' }}
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.head.ref != 'main' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -26,9 +26,9 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const body = [
-              "Only `main` can merge into `release` branches in this repository.",
+              "Only the same-repository `main` branch can merge into `release` branches in this repository.",
               "",
-              `Current source branch: \`${pr.head.ref}\``,
+              `Current source branch: \`${pr.head.repo.full_name}:${pr.head.ref}\``,
               "Please land your changes on `main` first, then open the promotion PR from `main` into the release branch."
             ].join("\\n");
 

--- a/.github/workflows/enforce-main-to-release.yml
+++ b/.github/workflows/enforce-main-to-release.yml
@@ -1,0 +1,48 @@
+name: enforce-main-to-release
+
+on:
+  pull_request_target:
+    branches:
+      - release
+      - 'release/**'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  block-non-main-source:
+    if: ${{ github.event.pull_request.head.ref != 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Close PR when source branch is not main
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = [
+              "Only `main` can merge into `release` branches in this repository.",
+              "",
+              `Current source branch: \`${pr.head.ref}\``,
+              "Please land your changes on `main` first, then open the promotion PR from `main` into the release branch."
+            ].join("\\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: "closed"
+            });
+            core.setFailed("Blocked: only main can merge into release branches.");

--- a/.github/workflows/perf-lint.yml
+++ b/.github/workflows/perf-lint.yml
@@ -2,6 +2,11 @@ name: perf-lint
 
 on:
   pull_request:
+    branches:
+      - dev
+      - main
+      - release
+      - 'release/**'
     paths:
       - '.github/workflows/**'
       - 'scripts/lint_programmatic_pressure_baseline.sh'
@@ -12,7 +17,18 @@ on:
       - 'crates/app/**'
   push:
     branches:
+      - dev
       - main
+      - release
+      - 'release/**'
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/lint_programmatic_pressure_baseline.sh'
+      - 'examples/benchmarks/**'
+      - 'crates/daemon/**'
+      - 'crates/spec/**'
+      - 'crates/kernel/**'
+      - 'crates/app/**'
 
 concurrency:
   group: perf-lint-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,17 @@ name: Security
 
 on:
   pull_request:
+    branches:
+      - dev
+      - main
+      - release
+      - 'release/**'
   push:
     branches:
+      - dev
       - main
+      - release
+      - 'release/**'
   schedule:
     - cron: "0 4 * * 1"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ If you are unsure which track applies, open an issue and ask maintainers for tri
 - `dev` is the active integration branch for day-to-day development.
 - Contributors should branch from `dev` and target `dev` with normal pull requests.
 - `main` is the stable promotion branch and should only receive reviewed changes from `dev`.
+- `release` or `release/*` branches are reserved for release hardening. When maintainers use one,
+  it should only receive reviewed changes from `main`.
 - Maintainers aim to promote stable slices from `dev` into `main` on a regular cadence. Exact
   timing depends on validation status, scope completion, and operational readiness.
 
@@ -80,9 +82,22 @@ If you are unsure which track applies, open an issue and ask maintainers for tri
 
 - Tagged releases are published from stable promotion points rather than from arbitrary in-flight
   commits.
+- Maintainers may use `release` or `release/*` branches as short-lived release hardening lanes
+  before tagging. Those branches should stay focused on release readiness, fixes, and verification.
 - Not every `dev -> main` promotion needs to become a public release.
 - Release readiness normally includes green CI, required validation, install flow sanity, and docs
   or changelog updates for shipped user-facing changes.
+
+## CI and Required Checks
+
+- `CI`, `CodeQL`, and `Security` run for pull requests and pushes targeting `dev`, `main`,
+  `release`, and `release/*`.
+- `perf-lint` follows the same branch set but only when workflow, benchmark, daemon, spec, kernel,
+  or app paths change.
+- The aggregate required check for promotion branches is `build`, emitted by
+  `.github/workflows/ci.yml`.
+- If branch protection is enabled for `dev`, `main`, or `release` lanes, require `build` instead
+  of tracking the internal job names individually.
 
 ## Where Do I Start?
 

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -11,7 +11,8 @@ These must hold at every commit on every branch:
 3. `cargo test --workspace` passes
 4. `cargo test --workspace --all-features` passes (test count evolves with the codebase; CI is the source of truth)
 
-Enforced by: CI (`verify` workflow). The optional `scripts/pre-commit` hook mirrors these cargo gates locally.
+Enforced by: CI (`.github/workflows/ci.yml`, surfaced through the aggregate `build` check). The
+optional `scripts/pre-commit` hook mirrors these cargo gates locally.
 
 ## Runtime Stability Guardrails
 

--- a/docs/plans/2026-03-18-dev-main-release-ci-lifecycle-implementation-plan.md
+++ b/docs/plans/2026-03-18-dev-main-release-ci-lifecycle-implementation-plan.md
@@ -1,0 +1,157 @@
+# Dev Main Release CI Lifecycle Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Align GitHub Actions with the repository's `dev -> main -> release` promotion model so `dev` receives continuous validation and branch protection can rely on a stable required check.
+
+**Architecture:** Keep the current workflow split between CI, security, CodeQL, perf lint, and release publishing, but change the branch filters so the integration workflows follow the promotion chain instead of only `main`. Add a final aggregate `build` job in `ci.yml` so branch protection can depend on one stable check name even if individual jobs change later.
+
+**Tech Stack:** GitHub Actions workflow YAML, shell validation, Rust workspace verification, Markdown planning docs
+
+---
+
+### Task 1: Align integration workflow trigger branches with the promotion chain
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/codeql.yml`
+- Modify: `.github/workflows/security.yml`
+- Modify: `.github/workflows/perf-lint.yml`
+- Create: `.github/workflows/enforce-main-to-release.yml`
+- Modify: `CONTRIBUTING.md`
+- Modify: `docs/references/github-collaboration.md`
+
+**Step 1: Update `ci.yml` branch filters**
+
+Change the `on:` block so:
+- `pull_request.branches` explicitly includes `dev`, `main`, `release`, and `release/**`
+- `push.branches` explicitly includes `dev`, `main`, `release`, and `release/**`
+
+Do not change the existing job bodies in this step.
+
+**Step 2: Update `codeql.yml` branch filters**
+
+Change the `on:` block so:
+- `pull_request.branches` explicitly includes `dev`, `main`, `release`, and `release/**`
+- `push.branches` explicitly includes `dev`, `main`, `release`, and `release/**`
+- keep the weekly `schedule` unchanged
+
+**Step 3: Update `security.yml` branch filters**
+
+Change the `on:` block so:
+- `pull_request.branches` explicitly includes `dev`, `main`, `release`, and `release/**`
+- `push.branches` explicitly includes `dev`, `main`, `release`, and `release/**`
+- keep the weekly `schedule` unchanged
+
+**Step 4: Update `perf-lint.yml` branch filters**
+
+Keep the current `paths` filter, but add matching branch filters so:
+- `pull_request.branches` explicitly includes `dev`, `main`, `release`, and `release/**`
+- `push.branches` explicitly includes `dev`, `main`, `release`, and `release/**`
+- `push.paths` matches the existing path-scoped files so normal pushes do not trigger unrelated perf lint runs
+
+This keeps the benchmark-lint workflow scoped to relevant files while making it available on `dev`.
+
+**Step 5: Add release-lane promotion enforcement**
+
+Create `.github/workflows/enforce-main-to-release.yml` mirroring the style of
+`enforce-dev-to-main.yml`, but scoped to:
+- `pull_request_target.branches`: `release`, `release/**`
+- source branch requirement: `main`
+
+The workflow should comment, close the PR, and fail the job when a release-lane PR comes from a
+branch other than `main`.
+
+**Step 6: Update contributor-facing collaboration docs**
+
+Document the full `dev -> main -> release` promotion chain in:
+- `CONTRIBUTING.md`
+- `docs/references/github-collaboration.md`
+
+Also document that the stable required status check is the aggregate `build` job from `ci.yml`.
+
+**Step 7: Run targeted YAML syntax validation**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' \
+  .github/workflows/ci.yml \
+  .github/workflows/codeql.yml \
+  .github/workflows/security.yml \
+  .github/workflows/perf-lint.yml \
+  .github/workflows/enforce-main-to-release.yml
+```
+
+Expected: command exits `0` with no syntax errors.
+
+### Task 2: Add a stable aggregate required check for branch protection
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Step 1: Add an aggregate `build` job**
+
+Append a new job named `build` that:
+- uses `needs` on `governance`, `rust-quality`, `rust-test-default`, `rust-test-all-features`, and `docs-build`
+- runs on `ubuntu-latest`
+- uses `if: ${{ always() }}` so the aggregate check still reports when an upstream job fails
+- fails unless every dependency result is exactly `success`
+
+Use an environment-driven shell step so the failure output makes it clear which upstream result blocked the aggregate check.
+
+**Step 2: Re-run focused workflow validation**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
+```
+
+Expected: command exits `0`.
+
+**Step 3: Check the rendered diff for workflow hygiene**
+
+Run:
+
+```bash
+git diff -- .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/security.yml .github/workflows/perf-lint.yml
+git diff --check
+```
+
+Expected: only the intended workflow trigger and aggregate-check changes appear, with no whitespace errors.
+
+### Task 3: Verify repository baseline and post-change behavior evidence
+
+**Files:**
+- Modify: `docs/plans/2026-03-18-dev-main-release-ci-lifecycle-implementation-plan.md`
+
+**Step 1: Run the repository baseline test suite once in the clean worktree**
+
+Run:
+
+```bash
+cargo test --workspace --locked
+```
+
+Expected: if the baseline is green, record that evidence; if it fails, capture the failure and continue only with that pre-existing risk noted.
+
+**Step 2: Re-run the validation commands after the workflow edits**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' \
+  .github/workflows/ci.yml \
+  .github/workflows/codeql.yml \
+  .github/workflows/security.yml \
+  .github/workflows/perf-lint.yml \
+  .github/workflows/enforce-main-to-release.yml
+git diff --check
+```
+
+Expected: both commands exit `0`.
+
+**Step 3: Summarize the required GitHub-side follow-up**
+
+Record in the final handoff that branch protection or rulesets should require the aggregate `build` check rather than a nonexistent legacy name. Do not mutate GitHub rulesets from this task unless explicitly requested.

--- a/docs/plans/2026-03-18-dev-main-release-ci-lifecycle-implementation-plan.md
+++ b/docs/plans/2026-03-18-dev-main-release-ci-lifecycle-implementation-plan.md
@@ -1,6 +1,6 @@
 # Dev Main Release CI Lifecycle Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Execution note:** Implement this plan task-by-task and record evidence for each validation step.
 
 **Goal:** Align GitHub Actions with the repository's `dev -> main -> release` promotion model so `dev` receives continuous validation and branch protection can rely on a stable required check.
 
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Align integration workflow trigger branches with the promotion chain
+## Task 1: Align integration workflow trigger branches with the promotion chain
 
 **Files:**
 - Modify: `.github/workflows/ci.yml`
@@ -57,10 +57,10 @@ This keeps the benchmark-lint workflow scoped to relevant files while making it 
 Create `.github/workflows/enforce-main-to-release.yml` mirroring the style of
 `enforce-dev-to-main.yml`, but scoped to:
 - `pull_request_target.branches`: `release`, `release/**`
-- source branch requirement: `main`
+- source branch requirement: the same-repository `main` branch
 
 The workflow should comment, close the PR, and fail the job when a release-lane PR comes from a
-branch other than `main`.
+branch other than the same-repository `main`.
 
 **Step 6: Update contributor-facing collaboration docs**
 
@@ -85,7 +85,7 @@ ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' \
 
 Expected: command exits `0` with no syntax errors.
 
-### Task 2: Add a stable aggregate required check for branch protection
+## Task 2: Add a stable aggregate required check for branch protection
 
 **Files:**
 - Modify: `.github/workflows/ci.yml`
@@ -121,7 +121,7 @@ git diff --check
 
 Expected: only the intended workflow trigger and aggregate-check changes appear, with no whitespace errors.
 
-### Task 3: Verify repository baseline and post-change behavior evidence
+## Task 3: Verify repository baseline and post-change behavior evidence
 
 **Files:**
 - Modify: `docs/plans/2026-03-18-dev-main-release-ci-lifecycle-implementation-plan.md`

--- a/docs/references/github-collaboration.md
+++ b/docs/references/github-collaboration.md
@@ -7,15 +7,30 @@ This document defines the active GitHub collaboration baseline for the `dev` bra
 - `dev` is the active integration branch for day-to-day OSS work.
 - Contributors should branch from `dev` and target `dev` with normal pull requests.
 - `main` is the stable promotion branch. Only reviewed `dev` changes should move into `main`.
+- `release` and `release/*` branches are optional release-hardening lanes. When used, they should
+  only receive reviewed `main` changes.
 - Promotion pull requests into `main` should come from `dev` and stay focused on stabilised work,
   not mixed feature development.
 
 ## Promotion and Release Rhythm
 
 - Maintainers aim to promote a stable slice from `dev` into `main` on a regular cadence.
+- When a dedicated release-hardening lane is needed, maintainers may promote `main` into `release`
+  or `release/*` before tagging.
 - Exact timing depends on validation status, scope completion, and operational readiness.
 - Releases are published from stable promotion points when the shipped slice is complete enough to
   support a tagged release. Not every `dev -> main` promotion must become a public release.
+
+## CI and Promotion Gates
+
+- `CI`, `CodeQL`, and `Security` validate pull requests and pushes for `dev`, `main`, `release`,
+  and `release/*`.
+- `perf-lint` uses the same branch set but stays path-scoped to workflow and benchmark-sensitive
+  files.
+- `enforce-dev-to-main` closes promotion PRs into `main` when the source branch is not `dev`.
+- `enforce-main-to-release` closes promotion PRs into `release` lanes when the source branch is
+  not `main`.
+- The stable branch-protection check is `build`, the aggregate job in `.github/workflows/ci.yml`.
 
 ## Intake Routes
 

--- a/docs/references/github-collaboration.md
+++ b/docs/references/github-collaboration.md
@@ -27,9 +27,10 @@ This document defines the active GitHub collaboration baseline for the `dev` bra
   and `release/*`.
 - `perf-lint` uses the same branch set but stays path-scoped to workflow and benchmark-sensitive
   files.
-- `enforce-dev-to-main` closes promotion PRs into `main` when the source branch is not `dev`.
-- `enforce-main-to-release` closes promotion PRs into `release` lanes when the source branch is
-  not `main`.
+- `enforce-dev-to-main` closes promotion PRs into `main` when the source is not the same-repository
+  `dev` branch.
+- `enforce-main-to-release` closes promotion PRs into `release` lanes when the source is not the
+  same-repository `main` branch.
 - The stable branch-protection check is `build`, the aggregate job in `.github/workflows/ci.yml`.
 
 ## Intake Routes

--- a/scripts/test_promotion_guard_workflows.sh
+++ b/scripts/test_promotion_guard_workflows.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+assert_guard_condition() {
+  local workflow_path="$1"
+  local job_name="$2"
+  local expected_ref="$3"
+
+  ruby - "$workflow_path" "$job_name" "$expected_ref" <<'RUBY'
+require "yaml"
+
+workflow_path, job_name, expected_ref = ARGV
+workflow = YAML.load_file(workflow_path)
+condition = workflow.fetch("jobs").fetch(job_name).fetch("if")
+
+required_fragments = [
+  "github.event.pull_request.head.repo.full_name != github.repository",
+  "github.event.pull_request.head.ref != '#{expected_ref}'"
+]
+
+missing = required_fragments.reject { |fragment| condition.include?(fragment) }
+unless missing.empty?
+  warn "workflow #{workflow_path} is missing required guard fragments: #{missing.join(', ')}"
+  warn "actual condition: #{condition}"
+  exit 1
+end
+RUBY
+}
+
+cd "$REPO_ROOT"
+
+assert_guard_condition ".github/workflows/enforce-dev-to-main.yml" "block-non-dev-source" "dev"
+assert_guard_condition ".github/workflows/enforce-main-to-release.yml" "block-non-main-source" "main"
+
+echo "promotion guard workflow checks passed"


### PR DESCRIPTION
## Summary

- Problem: `dev` is the primary development branch, but the repository workflows did not expose a stable CI status for the real `dev -> main -> release` promotion path, which left `dev` showing `No status` and left the release lane partially unenforced.
- Why it matters: branch protection and promotion governance only work when the required checks and merge guards match the repository's actual branch lifecycle.
- What changed: expanded the CI, CodeQL, security, and perf-lint workflow triggers to `dev`, `main`, `release`, and `release/**`; added an aggregate `build` job in `ci.yml` for a stable required check; added `enforce-main-to-release.yml`; aligned contributor and reliability docs with the promotion flow; added an implementation plan record.
- What did not change (scope boundary): this does not change Rust runtime behavior, crate boundaries, or release artifact semantics; it only aligns workflow triggering, promotion guards, and supporting docs.

## Linked Issues

- Closes #345
- Related #N/A

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: workflow trigger changes affect which branches receive required checks and add a new enforcement rule on the `main -> release` lane.
- Rollout / guardrails: use the aggregate `build` job as the stable required check, and review the first `dev -> main` and `main -> release` PRs to confirm the branch filters and enforcement behavior match repository intent.
- Rollback path: revert this PR, or disable the new `enforce-main-to-release.yml` workflow if it blocks an urgent release while the policy is being adjusted.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test --workspace --locked
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --all-features --locked
./scripts/check_dep_graph.sh
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/security.yml .github/workflows/perf-lint.yml .github/workflows/enforce-main-to-release.yml .github/workflows/enforce-dev-to-main.yml
scripts/bootstrap_release_local_artifacts.sh
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
git diff --check

All listed commands passed locally. The docs strict check required bootstrapping local `.docs` release artifacts first, which matches the repository's local governance flow.
```

## User-visible / Operator-visible Changes

- `dev` now receives CI runs on push and PR activity, with an aggregate `build` check that can be used as the stable required status.
- `main -> release` promotion is now explicitly enforced alongside the existing `dev -> main` guard.
- Contributor and reliability docs now describe the actual `dev -> main -> release` promotion lane and the checks that gate it.

## Failure Recovery

- Fast rollback or disable path: revert this PR, or temporarily disable `enforce-main-to-release.yml` if the policy needs to be relaxed during an incident.
- Observable failure symptoms reviewers should watch for: missing `build` status on `dev`-targeted PRs, unexpected `perf-lint` fan-out on unrelated pushes, or legitimate `main -> release` PRs being auto-closed incorrectly.

## Reviewer Focus

- Confirm the branch trigger matrix matches the intended `dev -> main -> release` lifecycle across `ci.yml`, `codeql.yml`, `security.yml`, and `perf-lint.yml`.
- Confirm the aggregate `build` job is the right stable status target for branch protection and fails whenever any required upstream job fails.
- Confirm `enforce-main-to-release.yml` mirrors the existing governance pattern cleanly and the docs describe the same policy the workflows enforce.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended CI workflows to run on dev, main, release, and release/** branches and broadened path triggers.
  * Added an aggregate "build" check that requires upstream CI jobs to succeed before completing.
  * Added enforcement that release-branch PRs must originate from main and strengthened dev→main source checks.

* **Tests**
  * Added scripted checks to validate promotion-guard workflow conditions.

* **Documentation**
  * Updated CONTRIBUTING and collaboration docs and added planning guidance for the new CI lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->