### PR TITLE
docs(release): finalize v0.1.0-alpha.2 reports

### DIFF
--- a/docs/releases/v0.1.0-alpha.2-announcement.md
+++ b/docs/releases/v0.1.0-alpha.2-announcement.md
@@ -1,0 +1,39 @@
+# Release v0.1.0-alpha.2 Announcement
+
+LoongClaw v0.1.0-alpha.2 is published from `dev` with verified release assets.
+
+## Highlights
+- Added a fast-lane summary command for chat flows to surface concise delegate context faster.
+- Surfaced the delegate child runtime contract in the app runtime so downstream tooling can reason about effective delegation behavior.
+- Tightened delegate prompt summary visibility and aligned the effective runtime contract with stricter disabled-tool coverage.
+- Hardened the dev-to-main release promotion lifecycle and source enforcement in CI.
+- Expanded delegate runtime, private-host, and process stdio test coverage to stabilize the prerelease line before broader promotion.
+
+## Contributors
+- Chummy
+- Mike-7777777
+- rootkawa
+- xj
+- xj
+
+## Downloads
+- [Release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.2)
+- [install.ps1](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/install.ps1)
+- [install.sh](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/install.sh)
+- [loongclaw-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz)
+- [loongclaw-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz.sha256](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz.sha256)
+- [loongclaw-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz)
+- [loongclaw-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz.sha256](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz.sha256)
+- [loongclaw-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip)
+- [loongclaw-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip.sha256](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip.sha256)
+- [loongclaw-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz)
+- [loongclaw-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz.sha256](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz.sha256)
+
+## Links
+- [Canonical release report](./v0.1.0-alpha.2.md)
+- [Changelog entry](../../CHANGELOG.md)
+- [Release workflow run](https://github.com/loongclaw-ai/loongclaw/actions/runs/23286158620)
+- [GitHub release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.2)
+- Generated at: `2026-03-19T08:45:52Z`
+- Trace ID: `c9e52bb4`
+- Trace path: `.docs/traces/20260319T084550Z-post-release-v0.1.0-alpha.2-c9e52bb4`

--- a/docs/releases/v0.1.0-alpha.2.md
+++ b/docs/releases/v0.1.0-alpha.2.md
@@ -1,56 +1,73 @@
 # Release v0.1.0-alpha.2
 
 ## Summary
-- Generated at: 2026-03-19T08:07:46Z
-- Release status: planned prerelease pending publish
+- Generated at: 2026-03-19T08:45:52Z
+- Release status: published (draft=false, prerelease=true)
 - Target commitish: `dev`
-- Artifact count: pending
-- Trace ID: `planned`
-- Trace path: `.docs/traces/20260319T080746Z-post-release-v0.1.0-alpha.2-planned`
+- Artifact count: 10
+- Trace ID: `c9e52bb4`
+- Trace path: `.docs/traces/20260319T084550Z-post-release-v0.1.0-alpha.2-c9e52bb4`
 
 ## Highlights
 - Added a fast-lane summary command for chat flows to surface concise delegate context faster.
 - Surfaced the delegate child runtime contract in the app runtime so downstream tooling can reason about effective delegation behavior.
+- Tightened delegate prompt summary visibility and aligned the effective runtime contract with stricter disabled-tool coverage.
 - Hardened the dev-to-main release promotion lifecycle and source enforcement in CI.
 - Expanded delegate runtime, private-host, and process stdio test coverage to stabilize the prerelease line before broader promotion.
 
 ## Contributors
-- Pending post-release contributor snapshot regeneration.
+- Chummy
+- Mike-7777777
+- rootkawa
+- xj
+- xj
 
 ## Process
-- Date: 2026-03-19T08:07:46Z
+- Date: 2026-03-19T08:45:52Z
 - Owner: release-gate automation
-- Scope summary: prepare and publish v0.1.0-alpha.2 from `upstream/dev` after verifying the fetched remote tip.
-- Gates run: baseline `task verify` passed on fetched `upstream/dev`; post-bump verification and publish are still pending.
+- Scope summary: published v0.1.0-alpha.2 from `dev` after release workflow verification.
+- Gates run: GitHub `release.yml`, asset presence verification, and release document generation.
 - Refactor budget item: no explicit refactor-budget paydown was supplied to the automation flow.
+- Automated post-release verification completed via `release-gate post-release`.
+- Selected workflow run: https://github.com/loongclaw-ai/loongclaw/actions/runs/23286158620 (run id `23286158620`).
 
 ## Artifacts
 | Asset | Size (bytes) | SHA256 | Download |
 |---|---:|---|---|
-| Pending publish | pending | pending | [release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.2) |
+| `install.ps1` | 7362 | `be485775b42475445861d4433951ea689421a3252748a30c12d557a1272234b1` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/install.ps1) |
+| `install.sh` | 10355 | `6cab16979c11f8c5c6bf9d1c18df97a7883cce44371ad6ceb754a69a47cc04b8` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/install.sh) |
+| `loongclaw-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz` | 11762780 | `18353c206caa91d3563c2d94323a08c6205c394dd472561ff15dd987c5e49803` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz.sha256` | 119 | `9729c65752eb1be4e21dccb7cc7e13d7294cdc2143787cf10eb1055a064cf04c` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz` | 13355773 | `737b2bc7ff411719f8660311b6752eabc70e2e0529b41032d98b9e6392db2749` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz.sha256` | 118 | `4cae117e64413e84503a1b4889fc512309128830166555a352ecedbc7df22d98` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip` | 12526270 | `78d1b1190a34c11623948eb1274d0164ac435d831b61ba272121c06999099789` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip) |
+| `loongclaw-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip.sha256` | 119 | `556bee69f16a6c3cb2d56d5b13842b389e2a18a2f177f5930ba0a1aef0d49126` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-pc-windows-msvc.zip.sha256) |
+| `loongclaw-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz` | 13751337 | `a5bd20f68dbf4d3067f76c3ed86ee4f8218019f74a6f3a3b11e5dfbc3abd1756` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz) |
+| `loongclaw-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz.sha256` | 123 | `97491733078698d9dad10f84a20285eaa78cc8ad3f02bf58807913503be39bf4` | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0-alpha.2/loongclaw-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.tar.gz.sha256) |
 
 ## Verification
 | Check | Result | Evidence |
 |---|---|---|
