### PR TITLE
Capture structured runtime delta evidence in runtime capability artifacts

### DIFF
--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1,8 +1,8 @@
 use crate::Capability;
 use crate::runtime_experiment_cli::{
     RuntimeExperimentArtifactDocument, RuntimeExperimentDecision,
-    RuntimeExperimentShowCommandOptions, RuntimeExperimentStatus,
-    execute_runtime_experiment_show_command,
+    RuntimeExperimentShowCommandOptions, RuntimeExperimentSnapshotDelta, RuntimeExperimentStatus,
+    derive_recorded_snapshot_delta_for_run, execute_runtime_experiment_show_command,
 };
 use crate::sha2::{self, Digest};
 use clap::{Args, Subcommand, ValueEnum};
@@ -154,6 +154,7 @@ pub struct RuntimeCapabilitySourceRunSummary {
     pub evaluation_summary: String,
     pub metrics: std::collections::BTreeMap<String, f64>,
     pub warnings: Vec<String>,
+    pub snapshot_delta: Option<RuntimeExperimentSnapshotDelta>,
     pub artifact_path: Option<String>,
 }
 
@@ -232,6 +233,8 @@ pub struct RuntimeCapabilityEvidenceDigest {
     pub latest_reviewed_at: Option<String>,
     pub source_decisions: RuntimeCapabilitySourceDecisionRollup,
     pub unique_warnings: Vec<String>,
+    pub delta_candidate_count: usize,
+    pub changed_surfaces: Vec<String>,
     pub metric_ranges: BTreeMap<String, RuntimeCapabilityMetricRange>,
 }
 
