### PR TITLE
fix: parse ollama json tool-call fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows Keep a Changelog and semantic versioning intent.
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored provider-side tool execution when OpenAI-compatible responses emit standalone JSON tool blocks or Ollama-style `<tool_call>...</tool_call>` fallbacks instead of native `tool_calls`.
+
 ## [0.1.0-alpha.2] - 2026-03-19
 
 ### Added

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5130,6 +5130,51 @@ async fn handle_turn_with_runtime_provider_shape_tool_search_followup_inline_raw
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_provider_shape_tool_search_followup_json_raw_output() {
+    let (reply, runtime) = run_provider_shape_tool_search_followup(
+        "session-provider-shape-json",
+        "search for the right tool, then read note.md and show raw json tool output",
+        "hello from json provider-shape discovery followup raw test",
+        json!({
+            "choices": [{
+                "message": {
+                    "content": "Let me search for the right tool first.\n{\n  \"name\": \"tool_search\",\n  \"arguments\": {\n    \"query\": \"read note.md\",\n    \"limit\": 3\n  }\n}"
+                }
+            }]
+        }),
+        json!({
+            "choices": [{
+                "message": {
+                    "content": "Now I'll read the file.\n{\n  \"name\": \"file_read\",\n  \"arguments\": {\n    \"path\": \"note.md\"\n  }\n}"
+                }
+            }]
+        }),
+        Ok("unused completion".to_owned()),
+    )
+    .await;
+
+    assert!(
+        reply.contains("[ok]"),
+        "raw-request mode should return the invoked tool output, got: {reply}"
+    );
+    assert!(
+        reply.contains("hello from json provider-shape discovery followup raw test"),
+        "expected second-round invoked tool output, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    assert_discovery_first_followup_summary(&persisted, true, "file.read");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_tool_turn_raw_request_skips_second_pass_completion() {
     use crate::test_support::TurnTestHarness;
 

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -645,7 +645,9 @@ enum JsonToolBlockCandidate {
         tool_intent: ToolIntent,
     },
     Malformed(JsonToolBlockParseError),
-    Unsupported,
+    Unsupported {
+        consumed_bytes: Option<usize>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -653,6 +655,12 @@ struct JsonToolCallEnvelope {
     raw_tool_name: String,
     args_json: Value,
     tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JsonToolCallEnvelopeMode {
+    PlainStandalone,
+    TaggedBlock,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -940,8 +948,10 @@ fn extract_plain_json_tool_call_turn(
                     ),
                 };
             }
-            JsonToolBlockCandidate::Unsupported => {
-                let next_cursor = start + 1;
+            JsonToolBlockCandidate::Unsupported { consumed_bytes } => {
+                let next_cursor = consumed_bytes
+                    .map(|consumed_bytes| start + consumed_bytes)
+                    .unwrap_or(start + 1);
                 cleaned.push_str(&text[cursor..next_cursor]);
                 cursor = next_cursor;
             }
@@ -972,8 +982,8 @@ fn parse_json_tool_call_sequence(
 
     for result in stream {
         let value = result.map_err(|_error| JsonToolBlockParseError::InvalidJson)?;
-        let envelope =
-            json_tool_call_envelope(&value).ok_or(JsonToolBlockParseError::UnsupportedShape)?;
+        let envelope = json_tool_call_envelope(&value, JsonToolCallEnvelopeMode::TaggedBlock)?
+            .ok_or(JsonToolBlockParseError::UnsupportedShape)?;
         tool_intents.push(build_json_tool_intent(
             envelope,
             session_id,
@@ -1007,10 +1017,19 @@ fn parse_plain_json_tool_call_candidate(
     };
     let consumed_bytes = stream.byte_offset();
     if !is_standalone_block_end(text, consumed_bytes) {
-        return JsonToolBlockCandidate::Unsupported;
+        return JsonToolBlockCandidate::Unsupported {
+            consumed_bytes: None,
+        };
     }
-    let Some(envelope) = json_tool_call_envelope(&value) else {
-        return JsonToolBlockCandidate::Unsupported;
+    let envelope = match json_tool_call_envelope(&value, JsonToolCallEnvelopeMode::PlainStandalone)
+    {
+        Ok(Some(envelope)) => envelope,
+        Ok(None) => {
+            return JsonToolBlockCandidate::Unsupported {
+                consumed_bytes: Some(consumed_bytes),
+            };
+        }
+        Err(error) => return JsonToolBlockCandidate::Malformed(error),
     };
     JsonToolBlockCandidate::Parsed {
         consumed_bytes,
@@ -1022,6 +1041,57 @@ fn parse_plain_json_tool_call_candidate(
             tool_offset,
         ),
     }
+}
+
+fn json_tool_call_envelope(
+    value: &Value,
+    mode: JsonToolCallEnvelopeMode,
+) -> Result<Option<JsonToolCallEnvelope>, JsonToolBlockParseError> {
+    let Some(object) = value.as_object() else {
+        return Ok(None);
+    };
+    let function = object.get("function").and_then(Value::as_object);
+    let Some(raw_tool_name) = object
+        .get("name")
+        .and_then(Value::as_str)
+        .or_else(|| object.get("tool").and_then(Value::as_str))
+        .or_else(|| object.get("tool_name").and_then(Value::as_str))
+        .or_else(|| {
+            function
+                .and_then(|function| function.get("name"))
+                .and_then(Value::as_str)
+        })
+    else {
+        return Ok(None);
+    };
+
+    let args_json = if let Some(arguments) = json_tool_argument_value(object, function) {
+        parse_json_tool_arguments_value(arguments)?
+    } else if matches!(mode, JsonToolCallEnvelopeMode::TaggedBlock)
+        || has_explicit_json_tool_call_marker(object)
+    {
+        json_tool_arguments_from_top_level(object)
+    } else {
+        return Ok(None);
+    };
+
+    let tool_call_id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| object.get("tool_call_id").and_then(Value::as_str))
+        .or_else(|| object.get("call_id").and_then(Value::as_str))
+        .or_else(|| {
+            function
+                .and_then(|function| function.get("id"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_owned);
+
+    Ok(Some(JsonToolCallEnvelope {
+        raw_tool_name: raw_tool_name.to_owned(),
+        args_json,
+        tool_call_id,
+    }))
 }
 
 fn build_json_tool_intent(
@@ -1044,21 +1114,11 @@ fn build_json_tool_intent(
     )
 }
 
-fn json_tool_call_envelope(value: &Value) -> Option<JsonToolCallEnvelope> {
-    let object = value.as_object()?;
-    let function = object.get("function").and_then(Value::as_object);
-    let raw_tool_name = object
-        .get("name")
-        .and_then(Value::as_str)
-        .or_else(|| object.get("tool").and_then(Value::as_str))
-        .or_else(|| object.get("tool_name").and_then(Value::as_str))
-        .or_else(|| {
-            function
-                .and_then(|function| function.get("name"))
-                .and_then(Value::as_str)
-        })?;
-
-    let args_json = object
+fn json_tool_argument_value<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    function: Option<&'a serde_json::Map<String, Value>>,
+) -> Option<&'a Value> {
+    object
         .get("arguments")
         .or_else(|| object.get("input"))
         .or_else(|| object.get("parameters"))
@@ -1067,39 +1127,24 @@ fn json_tool_call_envelope(value: &Value) -> Option<JsonToolCallEnvelope> {
         .or_else(|| function.and_then(|function| function.get("arguments")))
         .or_else(|| function.and_then(|function| function.get("input")))
         .or_else(|| function.and_then(|function| function.get("parameters")))
-        .map(parse_json_tool_arguments_value)
-        .unwrap_or_else(|| json_tool_arguments_from_top_level(object));
-
-    let tool_call_id = object
-        .get("id")
-        .and_then(Value::as_str)
-        .or_else(|| object.get("tool_call_id").and_then(Value::as_str))
-        .or_else(|| object.get("call_id").and_then(Value::as_str))
-        .or_else(|| {
-            function
-                .and_then(|function| function.get("id"))
-                .and_then(Value::as_str)
-        })
-        .map(str::to_owned);
-
-    Some(JsonToolCallEnvelope {
-        raw_tool_name: raw_tool_name.to_owned(),
-        args_json,
-        tool_call_id,
-    })
 }
 
-fn parse_json_tool_arguments_value(value: &Value) -> Value {
+fn has_explicit_json_tool_call_marker(object: &serde_json::Map<String, Value>) -> bool {
+    object.contains_key("arguments")
+        || object.contains_key("input")
+        || object.contains_key("parameters")
+        || object.contains_key("args")
+        || object.contains_key("payload")
+        || object.contains_key("function")
+        || object.contains_key("type")
+}
+
+fn parse_json_tool_arguments_value(value: &Value) -> Result<Value, JsonToolBlockParseError> {
     match value {
-        Value::String(raw) => match serde_json::from_str::<Value>(raw) {
-            Ok(parsed) => parsed,
-            Err(error) => json!({
-                "_parse_error": format!("{error}"),
-                "_raw_arguments": raw
-            }),
-        },
+        Value::String(raw) => serde_json::from_str::<Value>(raw)
+            .map_err(|_error| JsonToolBlockParseError::InvalidJson),
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
-            value.clone()
+            Ok(value.clone())
         }
     }
 }
@@ -2264,6 +2309,32 @@ mod tests {
     }
 
     #[test]
+    fn extract_provider_turn_parses_tool_call_wrapped_top_level_json_arguments() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "let me search for the right tool first.\n<tool_call>\n{\"name\":\"tool_search\",\"query\":\"read note.md\",\"limit\":3}\n</tool_call>"
+                }
+            }]
+        });
+
+        let turn = extract_provider_turn(&body).expect("turn");
+        assert_eq!(
+            turn.assistant_text,
+            "let me search for the right tool first."
+        );
+        assert_eq!(turn.tool_intents.len(), 1);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.search");
+        assert_eq!(
+            turn.tool_intents[0].args_json,
+            json!({
+                "query": "read note.md",
+                "limit": 3
+            })
+        );
+    }
+
+    #[test]
     fn extract_provider_turn_rewrites_plain_json_discoverable_tool_to_tool_invoke_after_search() {
         let body = serde_json::json!({
             "choices": [{
@@ -2289,6 +2360,68 @@ mod tests {
             json!({
                 "path": "note.md"
             })
+        );
+    }
+
+    #[test]
+    fn extract_provider_turn_does_not_execute_plain_json_top_level_arguments_without_envelope() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "example:\n{\n  \"name\": \"tool_search\",\n  \"query\": \"read note.md\"\n}"
+                }
+            }]
+        });
+
+        let turn = extract_provider_turn(&body).expect("turn");
+        assert!(turn.tool_intents.is_empty());
+        assert_eq!(
+            turn.assistant_text,
+            "example:\n{\n  \"name\": \"tool_search\",\n  \"query\": \"read note.md\"\n}"
+        );
+    }
+
+    #[test]
+    fn extract_provider_turn_marks_invalid_stringified_json_tool_arguments_malformed() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "let me search for the right tool first.\n{\n  \"name\": \"tool_search\",\n  \"arguments\": \"{bad\"\n}"
+                }
+            }]
+        });
+
+        let turn = extract_provider_turn(&body).expect("turn");
+        assert!(turn.tool_intents.is_empty());
+        assert_eq!(
+            turn.assistant_text,
+            "let me search for the right tool first.\n{\n  \"name\": \"tool_search\",\n  \"arguments\": \"{bad\"\n}"
+        );
+        assert_eq!(
+            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["status"],
+            "malformed"
+        );
+        assert_eq!(
+            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["error_code"],
+            "invalid_json"
+        );
+    }
+
+    #[test]
+    fn extract_provider_turn_does_not_execute_nested_tool_like_plain_json_objects() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "example:\n{\n  \"meta\":\n  {\n    \"name\": \"tool_search\",\n    \"arguments\": {\n      \"query\": \"read note.md\"\n    }\n  }\n}"
+                }
+            }]
+        });
+
+        let turn = extract_provider_turn(&body).expect("turn");
+        assert!(turn.tool_intents.is_empty());
+        assert_eq!(
+            turn.assistant_text,
+            "example:\n{\n  \"meta\":\n  {\n    \"name\": \"tool_search\",\n    \"arguments\": {\n      \"query\": \"read note.md\"\n    }\n  }\n}"
         );
     }
 

