### PR TITLE
feat(cli): add shell completion generation via clap_complete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,18 @@ jobs:
           cp scripts/install.sh dist/install.sh
           cp scripts/install.ps1 dist/install.ps1
 
+      - name: Generate shell completions
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          tar -xzf "dist/loongclaw-${RELEASE_TAG}-x86_64-unknown-linux-gnu.tar.gz" -C /tmp loongclaw
+          /tmp/loongclaw completions bash        > dist/loongclaw.bash
+          /tmp/loongclaw completions zsh         > dist/_loongclaw
+          /tmp/loongclaw completions fish        > dist/loongclaw.fish
+          /tmp/loongclaw completions powershell  > dist/loongclaw.ps1
+          /tmp/loongclaw completions elvish      > dist/loongclaw.elv
+
       - name: Resolve release channel
         id: release_meta
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2019,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "clap_complete",
  "dialoguer",
  "ed25519-dalek",
  "libc",

--- a/README.md
+++ b/README.md
@@ -191,6 +191,37 @@ cargo install --path crates/daemon
 ```
 </details>
 
+### Shell Completion
+
+`loongclaw completions <shell>` prints a completion script to stdout. GitHub
+releases also publish pre-generated completion files if you prefer to download
+them instead of generating them locally.
+
+<details>
+<summary>Install shell completion</summary>
+
+```bash
+loongclaw completions bash >> ~/.bash_completion
+source ~/.bash_completion
+```
+
+```zsh
+loongclaw completions zsh > "${fpath[1]}/_loongclaw"
+```
+
+```fish
+loongclaw completions fish > ~/.config/fish/completions/loongclaw.fish
+```
+
+```powershell
+loongclaw completions powershell >> $PROFILE
+```
+
+```elvish
+loongclaw completions elvish >> ~/.config/elvish/rc.elv
+```
+</details>
+
 ### First Success Path
 
 1. Run guided onboarding:

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -33,6 +33,7 @@ libc = "0.2"
 
 [dependencies]
 clap.workspace = true
+clap_complete = "4.5"
 dialoguer.workspace = true
 kernel = { package = "loongclaw-kernel", path = "../kernel" }
 loongclaw-bench = { path = "../bench" }

--- a/crates/daemon/src/completions_cli.rs
+++ b/crates/daemon/src/completions_cli.rs
@@ -1,0 +1,66 @@
+use clap::CommandFactory;
+use clap_complete::{Shell, generate};
+
+use loongclaw_spec::CliResult;
+
+pub struct CompletionsCommandOptions {
+    pub shell: Shell,
+}
+
+/// Generate completions into an arbitrary writer — enables unit testing without stdout capture.
+pub fn generate_completions(shell: Shell, writer: &mut dyn std::io::Write) {
+    let mut cmd = crate::Cli::command();
+    generate(shell, &mut cmd, crate::CLI_COMMAND_NAME, writer);
+}
+
+pub fn run_completions_cli(options: CompletionsCommandOptions) -> CliResult<()> {
+    generate_completions(options.shell, &mut std::io::stdout());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completions_bash_non_empty() {
+        let mut buf = Vec::new();
+        generate_completions(Shell::Bash, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn completions_zsh_contains_binary_name() {
+        let mut buf = Vec::new();
+        generate_completions(Shell::Zsh, &mut buf);
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("loongclaw"));
+    }
+
+    #[test]
+    fn completions_fish_non_empty() {
+        let mut buf = Vec::new();
+        generate_completions(Shell::Fish, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn completions_powershell_non_empty() {
+        let mut buf = Vec::new();
+        generate_completions(Shell::PowerShell, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn completions_elvish_non_empty() {
+        let mut buf = Vec::new();
+        generate_completions(Shell::Elvish, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn run_completions_cli_returns_ok() {
+        let result = run_completions_cli(CompletionsCommandOptions { shell: Shell::Fish });
+        assert!(result.is_ok());
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -40,6 +40,7 @@ pub use sha2;
 mod browser_companion_diagnostics;
 pub mod browser_preview;
 mod cli_handoff;
+pub mod completions_cli;
 pub mod doctor_cli;
 pub mod feishu_cli;
 pub mod feishu_support;
@@ -623,6 +624,11 @@ pub enum Commands {
     Feishu {
         #[command(subcommand)]
         command: feishu_cli::FeishuCommand,
+    },
+    /// Print a shell completion script to stdout
+    Completions {
+        /// Target shell (bash, zsh, fish, powershell, elvish)
+        shell: clap_complete::Shell,
     },
 }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -447,6 +447,11 @@ async fn main() {
             .await
         }
         Commands::Feishu { command } => feishu_cli::run_feishu_command(command).await,
+        Commands::Completions { shell } => {
+            completions_cli::run_completions_cli(completions_cli::CompletionsCommandOptions {
+                shell,
+            })
+        }
     };
     if let Err(error) = result {
         #[allow(clippy::print_stderr)]

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -21,6 +21,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - [WebChat](webchat.md)
 - [Prompt And Personality](prompt-and-personality.md)
 - [Memory Profiles](memory-profiles.md)
+- [Shell Completion](shell-completion.md)
 
 ## Notes
 

--- a/docs/product-specs/shell-completion.md
+++ b/docs/product-specs/shell-completion.md
@@ -1,0 +1,52 @@
+# Shell Completion
+
+## User Story
+As a LoongClaw user on bash, zsh, fish, powershell, or elvish,
+I want to generate a shell completion script so that I can
+tab-complete subcommands and flags without memorizing them.
+
+## Acceptance Criteria
+- [ ] `loongclaw completions bash` prints a bash completion script to stdout.
+- [ ] `loongclaw completions zsh` prints a zsh completion script to stdout.
+- [ ] `loongclaw completions fish` prints a fish completion script to stdout.
+- [ ] `loongclaw completions powershell` prints a PowerShell completion script to stdout.
+- [ ] `loongclaw completions elvish` prints an elvish completion script to stdout.
+- [ ] Invalid shell names produce a structured clap error and exit code 2.
+- [ ] CI generates completion files as release artifacts (`loongclaw.bash`, `_loongclaw`, `loongclaw.fish`, `loongclaw.ps1`, `loongclaw.elv`).
+
+## Install Instructions
+
+### bash
+
+```bash
+loongclaw completions bash >> ~/.bash_completion
+source ~/.bash_completion
+```
+
+### zsh
+
+```zsh
+loongclaw completions zsh > "${fpath[1]}/_loongclaw"
+# Ensure the directory is in $fpath before compinit runs.
+```
+
+### fish
+
+```fish
+loongclaw completions fish > ~/.config/fish/completions/loongclaw.fish
+```
+
+### PowerShell
+
+```powershell
+loongclaw completions powershell >> $PROFILE
+```
+
+### elvish
+
+```elvish
+loongclaw completions elvish >> ~/.config/elvish/rc.elv
+```
+
+## Out of Scope
+- Auto-installing completions during `loongclaw onboard`.

--- a/docs/releases/TEMPLATE.md
+++ b/docs/releases/TEMPLATE.md
@@ -22,6 +22,11 @@
 | Asset | Size (bytes) | SHA256 | Download |
 |---|---:|---|---|
 | loongclaw-vX.Y.Z[-suffix]-x86_64-unknown-linux-gnu.tar.gz | 0 | <sha256> | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/vX.Y.Z[-suffix]/<asset>) |
+| loongclaw.bash | 0 | n/a | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/vX.Y.Z[-suffix]/loongclaw.bash) |
+| _loongclaw | 0 | n/a | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/vX.Y.Z[-suffix]/_loongclaw) |
+| loongclaw.fish | 0 | n/a | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/vX.Y.Z[-suffix]/loongclaw.fish) |
+| loongclaw.ps1 | 0 | n/a | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/vX.Y.Z[-suffix]/loongclaw.ps1) |
+| loongclaw.elv | 0 | n/a | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/vX.Y.Z[-suffix]/loongclaw.elv) |
 
 ## Verification
 | Check | Result | Evidence |


### PR DESCRIPTION
## Summary

- Problem: No shell tab completion for `loongclaw` — users must memorize all subcommands and flags manually.
- Why it matters: Tab completion is a standard CLI ergonomic expectation; without it the CLI feels incomplete for daily use.
- What changed: Added `loongclaw completions <shell>` subcommand that prints a shell completion script to stdout. CI `publish-release` job now generates 5 completion files as release artifacts. Install instructions added to docs/README.
- What did not change (scope boundary): No changes to existing commands, kernel, or runtime behavior. Auto-install during `loongclaw onboard` is out of scope.

## Linked Issues

- Closes #308
- Refs #294

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas

Commands and evidence:

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 32.11s

$ cargo test --workspace --all-features
test result: ok. 537 passed; 0 failed; 0 ignored

$ loongclaw completions bash | wc -l
5441

$ loongclaw completions zsh | wc -l
3640

$ loongclaw completions fish | wc -l
548

$ loongclaw completions cobol; echo "exit: $?"
error: invalid value 'cobol' for '<SHELL>'
  [possible values: bash, elvish, fish, powershell, zsh]
exit: 2
```