@@ -550,6 +553,10 @@ fn build_source_run_summary(
         .evaluation
         .as_ref()
         .ok_or_else(|| "runtime capability source run is missing evaluation".to_owned())?;
+    let snapshot_delta = artifact_path
+        .map(|path| derive_recorded_snapshot_delta_for_run(run, &path.display().to_string()))
+        .transpose()?
+        .flatten();
     Ok(RuntimeCapabilitySourceRunSummary {
         run_id: run.run_id.clone(),
         experiment_id: run.experiment_id.clone(),
@@ -565,6 +572,7 @@ fn build_source_run_summary(
         evaluation_summary: evaluation.summary.clone(),
         metrics: evaluation.metrics.clone(),
         warnings: evaluation.warnings.clone(),
+        snapshot_delta,
         artifact_path: artifact_path.map(canonicalize_existing_path).transpose()?,
     })
 }
@@ -829,6 +837,8 @@ fn build_family_evidence_digest(
     let mut rejected = 0;
     let mut undecided = 0;
     let mut unique_warnings = BTreeSet::new();
+    let mut changed_surfaces = BTreeSet::new();
+    let mut delta_candidate_count = 0;
     let mut metric_bounds = BTreeMap::<String, RuntimeCapabilityMetricRange>::new();
 
     for artifact in artifacts {
@@ -836,6 +846,11 @@ fn build_family_evidence_digest(
             RuntimeExperimentDecision::Promoted => promoted += 1,
             RuntimeExperimentDecision::Rejected => rejected += 1,
             RuntimeExperimentDecision::Undecided => undecided += 1,
+        }
+
+        if let Some(snapshot_delta) = artifact.source_run.snapshot_delta.as_ref() {
+            delta_candidate_count += 1;
+            changed_surfaces.extend(snapshot_delta.changed_surfaces());
         }
 
         if artifact.decision == RuntimeCapabilityDecision::Accepted {
@@ -872,6 +887,8 @@ fn build_family_evidence_digest(
             undecided,
         },
         unique_warnings: unique_warnings.into_iter().collect(),
+        delta_candidate_count,
+        changed_surfaces: changed_surfaces.into_iter().collect(),
         metric_ranges: metric_bounds,
     }
 }
@@ -1180,6 +1197,24 @@ pub fn render_runtime_capability_text(artifact: &RuntimeCapabilityArtifactDocume
             render_string_values_with_separator(&artifact.source_run.warnings, " | ")
         ),
         format!(
+            "source_snapshot_delta_changed_surface_count={}",
+            artifact
+                .source_run
+                .snapshot_delta
+                .as_ref()
+                .map(|delta| delta.changed_surface_count.to_string())
+                .unwrap_or_else(|| "-".to_owned())
+        ),
+        format!(
+            "source_snapshot_delta_changed_surfaces={}",
+            artifact
+                .source_run
+                .snapshot_delta
+                .as_ref()
+                .map(|delta| render_string_values(&delta.changed_surfaces()))
+                .unwrap_or_else(|| "-".to_owned())
+        ),
+        format!(
             "review_summary={}",
             artifact
                 .review
@@ -1243,6 +1278,14 @@ pub fn render_runtime_capability_index_text(report: &RuntimeCapabilityIndexRepor
         lines.push(format!(
             "warnings={}",
             render_string_values_with_separator(&family.evidence.unique_warnings, " | ")
+        ));
+        lines.push(format!(
+            "delta_evidence_candidates={}",
+            family.evidence.delta_candidate_count
+        ));
+        lines.push(format!(
+            "delta_changed_surfaces={}",
+            render_string_values(&family.evidence.changed_surfaces)
         ));
         lines.push(format!(
             "checks={}",
@@ -1535,6 +1578,14 @@ pub fn render_runtime_capability_promotion_plan_text(
         format!(
             "tags={}",
             render_string_values(&report.planned_artifact.tags)
+        ),
+        format!(
+            "delta_evidence_candidates={}",
+            report.evidence.delta_candidate_count
+        ),
+        format!(
+            "delta_changed_surfaces={}",
+            render_string_values(&report.evidence.changed_surfaces)
         ),
         format!(
             "blockers={}",

--- a/crates/daemon/src/runtime_experiment_cli.rs
+++ b/crates/daemon/src/runtime_experiment_cli.rs
@@ -214,7 +214,7 @@ pub struct RuntimeExperimentRestoreExecution {
     pub restore: crate::runtime_restore_cli::RuntimeRestoreExecution,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeExperimentSnapshotDelta {
     pub changed_surface_count: usize,
     pub provider_active_profile: RuntimeExperimentScalarCompare,
@@ -232,13 +232,13 @@ pub struct RuntimeExperimentSnapshotDelta {
     pub external_skill_ids: RuntimeExperimentSetCompare,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeExperimentScalarCompare {
     pub before: Option<String>,
     pub after: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeExperimentSetCompare {
     pub added: Vec<String>,
     pub removed: Vec<String>,
@@ -253,6 +253,52 @@ impl RuntimeExperimentScalarCompare {
 impl RuntimeExperimentSetCompare {
     fn changed(&self) -> bool {
         !self.added.is_empty() || !self.removed.is_empty()
+    }
+}
+
+impl RuntimeExperimentSnapshotDelta {
+    pub(crate) fn changed_surfaces(&self) -> Vec<String> {
+        let mut surfaces = Vec::new();
+        if self.provider_active_profile.changed() {
+            surfaces.push("provider_active_profile".to_owned());
+        }
+        if self.provider_active_model.changed() {
+            surfaces.push("provider_active_model".to_owned());
+        }
+        if self.context_engine_selected.changed() {
+            surfaces.push("context_engine_selected".to_owned());
+        }
+        if self.context_engine_compaction.changed() {
+            surfaces.push("context_engine_compaction".to_owned());
+        }
+        if self.memory_selected.changed() {
+            surfaces.push("memory_selected".to_owned());
+        }
+        if self.memory_policy.changed() {
+            surfaces.push("memory_policy".to_owned());
+        }
+        if self.acp_selected.changed() {
+            surfaces.push("acp_selected".to_owned());
+        }
+        if self.acp_policy.changed() {
+            surfaces.push("acp_policy".to_owned());
+        }
+        if self.enabled_channel_ids.changed() {
+            surfaces.push("enabled_channel_ids".to_owned());
+        }
+        if self.enabled_service_channel_ids.changed() {
+            surfaces.push("enabled_service_channel_ids".to_owned());
+        }
+        if self.visible_tool_names.changed() {
+            surfaces.push("visible_tool_names".to_owned());
+        }
+        if self.capability_snapshot_sha256.changed() {
+            surfaces.push("capability_snapshot_sha256".to_owned());
+        }
+        if self.external_skill_ids.changed() {
+            surfaces.push("external_skill_ids".to_owned());
+        }
+        surfaces
     }
 }
 
@@ -418,6 +464,20 @@ pub fn execute_runtime_experiment_compare_command(
         compare_mode,
         snapshot_delta,
     })
+}
+
+pub(crate) fn derive_recorded_snapshot_delta_for_run(
+    artifact: &RuntimeExperimentArtifactDocument,
+    run_path: &str,
+) -> CliResult<Option<RuntimeExperimentSnapshotDelta>> {
+    let Some(result_snapshot) = artifact.result_snapshot.as_ref() else {
+        return Ok(None);
+    };
+    if artifact.baseline_snapshot.artifact_path.is_none() || result_snapshot.artifact_path.is_none()
+    {
+        return Ok(None);
+    }
+    load_runtime_experiment_compare_snapshot_delta(artifact, run_path, None, None, true)
 }
 
 pub fn execute_runtime_experiment_restore_command(

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -95,6 +95,47 @@ fn snapshot_id_from_payload(payload: &Value) -> String {
         .expect("snapshot payload should include lineage.snapshot_id")
 }
 
+fn rewrite_json_file(path: &Path, mutate: impl FnOnce(&mut Value)) {
+    let raw = fs::read_to_string(path).expect("read json fixture");
+    let mut payload = serde_json::from_str::<Value>(&raw).expect("decode json fixture");
+    mutate(&mut payload);
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&payload).expect("encode json fixture"),
+    )
+    .expect("write json fixture");
+}
+
+fn rewrite_runtime_capability_compare_config(config_path: &Path) {
+    let (_, mut config) = mvp::config::load(Some(
+        config_path
+            .to_str()
+            .expect("config path should be valid utf-8"),
+    ))
+    .expect("load config fixture");
+    let openai = config
+        .providers
+        .get("openai-main")
+        .cloned()
+        .expect("openai-main provider should exist");
+    config.set_active_provider_profile("openai-main", openai);
+    config.tools.browser.enabled = false;
+    config.tools.web.enabled = false;
+    config.acp.dispatch.enabled = false;
+    config.acp.default_agent = Some("codex".to_owned());
+    config.acp.allowed_agents = vec!["codex".to_owned()];
+    mvp::config::write(
+        Some(
+            config_path
+                .to_str()
+                .expect("config path should be valid utf-8"),
+        ),
+        &config,
+        true,
+    )
+    .expect("rewrite config fixture");
+}
+
 fn start_runtime_experiment(
     root: &Path,
     snapshot_path: &Path,
@@ -184,6 +225,128 @@ fn finish_runtime_experiment(
                 warning: vec!["manual verification only".to_owned()],
                 decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
                 status: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+    (run_path, finished)
+}
+
+fn finish_runtime_experiment_with_compare_delta(
+    root: &Path,
+    config_path: &Path,
+) -> (
+    PathBuf,
+    PathBuf,
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some("baseline".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment(root, &baseline_snapshot_path);
+
+    rewrite_runtime_capability_compare_config(config_path);
+
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        config_path,
+        "artifacts/runtime-snapshot-result.json",
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some("candidate".to_owned()),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: "provider and tool policy updated".to_owned(),
+                metric: vec!["task_success=1".to_owned(), "cost_delta=-0.2".to_owned()],
+                warning: vec!["manual verification only".to_owned()],
+                decision:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+                status:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+
+    (
+        run_path,
+        baseline_snapshot_path,
+        result_snapshot_path,
+        finished,
+    )
+}
+
+fn finish_runtime_experiment_variant_with_compare_delta(
+    root: &Path,
+    slug: &str,
+    cost_delta: f64,
+    warnings: &[&str],
+    decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let config_path = write_runtime_capability_config(root);
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        &config_path,
+        &format!("artifacts/runtime-snapshot-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some(format!("baseline-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment_variant(root, &baseline_snapshot_path, slug);
+
+    rewrite_runtime_capability_compare_config(&config_path);
+
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        &config_path,
+        &format!("artifacts/runtime-snapshot-result-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some(format!("candidate-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: format!("provider and tool policy updated ({slug})"),
+                metric: vec![
+                    "task_success=1".to_owned(),
+                    format!("cost_delta={cost_delta}"),
+                ],
+                warning: warnings.iter().map(|warning| (*warning).to_owned()).collect(),
+                decision,
+                status:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
                 json: false,
             },
         )
@@ -490,6 +653,128 @@ fn runtime_capability_propose_persists_candidate_from_finished_run() {
 }
 
 #[test]
+fn runtime_capability_propose_persists_snapshot_delta_when_recorded_snapshots_exist() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-snapshot-delta");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _baseline_snapshot_path, _result_snapshot_path, _run) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability-delta.json");
+
+    let candidate =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: Some("browser-preview-snapshot-delta".to_owned()),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    let payload = serde_json::to_value(&candidate).expect("serialize candidate");
+    let snapshot_delta = payload
+        .pointer("/source_run/snapshot_delta")
+        .and_then(Value::as_object)
+        .expect("candidate should persist snapshot-backed delta evidence");
+    let changed_surface_count = snapshot_delta
+        .get("changed_surface_count")
+        .and_then(Value::as_u64)
+        .expect("snapshot delta should include changed surface count");
+    assert!(
+        changed_surface_count > 0,
+        "snapshot delta should record at least one changed surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_leaves_snapshot_delta_empty_without_recorded_snapshots() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-no-snapshot-delta");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _run) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability-no-snapshot-delta.json");
+
+    rewrite_json_file(&run_path, |payload| {
+        payload["baseline_snapshot"]["artifact_path"] = Value::Null;
+        payload["result_snapshot"]["artifact_path"] = Value::Null;
+    });
+
+    let candidate =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: candidate_path.display().to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: Some("browser-preview-no-snapshot-delta".to_owned()),
+                json: false,
+            },
+        )
+        .expect("runtime capability propose should succeed");
+
+    let payload = serde_json::to_value(&candidate).expect("serialize candidate");
+    assert!(
+        payload
+            .pointer("/source_run/snapshot_delta")
+            .is_some_and(Value::is_null),
+        "candidate should keep snapshot delta empty when recorded snapshots are unavailable"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_rejects_broken_recorded_snapshot_delta() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-broken-snapshot-delta");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _baseline_snapshot_path, result_snapshot_path, _run) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+
+    fs::remove_file(&result_snapshot_path).expect("remove result snapshot to break recorded delta");
+
+    let error =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+                run: run_path.display().to_string(),
+                output: root
+                    .join("artifacts/runtime-capability-broken-snapshot-delta.json")
+                    .display()
+                    .to_string(),
+                target:
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+                target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                    .to_owned(),
+                bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                    .to_owned(),
+                required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+                tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+                label: Some("browser-preview-broken-snapshot-delta".to_owned()),
+                json: false,
+            },
+        )
+        .expect_err("broken recorded snapshots should reject capability proposal");
+
+    assert!(error.contains("snapshot"), "error: {error}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_propose_rejects_planned_runs() {
     let root = unique_temp_dir("loongclaw-runtime-capability-propose-planned");
     let config_path = write_runtime_capability_config(&root);
@@ -658,6 +943,53 @@ fn runtime_capability_show_round_trips_the_persisted_artifact() {
     .expect("show should round-trip the persisted artifact");
 
     assert_eq!(shown, proposed);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_show_accepts_artifacts_missing_snapshot_delta_field() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show-legacy-delta");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _, _, _) = finish_runtime_experiment_with_compare_delta(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability-legacy.json");
+
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target: loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+            target_summary: "Codify browser preview onboarding as a reusable managed skill"
+                .to_owned(),
+            bounded_scope: "Browser preview onboarding and companion readiness checks only"
+                .to_owned(),
+            required_capability: vec!["invoke_tool".to_owned(), "memory_read".to_owned()],
+            tag: vec!["browser".to_owned(), "onboarding".to_owned()],
+            label: Some("browser-preview-legacy".to_owned()),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed");
+
+    rewrite_json_file(&candidate_path, |payload| {
+        payload["source_run"]
+            .as_object_mut()
+            .expect("source_run should be an object")
+            .remove("snapshot_delta");
+    });
+
+    let shown = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect("show should keep backward compatibility with legacy artifacts");
+
+    assert!(
+        shown.source_run.snapshot_delta.is_none(),
+        "missing snapshot_delta should deserialize as None"
+    );
 
     fs::remove_dir_all(&root).ok();
 }
@@ -873,6 +1205,69 @@ fn runtime_capability_index_groups_related_candidates_and_reports_ready_family()
             .expect("cost delta range should exist")
             .max,
         -0.2
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_index_reports_delta_evidence_digest() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-delta-digest");
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_compare_delta(
+        &root,
+        "delta-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_compare_delta(
+        &root,
+        "delta-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) = propose_runtime_capability_variant(&root, &run_a_path, "delta-a");
+    let (candidate_b_path, _) = propose_runtime_capability_variant(&root, &run_b_path, "delta-b");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "delta-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "delta-b",
+    );
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let payload = serde_json::to_value(&report).expect("serialize index report");
+    let evidence = payload
+        .pointer("/families/0/evidence")
+        .and_then(Value::as_object)
+        .expect("index report should expose one family evidence object");
+    assert_eq!(
+        evidence
+            .get("delta_candidate_count")
+            .and_then(Value::as_u64)
+            .expect("evidence should include delta candidate count"),
+        2
+    );
+    let changed_surfaces = evidence
+        .get("changed_surfaces")
+        .and_then(Value::as_array)
+        .expect("evidence should include changed surfaces");
+    assert!(
+        !changed_surfaces.is_empty(),
+        "delta evidence digest should list at least one changed surface"
     );
 
     fs::remove_dir_all(&root).ok();
@@ -1388,6 +1783,84 @@ fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
 }
 
 #[test]
+fn runtime_capability_plan_surfaces_delta_evidence_digest() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-delta-digest");
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_compare_delta(
+        &root,
+        "plan-delta-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_compare_delta(
+        &root,
+        "plan-delta-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let (candidate_a_path, _) =
+        propose_runtime_capability_variant(&root, &run_a_path, "plan-delta-a");
+    let (candidate_b_path, _) =
+        propose_runtime_capability_variant(&root, &run_b_path, "plan-delta-b");
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "plan-delta-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "plan-delta-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+    let payload = serde_json::to_value(&plan).expect("serialize plan");
+    let evidence = payload
+        .get("evidence")
+        .and_then(Value::as_object)
+        .expect("plan should include family evidence");
+    assert_eq!(
+        evidence
+            .get("delta_candidate_count")
+            .and_then(Value::as_u64)
+            .expect("plan evidence should include delta candidate count"),
+        2
+    );
+    let changed_surfaces = evidence
+        .get("changed_surfaces")
+        .and_then(Value::as_array)
+        .expect("plan evidence should include changed surfaces");
+    assert!(
+        !changed_surfaces.is_empty(),
+        "plan evidence should surface at least one changed surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_plan_rejects_malformed_supported_artifact_during_scan() {
     let root = unique_temp_dir("loongclaw-runtime-capability-plan-malformed");
     let config_path = write_runtime_capability_config(&root);
@@ -1772,6 +2245,38 @@ fn runtime_capability_plan_rejects_unknown_family_id() {
     assert!(
         error.contains("missing-family"),
         "error should name the requested family id: {error}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_show_text_renders_snapshot_delta_summary() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-show-text-delta-summary");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _baseline_snapshot_path, _result_snapshot_path, _run) =
+        finish_runtime_experiment_with_compare_delta(&root, &config_path);
+
+    let candidate = propose_runtime_capability_variant_with_target(
+        &root,
+        &run_path,
+        "show-delta",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+
+    let rendered =
+        loongclaw_daemon::runtime_capability_cli::render_runtime_capability_text(&candidate);
+    assert!(
+        rendered.contains("source_snapshot_delta_changed_surface_count="),
+        "rendered text should include the compact changed-surface count"
+    );
+    assert!(
+        rendered.contains("source_snapshot_delta_changed_surfaces="),
+        "rendered text should include compact changed-surface names"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-19
+Last updated: 2026-03-20
 
 This roadmap is execution-focused. Every stage has:
 
@@ -289,9 +289,9 @@ Delivered in current baseline:
   - `runtime-snapshot` persists lineage-aware runtime checkpoint artifacts
   - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
   - `runtime-experiment start|finish|show|compare` records baseline snapshot, mutation summary, result snapshot, evaluation metrics, warnings, final decision, and optional snapshot-backed runtime deltas for operator review
-  - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, and explicit operator review without mutating live runtime state
-  - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests, and evaluates readiness as `ready`, `not_ready`, or `blocked`
-  - `runtime-capability plan` resolves one indexed capability family into a deterministic dry-run promotion plan with artifact identity, blockers, approval checklist, rollback hints, and provenance
+  - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, explicit operator review, and any recorded snapshot-backed delta evidence without mutating live runtime state
+  - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests including delta-evidence coverage and changed runtime surfaces, and evaluates readiness as `ready`, `not_ready`, or `blocked`
+  - `runtime-capability plan` resolves one indexed capability family into a deterministic dry-run promotion plan with artifact identity, blockers, approval checklist, rollback hints, provenance, and the same family-level delta evidence digest
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification

--- a/docs/plans/2026-03-20-runtime-capability-delta-evidence-design.md
+++ b/docs/plans/2026-03-20-runtime-capability-delta-evidence-design.md
@@ -1,0 +1,186 @@
+# Runtime Capability Delta Evidence Design
+
+## Context
+
+`runtime-experiment compare` already knows how to derive structured
+snapshot-backed runtime deltas from recorded baseline and result snapshots.
+
+`runtime-capability`, however, still stops one layer too early:
+
+- `propose` stores source run metadata, review intent, and bounded scope
+- `index` aggregates candidate evidence into family-level readiness summaries
+- `plan` emits a dry-run promotion artifact with provenance and blockers
+
+What is still missing is the structured delta itself. That means later
+promotion-oriented layers would have to recompute compare output on demand or
+infer material changes from prose fields such as `mutation_summary`,
+`target_summary`, and `bounded_scope`.
+
+Issue `#346` tracks that missing substrate. A previous stacked PR (`#348`)
+contained this slice, but it was closed after its base branch was merged and the
+base ref was deleted. The delta-evidence portion did not land in `dev`.
+
+## Problem
+
+The current capability artifact is not self-contained enough for the next
+promotion-materialization layer.
+
+Without persisted delta evidence:
+
+- operators cannot review the exact changed runtime surfaces from the
+  capability artifact itself
+- `index` and `plan` cannot surface compact evidence about what changed across a
+  family
+- later mutation-oriented work would need ad-hoc recomputation from snapshot
+  artifacts that may not remain available forever
+
+This is a correctness and auditability gap, not a UI polish issue.
+
+## Goals
+
+This replacement slice should:
+
+1. persist optional snapshot-backed delta evidence inside
+   `RuntimeCapabilitySourceRunSummary`
+2. aggregate compact family-level delta evidence in `index` and `plan`
+3. surface the evidence in `show`, `index`, and `plan` text and JSON outputs
+4. stay backward-compatible for existing capability artifacts that do not carry
+   delta evidence
+
+## Non-Goals
+
+This slice must not:
+
+- change readiness policy semantics
+- add promotion executors or apply paths
+- add new CLI flags
+- introduce background indexing, caches, or artifact migrations
+- broaden runtime-experiment compare semantics beyond extracting a reusable
+  helper
+
+## Approaches Considered
+
+### Approach A: Persist delta evidence in capability artifacts
+
+Reuse the existing runtime-experiment compare logic, store the optional delta on
+each proposed capability candidate, and aggregate a compact digest at family
+level.
+
+Pros:
+
+- fixes the actual missing substrate
+- keeps artifacts self-contained
+- reuses existing snapshot-compare semantics
+- keeps later promotion work deterministic and auditable
+
+Cons:
+
+- extends the persisted capability artifact schema
+- requires explicit tests for old-artifact compatibility
+
+### Approach B: Recompute delta evidence in `show`, `index`, and `plan`
+
+Leave capability artifacts unchanged and derive deltas only when commands are
+rendered.
+
+Pros:
+
+- smaller write-path change
+
+Cons:
+
+- artifacts remain incomplete
+- later layers depend on external snapshot availability
+- repeated recomputation invites drift and hidden failure modes
+
+### Recommendation
+
+Choose Approach A.
+
+The gap is in persisted evidence, not in rendering. Recomputing later would
+only hide the missing contract.
+
+## Data Model Changes
+
+### Candidate-Level Evidence
+
+Extend `RuntimeCapabilitySourceRunSummary` with:
+
+- `snapshot_delta: Option<RuntimeExperimentSnapshotDelta>`
+
+Rules:
+
+- `None` when the source run has no result snapshot
+- `None` when recorded snapshot artifact paths are absent
+- `Some(delta)` when recorded baseline/result snapshot paths exist and the delta
+  can be derived deterministically
+- return an error when recorded snapshot paths exist but the delta cannot be
+  derived because artifacts are missing or malformed
+
+### Family-Level Evidence Digest
+
+Extend `RuntimeCapabilityEvidenceDigest` with:
+
+- `delta_candidate_count: usize`
+- `changed_surfaces: Vec<String>`
+
+Rules:
+
+- count only candidates with `snapshot_delta.is_some()`
+- aggregate a sorted unique union of changed runtime surfaces across those
+  candidates
+- keep the digest compact; do not inline full before/after payloads at family
+  level
+
+## Command Behavior
+
+### `runtime-capability propose`
+
+- load the finished runtime-experiment artifact as today
+- derive the optional snapshot delta from the recorded snapshot paths when
+  available
+- persist it under `source_run.snapshot_delta`
+
+### `runtime-capability show`
+
+- continue to round-trip the full artifact as JSON
+- add compact text output for:
+  - delta presence
+  - changed surface count
+  - changed surface names
+
+### `runtime-capability index`
+
+- keep readiness evaluation unchanged
+- add family-level delta digest fields to the evidence object
+- add text rendering for:
+  - `delta_evidence_candidates`
+  - `delta_changed_surfaces`
+
+### `runtime-capability plan`
+
+- reuse the family evidence digest unchanged
+- surface the same compact delta summary in the plan output
+
+## Testing Strategy
+
+Follow TDD and add failing integration tests first for:
+
+1. `propose` persisting `snapshot_delta` when recorded snapshots are available
+2. `propose` leaving `snapshot_delta` empty when recorded snapshots are absent
+3. `propose` rejecting broken recorded snapshot references
+4. `index` reporting `delta_candidate_count` and `changed_surfaces`
+5. `plan` surfacing the same digest
+6. `show` rendering compact delta evidence text
+7. existing artifacts without the new field continuing to deserialize
+
+## Delivery Notes
+
+This slice should land as the replacement delivery for issue `#346`.
+
+The PR should explicitly state that:
+
+- `#348` was a stacked PR whose base branch was merged and removed
+- the delta-evidence subset never reached `dev`
+- this replacement PR closes the remaining substrate gap without changing
+  readiness policy or adding mutation behavior

--- a/docs/plans/2026-03-20-runtime-capability-delta-evidence-implementation-plan.md
+++ b/docs/plans/2026-03-20-runtime-capability-delta-evidence-implementation-plan.md
@@ -1,0 +1,348 @@
+# Runtime Capability Delta Evidence Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Persist snapshot-backed delta evidence inside runtime-capability artifacts and surface a compact family-level digest in `show`, `index`, and `plan`.
+
+**Architecture:** Reuse the existing runtime-experiment snapshot comparison logic as the single source of truth. Extend the capability artifact with an optional candidate-level delta, aggregate a minimal digest at family level, and keep readiness policy unchanged.
+
+**Tech Stack:** Rust, Cargo, Serde, Clap, daemon integration tests
+
+---
+
+### Task 1: Lock the replacement design into the branch
+
+**Files:**
+- Create: `docs/plans/2026-03-20-runtime-capability-delta-evidence-design.md`
+- Create: `docs/plans/2026-03-20-runtime-capability-delta-evidence-implementation-plan.md`
+
+**Step 1: Verify the design doc exists**
+
+Run: `test -f docs/plans/2026-03-20-runtime-capability-delta-evidence-design.md`
+Expected: exit code 0
+
+**Step 2: Verify the implementation plan exists**
+
+Run: `test -f docs/plans/2026-03-20-runtime-capability-delta-evidence-implementation-plan.md`
+Expected: exit code 0
+
+### Task 2: Add failing propose-path tests
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Add a fixture helper that finishes an experiment with a real compareable delta**
+
+Reuse the existing snapshot/config helpers instead of building new broad test
+infrastructure.
+
+**Step 2: Add a failing test for persisted snapshot delta**
+
+Test name:
+
+`runtime_capability_propose_persists_snapshot_delta_when_recorded_snapshots_exist`
+
+Assertions:
+
+- `candidate.source_run.snapshot_delta.is_some()`
+- `changed_surface_count > 0`
+- `changed_surfaces` includes at least one expected surface such as
+  `provider_active_profile`
+
+**Step 3: Run it to verify RED**
+
+Run:
+
+`cargo test -p loongclaw-daemon runtime_capability_propose_persists_snapshot_delta_when_recorded_snapshots_exist --test integration -- --nocapture`
+
+Expected: FAIL because `snapshot_delta` does not yet exist on the capability
+artifact
+
+**Step 4: Add a failing no-snapshot test**
+
+Test name:
+
+`runtime_capability_propose_leaves_snapshot_delta_empty_without_recorded_snapshots`
+
+Assertions:
+
+- `candidate.source_run.snapshot_delta.is_none()`
+
+**Step 5: Run it to verify RED**
+
+Run:
+
+`cargo test -p loongclaw-daemon runtime_capability_propose_leaves_snapshot_delta_empty_without_recorded_snapshots --test integration -- --nocapture`
+
+Expected: FAIL until the new field exists
+
+**Step 6: Add a failing broken-snapshot test**
+
+Test name:
+
+`runtime_capability_propose_rejects_broken_recorded_snapshot_delta`
+
+Setup:
+
+- create a finished run with recorded snapshot paths
+- delete or corrupt one referenced snapshot artifact after the run is persisted
+
+Assertion:
+
+- `execute_runtime_capability_propose_command(...)` returns an error mentioning
+  the unresolved recorded snapshot path
+
+**Step 7: Run it to verify RED**
+
+Run:
+
+`cargo test -p loongclaw-daemon runtime_capability_propose_rejects_broken_recorded_snapshot_delta --test integration -- --nocapture`
+
+Expected: FAIL until the propose path validates the recorded delta properly
+
+### Task 3: Add failing index, plan, and text-output tests
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/runtime_capability_cli.rs`
+
+**Step 1: Add a failing family digest test**
+
+Test name:
+
+`runtime_capability_index_reports_delta_evidence_digest`
+
+Assertions:
+
+- `family.evidence.delta_candidate_count == 2`
+- `family.evidence.changed_surfaces` is stable and sorted
+
+**Step 2: Run it to verify RED**
+
+Run:
+
+`cargo test -p loongclaw-daemon runtime_capability_index_reports_delta_evidence_digest --test integration -- --nocapture`
+
+Expected: FAIL because the digest fields do not exist yet
+
+**Step 3: Add a failing plan-output test**
+
+Test name:
+
+`runtime_capability_plan_surfaces_delta_evidence_digest`
+
+Assertions:
+
+- `plan.evidence.delta_candidate_count == 2`
+- `plan.evidence.changed_surfaces` matches the family digest
+
+**Step 4: Run it to verify RED**
+
+Run:
+
+`cargo test -p loongclaw-daemon runtime_capability_plan_surfaces_delta_evidence_digest --test integration -- --nocapture`
+
+Expected: FAIL until plan carries the new digest
+
+**Step 5: Add a failing show-text rendering test**
+
+Test name:
+
+`runtime_capability_show_text_renders_snapshot_delta_summary`
+
+Assertions:
+
+- rendered text includes changed surface count
+- rendered text includes changed surface names
+
+**Step 6: Run it to verify RED**
+
+Run:
+
+`cargo test -p loongclaw-daemon runtime_capability_show_text_renders_snapshot_delta_summary --test integration -- --nocapture`
+
+Expected: FAIL until text rendering is updated
+
+### Task 4: Implement candidate-level delta persistence
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+- Modify: `crates/daemon/src/runtime_experiment_cli.rs`
+
+**Step 1: Expose one reusable helper from the runtime-experiment path**
+
+Add a helper that derives the recorded snapshot delta for a finished run without
+duplicating compare semantics.
+
+**Step 2: Extend `RuntimeCapabilitySourceRunSummary`**
+
+Add:
+
+```rust
+pub snapshot_delta: Option<RuntimeExperimentSnapshotDelta>
+```
+
+**Step 3: Populate the field in `build_source_run_summary(...)`**
+
+Rules:
+
+- `None` when there is no recorded result snapshot or no recorded artifact path
+- `Some(delta)` when both recorded snapshot artifacts are resolvable
+- propagate errors when recorded artifact paths exist but cannot be loaded
+
+**Step 4: Re-run the propose-focused tests**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_propose_persists_snapshot_delta_when_recorded_snapshots_exist --test integration -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability_propose_leaves_snapshot_delta_empty_without_recorded_snapshots --test integration -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability_propose_rejects_broken_recorded_snapshot_delta --test integration -- --nocapture`
+
+Expected: PASS
+
+### Task 5: Implement the family-level delta digest
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+
+**Step 1: Extend `RuntimeCapabilityEvidenceDigest`**
+
+Add:
+
+- `delta_candidate_count: usize`
+- `changed_surfaces: Vec<String>`
+
+**Step 2: Aggregate the digest in `build_family_evidence_digest(...)`**
+
+Rules:
+
+- count only artifacts with `snapshot_delta.is_some()`
+- aggregate a stable sorted union of changed surface names
+- leave readiness evaluation unchanged
+
+**Step 3: Re-run the digest tests**
+
+Run:
+
+- `cargo test -p loongclaw-daemon runtime_capability_index_reports_delta_evidence_digest --test integration -- --nocapture`
+- `cargo test -p loongclaw-daemon runtime_capability_plan_surfaces_delta_evidence_digest --test integration -- --nocapture`
+
+Expected: PASS
+
+### Task 6: Surface the evidence in show, index, and plan output
+
+**Files:**
+- Modify: `crates/daemon/src/runtime_capability_cli.rs`
+
+**Step 1: Update `render_runtime_capability_text(...)`**
+
+Add compact summary lines for:
+
+- changed surface count
+- changed surface names
+
+**Step 2: Update `render_runtime_capability_index_text(...)`**
+
+Add compact summary lines for:
+
+- `delta_evidence_candidates`
+- `delta_changed_surfaces`
+
+**Step 3: Update `render_runtime_capability_promotion_plan_text(...)`**
+
+Reuse the same compact summary values from the family evidence digest.
+
+**Step 4: Re-run the rendering test**
+
+Run:
+
+`cargo test -p loongclaw-daemon runtime_capability_show_text_renders_snapshot_delta_summary --test integration -- --nocapture`
+
+Expected: PASS
+
+### Task 7: Update docs to describe the shipped evidence layer
+
+**Files:**
+- Modify: `docs/product-specs/runtime-capability.md`
+- Modify: `docs/ROADMAP.md`
+
+**Step 1: Update the product spec**
+
+Document that capability artifacts can preserve snapshot-backed runtime delta
+evidence and that families expose a compact changed-surface digest.
+
+**Step 2: Update the roadmap**
+
+Move the delta-evidence wording from “remaining deliverables” to the delivered
+runtime-capability slice.
+
+**Step 3: Verify docs mention the new layer**
+
+Run:
+
+`rg -n "snapshot-backed|delta evidence|changed_surfaces|runtime-capability" docs/product-specs/runtime-capability.md docs/ROADMAP.md`
+
+Expected: matches in both files
+
+### Task 8: Run focused and broader verification
+
+**Files:**
+- Modify only the delta-evidence implementation and doc files
+
+**Step 1: Run the focused runtime-capability suite**
+
+Run:
+
+`cargo test -p loongclaw-daemon runtime_capability_ --test integration -- --nocapture`
+
+Expected: PASS
+
+**Step 2: Run format check**
+
+Run:
+
+`cargo fmt --all -- --check`
+
+Expected: PASS
+
+**Step 3: Run strict daemon-targeted lint if needed**
+
+Run:
+
+`cargo clippy -p loongclaw-daemon --tests -- -D warnings`
+
+Expected: PASS
+
+### Task 9: Prepare replacement GitHub delivery
+
+**Files:**
+- Modify only the replacement slice files
+
+**Step 1: Inspect isolation**
+
+Run:
+
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`
+
+Expected: only runtime-capability delta-evidence files are included
+
+**Step 2: Commit**
+
+Suggested commit:
+
+`git commit -m "feat: persist runtime capability delta evidence"`
+
+**Step 3: Push to fork and open replacement PR**
+
+Branch:
+
+`issue-346-runtime-capability-delta-evidence`
+
+PR must:
+
+- target `dev`
+- include `Closes #346`
+- explain that the delta-evidence subset from the old stacked `#348` never
+  landed in `dev`
+- summarize validation commands exactly

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -16,19 +16,28 @@ experiment should be crystallized into a reusable lower-layer capability.
       `managed_skill`, `programmatic_flow`, or `profile_note_addendum`.
 - [ ] The candidate artifact records one bounded scope, normalized tags, and
       normalized required capabilities without mutating live runtime state.
+- [ ] When the source run still points at recorded baseline and result snapshot
+      artifacts, the candidate artifact persists the snapshot-backed runtime
+      delta evidence; when those recorded snapshots are unavailable, the delta
+      evidence remains explicitly empty instead of guessed.
 - [ ] `runtime-capability review` records one explicit operator decision
       (`accepted` or `rejected`) plus one review summary and optional warnings.
 - [ ] `runtime-capability show` round-trips the persisted artifact as JSON and
-      renders the review-critical fields first in text output.
+      renders the review-critical fields first in text output, including a
+      compact snapshot-delta summary when one exists.
 - [ ] `runtime-capability index` scans persisted candidate artifacts, groups
       matching promotion intent into deterministic capability families, and
       emits a compact evidence digest for each family.
+- [ ] Capability-family evidence digests surface how many candidates carried
+      snapshot-backed delta evidence plus the union of changed runtime surface
+      names across that family.
 - [ ] Each capability family reports readiness as `ready`, `not_ready`, or
       `blocked` from explicit evidence checks rather than opaque heuristics.
 - [ ] `runtime-capability plan` resolves one indexed family into a dry-run
       promotion plan that describes the target lower-layer artifact, stable
-      artifact id, blockers, approval checklist, rollback hints, and
-      provenance references without mutating runtime state.
+      artifact id, blockers, approval checklist, rollback hints, provenance
+      references, and the aggregated delta-evidence digest without mutating
+      runtime state.
 - [ ] Product docs describe `runtime-capability` as the governed review layer
       above `runtime-experiment`, with `index`/readiness and `plan` forming the
       dry-run planning ladder below any future promotion executor or automated


### PR DESCRIPTION
## Summary

- Problem: `runtime-capability` artifacts preserved promotion intent, review state, and dry-run planning metadata, but not the structured runtime delta that explains what changed between recorded baseline and result snapshots.
- Why it matters: later promotion-materialization work should consume self-contained, machine-readable evidence instead of recomputing compare output or inferring changes from prose summaries.
- What changed: persisted optional snapshot-backed delta evidence under `source_run`, aggregated `delta_candidate_count` and `changed_surfaces` into family evidence digests, surfaced compact delta summaries in `show`/`index`/`plan`, added integration coverage including legacy-artifact compatibility, and updated the roadmap/spec plus design docs for this replacement delivery.
- What did not change (scope boundary): no readiness-policy changes, no promotion executor or apply path, no new CLI flags, and no background indexing/materialization flow.

## Linked Issues

- Closes #346
- Related #348

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
-> pass

env CARGO_TARGET_DIR=<temp-dir> CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 cargo clippy -p loongclaw-daemon --tests -- -D warnings
-> pass

env CARGO_TARGET_DIR=<temp-dir> CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 cargo test -p loongclaw-daemon runtime_capability_show_accepts_artifacts_missing_snapshot_delta_field --test integration -- --nocapture
-> pass (1 passed)

env CARGO_TARGET_DIR=<temp-dir> CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 cargo test -p loongclaw-daemon runtime_capability_ --test integration -- --nocapture
-> pass (29 passed)

env CARGO_TARGET_DIR=<temp-dir> CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 cargo test --workspace --locked
-> fails in unrelated pre-existing app test: provider::tests::fetch_available_models_enriches_volcengine_auth_failures_with_ark_guidance
   root cause appears to be a nonblocking local test server read race in crates/app/src/provider/tests.rs:229 (WouldBlock after accept)

env CARGO_TARGET_DIR=<temp-dir> CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 cargo test -p loongclaw-app fetch_available_models_enriches_volcengine_auth_failures_with_ark_guidance --lib -- --nocapture
-> same unrelated failure reproduced
```

## User-visible / Operator-visible Changes

- `runtime-capability propose` now persists optional snapshot-backed delta evidence when recorded snapshots are still available.
- `runtime-capability show`, `index`, and `plan` now surface compact delta summaries without changing readiness semantics.
- legacy capability artifacts that do not yet carry `source_run.snapshot_delta` still load as `None`.

## Failure Recovery

- Fast rollback or disable path: revert this commit to remove persisted delta-evidence fields and rendering changes.
- Observable failure symptoms reviewers should watch for: `runtime-capability propose` now fails when a run records broken snapshot artifact paths instead of silently dropping delta evidence.

## Reviewer Focus

- `runtime_experiment_cli` helper reuse should stay the single source of truth for recorded snapshot delta derivation.
- `runtime_capability_cli` should persist optional delta evidence while keeping legacy artifact loading backward-compatible.
- readiness evaluation should remain unchanged; only evidence persistence, digests, and rendering should move.
- this PR replaces the delta-evidence slice that was present in stacked PR #348 but never landed after that PR's base branch was merged and deleted.