--- a/crates/app/src/provider/shape.rs
+++ b/crates/app/src/provider/shape.rs
@@ -40,6 +40,29 @@ pub fn extract_provider_turn_with_scope_and_messages(
             extract_openai_tool_intents(message, session_id, turn_id, &bridge_context);
 
         if tool_intents.is_empty() {
+            match extract_json_tool_call_turn(
+                assistant_text.as_str(),
+                session_id,
+                turn_id,
+                &bridge_context,
+            ) {
+                JsonToolBlockParseResult::Parsed {
+                    cleaned_text,
+                    tool_intents: json_tool_intents,
+                    telemetry,
+                } => {
+                    assistant_text = cleaned_text;
+                    tool_intents = json_tool_intents;
+                    attach_json_tool_block_parse_telemetry(&mut raw_meta, telemetry);
+                }
+                JsonToolBlockParseResult::Malformed { telemetry } => {
+                    attach_json_tool_block_parse_telemetry(&mut raw_meta, telemetry);
+                }
+                JsonToolBlockParseResult::Absent => {}
+            }
+        }
+
+        if tool_intents.is_empty() {
             match extract_inline_function_call_turn(
                 assistant_text.as_str(),
                 session_id,
@@ -561,6 +584,78 @@ fn normalize_text(raw: &str) -> Option<String> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct JsonToolBlockParseTelemetry {
+    status: &'static str,
+    tool_count: usize,
+    error_code: Option<&'static str>,
+}
+
+impl JsonToolBlockParseTelemetry {
+    fn parsed(tool_count: usize) -> Self {
+        Self {
+            status: "parsed",
+            tool_count,
+            error_code: None,
+        }
+    }
+
+    fn malformed(tool_count: usize, error_code: JsonToolBlockParseError) -> Self {
+        Self {
+            status: "malformed",
+            tool_count,
+            error_code: Some(error_code.as_str()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum JsonToolBlockParseResult {
+    Parsed {
+        cleaned_text: String,
+        tool_intents: Vec<ToolIntent>,
+        telemetry: JsonToolBlockParseTelemetry,
+    },
+    Malformed {
+        telemetry: JsonToolBlockParseTelemetry,
+    },
+    Absent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JsonToolBlockParseError {
+    MissingToolCallClose,
+    InvalidJson,
+    UnsupportedShape,
+}
+
+impl JsonToolBlockParseError {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingToolCallClose => "missing_tool_call_close",
+            Self::InvalidJson => "invalid_json",
+            Self::UnsupportedShape => "unsupported_shape",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum JsonToolBlockCandidate {
+    Parsed {
+        consumed_bytes: usize,
+        tool_intent: ToolIntent,
+    },
+    Malformed(JsonToolBlockParseError),
+    Unsupported,
+}
+
+#[derive(Debug, Clone)]
+struct JsonToolCallEnvelope {
+    raw_tool_name: String,
+    args_json: Value,
+    tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct InlineFunctionParseTelemetry {
     status: &'static str,
     tool_count: usize,
@@ -651,32 +746,389 @@ fn attach_inline_function_parse_telemetry(
     raw_meta: &mut Value,
     telemetry: InlineFunctionParseTelemetry,
 ) {
+    attach_provider_parse_telemetry(
+        raw_meta,
+        "inline_function",
+        telemetry.status,
+        telemetry.tool_count,
+        telemetry.error_code,
+    );
+}
+
+fn attach_json_tool_block_parse_telemetry(
+    raw_meta: &mut Value,
+    telemetry: JsonToolBlockParseTelemetry,
+) {
+    attach_provider_parse_telemetry(
+        raw_meta,
+        "json_tool_block",
+        telemetry.status,
+        telemetry.tool_count,
+        telemetry.error_code,
+    );
+}
+
+fn attach_provider_parse_telemetry(
+    raw_meta: &mut Value,
+    key: &str,
+    status: &str,
+    tool_count: usize,
+    error_code: Option<&str>,
+) {
     let Some(message) = raw_meta.as_object_mut() else {
         return;
     };
 
-    let mut inline_function = serde_json::Map::new();
-    inline_function.insert(
-        "status".to_owned(),
-        Value::String(telemetry.status.to_owned()),
-    );
-    inline_function.insert(
-        "tool_count".to_owned(),
-        Value::from(telemetry.tool_count as u64),
-    );
-    if let Some(error_code) = telemetry.error_code {
-        inline_function.insert(
+    let mut entry = serde_json::Map::new();
+    entry.insert("status".to_owned(), Value::String(status.to_owned()));
+    entry.insert("tool_count".to_owned(), Value::from(tool_count as u64));
+    if let Some(error_code) = error_code {
+        entry.insert(
             "error_code".to_owned(),
             Value::String(error_code.to_owned()),
         );
     }
 
-    let mut provider_parse = serde_json::Map::new();
-    provider_parse.insert("inline_function".to_owned(), Value::Object(inline_function));
-    message.insert(
-        "loongclaw_provider_parse".to_owned(),
-        Value::Object(provider_parse),
-    );
+    let provider_parse = message
+        .entry("loongclaw_provider_parse".to_owned())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Some(provider_parse) = provider_parse.as_object_mut() else {
+        return;
+    };
+    provider_parse.insert(key.to_owned(), Value::Object(entry));
+}
+
+fn extract_json_tool_call_turn(
+    text: &str,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
+) -> JsonToolBlockParseResult {
+    match extract_tagged_json_tool_call_turn(text, session_id, turn_id, bridge_context) {
+        JsonToolBlockParseResult::Absent => {
+            extract_plain_json_tool_call_turn(text, session_id, turn_id, bridge_context)
+        }
+        result @ JsonToolBlockParseResult::Parsed { .. }
+        | result @ JsonToolBlockParseResult::Malformed { .. } => result,
+    }
+}
+
+fn extract_tagged_json_tool_call_turn(
+    text: &str,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
+) -> JsonToolBlockParseResult {
+    const TOOL_CALL_OPEN: &str = "<tool_call>";
+    const TOOL_CALL_CLOSE: &str = "</tool_call>";
+
+    let mut cursor = 0usize;
+    let mut cleaned = String::new();
+    let mut tool_intents = Vec::new();
+    let mut found_json_tool_block = false;
+
+    while let Some(relative_start) = text[cursor..].find(TOOL_CALL_OPEN) {
+        let start = cursor + relative_start;
+        if !is_standalone_block_start(text, start)
+            || is_inside_markdown_fence(text, start)
+            || is_inside_markdown_indented_code_block(text, start)
+        {
+            let next_cursor = start + TOOL_CALL_OPEN.len();
+            cleaned.push_str(&text[cursor..next_cursor]);
+            cursor = next_cursor;
+            continue;
+        }
+
+        let body_start = start + TOOL_CALL_OPEN.len();
+        let body_remainder = &text[body_start..];
+        let Some(body_end) = body_remainder.find(TOOL_CALL_CLOSE) else {
+            return JsonToolBlockParseResult::Malformed {
+                telemetry: JsonToolBlockParseTelemetry::malformed(
+                    tool_intents.len(),
+                    JsonToolBlockParseError::MissingToolCallClose,
+                ),
+            };
+        };
+        let block_end = body_start + body_end + TOOL_CALL_CLOSE.len();
+        if !is_standalone_block_end(text, block_end) {
+            cleaned.push_str(&text[cursor..block_end]);
+            cursor = block_end;
+            continue;
+        }
+
+        let block_body = &text[body_start..body_start + body_end];
+        let parsed_tool_intents = match parse_json_tool_call_sequence(
+            block_body,
+            session_id,
+            turn_id,
+            bridge_context,
+            tool_intents.len(),
+        ) {
+            Ok(parsed_tool_intents) => parsed_tool_intents,
+            Err(error_code) => {
+                return JsonToolBlockParseResult::Malformed {
+                    telemetry: JsonToolBlockParseTelemetry::malformed(
+                        tool_intents.len(),
+                        error_code,
+                    ),
+                };
+            }
+        };
+
+        found_json_tool_block = true;
+        cleaned.push_str(&text[cursor..start]);
+        tool_intents.extend(parsed_tool_intents);
+        cursor = block_end;
+    }
+
+    if !found_json_tool_block {
+        return JsonToolBlockParseResult::Absent;
+    }
+
+    cleaned.push_str(&text[cursor..]);
+    JsonToolBlockParseResult::Parsed {
+        cleaned_text: normalize_text(cleaned.as_str()).unwrap_or_default(),
+        telemetry: JsonToolBlockParseTelemetry::parsed(tool_intents.len()),
+        tool_intents,
+    }
+}
+
+fn extract_plain_json_tool_call_turn(
+    text: &str,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
+) -> JsonToolBlockParseResult {
+    let mut cursor = 0usize;
+    let mut cleaned = String::new();
+    let mut tool_intents = Vec::new();
+    let mut found_json_tool_block = false;
+
+    while let Some(relative_start) = text[cursor..].find('{') {
+        let start = cursor + relative_start;
+        if !is_standalone_block_start(text, start)
+            || is_inside_markdown_fence(text, start)
+            || is_inside_markdown_indented_code_block(text, start)
+        {
+            let next_cursor = start + 1;
+            cleaned.push_str(&text[cursor..next_cursor]);
+            cursor = next_cursor;
+            continue;
+        }
+
+        match parse_plain_json_tool_call_candidate(
+            &text[start..],
+            session_id,
+            turn_id,
+            bridge_context,
+            tool_intents.len(),
+        ) {
+            JsonToolBlockCandidate::Parsed {
+                consumed_bytes,
+                tool_intent,
+            } => {
+                found_json_tool_block = true;
+                cleaned.push_str(&text[cursor..start]);
+                tool_intents.push(tool_intent);
+                cursor = start + consumed_bytes;
+            }
+            JsonToolBlockCandidate::Malformed(error_code) => {
+                return JsonToolBlockParseResult::Malformed {
+                    telemetry: JsonToolBlockParseTelemetry::malformed(
+                        tool_intents.len(),
+                        error_code,
+                    ),
+                };
+            }
+            JsonToolBlockCandidate::Unsupported => {
+                let next_cursor = start + 1;
+                cleaned.push_str(&text[cursor..next_cursor]);
+                cursor = next_cursor;
+            }
+        }
+    }
+
+    if !found_json_tool_block {
+        return JsonToolBlockParseResult::Absent;
+    }
+
+    cleaned.push_str(&text[cursor..]);
+    JsonToolBlockParseResult::Parsed {
+        cleaned_text: normalize_text(cleaned.as_str()).unwrap_or_default(),
+        telemetry: JsonToolBlockParseTelemetry::parsed(tool_intents.len()),
+        tool_intents,
+    }
+}
+
+fn parse_json_tool_call_sequence(
+    body: &str,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
+    tool_offset: usize,
+) -> Result<Vec<ToolIntent>, JsonToolBlockParseError> {
+    let stream = serde_json::Deserializer::from_str(body).into_iter::<Value>();
+    let mut tool_intents = Vec::new();
+
+    for result in stream {
+        let value = result.map_err(|_error| JsonToolBlockParseError::InvalidJson)?;
+        let envelope =
+            json_tool_call_envelope(&value).ok_or(JsonToolBlockParseError::UnsupportedShape)?;
+        tool_intents.push(build_json_tool_intent(
+            envelope,
+            session_id,
+            turn_id,
+            bridge_context,
+            tool_offset + tool_intents.len(),
+        ));
+    }
+
+    if tool_intents.is_empty() {
+        return Err(JsonToolBlockParseError::InvalidJson);
+    }
+
+    Ok(tool_intents)
+}
+
+fn parse_plain_json_tool_call_candidate(
+    text: &str,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
+    tool_offset: usize,
+) -> JsonToolBlockCandidate {
+    let mut stream = serde_json::Deserializer::from_str(text).into_iter::<Value>();
+    let Some(result) = stream.next() else {
+        return JsonToolBlockCandidate::Malformed(JsonToolBlockParseError::InvalidJson);
+    };
+    let value = match result {
+        Ok(value) => value,
+        Err(_) => return JsonToolBlockCandidate::Malformed(JsonToolBlockParseError::InvalidJson),
+    };
+    let consumed_bytes = stream.byte_offset();
+    if !is_standalone_block_end(text, consumed_bytes) {
+        return JsonToolBlockCandidate::Unsupported;
+    }
+    let Some(envelope) = json_tool_call_envelope(&value) else {
+        return JsonToolBlockCandidate::Unsupported;
+    };
+    JsonToolBlockCandidate::Parsed {
+        consumed_bytes,
+        tool_intent: build_json_tool_intent(
+            envelope,
+            session_id,
+            turn_id,
+            bridge_context,
+            tool_offset,
+        ),
+    }
+}
+
+fn build_json_tool_intent(
+    envelope: JsonToolCallEnvelope,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+    bridge_context: &ProviderToolBridgeContext,
+    tool_index: usize,
+) -> ToolIntent {
+    build_provider_tool_intent(
+        envelope.raw_tool_name.as_str(),
+        envelope.args_json,
+        "provider_json_tool_call",
+        session_id,
+        turn_id,
+        envelope
+            .tool_call_id
+            .unwrap_or_else(|| format!("json-call-{tool_index}")),
+        bridge_context,
+    )
+}
+
+fn json_tool_call_envelope(value: &Value) -> Option<JsonToolCallEnvelope> {
+    let object = value.as_object()?;
+    let function = object.get("function").and_then(Value::as_object);
+    let raw_tool_name = object
+        .get("name")
+        .and_then(Value::as_str)
+        .or_else(|| object.get("tool").and_then(Value::as_str))
+        .or_else(|| object.get("tool_name").and_then(Value::as_str))
+        .or_else(|| {
+            function
+                .and_then(|function| function.get("name"))
+                .and_then(Value::as_str)
+        })?;
+
+    let args_json = object
+        .get("arguments")
+        .or_else(|| object.get("input"))
+        .or_else(|| object.get("parameters"))
+        .or_else(|| object.get("args"))
+        .or_else(|| object.get("payload"))
+        .or_else(|| function.and_then(|function| function.get("arguments")))
+        .or_else(|| function.and_then(|function| function.get("input")))
+        .or_else(|| function.and_then(|function| function.get("parameters")))
+        .map(parse_json_tool_arguments_value)
+        .unwrap_or_else(|| json_tool_arguments_from_top_level(object));
+
+    let tool_call_id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| object.get("tool_call_id").and_then(Value::as_str))
+        .or_else(|| object.get("call_id").and_then(Value::as_str))
+        .or_else(|| {
+            function
+                .and_then(|function| function.get("id"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_owned);
+
+    Some(JsonToolCallEnvelope {
+        raw_tool_name: raw_tool_name.to_owned(),
+        args_json,
+        tool_call_id,
+    })
+}
+
+fn parse_json_tool_arguments_value(value: &Value) -> Value {
+    match value {
+        Value::String(raw) => match serde_json::from_str::<Value>(raw) {
+            Ok(parsed) => parsed,
+            Err(error) => json!({
+                "_parse_error": format!("{error}"),
+                "_raw_arguments": raw
+            }),
+        },
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+            value.clone()
+        }
+    }
+}
+
+fn json_tool_arguments_from_top_level(object: &serde_json::Map<String, Value>) -> Value {
+    const RESERVED_FIELDS: &[&str] = &[
+        "name",
+        "tool",
+        "tool_name",
+        "function",
+        "id",
+        "tool_call_id",
+        "call_id",
+        "type",
+        "arguments",
+        "input",
+        "parameters",
+        "args",
+        "payload",
+    ];
+
+    let mut payload = serde_json::Map::new();
+    for (key, value) in object {
+        if RESERVED_FIELDS.contains(&key.as_str()) {
+            continue;
+        }
+        payload.insert(key.clone(), value.clone());
+    }
+    Value::Object(payload)
 }
 
 fn extract_inline_function_call_turn(
@@ -902,7 +1354,7 @@ fn inline_parameter_schema_types()
     })
 }
 
-fn is_standalone_inline_function_start(text: &str, start: usize) -> bool {
+fn is_standalone_block_start(text: &str, start: usize) -> bool {
     let line_start = text[..start]
         .rfind('\n')
         .map(|index| index + 1)
@@ -912,7 +1364,7 @@ fn is_standalone_inline_function_start(text: &str, start: usize) -> bool {
         .all(|ch| matches!(ch, ' ' | '\t' | '\r'))
 }
 
-fn is_standalone_inline_function_end(text: &str, end: usize) -> bool {
+fn is_standalone_block_end(text: &str, end: usize) -> bool {
     let line_end = text[end..]
         .find('\n')
         .map(|relative| end + relative)
@@ -920,6 +1372,14 @@ fn is_standalone_inline_function_end(text: &str, end: usize) -> bool {
     text[end..line_end]
         .chars()
         .all(|ch| matches!(ch, ' ' | '\t' | '\r'))
+}
+
+fn is_standalone_inline_function_start(text: &str, start: usize) -> bool {
+    is_standalone_block_start(text, start)
+}
+
+fn is_standalone_inline_function_end(text: &str, end: usize) -> bool {
+    is_standalone_block_end(text, end)
 }
 
 fn is_inside_markdown_fence(text: &str, index: usize) -> bool {
@@ -1740,6 +2200,113 @@ mod tests {
         assert_eq!(
             turn.tool_intents[0].args_json["lease"],
             "lease-external-skill-inline"
+        );
+    }
+
+    #[test]
+    fn extract_provider_turn_parses_plain_json_tool_block() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "let me search for the right tool first.\n{\n  \"name\": \"tool_search\",\n  \"arguments\": {\n    \"query\": \"read note.md\",\n    \"limit\": 3\n  }\n}"
+                }
+            }]
+        });
+
+        let turn = extract_provider_turn(&body).expect("turn");
+        assert_eq!(
+            turn.assistant_text,
+            "let me search for the right tool first."
+        );
+        assert_eq!(turn.tool_intents.len(), 1);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.search");
+        assert_eq!(
+            turn.tool_intents[0].args_json,
+            json!({
+                "query": "read note.md",
+                "limit": 3
+            })
+        );
+        assert_eq!(
+            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["status"],
+            "parsed"
+        );
+        assert_eq!(
+            turn.raw_meta["loongclaw_provider_parse"]["json_tool_block"]["tool_count"],
+            1
+        );
+    }
+
+    #[test]
+    fn extract_provider_turn_parses_tool_call_wrapped_json_blocks() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "let me search for the right tool first.\n<tool_call>\n{\"name\":\"tool_search\",\"arguments\":{\"query\":\"read note.md\",\"limit\":3}}\n</tool_call>"
+                }
+            }]
+        });
+
+        let turn = extract_provider_turn(&body).expect("turn");
+        assert_eq!(
+            turn.assistant_text,
+            "let me search for the right tool first."
+        );
+        assert_eq!(turn.tool_intents.len(), 1);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.search");
+        assert_eq!(
+            turn.tool_intents[0].args_json,
+            json!({
+                "query": "read note.md",
+                "limit": 3
+            })
+        );
+    }
+
+    #[test]
+    fn extract_provider_turn_rewrites_plain_json_discoverable_tool_to_tool_invoke_after_search() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "now i'll read the file.\n{\n  \"name\": \"file_read\",\n  \"arguments\": {\n    \"path\": \"note.md\"\n  }\n}"
+                }
+            }]
+        });
+        let messages = discovery_followup_messages("file.read", "lease-json-followup");
+
+        let turn = extract_provider_turn_with_scope_and_messages(&body, None, None, &messages)
+            .expect("turn");
+        assert_eq!(turn.assistant_text, "now i'll read the file.");
+        assert_eq!(turn.tool_intents.len(), 1);
+        assert_eq!(turn.tool_intents[0].tool_name, "tool.invoke");
+        assert_eq!(turn.tool_intents[0].args_json["tool_id"], "file.read");
+        assert_eq!(
+            turn.tool_intents[0].args_json["lease"],
+            "lease-json-followup"
+        );
+        assert_eq!(
+            turn.tool_intents[0].args_json["arguments"],
+            json!({
+                "path": "note.md"
+            })
+        );
+    }
+
+    #[test]
+    fn extract_provider_turn_does_not_execute_fenced_json_tool_examples() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "example:\n```json\n{\n  \"name\": \"tool_search\",\n  \"arguments\": {\n    \"query\": \"read note.md\"\n  }\n}\n```"
+                }
+            }]
+        });
+
+        let turn = extract_provider_turn(&body).expect("turn");
+        assert!(turn.tool_intents.is_empty());
+        assert_eq!(
+            turn.assistant_text,
+            "example:\n```json\n{\n  \"name\": \"tool_search\",\n  \"arguments\": {\n    \"query\": \"read note.md\"\n  }\n}\n```"
         );
     }
 

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -11,7 +11,7 @@ use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
 use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc,
