### PR TITLE
fix(audit): make durable journal locking windows-safe

### DIFF
--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -3,7 +3,6 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use kernel::probe_jsonl_audit_journal_runtime_ready;
 use loongclaw_app as mvp;
@@ -11,7 +10,6 @@ use loongclaw_spec::CliResult;
 use serde_json::json;
 
 const MODEL_CATALOG_PROBE_FAILED_MARKER: &str = "model catalog probe failed";
-static AUDIT_RUNTIME_PROBE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone)]
 pub struct DoctorCommandOptions {
@@ -367,54 +365,84 @@ fn durable_audit_metadata_issue(path: &Path) -> Option<String> {
 }
 
 fn durable_audit_runtime_probe(path: &Path) -> Result<(), String> {
-    let directory = path.parent().unwrap_or(Path::new(""));
-    if !directory.as_os_str().is_empty() && !directory.exists() {
-        return Ok(());
-    }
-
-    let use_existing_path = path.is_file();
-    let probe_path = if use_existing_path {
-        path.to_path_buf()
-    } else {
-        durable_audit_probe_path(path)
-    };
-    let probe_result = probe_jsonl_audit_journal_runtime_ready(&probe_path).map_err(|error| {
+    let path_entry_existed = fs::symlink_metadata(path).is_ok();
+    let created_directories = durable_audit_missing_parent_dirs(path);
+    let probe_result = probe_jsonl_audit_journal_runtime_ready(path).map_err(|error| {
         format!(
             "runtime open + lock probe failed for {}: {error}",
             path.display()
         )
     });
+    let cleanup_result =
+        durable_audit_runtime_probe_cleanup(path, path_entry_existed, &created_directories);
 
-    if !use_existing_path {
-        match fs::remove_file(&probe_path) {
-            Ok(()) => {}
+    match (probe_result, cleanup_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn durable_audit_missing_parent_dirs(path: &Path) -> Vec<PathBuf> {
+    let mut missing = Vec::new();
+    let Some(mut current) = path.parent() else {
+        return missing;
+    };
+
+    while !current.as_os_str().is_empty() && !current.exists() {
+        missing.push(current.to_path_buf());
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent;
+    }
+
+    missing.reverse();
+    missing
+}
+
+fn durable_audit_runtime_probe_cleanup(
+    path: &Path,
+    path_entry_existed: bool,
+    created_directories: &[PathBuf],
+) -> Result<(), String> {
+    if !path_entry_existed {
+        match fs::metadata(path) {
+            Ok(metadata) if metadata.len() == 0 => {
+                fs::remove_file(path).map_err(|error| {
+                    format!(
+                        "runtime open + lock probe cleanup failed for {}: {error}",
+                        path.display()
+                    )
+                })?;
+            }
+            Ok(_) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) if probe_result.is_ok() => {
+            Err(error) => {
                 return Err(format!(
                     "runtime open + lock probe cleanup failed for {}: {error}",
                     path.display()
                 ));
             }
-            Err(_) => {}
         }
     }
 
-    probe_result
-}
-
-fn durable_audit_probe_path(path: &Path) -> PathBuf {
-    let sequence = AUDIT_RUNTIME_PROBE_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let directory = path.parent().unwrap_or(Path::new(""));
-    let probe_name = format!(
-        ".loongclaw-audit-probe-{}-{sequence}.jsonl",
-        std::process::id()
-    );
-
-    if directory.as_os_str().is_empty() {
-        PathBuf::from(probe_name)
-    } else {
-        directory.join(probe_name)
+    for directory in created_directories.iter().rev() {
+        match fs::remove_dir(directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+            Err(error) => {
+                return Err(format!(
+                    "runtime open + lock probe cleanup failed for {}: failed to remove {}: {error}",
+                    path.display(),
+                    directory.display()
+                ));
+            }
+        }
     }
+
+    Ok(())
 }
 
 fn check_audit_journal_directory(
@@ -2362,6 +2390,51 @@ mod tests {
         assert_eq!(check.name, "audit retention");
         assert_eq!(check.level, DoctorCheckLevel::Fail);
         assert!(check.detail.contains("runtime open + lock probe failed"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn audit_retention_doctor_check_fails_when_missing_parent_chain_is_not_creatable() {
+        let temp_dir = browser_companion_temp_dir("audit-target-missing-parent-chain");
+        let readonly_dir = temp_dir.join("readonly-audit");
+        std::fs::create_dir_all(&readonly_dir).expect("create readonly audit directory");
+        let original_permissions = std::fs::metadata(&readonly_dir)
+            .expect("readonly audit directory metadata")
+            .permissions();
+        let mut permissions = original_permissions.clone();
+        permissions.set_mode(0o555);
+        std::fs::set_permissions(&readonly_dir, permissions)
+            .expect("mark audit directory readonly");
+        let _permission_restore =
+            PermissionRestore::new(readonly_dir.clone(), original_permissions);
+
+        let journal_path = readonly_dir.join("nested").join("events.jsonl");
+        let check = audit_retention_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::Fanout,
+            path: journal_path.display().to_string(),
+            retain_in_memory: true,
+        });
+
+        assert_eq!(check.name, "audit retention");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(check.detail.contains("runtime open + lock probe failed"));
+    }
+
+    #[test]
+    fn audit_retention_doctor_check_cleans_up_probe_artifacts_for_creatable_missing_path() {
+        let temp_dir = browser_companion_temp_dir("audit-target-cleanup");
+        let journal_path = temp_dir.join("nested").join("events.jsonl");
+
+        let check = audit_retention_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::Fanout,
+            path: journal_path.display().to_string(),
+            retain_in_memory: true,
+        });
+
+        assert_eq!(check.name, "audit retention");
+        assert_eq!(check.level, DoctorCheckLevel::Pass);
+        assert!(!journal_path.exists());
+        assert!(!journal_path.parent().expect("nested parent").exists());
     }
 
     fn unique_temp_feishu_db(label: &str) -> String {

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -2,13 +2,16 @@ use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsStr;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use kernel::probe_jsonl_audit_journal_runtime_ready;
 use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
 use serde_json::json;
 
 const MODEL_CATALOG_PROBE_FAILED_MARKER: &str = "model catalog probe failed";
+static AUDIT_RUNTIME_PROBE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone)]
 pub struct DoctorCommandOptions {
@@ -323,6 +326,21 @@ fn durable_audit_retention_doctor_check(
 }
 
 fn durable_audit_target_issue(path: &Path) -> Option<String> {
+    durable_audit_target_issue_with_probe(path, durable_audit_runtime_probe)
+}
+
+fn durable_audit_target_issue_with_probe<F>(path: &Path, runtime_probe: F) -> Option<String>
+where
+    F: Fn(&Path) -> Result<(), String>,
+{
+    if let Some(issue) = durable_audit_metadata_issue(path) {
+        return Some(issue);
+    }
+
+    runtime_probe(path).err()
+}
+
+fn durable_audit_metadata_issue(path: &Path) -> Option<String> {
     let metadata = match fs::metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
@@ -346,6 +364,57 @@ fn durable_audit_target_issue(path: &Path) -> Option<String> {
     }
 
     None
+}
+
+fn durable_audit_runtime_probe(path: &Path) -> Result<(), String> {
+    let directory = path.parent().unwrap_or(Path::new(""));
+    if !directory.as_os_str().is_empty() && !directory.exists() {
+        return Ok(());
+    }
+
+    let use_existing_path = path.is_file();
+    let probe_path = if use_existing_path {
+        path.to_path_buf()
+    } else {
+        durable_audit_probe_path(path)
+    };
+    let probe_result = probe_jsonl_audit_journal_runtime_ready(&probe_path).map_err(|error| {
+        format!(
+            "runtime open + lock probe failed for {}: {error}",
+            path.display()
+        )
+    });
+
+    if !use_existing_path {
+        match fs::remove_file(&probe_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) if probe_result.is_ok() => {
+                return Err(format!(
+                    "runtime open + lock probe cleanup failed for {}: {error}",
+                    path.display()
+                ));
+            }
+            Err(_) => {}
+        }
+    }
+
+    probe_result
+}
+
+fn durable_audit_probe_path(path: &Path) -> PathBuf {
+    let sequence = AUDIT_RUNTIME_PROBE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let directory = path.parent().unwrap_or(Path::new(""));
+    let probe_name = format!(
+        ".loongclaw-audit-probe-{}-{sequence}.jsonl",
+        std::process::id()
+    );
+
+    if directory.as_os_str().is_empty() {
+        PathBuf::from(probe_name)
+    } else {
+        directory.join(probe_name)
+    }
 }
 
 fn check_audit_journal_directory(
@@ -2265,6 +2334,34 @@ mod tests {
         assert_eq!(check.name, "audit retention");
         assert_eq!(check.level, DoctorCheckLevel::Fail);
         assert!(check.detail.contains("not writable"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn audit_retention_doctor_check_fails_when_parent_directory_is_not_writable() {
+        let temp_dir = browser_companion_temp_dir("audit-target-parent-readonly");
+        let readonly_dir = temp_dir.join("readonly-audit");
+        std::fs::create_dir_all(&readonly_dir).expect("create readonly audit directory");
+        let original_permissions = std::fs::metadata(&readonly_dir)
+            .expect("readonly audit directory metadata")
+            .permissions();
+        let mut permissions = original_permissions.clone();
+        permissions.set_mode(0o555);
+        std::fs::set_permissions(&readonly_dir, permissions)
+            .expect("mark audit directory readonly");
+        let _permission_restore =
+            PermissionRestore::new(readonly_dir.clone(), original_permissions);
+
+        let journal_path = readonly_dir.join("events.jsonl");
+        let check = audit_retention_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::Fanout,
+            path: journal_path.display().to_string(),
+            retain_in_memory: true,
+        });
+
+        assert_eq!(check.name, "audit retention");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(check.detail.contains("runtime open + lock probe failed"));
     }
 
     fn unique_temp_feishu_db(label: &str) -> String {

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -52,29 +52,65 @@ pub struct JsonlAuditSink {
     journal: Mutex<File>,
 }
 
+fn prepare_audit_journal_parent(path: &Path) -> Result<(), AuditError> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to prepare audit journal parent directory `{}`: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
+fn open_jsonl_audit_journal(path: &Path) -> Result<File, AuditError> {
+    prepare_audit_journal_parent(path)?;
+
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to open audit journal `{}`: {error}",
+                path.display()
+            ))
+        })
+}
+
+fn lock_audit_journal(journal: &File, path: &Path) -> Result<(), AuditError> {
+    journal.lock().map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to lock audit journal `{}`: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn unlock_audit_journal(journal: &File, path: &Path) -> Result<(), AuditError> {
+    journal.unlock().map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to unlock audit journal `{}`: {error}",
+            path.display()
+        ))
+    })
+}
+
+/// Exercise the same open + lock + unlock path that production audit writes use.
+pub fn probe_jsonl_audit_journal_runtime_ready(path: &Path) -> Result<(), AuditError> {
+    let journal = open_jsonl_audit_journal(path)?;
+    lock_audit_journal(&journal, path)?;
+    unlock_audit_journal(&journal, path)
+}
+
 impl JsonlAuditSink {
     pub fn new(path: PathBuf) -> Result<Self, AuditError> {
-        if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            fs::create_dir_all(parent).map_err(|error| {
-                AuditError::Sink(format!(
-                    "failed to prepare audit journal parent directory `{}`: {error}",
-                    parent.display()
-                ))
-            })?;
-        }
-
-        let journal = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .map_err(|error| {
-                AuditError::Sink(format!(
-                    "failed to open audit journal `{}`: {error}",
-                    path.display()
-                ))
-            })?;
+        let journal = open_jsonl_audit_journal(&path)?;
 
         Ok(Self {
             path,
@@ -105,12 +141,7 @@ impl AuditSink for JsonlAuditSink {
             .map_err(|_error| AuditError::Sink("audit journal mutex poisoned".to_owned()))?;
         let encoded = serialize_audit_event_line(&event, &self.path)?;
 
-        guard.lock().map_err(|error| {
-            AuditError::Sink(format!(
-                "failed to lock audit journal `{}`: {error}",
-                self.path.display()
-            ))
-        })?;
+        lock_audit_journal(&guard, &self.path)?;
 
         let write_result = guard
             .write_all(&encoded)
@@ -129,12 +160,7 @@ impl AuditSink for JsonlAuditSink {
                 })
             });
 
-        let unlock_result = guard.unlock().map_err(|error| {
-            AuditError::Sink(format!(
-                "failed to unlock audit journal `{}`: {error}",
-                self.path.display()
-            ))
-        });
+        let unlock_result = unlock_audit_journal(&guard, &self.path);
 
         match (write_result, unlock_result) {
             (Err(error), _) => Err(error),

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -27,7 +27,7 @@ pub use architecture::{
 };
 pub use audit::{
     AuditEvent, AuditEventKind, AuditSink, ExecutionPlane, FanoutAuditSink, InMemoryAuditSink,
-    JsonlAuditSink, NoopAuditSink, PlaneTier,
+    JsonlAuditSink, NoopAuditSink, PlaneTier, probe_jsonl_audit_journal_runtime_ready,
 };
 pub use awareness::{CodebaseAwarenessConfig, CodebaseAwarenessEngine, CodebaseAwarenessSnapshot};
 pub use bootstrap::{

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 
 use crate::audit::{
     AuditEvent, AuditEventKind, AuditSink, FanoutAuditSink, InMemoryAuditSink, JsonlAuditSink,
+    probe_jsonl_audit_journal_runtime_ready,
 };
 use crate::clock::FixedClock;
 use crate::contracts::{Capability, HarnessOutcome, TaskIntent};
@@ -147,10 +148,21 @@ fn jsonl_audit_sink_surfaces_io_errors() {
 }
 
 #[test]
+fn jsonl_audit_sink_runtime_probe_accepts_fresh_journal_path() {
+    let path = fresh_audit_temp_path("jsonl-probe");
+
+    probe_jsonl_audit_journal_runtime_ready(&path)
+        .expect("runtime readiness probe should succeed for a fresh journal path");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
 fn jsonl_audit_sink_waits_for_existing_file_lock_before_appending() {
     let path = fresh_audit_temp_path("jsonl-lock");
     let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
     let external_lock = fs::OpenOptions::new()
+        .read(true)
         .append(true)
         .open(&path)
         .expect("open external audit journal handle");

--- a/docs/product-specs/doctor.md
+++ b/docs/product-specs/doctor.md
@@ -25,6 +25,8 @@ can recover a broken setup without reverse-engineering runtime internals.
 - [ ] Doctor checks cover the current MVP path: config presence, provider
       readiness, SQLite memory readiness, shipped channel prerequisites, and
       the optional browser preview companion readiness path.
+- [ ] Durable audit readiness checks exercise the runtime `open + lock + unlock`
+      path for JSONL retention instead of relying on metadata-only validation.
 - [ ] When `tools.browser_companion.enabled=true`, doctor surfaces companion
       install/runtime readiness as warnings with concrete repair steps instead
       of turning the optional managed lane into a hard core-runtime failure.


### PR DESCRIPTION
## Summary

- Problem: windows could fail to lock the durable jsonl audit journal during bootstrap, and doctor could still false-pass some missing-path cases because it probed a sibling file instead of the exact target path.
- Why it matters: this broke durable audit retention on windows and left a readiness-check gap where doctor could report healthy behavior even though the real durable target would still fail at runtime.
- What changed: kernel audit journal opening now uses a windows-safe read + append mode before locking; doctor now reuses the runtime open + lock + unlock path and probes the exact target path; daemon and kernel regression tests plus the doctor spec were updated to cover the runtime path and the missing-parent-chain false-pass case.
- What did not change (scope boundary): this does not change the audit format, retention policy, config schema, or unrelated provider and routing behavior.

## Linked Issues

- Closes #366
- Related #366

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed locally

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed locally before merge

cargo test --workspace --locked
- hit an existing unrelated flaky provider test on one macos host
  (fetch_available_models_enriches_volcengine_auth_failures_with_ark_guidance:
  WouldBlock on a loopback mock-server read), so this exact template item stays
  unchecked even though the PR head passed CI

cargo test -p loongclaw-kernel jsonl_audit_sink_runtime_probe_accepts_fresh_journal_path -- --nocapture
- passed locally

cargo test -p loongclaw-kernel jsonl_audit_sink_waits_for_existing_file_lock_before_appending -- --nocapture
- passed locally

cargo test -p loongclaw-daemon audit_retention_doctor_check_fails_when_parent_directory_is_not_writable --lib -- --nocapture
- passed locally

cargo test -p loongclaw-daemon audit_retention_doctor_check_fails_when_missing_parent_chain_is_not_creatable --lib -- --nocapture
- passed locally

cargo test -p loongclaw-daemon audit_retention_doctor_check_cleans_up_probe_artifacts_for_creatable_missing_path --lib -- --nocapture
- passed locally

cargo test -p loongclaw-daemon audit_retention_doctor_check_ --lib -- --nocapture
- passed locally after the follow-up exact-path probe fix

cargo test -p loongclaw-kernel jsonl_audit_sink_ -- --nocapture
- passed locally after the follow-up exact-path probe fix

cargo test -p loongclaw-app bootstrap_kernel_context_with_config_writes_ --lib -- --nocapture
- passed locally

env CARGO_TARGET_DIR=<temp-dir> cargo check --manifest-path Cargo.toml --workspace --all-features --target x86_64-pc-windows-msvc
- blocked locally by missing windows c sdk headers on the macos host, not by rust compile errors from this change

CI on head 0c1f130db900b5c49cec1f9492bf0e62bad6710e
- rust-test-default: passed
- rust-test-all-features: passed
- rust-quality: passed
- perf-lint: passed
- docs-build: passed
- governance: passed
```

## User-visible / Operator-visible Changes

- durable jsonl audit journals now open with a windows-safe access mode before locking, so bootstrap audit writes no longer fail on the previous append-only lock path.
- doctor now fails when the exact durable audit target path cannot actually be opened and locked, instead of false-passing some missing-path cases.

## Failure Recovery

- Fast rollback or disable path: revert merge commit `39ae6c52c615539856159dd656a9bcafe88619d6`, or temporarily switch audit retention back to in-memory mode if a deployment hits an unexpected durable journal permission edge case.
- Observable failure symptoms reviewers should watch for: doctor reporting durable audit target failures for genuinely uncreatable paths, or bootstrap audit writes surfacing explicit path and lock errors instead of appearing healthy.

## Reviewer Focus

- `crates/kernel/src/audit.rs` for the windows-safe open mode and lock sequencing.
- `crates/daemon/src/doctor_cli.rs` for exact-path probe semantics and cleanup of created artifacts.
- `crates/kernel/src/tests.rs` and daemon doctor tests for the missing-parent-chain regression coverage.