-| Baseline `task verify` on fetched `upstream/dev` | PASS | local prerelease prep worktree at `e8da519` |
-| Release workflow completed successfully | PENDING | waiting for tag push |
-| Expected cross-platform assets are present | PENDING | waiting for GitHub release assets |
+| Release workflow completed successfully | PASS | [workflow run](https://github.com/loongclaw-ai/loongclaw/actions/runs/23286158620) |
+| GitHub release is not draft | PASS | [release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.2) |
+| Expected cross-platform assets are present | PASS | 10 assets validated |
 
 ## Refactor Budget
-- Hotspot metric paid down: none recorded by the planned prerelease flow yet.
-- Evidence: prerelease prep branch `release/dev-prerelease-v0.1.0-alpha.2` from `upstream/dev` commit `e8da519`.
-- If no paydown shipped, rationale: this prerelease is scoped to packaging and reporting the already-merged delta since `v0.1.0-alpha.1`.
+- Hotspot metric paid down: none recorded by the automated release flow.
+- Evidence: release workflow run `23286158620` and generated release artifacts for `v0.1.0-alpha.2`.
+- If no paydown shipped, rationale: this release was automated from existing repository metadata without an attached refactor-budget payload.
 
 ## Known Issues
-- Final asset inventory, workflow run URL, and contributor list remain pending until publish completes.
+- None observed during automated post-release verification.
 
 ## Rollback
-- If publish fails after tag creation, inspect the GitHub Actions run, patch the blocking issue on `dev`, and rerun `release.yml` for `v0.1.0-alpha.2`.
-- If the tag itself proves invalid, replace it with a newer prerelease and document supersession in `CHANGELOG.md`.
+- If a bad artifact is detected, mark the release as draft, remove broken assets, and re-run `release.yml` for the same tag.
+- If the tag itself is invalid, create a replacement patch release and document supersession in `CHANGELOG.md`.
 
 ## Detail Links
-- [Planned release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.2)
-- [Release workflow definition](../../.github/workflows/release.yml)
+- [Release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0-alpha.2)
+- [Release workflow run](https://github.com/loongclaw-ai/loongclaw/actions/runs/23286158620)
 - [Changelog entry](../../CHANGELOG.md)
-- Trace directory: `.docs/traces/20260319T080746Z-post-release-v0.1.0-alpha.2-planned`
+- [Release workflow definition](../../.github/workflows/release.yml)
+- Trace directory: `.docs/traces/20260319T084550Z-post-release-v0.1.0-alpha.2-c9e52bb4`
 - Local debug log: `.docs/releases/v0.1.0-alpha.2-debug.md`


### PR DESCRIPTION
## Summary
- add the generated canonical release report for v0.1.0-alpha.2
- add the generated announcement report for the published prerelease
- capture the final workflow, asset, and trace evidence on dev

## Verification
- task verify
- LOONGCLAW_RELEASE_DOCS_STRICT=1 ./scripts/check-docs.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v0.1.0-alpha.2 release announcement with verified artifacts
  * Release documentation includes chat-flow and delegate runtime/prompt visibility improvements
  * CI/CD process hardening and expanded prerelease test coverage
  * Installation scripts and platform-specific binaries with SHA256 checksums now available for download

<!-- end of auto-generated comment: release notes by coderabbit.ai -->