### PR TITLE
Add aggregate fast-lane execution diagnostics

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -891,6 +891,21 @@ fn format_fast_lane_summary(
     limit: usize,
     summary: &FastLaneToolBatchEventSummary,
 ) -> String {
+    let parallel_safe_ratio = format_ratio(
+        summary.total_parallel_safe_intents_seen,
+        summary.total_intents_seen,
+    );
+    let serial_only_ratio = format_ratio(
+        summary.total_serial_only_intents_seen,
+        summary.total_intents_seen,
+    );
+    let configured_max_in_flight_avg = format_average(
+        summary.parallel_execution_max_in_flight_sum,
+        summary.parallel_execution_max_in_flight_samples,
+    );
+    let scheduling_class_rollup = format_rollup_counts(&summary.scheduling_class_counts);
+    let execution_mode_rollup = format_rollup_counts(&summary.execution_mode_counts);
+
     [
         format!("fast_lane_summary session={session_id} limit={limit}"),
         format!(
@@ -898,6 +913,32 @@ fn format_fast_lane_summary(
             summary.batch_events,
             format_fast_lane_summary_optional(summary.latest_schema_version)
         ),
+        format!(
+            "aggregate_batches parallel_enabled={} parallel_only={} mixed={} sequential_only={} without_segments={}",
+            summary.parallel_execution_enabled_batches,
+            summary.parallel_only_batches,
+            summary.mixed_execution_batches,
+            summary.sequential_only_batches,
+            summary.batches_without_segments,
+        ),
+        format!(
+            "aggregate_intents total={} parallel_safe={} serial_only={} parallel_safe_ratio={} serial_only_ratio={}",
+            summary.total_intents_seen,
+            summary.total_parallel_safe_intents_seen,
+            summary.total_serial_only_intents_seen,
+            parallel_safe_ratio,
+            serial_only_ratio,
+        ),
+        format!(
+            "aggregate_segments parallel={} sequential={} configured_max_in_flight_avg={} configured_max_in_flight_max={} configured_max_in_flight_samples={}",
+            summary.total_parallel_segments_seen,
+            summary.total_sequential_segments_seen,
+            configured_max_in_flight_avg,
+            format_fast_lane_summary_optional(summary.parallel_execution_max_in_flight_max),
+            summary.parallel_execution_max_in_flight_samples,
+        ),
+        format!("rollup scheduling_classes={scheduling_class_rollup}"),
+        format!("rollup execution_modes={execution_mode_rollup}"),
         format!(
             "latest_batch total_intents={} parallel_enabled={} max_in_flight={} parallel_safe_intents={} serial_only_intents={} parallel_segments={} sequential_segments={}",
             format_fast_lane_summary_optional(summary.latest_total_intents),
@@ -1490,6 +1531,22 @@ fn format_milli_ratio(value: Option<u32>) -> String {
         .unwrap_or_else(|| "-".to_owned())
 }
 
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_ratio(numerator: u64, denominator: u64) -> String {
+    if denominator == 0 {
+        return "-".to_owned();
+    }
+    format!("{:.3}", numerator as f64 / denominator as f64)
+}
+
+#[cfg(any(test, feature = "memory-sqlite"))]
+fn format_average(sum: u64, samples: u32) -> String {
+    if samples == 0 {
+        return "-".to_owned();
+    }
+    format!("{:.3}", sum as f64 / f64::from(samples))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2017,6 +2074,9 @@ mod tests {
         assert!(direct_output.contains("batch_events=1"));
         assert!(direct_output.contains("total_intents=5"));
         assert!(direct_output.contains("parallel_safe_intents=4"));
+        assert!(direct_output.contains(
+            "aggregate_batches parallel_enabled=1 parallel_only=0 mixed=1 sequential_only=0 without_segments=0"
+        ));
         assert!(direct_output.contains("latest_segments=0:parallel_safe/parallel/2,1:serial_only/sequential/1,2:parallel_safe/parallel/2"));
 
         let kernel_payloads = fast_lane_tool_batch_event_payloads();
@@ -2037,6 +2097,9 @@ mod tests {
         assert!(kernel_output.contains("batch_events=1"));
         assert!(kernel_output.contains("total_intents=5"));
         assert!(kernel_output.contains("parallel_safe_intents=4"));
+        assert!(kernel_output.contains(
+            "aggregate_batches parallel_enabled=1 parallel_only=0 mixed=1 sequential_only=0 without_segments=0"
+        ));
         assert!(kernel_output.contains("latest_segments=0:parallel_safe/parallel/2,1:serial_only/sequential/1,2:parallel_safe/parallel/2"));
 
         let captured = invocations.lock().expect("invocations lock");
@@ -2050,6 +2113,58 @@ mod tests {
         assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
 
         cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[test]
+    fn format_fast_lane_summary_includes_window_aggregates() {
+        let summary = FastLaneToolBatchEventSummary {
+            batch_events: 4,
+            latest_schema_version: Some(2),
+            latest_total_intents: Some(0),
+            latest_parallel_execution_enabled: Some(false),
+            latest_parallel_execution_max_in_flight: None,
+            latest_parallel_safe_intents: Some(0),
+            latest_serial_only_intents: Some(0),
+            latest_parallel_segments: Some(0),
+            latest_sequential_segments: Some(0),
+            latest_segments: Vec::new(),
+            parallel_execution_enabled_batches: 2,
+            parallel_only_batches: 1,
+            mixed_execution_batches: 1,
+            sequential_only_batches: 1,
+            batches_without_segments: 1,
+            total_intents_seen: 8,
+            total_parallel_safe_intents_seen: 5,
+            total_serial_only_intents_seen: 3,
+            total_parallel_segments_seen: 3,
+            total_sequential_segments_seen: 3,
+            parallel_execution_max_in_flight_samples: 3,
+            parallel_execution_max_in_flight_sum: 6,
+            parallel_execution_max_in_flight_max: Some(3),
+            scheduling_class_counts: BTreeMap::from([
+                ("parallel_safe".to_owned(), 3),
+                ("serial_only".to_owned(), 3),
+            ]),
+            execution_mode_counts: BTreeMap::from([
+                ("parallel".to_owned(), 3),
+                ("sequential".to_owned(), 3),
+            ]),
+        };
+
+        let output = format_fast_lane_summary("session-fast-lane", 64, &summary);
+
+        assert!(output.contains("fast_lane_summary session=session-fast-lane limit=64"));
+        assert!(output.contains(
+            "aggregate_batches parallel_enabled=2 parallel_only=1 mixed=1 sequential_only=1 without_segments=1"
+        ));
+        assert!(output.contains(
+            "aggregate_intents total=8 parallel_safe=5 serial_only=3 parallel_safe_ratio=0.625 serial_only_ratio=0.375"
+        ));
+        assert!(output.contains(
+            "aggregate_segments parallel=3 sequential=3 configured_max_in_flight_avg=2.000 configured_max_in_flight_max=3 configured_max_in_flight_samples=3"
+        ));
+        assert!(output.contains("rollup scheduling_classes=parallel_safe:3,serial_only:3"));
+        assert!(output.contains("rollup execution_modes=parallel:3,sequential:3"));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -422,6 +422,21 @@ pub struct FastLaneToolBatchSegmentSnapshot {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FastLaneToolBatchEventSummary {
     pub batch_events: u32,
+    pub parallel_execution_enabled_batches: u32,
+    pub parallel_only_batches: u32,
+    pub mixed_execution_batches: u32,
+    pub sequential_only_batches: u32,
+    pub batches_without_segments: u32,
+    pub total_intents_seen: u64,
+    pub total_parallel_safe_intents_seen: u64,
+    pub total_serial_only_intents_seen: u64,
+    pub total_parallel_segments_seen: u64,
+    pub total_sequential_segments_seen: u64,
+    pub parallel_execution_max_in_flight_samples: u32,
+    pub parallel_execution_max_in_flight_sum: u64,
+    pub parallel_execution_max_in_flight_max: Option<u32>,
+    pub scheduling_class_counts: BTreeMap<String, u32>,
+    pub execution_mode_counts: BTreeMap<String, u32>,
     pub latest_schema_version: Option<u32>,
     pub latest_total_intents: Option<u32>,
     pub latest_parallel_execution_enabled: Option<bool>,
@@ -802,18 +817,94 @@ fn fold_fast_lane_tool_batch_event_record(
 
     summary.batch_events = summary.batch_events.saturating_add(1);
     summary.latest_schema_version = read_u32_opt(&record.payload, "schema_version");
-    summary.latest_total_intents = read_u32_opt(&record.payload, "total_intents");
-    summary.latest_parallel_execution_enabled = record
+
+    let total_intents = read_u32_opt(&record.payload, "total_intents");
+    summary.latest_total_intents = total_intents;
+    summary.total_intents_seen = summary
+        .total_intents_seen
+        .saturating_add(total_intents.map(u64::from).unwrap_or_default());
+
+    let parallel_execution_enabled = record
         .payload
         .get("parallel_execution_enabled")
         .and_then(Value::as_bool);
-    summary.latest_parallel_execution_max_in_flight =
+    summary.latest_parallel_execution_enabled = parallel_execution_enabled;
+    if parallel_execution_enabled == Some(true) {
+        summary.parallel_execution_enabled_batches =
+            summary.parallel_execution_enabled_batches.saturating_add(1);
+    }
+
+    let parallel_execution_max_in_flight =
         read_u32_opt(&record.payload, "parallel_execution_max_in_flight");
-    summary.latest_parallel_safe_intents = read_u32_opt(&record.payload, "parallel_safe_intents");
-    summary.latest_serial_only_intents = read_u32_opt(&record.payload, "serial_only_intents");
-    summary.latest_parallel_segments = read_u32_opt(&record.payload, "parallel_segments");
-    summary.latest_sequential_segments = read_u32_opt(&record.payload, "sequential_segments");
-    summary.latest_segments = parse_fast_lane_tool_batch_segments(record.payload.get("segments"));
+    summary.latest_parallel_execution_max_in_flight = parallel_execution_max_in_flight;
+    if let Some(value) = parallel_execution_max_in_flight {
+        summary.parallel_execution_max_in_flight_samples = summary
+            .parallel_execution_max_in_flight_samples
+            .saturating_add(1);
+        summary.parallel_execution_max_in_flight_sum = summary
+            .parallel_execution_max_in_flight_sum
+            .saturating_add(u64::from(value));
+        summary.parallel_execution_max_in_flight_max = Some(
+            summary
+                .parallel_execution_max_in_flight_max
+                .map_or(value, |current| current.max(value)),
+        );
+    }
+
+    let parallel_safe_intents = read_u32_opt(&record.payload, "parallel_safe_intents");
+    summary.latest_parallel_safe_intents = parallel_safe_intents;
+    summary.total_parallel_safe_intents_seen = summary
+        .total_parallel_safe_intents_seen
+        .saturating_add(parallel_safe_intents.map(u64::from).unwrap_or_default());
+
+    let serial_only_intents = read_u32_opt(&record.payload, "serial_only_intents");
+    summary.latest_serial_only_intents = serial_only_intents;
+    summary.total_serial_only_intents_seen = summary
+        .total_serial_only_intents_seen
+        .saturating_add(serial_only_intents.map(u64::from).unwrap_or_default());
+
+    let parallel_segments = read_u32_opt(&record.payload, "parallel_segments");
+    summary.latest_parallel_segments = parallel_segments;
+    summary.total_parallel_segments_seen = summary
+        .total_parallel_segments_seen
+        .saturating_add(parallel_segments.map(u64::from).unwrap_or_default());
+
+    let sequential_segments = read_u32_opt(&record.payload, "sequential_segments");
+    summary.latest_sequential_segments = sequential_segments;
+    summary.total_sequential_segments_seen = summary
+        .total_sequential_segments_seen
+        .saturating_add(sequential_segments.map(u64::from).unwrap_or_default());
+
+    match (
+        parallel_segments.unwrap_or_default() > 0,
+        sequential_segments.unwrap_or_default() > 0,
+    ) {
+        (true, false) => {
+            summary.parallel_only_batches = summary.parallel_only_batches.saturating_add(1);
+        }
+        (false, true) => {
+            summary.sequential_only_batches = summary.sequential_only_batches.saturating_add(1);
+        }
+        (true, true) => {
+            summary.mixed_execution_batches = summary.mixed_execution_batches.saturating_add(1);
+        }
+        (false, false) => {
+            summary.batches_without_segments = summary.batches_without_segments.saturating_add(1);
+        }
+    }
+
+    let segments = parse_fast_lane_tool_batch_segments(record.payload.get("segments"));
+    for segment in &segments {
+        let scheduling_class = segment.scheduling_class.trim();
+        if !scheduling_class.is_empty() {
+            bump_count(&mut summary.scheduling_class_counts, scheduling_class);
+        }
+        let execution_mode = segment.execution_mode.trim();
+        if !execution_mode.is_empty() {
+            bump_count(&mut summary.execution_mode_counts, execution_mode);
+        }
+    }
+    summary.latest_segments = segments;
 }
 
 pub(crate) fn summarize_turn_checkpoint_history<'a, I>(
@@ -1516,6 +1607,142 @@ mod tests {
     }
 
     #[test]
+    fn summarize_fast_lane_tool_batch_events_tracks_window_aggregates() {
+        let payloads = [
+            json!({
+                "type": "conversation_event",
+                "event": "fast_lane_tool_batch",
+                "payload": {
+                    "schema_version": 1,
+                    "total_intents": 3,
+                    "parallel_execution_enabled": true,
+                    "parallel_execution_max_in_flight": 3,
+                    "parallel_safe_intents": 3,
+                    "serial_only_intents": 0,
+                    "parallel_segments": 2,
+                    "sequential_segments": 0,
+                    "segments": [
+                        {
+                            "segment_index": 0,
+                            "scheduling_class": "parallel_safe",
+                            "execution_mode": "parallel",
+                            "intent_count": 2
+                        },
+                        {
+                            "segment_index": 1,
+                            "scheduling_class": "parallel_safe",
+                            "execution_mode": "parallel",
+                            "intent_count": 1
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "fast_lane_tool_batch",
+                "payload": {
+                    "schema_version": 1,
+                    "total_intents": 3,
+                    "parallel_execution_enabled": true,
+                    "parallel_execution_max_in_flight": 2,
+                    "parallel_safe_intents": 2,
+                    "serial_only_intents": 1,
+                    "parallel_segments": 1,
+                    "sequential_segments": 1,
+                    "segments": [
+                        {
+                            "segment_index": 0,
+                            "scheduling_class": "parallel_safe",
+                            "execution_mode": "parallel",
+                            "intent_count": 2
+                        },
+                        {
+                            "segment_index": 1,
+                            "scheduling_class": "serial_only",
+                            "execution_mode": "sequential",
+                            "intent_count": 1
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "fast_lane_tool_batch",
+                "payload": {
+                    "schema_version": 1,
+                    "total_intents": 2,
+                    "parallel_execution_enabled": false,
+                    "parallel_execution_max_in_flight": 1,
+                    "parallel_safe_intents": 0,
+                    "serial_only_intents": 2,
+                    "parallel_segments": 0,
+                    "sequential_segments": 2,
+                    "segments": [
+                        {
+                            "segment_index": 0,
+                            "scheduling_class": "serial_only",
+                            "execution_mode": "sequential",
+                            "intent_count": 1
+                        },
+                        {
+                            "segment_index": 1,
+                            "scheduling_class": "serial_only",
+                            "execution_mode": "sequential",
+                            "intent_count": 1
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "conversation_event",
+                "event": "fast_lane_tool_batch",
+                "payload": {
+                    "schema_version": 2,
+                    "total_intents": 0,
+                    "parallel_execution_enabled": false,
+                    "parallel_safe_intents": 0,
+                    "serial_only_intents": 0,
+                    "parallel_segments": 0,
+                    "sequential_segments": 0,
+                    "segments": []
+                }
+            })
+            .to_string(),
+        ];
+
+        let summary = summarize_fast_lane_tool_batch_events(payloads.iter().map(String::as_str));
+
+        assert_eq!(summary.batch_events, 4);
+        assert_eq!(summary.parallel_execution_enabled_batches, 2);
+        assert_eq!(summary.parallel_only_batches, 1);
+        assert_eq!(summary.mixed_execution_batches, 1);
+        assert_eq!(summary.sequential_only_batches, 1);
+        assert_eq!(summary.batches_without_segments, 1);
+        assert_eq!(summary.total_intents_seen, 8);
+        assert_eq!(summary.total_parallel_safe_intents_seen, 5);
+        assert_eq!(summary.total_serial_only_intents_seen, 3);
+        assert_eq!(summary.total_parallel_segments_seen, 3);
+        assert_eq!(summary.total_sequential_segments_seen, 3);
+        assert_eq!(summary.parallel_execution_max_in_flight_samples, 3);
+        assert_eq!(summary.parallel_execution_max_in_flight_sum, 6);
+        assert_eq!(summary.parallel_execution_max_in_flight_max, Some(3));
+        assert_eq!(
+            summary.scheduling_class_counts,
+            BTreeMap::from([
+                ("parallel_safe".to_owned(), 3),
+                ("serial_only".to_owned(), 3),
+            ])
+        );
+        assert_eq!(
+            summary.execution_mode_counts,
+            BTreeMap::from([("parallel".to_owned(), 3), ("sequential".to_owned(), 3),])
+        );
+    }
+
+    #[test]
     fn summarize_fast_lane_tool_batch_events_ignores_malformed_segments() {
         let payloads = [json!({
             "type": "conversation_event",
@@ -1548,6 +1775,14 @@ mod tests {
 
         let summary = summarize_fast_lane_tool_batch_events(payloads.iter().map(String::as_str));
 
+        assert_eq!(
+            summary.scheduling_class_counts,
+            BTreeMap::from([("parallel_safe".to_owned(), 1)])
+        );
+        assert_eq!(
+            summary.execution_mode_counts,
+            BTreeMap::from([("parallel".to_owned(), 1)])
+        );
         assert_eq!(
             summary.latest_segments,
             vec![FastLaneToolBatchSegmentSnapshot {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5440,6 +5440,8 @@ async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_
     config
         .conversation
         .fast_lane_parallel_tool_execution_max_in_flight = 2;
+    let sqlite_path = unique_memory_sqlite_path("fast-lane-batch-event");
+    config.memory.sqlite_path = sqlite_path.clone();
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     crate::memory::append_turn_direct(
@@ -5556,6 +5558,8 @@ async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_
     assert_eq!(segments[2]["scheduling_class"], "parallel_safe");
     assert_eq!(segments[2]["execution_mode"], "parallel");
     assert_eq!(segments[2]["intent_count"], 2);
+
+    let _ = std::fs::remove_file(sqlite_path);
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -5569,6 +5573,8 @@ async fn handle_turn_with_runtime_fast_lane_batch_persist_failure_surfaces_runti
     config
         .conversation
         .fast_lane_parallel_tool_execution_max_in_flight = 2;
+    let sqlite_path = unique_memory_sqlite_path("fast-lane-batch-persist-failure");
+    config.memory.sqlite_path = sqlite_path.clone();
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     crate::memory::append_turn_direct(
@@ -5671,6 +5677,8 @@ async fn handle_turn_with_runtime_fast_lane_batch_persist_failure_surfaces_runti
         }),
         "expected fast-lane batch persistence failure audit event, got: {runtime_ops:?}"
     );
+
+    let _ = std::fs::remove_file(sqlite_path);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app/src/conversation/turn_middleware_registry.rs
+++ b/crates/app/src/conversation/turn_middleware_registry.rs
@@ -256,7 +256,10 @@ impl Drop for ScopedTurnMiddlewareEnvOverride {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{
+        MutexGuard,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
 
     use async_trait::async_trait;
 
@@ -264,6 +267,12 @@ mod tests {
         SYSTEM_PROMPT_ADDITION_TURN_MIDDLEWARE_ID, SYSTEM_PROMPT_TOOL_VIEW_TURN_MIDDLEWARE_ID,
     };
     use super::*;
+
+    fn registry_test_guard() -> MutexGuard<'static, ()> {
+        super::super::context_engine_registry::conversation_selector_env_lock()
+            .lock()
+            .expect("registry test lock")
+    }
 
     struct StaticIdTurnMiddleware {
         id: &'static str,
@@ -278,6 +287,7 @@ mod tests {
 
     #[test]
     fn list_turn_middleware_ids_includes_builtin_defaults() {
+        let _registry_lock = registry_test_guard();
         let ids = list_turn_middleware_ids().expect("list ids");
         assert!(
             ids.iter()
@@ -293,6 +303,7 @@ mod tests {
 
     #[test]
     fn registry_can_register_and_resolve_custom_turn_middleware() {
+        let _registry_lock = registry_test_guard();
         register_turn_middleware("registry-turn-middleware-custom", || {
             Box::new(StaticIdTurnMiddleware {
                 id: "registry-turn-middleware-custom",
@@ -306,6 +317,7 @@ mod tests {
 
     #[test]
     fn resolve_turn_middleware_returns_error_for_unknown_id() {
+        let _registry_lock = registry_test_guard();
         let error = match resolve_turn_middleware("not-registered") {
             Ok(middleware) => panic!(
                 "expected unknown turn middleware to fail, got {}",
@@ -318,6 +330,7 @@ mod tests {
 
     #[test]
     fn list_turn_middleware_metadata_exposes_capabilities() {
+        let _registry_lock = registry_test_guard();
         register_turn_middleware("registry-turn-middleware-capability", || {
             Box::new(StaticIdTurnMiddleware {
                 id: "registry-turn-middleware-capability",
@@ -336,6 +349,7 @@ mod tests {
 
     #[test]
     fn register_turn_middleware_rejects_duplicate_id() {
+        let _registry_lock = registry_test_guard();
         register_turn_middleware("registry-turn-middleware-duplicate", || {
             Box::new(StaticIdTurnMiddleware {
                 id: "registry-turn-middleware-duplicate",
@@ -357,6 +371,7 @@ mod tests {
 
     #[test]
     fn register_turn_middleware_duplicate_id_does_not_invoke_factory() {
+        let _registry_lock = registry_test_guard();
         register_turn_middleware("registry-turn-middleware-duplicate-fast-fail", || {
             Box::new(StaticIdTurnMiddleware {
                 id: "registry-turn-middleware-duplicate-fast-fail",
@@ -387,6 +402,7 @@ mod tests {
 
     #[test]
     fn list_turn_middleware_metadata_runs_factories_outside_registry_lock() {
+        let _registry_lock = registry_test_guard();
         let factory_ran_outside_registry_lock = Arc::new(AtomicBool::new(false));
         let observed = factory_ran_outside_registry_lock.clone();
         register_turn_middleware("registry-turn-middleware-metadata-lock-scope", move || {
@@ -411,6 +427,7 @@ mod tests {
 
     #[test]
     fn resolve_turn_middleware_runs_factory_outside_registry_lock() {
+        let _registry_lock = registry_test_guard();
         let factory_ran_outside_registry_lock = Arc::new(AtomicBool::new(false));
         let observed = factory_ran_outside_registry_lock.clone();
         register_turn_middleware("registry-turn-middleware-resolve-lock-scope", move || {
@@ -435,9 +452,7 @@ mod tests {
 
     #[test]
     fn turn_middleware_ids_from_env_normalizes_and_deduplicates() {
-        let _env_lock = super::super::context_engine_registry::conversation_selector_env_lock()
-            .lock()
-            .expect("env lock");
+        let _registry_lock = registry_test_guard();
         let _scoped_env = ScopedTurnMiddlewareEnvOverride::set(Some(" Alpha , beta ,, alpha "));
         let ids = turn_middleware_ids_from_env().expect("turn middleware ids from env");
         assert_eq!(ids, vec!["alpha".to_owned(), "beta".to_owned()]);


### PR DESCRIPTION
## Summary

- Problem: fast-lane reporting only exposed the latest batch snapshot and did not show recent-window aggregate counters and segment rollups.
- Why it matters: operators could inspect one batch in detail, but they could not see broader recent fast-lane behavior or the aggregate execution profile across batches.
- What changed: added aggregate batch, intent, and segment diagnostics to fast-lane analytics and `/fast_lane_summary`, while preserving the latest batch snapshot, and isolated the affected fast-lane tests from the shared default sqlite path so verification stays deterministic.
- What did not change (scope boundary): this does not change fast-lane scheduling policy or tool-execution behavior; it only expands diagnostics and test isolation.

## Linked Issues

- Closes #364
- Related #374

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
- passed

cargo test -p loongclaw-app fast_lane -- --test-threads=1
- passed

cargo test -p loongclaw-app --all-features -- --test-threads=1
- passed with an isolated `HOME` locally to avoid a sandbox-protected persisted channel runtime file under the real home directory
```

## User-visible / Operator-visible Changes

- `/fast_lane_summary` now includes recent-window aggregate batch, intent, and segment diagnostics in addition to the latest batch snapshot.

## Failure Recovery

- Fast rollback or disable path: revert this change to remove the aggregate rollups and restore the previous latest-batch-only view.
- Observable failure symptoms reviewers should watch for: aggregate counters drifting from the underlying batch data, summary output losing the latest batch snapshot, or test flakes reappearing because of shared sqlite state.

## Reviewer Focus

- `crates/app/src/conversation/analytics.rs` and `crates/app/src/chat.rs` for aggregate rollup calculation and summary rendering.
- `crates/app/src/conversation/tests.rs` for the new aggregate assertions.
- `crates/app/src/conversation/turn_middleware_registry.rs` for the local test-isolation support staying scoped to verification.
