### PR TITLE
Capture structured runtime delta evidence in runtime capability artifacts

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -50,6 +50,7 @@ pub mod next_actions;
 pub mod onboard_cli;
 pub mod onboard_presentation;
 pub mod provider_presentation;
+pub mod runtime_capability_cli;
 pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;
 pub mod skills_cli;
@@ -409,6 +410,11 @@ pub enum Commands {
     RuntimeExperiment {
         #[command(subcommand)]
         command: runtime_experiment_cli::RuntimeExperimentCommands,
+    },
+    /// Manage run-derived capability candidate records
+    RuntimeCapability {
+        #[command(subcommand)]
+        command: runtime_capability_cli::RuntimeCapabilityCommands,
     },
     /// List available conversation context engines and selected runtime engine
     ListContextEngines {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -211,6 +211,9 @@ async fn main() {
         Commands::RuntimeExperiment { command } => {
             runtime_experiment_cli::run_runtime_experiment_cli(command)
         }
+        Commands::RuntimeCapability { command } => {
+            runtime_capability_cli::run_runtime_capability_cli(command)
+        }
         Commands::ListContextEngines { config, json } => {
             run_list_context_engines_cli(config.as_deref(), json)
         }

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1,0 +1,586 @@
+use crate::runtime_experiment_cli::{
+    RuntimeExperimentArtifactDocument, RuntimeExperimentDecision,
+    RuntimeExperimentShowCommandOptions, RuntimeExperimentStatus,
+    execute_runtime_experiment_show_command,
+};
+use crate::sha2::{self, Digest};
+use clap::{Args, Subcommand, ValueEnum};
+use loongclaw_spec::CliResult;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+pub const RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeCapabilityCommands {
+    /// Create one capability-candidate artifact from one finished experiment run
+    Propose(RuntimeCapabilityProposeCommandOptions),
+    /// Record one explicit operator review decision for a capability candidate
+    Review(RuntimeCapabilityReviewCommandOptions),
+    /// Load and render one persisted capability-candidate artifact
+    Show(RuntimeCapabilityShowCommandOptions),
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityProposeCommandOptions {
+    #[arg(long)]
+    pub run: String,
+    #[arg(long)]
+    pub output: String,
+    #[arg(long, value_enum)]
+    pub target: RuntimeCapabilityTarget,
+    #[arg(long)]
+    pub target_summary: String,
+    #[arg(long)]
+    pub bounded_scope: String,
+    #[arg(long = "required-capability")]
+    pub required_capability: Vec<String>,
+    #[arg(long = "tag")]
+    pub tag: Vec<String>,
+    #[arg(long)]
+    pub label: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityReviewCommandOptions {
+    #[arg(long)]
+    pub candidate: String,
+    #[arg(long, value_enum)]
+    pub decision: RuntimeCapabilityReviewDecision,
+    #[arg(long)]
+    pub review_summary: String,
+    #[arg(long = "warning")]
+    pub warning: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityShowCommandOptions {
+    #[arg(long)]
+    pub candidate: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityTarget {
+    ManagedSkill,
+    ProgrammaticFlow,
+    ProfileNoteAddendum,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityStatus {
+    Proposed,
+    Reviewed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityDecision {
+    Undecided,
+    Accepted,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum RuntimeCapabilityReviewDecision {
+    Accepted,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityArtifactSchema {
+    pub version: u32,
+    pub surface: String,
+    pub purpose: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityProposal {
+    pub target: RuntimeCapabilityTarget,
+    pub summary: String,
+    pub bounded_scope: String,
+    pub tags: Vec<String>,
+    pub required_capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeCapabilitySourceRunSummary {
+    pub run_id: String,
+    pub experiment_id: String,
+    pub label: Option<String>,
+    pub status: RuntimeExperimentStatus,
+    pub decision: RuntimeExperimentDecision,
+    pub mutation_summary: String,
+    pub baseline_snapshot_id: String,
+    pub result_snapshot_id: Option<String>,
+    pub evaluation_summary: String,
+    pub metrics: std::collections::BTreeMap<String, f64>,
+    pub warnings: Vec<String>,
+    pub artifact_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityReview {
+    pub summary: String,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeCapabilityArtifactDocument {
+    pub schema: RuntimeCapabilityArtifactSchema,
+    pub candidate_id: String,
+    pub created_at: String,
+    pub reviewed_at: Option<String>,
+    pub label: Option<String>,
+    pub status: RuntimeCapabilityStatus,
+    pub decision: RuntimeCapabilityDecision,
+    pub proposal: RuntimeCapabilityProposal,
+    pub source_run: RuntimeCapabilitySourceRunSummary,
+    pub review: Option<RuntimeCapabilityReview>,
+}
+
+pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
+    match command {
+        RuntimeCapabilityCommands::Propose(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_capability_propose_command(options)?;
+            emit_runtime_capability_artifact(&artifact, as_json)
+        }
+        RuntimeCapabilityCommands::Review(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_capability_review_command(options)?;
+            emit_runtime_capability_artifact(&artifact, as_json)
+        }
+        RuntimeCapabilityCommands::Show(options) => {
+            let as_json = options.json;
+            let artifact = execute_runtime_capability_show_command(options)?;
+            emit_runtime_capability_artifact(&artifact, as_json)
+        }
+    }
+}
+
+pub fn execute_runtime_capability_propose_command(
+    options: RuntimeCapabilityProposeCommandOptions,
+) -> CliResult<RuntimeCapabilityArtifactDocument> {
+    let run = execute_runtime_experiment_show_command(RuntimeExperimentShowCommandOptions {
+        run: options.run.clone(),
+        json: false,
+    })?;
+    validate_proposable_run(&run, &options.run)?;
+
+    let created_at = now_rfc3339()?;
+    let label = optional_arg(options.label.as_deref());
+    let summary = required_trimmed_arg("target_summary", &options.target_summary)?;
+    let bounded_scope = required_trimmed_arg("bounded_scope", &options.bounded_scope)?;
+    let tags = normalize_repeated_values(&options.tag);
+    let required_capabilities = parse_required_capabilities(&options.required_capability)?;
+    let source_run = build_source_run_summary(&run, Some(Path::new(&options.run)))?;
+    let candidate_id = compute_candidate_id(
+        &created_at,
+        label.as_deref(),
+        &source_run,
+        options.target,
+        &summary,
+        &bounded_scope,
+        &tags,
+        &required_capabilities,
+    )?;
+    let artifact = RuntimeCapabilityArtifactDocument {
+        schema: RuntimeCapabilityArtifactSchema {
+            version: RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION,
+            surface: "runtime_capability".to_owned(),
+            purpose: "promotion_candidate_record".to_owned(),
+        },
+        candidate_id,
+        created_at,
+        reviewed_at: None,
+        label,
+        status: RuntimeCapabilityStatus::Proposed,
+        decision: RuntimeCapabilityDecision::Undecided,
+        proposal: RuntimeCapabilityProposal {
+            target: options.target,
+            summary,
+            bounded_scope,
+            tags,
+            required_capabilities,
+        },
+        source_run,
+        review: None,
+    };
+    persist_runtime_capability_artifact(&options.output, &artifact)?;
+    Ok(artifact)
+}
+
+pub fn execute_runtime_capability_review_command(
+    options: RuntimeCapabilityReviewCommandOptions,
+) -> CliResult<RuntimeCapabilityArtifactDocument> {
+    let mut artifact = load_runtime_capability_artifact(Path::new(&options.candidate))?;
+    if artifact.status != RuntimeCapabilityStatus::Proposed {
+        return Err(format!(
+            "runtime capability candidate {} is already reviewed",
+            options.candidate
+        ));
+    }
+
+    artifact.reviewed_at = Some(now_rfc3339()?);
+    artifact.status = RuntimeCapabilityStatus::Reviewed;
+    artifact.decision = match options.decision {
+        RuntimeCapabilityReviewDecision::Accepted => RuntimeCapabilityDecision::Accepted,
+        RuntimeCapabilityReviewDecision::Rejected => RuntimeCapabilityDecision::Rejected,
+    };
+    artifact.review = Some(RuntimeCapabilityReview {
+        summary: required_trimmed_arg("review_summary", &options.review_summary)?,
+        warnings: normalize_repeated_values(&options.warning),
+    });
+    persist_runtime_capability_artifact(&options.candidate, &artifact)?;
+    Ok(artifact)
+}
+
+pub fn execute_runtime_capability_show_command(
+    options: RuntimeCapabilityShowCommandOptions,
+) -> CliResult<RuntimeCapabilityArtifactDocument> {
+    load_runtime_capability_artifact(Path::new(&options.candidate))
+}
+
+fn emit_runtime_capability_artifact(
+    artifact: &RuntimeCapabilityArtifactDocument,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(artifact)
+            .map_err(|error| format!("serialize runtime capability artifact failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_capability_text(artifact));
+    Ok(())
+}
+
+fn validate_proposable_run(
+    run: &RuntimeExperimentArtifactDocument,
+    run_path: &str,
+) -> CliResult<()> {
+    if run.status == RuntimeExperimentStatus::Planned {
+        return Err(format!(
+            "runtime capability propose requires a finished runtime experiment run; {} is still planned",
+            run_path
+        ));
+    }
+    if run.evaluation.is_none() {
+        return Err(format!(
+            "runtime capability propose requires evaluation data on source run {}",
+            run_path
+        ));
+    }
+    Ok(())
+}
+
+fn build_source_run_summary(
+    run: &RuntimeExperimentArtifactDocument,
+    artifact_path: Option<&Path>,
+) -> CliResult<RuntimeCapabilitySourceRunSummary> {
+    let evaluation = run
+        .evaluation
+        .as_ref()
+        .ok_or_else(|| "runtime capability source run is missing evaluation".to_owned())?;
+    Ok(RuntimeCapabilitySourceRunSummary {
+        run_id: run.run_id.clone(),
+        experiment_id: run.experiment_id.clone(),
+        label: run.label.clone(),
+        status: run.status,
+        decision: run.decision,
+        mutation_summary: run.mutation.summary.clone(),
+        baseline_snapshot_id: run.baseline_snapshot.snapshot_id.clone(),
+        result_snapshot_id: run
+            .result_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.snapshot_id.clone()),
+        evaluation_summary: evaluation.summary.clone(),
+        metrics: evaluation.metrics.clone(),
+        warnings: evaluation.warnings.clone(),
+        artifact_path: artifact_path.map(canonicalize_existing_path).transpose()?,
+    })
+}
+
+fn load_runtime_capability_artifact(path: &Path) -> CliResult<RuntimeCapabilityArtifactDocument> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read runtime capability artifact {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let artifact =
+        serde_json::from_str::<RuntimeCapabilityArtifactDocument>(&raw).map_err(|error| {
+            format!(
+                "decode runtime capability artifact {} failed: {error}",
+                path.display()
+            )
+        })?;
+    if artifact.schema.version != RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION {
+        return Err(format!(
+            "runtime capability artifact {} uses unsupported schema version {}; expected {}",
+            path.display(),
+            artifact.schema.version,
+            RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION
+        ));
+    }
+    Ok(artifact)
+}
+
+fn now_rfc3339() -> CliResult<String> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| format!("format runtime capability timestamp failed: {error}"))
+}
+
+fn optional_arg(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn required_trimmed_arg(name: &str, raw: &str) -> CliResult<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(format!("runtime capability {name} cannot be empty"));
+    }
+    Ok(trimmed.to_owned())
+}
+
+fn normalize_repeated_values(values: &[String]) -> Vec<String> {
+    let mut normalized = values
+        .iter()
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn parse_required_capabilities(values: &[String]) -> CliResult<Vec<String>> {
+    let mut normalized = BTreeSet::new();
+    for raw in values {
+        let value = normalize_required_capability(raw)?;
+        normalized.insert(value);
+    }
+    Ok(normalized.into_iter().collect())
+}
+
+fn normalize_required_capability(raw: &str) -> CliResult<String> {
+    let normalized = raw.trim().replace('-', "_").to_ascii_lowercase();
+    let canonical = match normalized.as_str() {
+        "invoke_tool" => "invoke_tool",
+        "invoke_connector" => "invoke_connector",
+        "memory_read" => "memory_read",
+        "memory_write" => "memory_write",
+        "filesystem_read" => "filesystem_read",
+        "filesystem_write" => "filesystem_write",
+        "network_egress" => "network_egress",
+        "schedule_task" => "schedule_task",
+        "observe_telemetry" => "observe_telemetry",
+        _ => {
+            return Err(format!(
+                "runtime capability required capability `{}` is unknown",
+                raw.trim()
+            ));
+        }
+    };
+    Ok(canonical.to_owned())
+}
+
+fn compute_candidate_id(
+    created_at: &str,
+    label: Option<&str>,
+    source_run: &RuntimeCapabilitySourceRunSummary,
+    target: RuntimeCapabilityTarget,
+    summary: &str,
+    bounded_scope: &str,
+    tags: &[String],
+    required_capabilities: &[String],
+) -> CliResult<String> {
+    let encoded = serde_json::to_vec(&json!({
+        "created_at": created_at,
+        "label": label,
+        "source_run_id": source_run.run_id,
+        "target": render_target(target),
+        "summary": summary,
+        "bounded_scope": bounded_scope,
+        "tags": tags,
+        "required_capabilities": required_capabilities,
+    }))
+    .map_err(|error| format!("serialize runtime capability candidate_id input failed: {error}"))?;
+    Ok(format!("{:x}", sha2::Sha256::digest(encoded)))
+}
+
+fn persist_runtime_capability_artifact(
+    output: &str,
+    artifact: &RuntimeCapabilityArtifactDocument,
+) -> CliResult<()> {
+    let output_path = PathBuf::from(output);
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create runtime capability artifact directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let encoded = serde_json::to_string_pretty(artifact)
+        .map_err(|error| format!("serialize runtime capability artifact failed: {error}"))?;
+    fs::write(&output_path, encoded).map_err(|error| {
+        format!(
+            "write runtime capability artifact {} failed: {error}",
+            output_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn canonicalize_existing_path(path: &Path) -> CliResult<String> {
+    fs::canonicalize(path)
+        .map(|resolved| resolved.display().to_string())
+        .map_err(|error| {
+            format!(
+                "canonicalize artifact path {} failed: {error}",
+                path.display()
+            )
+        })
+}
+
+pub fn render_runtime_capability_text(artifact: &RuntimeCapabilityArtifactDocument) -> String {
+    [
+        format!("candidate_id={}", artifact.candidate_id),
+        format!("status={}", render_capability_status(artifact.status)),
+        format!("decision={}", render_capability_decision(artifact.decision)),
+        format!("target={}", render_target(artifact.proposal.target)),
+        format!("target_summary={}", artifact.proposal.summary),
+        format!("bounded_scope={}", artifact.proposal.bounded_scope),
+        format!(
+            "required_capabilities={}",
+            render_string_values(&artifact.proposal.required_capabilities)
+        ),
+        format!("tags={}", render_string_values(&artifact.proposal.tags)),
+        format!("source_run_id={}", artifact.source_run.run_id),
+        format!("source_experiment_id={}", artifact.source_run.experiment_id),
+        format!(
+            "source_run_status={}",
+            render_experiment_status(artifact.source_run.status)
+        ),
+        format!(
+            "source_run_decision={}",
+            render_experiment_decision(artifact.source_run.decision)
+        ),
+        format!(
+            "source_metrics={}",
+            render_metrics(&artifact.source_run.metrics)
+        ),
+        format!(
+            "source_warnings={}",
+            render_string_values_with_separator(&artifact.source_run.warnings, " | ")
+        ),
+        format!(
+            "review_summary={}",
+            artifact
+                .review
+                .as_ref()
+                .map(|review| review.summary.as_str())
+                .unwrap_or("-")
+        ),
+        format!(
+            "review_warnings={}",
+            artifact
+                .review
+                .as_ref()
+                .map(|review| render_string_values_with_separator(&review.warnings, " | "))
+                .unwrap_or_else(|| "-".to_owned())
+        ),
+    ]
+    .join("\n")
+}
+
+fn render_metrics(metrics: &std::collections::BTreeMap<String, f64>) -> String {
+    if metrics.is_empty() {
+        "-".to_owned()
+    } else {
+        metrics
+            .iter()
+            .map(|(key, value)| format!("{key}:{value}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+fn render_string_values(values: &[String]) -> String {
+    if values.is_empty() {
+        "-".to_owned()
+    } else {
+        values.join(",")
+    }
+}
+
+fn render_string_values_with_separator(values: &[String], separator: &str) -> String {
+    if values.is_empty() {
+        "-".to_owned()
+    } else {
+        values.join(separator)
+    }
+}
+
+fn render_target(target: RuntimeCapabilityTarget) -> &'static str {
+    match target {
+        RuntimeCapabilityTarget::ManagedSkill => "managed_skill",
+        RuntimeCapabilityTarget::ProgrammaticFlow => "programmatic_flow",
+        RuntimeCapabilityTarget::ProfileNoteAddendum => "profile_note_addendum",
+    }
+}
+
+fn render_capability_status(status: RuntimeCapabilityStatus) -> &'static str {
+    match status {
+        RuntimeCapabilityStatus::Proposed => "proposed",
+        RuntimeCapabilityStatus::Reviewed => "reviewed",
+    }
+}
+
+fn render_capability_decision(decision: RuntimeCapabilityDecision) -> &'static str {
+    match decision {
+        RuntimeCapabilityDecision::Undecided => "undecided",
+        RuntimeCapabilityDecision::Accepted => "accepted",
+        RuntimeCapabilityDecision::Rejected => "rejected",
+    }
+}
+
+fn render_experiment_status(status: RuntimeExperimentStatus) -> &'static str {
+    match status {
+        RuntimeExperimentStatus::Planned => "planned",
+        RuntimeExperimentStatus::Completed => "completed",
+        RuntimeExperimentStatus::Aborted => "aborted",
+    }
+}
+
+fn render_experiment_decision(decision: RuntimeExperimentDecision) -> &'static str {
+    match decision {
+        RuntimeExperimentDecision::Undecided => "undecided",
+        RuntimeExperimentDecision::Promoted => "promoted",
+        RuntimeExperimentDecision::Rejected => "rejected",
+    }
+}

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1450,24 +1450,27 @@ fn build_runtime_capability_promotion_provenance(
     artifacts: &[RuntimeCapabilityArtifactDocument],
     evidence: &RuntimeCapabilityEvidenceDigest,
 ) -> RuntimeCapabilityPromotionProvenance {
+    let mut ordered_artifacts = artifacts.to_vec();
+    sort_runtime_capability_artifacts(&mut ordered_artifacts);
+
     RuntimeCapabilityPromotionProvenance {
-        candidate_ids: artifacts
+        candidate_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.candidate_id.clone())
             .collect(),
-        source_run_ids: artifacts
+        source_run_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.source_run.run_id.clone())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect(),
-        experiment_ids: artifacts
+        experiment_ids: ordered_artifacts
             .iter()
             .map(|artifact| artifact.source_run.experiment_id.clone())
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect(),
-        source_run_artifact_paths: artifacts
+        source_run_artifact_paths: ordered_artifacts
             .iter()
             .filter_map(|artifact| artifact.source_run.artifact_path.clone())
             .collect::<BTreeSet<_>>()

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -27,6 +27,8 @@ pub enum RuntimeCapabilityCommands {
     Show(RuntimeCapabilityShowCommandOptions),
     /// Aggregate candidate artifacts into deterministic capability families and readiness states
     Index(RuntimeCapabilityIndexCommandOptions),
+    /// Derive one dry-run promotion plan from one indexed capability family
+    Plan(RuntimeCapabilityPlanCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -77,6 +79,16 @@ pub struct RuntimeCapabilityShowCommandOptions {
 pub struct RuntimeCapabilityIndexCommandOptions {
     #[arg(long)]
     pub root: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityPlanCommandOptions {
+    #[arg(long)]
+    pub root: String,
+    #[arg(long)]
+    pub family_id: String,
     #[arg(long, default_value_t = false)]
     pub json: bool,
 }
@@ -238,6 +250,44 @@ pub struct RuntimeCapabilityIndexReport {
     pub families: Vec<RuntimeCapabilityFamilySummary>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityPromotionArtifactPlan {
+    pub target_kind: RuntimeCapabilityTarget,
+    pub artifact_kind: String,
+    pub artifact_id: String,
+    pub delivery_surface: String,
+    pub summary: String,
+    pub bounded_scope: String,
+    pub required_capabilities: Vec<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityPromotionProvenance {
+    pub candidate_ids: Vec<String>,
+    pub source_run_ids: Vec<String>,
+    pub experiment_ids: Vec<String>,
+    pub source_run_artifact_paths: Vec<String>,
+    pub latest_candidate_at: Option<String>,
+    pub latest_reviewed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityPromotionPlanReport {
+    pub generated_at: String,
+    pub root: String,
+    pub family_id: String,
+    pub promotable: bool,
+    pub proposal: RuntimeCapabilityProposal,
+    pub evidence: RuntimeCapabilityEvidenceDigest,
+    pub readiness: RuntimeCapabilityFamilyReadiness,
+    pub planned_artifact: RuntimeCapabilityPromotionArtifactPlan,
+    pub blockers: Vec<RuntimeCapabilityFamilyReadinessCheck>,
+    pub approval_checklist: Vec<String>,
+    pub rollback_hints: Vec<String>,
+    pub provenance: RuntimeCapabilityPromotionProvenance,
+}
+
 pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
     match command {
         RuntimeCapabilityCommands::Propose(options) => {
@@ -259,6 +309,11 @@ pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResu
             let as_json = options.json;
             let report = execute_runtime_capability_index_command(options)?;
             emit_runtime_capability_index_report(&report, as_json)
+        }
+        RuntimeCapabilityCommands::Plan(options) => {
+            let as_json = options.json;
+            let report = execute_runtime_capability_plan_command(options)?;
+            emit_runtime_capability_promotion_plan(&report, as_json)
         }
     }
 }
@@ -351,36 +406,14 @@ pub fn execute_runtime_capability_index_command(
 ) -> CliResult<RuntimeCapabilityIndexReport> {
     let root_path = Path::new(&options.root);
     let root = canonicalize_existing_path(root_path)?;
-    let mut artifacts = Vec::new();
-    collect_runtime_capability_artifacts(root_path, &mut artifacts)?;
-
-    let total_candidate_count = artifacts.len();
-    let mut families_by_id = BTreeMap::<String, Vec<RuntimeCapabilityArtifactDocument>>::new();
-    for artifact in artifacts {
-        let family_id = compute_family_id(&artifact.proposal)?;
-        families_by_id.entry(family_id).or_default().push(artifact);
-    }
+    let families_by_id = collect_runtime_capability_family_artifacts(root_path)?;
+    let total_candidate_count = families_by_id.values().map(Vec::len).sum();
 
     let mut families = Vec::new();
-    for (family_id, mut artifacts) in families_by_id {
-        sort_runtime_capability_artifacts(&mut artifacts);
-        let proposal = artifacts
-            .first()
-            .map(|artifact| artifact.proposal.clone())
-            .ok_or_else(|| "runtime capability family cannot be empty".to_owned())?;
-        let candidate_ids = artifacts
-            .iter()
-            .map(|artifact| artifact.candidate_id.clone())
-            .collect::<Vec<_>>();
-        let evidence = build_family_evidence_digest(&artifacts);
-        let readiness = evaluate_family_readiness(&artifacts, &evidence);
-        families.push(RuntimeCapabilityFamilySummary {
-            family_id,
-            proposal,
-            candidate_ids,
-            evidence,
-            readiness,
-        });
+    for (family_id, artifacts) in families_by_id {
+        families.push(build_runtime_capability_family_summary(
+            family_id, artifacts,
+        )?);
     }
 
     Ok(RuntimeCapabilityIndexReport {
@@ -389,6 +422,54 @@ pub fn execute_runtime_capability_index_command(
         total_candidate_count,
         family_count: families.len(),
         families,
+    })
+}
+
+pub fn execute_runtime_capability_plan_command(
+    options: RuntimeCapabilityPlanCommandOptions,
+) -> CliResult<RuntimeCapabilityPromotionPlanReport> {
+    let root_path = Path::new(&options.root);
+    let root = canonicalize_existing_path(root_path)?;
+    let families_by_id = collect_runtime_capability_family_artifacts(root_path)?;
+    let family_artifacts = families_by_id
+        .get(&options.family_id)
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "runtime capability family `{}` not found under {}",
+                options.family_id, root
+            )
+        })?;
+    let family = build_runtime_capability_family_summary(
+        options.family_id.clone(),
+        family_artifacts.clone(),
+    )?;
+    let planned_artifact =
+        build_runtime_capability_promotion_artifact(&family.family_id, &family.proposal);
+    let blockers = family
+        .readiness
+        .checks
+        .iter()
+        .filter(|check| check.status != RuntimeCapabilityFamilyReadinessCheckStatus::Pass)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(RuntimeCapabilityPromotionPlanReport {
+        generated_at: now_rfc3339()?,
+        root,
+        family_id: family.family_id.clone(),
+        promotable: family.readiness.status == RuntimeCapabilityFamilyReadinessStatus::Ready,
+        proposal: family.proposal.clone(),
+        evidence: family.evidence.clone(),
+        readiness: family.readiness.clone(),
+        planned_artifact: planned_artifact.clone(),
+        blockers,
+        approval_checklist: build_runtime_capability_approval_checklist(&planned_artifact),
+        rollback_hints: build_runtime_capability_rollback_hints(&planned_artifact),
+        provenance: build_runtime_capability_promotion_provenance(
+            &family_artifacts,
+            &family.evidence,
+        ),
     })
 }
 
@@ -420,6 +501,22 @@ fn emit_runtime_capability_index_report(
     }
 
     println!("{}", render_runtime_capability_index_text(report));
+    Ok(())
+}
+
+fn emit_runtime_capability_promotion_plan(
+    report: &RuntimeCapabilityPromotionPlanReport,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(report).map_err(|error| {
+            format!("serialize runtime capability promotion plan failed: {error}")
+        })?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_capability_promotion_plan_text(report));
     Ok(())
 }
 
@@ -563,6 +660,20 @@ fn collect_runtime_capability_artifacts(
     Ok(())
 }
 
+fn collect_runtime_capability_family_artifacts(
+    root: &Path,
+) -> CliResult<BTreeMap<String, Vec<RuntimeCapabilityArtifactDocument>>> {
+    let mut artifacts = Vec::new();
+    collect_runtime_capability_artifacts(root, &mut artifacts)?;
+
+    let mut families_by_id = BTreeMap::<String, Vec<RuntimeCapabilityArtifactDocument>>::new();
+    for artifact in artifacts {
+        let family_id = compute_family_id(&artifact.proposal)?;
+        families_by_id.entry(family_id).or_default().push(artifact);
+    }
+    Ok(families_by_id)
+}
+
 fn load_supported_runtime_capability_artifact(
     path: &Path,
 ) -> CliResult<Option<RuntimeCapabilityArtifactDocument>> {
@@ -597,6 +708,31 @@ fn sort_runtime_capability_artifacts(artifacts: &mut [RuntimeCapabilityArtifactD
             .cmp(&right.created_at)
             .then_with(|| left.candidate_id.cmp(&right.candidate_id))
     });
+}
+
+fn build_runtime_capability_family_summary(
+    family_id: String,
+    mut artifacts: Vec<RuntimeCapabilityArtifactDocument>,
+) -> CliResult<RuntimeCapabilityFamilySummary> {
+    sort_runtime_capability_artifacts(&mut artifacts);
+    let proposal = artifacts
+        .first()
+        .map(|artifact| artifact.proposal.clone())
+        .ok_or_else(|| "runtime capability family cannot be empty".to_owned())?;
+    let candidate_ids = artifacts
+        .iter()
+        .map(|artifact| artifact.candidate_id.clone())
+        .collect::<Vec<_>>();
+    let evidence = build_family_evidence_digest(&artifacts);
+    let readiness = evaluate_family_readiness(&artifacts, &evidence);
+
+    Ok(RuntimeCapabilityFamilySummary {
+        family_id,
+        proposal,
+        candidate_ids,
+        evidence,
+        readiness,
+    })
 }
 
 fn compute_family_id(proposal: &RuntimeCapabilityProposal) -> CliResult<String> {
@@ -1201,5 +1337,224 @@ fn render_family_readiness_check_status(
         RuntimeCapabilityFamilyReadinessCheckStatus::Pass => "pass",
         RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence => "needs_evidence",
         RuntimeCapabilityFamilyReadinessCheckStatus::Blocked => "blocked",
+    }
+}
+
+fn build_runtime_capability_promotion_artifact(
+    family_id: &str,
+    proposal: &RuntimeCapabilityProposal,
+) -> RuntimeCapabilityPromotionArtifactPlan {
+    let (artifact_kind, delivery_surface, id_prefix) =
+        runtime_capability_promotion_target_contract(proposal.target);
+    let artifact_id = format!(
+        "{id_prefix}-{}-{}",
+        slugify_runtime_capability_identifier(&proposal.summary),
+        family_id.chars().take(12).collect::<String>()
+    );
+
+    RuntimeCapabilityPromotionArtifactPlan {
+        target_kind: proposal.target,
+        artifact_kind: artifact_kind.to_owned(),
+        artifact_id,
+        delivery_surface: delivery_surface.to_owned(),
+        summary: proposal.summary.clone(),
+        bounded_scope: proposal.bounded_scope.clone(),
+        required_capabilities: proposal.required_capabilities.clone(),
+        tags: proposal.tags.clone(),
+    }
+}
+
+fn runtime_capability_promotion_target_contract(
+    target: RuntimeCapabilityTarget,
+) -> (&'static str, &'static str, &'static str) {
+    match target {
+        RuntimeCapabilityTarget::ManagedSkill => {
+            ("managed_skill_bundle", "managed_skills", "managed-skill")
+        }
+        RuntimeCapabilityTarget::ProgrammaticFlow => (
+            "programmatic_flow_spec",
+            "programmatic_flows",
+            "programmatic-flow",
+        ),
+        RuntimeCapabilityTarget::ProfileNoteAddendum => {
+            ("profile_note_addendum", "profile_note", "profile-note")
+        }
+    }
+}
+
+fn slugify_runtime_capability_identifier(raw: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_dash = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_was_dash = false;
+        } else if !last_was_dash {
+            slug.push('-');
+            last_was_dash = true;
+        }
+    }
+    let trimmed = slug.trim_matches('-').to_owned();
+    if trimmed.is_empty() {
+        "capability".to_owned()
+    } else {
+        trimmed
+    }
+}
+
+fn build_runtime_capability_approval_checklist(
+    planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
+) -> Vec<String> {
+    let mut checklist = vec![
+        "confirm summary and bounded scope still describe exactly one lower-layer artifact"
+            .to_owned(),
+        "confirm required capabilities remain least-privilege for the planned artifact".to_owned(),
+        "confirm provenance references still represent the intended behavior to codify".to_owned(),
+        format!(
+            "confirm the chosen delivery surface `{}` matches the target kind",
+            planned_artifact.delivery_surface
+        ),
+    ];
+    checklist.push(match planned_artifact.target_kind {
+        RuntimeCapabilityTarget::ManagedSkill => {
+            "confirm the behavior belongs in a reusable managed skill".to_owned()
+        }
+        RuntimeCapabilityTarget::ProgrammaticFlow => {
+            "confirm the behavior can be expressed as a deterministic programmatic flow".to_owned()
+        }
+        RuntimeCapabilityTarget::ProfileNoteAddendum => {
+            "confirm the behavior belongs in advisory profile guidance rather than executable logic"
+                .to_owned()
+        }
+    });
+    checklist
+}
+
+fn build_runtime_capability_rollback_hints(
+    planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
+) -> Vec<String> {
+    vec![
+        format!(
+            "capture the current `{}` state before applying artifact `{}`",
+            planned_artifact.delivery_surface, planned_artifact.artifact_id
+        ),
+        format!(
+            "remove or revert `{}` from `{}` if downstream validation fails",
+            planned_artifact.artifact_id, planned_artifact.delivery_surface
+        ),
+        "keep candidate ids and source-run references attached to the rollback record".to_owned(),
+    ]
+}
+
+fn build_runtime_capability_promotion_provenance(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityPromotionProvenance {
+    RuntimeCapabilityPromotionProvenance {
+        candidate_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.candidate_id.clone())
+            .collect(),
+        source_run_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.source_run.run_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        experiment_ids: artifacts
+            .iter()
+            .map(|artifact| artifact.source_run.experiment_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        source_run_artifact_paths: artifacts
+            .iter()
+            .filter_map(|artifact| artifact.source_run.artifact_path.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        latest_candidate_at: evidence.latest_candidate_at.clone(),
+        latest_reviewed_at: evidence.latest_reviewed_at.clone(),
+    }
+}
+
+pub fn render_runtime_capability_promotion_plan_text(
+    report: &RuntimeCapabilityPromotionPlanReport,
+) -> String {
+    [
+        format!("family_id={}", report.family_id),
+        format!("promotable={}", report.promotable),
+        format!(
+            "readiness={}",
+            render_family_readiness_status(report.readiness.status)
+        ),
+        format!(
+            "target={}",
+            render_target(report.planned_artifact.target_kind)
+        ),
+        format!("artifact_kind={}", report.planned_artifact.artifact_kind),
+        format!("artifact_id={}", report.planned_artifact.artifact_id),
+        format!(
+            "delivery_surface={}",
+            report.planned_artifact.delivery_surface
+        ),
+        format!("target_summary={}", report.planned_artifact.summary),
+        format!("bounded_scope={}", report.planned_artifact.bounded_scope),
+        format!(
+            "required_capabilities={}",
+            render_string_values(&report.planned_artifact.required_capabilities)
+        ),
+        format!(
+            "tags={}",
+            render_string_values(&report.planned_artifact.tags)
+        ),
+        format!(
+            "blockers={}",
+            render_family_readiness_checks(&report.blockers)
+        ),
+        format!(
+            "checks={}",
+            render_family_readiness_checks(&report.readiness.checks)
+        ),
+        format!(
+            "approval_checklist={}",
+            render_string_values_with_separator(&report.approval_checklist, " | ")
+        ),
+        format!(
+            "rollback_hints={}",
+            render_string_values_with_separator(&report.rollback_hints, " | ")
+        ),
+        format!(
+            "provenance_candidate_ids={}",
+            render_string_values(&report.provenance.candidate_ids)
+        ),
+        format!(
+            "provenance_source_run_ids={}",
+            render_string_values(&report.provenance.source_run_ids)
+        ),
+        format!(
+            "provenance_experiment_ids={}",
+            render_string_values(&report.provenance.experiment_ids)
+        ),
+        format!(
+            "provenance_source_run_artifact_paths={}",
+            render_string_values_with_separator(
+                &report.provenance.source_run_artifact_paths,
+                " | "
+            )
+        ),
+    ]
+    .join("\n")
+}
+
+fn render_family_readiness_checks(checks: &[RuntimeCapabilityFamilyReadinessCheck]) -> String {
+    if checks.is_empty() {
+        "-".to_owned()
+    } else {
+        checks
+            .iter()
+            .map(render_family_readiness_check)
+            .collect::<Vec<_>>()
+            .join(" | ")
     }
 }

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1,7 +1,7 @@
 use crate::runtime_experiment_cli::{
     RuntimeExperimentArtifactDocument, RuntimeExperimentDecision,
-    RuntimeExperimentShowCommandOptions, RuntimeExperimentStatus,
-    execute_runtime_experiment_show_command,
+    RuntimeExperimentShowCommandOptions, RuntimeExperimentSnapshotDelta, RuntimeExperimentStatus,
+    derive_recorded_snapshot_delta_for_run, execute_runtime_experiment_show_command,
 };
 use crate::sha2::{self, Digest};
 use clap::{Args, Subcommand, ValueEnum};
@@ -151,6 +151,7 @@ pub struct RuntimeCapabilitySourceRunSummary {
     pub evaluation_summary: String,
     pub metrics: std::collections::BTreeMap<String, f64>,
     pub warnings: Vec<String>,
+    pub snapshot_delta: Option<RuntimeExperimentSnapshotDelta>,
     pub artifact_path: Option<String>,
 }
 
@@ -229,6 +230,8 @@ pub struct RuntimeCapabilityEvidenceDigest {
     pub latest_reviewed_at: Option<String>,
     pub source_decisions: RuntimeCapabilitySourceDecisionRollup,
     pub unique_warnings: Vec<String>,
+    pub delta_candidate_count: usize,
+    pub changed_surfaces: Vec<String>,
     pub metric_ranges: BTreeMap<String, RuntimeCapabilityMetricRange>,
 }
 
@@ -547,6 +550,10 @@ fn build_source_run_summary(
         .evaluation
         .as_ref()
         .ok_or_else(|| "runtime capability source run is missing evaluation".to_owned())?;
+    let snapshot_delta = artifact_path
+        .map(|path| derive_recorded_snapshot_delta_for_run(run, &path.display().to_string()))
+        .transpose()?
+        .flatten();
     Ok(RuntimeCapabilitySourceRunSummary {
         run_id: run.run_id.clone(),
         experiment_id: run.experiment_id.clone(),
@@ -562,6 +569,7 @@ fn build_source_run_summary(
         evaluation_summary: evaluation.summary.clone(),
         metrics: evaluation.metrics.clone(),
         warnings: evaluation.warnings.clone(),
+        snapshot_delta,
         artifact_path: artifact_path.map(canonicalize_existing_path).transpose()?,
     })
 }
@@ -791,6 +799,8 @@ fn build_family_evidence_digest(
     let mut rejected = 0;
     let mut undecided = 0;
     let mut unique_warnings = BTreeSet::new();
+    let mut changed_surfaces = BTreeSet::new();
+    let mut delta_candidate_count = 0;
     let mut metric_bounds = BTreeMap::<String, RuntimeCapabilityMetricRange>::new();
 
     for artifact in artifacts {
@@ -798,6 +808,11 @@ fn build_family_evidence_digest(
             RuntimeExperimentDecision::Promoted => promoted += 1,
             RuntimeExperimentDecision::Rejected => rejected += 1,
             RuntimeExperimentDecision::Undecided => undecided += 1,
+        }
+
+        if let Some(snapshot_delta) = artifact.source_run.snapshot_delta.as_ref() {
+            delta_candidate_count += 1;
+            changed_surfaces.extend(snapshot_delta.changed_surfaces());
         }
 
         if artifact.decision == RuntimeCapabilityDecision::Accepted {
@@ -834,6 +849,8 @@ fn build_family_evidence_digest(
             undecided,
         },
         unique_warnings: unique_warnings.into_iter().collect(),
+        delta_candidate_count,
+        changed_surfaces: changed_surfaces.into_iter().collect(),
         metric_ranges: metric_bounds,
     }
 }
@@ -1155,6 +1172,24 @@ pub fn render_runtime_capability_text(artifact: &RuntimeCapabilityArtifactDocume
             render_string_values_with_separator(&artifact.source_run.warnings, " | ")
         ),
         format!(
+            "source_snapshot_delta_changed_surface_count={}",
+            artifact
+                .source_run
+                .snapshot_delta
+                .as_ref()
+                .map(|delta| delta.changed_surface_count.to_string())
+                .unwrap_or_else(|| "-".to_owned())
+        ),
+        format!(
+            "source_snapshot_delta_changed_surfaces={}",
+            artifact
+                .source_run
+                .snapshot_delta
+                .as_ref()
+                .map(|delta| render_string_values(&delta.changed_surfaces()))
+                .unwrap_or_else(|| "-".to_owned())
+        ),
+        format!(
             "review_summary={}",
             artifact
                 .review
@@ -1218,6 +1253,14 @@ pub fn render_runtime_capability_index_text(report: &RuntimeCapabilityIndexRepor
         lines.push(format!(
             "warnings={}",
             render_string_values_with_separator(&family.evidence.unique_warnings, " | ")
+        ));
+        lines.push(format!(
+            "delta_evidence_candidates={}",
+            family.evidence.delta_candidate_count
+        ));
+        lines.push(format!(
+            "delta_changed_surfaces={}",
+            render_string_values(&family.evidence.changed_surfaces)
         ));
         lines.push(format!(
             "checks={}",
@@ -1510,6 +1553,14 @@ pub fn render_runtime_capability_promotion_plan_text(
         format!(
             "tags={}",
             render_string_values(&report.planned_artifact.tags)
+        ),
+        format!(
+            "delta_evidence_candidates={}",
+            report.evidence.delta_candidate_count
+        ),
+        format!(
+            "delta_changed_surfaces={}",
+            render_string_values(&report.evidence.changed_surfaces)
         ),
         format!(
             "blockers={}",

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -9,7 +9,7 @@ use loongclaw_spec::CliResult;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -25,6 +25,8 @@ pub enum RuntimeCapabilityCommands {
     Review(RuntimeCapabilityReviewCommandOptions),
     /// Load and render one persisted capability-candidate artifact
     Show(RuntimeCapabilityShowCommandOptions),
+    /// Aggregate candidate artifacts into deterministic capability families and readiness states
+    Index(RuntimeCapabilityIndexCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -67,6 +69,14 @@ pub struct RuntimeCapabilityReviewCommandOptions {
 pub struct RuntimeCapabilityShowCommandOptions {
     #[arg(long)]
     pub candidate: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityIndexCommandOptions {
+    #[arg(long)]
+    pub root: String,
     #[arg(long, default_value_t = false)]
     pub json: bool,
 }
@@ -152,6 +162,82 @@ pub struct RuntimeCapabilityArtifactDocument {
     pub review: Option<RuntimeCapabilityReview>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityFamilyReadinessStatus {
+    Ready,
+    NotReady,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityFamilyReadinessCheckStatus {
+    Pass,
+    NeedsEvidence,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityFamilyReadinessCheck {
+    pub dimension: String,
+    pub status: RuntimeCapabilityFamilyReadinessCheckStatus,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityFamilyReadiness {
+    pub status: RuntimeCapabilityFamilyReadinessStatus,
+    pub checks: Vec<RuntimeCapabilityFamilyReadinessCheck>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityMetricRange {
+    pub min: f64,
+    pub max: f64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilitySourceDecisionRollup {
+    pub promoted: usize,
+    pub rejected: usize,
+    pub undecided: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityEvidenceDigest {
+    pub total_candidates: usize,
+    pub reviewed_candidates: usize,
+    pub undecided_candidates: usize,
+    pub accepted_candidates: usize,
+    pub rejected_candidates: usize,
+    pub distinct_source_run_count: usize,
+    pub distinct_experiment_count: usize,
+    pub latest_candidate_at: Option<String>,
+    pub latest_reviewed_at: Option<String>,
+    pub source_decisions: RuntimeCapabilitySourceDecisionRollup,
+    pub unique_warnings: Vec<String>,
+    pub metric_ranges: BTreeMap<String, RuntimeCapabilityMetricRange>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityFamilySummary {
+    pub family_id: String,
+    pub proposal: RuntimeCapabilityProposal,
+    pub candidate_ids: Vec<String>,
+    pub evidence: RuntimeCapabilityEvidenceDigest,
+    pub readiness: RuntimeCapabilityFamilyReadiness,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeCapabilityIndexReport {
+    pub generated_at: String,
+    pub root: String,
+    pub total_candidate_count: usize,
+    pub family_count: usize,
+    pub families: Vec<RuntimeCapabilityFamilySummary>,
+}
+
 pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
     match command {
         RuntimeCapabilityCommands::Propose(options) => {
@@ -168,6 +254,11 @@ pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResu
             let as_json = options.json;
             let artifact = execute_runtime_capability_show_command(options)?;
             emit_runtime_capability_artifact(&artifact, as_json)
+        }
+        RuntimeCapabilityCommands::Index(options) => {
+            let as_json = options.json;
+            let report = execute_runtime_capability_index_command(options)?;
+            emit_runtime_capability_index_report(&report, as_json)
         }
     }
 }
@@ -255,6 +346,52 @@ pub fn execute_runtime_capability_show_command(
     load_runtime_capability_artifact(Path::new(&options.candidate))
 }
 
+pub fn execute_runtime_capability_index_command(
+    options: RuntimeCapabilityIndexCommandOptions,
+) -> CliResult<RuntimeCapabilityIndexReport> {
+    let root_path = Path::new(&options.root);
+    let root = canonicalize_existing_path(root_path)?;
+    let mut artifacts = Vec::new();
+    collect_runtime_capability_artifacts(root_path, &mut artifacts)?;
+
+    let total_candidate_count = artifacts.len();
+    let mut families_by_id = BTreeMap::<String, Vec<RuntimeCapabilityArtifactDocument>>::new();
+    for artifact in artifacts {
+        let family_id = compute_family_id(&artifact.proposal)?;
+        families_by_id.entry(family_id).or_default().push(artifact);
+    }
+
+    let mut families = Vec::new();
+    for (family_id, mut artifacts) in families_by_id {
+        sort_runtime_capability_artifacts(&mut artifacts);
+        let proposal = artifacts
+            .first()
+            .map(|artifact| artifact.proposal.clone())
+            .ok_or_else(|| "runtime capability family cannot be empty".to_owned())?;
+        let candidate_ids = artifacts
+            .iter()
+            .map(|artifact| artifact.candidate_id.clone())
+            .collect::<Vec<_>>();
+        let evidence = build_family_evidence_digest(&artifacts);
+        let readiness = evaluate_family_readiness(&artifacts, &evidence);
+        families.push(RuntimeCapabilityFamilySummary {
+            family_id,
+            proposal,
+            candidate_ids,
+            evidence,
+            readiness,
+        });
+    }
+
+    Ok(RuntimeCapabilityIndexReport {
+        generated_at: now_rfc3339()?,
+        root,
+        total_candidate_count,
+        family_count: families.len(),
+        families,
+    })
+}
+
 fn emit_runtime_capability_artifact(
     artifact: &RuntimeCapabilityArtifactDocument,
     as_json: bool,
@@ -267,6 +404,22 @@ fn emit_runtime_capability_artifact(
     }
 
     println!("{}", render_runtime_capability_text(artifact));
+    Ok(())
+}
+
+fn emit_runtime_capability_index_report(
+    report: &RuntimeCapabilityIndexReport,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(report).map_err(|error| {
+            format!("serialize runtime capability index report failed: {error}")
+        })?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_capability_index_text(report));
     Ok(())
 }
 
@@ -338,7 +491,374 @@ fn load_runtime_capability_artifact(path: &Path) -> CliResult<RuntimeCapabilityA
             RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION
         ));
     }
+    validate_runtime_capability_artifact_state(&artifact, path)?;
     Ok(artifact)
+}
+
+fn validate_runtime_capability_artifact_state(
+    artifact: &RuntimeCapabilityArtifactDocument,
+    path: &Path,
+) -> CliResult<()> {
+    match artifact.status {
+        RuntimeCapabilityStatus::Proposed => {
+            if artifact.reviewed_at.is_some()
+                || artifact.review.is_some()
+                || artifact.decision != RuntimeCapabilityDecision::Undecided
+            {
+                return Err(format!(
+                    "runtime capability artifact {} has inconsistent proposed state",
+                    path.display()
+                ));
+            }
+        }
+        RuntimeCapabilityStatus::Reviewed => {
+            if artifact.reviewed_at.is_none()
+                || artifact.review.is_none()
+                || artifact.decision == RuntimeCapabilityDecision::Undecided
+            {
+                return Err(format!(
+                    "runtime capability artifact {} has inconsistent reviewed state",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_runtime_capability_artifacts(
+    root: &Path,
+    artifacts: &mut Vec<RuntimeCapabilityArtifactDocument>,
+) -> CliResult<()> {
+    let mut entries = fs::read_dir(root)
+        .map_err(|error| {
+            format!(
+                "read runtime capability index root {} failed: {error}",
+                root.display()
+            )
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            format!(
+                "enumerate runtime capability index root {} failed: {error}",
+                root.display()
+            )
+        })?;
+    entries.sort_by_key(|entry| entry.path());
+
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_runtime_capability_artifacts(&path, artifacts)?;
+            continue;
+        }
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(artifact) = load_supported_runtime_capability_artifact(&path)? else {
+            continue;
+        };
+        artifacts.push(artifact);
+    }
+    Ok(())
+}
+
+fn load_supported_runtime_capability_artifact(
+    path: &Path,
+) -> CliResult<Option<RuntimeCapabilityArtifactDocument>> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read runtime capability index entry {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let value = serde_json::from_str::<serde_json::Value>(&raw).map_err(|error| {
+        format!(
+            "decode runtime capability index entry {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let Some(surface) = value
+        .get("schema")
+        .and_then(|schema| schema.get("surface"))
+        .and_then(serde_json::Value::as_str)
+    else {
+        return Ok(None);
+    };
+    if surface != "runtime_capability" {
+        return Ok(None);
+    }
+    load_runtime_capability_artifact(path).map(Some)
+}
+
+fn sort_runtime_capability_artifacts(artifacts: &mut [RuntimeCapabilityArtifactDocument]) {
+    artifacts.sort_by(|left, right| {
+        left.created_at
+            .cmp(&right.created_at)
+            .then_with(|| left.candidate_id.cmp(&right.candidate_id))
+    });
+}
+
+fn compute_family_id(proposal: &RuntimeCapabilityProposal) -> CliResult<String> {
+    let encoded = serde_json::to_vec(&json!({
+        "target": render_target(proposal.target),
+        "summary": proposal.summary,
+        "bounded_scope": proposal.bounded_scope,
+        "tags": proposal.tags,
+        "required_capabilities": proposal.required_capabilities,
+    }))
+    .map_err(|error| format!("serialize runtime capability family_id input failed: {error}"))?;
+    Ok(format!("{:x}", sha2::Sha256::digest(encoded)))
+}
+
+fn build_family_evidence_digest(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+) -> RuntimeCapabilityEvidenceDigest {
+    let reviewed_candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.status == RuntimeCapabilityStatus::Reviewed)
+        .count();
+    let undecided_candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Undecided)
+        .count();
+    let accepted_candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Accepted)
+        .count();
+    let rejected_candidates = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Rejected)
+        .count();
+    let distinct_source_run_count = artifacts
+        .iter()
+        .map(|artifact| artifact.source_run.run_id.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    let distinct_experiment_count = artifacts
+        .iter()
+        .map(|artifact| artifact.source_run.experiment_id.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    let latest_candidate_at = artifacts
+        .iter()
+        .map(|artifact| artifact.created_at.as_str())
+        .max()
+        .map(str::to_owned);
+    let latest_reviewed_at = artifacts
+        .iter()
+        .filter_map(|artifact| artifact.reviewed_at.as_deref())
+        .max()
+        .map(str::to_owned);
+
+    let mut promoted = 0;
+    let mut rejected = 0;
+    let mut undecided = 0;
+    let mut unique_warnings = BTreeSet::new();
+    let mut metric_bounds = BTreeMap::<String, RuntimeCapabilityMetricRange>::new();
+
+    for artifact in artifacts {
+        match artifact.source_run.decision {
+            RuntimeExperimentDecision::Promoted => promoted += 1,
+            RuntimeExperimentDecision::Rejected => rejected += 1,
+            RuntimeExperimentDecision::Undecided => undecided += 1,
+        }
+
+        if artifact.decision == RuntimeCapabilityDecision::Accepted {
+            for warning in &artifact.source_run.warnings {
+                unique_warnings.insert(warning.clone());
+            }
+        }
+
+        for (metric, value) in &artifact.source_run.metrics {
+            let entry = metric_bounds.entry(metric.clone()).or_insert_with(|| {
+                RuntimeCapabilityMetricRange {
+                    min: *value,
+                    max: *value,
+                }
+            });
+            entry.min = entry.min.min(*value);
+            entry.max = entry.max.max(*value);
+        }
+    }
+
+    RuntimeCapabilityEvidenceDigest {
+        total_candidates: artifacts.len(),
+        reviewed_candidates,
+        undecided_candidates,
+        accepted_candidates,
+        rejected_candidates,
+        distinct_source_run_count,
+        distinct_experiment_count,
+        latest_candidate_at,
+        latest_reviewed_at,
+        source_decisions: RuntimeCapabilitySourceDecisionRollup {
+            promoted,
+            rejected,
+            undecided,
+        },
+        unique_warnings: unique_warnings.into_iter().collect(),
+        metric_ranges: metric_bounds,
+    }
+}
+
+fn evaluate_family_readiness(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadiness {
+    let review_consensus = evaluate_review_consensus(evidence);
+    let stability = evaluate_stability(evidence);
+    let accepted_source_integrity = evaluate_accepted_source_integrity(artifacts, evidence);
+    let warning_pressure = evaluate_warning_pressure(evidence);
+    let checks = vec![
+        review_consensus,
+        stability,
+        accepted_source_integrity,
+        warning_pressure,
+    ];
+    let status = if checks
+        .iter()
+        .any(|check| check.status == RuntimeCapabilityFamilyReadinessCheckStatus::Blocked)
+    {
+        RuntimeCapabilityFamilyReadinessStatus::Blocked
+    } else if checks
+        .iter()
+        .all(|check| check.status == RuntimeCapabilityFamilyReadinessCheckStatus::Pass)
+    {
+        RuntimeCapabilityFamilyReadinessStatus::Ready
+    } else {
+        RuntimeCapabilityFamilyReadinessStatus::NotReady
+    };
+    RuntimeCapabilityFamilyReadiness { status, checks }
+}
+
+fn evaluate_review_consensus(
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    let (status, summary) = if evidence.rejected_candidates > 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Blocked,
+            format!(
+                "{} candidate(s) in this family were explicitly rejected",
+                evidence.rejected_candidates
+            ),
+        )
+    } else if evidence.undecided_candidates > 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            format!(
+                "{} candidate(s) still require operator review",
+                evidence.undecided_candidates
+            ),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            "all candidate evidence is reviewed and accepted".to_owned(),
+        )
+    };
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "review_consensus".to_owned(),
+        status,
+        summary,
+    }
+}
+
+fn evaluate_stability(
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    let (status, summary) = if evidence.distinct_source_run_count >= 2 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            format!(
+                "family is supported by {} distinct source runs",
+                evidence.distinct_source_run_count
+            ),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            "family needs repeated evidence from at least two distinct source runs".to_owned(),
+        )
+    };
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "stability".to_owned(),
+        status,
+        summary,
+    }
+}
+
+fn evaluate_accepted_source_integrity(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    if evidence.accepted_candidates == 0 {
+        return RuntimeCapabilityFamilyReadinessCheck {
+            dimension: "accepted_source_integrity".to_owned(),
+            status: RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            summary: "family has no accepted candidates yet".to_owned(),
+        };
+    }
+
+    let invalid_sources = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Accepted)
+        .filter(|artifact| {
+            artifact.source_run.status != RuntimeExperimentStatus::Completed
+                || artifact.source_run.decision != RuntimeExperimentDecision::Promoted
+                || artifact.source_run.result_snapshot_id.is_none()
+        })
+        .count();
+
+    let (status, summary) = if invalid_sources > 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Blocked,
+            format!(
+                "{} accepted candidate(s) came from incomplete or non-promoted source runs",
+                invalid_sources
+            ),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            "accepted candidates all trace back to completed promoted runs".to_owned(),
+        )
+    };
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "accepted_source_integrity".to_owned(),
+        status,
+        summary,
+    }
+}
+
+fn evaluate_warning_pressure(
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    let (status, summary) = if evidence.accepted_candidates == 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            "warning pressure cannot be evaluated before the family has accepted evidence"
+                .to_owned(),
+        )
+    } else if evidence.unique_warnings.is_empty() {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            "accepted candidates carry no source warnings".to_owned(),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            format!(
+                "accepted evidence still carries warnings: {}",
+                evidence.unique_warnings.join(" | ")
+            ),
+        )
+    };
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "warning_pressure".to_owned(),
+        status,
+        summary,
+    }
 }
 
 fn now_rfc3339() -> CliResult<String> {
@@ -518,6 +1038,66 @@ pub fn render_runtime_capability_text(artifact: &RuntimeCapabilityArtifactDocume
     .join("\n")
 }
 
+pub fn render_runtime_capability_index_text(report: &RuntimeCapabilityIndexReport) -> String {
+    let mut lines = vec![
+        format!("root={}", report.root),
+        format!("family_count={}", report.family_count),
+        format!("total_candidate_count={}", report.total_candidate_count),
+    ];
+
+    for family in &report.families {
+        lines.push(String::new());
+        lines.push(format!("family_id={}", family.family_id));
+        lines.push(format!(
+            "readiness={}",
+            render_family_readiness_status(family.readiness.status)
+        ));
+        lines.push(format!("target={}", render_target(family.proposal.target)));
+        lines.push(format!("target_summary={}", family.proposal.summary));
+        lines.push(format!("bounded_scope={}", family.proposal.bounded_scope));
+        lines.push(format!(
+            "candidate_ids={}",
+            render_string_values(&family.candidate_ids)
+        ));
+        lines.push(format!(
+            "evidence_counts=total:{} reviewed:{} accepted:{} rejected:{} undecided:{}",
+            family.evidence.total_candidates,
+            family.evidence.reviewed_candidates,
+            family.evidence.accepted_candidates,
+            family.evidence.rejected_candidates,
+            family.evidence.undecided_candidates
+        ));
+        lines.push(format!(
+            "distinct_source_runs={}",
+            family.evidence.distinct_source_run_count
+        ));
+        lines.push(format!(
+            "distinct_experiments={}",
+            family.evidence.distinct_experiment_count
+        ));
+        lines.push(format!(
+            "metric_ranges={}",
+            render_metric_ranges(&family.evidence.metric_ranges)
+        ));
+        lines.push(format!(
+            "warnings={}",
+            render_string_values_with_separator(&family.evidence.unique_warnings, " | ")
+        ));
+        lines.push(format!(
+            "checks={}",
+            family
+                .readiness
+                .checks
+                .iter()
+                .map(render_family_readiness_check)
+                .collect::<Vec<_>>()
+                .join(" | ")
+        ));
+    }
+
+    lines.join("\n")
+}
+
 fn render_metrics(metrics: &std::collections::BTreeMap<String, f64>) -> String {
     if metrics.is_empty() {
         "-".to_owned()
@@ -544,6 +1124,27 @@ fn render_string_values_with_separator(values: &[String], separator: &str) -> St
     } else {
         values.join(separator)
     }
+}
+
+fn render_metric_ranges(ranges: &BTreeMap<String, RuntimeCapabilityMetricRange>) -> String {
+    if ranges.is_empty() {
+        "-".to_owned()
+    } else {
+        ranges
+            .iter()
+            .map(|(key, range)| format!("{key}:{}..{}", range.min, range.max))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+fn render_family_readiness_check(check: &RuntimeCapabilityFamilyReadinessCheck) -> String {
+    format!(
+        "{}:{}:{}",
+        check.dimension,
+        render_family_readiness_check_status(check.status),
+        check.summary
+    )
 }
 
 fn render_target(target: RuntimeCapabilityTarget) -> &'static str {
@@ -582,5 +1183,23 @@ fn render_experiment_decision(decision: RuntimeExperimentDecision) -> &'static s
         RuntimeExperimentDecision::Undecided => "undecided",
         RuntimeExperimentDecision::Promoted => "promoted",
         RuntimeExperimentDecision::Rejected => "rejected",
+    }
+}
+
+fn render_family_readiness_status(status: RuntimeCapabilityFamilyReadinessStatus) -> &'static str {
+    match status {
+        RuntimeCapabilityFamilyReadinessStatus::Ready => "ready",
+        RuntimeCapabilityFamilyReadinessStatus::NotReady => "not_ready",
+        RuntimeCapabilityFamilyReadinessStatus::Blocked => "blocked",
+    }
+}
+
+fn render_family_readiness_check_status(
+    status: RuntimeCapabilityFamilyReadinessCheckStatus,
+) -> &'static str {
+    match status {
+        RuntimeCapabilityFamilyReadinessCheckStatus::Pass => "pass",
+        RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence => "needs_evidence",
+        RuntimeCapabilityFamilyReadinessCheckStatus::Blocked => "blocked",
     }
 }

--- a/crates/daemon/src/runtime_experiment_cli.rs
+++ b/crates/daemon/src/runtime_experiment_cli.rs
@@ -214,7 +214,7 @@ pub struct RuntimeExperimentRestoreExecution {
     pub restore: crate::runtime_restore_cli::RuntimeRestoreExecution,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeExperimentSnapshotDelta {
     pub changed_surface_count: usize,
     pub provider_active_profile: RuntimeExperimentScalarCompare,
@@ -232,13 +232,13 @@ pub struct RuntimeExperimentSnapshotDelta {
     pub external_skill_ids: RuntimeExperimentSetCompare,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeExperimentScalarCompare {
     pub before: Option<String>,
     pub after: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeExperimentSetCompare {
     pub added: Vec<String>,
     pub removed: Vec<String>,
@@ -253,6 +253,52 @@ impl RuntimeExperimentScalarCompare {
 impl RuntimeExperimentSetCompare {
     fn changed(&self) -> bool {
         !self.added.is_empty() || !self.removed.is_empty()
+    }
+}
+
+impl RuntimeExperimentSnapshotDelta {
+    pub(crate) fn changed_surfaces(&self) -> Vec<String> {
+        let mut surfaces = Vec::new();
+        if self.provider_active_profile.changed() {
+            surfaces.push("provider_active_profile".to_owned());
+        }
+        if self.provider_active_model.changed() {
+            surfaces.push("provider_active_model".to_owned());
+        }
+        if self.context_engine_selected.changed() {
+            surfaces.push("context_engine_selected".to_owned());
+        }
+        if self.context_engine_compaction.changed() {
+            surfaces.push("context_engine_compaction".to_owned());
+        }
+        if self.memory_selected.changed() {
+            surfaces.push("memory_selected".to_owned());
+        }
+        if self.memory_policy.changed() {
+            surfaces.push("memory_policy".to_owned());
+        }
+        if self.acp_selected.changed() {
+            surfaces.push("acp_selected".to_owned());
+        }
+        if self.acp_policy.changed() {
+            surfaces.push("acp_policy".to_owned());
+        }
+        if self.enabled_channel_ids.changed() {
+            surfaces.push("enabled_channel_ids".to_owned());
+        }
+        if self.enabled_service_channel_ids.changed() {
+            surfaces.push("enabled_service_channel_ids".to_owned());
+        }
+        if self.visible_tool_names.changed() {
+            surfaces.push("visible_tool_names".to_owned());
+        }
+        if self.capability_snapshot_sha256.changed() {
+            surfaces.push("capability_snapshot_sha256".to_owned());
+        }
+        if self.external_skill_ids.changed() {
+            surfaces.push("external_skill_ids".to_owned());
+        }
+        surfaces
     }
 }
 
@@ -418,6 +464,20 @@ pub fn execute_runtime_experiment_compare_command(
         compare_mode,
         snapshot_delta,
     })
+}
+
+pub(crate) fn derive_recorded_snapshot_delta_for_run(
+    artifact: &RuntimeExperimentArtifactDocument,
+    run_path: &str,
+) -> CliResult<Option<RuntimeExperimentSnapshotDelta>> {
+    let Some(result_snapshot) = artifact.result_snapshot.as_ref() else {
+        return Ok(None);
+    };
+    if artifact.baseline_snapshot.artifact_path.is_none() || result_snapshot.artifact_path.is_none()
+    {
+        return Ok(None);
+    }
+    load_runtime_experiment_compare_snapshot_delta(artifact, run_path, None, None, true)
 }
 
 pub fn execute_runtime_experiment_restore_command(

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -584,6 +584,154 @@ fn runtime_experiment_cli_rejects_compare_recorded_snapshots_with_manual_paths()
 }
 
 #[test]
+fn runtime_capability_cli_parses_propose_review_and_show() {
+    let propose = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "propose",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--output",
+        "/tmp/runtime-capability.json",
+        "--target",
+        "managed-skill",
+        "--target-summary",
+        "Codify browser preview onboarding as a reusable managed skill",
+        "--bounded-scope",
+        "Browser preview onboarding and companion readiness checks only",
+        "--required-capability",
+        "invoke_tool",
+        "--required-capability",
+        "memory_read",
+        "--tag",
+        "browser",
+        "--tag",
+        "onboarding",
+        "--label",
+        "browser-preview-skill-candidate",
+        "--json",
+    ])
+    .expect("`runtime-capability propose` should parse");
+
+    match propose.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                options,
+            ) => {
+                assert_eq!(options.run, "/tmp/runtime-experiment.json");
+                assert_eq!(options.output, "/tmp/runtime-capability.json");
+                assert_eq!(
+                    options.target,
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill
+                );
+                assert_eq!(
+                    options.target_summary,
+                    "Codify browser preview onboarding as a reusable managed skill"
+                );
+                assert_eq!(
+                    options.bounded_scope,
+                    "Browser preview onboarding and companion readiness checks only"
+                );
+                assert_eq!(
+                    options.required_capability,
+                    vec!["invoke_tool".to_owned(), "memory_read".to_owned()]
+                );
+                assert_eq!(
+                    options.tag,
+                    vec!["browser".to_owned(), "onboarding".to_owned()]
+                );
+                assert_eq!(
+                    options.label.as_deref(),
+                    Some("browser-preview-skill-candidate")
+                );
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let review = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "review",
+        "--candidate",
+        "/tmp/runtime-capability.json",
+        "--decision",
+        "accepted",
+        "--review-summary",
+        "Promotion target is bounded and evidence supports manual codification",
+        "--warning",
+        "still requires manual implementation",
+        "--json",
+    ])
+    .expect("`runtime-capability review` should parse");
+
+    match review.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
+                options,
+            ) => {
+                assert_eq!(options.candidate, "/tmp/runtime-capability.json");
+                assert_eq!(
+                    options.decision,
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted
+                );
+                assert_eq!(
+                    options.review_summary,
+                    "Promotion target is bounded and evidence supports manual codification"
+                );
+                assert_eq!(
+                    options.warning,
+                    vec!["still requires manual implementation".to_owned()]
+                );
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let show = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "show",
+        "--candidate",
+        "/tmp/runtime-capability.json",
+        "--json",
+    ])
+    .expect("`runtime-capability show` should parse");
+
+    match show.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(options) => {
+                assert_eq!(options.candidate, "/tmp/runtime-capability.json");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
+                _,
+            )) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn acp_event_summary_cli_rejects_zero_limit() {
     let error = run_acp_event_summary_cli(None, Some("session-a"), 0, false)
         .expect_err("zero limit must be rejected");

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -584,7 +584,7 @@ fn runtime_experiment_cli_rejects_compare_recorded_snapshots_with_manual_paths()
 }
 
 #[test]
-fn runtime_capability_cli_parses_propose_review_and_show() {
+fn runtime_capability_cli_parses_propose_review_show_and_index() {
     let propose = Cli::try_parse_from([
         "loongclaw",
         "runtime-capability",
@@ -649,7 +649,8 @@ fn runtime_capability_cli_parses_propose_review_and_show() {
             other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
                 _,
             )
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -695,7 +696,8 @@ fn runtime_capability_cli_parses_propose_review_and_show() {
             other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
                 _,
             )
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -723,7 +725,35 @@ fn runtime_capability_cli_parses_propose_review_and_show() {
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
                 _,
-            )) => {
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let index = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "index",
+        "--root",
+        "/tmp/runtime-capability",
+        "--json",
+    ])
+    .expect("`runtime-capability index` should parse");
+
+    match index.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(options) => {
+                assert_eq!(options.root, "/tmp/runtime-capability");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -584,7 +584,7 @@ fn runtime_experiment_cli_rejects_compare_recorded_snapshots_with_manual_paths()
 }
 
 #[test]
-fn runtime_capability_cli_parses_propose_review_show_and_index() {
+fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
     let propose = Cli::try_parse_from([
         "loongclaw",
         "runtime-capability",
@@ -650,7 +650,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -697,7 +698,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -726,7 +728,8 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
                 _,
             )
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -753,7 +756,39 @@ fn runtime_capability_cli_parses_propose_review_show_and_index() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let plan = Cli::try_parse_from([
+        "loongclaw",
+        "runtime-capability",
+        "plan",
+        "--root",
+        "/tmp/runtime-capability",
+        "--family-id",
+        "family-123",
+        "--json",
+    ])
+    .expect("`runtime-capability plan` should parse");
+
+    match plan.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(options) => {
+                assert_eq!(options.root, "/tmp/runtime-capability");
+                assert_eq!(options.family_id, "family-123");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -32,6 +32,7 @@ mod migrate_cli;
 mod migration;
 mod onboard_cli;
 mod programmatic;
+mod runtime_capability_cli;
 mod runtime_experiment_cli;
 mod runtime_restore_cli;
 mod runtime_snapshot_cli;

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -1,0 +1,400 @@
+#![allow(unsafe_code)]
+#![allow(
+    clippy::disallowed_methods,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks
+)]
+
+use super::*;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+fn write_runtime_capability_config(root: &Path) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.tools.file_root = Some(root.display().to_string());
+    config.tools.browser.enabled = true;
+    config.tools.web.enabled = true;
+    config.acp.enabled = true;
+    config.acp.dispatch.enabled = true;
+    config.acp.default_agent = Some("planner".to_owned());
+    config.acp.allowed_agents = vec!["planner".to_owned(), "codex".to_owned()];
+    config.providers.insert(
+        "openai-main".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: false,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "gpt-4.1-mini".to_owned(),
+                ..Default::default()
+            },
+        },
+    );
+    config.set_active_provider_profile(
+        "deepseek-lab",
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Deepseek,
+                model: "deepseek-chat".to_owned(),
+                api_key: Some("demo-token".to_owned()),
+                ..Default::default()
+            },
+        },
+    );
+
+    let config_path = root.join("loongclaw.toml");
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    config_path
+}
+
+fn write_snapshot_artifact(
+    root: &Path,
+    config_path: &Path,
+    relative: &str,
+    metadata: loongclaw_daemon::RuntimeSnapshotArtifactMetadata,
+) -> (PathBuf, Value) {
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let payload =
+        loongclaw_daemon::build_runtime_snapshot_artifact_json_payload(&snapshot, &metadata)
+            .expect("build runtime snapshot artifact");
+    let artifact_path = root.join(relative);
+    if let Some(parent) = artifact_path.parent() {
+        fs::create_dir_all(parent).expect("create artifact directory");
+    }
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(&payload).expect("encode snapshot artifact"),
+    )
+    .expect("write snapshot artifact");
+    (artifact_path, payload)
+}
+
+fn snapshot_id_from_payload(payload: &Value) -> String {
+    payload
+        .get("lineage")
+        .and_then(|lineage| lineage.get("snapshot_id"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .expect("snapshot payload should include lineage.snapshot_id")
+}
+
+fn start_runtime_experiment(
+    root: &Path,
+    snapshot_path: &Path,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let run_path = root.join("artifacts/runtime-experiment.json");
+    let run = loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_start_command(
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStartCommandOptions {
+            snapshot: snapshot_path.display().to_string(),
+            output: run_path.display().to_string(),
+            mutation_summary: "enable browser preview skill".to_owned(),
+            experiment_id: Some("exp-42".to_owned()),
+            label: Some("browser-preview-a".to_owned()),
+            tag: vec!["browser".to_owned(), "preview".to_owned()],
+            json: false,
+        },
+    )
+    .expect("runtime experiment start should succeed");
+    (run_path, run)
+}
+
+fn finish_runtime_experiment(
+    root: &Path,
+    config_path: &Path,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(root, &baseline_snapshot_path);
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "provider and tool policy updated".to_owned(),
+                metric: vec!["task_success=1".to_owned(), "cost_delta=-0.2".to_owned()],
+                warning: vec!["manual verification only".to_owned()],
+                decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+    (run_path, finished)
+}
+
+#[test]
+fn runtime_capability_propose_persists_candidate_from_finished_run() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, run) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    let candidate =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec![
+                    "invoke_tool".to_owned(),
+                    "memory_read".to_owned(),
+                    "invoke_tool".to_owned(),
+                ],
+                tag: vec![
+                    "browser".to_owned(),
+                    "onboarding".to_owned(),
+                    "browser".to_owned(),
+                ],
+                label: Some("browser-preview-skill-candidate".to_owned()),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    assert_eq!(
+        candidate.label.as_deref(),
+        Some("browser-preview-skill-candidate")
+    );
+    assert_eq!(
+        candidate.source_run.run_id, run.run_id,
+        "candidate should retain source run linkage"
+    );
+    assert_eq!(
+        candidate.proposal.required_capabilities,
+        vec!["invoke_tool".to_owned(), "memory_read".to_owned()]
+    );
+    assert_eq!(
+        candidate.proposal.tags,
+        vec!["browser".to_owned(), "onboarding".to_owned()]
+    );
+    assert!(
+        candidate_path.exists(),
+        "propose should persist the candidate artifact"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_rejects_planned_runs() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-planned");
+    let config_path = write_runtime_capability_config(&root);
+    let (snapshot_path, _) = write_snapshot_artifact(
+        &root,
+        &config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(&root, &snapshot_path);
+
+    let error =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: root
+                    .join("artifacts/runtime-capability.json")
+                    .display()
+                    .to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned()],
+                tag: vec!["browser".to_owned()],
+                label: None,
+                json: false,
+            },
+        )
+        .expect_err("planned run should be rejected");
+
+    assert!(error.contains("finished"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_rejects_unknown_required_capability() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-capability");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+
+    let error =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: root
+                    .join("artifacts/runtime-capability.json")
+                    .display()
+                    .to_string(),
+                target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProgrammaticFlow,
+                target_summary: "Codify runtime comparison as a reusable flow".to_owned(),
+                bounded_scope: "Runtime experiment compare reports only".to_owned(),
+                required_capability: vec!["totally_unknown".to_owned()],
+                tag: vec!["runtime".to_owned()],
+                label: None,
+                json: false,
+            },
+        )
+        .expect_err("unknown capabilities should be rejected");
+
+    assert!(error.contains("totally_unknown"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_review_records_terminal_decision_once() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-review");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    let proposed =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: None,
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    let reviewed =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_review_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewCommandOptions {
+                candidate: candidate_path.display().to_string(),
+                decision: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+                review_summary:
+                    "Promotion target is bounded and evidence supports manual codification"
+                        .to_owned(),
+                warning: vec!["still requires manual implementation".to_owned()],
+                json: false,
+            },
+        )
+        .expect("runtime capability review should succeed");
+
+    assert_eq!(reviewed.candidate_id, proposed.candidate_id);
+    assert!(
+        reviewed.reviewed_at.is_some(),
+        "review should record a terminal timestamp"
+    );
+
+    let error =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_review_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewCommandOptions {
+                candidate: candidate_path.display().to_string(),
+                decision: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
+                review_summary: "second review should fail".to_owned(),
+                warning: Vec::new(),
+                json: false,
+            },
+        )
+        .expect_err("double review should fail");
+
+    assert!(error.contains("already reviewed"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_show_round_trips_the_persisted_artifact() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    let proposed =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProfileNoteAddendum,
+                target_summary: "Persist browser preview operator guidance".to_owned(),
+                bounded_scope: "Imported operator guidance only".to_owned(),
+                required_capability: vec!["memory_write".to_owned()],
+                tag: vec!["memory".to_owned(), "guidance".to_owned()],
+                label: Some("browser-preview-guidance".to_owned()),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    let shown = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect("show should round-trip the persisted artifact");
+
+    assert_eq!(shown, proposed);
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -258,25 +258,47 @@ fn propose_runtime_capability_variant(
     loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument,
 ) {
     let candidate_path = root.join(format!("artifacts/runtime-capability-{slug}.json"));
-    let candidate =
-        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
-            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
-                run: run_path.display().to_string(),
-                output: candidate_path.display().to_string(),
-                target:
-                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
-                target_summary: "Codify browser preview onboarding as a reusable managed skill"
-                    .to_owned(),
-                bounded_scope: "Browser preview onboarding and companion readiness checks only"
-                    .to_owned(),
-                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
-                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
-                label: Some(format!("browser-preview-skill-candidate-{slug}")),
-                json: false,
-            },
-        )
-        .expect("runtime capability propose should succeed");
+    let candidate = propose_runtime_capability_variant_with_target(
+        root,
+        run_path,
+        slug,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
     (candidate_path, candidate)
+}
+
+fn propose_runtime_capability_variant_with_target(
+    root: &Path,
+    run_path: &Path,
+    slug: &str,
+    target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget,
+    target_summary: &str,
+    bounded_scope: &str,
+    required_capabilities: &[&str],
+    tags: &[&str],
+) -> loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument {
+    let candidate_path = root.join(format!("artifacts/runtime-capability-{slug}.json"));
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target,
+            target_summary: target_summary.to_owned(),
+            bounded_scope: bounded_scope.to_owned(),
+            required_capability: required_capabilities
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            tag: tags.iter().map(|value| (*value).to_owned()).collect(),
+            label: Some(format!("runtime-capability-{slug}")),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed")
 }
 
 fn review_runtime_capability_variant(
@@ -775,6 +797,360 @@ fn runtime_capability_index_marks_family_blocked_on_conflicting_reviews() {
                     == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Blocked
         }),
         "review consensus should block mixed accepted/rejected evidence"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-ready");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "ready-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "ready-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path = root.join("artifacts/runtime-capability-ready-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-ready-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "ready-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "ready-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "ready-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "ready-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(plan.promotable, "ready family should be promotable");
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Ready
+    );
+    assert_eq!(plan.planned_artifact.artifact_kind, "managed_skill_bundle");
+    assert_eq!(plan.planned_artifact.delivery_surface, "managed_skills");
+    assert!(
+        plan.planned_artifact
+            .artifact_id
+            .starts_with("managed-skill-"),
+        "artifact id should carry a managed-skill prefix"
+    );
+    assert!(
+        plan.planned_artifact
+            .artifact_id
+            .ends_with(&family.family_id[..12]),
+        "artifact id should be family-derived"
+    );
+    assert!(
+        plan.blockers.is_empty(),
+        "ready family should have no blockers"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("managed skill")),
+        "checklist should include the target-specific managed skill review item"
+    );
+    assert!(
+        plan.rollback_hints
+            .iter()
+            .any(|hint| hint.contains("managed_skills")),
+        "rollback hints should mention the managed skill delivery surface"
+    );
+    assert_eq!(plan.provenance.candidate_ids.len(), 2);
+    assert_eq!(plan.provenance.source_run_ids.len(), 2);
+    assert!(
+        plan.provenance.source_run_artifact_paths.contains(
+            &fs::canonicalize(&run_a_path)
+                .expect("canonicalize run a path")
+                .display()
+                .to_string()
+        )
+    );
+    assert!(
+        plan.provenance.source_run_artifact_paths.contains(
+            &fs::canonicalize(&run_b_path)
+                .expect("canonicalize run b path")
+                .display()
+                .to_string()
+        )
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_reports_missing_evidence_for_programmatic_flow_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-not-ready");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "flow",
+        -0.2,
+        &["manual verification only"],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_path = root.join("artifacts/runtime-capability-flow.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_path,
+        "flow",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProgrammaticFlow,
+        "Codify runtime compare summarization as a reusable flow",
+        "Runtime experiment compare report generation only",
+        &["invoke_tool", "memory_read"],
+        &["runtime", "compare"],
+    );
+    review_runtime_capability_variant(
+        &candidate_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "flow",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(
+        !plan.promotable,
+        "not-ready family should not be promotable"
+    );
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::NotReady
+    );
+    assert_eq!(
+        plan.planned_artifact.artifact_kind,
+        "programmatic_flow_spec"
+    );
+    assert_eq!(plan.planned_artifact.delivery_surface, "programmatic_flows");
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "stability"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "stability should surface as a missing-evidence blocker"
+    );
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "warning_pressure"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "warnings should surface as missing-evidence blockers"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("programmatic flow")),
+        "checklist should include the target-specific programmatic flow review item"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_reports_blocked_profile_note_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-blocked");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "note-a",
+        -0.1,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "note-b",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_a_path = root.join("artifacts/runtime-capability-note-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-note-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "note-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProfileNoteAddendum,
+        "Record browser preview operator guidance in profile memory",
+        "Browser preview operator guidance only",
+        &["memory_write"],
+        &["profile", "guidance"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "note-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ProfileNoteAddendum,
+        "Record browser preview operator guidance in profile memory",
+        "Browser preview operator guidance only",
+        &["memory_write"],
+        &["profile", "guidance"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "note-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
+        "note-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(!plan.promotable, "blocked family should not be promotable");
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Blocked
+    );
+    assert_eq!(plan.planned_artifact.artifact_kind, "profile_note_addendum");
+    assert_eq!(plan.planned_artifact.delivery_surface, "profile_note");
+    assert!(
+        plan.blockers.iter().any(|blocker| {
+            blocker.dimension == "review_consensus"
+                && blocker.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Blocked
+        }),
+        "blocked review consensus should surface as a hard-stop blocker"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("advisory profile guidance")),
+        "checklist should include the target-specific profile-note review item"
+    );
+    assert!(
+        plan.rollback_hints
+            .iter()
+            .any(|hint| hint.contains("profile_note")),
+        "rollback hints should mention the profile note delivery surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_rejects_unknown_family_id() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-missing-family");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    propose_runtime_capability_variant(&root, &run_path, "missing");
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: "missing-family".to_owned(),
+            json: false,
+        },
+    )
+    .expect_err("unknown family id should be rejected");
+
+    assert!(
+        error.contains("missing-family"),
+        "error should name the requested family id: {error}"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -318,6 +318,23 @@ fn review_runtime_capability_variant(
     .expect("runtime capability review should succeed")
 }
 
+fn rewrite_runtime_capability_created_at(candidate_path: &Path, created_at: &str) {
+    let mut payload = serde_json::from_str::<Value>(
+        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
+    )
+    .expect("decode runtime capability artifact");
+    let created_at_value = payload
+        .as_object_mut()
+        .and_then(|artifact| artifact.get_mut("created_at"))
+        .expect("runtime capability artifact should include created_at");
+    *created_at_value = Value::String(created_at.to_owned());
+    fs::write(
+        candidate_path,
+        serde_json::to_string_pretty(&payload).expect("encode runtime capability artifact"),
+    )
+    .expect("rewrite runtime capability artifact");
+}
+
 #[test]
 fn runtime_capability_propose_persists_candidate_from_finished_run() {
     let root = unique_temp_dir("loongclaw-runtime-capability-propose");
@@ -1127,6 +1144,95 @@ fn runtime_capability_plan_reports_blocked_profile_note_family() {
             .iter()
             .any(|hint| hint.contains("profile_note")),
         "rollback hints should mention the profile note delivery surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_provenance_candidate_ids_follow_family_order() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-provenance-order");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_z_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "z-run",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "a-run",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let candidate_z_path = root.join("artifacts/runtime-capability-zzz-first.json");
+    let candidate_a_path = root.join("artifacts/runtime-capability-aaa-second.json");
+    let candidate_z = propose_runtime_capability_variant_with_target(
+        &root,
+        &run_z_path,
+        "zzz-first",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    let candidate_a = propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "aaa-second",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    rewrite_runtime_capability_created_at(&candidate_z_path, "2026-03-18T08:00:00Z");
+    rewrite_runtime_capability_created_at(&candidate_a_path, "2026-03-18T08:00:01Z");
+    review_runtime_capability_variant(
+        &candidate_z_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "zzz-first",
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "aaa-second",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert_eq!(
+        family.candidate_ids,
+        vec![candidate_z.candidate_id, candidate_a.candidate_id],
+        "family summary should use semantic candidate order"
+    );
+    assert_eq!(
+        plan.provenance.candidate_ids, family.candidate_ids,
+        "planner provenance should preserve the family candidate order"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -96,6 +96,47 @@ fn snapshot_id_from_payload(payload: &Value) -> String {
         .expect("snapshot payload should include lineage.snapshot_id")
 }
 
+fn rewrite_json_file(path: &Path, mutate: impl FnOnce(&mut Value)) {
+    let raw = fs::read_to_string(path).expect("read json fixture");
+    let mut payload = serde_json::from_str::<Value>(&raw).expect("decode json fixture");
+    mutate(&mut payload);
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&payload).expect("encode json fixture"),
+    )
+    .expect("write json fixture");
+}
+
+fn rewrite_runtime_capability_compare_config(config_path: &Path) {
+    let (_, mut config) = mvp::config::load(Some(
+        config_path
+            .to_str()
+            .expect("config path should be valid utf-8"),
+    ))
+    .expect("load config fixture");
+    let openai = config
+        .providers
+        .get("openai-main")
+        .cloned()
+        .expect("openai-main provider should exist");
+    config.set_active_provider_profile("openai-main", openai);
+    config.tools.browser.enabled = false;
+    config.tools.web.enabled = false;
+    config.acp.dispatch.enabled = false;
+    config.acp.default_agent = Some("codex".to_owned());
+    config.acp.allowed_agents = vec!["codex".to_owned()];
+    mvp::config::write(
+        Some(
+            config_path
+                .to_str()
+                .expect("config path should be valid utf-8"),
+        ),
+        &config,
+        true,
+    )
+    .expect("rewrite config fixture");
+}
+
 fn start_runtime_experiment(
     root: &Path,
     snapshot_path: &Path,
@@ -141,6 +182,68 @@ fn start_runtime_experiment_variant(
     )
     .expect("runtime experiment start should succeed");
     (run_path, run)
+}
+
+fn finish_runtime_experiment_with_compare_delta(
+    root: &Path,
+    config_path: &Path,
+) -> (
+    PathBuf,
+    PathBuf,
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(root, &baseline_snapshot_path);
+
+    rewrite_runtime_capability_compare_config(config_path);
+
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "provider and tool policy updated".to_owned(),
+                metric: vec!["task_success=1".to_owned(), "cost_delta=-0.2".to_owned()],
+                warning: vec!["manual verification only".to_owned()],
+                decision:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+
+    (
+        run_path,
+        baseline_snapshot_path,
+        result_snapshot_path,
+        finished,
+    )
 }
 
 fn finish_runtime_experiment(
@@ -249,6 +352,66 @@ fn finish_runtime_experiment_variant(
     (run_path, finished)
 }
 
+fn finish_runtime_experiment_variant_with_compare_delta(
+    root: &Path,
+    slug: &str,
+    cost_delta: f64,
+    warnings: &[&str],
+    decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let config_path = write_runtime_capability_config(root);
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        &config_path,
+        &format!("artifacts/runtime-snapshot-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some(format!("baseline-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment_variant(root, &baseline_snapshot_path, slug);
+
+    rewrite_runtime_capability_compare_config(&config_path);
+
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        &config_path,
+        &format!("artifacts/runtime-snapshot-result-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some(format!("candidate-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: format!("provider and tool policy updated ({slug})"),
+                metric: vec![
+                    "task_success=1".to_owned(),
+                    format!("cost_delta={cost_delta}"),
+                ],
+                warning: warnings.iter().map(|warning| (*warning).to_owned()).collect(),
+                decision,
+                status:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+    (run_path, finished)
+}
+
 fn propose_runtime_capability_variant(
     root: &Path,
     run_path: &Path,
@@ -319,20 +482,13 @@ fn review_runtime_capability_variant(
 }
 
 fn rewrite_runtime_capability_created_at(candidate_path: &Path, created_at: &str) {
-    let mut payload = serde_json::from_str::<Value>(
-        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
-    )
-    .expect("decode runtime capability artifact");
-    let created_at_value = payload
-        .as_object_mut()
-        .and_then(|artifact| artifact.get_mut("created_at"))
-        .expect("runtime capability artifact should include created_at");
-    *created_at_value = Value::String(created_at.to_owned());
-    fs::write(
-        candidate_path,
-        serde_json::to_string_pretty(&payload).expect("encode runtime capability artifact"),
-    )
-    .expect("rewrite runtime capability artifact");
+    rewrite_json_file(candidate_path, |payload| {
+        let created_at_value = payload
+            .as_object_mut()
+            .and_then(|artifact| artifact.get_mut("created_at"))
+            .expect("runtime capability artifact should include created_at");
+        *created_at_value = Value::String(created_at.to_owned());
+    });
 }
 
 #[test]
@@ -388,6 +544,135 @@ fn runtime_capability_propose_persists_candidate_from_finished_run() {
     assert!(
         candidate_path.exists(),
         "propose should persist the candidate artifact"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_persists_snapshot_delta() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-delta");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _, _, _) = finish_runtime_experiment_with_compare_delta(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability-delta.json");
+
+    let candidate =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: Some("browser-preview-delta".to_owned()),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    let snapshot_delta = candidate
+        .source_run
+        .snapshot_delta
+        .as_ref()
+        .expect("candidate should retain recorded snapshot delta");
+    assert!(
+        snapshot_delta.changed_surface_count >= 1,
+        "snapshot delta should report changed surfaces"
+    );
+    assert_ne!(
+        snapshot_delta.provider_active_profile.before, snapshot_delta.provider_active_profile.after,
+        "provider profile should change across the compare snapshots"
+    );
+    assert!(
+        !snapshot_delta.visible_tool_names.removed.is_empty(),
+        "compare delta should capture removed visible tools"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_leaves_snapshot_delta_empty_without_recorded_snapshot_paths() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-no-delta");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, finished) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability-no-delta.json");
+
+    rewrite_json_file(&run_path, |payload| {
+        payload["baseline_snapshot"]["artifact_path"] = Value::Null;
+        payload["result_snapshot"]["artifact_path"] = Value::Null;
+    });
+    assert!(
+        finished.result_snapshot.is_some(),
+        "fixture should still represent a finished run"
+    );
+
+    let candidate =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: Some("browser-preview-no-delta".to_owned()),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should still succeed without artifact paths");
+
+    assert!(
+        candidate.source_run.snapshot_delta.is_none(),
+        "missing recorded snapshot paths should degrade to no snapshot delta"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_rejects_broken_recorded_snapshot_delta() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-broken-delta");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _, result_snapshot_path, _) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+
+    fs::remove_file(&result_snapshot_path).expect("result snapshot fixture should be removable");
+
+    let error =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: root
+                    .join("artifacts/runtime-capability-broken-delta.json")
+                    .display()
+                    .to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: Some("browser-preview-broken-delta".to_owned()),
+                json: false,
+            },
+        )
+        .expect_err("broken recorded snapshots should be rejected");
+
+    assert!(
+        error.contains("snapshot") || error.contains("result"),
+        "error should mention the broken recorded snapshot evidence: {error}"
     );
 
     fs::remove_dir_all(&root).ok();
@@ -567,6 +852,53 @@ fn runtime_capability_show_round_trips_the_persisted_artifact() {
 }
 
 #[test]
+fn runtime_capability_show_accepts_artifacts_missing_snapshot_delta_field() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show-legacy-delta");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _, _, _) = finish_runtime_experiment_with_compare_delta(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability-legacy.json");
+
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+            target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                .to_owned(),
+            bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                .to_owned(),
+            required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+            tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+            label: Some("browser-preview-legacy".to_owned()),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed");
+
+    rewrite_json_file(&candidate_path, |payload| {
+        payload["source_run"]
+            .as_object_mut()
+            .expect("source_run should be an object")
+            .remove("snapshot_delta");
+    });
+
+    let shown = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect("show should keep backward compatibility with legacy artifacts");
+
+    assert!(
+        shown.source_run.snapshot_delta.is_none(),
+        "missing snapshot_delta should deserialize as None"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_show_rejects_inconsistent_review_state() {
     let root = unique_temp_dir("loongclaw-runtime-capability-show-invalid-state");
     let config_path = write_runtime_capability_config(&root);
@@ -617,19 +949,15 @@ fn runtime_capability_show_rejects_inconsistent_review_state() {
 #[test]
 fn runtime_capability_index_groups_related_candidates_and_reports_ready_family() {
     let root = unique_temp_dir("loongclaw-runtime-capability-index-ready");
-    let config_path = write_runtime_capability_config(&root);
-
-    let (run_a_path, _) = finish_runtime_experiment_variant(
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_compare_delta(
         &root,
-        &config_path,
         "a",
         -0.2,
         &[],
         loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
     );
-    let (run_b_path, _) = finish_runtime_experiment_variant(
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_compare_delta(
         &root,
-        &config_path,
         "b",
         -0.4,
         &[],
@@ -678,6 +1006,24 @@ fn runtime_capability_index_groups_related_candidates_and_reports_ready_family()
     assert_eq!(family.evidence.total_candidates, 2);
     assert_eq!(family.evidence.accepted_candidates, 2);
     assert_eq!(family.evidence.distinct_source_run_count, 2);
+    assert_eq!(
+        family.evidence.delta_candidate_count, 2,
+        "both accepted candidates should contribute snapshot delta evidence"
+    );
+    assert!(
+        family
+            .evidence
+            .changed_surfaces
+            .contains(&"provider_active_profile".to_owned()),
+        "aggregated delta evidence should keep provider profile changes"
+    );
+    assert!(
+        family
+            .evidence
+            .changed_surfaces
+            .contains(&"visible_tool_names".to_owned()),
+        "aggregated delta evidence should keep visible tool changes"
+    );
     assert_eq!(
         family
             .evidence
@@ -822,19 +1168,15 @@ fn runtime_capability_index_marks_family_blocked_on_conflicting_reviews() {
 #[test]
 fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
     let root = unique_temp_dir("loongclaw-runtime-capability-plan-ready");
-    let config_path = write_runtime_capability_config(&root);
-
-    let (run_a_path, _) = finish_runtime_experiment_variant(
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_compare_delta(
         &root,
-        &config_path,
         "ready-a",
         -0.2,
         &[],
         loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
     );
-    let (run_b_path, _) = finish_runtime_experiment_variant(
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_compare_delta(
         &root,
-        &config_path,
         "ready-b",
         -0.4,
         &[],
@@ -903,6 +1245,22 @@ fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
     );
     assert_eq!(plan.planned_artifact.artifact_kind, "managed_skill_bundle");
     assert_eq!(plan.planned_artifact.delivery_surface, "managed_skills");
+    assert_eq!(
+        plan.evidence.delta_candidate_count, 2,
+        "planner should surface aggregated delta evidence"
+    );
+    assert!(
+        plan.evidence
+            .changed_surfaces
+            .contains(&"provider_active_profile".to_owned()),
+        "planner should surface the provider-profile delta hint"
+    );
+    assert!(
+        plan.evidence
+            .changed_surfaces
+            .contains(&"visible_tool_names".to_owned()),
+        "planner should surface the visible-tool delta hint"
+    );
     assert!(
         plan.planned_artifact
             .artifact_id

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -119,6 +119,30 @@ fn start_runtime_experiment(
     (run_path, run)
 }
 
+fn start_runtime_experiment_variant(
+    root: &Path,
+    snapshot_path: &Path,
+    slug: &str,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let run_path = root.join(format!("artifacts/runtime-experiment-{slug}.json"));
+    let run = loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_start_command(
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentStartCommandOptions {
+            snapshot: snapshot_path.display().to_string(),
+            output: run_path.display().to_string(),
+            mutation_summary: format!("enable browser preview skill ({slug})"),
+            experiment_id: Some("exp-42".to_owned()),
+            label: Some(format!("browser-preview-{slug}")),
+            tag: vec!["browser".to_owned(), slug.to_owned()],
+            json: false,
+        },
+    )
+    .expect("runtime experiment start should succeed");
+    (run_path, run)
+}
+
 fn finish_runtime_experiment(
     root: &Path,
     config_path: &Path,
@@ -166,6 +190,110 @@ fn finish_runtime_experiment(
         )
         .expect("runtime experiment finish should succeed");
     (run_path, finished)
+}
+
+fn finish_runtime_experiment_variant(
+    root: &Path,
+    config_path: &Path,
+    slug: &str,
+    cost_delta: f64,
+    warnings: &[&str],
+    decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        &format!("artifacts/runtime-snapshot-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some(format!("baseline-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment_variant(root, &baseline_snapshot_path, slug);
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        &format!("artifacts/runtime-snapshot-result-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some(format!("candidate-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: format!("provider and tool policy updated ({slug})"),
+                metric: vec![
+                    "task_success=1".to_owned(),
+                    format!("cost_delta={cost_delta}"),
+                ],
+                warning: warnings.iter().map(|warning| (*warning).to_owned()).collect(),
+                decision,
+                status:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+    (run_path, finished)
+}
+
+fn propose_runtime_capability_variant(
+    root: &Path,
+    run_path: &Path,
+    slug: &str,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument,
+) {
+    let candidate_path = root.join(format!("artifacts/runtime-capability-{slug}.json"));
+    let candidate =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: Some(format!("browser-preview-skill-candidate-{slug}")),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+    (candidate_path, candidate)
+}
+
+fn review_runtime_capability_variant(
+    candidate_path: &Path,
+    decision: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision,
+    slug: &str,
+) -> loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityArtifactDocument {
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_review_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            decision,
+            review_summary: format!("reviewed runtime capability candidate {slug}"),
+            warning: Vec::new(),
+            json: false,
+        },
+    )
+    .expect("runtime capability review should succeed")
 }
 
 #[test]
@@ -395,6 +523,259 @@ fn runtime_capability_show_round_trips_the_persisted_artifact() {
     .expect("show should round-trip the persisted artifact");
 
     assert_eq!(shown, proposed);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_show_rejects_inconsistent_review_state() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show-invalid-state");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability.json");
+
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+            target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                .to_owned(),
+            bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                .to_owned(),
+            required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+            tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+            label: Some("browser-preview-invalid-state".to_owned()),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed");
+
+    let mut raw = serde_json::from_str::<Value>(
+        &fs::read_to_string(&candidate_path).expect("read persisted capability candidate"),
+    )
+    .expect("decode persisted capability candidate");
+    raw["status"] = Value::String("reviewed".to_owned());
+    fs::write(
+        &candidate_path,
+        serde_json::to_string_pretty(&raw).expect("encode malformed capability candidate"),
+    )
+    .expect("persist malformed capability candidate");
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect_err("inconsistent review state should be rejected");
+
+    assert!(error.contains("inconsistent"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_groups_related_candidates_and_reports_ready_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-ready");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) = propose_runtime_capability_variant(&root, &run_a_path, "a");
+    let (candidate_b_path, _) = propose_runtime_capability_variant(&root, &run_b_path, "b");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "b",
+    );
+
+    fs::write(
+        root.join("artifacts/ignore-me.json"),
+        "{\"hello\":\"world\"}",
+    )
+    .expect("write unrelated json fixture");
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+
+    assert_eq!(report.total_candidate_count, 2);
+    assert_eq!(report.family_count, 1);
+
+    let family = report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    assert_eq!(
+        family.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Ready
+    );
+    assert_eq!(family.evidence.total_candidates, 2);
+    assert_eq!(family.evidence.accepted_candidates, 2);
+    assert_eq!(family.evidence.distinct_source_run_count, 2);
+    assert_eq!(
+        family
+            .evidence
+            .metric_ranges
+            .get("cost_delta")
+            .expect("cost delta range should exist")
+            .min,
+        -0.4
+    );
+    assert_eq!(
+        family
+            .evidence
+            .metric_ranges
+            .get("cost_delta")
+            .expect("cost delta range should exist")
+            .max,
+        -0.2
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_marks_family_not_ready_when_evidence_is_incomplete() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-not-ready");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "solo",
+        -0.2,
+        &["manual verification only"],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (candidate_path, _) = propose_runtime_capability_variant(&root, &run_path, "solo");
+    review_runtime_capability_variant(
+        &candidate_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "solo",
+    );
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+
+    let family = report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    assert_eq!(
+        family.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::NotReady
+    );
+    assert!(
+        family.readiness.checks.iter().any(|check| {
+            check.dimension == "stability"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "stability should require repeated evidence"
+    );
+    assert!(
+        family.readiness.checks.iter().any(|check| {
+            check.dimension == "warning_pressure"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "warnings should keep the family out of ready state"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_marks_family_blocked_on_conflicting_reviews() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-blocked");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "accept",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "reject",
+        -0.1,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) = propose_runtime_capability_variant(&root, &run_a_path, "accept");
+    let (candidate_b_path, _) = propose_runtime_capability_variant(&root, &run_b_path, "reject");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "accept",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
+        "reject",
+    );
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+
+    let family = report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    assert_eq!(
+        family.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Blocked
+    );
+    assert!(
+        family.readiness.checks.iter().any(|check| {
+            check.dimension == "review_consensus"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Blocked
+        }),
+        "review consensus should block mixed accepted/rejected evidence"
+    );
 
     fs::remove_dir_all(&root).ok();
 }

--- a/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
@@ -377,6 +377,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_id_mismatch() {
 #   "metadata": {
 #     "bridge_kind":"process_stdio",
 #     "command":"python3",
+#     "process_timeout_ms":"15000",
 #     "args_json":"[\"-c\",\"import json,sys,time; sys.stdout.write(json.dumps({'method':'tools/call','id':'wrong-id','payload':{'ok':True}})+'\\\\n'); sys.stdout.flush(); time.sleep(0.05)\"]",
 #     "version":"1.0.0"
 #   }
@@ -488,6 +489,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_method_mismatch() {
 #   "metadata": {
 #     "bridge_kind":"process_stdio",
 #     "command":"python3",
+#     "process_timeout_ms":"15000",
 #     "args_json":"[\"-c\",\"import json,sys,time; sys.stdout.write(json.dumps({'method':'tools/list','id':'stdio-mismatch-method-provider:primary:invoke','payload':{'ok':True}})+'\\\\n'); sys.stdout.flush(); time.sleep(0.05)\"]",
 #     "version":"1.0.0"
 #   }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -291,6 +291,7 @@ Delivered in current baseline:
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
   - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
   - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests, and evaluates readiness as `ready`, `not_ready`, or `blocked`
+  - `runtime-capability plan` resolves one indexed capability family into a deterministic dry-run promotion plan with artifact identity, blockers, approval checklist, rollback hints, and provenance
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -310,7 +311,7 @@ Remaining deliverables:
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
   - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
-  - add a dry-run promotion planner on top of the capability-family readiness output instead of jumping directly to automatic mutation
+  - keep the new dry-run promotion planner read-only and use it as the contract for any future promotion executor instead of jumping directly to automatic mutation
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
   - partial governed adapter skeleton now exists for richer page actions:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -289,6 +289,7 @@ Delivered in current baseline:
   - `runtime-snapshot` persists lineage-aware runtime checkpoint artifacts
   - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
+  - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -307,7 +308,7 @@ Remaining deliverables:
   - sustain tagged release publishing across macOS/Linux/Windows
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
-  - use the shipped snapshot/restore/experiment record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
+  - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
   - partial governed adapter skeleton now exists for richer page actions:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-18
+Last updated: 2026-03-19
 
 This roadmap is execution-focused. Every stage has:
 
@@ -290,6 +290,7 @@ Delivered in current baseline:
   - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
   - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
+  - capability artifacts can now retain snapshot-backed runtime delta evidence from recorded baseline/result snapshots so later promotion layers consume structured change evidence instead of recomputing compare output
   - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests, and evaluates readiness as `ready`, `not_ready`, or `blocked`
   - `runtime-capability plan` resolves one indexed capability family into a deterministic dry-run promotion plan with artifact identity, blockers, approval checklist, rollback hints, and provenance
 - modular channel/provider architecture for extension-safe evolution:
@@ -310,7 +311,7 @@ Remaining deliverables:
   - sustain tagged release publishing across macOS/Linux/Windows
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
-  - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
+  - use the shipped snapshot/restore/experiment/capability record layer, including structured runtime delta evidence, as the prerequisite for later evaluator pipelines and automated skill-optimization loops
   - keep the new dry-run promotion planner read-only and use it as the contract for any future promotion executor instead of jumping directly to automatic mutation
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-16
+Last updated: 2026-03-18
 
 This roadmap is execution-focused. Every stage has:
 
@@ -290,6 +290,7 @@ Delivered in current baseline:
   - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
   - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
+  - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests, and evaluates readiness as `ready`, `not_ready`, or `blocked`
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -309,6 +310,7 @@ Remaining deliverables:
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
   - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
+  - add a dry-run promotion planner on top of the capability-family readiness output instead of jumping directly to automatic mutation
 - managed browser automation companion:
   - keep `browser.open`, `browser.extract`, and `browser.click` as the shipped safe browser lane
   - partial governed adapter skeleton now exists for richer page actions:

--- a/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md
+++ b/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md
@@ -1,0 +1,317 @@
+# Alpha-Test Runtime Capability Candidate Foundation Design
+
+## Problem
+
+`runtime-snapshot` and `runtime-experiment` now give LoongClaw a clean,
+operator-controlled record layer for:
+
+- one baseline runtime state
+- one candidate result state
+- one explicit experiment decision
+- one optional runtime-surface delta report
+
+That closes the "what changed?" gap, but it still leaves the next
+self-evolution gap open.
+
+After an experiment run is compared and accepted or rejected, the operator still
+has no first-class artifact that answers:
+
+- what reusable capability candidate did this run produce?
+- should the candidate become a `managed_skill`, a `programmatic_flow`, or a
+  `profile_note_addendum`?
+- what bounded scope and required capabilities should that candidate carry?
+- did an operator later accept or reject that capability candidate itself?
+
+Today those answers live in ad-hoc notes, issue comments, or operator memory.
+That is workable for one-off exploration, but it is not a durable foundation for
+governed self-evolution.
+
+## Goal
+
+Define the smallest LoongClaw-native `runtime-capability` record layer that:
+
+1. derives one capability candidate from one finished `runtime-experiment` run
+2. keeps the first slice local-first, deterministic, and operator-readable
+3. records the intended promotion target and bounded scope without mutating live
+   runtime state
+4. adds an explicit review gate above experiment results and below any future
+   automatic promotion system
+5. stays small enough to ship before any autonomous skill/script generation
+
+## Non-Goals
+
+- automatically generating or applying `managed_skill` artifacts
+- automatically generating or applying `programmatic_flow` definitions
+- mutating `profile_note` or runtime config during candidate creation/review
+- automatically deciding which target type to use
+- evaluating arbitrary shell commands or free-form plans inside this command
+- replacing `runtime-experiment` as the source of truth for experiment evidence
+- building a dashboard, queue, or optimizer loop in the first slice
+
+## Constraints
+
+- `runtime-experiment` remains the source of truth for experiment evidence and
+  runtime-state comparison.
+- The first artifact format must remain plain JSON, operator-readable, and easy
+  to diff in git or local storage.
+- The first command surface must not require live runtime mutation, daemon
+  writes, or background services.
+- Capability candidates must stay portable; embedded data should be summaries,
+  not full copied run payloads.
+- The target types should align with shipped LoongClaw concepts, not introduce a
+  new parallel taxonomy.
+
+## Approaches Considered
+
+### Option A: Extend `runtime-experiment` artifacts directly
+
+Add capability-target metadata and candidate review fields directly to the
+existing run artifact schema.
+
+Pros:
+
+- smallest apparent surface area
+- no new command family
+- direct linkage to the experiment record
+
+Cons:
+
+- mixes "experiment evidence" with "promotion candidate" concerns
+- makes the run artifact responsible for two different lifecycle stages
+- increases schema churn on the record layer that was intentionally kept small
+
+### Option B: Add a separate `runtime-capability` artifact and CLI
+
+Create a new `runtime-capability` command family with `propose`, `review`, and
+`show`, backed by a separate capability-candidate artifact derived from one
+finished run.
+
+Pros:
+
+- preserves the boundary between experiment evidence and promotion intent
+- creates the missing middle layer between run comparison and future automation
+- stays operator-controlled and local-first
+- keeps the first slice additive and easy to test
+
+Cons:
+
+- introduces another JSON artifact type to explain
+- duplicates a small subset of source run metadata for portability
+- does not yet perform any automatic promotion
+
+### Option C: Jump directly to automatic skill/script promotion
+
+Let the system translate selected experiment runs directly into reusable
+artifacts and apply them automatically.
+
+Pros:
+
+- closest to the long-term self-evolving runtime vision
+- highest headline value
+
+Cons:
+
+- couples generation, review, policy, mutation, and rollback too early
+- creates immediate safety and audit questions around incorrect promotion
+- risks slop debt before the candidate record contract is proven
+
+## Decision
+
+Choose Option B.
+
+`alpha-test` should first gain a separate capability-candidate artifact and CLI
+surface. That keeps `runtime-experiment` focused on "what happened in one run"
+while `runtime-capability` answers "what reusable capability candidate should be
+considered next."
+
+The first slice should remain record-oriented and explicit. It should not
+generate code, install skills, or mutate config.
+
+## Proposed Surface
+
+### Command family
+
+- `loongclaw runtime-capability propose`
+- `loongclaw runtime-capability review`
+- `loongclaw runtime-capability show`
+
+### Propose command
+
+Create one capability-candidate artifact from one finished experiment run.
+
+```bash
+loongclaw runtime-capability propose \
+  --run artifacts/runtime-experiment.json \
+  --output artifacts/runtime-capability.json \
+  --target managed_skill \
+  --target-summary "Codify browser preview onboarding as a reusable managed skill" \
+  --bounded-scope "Browser preview onboarding and companion readiness checks only" \
+  --required-capability invoke_tool \
+  --required-capability memory_read \
+  --tag browser \
+  --tag onboarding
+```
+
+Behavior:
+
+- load the source run artifact
+- require the run to be finished (`completed` or `aborted`), not `planned`
+- require the run to include an evaluation payload
+- persist a new capability-candidate artifact with:
+  - stable `candidate_id`
+  - source run summary
+  - explicit target type
+  - bounded scope
+  - normalized tags
+  - normalized required capabilities
+  - `proposed` / `undecided` starting state
+
+### Review command
+
+Attach one explicit operator review decision to a proposed capability candidate.
+
+```bash
+loongclaw runtime-capability review \
+  --candidate artifacts/runtime-capability.json \
+  --decision accepted \
+  --review-summary "Promotion target is bounded and evidence supports manual codification" \
+  --warning "still requires manual implementation"
+```
+
+Behavior:
+
+- load the existing candidate artifact
+- require the current candidate status to be `proposed`
+- record one terminal review decision (`accepted` or `rejected`)
+- record one review summary and optional warnings
+- persist the updated artifact in place
+
+### Show command
+
+Render one persisted capability-candidate artifact without mutation.
+
+```bash
+loongclaw runtime-capability show --candidate artifacts/runtime-capability.json [--json]
+```
+
+Text output should keep review-critical fields first:
+
+- `candidate_id`
+- `status`
+- `decision`
+- `target`
+- `target_summary`
+- `bounded_scope`
+- `source_run_id`
+- `source_run_decision`
+- `source_run_metrics`
+- `review_summary`
+
+## Proposed Artifact Model
+
+```json
+{
+  "schema": {
+    "version": 1,
+    "surface": "runtime_capability",
+    "purpose": "promotion_candidate_record"
+  },
+  "candidate_id": "candidate-...",
+  "created_at": "2026-03-17T08:00:00Z",
+  "reviewed_at": null,
+  "label": "browser-preview-skill-candidate",
+  "status": "proposed",
+  "decision": "undecided",
+  "proposal": {
+    "target": "managed_skill",
+    "summary": "Codify browser preview onboarding as a reusable managed skill",
+    "bounded_scope": "Browser preview onboarding and companion readiness checks only",
+    "tags": ["browser", "onboarding"],
+    "required_capabilities": ["invoke_tool", "memory_read"]
+  },
+  "source_run": {
+    "run_id": "run-...",
+    "experiment_id": "exp-42",
+    "label": "browser-preview-a",
+    "status": "completed",
+    "decision": "promoted",
+    "mutation_summary": "enable browser preview skill",
+    "baseline_snapshot_id": "snapshot-a",
+    "result_snapshot_id": "snapshot-b",
+    "evaluation_summary": "provider and tool policy updated",
+    "metrics": {
+      "cost_delta": -0.2,
+      "task_success": 1.0
+    },
+    "warnings": ["manual verification only"],
+    "artifact_path": "/abs/path/runtime-experiment.json"
+  },
+  "review": null
+}
+```
+
+### Key model choices
+
+- `source_run` stores a compact experiment summary so the candidate remains
+  readable even when the original run file is not open.
+- `artifact_path` remains optional traceability metadata; it is not the source
+  of truth.
+- `proposal.target` is intentionally limited to shipped LoongClaw terms:
+  `managed_skill`, `programmatic_flow`, and `profile_note_addendum`.
+- `required_capabilities` are normalized string identifiers so the artifact can
+  remain language-agnostic and diff-friendly.
+- `review` is absent until the operator performs an explicit review action.
+
+## Why Not Reuse Experiment Decisions Directly
+
+`runtime-experiment` answers whether one runtime mutation attempt looked good or
+bad. That is necessary evidence, but it is not the same as deciding how the
+result should be crystallized into a reusable capability.
+
+Keeping `runtime-capability` separate preserves this boundary:
+
+- experiment run = one evaluated runtime change
+- capability candidate = one proposed reusable codification of that change
+
+## Error Handling
+
+- missing run file -> hard error
+- unsupported run artifact schema version -> hard error
+- `propose` from a `planned` run -> hard error
+- `propose` from a run without evaluation -> hard error
+- empty `target_summary` or `bounded_scope` -> hard error
+- unknown required capability string -> hard error naming the offending value
+- `review` on an already reviewed candidate -> hard error
+- malformed candidate review summary -> hard error
+
+## Testing Strategy
+
+1. CLI parsing for `runtime-capability propose|review|show`
+2. propose flow persists a normalized candidate artifact from a finished run
+3. propose rejects unfinished runs
+4. propose rejects unknown capability strings
+5. review flow updates the candidate once and persists review data
+6. review rejects double review
+7. `show --json` round-trips the persisted artifact
+8. text rendering surfaces decision-critical fields first
+
+## Rollout
+
+1. Land the artifact schema and CLI surface.
+2. Update product docs and roadmap references so `runtime-capability` is
+   explained as the review gate above experiment runs and below future
+   automation.
+3. Keep actual skill/script/profile-note mutation out of scope until the record
+   contract is proven in real operator use.
+
+## Recommendation
+
+Implement `runtime-capability` as the next governed self-evolution slice for
+`alpha-test`.
+
+It adds the missing middle layer without compromising the existing safety model:
+
+- experiments stay about evidence
+- candidates stay about reusable intent
+- future automation can build on explicit records instead of ad-hoc operator
+  memory

--- a/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md
+++ b/docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md
@@ -1,0 +1,224 @@
+# Runtime Capability Candidate Foundation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a minimal `runtime-capability` record layer that derives one reusable capability candidate from one finished `runtime-experiment` run and records one explicit operator review decision.
+
+**Architecture:** Reuse the existing daemon-side record-artifact pattern from `runtime_experiment_cli`, keep the new surface file-based and operator-controlled, and do not mutate live runtime config, managed skills, or profile notes. The new artifact stores a compact source-run summary plus proposal/review metadata so later automation has a stable contract.
+
+**Tech Stack:** Rust, `clap`, `serde`, daemon CLI integration tests, Markdown product docs
+
+---
+
+### Task 1: Write the design and planning artifacts
+
+**Files:**
+- Create: `docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md`
+- Create: `docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Describe the problem, goal, non-goals, command surface, artifact schema,
+testing strategy, and recommendation.
+
+**Step 2: Verify the design artifact exists**
+
+Run: `test -f docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md`
+Expected: exit 0
+
+**Step 3: Write the implementation plan**
+
+Capture the exact file changes, tests, commands, and verification steps below.
+
+**Step 4: Verify the plan artifact exists**
+
+Run: `test -f docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md`
+Expected: exit 0
+
+### Task 2: Add failing CLI parsing coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Write the failing parse tests**
+
+Add parse coverage for:
+
+- `runtime-capability propose`
+- `runtime-capability review`
+- `runtime-capability show`
+
+The tests should assert:
+
+- `--run`, `--output`, `--target`, `--target-summary`, `--bounded-scope`,
+  repeated `--required-capability`, repeated `--tag`, and `--json` parse into
+  the correct option struct for `propose`
+- `--candidate`, `--decision`, `--review-summary`, repeated `--warning`, and
+  `--json` parse into the correct option struct for `review`
+- `--candidate` and `--json` parse into the correct option struct for `show`
+
+**Step 2: Run the targeted parse tests to verify RED**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_cli_ -- --nocapture`
+Expected: FAIL because the command family and types do not exist yet
+
+### Task 3: Add failing runtime-capability integration tests
+
+**Files:**
+- Create if needed: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+- Modify if preferred by repo convention: `crates/daemon/tests/integration/runtime_experiment_cli.rs`
+
+**Step 1: Write the failing propose/show/review tests**
+
+Cover:
+
+- `propose` persists a capability-candidate artifact from a finished run
+- proposal tags and required capabilities are normalized and deduplicated
+- source run summary carries run id, experiment id, decision, mutation summary,
+  metrics, warnings, and optional artifact path
+- `propose` rejects a `planned` run
+- `propose` rejects an unknown capability string
+- `review` records one terminal decision and review summary
+- `review` rejects double review
+- `show` round-trips the persisted artifact
+
+**Step 2: Run the targeted integration tests to verify RED**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_ -- --nocapture`
+Expected: FAIL because the runtime-capability code path does not exist yet
+
+### Task 4: Implement the new daemon CLI surface
+
+**Files:**
+- Create: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+
+**Step 1: Add the new command family and option structs**
+
+Implement:
+
+- `RuntimeCapabilityCommands`
+- `RuntimeCapabilityProposeCommandOptions`
+- `RuntimeCapabilityReviewCommandOptions`
+- `RuntimeCapabilityShowCommandOptions`
+
+Also add the command family to top-level daemon CLI parsing and dispatch.
+
+**Step 2: Add the artifact structs and helpers**
+
+Implement:
+
+- schema, proposal, source-run summary, review, and artifact document structs
+- normalized target enum
+- normalized review-decision enum
+- helper functions for timestamps, text validation, repeated-value normalization,
+  capability parsing, artifact persistence, and text rendering
+
+**Step 3: Implement `propose` with minimal run-derived logic**
+
+`propose` should:
+
+- load a finished `runtime-experiment` artifact
+- reject unfinished runs or runs without evaluation
+- build a compact source-run summary
+- normalize tags and required capabilities
+- compute a stable `candidate_id`
+- persist the new artifact to the requested output path
+
+**Step 4: Implement `review` and `show`**
+
+`review` should:
+
+- load the candidate artifact
+- reject non-proposed candidates
+- persist `reviewed_at`, terminal decision, summary, and warnings
+
+`show` should:
+
+- load the artifact
+- print JSON or a stable text summary without mutation
+
+**Step 5: Run targeted daemon tests to verify GREEN**
+
+Run: `cargo test -p loongclaw-daemon --test integration runtime_capability_ runtime_experiment_cli_ -- --nocapture`
+Expected: PASS
+
+### Task 5: Update product docs and roadmap references
+
+**Files:**
+- Create: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/product-specs/index.md`
+- Modify: `docs/ROADMAP.md`
+- Modify if needed: `AGENTS.md`
+- Modify if needed: `CLAUDE.md`
+
+**Step 1: Add the product spec**
+
+Describe `runtime-capability` as the review layer above `runtime-experiment`
+and below future automation. Keep automatic mutation explicitly out of scope.
+
+**Step 2: Wire the product spec index**
+
+Add `Runtime Capability` to `docs/product-specs/index.md`.
+
+**Step 3: Update the roadmap**
+
+Mention the new capability-candidate record layer as a prerequisite for later
+skill-optimization loops or governed promotion work.
+
+**Step 4: Run doc spot checks**
+
+Run: `rg -n "runtime-capability|runtime capability|skill-optimization" docs/product-specs docs/ROADMAP.md`
+Expected: matches in the new/updated docs only
+
+### Task 6: Verify, isolate, and commit
+
+**Files:**
+- Review all touched files
+
+**Step 1: Run focused verification**
+
+Run:
+
+- `cargo test -p loongclaw-daemon --test integration runtime_capability_ runtime_experiment_cli_ -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability -- --nocapture`
+
+Expected: PASS
+
+**Step 2: Run repo-level CI-parity checks**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 3: Inspect the final diff**
+
+Run:
+
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`
+
+Expected: only runtime-capability and directly related doc/test changes
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-design.md \
+  docs/plans/2026-03-17-alpha-test-runtime-capability-candidate-foundation-implementation-plan.md \
+  docs/product-specs/runtime-capability.md \
+  docs/product-specs/index.md \
+  docs/ROADMAP.md \
+  crates/daemon/src/runtime_capability_cli.rs \
+  crates/daemon/src/lib.rs \
+  crates/daemon/src/main.rs \
+  crates/daemon/tests/integration/cli_tests.rs \
+  crates/daemon/tests/integration/runtime_capability_cli.rs
+git commit -m "feat(daemon): add runtime capability candidate records"
+```

--- a/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md
+++ b/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md
@@ -1,0 +1,287 @@
+# Runtime Capability Index and Readiness Gate Design
+
+## Problem
+
+`runtime-capability` currently gives LoongClaw one governed record per finished
+experiment run:
+
+- one proposal
+- one explicit target type
+- one explicit operator review decision
+
+That closes the "should this single run become a reusable lower-layer artifact?"
+gap, but it still leaves the next governance gap open.
+
+Operators still cannot answer, in one deterministic view:
+
+- which candidate records are really the same underlying promotion intent?
+- how many independent runs now support that intent?
+- is the evidence strong enough to treat the intent as promotion-ready?
+- what compact digest should later automation use instead of reopening every
+  source run artifact?
+
+Without that middle layer, every future promotion flow would have to reason over
+ad-hoc sets of individual candidate files. That is expensive, noisy, and easy
+to get wrong.
+
+## Goal
+
+Add the next strictly read-only layer above individual capability candidates:
+
+1. aggregate compatible candidates into deterministic capability families
+2. summarize evidence into a compact, auditable digest
+3. evaluate readiness as `ready`, `not_ready`, or `blocked`
+4. keep the entire slice local-first, deterministic, and operator-readable
+5. avoid automatic promotion or mutation in this phase
+
+## Non-Goals
+
+- automatically generating or applying managed skills
+- automatically generating or applying programmatic flows
+- automatically mutating runtime config or profile notes
+- semantic clustering powered by an LLM or fuzzy matching
+- background queues, schedulers, or continuously running index daemons
+- changing `runtime-experiment` to become the source of truth for family state
+- introducing a promotion executor in the same change
+
+## Constraints
+
+- The source of truth remains the persisted `runtime-capability` candidate
+  artifacts.
+- The new layer must stay additive and keep existing candidate artifacts valid.
+- The grouping rule must be deterministic and explainable from stored fields.
+- Readiness must come from explicit evidence checks, not opaque heuristics.
+- The first slice should optimize for auditability and token savings over
+  autonomy.
+
+## Approaches Considered
+
+### Option A: Add an index command that derives families from proposal intent
+
+Scan candidate artifacts under one root, derive a stable family id from the
+normalized promotion-intent fields, and emit one read-only report.
+
+Pros:
+
+- additive and backward-compatible
+- keeps candidate artifacts unchanged
+- deterministic and easy to diff
+- minimal code surface
+
+Cons:
+
+- only exact promotion-intent matches aggregate together
+- does not repair older artifacts with inconsistent free-form wording
+
+### Option B: Add a new persisted family artifact and update candidates to point to it
+
+Introduce a new artifact type, persist one family record, and embed a stable
+family id into every candidate.
+
+Pros:
+
+- explicit family storage
+- faster later lookups
+
+Cons:
+
+- more schema churn immediately after the foundation landed
+- requires deciding write/update ownership for a new artifact type
+- adds mutation semantics to a slice that can stay read-only for now
+
+### Option C: Use semantic clustering to infer families automatically
+
+Let a model or fuzzy matcher group candidates with similar summaries and scopes.
+
+Pros:
+
+- groups near-duplicate wording together
+
+Cons:
+
+- opaque and unstable
+- hard to audit
+- introduces model dependence into a governance gate
+
+## Decision
+
+Choose Option A.
+
+The next slice should stay deterministic, read-only, and cheap. A capability
+family is defined as "the same normalized promotion intent":
+
+- same target type
+- same target summary
+- same bounded scope
+- same normalized tag set
+- same normalized required-capability set
+
+That intent fingerprint is strict by design. If an operator changes the intended
+promotion summary or scope, LoongClaw should treat that as a different family
+instead of silently merging it.
+
+## Proposed Surface
+
+### Command family
+
+Keep the existing commands and add one new read-only command:
+
+- `loongclaw runtime-capability propose`
+- `loongclaw runtime-capability review`
+- `loongclaw runtime-capability show`
+- `loongclaw runtime-capability index`
+
+### Index command
+
+```bash
+loongclaw runtime-capability index \
+  --root artifacts/runtime-capability \
+  [--json]
+```
+
+Behavior:
+
+- recursively scan `--root`
+- load JSON files that decode as supported `runtime-capability` artifacts
+- derive one stable family id from normalized proposal intent
+- group candidates by family id
+- build one compact evidence digest per family
+- evaluate readiness through explicit deterministic checks
+- render text or JSON without mutating any artifact
+
+## Family Model
+
+### Family id
+
+Compute `family_id` from a SHA-256 hash of:
+
+- `proposal.target`
+- `proposal.summary`
+- `proposal.bounded_scope`
+- normalized `proposal.tags`
+- normalized `proposal.required_capabilities`
+
+This intentionally excludes:
+
+- `candidate_id`
+- timestamps
+- source run ids
+- labels
+- operator review text
+
+The family key therefore represents promotion intent, not one specific piece of
+evidence.
+
+### Compact evidence digest
+
+Each family summary should expose compact evidence instead of replaying every
+source artifact:
+
+- candidate count
+- reviewed / undecided counts
+- accepted / rejected counts
+- distinct source run count
+- distinct experiment id count
+- latest candidate timestamp
+- latest review timestamp
+- source decision rollup
+- unique warnings observed across accepted candidates
+- per-metric min/max rollups
+
+This gives later automation a stable digest to reason over without reopening all
+candidate and experiment files.
+
+## Readiness Gate
+
+Readiness is derived from explicit check results. Each check reports:
+
+- dimension name
+- status: `pass`, `needs_evidence`, or `blocked`
+- summary
+
+Overall readiness is:
+
+- `blocked` if any check is `blocked`
+- `ready` if every check passes
+- `not_ready` otherwise
+
+### Checks
+
+#### 1. Review consensus
+
+- `pass`: every candidate in the family has been reviewed and accepted
+- `needs_evidence`: at least one candidate remains undecided and there are no
+  rejected candidates
+- `blocked`: any candidate in the family was rejected
+
+Rationale: promotion cannot be considered ready if the family already contains a
+negative operator decision or unresolved candidate evidence.
+
+#### 2. Stability
+
+- `pass`: the family contains evidence from at least two distinct source runs
+- `needs_evidence`: fewer than two distinct source runs exist
+
+Rationale: one successful run is promising; two independent runs is the minimum
+signal that the capability is repeatable rather than accidental.
+
+#### 3. Accepted-source integrity
+
+Evaluate only accepted candidates:
+
+- `pass`: every accepted candidate came from a `completed` run whose source run
+  decision was `promoted` and whose result snapshot id is present
+- `needs_evidence`: there are no accepted candidates yet
+- `blocked`: any accepted candidate violates those integrity conditions
+
+Rationale: accepted promotion evidence should not be built on aborted or
+incomplete runtime results.
+
+#### 4. Warning pressure
+
+- `pass`: accepted candidates carry no source warnings
+- `needs_evidence`: accepted candidates exist but still carry warnings
+
+Rationale: warnings are not automatically fatal, but they should prevent the
+family from being considered promotion-ready in the first slice.
+
+## Why This Is Simpler Than a Persisted Family Artifact
+
+The index report can be regenerated from candidate artifacts at any time.
+Nothing new needs to be synchronized, updated, or rolled back. That keeps the
+current change:
+
+- lightweight
+- deterministic
+- backward-compatible
+- easier to test
+
+If later stages need persisted promotion plans, they can consume the family
+report contract without forcing this slice to mutate disk state beyond existing
+candidate records.
+
+## Testing Strategy
+
+1. Extend CLI parsing coverage for `runtime-capability index`.
+2. Add integration coverage proving:
+   - same promotion intent across two candidate artifacts collapses into one
+     family
+   - the family becomes `ready` only after repeated accepted evidence
+   - a family becomes `not_ready` when evidence is incomplete
+   - a family becomes `blocked` when review decisions conflict
+   - non-capability JSON files under the root are ignored
+3. Re-run targeted daemon integration tests and direct integration binary
+   verification.
+
+## Recommendation
+
+Ship the capability-family index and readiness gate now, but keep it read-only.
+
+That gives LoongClaw the missing governed middle layer:
+
+- experiments answer "what changed?"
+- candidates answer "what lower-layer capability could exist?"
+- the family index answers "is there enough stable evidence to plan promotion?"
+
+Automatic promotion should remain a later, dry-run-only step built on top of
+this index contract instead of being entangled with it.

--- a/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md
+++ b/docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md
@@ -1,0 +1,181 @@
+# Runtime Capability Index and Readiness Gate Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a read-only `runtime-capability index` layer that groups candidate artifacts into deterministic capability families and evaluates readiness as `ready`, `not_ready`, or `blocked`.
+
+**Architecture:** Reuse the existing daemon-side artifact loading pattern from `runtime_capability_cli`, derive family identity from normalized proposal intent instead of creating a new persisted family artifact, and compute readiness from explicit evidence checks that stay fully deterministic and auditable.
+
+**Tech Stack:** Rust, `clap`, `serde`, daemon integration tests, Markdown docs
+
+---
+
+### Task 1: Write the design and planning artifacts
+
+**Files:**
+- Create: `docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md`
+- Create: `docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Describe the capability-family concept, the deterministic family fingerprint,
+the compact evidence digest, the readiness checks, the non-goals, and the
+testing strategy.
+
+**Step 2: Verify the design artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md`
+Expected: exit 0
+
+**Step 3: Write the implementation plan**
+
+Capture the exact file changes, tests, and verification steps below.
+
+**Step 4: Verify the plan artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md`
+Expected: exit 0
+
+### Task 2: Add failing CLI parsing coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Write the failing parse tests**
+
+Extend runtime-capability CLI parsing coverage so `index` parses:
+
+- `--root`
+- `--json`
+
+**Step 2: Run the targeted parsing test to verify RED**
+
+Run: `target/debug/deps/integration-be821edddb3e2519 --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_and_show --nocapture`
+Expected: FAIL because `index` is not parsed yet
+
+### Task 3: Add failing runtime-capability integration coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Write the failing index tests**
+
+Add integration tests covering:
+
+- one family aggregates two accepted candidates with the same promotion intent
+- the aggregated family reports compact evidence counts and metric ranges
+- one accepted candidate alone yields `not_ready`
+- a mix of accepted and rejected reviewed candidates yields `blocked`
+- non-capability files under the scan root are ignored
+
+**Step 2: Run the targeted runtime-capability tests to verify RED**
+
+Run: `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
+Expected: FAIL because the index surface does not exist yet
+
+### Task 4: Implement the new read-only index surface
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+
+**Step 1: Add the new command and option struct**
+
+Implement:
+
+- `RuntimeCapabilityCommands::Index`
+- `RuntimeCapabilityIndexCommandOptions`
+
+**Step 2: Add the family/report model**
+
+Implement:
+
+- family summary types
+- evidence digest types
+- readiness check types
+- readiness status enums
+
+**Step 3: Implement candidate discovery and grouping**
+
+Implement recursive root scanning, supported artifact loading, deterministic
+family-id derivation, and grouping by normalized proposal intent.
+
+**Step 4: Implement readiness evaluation**
+
+Implement the explicit check pipeline:
+
+- review consensus
+- stability
+- accepted-source integrity
+- warning pressure
+
+and derive overall readiness from those checks.
+
+**Step 5: Implement JSON/text rendering**
+
+Keep text output compact and review-first while exposing enough evidence to see
+why a family is `ready`, `not_ready`, or `blocked`.
+
+**Step 6: Run the targeted tests to verify GREEN**
+
+Run: `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
+Expected: PASS
+
+### Task 5: Update product docs and roadmap references
+
+**Files:**
+- Modify: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update the product spec**
+
+Document `runtime-capability index` as the aggregation/readiness layer above
+individual candidate records and below any future promotion planner.
+
+**Step 2: Update the roadmap**
+
+Describe the new index/readiness layer as the next governed self-evolution step
+after candidate records and before any dry-run promotion planning.
+
+**Step 3: Run doc spot checks**
+
+Run: `rg -n "runtime-capability|readiness|promotion" docs/product-specs/runtime-capability.md docs/ROADMAP.md`
+Expected: the new index/readiness references appear in the updated docs
+
+### Task 6: Verify and prepare clean delivery
+
+**Files:**
+- Review all touched files
+
+**Step 1: Run focused verification**
+
+Run:
+
+- `target/debug/deps/integration-be821edddb3e2519 runtime_capability_ --nocapture`
+- `target/debug/deps/integration-be821edddb3e2519 --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_and_show --nocapture`
+
+Expected: PASS
+
+**Step 2: Run repo-level verification as capacity allows**
+
+Run the strongest available checks that are not blocked by unrelated global
+cargo lock contention:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+
+If cargo lock contention persists, record the blocker and supplement with direct
+integration-binary verification for the touched daemon surface.
+
+**Step 3: Inspect the final diff**
+
+Run:
+
+- `git status --short`
+- `git diff --stat`
+- `git diff`
+
+Expected: only runtime-capability index/readiness code, tests, and directly
+related docs

--- a/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md
+++ b/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md
@@ -1,0 +1,337 @@
+# Runtime Capability Promotion Plan Dry-Run Design
+
+## Problem
+
+`runtime-capability` now gives LoongClaw two governed layers above finished
+runtime experiments:
+
+- one capability candidate per finished run
+- one deterministic family index with compact evidence and readiness
+
+That closes the "what reusable intent emerged?" and "is this family ready?"
+questions, but one operational gap still remains.
+
+Even when a family is indexed and evaluated, the operator still cannot answer in
+one deterministic view:
+
+- what exact lower-layer artifact should this family become?
+- what stable identifier should that artifact carry?
+- is the family actually promotable right now, or only plan-able?
+- what blockers still stop promotion?
+- what approval checklist and rollback notes should the eventual mutation step
+  follow?
+
+Without that dry-run layer, any later promotion executor would still need to
+re-open raw family summaries and improvise a plan at mutation time. That keeps
+the most safety-sensitive step underspecified.
+
+## Goal
+
+Add the smallest read-only promotion-planning layer above capability-family
+readiness:
+
+1. resolve one indexed family into one deterministic promotion plan
+2. describe the exact lower-layer artifact kind and stable identifier that would
+   be created
+3. expose whether the family is promotable now without mutating disk or runtime
+4. surface blockers, approval checklist items, rollback hints, and provenance in
+   one compact operator-readable report
+5. keep the entire slice local-first, deterministic, and auditable
+
+## Non-Goals
+
+- automatically generating or applying managed skills
+- automatically generating or applying programmatic flows
+- automatically mutating `profile_note` or runtime config
+- persisting a separate promotion-plan artifact
+- background daemons, queues, or schedulers
+- semantic ranking or LLM-based plan synthesis
+- solving multi-family prioritization in this slice
+
+## Constraints
+
+- The source of truth remains the persisted `runtime-capability` candidate
+  artifacts plus the derived family index view.
+- This slice must stay additive and read-only.
+- The plan contract must be deterministic from stored fields, not from external
+  state or model inference.
+- Planner output should be cheap enough that later automation can consume it
+  instead of replaying every candidate artifact.
+- The planner must still render a useful report for `not_ready` and `blocked`
+  families; failure to be promotable is data, not a command error.
+
+## Approaches Considered
+
+### Option A: Add a read-only `plan` command above `index`
+
+Compute the family index on demand, resolve one family by id, and derive a
+deterministic promotion-plan report.
+
+Pros:
+
+- additive and read-only
+- reuses the existing readiness/evidence contract
+- no new persisted state to synchronize
+- keeps later mutation layers honest by making the plan explicit first
+
+Cons:
+
+- requires re-scanning candidate artifacts for each planning request
+- still leaves actual mutation to a later slice
+
+### Option B: Persist a separate promotion-plan artifact
+
+Store one plan document on disk and update it whenever the family changes.
+
+Pros:
+
+- faster lookups later
+- explicit artifact path for every plan
+
+Cons:
+
+- adds a new write/update lifecycle immediately
+- forces ownership rules for stale plan invalidation
+- turns a read-only slice into another persistence surface
+
+### Option C: Jump directly to automatic promotion
+
+Let the system read a ready family and immediately generate the lower-layer
+artifact.
+
+Pros:
+
+- closest to the long-term autonomous loop
+
+Cons:
+
+- collapses planning and mutation into one step
+- reduces auditability exactly where safety matters most
+- introduces unnecessary slop debt before the plan contract is proven
+
+## Decision
+
+Choose Option A.
+
+The next governed self-evolution slice should make the would-be promotion
+explicit before anything is allowed to mutate state. The planner should consume
+the deterministic family view, preserve that same strictness, and add only the
+missing operator-facing details:
+
+- planned lower-layer artifact kind
+- stable artifact identifier
+- promotability boolean
+- blockers
+- approval checklist
+- rollback hints
+- provenance references
+
+## Proposed Surface
+
+### Command family
+
+Keep the existing commands and add one new read-only command:
+
+- `loongclaw runtime-capability propose`
+- `loongclaw runtime-capability review`
+- `loongclaw runtime-capability show`
+- `loongclaw runtime-capability index`
+- `loongclaw runtime-capability plan`
+
+### Plan command
+
+```bash
+loongclaw runtime-capability plan \
+  --root artifacts/runtime-capability \
+  --family-id <family-id> \
+  [--json]
+```
+
+Behavior:
+
+- recursively scan `--root` using the same supported-artifact rules as `index`
+- derive the same deterministic family summaries
+- select exactly one family by `family_id`
+- derive one deterministic promotion plan from that family
+- render text or JSON without mutating any artifact
+
+Command errors should be limited to:
+
+- unreadable root
+- malformed artifact load
+- missing family id
+
+`not_ready` and `blocked` families should still produce a plan report with
+`promotable=false`.
+
+## Promotion Plan Model
+
+### Report shape
+
+The plan report should contain:
+
+- `generated_at`
+- `root`
+- `family_id`
+- `promotable`
+- `proposal`
+- `evidence`
+- `readiness`
+- `planned_artifact`
+- `blockers`
+- `approval_checklist`
+- `rollback_hints`
+- `provenance`
+
+The planner should reuse the existing family proposal/evidence/readiness model
+instead of duplicating those semantics in a second schema.
+
+### Planned artifact
+
+Each plan resolves to one lower-layer artifact description:
+
+- `target_kind`
+- `artifact_kind`
+- `artifact_id`
+- `delivery_surface`
+- `summary`
+- `bounded_scope`
+- `required_capabilities`
+- `tags`
+
+`artifact_id` should be deterministic and human-scannable:
+
+- start with a target-specific prefix
+- append a slug derived from `proposal.summary`
+- suffix with a short prefix of `family_id` for collision resistance
+
+Example shapes:
+
+- `managed_skill` -> `artifact_kind=managed_skill_bundle`
+- `programmatic_flow` -> `artifact_kind=programmatic_flow_spec`
+- `profile_note_addendum` -> `artifact_kind=profile_note_addendum`
+
+The planner should not guess filesystem paths yet. The executor layer can choose
+the final write location later. This slice only promises the exact logical
+artifact identity and delivery lane.
+
+### Promotable
+
+`promotable` should be `true` only when the family's readiness status is
+`ready`.
+
+This keeps the rule obvious:
+
+- `ready` -> the family is promotable in principle
+- `not_ready` -> the family has missing evidence
+- `blocked` -> the family currently should not be promoted
+
+### Blockers
+
+`blockers` should be derived from readiness checks that are not `pass`.
+
+- `needs_evidence` checks become actionable missing-evidence blockers
+- `blocked` checks become hard-stop blockers
+
+This avoids inventing a second blocker engine.
+
+### Approval checklist
+
+The planner should emit a short deterministic checklist that the eventual
+mutation step must satisfy. The checklist should stay generic enough to cover
+all target kinds:
+
+- confirm the summary and bounded scope still describe exactly one lower-layer
+  artifact
+- confirm required capabilities remain least-privilege for that artifact
+- confirm provenance references still represent the intended behavior to codify
+- confirm the chosen delivery surface matches the target kind
+
+One extra target-specific item should be added:
+
+- `managed_skill`: confirm the behavior belongs in a reusable managed skill
+- `programmatic_flow`: confirm the behavior can be expressed as a deterministic
+  programmatic flow
+- `profile_note_addendum`: confirm the behavior belongs in advisory profile
+  guidance rather than executable logic
+
+### Rollback hints
+
+Rollback hints should stay high-signal and executor-neutral:
+
+- capture the current state of the target delivery surface before applying
+- remove or revert the promoted artifact by `artifact_id` if downstream
+  validation fails
+- keep the candidate ids and source-run references attached to the rollback
+  record so the revert stays auditable
+
+### Provenance
+
+The plan should carry the minimum references needed to audit where it came from:
+
+- candidate ids
+- source run ids
+- experiment ids
+- source run artifact paths when recorded on the candidate
+- latest candidate / review timestamps
+
+This is enough to trace the plan without reopening every file during normal
+review.
+
+## Text Output
+
+Text output should remain review-first and compact.
+
+Recommended order:
+
+1. family identity and promotability
+2. planned artifact description
+3. readiness/check summary
+4. blockers
+5. approval checklist
+6. rollback hints
+7. provenance references
+
+Example sketch:
+
+```text
+family_id=...
+promotable=true
+target=managed_skill
+artifact_kind=managed_skill_bundle
+artifact_id=managed-skill-browser-preview-onboarding-3f2a9c7d1b2e
+delivery_surface=managed_skills
+required_capabilities=invoke_tool,memory_read
+blockers=-
+checks=review_consensus:pass:... | stability:pass:...
+approval_checklist=confirm bounded scope | confirm least-privilege capabilities | ...
+rollback_hints=capture current managed_skills state | remove artifact_id on failure | ...
+provenance_candidate_ids=...
+provenance_source_run_ids=...
+```
+
+## Why This Is Simpler Than Persisted Plan State
+
+The planner can always be regenerated from candidate artifacts. That preserves
+the current self-evolution pyramid:
+
+- experiments create evidence
+- candidates capture promotion intent
+- family index summarizes readiness
+- promotion planner describes the would-be lower layer
+- a future executor can mutate only after all prior layers are explicit
+
+Nothing new needs to be synchronized or garbage-collected in this slice.
+
+## Testing Strategy
+
+1. Extend CLI parsing coverage for `runtime-capability plan`.
+2. Add failing integration tests for:
+   - planning a ready family
+   - planning a not-ready family and surfacing blockers
+   - planning a blocked family and surfacing blockers
+   - rejecting unknown family ids
+   - emitting target-specific artifact metadata and provenance references
+3. Implement the smallest plan derivation logic needed to satisfy those tests.
+4. Update product docs and roadmap so the runtime-capability ladder is described
+   as candidate -> index/readiness -> dry-run planner -> future executor.

--- a/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md
+++ b/docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md
@@ -1,0 +1,188 @@
+# Runtime Capability Promotion Plan Dry-Run Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a read-only `runtime-capability plan` layer that resolves one indexed capability family into a deterministic dry-run promotion plan without mutating runtime state.
+
+**Architecture:** Reuse the existing candidate loading and family-readiness logic in `runtime_capability_cli`, derive one promotion-plan report from one family summary, and keep the new surface strictly read-only so later mutation layers can consume an explicit plan contract instead of improvising promotion details.
+
+**Tech Stack:** Rust, `clap`, `serde`, daemon integration tests, Markdown docs
+
+---
+
+### Task 1: Write the design and planning artifacts
+
+**Files:**
+- Create: `docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md`
+- Create: `docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md`
+
+**Step 1: Write the design doc**
+
+Describe the planner contract, the command surface, the planned-artifact model,
+the promotable rule, blockers, approval checklist, rollback hints, provenance,
+and why this slice stays read-only.
+
+**Step 2: Verify the design artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-design.md`
+Expected: exit 0
+
+**Step 3: Write the implementation plan**
+
+Capture the exact file changes, tests, docs, and verification steps below.
+
+**Step 4: Verify the plan artifact exists**
+
+Run: `test -f docs/plans/2026-03-18-runtime-capability-promotion-plan-dry-run-implementation-plan.md`
+Expected: exit 0
+
+### Task 2: Add failing CLI parsing coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Write the failing parse test**
+
+Extend runtime-capability CLI parsing coverage so `plan` parses:
+
+- `--root`
+- `--family-id`
+- `--json`
+
+**Step 2: Run the targeted parsing test to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_cli_parses_propose_review_show_index_and_plan --test integration -- --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_show_index_and_plan --nocapture`
+Expected: FAIL because the `plan` subcommand does not exist yet
+
+### Task 3: Add failing runtime-capability planner integration coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Write the failing planner tests**
+
+Add integration tests covering:
+
+- planning a ready managed-skill family
+- planning a `not_ready` family and surfacing missing-evidence blockers
+- planning a `blocked` family and surfacing hard-stop blockers
+- rejecting an unknown `family_id`
+- exposing deterministic artifact metadata, approval checklist, rollback hints,
+  and provenance references
+
+**Step 2: Run the targeted runtime-capability tests to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_plan --test integration -- --nocapture`
+Expected: FAIL because the planner surface does not exist yet
+
+### Task 4: Implement the read-only planner surface
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/lib.rs`
+
+**Step 1: Add the new command and option struct**
+
+Implement:
+
+- `RuntimeCapabilityCommands::Plan`
+- `RuntimeCapabilityPlanCommandOptions`
+
+**Step 2: Add the promotion-plan report model**
+
+Implement:
+
+- promotion-plan report type
+- planned-artifact type
+- provenance type
+
+Reuse existing proposal, evidence, and readiness types instead of cloning that
+logic into a second schema.
+
+**Step 3: Implement family lookup and plan derivation**
+
+Implement:
+
+- family resolution by `family_id`
+- deterministic planned-artifact identity derivation
+- promotable boolean derived from readiness
+- blockers derived from non-pass readiness checks
+- approval checklist and rollback hints derived from target kind plus generic
+  governance rules
+- provenance extraction from indexed candidate evidence
+
+**Step 4: Implement JSON/text rendering**
+
+Keep text output compact and review-first while exposing:
+
+- promotability
+- target/artifact description
+- blockers
+- approval checklist
+- rollback hints
+- provenance references
+
+**Step 5: Run the targeted tests to verify GREEN**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_plan --test integration -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability_cli_parses_propose_review_show_index_and_plan --test integration -- --exact integration::cli_tests::runtime_capability_cli_parses_propose_review_show_index_and_plan --nocapture`
+
+Expected: PASS
+
+### Task 5: Update product docs and roadmap references
+
+**Files:**
+- Modify: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update the product spec**
+
+Document `runtime-capability plan` as the dry-run planning layer above family
+readiness and below any future promotion executor.
+
+**Step 2: Update the roadmap**
+
+Describe the planner as the next shipped governed self-evolution step after the
+family index/readiness layer.
+
+**Step 3: Run doc spot checks**
+
+Run: `rg -n "runtime-capability|promotion planner|dry-run" docs/product-specs/runtime-capability.md docs/ROADMAP.md`
+Expected: the new planner references appear in the updated docs
+
+### Task 6: Verify and prepare clean delivery
+
+**Files:**
+- Review all touched files
+
+**Step 1: Run focused verification**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_ --test integration -- --nocapture`
+
+Expected: PASS
+
+**Step 2: Run repo-level verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace`
+- `cargo test --workspace --all-features`
+
+Expected: PASS
+
+**Step 3: Inspect the final diff**
+
+Run:
+
+- `git status --short`
+- `git diff --stat`
+- `git diff`
+
+Expected: only runtime-capability planner code, tests, docs, and directly
+related GitHub delivery text are present

--- a/docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-design.md
+++ b/docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-design.md
@@ -1,0 +1,260 @@
+# Runtime Capability Structured Delta Evidence Design
+
+## Context
+
+`runtime-capability` now gives LoongClaw a governed review ladder over finished
+runtime experiments:
+
+- `propose` records one candidate artifact
+- `review` records one explicit operator decision
+- `show` renders one persisted candidate
+- `index` groups compatible candidates into readiness-scored families
+- `plan` derives one deterministic dry-run promotion plan
+
+That ladder is now blocked on one missing substrate: the capability artifact
+keeps promotion intent and review metadata, but it does not keep the
+machine-readable runtime delta that explains what actually changed.
+
+Today that structured delta only exists transiently inside
+`runtime-experiment compare` when matching baseline and result snapshots are
+available.
+
+## Problem
+
+The next self-evolution layer should not jump directly to an executor.
+
+An executor, materializer, or later automated loop needs deterministic evidence
+for the promoted change, not only free-form summaries such as:
+
+- `mutation_summary`
+- `target_summary`
+- `bounded_scope`
+
+Without structured delta evidence inside the persisted capability artifact,
+later layers would have to:
+
+- recompute compare output on demand
+- depend on external snapshot paths remaining available forever
+- infer material changes from prose
+
+That is exactly the kind of fragile, token-heavy, hard-to-audit path we should
+avoid.
+
+## Goals
+
+Add the smallest read-only evidence layer that makes capability artifacts more
+self-contained and more useful for later promotion-materialization work.
+
+This slice should:
+
+1. capture snapshot-backed runtime delta evidence during
+   `runtime-capability propose` when the source run has matching snapshots
+2. persist that evidence inside the capability artifact in a backward-compatible
+   way
+3. surface compact delta evidence in `show`, `index`, and `plan`
+4. fail clearly when the source run claims recorded snapshots but the delta
+   cannot be derived deterministically
+
+## Non-Goals
+
+This slice should not:
+
+- add a promotion executor
+- mutate managed skills, programmatic flows, or profile notes
+- introduce background indexing or caches
+- invent target-specific payload synthesis heuristics
+- change readiness policy based on delta evidence in the first slice
+
+## Options
+
+### Option A: Persist snapshot-backed delta evidence in capability artifacts
+
+During `runtime-capability propose`, derive the recorded snapshot delta from the
+source experiment when possible and store it alongside the existing
+source-run summary. Also expose a compact family-level digest so `index` and
+`plan` surface the new evidence without duplicating full per-candidate deltas.
+
+Pros:
+
+- fixes the real missing substrate instead of papering over it
+- keeps the capability artifact self-contained enough for later layers
+- reuses existing snapshot-compare logic rather than inventing new inference
+- stays read-only and audit-friendly
+
+Cons:
+
+- requires a schema extension on capability artifacts
+- requires careful handling for old artifacts and missing snapshot paths
+
+### Option B: Recompute delta evidence on demand in `show`, `index`, and `plan`
+
+Keep capability artifacts unchanged. Whenever a later command needs structured
+delta evidence, reload the source run, locate its snapshots, and recompute the
+delta live.
+
+Pros:
+
+- avoids extending the capability-artifact schema now
+- minimizes immediate write-path changes
+
+Cons:
+
+- leaves capability artifacts incomplete
+- makes later layers depend on external snapshot availability
+- duplicates expensive or failure-prone recomputation
+- weakens auditability because rendered evidence is no longer artifact-local
+
+### Option C: Skip evidence work and jump to a promotion executor
+
+Introduce `apply` now and let it use summaries, tags, and plan metadata as the
+input contract.
+
+Pros:
+
+- feels closer to an end-to-end self-evolution loop
+
+Cons:
+
+- solves the wrong problem
+- would force the executor to guess or scaffold payloads from prose
+- increases safety risk and slop debt before the evidence model is ready
+
+## Decision
+
+Choose Option A.
+
+The blocker is not "missing mutation code". The blocker is that the persisted
+promotion evidence is still too shallow. We should deepen the evidence layer
+first so future materialization and apply paths can stay deterministic,
+lightweight, and safe.
+
+## Proposed Model
+
+### Candidate-level evidence
+
+Extend `RuntimeCapabilitySourceRunSummary` with:
+
+- `snapshot_delta: Option<RuntimeExperimentSnapshotDelta>`
+
+Rationale:
+
+- the delta belongs to the source run, not to the abstract proposal
+- the capability artifact already stores other source-run evidence
+- the field can stay optional for backward compatibility and no-snapshot runs
+
+### Family-level digest
+
+Extend `RuntimeCapabilityEvidenceDigest` with a compact summary derived from all
+candidate-level deltas:
+
+- `delta_candidate_count`: number of candidates that include snapshot delta
+- `changed_surfaces`: sorted union of changed runtime surfaces observed across
+  the family
+
+Rationale:
+
+- `index` and `plan` need operator-facing signal without embedding every raw
+  before/after pair into the family summary
+- later layers can still drill into per-candidate artifacts when they need the
+  full delta
+
+## Command Behavior
+
+### `runtime-capability propose`
+
+Behavior:
+
+- load the finished experiment run as today
+- derive the optional snapshot delta from the source run's recorded baseline and
+  result snapshots
+- persist the delta under `source_run.snapshot_delta`
+
+Delta rules:
+
+- if the run has no result snapshot, store `None`
+- if the run has result snapshot metadata but no recorded snapshot artifact
+  paths, store `None`
+- if both snapshot paths exist, compute the delta deterministically from those
+  snapshots
+- if both snapshot paths exist but the delta cannot be derived because the
+  snapshot files are unreadable, mismatched, or malformed, fail the command
+
+That last rule avoids false-success artifacts with silently degraded evidence.
+
+### `runtime-capability show`
+
+Add compact rendering for:
+
+- whether snapshot delta evidence exists
+- changed surface count
+- changed surfaces
+
+JSON output naturally includes the persisted `snapshot_delta` field.
+
+### `runtime-capability index`
+
+Aggregate candidate-level delta evidence into the family digest:
+
+- `delta_candidate_count`
+- `changed_surfaces`
+
+This slice does not change readiness scoring yet. Delta evidence is surfaced for
+operator review, not used as a hard gate.
+
+### `runtime-capability plan`
+
+Reuse the family digest so the dry-run plan shows which runtime surfaces
+actually changed across the candidate family.
+
+This makes the plan more actionable without pretending we already have a
+materialized lower-layer payload.
+
+## Reuse Strategy
+
+Do not duplicate snapshot-delta logic inside `runtime-capability`.
+
+Instead:
+
+- extract or reuse the existing compare helpers from `runtime_experiment_cli`
+- build one small helper that conditionally derives recorded snapshot delta from
+  a finished run artifact
+
+That keeps one source of truth for delta semantics.
+
+## Error Handling
+
+Expected outcomes:
+
+- old capability artifacts without `snapshot_delta` continue to load
+- no-snapshot experiment runs still produce valid capability artifacts
+- broken recorded snapshots fail during `propose` rather than producing partial
+  evidence
+
+This preserves backward compatibility without hiding real source-evidence
+corruption.
+
+## Testing
+
+Required coverage:
+
+1. `runtime-capability propose` persists `snapshot_delta` when the source run
+   has recorded snapshots
+2. `runtime-capability propose` leaves `snapshot_delta=None` when no recorded
+   snapshots are available
+3. `runtime-capability propose` fails when recorded snapshot paths exist but are
+   unreadable or inconsistent
+4. `runtime-capability index` reports the expected `delta_candidate_count` and
+   `changed_surfaces`
+5. `runtime-capability plan` surfaces the same aggregated delta digest
+6. older fixture artifacts without the new field still deserialize
+
+## Why This Slice Next
+
+This is the smallest step that:
+
+- improves self-evolution fidelity
+- keeps safety stronger than convenience
+- reduces future recomputation cost
+- creates a truthful substrate for later `materialize` or `apply` work
+
+It deepens the evidence pyramid before we add any new mutation power.

--- a/docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-implementation-plan.md
+++ b/docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-implementation-plan.md
@@ -1,0 +1,298 @@
+# Runtime Capability Structured Delta Evidence Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Persist snapshot-backed runtime delta evidence inside runtime-capability artifacts and surface a compact digest in `show`, `index`, and `plan` without adding any mutation path.
+
+**Architecture:** Reuse the existing runtime-experiment snapshot-delta machinery as the single source of truth, attach the optional delta to `RuntimeCapabilitySourceRunSummary`, derive a compact family-level digest from candidate deltas, and keep the slice backward-compatible for old artifacts and no-snapshot runs.
+
+**Tech Stack:** Rust, Cargo, Clap, Serde, existing daemon integration tests
+
+---
+
+### Task 1: Lock the design artifacts into the branch
+
+**Files:**
+- Create: `docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-design.md`
+- Create: `docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-implementation-plan.md`
+
+**Step 1: Verify the design doc exists**
+
+Run: `test -f docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-design.md`
+Expected: exit code 0
+
+**Step 2: Verify the implementation plan exists**
+
+Run: `test -f docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-implementation-plan.md`
+Expected: exit code 0
+
+**Step 3: Commit the plan docs when implementation is complete**
+
+```bash
+git add docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-design.md \
+  docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-implementation-plan.md
+```
+
+### Task 2: Add failing CLI/integration tests for delta evidence capture
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Extend CLI parse coverage only if new flags or output schema contracts need explicit assertions**
+
+If no CLI flag changes are needed, keep `cli_tests.rs` unchanged.
+
+**Step 2: Write a failing integration test for propose-with-recorded-snapshots**
+
+Add a test that:
+
+- creates a finished runtime experiment with recorded baseline/result snapshots
+- runs `execute_runtime_capability_propose_command`
+- asserts `candidate.source_run.snapshot_delta.is_some()`
+- asserts at least one expected changed surface is present in the persisted
+  delta
+
+**Step 3: Run the targeted test to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_propose_persists_snapshot_delta --test integration -- --nocapture`
+Expected: FAIL because the capability artifact does not yet expose
+`snapshot_delta`
+
+**Step 4: Write a failing integration test for the no-snapshot path**
+
+Add a test that:
+
+- creates a finished runtime experiment without recorded comparable snapshots
+- runs `execute_runtime_capability_propose_command`
+- asserts `candidate.source_run.snapshot_delta.is_none()`
+
+**Step 5: Run the targeted no-snapshot test to verify RED or coverage gap**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_propose_leaves_snapshot_delta_empty_without_recorded_snapshots --test integration -- --nocapture`
+Expected: FAIL until the new field exists
+
+**Step 6: Write a failing integration test for broken recorded snapshots**
+
+Add a test that:
+
+- creates a finished runtime experiment with recorded snapshot paths
+- removes or corrupts one referenced snapshot file
+- runs `execute_runtime_capability_propose_command`
+- asserts the command returns an error that makes the missing snapshot evidence
+  explicit
+
+**Step 7: Run the broken-snapshot test to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_propose_rejects_broken_recorded_snapshot_delta --test integration -- --nocapture`
+Expected: FAIL until propose validates the recorded snapshot delta path
+
+### Task 3: Add failing aggregation tests for index and plan
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Write a failing family-index test for aggregated delta digest**
+
+Add a test that:
+
+- creates two compatible accepted candidates with snapshot delta evidence
+- runs `execute_runtime_capability_index_command`
+- asserts the matching family reports:
+  - `delta_candidate_count == 2`
+  - sorted `changed_surfaces` union from the underlying deltas
+
+**Step 2: Run the family-index test to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_index_reports_delta_evidence_digest --test integration -- --nocapture`
+Expected: FAIL because the evidence digest does not yet include the new fields
+
+**Step 3: Write a failing planner test for surfaced delta digest**
+
+Add a test that:
+
+- creates a promotable family with snapshot delta evidence
+- runs `execute_runtime_capability_plan_command`
+- asserts the emitted evidence includes the same `delta_candidate_count` and
+  `changed_surfaces`
+
+**Step 4: Run the planner test to verify RED**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_plan_surfaces_delta_evidence_digest --test integration -- --nocapture`
+Expected: FAIL until plan reuses the new digest
+
+### Task 4: Implement the optional candidate-level snapshot delta
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/runtime_experiment_cli.rs`
+
+**Step 1: Expose or extract one reusable snapshot-delta helper from the runtime-experiment path**
+
+Keep one source of truth for snapshot comparison semantics.
+
+**Step 2: Extend `RuntimeCapabilitySourceRunSummary`**
+
+Add:
+
+```rust
+pub snapshot_delta: Option<RuntimeExperimentSnapshotDelta>
+```
+
+**Step 3: Populate the field during propose**
+
+Implement minimal logic:
+
+- `None` when the source run has no usable recorded snapshots
+- `Some(delta)` when the run has matching recorded snapshots
+- error on broken recorded snapshot references
+
+**Step 4: Re-run the propose-focused tests**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_propose_persists_snapshot_delta --test integration -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability_propose_leaves_snapshot_delta_empty_without_recorded_snapshots --test integration -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability_propose_rejects_broken_recorded_snapshot_delta --test integration -- --nocapture`
+
+Expected: PASS
+
+### Task 5: Implement the family-level delta digest
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Extend `RuntimeCapabilityEvidenceDigest`**
+
+Add:
+
+- `delta_candidate_count: usize`
+- `changed_surfaces: Vec<String>`
+
+**Step 2: Derive the compact digest from candidate-level deltas**
+
+Rules:
+
+- count only candidates with `snapshot_delta.is_some()`
+- expose a stable sorted union of changed surface names
+- keep the digest compact; do not inline all before/after values at family level
+
+**Step 3: Re-run the failing index test**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_index_reports_delta_evidence_digest --test integration -- --nocapture`
+Expected: PASS
+
+### Task 6: Surface the new evidence in `show` and `plan`
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Update text rendering for `show`**
+
+Render compact candidate-level delta lines only when evidence exists.
+
+**Step 2: Ensure `plan` reuses the evidence digest unchanged**
+
+Do not invent a second delta summary model.
+
+**Step 3: Re-run the planner-focused failing test**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_plan_surfaces_delta_evidence_digest --test integration -- --nocapture`
+Expected: PASS
+
+### Task 7: Update product docs and roadmap
+
+**Files:**
+- Modify: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update the product spec**
+
+Document that capability artifacts may persist snapshot-backed runtime delta
+evidence and that the review/planning ladder now carries structured change
+evidence below any future promotion executor.
+
+**Step 2: Update the roadmap**
+
+Clarify that the runtime-capability track now preserves structured delta
+evidence as the prerequisite for later promotion-materialization work.
+
+**Step 3: Verify the docs mention the new layer**
+
+Run: `rg -n "runtime-capability|snapshot delta|structured delta" docs/product-specs/runtime-capability.md docs/ROADMAP.md`
+Expected: matches in both files
+
+### Task 8: Run focused verification, then full CI-parity verification
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/runtime_experiment_cli.rs`
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+- Modify: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Run the focused runtime-capability suite**
+
+Run: `cargo test -p loongclaw-daemon runtime_capability_ --test integration -- --nocapture`
+Expected: PASS
+
+**Step 2: Run format check**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS
+
+**Step 3: Run strict clippy**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: PASS
+
+**Step 4: Run workspace tests**
+
+Run: `cargo test --workspace`
+Expected: PASS
+
+**Step 5: Run all-features workspace tests**
+
+Run: `cargo test --workspace --all-features`
+Expected: PASS
+
+### Task 9: Commit and publish the slice
+
+**Files:**
+- Modify only the runtime-capability delta-evidence files from this plan
+
+**Step 1: Inspect worktree isolation**
+
+Run:
+
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`
+
+Expected: only the planned files are included
+
+**Step 2: Commit**
+
+```bash
+git add crates/daemon/src/runtime_capability_cli.rs \
+  crates/daemon/src/runtime_experiment_cli.rs \
+  crates/daemon/tests/integration/runtime_capability_cli.rs \
+  crates/daemon/tests/integration/cli_tests.rs \
+  docs/product-specs/runtime-capability.md \
+  docs/ROADMAP.md \
+  docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-design.md \
+  docs/plans/2026-03-19-runtime-capability-structured-delta-evidence-implementation-plan.md
+git commit -m "feat: capture runtime capability delta evidence"
+```
+
+**Step 3: Push and open the stacked PR**
+
+Base branch: `feat/runtime-capability-index-readiness-gate`
+
+PR body must include:
+
+- `Closes #346`
+- summary of the new structured delta evidence layer
+- exact validation commands

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -17,6 +17,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - [Channel Setup](channel-setup.md)
 - [Tool Surface](tool-surface.md)
 - [Runtime Experiment](runtime-experiment.md)
+- [Runtime Capability](runtime-capability.md)
 - [WebChat](webchat.md)
 - [Prompt And Personality](prompt-and-personality.md)
 - [Memory Profiles](memory-profiles.md)
@@ -25,6 +26,7 @@ Product specs describe **what** the product does from the user's perspective, no
 
 - `Installation`, `Onboarding`, `One-Shot Ask`, `Doctor`, `Browser Automation`, `Tool Surface`, and `Channel Setup` define the shipped first-run and support journey for the current MVP.
 - `Runtime Experiment` defines the shipped local experiment-record surface layered on top of runtime snapshot and restore artifacts.
+- `Runtime Capability` defines the shipped local capability-candidate review surface layered on top of runtime experiment artifacts.
 - `Browser Automation Companion` and `WebChat` are expectation-setting specs for the next user-facing surfaces. They should not be documented as generally available before the implementation exists.
 
 Template for new specs:

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -9,7 +9,7 @@ experiment should be crystallized into a reusable lower-layer capability.
 ## Acceptance Criteria
 
 - [ ] LoongClaw exposes a `runtime-capability` command family with `propose`,
-      `review`, `show`, and `index` subcommands.
+      `review`, `show`, `index`, and `plan` subcommands.
 - [ ] `runtime-capability propose` creates a persisted capability-candidate
       artifact from one finished `runtime-experiment` run.
 - [ ] The candidate artifact records one explicit target type:
@@ -25,9 +25,14 @@ experiment should be crystallized into a reusable lower-layer capability.
       emits a compact evidence digest for each family.
 - [ ] Each capability family reports readiness as `ready`, `not_ready`, or
       `blocked` from explicit evidence checks rather than opaque heuristics.
+- [ ] `runtime-capability plan` resolves one indexed family into a dry-run
+      promotion plan that describes the target lower-layer artifact, stable
+      artifact id, blockers, approval checklist, rollback hints, and
+      provenance references without mutating runtime state.
 - [ ] Product docs describe `runtime-capability` as the governed review layer
-      above `runtime-experiment` and below any future dry-run promotion planner
-      or automated promotion loop.
+      above `runtime-experiment`, with `index`/readiness and `plan` forming the
+      dry-run planning ladder below any future promotion executor or automated
+      promotion loop.
 
 ## Out of Scope
 
@@ -36,4 +41,5 @@ experiment should be crystallized into a reusable lower-layer capability.
 - Automatically mutating `profile_note` or runtime config
 - Automatic promotion, rollback, or optimizer orchestration
 - Persisted capability-family state or background indexing daemons
+- Persisted promotion-plan artifacts or plan caches
 - Candidate queues, dashboards, or autonomous ranking systems

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -1,0 +1,32 @@
+# Runtime Capability
+
+## User Story
+
+As a LoongClaw operator, I want to derive one explicit capability candidate from
+one finished runtime experiment so that I can review how a successful or failed
+experiment should be crystallized into a reusable lower-layer capability.
+
+## Acceptance Criteria
+
+- [ ] LoongClaw exposes a `runtime-capability` command family with `propose`,
+      `review`, and `show` subcommands.
+- [ ] `runtime-capability propose` creates a persisted capability-candidate
+      artifact from one finished `runtime-experiment` run.
+- [ ] The candidate artifact records one explicit target type:
+      `managed_skill`, `programmatic_flow`, or `profile_note_addendum`.
+- [ ] The candidate artifact records one bounded scope, normalized tags, and
+      normalized required capabilities without mutating live runtime state.
+- [ ] `runtime-capability review` records one explicit operator decision
+      (`accepted` or `rejected`) plus one review summary and optional warnings.
+- [ ] `runtime-capability show` round-trips the persisted artifact as JSON and
+      renders the review-critical fields first in text output.
+- [ ] Product docs describe `runtime-capability` as the governed review layer
+      above `runtime-experiment` and below any future automated promotion loop.
+
+## Out of Scope
+
+- Automatically generating or applying managed skills
+- Automatically generating or applying programmatic flows
+- Automatically mutating `profile_note` or runtime config
+- Automatic promotion, rollback, or optimizer orchestration
+- Candidate queues, dashboards, or autonomous ranking systems

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -9,7 +9,7 @@ experiment should be crystallized into a reusable lower-layer capability.
 ## Acceptance Criteria
 
 - [ ] LoongClaw exposes a `runtime-capability` command family with `propose`,
-      `review`, and `show` subcommands.
+      `review`, `show`, and `index` subcommands.
 - [ ] `runtime-capability propose` creates a persisted capability-candidate
       artifact from one finished `runtime-experiment` run.
 - [ ] The candidate artifact records one explicit target type:
@@ -20,8 +20,14 @@ experiment should be crystallized into a reusable lower-layer capability.
       (`accepted` or `rejected`) plus one review summary and optional warnings.
 - [ ] `runtime-capability show` round-trips the persisted artifact as JSON and
       renders the review-critical fields first in text output.
+- [ ] `runtime-capability index` scans persisted candidate artifacts, groups
+      matching promotion intent into deterministic capability families, and
+      emits a compact evidence digest for each family.
+- [ ] Each capability family reports readiness as `ready`, `not_ready`, or
+      `blocked` from explicit evidence checks rather than opaque heuristics.
 - [ ] Product docs describe `runtime-capability` as the governed review layer
-      above `runtime-experiment` and below any future automated promotion loop.
+      above `runtime-experiment` and below any future dry-run promotion planner
+      or automated promotion loop.
 
 ## Out of Scope
 
@@ -29,4 +35,5 @@ experiment should be crystallized into a reusable lower-layer capability.
 - Automatically generating or applying programmatic flows
 - Automatically mutating `profile_note` or runtime config
 - Automatic promotion, rollback, or optimizer orchestration
+- Persisted capability-family state or background indexing daemons
 - Candidate queues, dashboards, or autonomous ranking systems

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -12,6 +12,9 @@ experiment should be crystallized into a reusable lower-layer capability.
       `review`, `show`, `index`, and `plan` subcommands.
 - [ ] `runtime-capability propose` creates a persisted capability-candidate
       artifact from one finished `runtime-experiment` run.
+- [ ] When the source run has recorded baseline/result snapshots,
+      `runtime-capability propose` preserves the source run's snapshot-backed
+      runtime delta evidence inside the candidate artifact.
 - [ ] The candidate artifact records one explicit target type:
       `managed_skill`, `programmatic_flow`, or `profile_note_addendum`.
 - [ ] The candidate artifact records one bounded scope, normalized tags, and
@@ -23,12 +26,18 @@ experiment should be crystallized into a reusable lower-layer capability.
 - [ ] `runtime-capability index` scans persisted candidate artifacts, groups
       matching promotion intent into deterministic capability families, and
       emits a compact evidence digest for each family.
+- [ ] Capability-family evidence includes a compact digest of recorded snapshot
+      delta coverage and changed runtime surfaces when candidate artifacts carry
+      structured delta evidence.
 - [ ] Each capability family reports readiness as `ready`, `not_ready`, or
       `blocked` from explicit evidence checks rather than opaque heuristics.
 - [ ] `runtime-capability plan` resolves one indexed family into a dry-run
       promotion plan that describes the target lower-layer artifact, stable
       artifact id, blockers, approval checklist, rollback hints, and
       provenance references without mutating runtime state.
+- [ ] The review/planning ladder preserves structured runtime delta evidence as
+      a prerequisite for any future promotion materializer or executor, rather
+      than forcing later layers to infer change intent from prose alone.
 - [ ] Product docs describe `runtime-capability` as the governed review layer
       above `runtime-experiment`, with `index`/readiness and `plan` forming the
       dry-run planning ladder below any future promotion executor or automated


### PR DESCRIPTION
## Summary

- Problem: `runtime-capability` artifacts preserved promotion intent and review state, but not the structured runtime delta explaining what changed between recorded baseline and result snapshots.
- Why it matters: later promotion and review flows should consume self-contained delta evidence instead of recomputing compare output or relying on prose summaries.
- What changed: added optional snapshot-backed delta evidence under runtime capability source-run summaries, aggregated changed surfaces and delta candidate counts into evidence digests, extended integration coverage, and updated roadmap/spec and planning docs for the slice.
- What did not change (scope boundary): this did not add a promotion executor or apply path, and it did not change readiness-policy semantics.

## Linked Issues

- Closes #346
- Related #370

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed

cargo test -p loongclaw-daemon runtime_capability_ --test integration -- --nocapture
- passed

cargo test --workspace
- passed at the time this stacked slice was prepared

cargo test --workspace --all-features
- passed at the time this stacked slice was prepared
```

## User-visible / Operator-visible Changes

- runtime capability artifacts gained structured runtime delta evidence and surfaced that evidence through the CLI planning/indexing views.

## Failure Recovery

- Fast rollback or disable path: revert this change to remove the persisted delta-evidence fields and rendering changes.
- Observable failure symptoms reviewers should watch for: missing or incorrect changed-surface summaries, legacy artifacts failing to load, or runtime capability evidence digests drifting from the underlying snapshots.

## Reviewer Focus

- `crates/daemon/src/runtime_capability_cli.rs` and `crates/daemon/src/runtime_experiment_cli.rs` for optional delta persistence and backward-compatible loading.
- `crates/daemon/tests/integration/runtime_capability_cli.rs` for legacy-artifact and summary coverage.
- `docs/product-specs/runtime-capability.md` and roadmap/planning docs for the intended delta-evidence contract.