@@ -25,6 +25,18 @@ const OPENAI_AUTH_ENV_KEYS: &[&str] = &[
     "OPENAI_API_KEY",
 ];
 const VOLCENGINE_AUTH_ENV_KEYS: &[&str] = &["ARK_API_KEY"];
+
+fn read_http_request_with_timeout(stream: &mut TcpStream, timeout: Duration) -> String {
+    stream
+        .set_nonblocking(false)
+        .expect("set stream blocking");
+    stream
+        .set_read_timeout(Some(timeout))
+        .expect("set stream read timeout");
+    let mut request_buf = [0_u8; 8192];
+    let len = stream.read(&mut request_buf).expect("read request");
+    String::from_utf8_lossy(&request_buf[..len]).to_string()
+}
 
 fn build_provider_failover_test_kernel_context(
     agent_id: &str,
@@ -152,15 +164,8 @@ async fn fetch_available_models_rejects_missing_volcengine_credentials_before_ne
         while Instant::now() < deadline {
             match listener.accept() {
                 Ok((mut stream, _)) => {
-                    stream
-                        .set_nonblocking(false)
-                        .expect("set request stream blocking");
-                    stream
-                        .set_read_timeout(Some(Duration::from_millis(250)))
-                        .expect("set request stream read timeout");
-                    let mut request_buf = [0_u8; 8192];
-                    let len = stream.read(&mut request_buf).expect("read request");
-                    let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
+                    let request =
+                        read_http_request_with_timeout(&mut stream, Duration::from_millis(250));
                     requests.push(request);
                     let body = r#"{"error":{"message":"unexpected request"}}"#;
                     let response = format!(
@@ -231,15 +236,8 @@ async fn fetch_available_models_enriches_volcengine_auth_failures_with_ark_guida
             }
             match listener.accept() {
                 Ok((mut stream, _)) => {
-                    stream
-                        .set_nonblocking(false)
-                        .expect("set request stream blocking");
-                    stream
-                        .set_read_timeout(Some(Duration::from_millis(250)))
-                        .expect("set request stream read timeout");
-                    let mut request_buf = [0_u8; 8192];
-                    let len = stream.read(&mut request_buf).expect("read request");
-                    let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
+                    let request =
+                        read_http_request_with_timeout(&mut stream, Duration::from_millis(250));
                     requests.push(request);
 
                     let body = r#"{"error":{"code":"AuthenticationError","message":"the API key or AK/SK in the request is missing or invalid","type":"Unauthorized"}}"#;

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -27,9 +27,7 @@ const OPENAI_AUTH_ENV_KEYS: &[&str] = &[
 const VOLCENGINE_AUTH_ENV_KEYS: &[&str] = &["ARK_API_KEY"];
 
 fn read_http_request_with_timeout(stream: &mut TcpStream, timeout: Duration) -> String {
-    stream
-        .set_nonblocking(false)
-        .expect("set stream blocking");
+    stream.set_nonblocking(false).expect("set stream blocking");
     stream
         .set_read_timeout(Some(timeout))
         .expect("set stream read timeout");


### PR DESCRIPTION
## Summary

- Problem:
  openai-compatible provider sessions could emit textual json tool-call fallbacks instead of native `tool_calls`, and loongclaw treated those blocks as plain assistant text.
- Why it matters:
  discovery-first flows stalled before execution, so `tool.search -> tool.invoke` never completed for affected ollama-backed sessions.
- What changed:
  provider shaping now parses standalone json and ollama-style `<tool_call>...</tool_call>` blocks into `ToolIntent`s, preserves discovery-first rewrite behavior for discoverable tools, records parse telemetry, and adds regression coverage for the raw-output followup path.
- What did not change (scope boundary):
  native provider `tool_calls` handling, existing inline `<function=...>` fallback support, and provider transport behavior stay unchanged.

## Linked Issues

- Closes #367
- Related # n/a

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app provider::tests::fetch_available_models_enriches_volcengine_auth_failures_with_ark_guidance -- --exact --nocapture
cargo test --workspace --locked
cargo test --workspace --all-features --locked

all commands completed successfully.
the single targeted provider test rerun was used to verify that one transient local mock-server read race during an earlier workspace attempt was not a stable regression before re-running the original workspace command.
```

## User-visible / Operator-visible Changes

- ollama-backed openai-compatible sessions can now execute provider-advertised tools when the model emits standalone json or `<tool_call>` fallback blocks instead of native `tool_calls`.

## Failure Recovery

- Fast rollback or disable path:
  revert this commit, or temporarily disable provider tool schema for the affected profile if tool execution must be suppressed as a workaround.
- Observable failure symptoms reviewers should watch for:
  fenced code examples getting executed as tools, malformed json fallback blocks being silently accepted, or discovery followups failing to rewrite discoverable tools to `tool.invoke`.

## Reviewer Focus

- `crates/app/src/provider/shape.rs`
  review the standalone json and `<tool_call>` extraction path, especially the guardrails that avoid executing fenced or indented code examples.
- `crates/app/src/conversation/tests.rs`
  review the discovery-first raw-output regression to confirm the second-round tool execution path still resolves to `tool.invoke`.
