### PR TITLE
chore(release): prepare v0.1.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows Keep a Changelog and semantic versioning intent.
 
 ## [Unreleased]
 
+## [0.1.0-alpha.2] - 2026-03-19
+
+### Added
+
+- Added a fast-lane summary command for chat flows to surface concise delegate context faster.
+- Surfaced the delegate child runtime contract in the app runtime so downstream tooling can reason about effective delegation behavior.
+
+### Changed
+
+- Tightened delegate prompt summary visibility and aligned the effective runtime contract with stricter disabled-tool coverage.
+- Hardened the dev-to-main release promotion lifecycle and source enforcement in CI.
+- Expanded delegate runtime, private-host, and process stdio test coverage to stabilize the prerelease line before broader promotion.
+- Refreshed contributor governance and README visuals, including new Chinese SVG diagrams and restored core harness docs changes.
+
 ## [0.1.0-alpha.1] - 2026-03-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,7 +1947,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loongclaw-app"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "aes",
  "async-trait",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-bench"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "loongclaw-app",
  "loongclaw-kernel",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-contracts"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "semver",
  "serde",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-daemon"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "axum",
  "base64",
@@ -2029,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-kernel"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "loongclaw-contracts",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-protocol"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "serde",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-spec"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["chumyin"]
 
 [workspace.dependencies]

--- a/docs/releases/v0.1.0-alpha.2.md
+++ b/docs/releases/v0.1.0-alpha.2.md
@@ -1,0 +1,56 @@
+# Release v0.1.0-alpha.2
+
+## Summary
+- Generated at: 2026-03-19T08:07:46Z
+- Release status: planned prerelease pending publish
+- Target commitish: `dev`
+- Artifact count: pending
+- Trace ID: `planned`
+- Trace path: `.docs/traces/20260319T080746Z-post-release-v0.1.0-alpha.2-planned`
+
+## Highlights
+- Added a fast-lane summary command for chat flows to surface concise delegate context faster.
+- Surfaced the delegate child runtime contract in the app runtime so downstream tooling can reason about effective delegation behavior.
+- Hardened the dev-to-main release promotion lifecycle and source enforcement in CI.
+- Expanded delegate runtime, private-host, and process stdio test coverage to stabilize the prerelease line before broader promotion.
+
+## Contributors
+- Pending post-release contributor snapshot regeneration.
+
+## Process
+- Date: 2026-03-19T08:07:46Z
+- Owner: release-gate automation
+- Scope summary: prepare and publish v0.1.0-alpha.2 from `upstream/dev` after verifying the fetched remote tip.
+- Gates run: baseline `task verify` passed on fetched `upstream/dev`; post-bump verification and publish are still pending.
+- Refactor budget item: no explicit refactor-budget paydown was supplied to the automation flow.
+
+## Artifacts
+| Asset | Size (bytes) | SHA256 | Download |
+|---|---:|---|---|
+| Pending publish | pending | pending | [release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.2) |
+
+## Verification
+| Check | Result | Evidence |
+|---|---|---|
+| Baseline `task verify` on fetched `upstream/dev` | PASS | local prerelease prep worktree at `e8da519` |
+| Release workflow completed successfully | PENDING | waiting for tag push |
+| Expected cross-platform assets are present | PENDING | waiting for GitHub release assets |
+
+## Refactor Budget
+- Hotspot metric paid down: none recorded by the planned prerelease flow yet.
+- Evidence: prerelease prep branch `release/dev-prerelease-v0.1.0-alpha.2` from `upstream/dev` commit `e8da519`.
+- If no paydown shipped, rationale: this prerelease is scoped to packaging and reporting the already-merged delta since `v0.1.0-alpha.1`.
+
+## Known Issues
+- Final asset inventory, workflow run URL, and contributor list remain pending until publish completes.
+
+## Rollback
+- If publish fails after tag creation, inspect the GitHub Actions run, patch the blocking issue on `dev`, and rerun `release.yml` for `v0.1.0-alpha.2`.
+- If the tag itself proves invalid, replace it with a newer prerelease and document supersession in `CHANGELOG.md`.
+
+## Detail Links
+- [Planned release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.2)
+- [Release workflow definition](../../.github/workflows/release.yml)
+- [Changelog entry](../../CHANGELOG.md)
+- Trace directory: `.docs/traces/20260319T080746Z-post-release-v0.1.0-alpha.2-planned`
+- Local debug log: `.docs/releases/v0.1.0-alpha.2-debug.md`


### PR DESCRIPTION
## Summary
- bump workspace version to v0.1.0-alpha.2
- add changelog entry for the delta since v0.1.0-alpha.1
- add the provisional release-process doc required by release-gate preflight

## Verification
- task verify
- release-gate check --tag v0.1.0-alpha.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v0.1.0-alpha.2

* **New Features**
  * Added fast-lane chat-flow summary command for quicker context retrieval
  * Exposed delegate child runtime contract for downstream reasoning

* **Tests**
  * Expanded test coverage across runtime, hosting, and process handling

* **Chores**
  * Version bumped to 0.1.0-alpha.2
  * Hardened dev-to-main release promotion lifecycle
  * Updated documentation and visuals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->