## User-visible / Operator-visible Changes

New subcommand available:

```
loongclaw completions <shell>
```

Supported shells: `bash`, `zsh`, `fish`, `powershell`, `elvish`. Prints completion script to stdout. Invalid shell name exits with code 2.

Release artifacts now include: `loongclaw.bash`, `_loongclaw`, `loongclaw.fish`, `loongclaw.ps1`, `loongclaw.elv`.

## Failure Recovery

- Fast rollback or disable path: Revert `completions_cli.rs`, remove `Completions` variant from `Commands` enum, remove the CI step. No state is mutated — the command is purely stdout output.
- Observable failure symptoms reviewers should watch for: `publish-release` CI step failing if the Linux archive name doesn't match the expected pattern `loongclaw-${RELEASE_TAG}-x86_64-unknown-linux-gnu.tar.gz`.

## Reviewer Focus

- `.github/workflows/release.yml` — the "Generate shell completions" step extracts the Linux binary from the already-downloaded archive and runs it. Verify the archive filename pattern matches what `build-binaries` produces.
- `crates/daemon/src/lib.rs` — `Completions { shell: clap_complete::Shell }` uses a fully-qualified path in the enum field; confirm this resolves correctly without an explicit `use clap_complete;` import.
- `completions_cli.rs` — `generate_completions()` is split from `run_completions_cli()` solely for testability (writer injection). The public API surface is intentionally minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shell completion support via `loongclaw completions` command for bash, zsh, fish, powershell, and elvish.
  * Shell-specific completion artifacts now included in releases.

* **Documentation**
  * Added shell completion specification and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
