### PR TITLE
Add observed fast-lane execution diagnostics

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -879,7 +879,7 @@ fn format_fast_lane_segments(segments: &[FastLaneToolBatchSegmentSnapshot]) -> S
             ) {
                 (None, None) => String::new(),
                 (observed_peak_in_flight, observed_wall_time_ms) => format!(
-                    "[peak={},wall_ms={}]",
+                    "[peak={} wall_ms={}]",
                     format_fast_lane_summary_optional(observed_peak_in_flight),
                     format_fast_lane_summary_optional(observed_wall_time_ms)
                 ),
@@ -1919,6 +1919,41 @@ mod tests {
         ]
     }
 
+    #[cfg(feature = "memory-sqlite")]
+    fn legacy_fast_lane_tool_batch_event_payloads() -> Vec<String> {
+        vec![
+            json!({
+                "type": "conversation_event",
+                "event": "fast_lane_tool_batch",
+                "payload": {
+                    "schema_version": 1,
+                    "total_intents": 3,
+                    "parallel_execution_enabled": true,
+                    "parallel_execution_max_in_flight": 2,
+                    "parallel_safe_intents": 2,
+                    "serial_only_intents": 1,
+                    "parallel_segments": 1,
+                    "sequential_segments": 1,
+                    "segments": [
+                        {
+                            "segment_index": 0,
+                            "scheduling_class": "parallel_safe",
+                            "execution_mode": "parallel",
+                            "intent_count": 2
+                        },
+                        {
+                            "segment_index": 1,
+                            "scheduling_class": "serial_only",
+                            "execution_mode": "sequential",
+                            "intent_count": 1
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        ]
+    }
+
     #[tokio::test]
     async fn run_cli_ask_rejects_empty_message() {
         let error = run_cli_ask(None, None, "   ", &CliChatOptions::default())
@@ -2130,7 +2165,7 @@ mod tests {
             "latest_batch total_intents=5 parallel_enabled=true max_in_flight=2 observed_peak_in_flight=2 observed_wall_time_ms=34 parallel_safe_intents=4 serial_only_intents=1 parallel_segments=2 sequential_segments=1"
         ));
         assert!(direct_output.contains(
-            "latest_segments=0:parallel_safe/parallel/2[peak=2,wall_ms=14],1:serial_only/sequential/1[peak=1,wall_ms=8],2:parallel_safe/parallel/2[peak=2,wall_ms=12]"
+            "latest_segments=0:parallel_safe/parallel/2[peak=2 wall_ms=14],1:serial_only/sequential/1[peak=1 wall_ms=8],2:parallel_safe/parallel/2[peak=2 wall_ms=12]"
         ));
 
         let kernel_payloads = fast_lane_tool_batch_event_payloads();
@@ -2164,7 +2199,7 @@ mod tests {
             "latest_batch total_intents=5 parallel_enabled=true max_in_flight=2 observed_peak_in_flight=2 observed_wall_time_ms=34 parallel_safe_intents=4 serial_only_intents=1 parallel_segments=2 sequential_segments=1"
         ));
         assert!(kernel_output.contains(
-            "latest_segments=0:parallel_safe/parallel/2[peak=2,wall_ms=14],1:serial_only/sequential/1[peak=1,wall_ms=8],2:parallel_safe/parallel/2[peak=2,wall_ms=12]"
+            "latest_segments=0:parallel_safe/parallel/2[peak=2 wall_ms=14],1:serial_only/sequential/1[peak=1 wall_ms=8],2:parallel_safe/parallel/2[peak=2 wall_ms=12]"
         ));
 
         let captured = invocations.lock().expect("invocations lock");
@@ -2176,6 +2211,41 @@ mod tests {
         );
         assert_eq!(captured[0].payload["limit"], json!(88));
         assert_eq!(captured[0].payload["allow_extended_limit"], json!(true));
+
+        cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fast_lane_summary_output_accepts_legacy_schema_v1_events() {
+        let (_config, memory_config, sqlite_path) = init_chat_test_memory("fast-lane-legacy");
+
+        let payloads = legacy_fast_lane_tool_batch_event_payloads();
+        append_assistant_payloads("chat-binding-fast-lane-legacy", &payloads, &memory_config);
+
+        let output = load_fast_lane_summary_output(
+            "chat-binding-fast-lane-legacy",
+            32,
+            ConversationRuntimeBinding::direct(),
+            &memory_config,
+        )
+        .await
+        .expect("load fast lane summary for legacy schema");
+
+        assert!(output.contains("schema_version=1"));
+        assert!(output.contains(
+            "aggregate_execution configured_max_in_flight_avg=2.000 configured_max_in_flight_max=2 configured_max_in_flight_samples=1 observed_peak_in_flight_avg=- observed_peak_in_flight_max=- observed_peak_in_flight_samples=0 degraded_parallel_segments=0"
+        ));
+        assert!(output.contains(
+            "aggregate_latency observed_wall_time_ms_avg=- observed_wall_time_ms_max=- observed_wall_time_ms_samples=0"
+        ));
+        assert!(output.contains(
+            "latest_batch total_intents=3 parallel_enabled=true max_in_flight=2 observed_peak_in_flight=- observed_wall_time_ms=- parallel_safe_intents=2 serial_only_intents=1 parallel_segments=1 sequential_segments=1"
+        ));
+        assert!(
+            output
+                .contains("latest_segments=0:parallel_safe/parallel/2,1:serial_only/sequential/1")
+        );
 
         cleanup_chat_test_memory(&sqlite_path);
     }

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -873,12 +873,24 @@ fn format_fast_lane_segments(segments: &[FastLaneToolBatchSegmentSnapshot]) -> S
     segments
         .iter()
         .map(|segment| {
+            let observed_suffix = match (
+                segment.observed_peak_in_flight,
+                segment.observed_wall_time_ms,
+            ) {
+                (None, None) => String::new(),
+                (observed_peak_in_flight, observed_wall_time_ms) => format!(
+                    "[peak={},wall_ms={}]",
+                    format_fast_lane_summary_optional(observed_peak_in_flight),
+                    format_fast_lane_summary_optional(observed_wall_time_ms)
+                ),
+            };
             format!(
-                "{}:{}/{}/{}",
+                "{}:{}/{}/{}{}",
                 segment.segment_index,
                 segment.scheduling_class,
                 segment.execution_mode,
-                segment.intent_count
+                segment.intent_count,
+                observed_suffix,
             )
         })
         .collect::<Vec<_>>()
@@ -902,6 +914,14 @@ fn format_fast_lane_summary(
     let configured_max_in_flight_avg = format_average(
         summary.parallel_execution_max_in_flight_sum,
         summary.parallel_execution_max_in_flight_samples,
+    );
+    let observed_peak_in_flight_avg = format_average(
+        summary.observed_peak_in_flight_sum,
+        summary.observed_peak_in_flight_samples,
+    );
+    let observed_wall_time_ms_avg = format_average(
+        summary.observed_wall_time_ms_sum,
+        summary.observed_wall_time_ms_samples,
     );
     let scheduling_class_rollup = format_rollup_counts(&summary.scheduling_class_counts);
     let execution_mode_rollup = format_rollup_counts(&summary.execution_mode_counts);
@@ -930,20 +950,35 @@ fn format_fast_lane_summary(
             serial_only_ratio,
         ),
         format!(
-            "aggregate_segments parallel={} sequential={} configured_max_in_flight_avg={} configured_max_in_flight_max={} configured_max_in_flight_samples={}",
+            "aggregate_segments parallel={} sequential={}",
             summary.total_parallel_segments_seen,
             summary.total_sequential_segments_seen,
+        ),
+        format!(
+            "aggregate_execution configured_max_in_flight_avg={} configured_max_in_flight_max={} configured_max_in_flight_samples={} observed_peak_in_flight_avg={} observed_peak_in_flight_max={} observed_peak_in_flight_samples={} degraded_parallel_segments={}",
             configured_max_in_flight_avg,
             format_fast_lane_summary_optional(summary.parallel_execution_max_in_flight_max),
             summary.parallel_execution_max_in_flight_samples,
+            observed_peak_in_flight_avg,
+            format_fast_lane_summary_optional(summary.observed_peak_in_flight_max),
+            summary.observed_peak_in_flight_samples,
+            summary.degraded_parallel_segments,
+        ),
+        format!(
+            "aggregate_latency observed_wall_time_ms_avg={} observed_wall_time_ms_max={} observed_wall_time_ms_samples={}",
+            observed_wall_time_ms_avg,
+            format_fast_lane_summary_optional(summary.observed_wall_time_ms_max),
+            summary.observed_wall_time_ms_samples,
         ),
         format!("rollup scheduling_classes={scheduling_class_rollup}"),
         format!("rollup execution_modes={execution_mode_rollup}"),
         format!(
-            "latest_batch total_intents={} parallel_enabled={} max_in_flight={} parallel_safe_intents={} serial_only_intents={} parallel_segments={} sequential_segments={}",
+            "latest_batch total_intents={} parallel_enabled={} max_in_flight={} observed_peak_in_flight={} observed_wall_time_ms={} parallel_safe_intents={} serial_only_intents={} parallel_segments={} sequential_segments={}",
             format_fast_lane_summary_optional(summary.latest_total_intents),
             format_fast_lane_summary_optional(summary.latest_parallel_execution_enabled),
             format_fast_lane_summary_optional(summary.latest_parallel_execution_max_in_flight),
+            format_fast_lane_summary_optional(summary.latest_observed_peak_in_flight),
+            format_fast_lane_summary_optional(summary.latest_observed_wall_time_ms),
             format_fast_lane_summary_optional(summary.latest_parallel_safe_intents),
             format_fast_lane_summary_optional(summary.latest_serial_only_intents),
             format_fast_lane_summary_optional(summary.latest_parallel_segments),
@@ -1842,10 +1877,12 @@ mod tests {
                 "type": "conversation_event",
                 "event": "fast_lane_tool_batch",
                 "payload": {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "total_intents": 5,
                     "parallel_execution_enabled": true,
                     "parallel_execution_max_in_flight": 2,
+                    "observed_peak_in_flight": 2,
+                    "observed_wall_time_ms": 34,
                     "parallel_safe_intents": 4,
                     "serial_only_intents": 1,
                     "parallel_segments": 2,
@@ -1855,19 +1892,25 @@ mod tests {
                             "segment_index": 0,
                             "scheduling_class": "parallel_safe",
                             "execution_mode": "parallel",
-                            "intent_count": 2
+                            "intent_count": 2,
+                            "observed_peak_in_flight": 2,
+                            "observed_wall_time_ms": 14
                         },
                         {
                             "segment_index": 1,
                             "scheduling_class": "serial_only",
                             "execution_mode": "sequential",
-                            "intent_count": 1
+                            "intent_count": 1,
+                            "observed_peak_in_flight": 1,
+                            "observed_wall_time_ms": 8
                         },
                         {
                             "segment_index": 2,
                             "scheduling_class": "parallel_safe",
                             "execution_mode": "parallel",
-                            "intent_count": 2
+                            "intent_count": 2,
+                            "observed_peak_in_flight": 2,
+                            "observed_wall_time_ms": 12
                         }
                     ]
                 }
@@ -2077,7 +2120,18 @@ mod tests {
         assert!(direct_output.contains(
             "aggregate_batches parallel_enabled=1 parallel_only=0 mixed=1 sequential_only=0 without_segments=0"
         ));
-        assert!(direct_output.contains("latest_segments=0:parallel_safe/parallel/2,1:serial_only/sequential/1,2:parallel_safe/parallel/2"));
+        assert!(direct_output.contains(
+            "aggregate_execution configured_max_in_flight_avg=2.000 configured_max_in_flight_max=2 configured_max_in_flight_samples=1 observed_peak_in_flight_avg=2.000 observed_peak_in_flight_max=2 observed_peak_in_flight_samples=1 degraded_parallel_segments=0"
+        ));
+        assert!(direct_output.contains(
+            "aggregate_latency observed_wall_time_ms_avg=34.000 observed_wall_time_ms_max=34 observed_wall_time_ms_samples=1"
+        ));
+        assert!(direct_output.contains(
+            "latest_batch total_intents=5 parallel_enabled=true max_in_flight=2 observed_peak_in_flight=2 observed_wall_time_ms=34 parallel_safe_intents=4 serial_only_intents=1 parallel_segments=2 sequential_segments=1"
+        ));
+        assert!(direct_output.contains(
+            "latest_segments=0:parallel_safe/parallel/2[peak=2,wall_ms=14],1:serial_only/sequential/1[peak=1,wall_ms=8],2:parallel_safe/parallel/2[peak=2,wall_ms=12]"
+        ));
 
         let kernel_payloads = fast_lane_tool_batch_event_payloads();
         let (kernel_ctx, invocations) =
@@ -2100,7 +2154,18 @@ mod tests {
         assert!(kernel_output.contains(
             "aggregate_batches parallel_enabled=1 parallel_only=0 mixed=1 sequential_only=0 without_segments=0"
         ));
-        assert!(kernel_output.contains("latest_segments=0:parallel_safe/parallel/2,1:serial_only/sequential/1,2:parallel_safe/parallel/2"));
+        assert!(kernel_output.contains(
+            "aggregate_execution configured_max_in_flight_avg=2.000 configured_max_in_flight_max=2 configured_max_in_flight_samples=1 observed_peak_in_flight_avg=2.000 observed_peak_in_flight_max=2 observed_peak_in_flight_samples=1 degraded_parallel_segments=0"
+        ));
+        assert!(kernel_output.contains(
+            "aggregate_latency observed_wall_time_ms_avg=34.000 observed_wall_time_ms_max=34 observed_wall_time_ms_samples=1"
+        ));
+        assert!(kernel_output.contains(
+            "latest_batch total_intents=5 parallel_enabled=true max_in_flight=2 observed_peak_in_flight=2 observed_wall_time_ms=34 parallel_safe_intents=4 serial_only_intents=1 parallel_segments=2 sequential_segments=1"
+        ));
+        assert!(kernel_output.contains(
+            "latest_segments=0:parallel_safe/parallel/2[peak=2,wall_ms=14],1:serial_only/sequential/1[peak=1,wall_ms=8],2:parallel_safe/parallel/2[peak=2,wall_ms=12]"
+        ));
 
         let captured = invocations.lock().expect("invocations lock");
         assert_eq!(captured.len(), 1);
@@ -2123,6 +2188,8 @@ mod tests {
             latest_total_intents: Some(0),
             latest_parallel_execution_enabled: Some(false),
             latest_parallel_execution_max_in_flight: None,
+            latest_observed_peak_in_flight: Some(1),
+            latest_observed_wall_time_ms: Some(11),
             latest_parallel_safe_intents: Some(0),
             latest_serial_only_intents: Some(0),
             latest_parallel_segments: Some(0),
@@ -2141,6 +2208,13 @@ mod tests {
             parallel_execution_max_in_flight_samples: 3,
             parallel_execution_max_in_flight_sum: 6,
             parallel_execution_max_in_flight_max: Some(3),
+            observed_peak_in_flight_samples: 3,
+            observed_peak_in_flight_sum: 5,
+            observed_peak_in_flight_max: Some(3),
+            observed_wall_time_ms_samples: 3,
+            observed_wall_time_ms_sum: 72,
+            observed_wall_time_ms_max: Some(33),
+            degraded_parallel_segments: 1,
             scheduling_class_counts: BTreeMap::from([
                 ("parallel_safe".to_owned(), 3),
                 ("serial_only".to_owned(), 3),
@@ -2160,8 +2234,15 @@ mod tests {
         assert!(output.contains(
             "aggregate_intents total=8 parallel_safe=5 serial_only=3 parallel_safe_ratio=0.625 serial_only_ratio=0.375"
         ));
+        assert!(output.contains("aggregate_segments parallel=3 sequential=3"));
         assert!(output.contains(
-            "aggregate_segments parallel=3 sequential=3 configured_max_in_flight_avg=2.000 configured_max_in_flight_max=3 configured_max_in_flight_samples=3"
+            "aggregate_execution configured_max_in_flight_avg=2.000 configured_max_in_flight_max=3 configured_max_in_flight_samples=3 observed_peak_in_flight_avg=1.667 observed_peak_in_flight_max=3 observed_peak_in_flight_samples=3 degraded_parallel_segments=1"
+        ));
+        assert!(output.contains(
+            "aggregate_latency observed_wall_time_ms_avg=24.000 observed_wall_time_ms_max=33 observed_wall_time_ms_samples=3"
+        ));
+        assert!(output.contains(
+            "latest_batch total_intents=0 parallel_enabled=false max_in_flight=- observed_peak_in_flight=1 observed_wall_time_ms=11 parallel_safe_intents=0 serial_only_intents=0 parallel_segments=0 sequential_segments=0"
         ));
         assert!(output.contains("rollup scheduling_classes=parallel_safe:3,serial_only:3"));
         assert!(output.contains("rollup execution_modes=parallel:3,sequential:3"));

--- a/crates/app/src/conversation/analytics.rs
+++ b/crates/app/src/conversation/analytics.rs
@@ -417,6 +417,8 @@ pub struct FastLaneToolBatchSegmentSnapshot {
     pub scheduling_class: String,
     pub execution_mode: String,
     pub intent_count: u32,
+    pub observed_peak_in_flight: Option<u32>,
+    pub observed_wall_time_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -435,12 +437,21 @@ pub struct FastLaneToolBatchEventSummary {
     pub parallel_execution_max_in_flight_samples: u32,
     pub parallel_execution_max_in_flight_sum: u64,
     pub parallel_execution_max_in_flight_max: Option<u32>,
+    pub observed_peak_in_flight_samples: u32,
+    pub observed_peak_in_flight_sum: u64,
+    pub observed_peak_in_flight_max: Option<u32>,
+    pub observed_wall_time_ms_samples: u32,
+    pub observed_wall_time_ms_sum: u64,
+    pub observed_wall_time_ms_max: Option<u64>,
+    pub degraded_parallel_segments: u64,
     pub scheduling_class_counts: BTreeMap<String, u32>,
     pub execution_mode_counts: BTreeMap<String, u32>,
     pub latest_schema_version: Option<u32>,
     pub latest_total_intents: Option<u32>,
     pub latest_parallel_execution_enabled: Option<bool>,
     pub latest_parallel_execution_max_in_flight: Option<u32>,
+    pub latest_observed_peak_in_flight: Option<u32>,
+    pub latest_observed_wall_time_ms: Option<u64>,
     pub latest_parallel_safe_intents: Option<u32>,
     pub latest_serial_only_intents: Option<u32>,
     pub latest_parallel_segments: Option<u32>,
@@ -851,6 +862,34 @@ fn fold_fast_lane_tool_batch_event_record(
         );
     }
 
+    let observed_peak_in_flight = read_u32_opt(&record.payload, "observed_peak_in_flight");
+    summary.latest_observed_peak_in_flight = observed_peak_in_flight;
+    if let Some(value) = observed_peak_in_flight {
+        summary.observed_peak_in_flight_samples =
+            summary.observed_peak_in_flight_samples.saturating_add(1);
+        summary.observed_peak_in_flight_sum = summary
+            .observed_peak_in_flight_sum
+            .saturating_add(u64::from(value));
+        summary.observed_peak_in_flight_max = Some(
+            summary
+                .observed_peak_in_flight_max
+                .map_or(value, |current| current.max(value)),
+        );
+    }
+
+    let observed_wall_time_ms = read_u64_opt(&record.payload, "observed_wall_time_ms");
+    summary.latest_observed_wall_time_ms = observed_wall_time_ms;
+    if let Some(value) = observed_wall_time_ms {
+        summary.observed_wall_time_ms_samples =
+            summary.observed_wall_time_ms_samples.saturating_add(1);
+        summary.observed_wall_time_ms_sum = summary.observed_wall_time_ms_sum.saturating_add(value);
+        summary.observed_wall_time_ms_max = Some(
+            summary
+                .observed_wall_time_ms_max
+                .map_or(value, |current| current.max(value)),
+        );
+    }
+
     let parallel_safe_intents = read_u32_opt(&record.payload, "parallel_safe_intents");
     summary.latest_parallel_safe_intents = parallel_safe_intents;
     summary.total_parallel_safe_intents_seen = summary
@@ -902,6 +941,10 @@ fn fold_fast_lane_tool_batch_event_record(
         let execution_mode = segment.execution_mode.trim();
         if !execution_mode.is_empty() {
             bump_count(&mut summary.execution_mode_counts, execution_mode);
+        }
+        if execution_mode == "parallel" && segment.observed_peak_in_flight == Some(1) {
+            summary.degraded_parallel_segments =
+                summary.degraded_parallel_segments.saturating_add(1);
         }
     }
     summary.latest_segments = segments;
@@ -1482,6 +1525,8 @@ fn parse_fast_lane_tool_batch_segments(
                             .and_then(Value::as_str)?
                             .to_owned(),
                         intent_count: read_u32_opt(segment, "intent_count")?,
+                        observed_peak_in_flight: read_u32_opt(segment, "observed_peak_in_flight"),
+                        observed_wall_time_ms: read_u64_opt(segment, "observed_wall_time_ms"),
                     })
                 })
                 .collect()
@@ -1494,6 +1539,10 @@ fn read_u32_opt(value: &Value, key: &str) -> Option<u32> {
         .get(key)
         .and_then(Value::as_u64)
         .map(|num| num.min(u32::MAX as u64) as u32)
+}
+
+fn read_u64_opt(value: &Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(Value::as_u64)
 }
 
 fn read_f64_milli_opt(value: &Value, key: &str) -> Option<u32> {
@@ -1526,10 +1575,12 @@ mod tests {
                 "type": "conversation_event",
                 "event": "fast_lane_tool_batch",
                 "payload": {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "total_intents": 2,
                     "parallel_execution_enabled": true,
                     "parallel_execution_max_in_flight": 2,
+                    "observed_peak_in_flight": 2,
+                    "observed_wall_time_ms": 24,
                     "parallel_safe_intents": 2,
                     "serial_only_intents": 0,
                     "parallel_segments": 1,
@@ -1539,7 +1590,9 @@ mod tests {
                             "segment_index": 0,
                             "scheduling_class": "parallel_safe",
                             "execution_mode": "parallel",
-                            "intent_count": 2
+                            "intent_count": 2,
+                            "observed_peak_in_flight": 2,
+                            "observed_wall_time_ms": 24
                         }
                     ]
                 }
@@ -1549,10 +1602,12 @@ mod tests {
                 "type": "conversation_event",
                 "event": "fast_lane_tool_batch",
                 "payload": {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "total_intents": 3,
                     "parallel_execution_enabled": true,
                     "parallel_execution_max_in_flight": 3,
+                    "observed_peak_in_flight": 2,
+                    "observed_wall_time_ms": 41,
                     "parallel_safe_intents": 2,
                     "serial_only_intents": 1,
                     "parallel_segments": 1,
@@ -1562,13 +1617,17 @@ mod tests {
                             "segment_index": 0,
                             "scheduling_class": "parallel_safe",
                             "execution_mode": "parallel",
-                            "intent_count": 2
+                            "intent_count": 2,
+                            "observed_peak_in_flight": 2,
+                            "observed_wall_time_ms": 29
                         },
                         {
                             "segment_index": 1,
                             "scheduling_class": "serial_only",
                             "execution_mode": "sequential",
-                            "intent_count": 1
+                            "intent_count": 1,
+                            "observed_peak_in_flight": 1,
+                            "observed_wall_time_ms": 12
                         }
                     ]
                 }
@@ -1579,10 +1638,12 @@ mod tests {
         let summary = summarize_fast_lane_tool_batch_events(payloads.iter().map(String::as_str));
 
         assert_eq!(summary.batch_events, 2);
-        assert_eq!(summary.latest_schema_version, Some(1));
+        assert_eq!(summary.latest_schema_version, Some(2));
         assert_eq!(summary.latest_total_intents, Some(3));
         assert_eq!(summary.latest_parallel_execution_enabled, Some(true));
         assert_eq!(summary.latest_parallel_execution_max_in_flight, Some(3));
+        assert_eq!(summary.latest_observed_peak_in_flight, Some(2));
+        assert_eq!(summary.latest_observed_wall_time_ms, Some(41));
         assert_eq!(summary.latest_parallel_safe_intents, Some(2));
         assert_eq!(summary.latest_serial_only_intents, Some(1));
         assert_eq!(summary.latest_parallel_segments, Some(1));
@@ -1595,12 +1656,16 @@ mod tests {
                     scheduling_class: "parallel_safe".to_owned(),
                     execution_mode: "parallel".to_owned(),
                     intent_count: 2,
+                    observed_peak_in_flight: Some(2),
+                    observed_wall_time_ms: Some(29),
                 },
                 FastLaneToolBatchSegmentSnapshot {
                     segment_index: 1,
                     scheduling_class: "serial_only".to_owned(),
                     execution_mode: "sequential".to_owned(),
                     intent_count: 1,
+                    observed_peak_in_flight: Some(1),
+                    observed_wall_time_ms: Some(12),
                 },
             ]
         );
@@ -1613,10 +1678,12 @@ mod tests {
                 "type": "conversation_event",
                 "event": "fast_lane_tool_batch",
                 "payload": {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "total_intents": 3,
                     "parallel_execution_enabled": true,
                     "parallel_execution_max_in_flight": 3,
+                    "observed_peak_in_flight": 3,
+                    "observed_wall_time_ms": 33,
                     "parallel_safe_intents": 3,
                     "serial_only_intents": 0,
                     "parallel_segments": 2,
@@ -1626,13 +1693,17 @@ mod tests {
                             "segment_index": 0,
                             "scheduling_class": "parallel_safe",
                             "execution_mode": "parallel",
-                            "intent_count": 2
+                            "intent_count": 2,
+                            "observed_peak_in_flight": 2,
+                            "observed_wall_time_ms": 18
                         },
                         {
                             "segment_index": 1,
                             "scheduling_class": "parallel_safe",
                             "execution_mode": "parallel",
-                            "intent_count": 1
+                            "intent_count": 1,
+                            "observed_peak_in_flight": 1,
+                            "observed_wall_time_ms": 15
                         }
                     ]
                 }
@@ -1642,10 +1713,12 @@ mod tests {
                 "type": "conversation_event",
                 "event": "fast_lane_tool_batch",
                 "payload": {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "total_intents": 3,
                     "parallel_execution_enabled": true,
                     "parallel_execution_max_in_flight": 2,
+                    "observed_peak_in_flight": 2,
+                    "observed_wall_time_ms": 27,
                     "parallel_safe_intents": 2,
                     "serial_only_intents": 1,
                     "parallel_segments": 1,
@@ -1655,13 +1728,17 @@ mod tests {
                             "segment_index": 0,
                             "scheduling_class": "parallel_safe",
                             "execution_mode": "parallel",
-                            "intent_count": 2
+                            "intent_count": 2,
+                            "observed_peak_in_flight": 1,
+                            "observed_wall_time_ms": 16
                         },
                         {
                             "segment_index": 1,
                             "scheduling_class": "serial_only",
                             "execution_mode": "sequential",
-                            "intent_count": 1
+                            "intent_count": 1,
+                            "observed_peak_in_flight": 1,
+                            "observed_wall_time_ms": 11
                         }
                     ]
                 }
@@ -1729,6 +1806,13 @@ mod tests {
         assert_eq!(summary.parallel_execution_max_in_flight_samples, 3);
         assert_eq!(summary.parallel_execution_max_in_flight_sum, 6);
         assert_eq!(summary.parallel_execution_max_in_flight_max, Some(3));
+        assert_eq!(summary.observed_peak_in_flight_samples, 2);
+        assert_eq!(summary.observed_peak_in_flight_sum, 5);
+        assert_eq!(summary.observed_peak_in_flight_max, Some(3));
+        assert_eq!(summary.observed_wall_time_ms_samples, 2);
+        assert_eq!(summary.observed_wall_time_ms_sum, 60);
+        assert_eq!(summary.observed_wall_time_ms_max, Some(33));
+        assert_eq!(summary.degraded_parallel_segments, 2);
         assert_eq!(
             summary.scheduling_class_counts,
             BTreeMap::from([
@@ -1790,6 +1874,8 @@ mod tests {
                 scheduling_class: "parallel_safe".to_owned(),
                 execution_mode: "parallel".to_owned(),
                 intent_count: 2,
+                observed_peak_in_flight: None,
+                observed_wall_time_ms: None,
             }]
         );
     }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5576,10 +5576,22 @@ async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_
     assert_eq!(payloads.len(), 1, "expected one fast-lane batch event");
 
     let payload = &payloads[0];
-    assert_eq!(payload["schema_version"], 1);
+    assert_eq!(payload["schema_version"], 2);
     assert_eq!(payload["total_intents"], 5);
     assert_eq!(payload["parallel_execution_enabled"], true);
     assert_eq!(payload["parallel_execution_max_in_flight"], 2);
+    assert!(
+        payload["observed_peak_in_flight"]
+            .as_u64()
+            .expect("observed peak should exist")
+            >= 1
+    );
+    assert!(
+        payload["observed_wall_time_ms"]
+            .as_u64()
+            .expect("observed wall time should exist")
+            >= 1
+    );
     assert_eq!(payload["parallel_safe_intents"], 4);
     assert_eq!(payload["serial_only_intents"], 1);
     assert_eq!(payload["parallel_segments"], 2);
@@ -5595,14 +5607,45 @@ async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_
     assert_eq!(segments[0]["scheduling_class"], "parallel_safe");
     assert_eq!(segments[0]["execution_mode"], "parallel");
     assert_eq!(segments[0]["intent_count"], 2);
+    assert!(
+        segments[0]["observed_peak_in_flight"]
+            .as_u64()
+            .expect("parallel segment observed peak should exist")
+            >= 1
+    );
+    assert!(
+        segments[0]["observed_wall_time_ms"]
+            .as_u64()
+            .expect("parallel segment wall time should exist")
+            >= 1
+    );
     assert_eq!(segments[1]["segment_index"], 1);
     assert_eq!(segments[1]["scheduling_class"], "serial_only");
     assert_eq!(segments[1]["execution_mode"], "sequential");
     assert_eq!(segments[1]["intent_count"], 1);
+    assert_eq!(segments[1]["observed_peak_in_flight"], 1);
+    assert!(
+        segments[1]["observed_wall_time_ms"]
+            .as_u64()
+            .expect("sequential segment wall time should exist")
+            >= 1
+    );
     assert_eq!(segments[2]["segment_index"], 2);
     assert_eq!(segments[2]["scheduling_class"], "parallel_safe");
     assert_eq!(segments[2]["execution_mode"], "parallel");
     assert_eq!(segments[2]["intent_count"], 2);
+    assert!(
+        segments[2]["observed_peak_in_flight"]
+            .as_u64()
+            .expect("parallel segment observed peak should exist")
+            >= 1
+    );
+    assert!(
+        segments[2]["observed_wall_time_ms"]
+            .as_u64()
+            .expect("parallel segment wall time should exist")
+            >= 1
+    );
 
     let _ = std::fs::remove_file(sqlite_path);
 }
@@ -10978,10 +11021,12 @@ async fn load_fast_lane_tool_batch_event_summary_accepts_explicit_runtime_bindin
         "type": "conversation_event",
         "event": "fast_lane_tool_batch",
         "payload": {
-            "schema_version": 1,
+            "schema_version": 2,
             "total_intents": 5,
             "parallel_execution_enabled": true,
             "parallel_execution_max_in_flight": 2,
+            "observed_peak_in_flight": 2,
+            "observed_wall_time_ms": 31,
             "parallel_safe_intents": 4,
             "serial_only_intents": 1,
             "parallel_segments": 2,
@@ -10991,19 +11036,25 @@ async fn load_fast_lane_tool_batch_event_summary_accepts_explicit_runtime_bindin
                     "segment_index": 0,
                     "scheduling_class": "parallel_safe",
                     "execution_mode": "parallel",
-                    "intent_count": 2
+                    "intent_count": 2,
+                    "observed_peak_in_flight": 2,
+                    "observed_wall_time_ms": 12
                 },
                 {
                     "segment_index": 1,
                     "scheduling_class": "serial_only",
                     "execution_mode": "sequential",
-                    "intent_count": 1
+                    "intent_count": 1,
+                    "observed_peak_in_flight": 1,
+                    "observed_wall_time_ms": 7
                 },
                 {
                     "segment_index": 2,
                     "scheduling_class": "parallel_safe",
                     "execution_mode": "parallel",
-                    "intent_count": 2
+                    "intent_count": 2,
+                    "observed_peak_in_flight": 2,
+                    "observed_wall_time_ms": 12
                 }
             ]
         }
@@ -11025,13 +11076,15 @@ async fn load_fast_lane_tool_batch_event_summary_accepts_explicit_runtime_bindin
     .await
     .expect("load fast-lane batch summary via direct binding");
     assert_eq!(direct_summary.batch_events, 1);
-    assert_eq!(direct_summary.latest_schema_version, Some(1));
+    assert_eq!(direct_summary.latest_schema_version, Some(2));
     assert_eq!(direct_summary.latest_total_intents, Some(5));
     assert_eq!(direct_summary.latest_parallel_execution_enabled, Some(true));
     assert_eq!(
         direct_summary.latest_parallel_execution_max_in_flight,
         Some(2)
     );
+    assert_eq!(direct_summary.latest_observed_peak_in_flight, Some(2));
+    assert_eq!(direct_summary.latest_observed_wall_time_ms, Some(31));
     assert_eq!(direct_summary.latest_parallel_safe_intents, Some(4));
     assert_eq!(direct_summary.latest_serial_only_intents, Some(1));
     assert_eq!(direct_summary.latest_parallel_segments, Some(2));
@@ -11051,13 +11104,15 @@ async fn load_fast_lane_tool_batch_event_summary_accepts_explicit_runtime_bindin
     .await
     .expect("load fast-lane batch summary via kernel binding");
     assert_eq!(kernel_summary.batch_events, 1);
-    assert_eq!(kernel_summary.latest_schema_version, Some(1));
+    assert_eq!(kernel_summary.latest_schema_version, Some(2));
     assert_eq!(kernel_summary.latest_total_intents, Some(5));
     assert_eq!(kernel_summary.latest_parallel_execution_enabled, Some(true));
     assert_eq!(
         kernel_summary.latest_parallel_execution_max_in_flight,
         Some(2)
     );
+    assert_eq!(kernel_summary.latest_observed_peak_in_flight, Some(2));
+    assert_eq!(kernel_summary.latest_observed_wall_time_ms, Some(31));
     assert_eq!(kernel_summary.latest_parallel_safe_intents, Some(4));
     assert_eq!(kernel_summary.latest_serial_only_intents, Some(1));
     assert_eq!(kernel_summary.latest_parallel_segments, Some(2));

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -11090,6 +11090,30 @@ async fn load_fast_lane_tool_batch_event_summary_accepts_explicit_runtime_bindin
     assert_eq!(direct_summary.latest_parallel_segments, Some(2));
     assert_eq!(direct_summary.latest_sequential_segments, Some(1));
     assert_eq!(direct_summary.latest_segments.len(), 3);
+    assert_eq!(
+        direct_summary.latest_segments[0].observed_peak_in_flight,
+        Some(2)
+    );
+    assert_eq!(
+        direct_summary.latest_segments[0].observed_wall_time_ms,
+        Some(12)
+    );
+    assert_eq!(
+        direct_summary.latest_segments[1].observed_peak_in_flight,
+        Some(1)
+    );
+    assert_eq!(
+        direct_summary.latest_segments[1].observed_wall_time_ms,
+        Some(7)
+    );
+    assert_eq!(
+        direct_summary.latest_segments[2].observed_peak_in_flight,
+        Some(2)
+    );
+    assert_eq!(
+        direct_summary.latest_segments[2].observed_wall_time_ms,
+        Some(12)
+    );
 
     let audit = Arc::new(InMemoryAuditSink::default());
     let (kernel_ctx, invocations) =
@@ -11118,6 +11142,30 @@ async fn load_fast_lane_tool_batch_event_summary_accepts_explicit_runtime_bindin
     assert_eq!(kernel_summary.latest_parallel_segments, Some(2));
     assert_eq!(kernel_summary.latest_sequential_segments, Some(1));
     assert_eq!(kernel_summary.latest_segments.len(), 3);
+    assert_eq!(
+        kernel_summary.latest_segments[0].observed_peak_in_flight,
+        Some(2)
+    );
+    assert_eq!(
+        kernel_summary.latest_segments[0].observed_wall_time_ms,
+        Some(12)
+    );
+    assert_eq!(
+        kernel_summary.latest_segments[1].observed_peak_in_flight,
+        Some(1)
+    );
+    assert_eq!(
+        kernel_summary.latest_segments[1].observed_wall_time_ms,
+        Some(7)
+    );
+    assert_eq!(
+        kernel_summary.latest_segments[2].observed_peak_in_flight,
+        Some(2)
+    );
+    assert_eq!(
+        kernel_summary.latest_segments[2].observed_wall_time_ms,
+        Some(12)
+    );
 
     let captured = invocations.lock().expect("invocations lock");
     assert_eq!(captured.len(), 1);

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1354,12 +1354,13 @@ impl TurnEngine {
         let result = async {
             let mut outputs = Vec::with_capacity(prepared.len());
             let mut remaining = prepared;
-            for (segment_index, segment) in batch_segments.iter().copied().enumerate() {
+            debug_assert_eq!(trace.segments.len(), batch_segments.len());
+            for (segment, trace_segment) in batch_segments
+                .iter()
+                .copied()
+                .zip(trace.segments.iter_mut())
+            {
                 let (prepared_segment, rest) = remaining.split_at(segment.len);
-                let trace_segment = trace
-                    .segments
-                    .get_mut(segment_index)
-                    .expect("trace should include every prepared batch segment");
                 let mut segment_outputs = match segment.execution_mode {
                     ToolBatchExecutionMode::Parallel => {
                         self.execute_prepared_batch_in_parallel(
@@ -2540,14 +2541,14 @@ mod tests {
             )
             .await;
 
-        match result {
-            TurnResult::FinalText(_) => {}
-            other => panic!("expected FinalText, got {other:?}"),
-        }
+        assert!(
+            matches!(result, TurnResult::FinalText(_)),
+            "expected FinalText, got {result:?}"
+        );
 
         let trace = trace.expect("trace should exist");
         assert_eq!(trace.total_intents, 5);
-        assert_eq!(trace.parallel_execution_enabled, true);
+        assert!(trace.parallel_execution_enabled);
         assert_eq!(trace.parallel_execution_max_in_flight, 2);
         assert_eq!(trace.observed_peak_in_flight, 2);
         assert!(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
 
 use async_trait::async_trait;
 use futures_util::stream::{self, StreamExt};
@@ -964,6 +966,8 @@ pub(crate) struct ToolBatchExecutionSegmentTrace {
     pub scheduling_class: ToolSchedulingClass,
     pub execution_mode: ToolBatchExecutionMode,
     pub intent_count: usize,
+    pub observed_peak_in_flight: Option<usize>,
+    pub observed_wall_time_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -971,10 +975,29 @@ pub(crate) struct ToolBatchExecutionTrace {
     pub total_intents: usize,
     pub parallel_execution_enabled: bool,
     pub parallel_execution_max_in_flight: usize,
+    pub observed_peak_in_flight: usize,
+    pub observed_wall_time_ms: u64,
     pub segments: Vec<ToolBatchExecutionSegmentTrace>,
 }
 
+impl ToolBatchExecutionSegmentTrace {
+    fn record_observation(&mut self, observed_peak_in_flight: usize, observed_wall_time_ms: u64) {
+        self.observed_peak_in_flight = Some(observed_peak_in_flight);
+        self.observed_wall_time_ms = Some(observed_wall_time_ms);
+    }
+}
+
 impl ToolBatchExecutionTrace {
+    fn finish_observation(&mut self, observed_wall_time_ms: u64) {
+        self.observed_wall_time_ms = observed_wall_time_ms;
+        self.observed_peak_in_flight = self
+            .segments
+            .iter()
+            .filter_map(|segment| segment.observed_peak_in_flight)
+            .max()
+            .unwrap_or_default();
+    }
+
     pub(crate) fn as_event_payload(&self) -> serde_json::Value {
         let parallel_safe_intents = self
             .segments
@@ -1000,10 +1023,12 @@ impl ToolBatchExecutionTrace {
             .count();
 
         json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "total_intents": self.total_intents,
             "parallel_execution_enabled": self.parallel_execution_enabled,
             "parallel_execution_max_in_flight": self.parallel_execution_max_in_flight,
+            "observed_peak_in_flight": self.observed_peak_in_flight,
+            "observed_wall_time_ms": self.observed_wall_time_ms,
             "parallel_safe_intents": parallel_safe_intents,
             "serial_only_intents": serial_only_intents,
             "parallel_segments": parallel_segments,
@@ -1017,10 +1042,26 @@ impl ToolBatchExecutionTrace {
                         "scheduling_class": segment.scheduling_class.as_str(),
                         "execution_mode": segment.execution_mode.as_str(),
                         "intent_count": segment.intent_count,
+                        "observed_peak_in_flight": segment.observed_peak_in_flight,
+                        "observed_wall_time_ms": segment.observed_wall_time_ms,
                     })
                 })
                 .collect::<Vec<_>>(),
         })
+    }
+}
+
+fn elapsed_ms_u64(started_at: Instant) -> u64 {
+    started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+fn observe_peak_in_flight(peak: &AtomicUsize, current: usize) {
+    let mut observed = peak.load(Ordering::Relaxed);
+    while current > observed {
+        match peak.compare_exchange_weak(observed, current, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => return,
+            Err(next) => observed = next,
+        }
     }
 }
 
@@ -1279,81 +1320,103 @@ impl TurnEngine {
                 Err(result) => return (result, None),
             }
         }
-        let trace = self.trace_prepared_batch(&prepared);
+        let batch_segments = self.prepared_batch_segments(&prepared);
+        let mut trace = self.trace_prepared_batch(&prepared, &batch_segments);
 
         let outputs = match self
-            .execute_prepared_batch(&prepared, session_context, app_dispatcher, binding)
+            .execute_prepared_batch(
+                &prepared,
+                &batch_segments,
+                session_context,
+                app_dispatcher,
+                binding,
+                &mut trace,
+            )
             .await
         {
             Ok(outputs) => outputs,
-            Err(result) => return (result, trace),
+            Err(result) => return (result, Some(trace)),
         };
 
-        (TurnResult::FinalText(outputs.join("\n")), trace)
+        (TurnResult::FinalText(outputs.join("\n")), Some(trace))
     }
 
     async fn execute_prepared_batch<D: AppToolDispatcher + ?Sized>(
         &self,
         prepared: &[PreparedToolIntent],
+        batch_segments: &[PreparedBatchSegment],
         session_context: &SessionContext,
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
+        trace: &mut ToolBatchExecutionTrace,
     ) -> Result<Vec<String>, TurnResult> {
-        let mut outputs = Vec::with_capacity(prepared.len());
-        let mut remaining = prepared;
-        for segment in self.prepared_batch_segments(prepared) {
-            let (prepared_segment, rest) = remaining.split_at(segment.len);
-            let mut segment_outputs = match segment.execution_mode {
-                ToolBatchExecutionMode::Parallel => {
-                    self.execute_prepared_batch_in_parallel(
-                        prepared_segment,
-                        session_context,
-                        app_dispatcher,
-                        binding,
-                    )
-                    .await?
-                }
-                ToolBatchExecutionMode::Sequential => {
-                    self.execute_prepared_batch_sequential(
-                        prepared_segment,
-                        session_context,
-                        app_dispatcher,
-                        binding,
-                    )
-                    .await?
-                }
-            };
-            outputs.append(&mut segment_outputs);
-            remaining = rest;
-        }
+        let started_at = Instant::now();
+        let result = async {
+            let mut outputs = Vec::with_capacity(prepared.len());
+            let mut remaining = prepared;
+            for (segment_index, segment) in batch_segments.iter().copied().enumerate() {
+                let (prepared_segment, rest) = remaining.split_at(segment.len);
+                let trace_segment = trace
+                    .segments
+                    .get_mut(segment_index)
+                    .expect("trace should include every prepared batch segment");
+                let mut segment_outputs = match segment.execution_mode {
+                    ToolBatchExecutionMode::Parallel => {
+                        self.execute_prepared_batch_in_parallel(
+                            prepared_segment,
+                            session_context,
+                            app_dispatcher,
+                            binding,
+                            trace_segment,
+                        )
+                        .await?
+                    }
+                    ToolBatchExecutionMode::Sequential => {
+                        self.execute_prepared_batch_sequential(
+                            prepared_segment,
+                            session_context,
+                            app_dispatcher,
+                            binding,
+                            trace_segment,
+                        )
+                        .await?
+                    }
+                };
+                outputs.append(&mut segment_outputs);
+                remaining = rest;
+            }
 
-        Ok(outputs)
+            Ok(outputs)
+        }
+        .await;
+        trace.finish_observation(elapsed_ms_u64(started_at));
+        result
     }
 
     fn trace_prepared_batch(
         &self,
         prepared: &[PreparedToolIntent],
-    ) -> Option<ToolBatchExecutionTrace> {
-        if prepared.is_empty() {
-            return None;
-        }
-
-        Some(ToolBatchExecutionTrace {
+        batch_segments: &[PreparedBatchSegment],
+    ) -> ToolBatchExecutionTrace {
+        ToolBatchExecutionTrace {
             total_intents: prepared.len(),
             parallel_execution_enabled: self.parallel_tool_execution_enabled,
             parallel_execution_max_in_flight: self.parallel_tool_execution_max_in_flight,
-            segments: self
-                .prepared_batch_segments(prepared)
-                .into_iter()
+            observed_peak_in_flight: 0,
+            observed_wall_time_ms: 0,
+            segments: batch_segments
+                .iter()
                 .enumerate()
                 .map(|(segment_index, segment)| ToolBatchExecutionSegmentTrace {
                     segment_index,
                     scheduling_class: segment.scheduling_class,
                     execution_mode: segment.execution_mode,
                     intent_count: segment.len,
+                    observed_peak_in_flight: None,
+                    observed_wall_time_ms: None,
                 })
                 .collect(),
-        })
+        }
     }
 
     fn prepared_batch_segments(
@@ -1385,6 +1448,7 @@ impl TurnEngine {
         segment_len: usize,
     ) -> ToolBatchExecutionMode {
         if self.parallel_tool_execution_enabled
+            && self.parallel_tool_execution_max_in_flight > 1
             && scheduling_class == ToolSchedulingClass::ParallelSafe
             && segment_len > 1
         {
@@ -1400,24 +1464,34 @@ impl TurnEngine {
         session_context: &SessionContext,
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
+        trace_segment: &mut ToolBatchExecutionSegmentTrace,
     ) -> Result<Vec<String>, TurnResult> {
-        let mut outputs = Vec::with_capacity(prepared.len());
-        for prepared_intent in prepared {
-            let outcome = self
-                .execute_prepared_tool_intent(
-                    prepared_intent,
-                    session_context,
-                    app_dispatcher,
-                    binding,
-                )
-                .await?;
-            outputs.push(format_tool_result_line_with_limit(
-                &prepared_intent.intent,
-                &outcome,
-                self.tool_result_payload_summary_limit_chars,
-            ));
+        let started_at = Instant::now();
+        let result = async {
+            let mut outputs = Vec::with_capacity(prepared.len());
+            for prepared_intent in prepared {
+                let outcome = self
+                    .execute_prepared_tool_intent(
+                        prepared_intent,
+                        session_context,
+                        app_dispatcher,
+                        binding,
+                    )
+                    .await?;
+                outputs.push(format_tool_result_line_with_limit(
+                    &prepared_intent.intent,
+                    &outcome,
+                    self.tool_result_payload_summary_limit_chars,
+                ));
+            }
+            Ok(outputs)
         }
-        Ok(outputs)
+        .await;
+        trace_segment.record_observation(
+            if prepared.is_empty() { 0 } else { 1 },
+            elapsed_ms_u64(started_at),
+        );
+        result
     }
 
     async fn execute_prepared_batch_in_parallel<D: AppToolDispatcher + ?Sized>(
@@ -1426,37 +1500,57 @@ impl TurnEngine {
         session_context: &SessionContext,
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
+        trace_segment: &mut ToolBatchExecutionSegmentTrace,
     ) -> Result<Vec<String>, TurnResult> {
+        let started_at = Instant::now();
         let payload_summary_limit_chars = self.tool_result_payload_summary_limit_chars;
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let observed_peak = Arc::new(AtomicUsize::new(0));
         let mut results = Vec::with_capacity(prepared.len());
         let mut executions = stream::iter(prepared.iter().cloned().enumerate().map(
-            |(index, prepared_intent)| async move {
-                let result = self
-                    .execute_prepared_tool_intent(
-                        &prepared_intent,
-                        session_context,
-                        app_dispatcher,
-                        binding,
-                    )
-                    .await
-                    .map(|outcome| {
-                        format_tool_result_line_with_limit(
-                            &prepared_intent.intent,
-                            &outcome,
-                            payload_summary_limit_chars,
+            |(index, prepared_intent)| {
+                let in_flight = Arc::clone(&in_flight);
+                let observed_peak = Arc::clone(&observed_peak);
+                async move {
+                    let current_in_flight = in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+                    observe_peak_in_flight(observed_peak.as_ref(), current_in_flight);
+                    let result = self
+                        .execute_prepared_tool_intent(
+                            &prepared_intent,
+                            session_context,
+                            app_dispatcher,
+                            binding,
                         )
-                    });
-                (index, result)
+                        .await
+                        .map(|outcome| {
+                            format_tool_result_line_with_limit(
+                                &prepared_intent.intent,
+                                &outcome,
+                                payload_summary_limit_chars,
+                            )
+                        });
+                    in_flight.fetch_sub(1, Ordering::Relaxed);
+                    (index, result)
+                }
             },
         ))
         .buffer_unordered(self.parallel_tool_execution_max_in_flight);
 
-        while let Some((index, result)) = executions.next().await {
-            match result {
-                Ok(output) => results.push((index, output)),
-                Err(turn_result) => return Err(turn_result),
+        let result = async {
+            while let Some((index, result)) = executions.next().await {
+                match result {
+                    Ok(output) => results.push((index, output)),
+                    Err(turn_result) => return Err(turn_result),
+                }
             }
+            Ok(())
         }
+        .await;
+        trace_segment.record_observation(
+            observed_peak.load(Ordering::Relaxed),
+            elapsed_ms_u64(started_at),
+        );
+        result?;
         results.sort_by_key(|(index, _)| *index);
 
         Ok(results.into_iter().map(|(_, output)| output).collect())
@@ -1629,6 +1723,7 @@ mod tests {
     use crate::test_support::unique_temp_dir;
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     use serde_json::json;
 
@@ -1709,6 +1804,103 @@ mod tests {
                 tool_call_id: tool_call_id.to_owned(),
             }],
             raw_meta: json!({}),
+        }
+    }
+
+    fn provider_app_tool_intent(
+        tool_name: &str,
+        args_json: serde_json::Value,
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+    ) -> ToolIntent {
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            tool_name,
+            args_json,
+            Some(session_id),
+            Some(turn_id),
+        );
+        ToolIntent {
+            tool_name,
+            args_json,
+            source: "assistant".to_owned(),
+            session_id: session_id.to_owned(),
+            turn_id: turn_id.to_owned(),
+            tool_call_id: tool_call_id.to_owned(),
+        }
+    }
+
+    fn fast_lane_observed_execution_turn(
+        session_id: &str,
+        turn_id: &str,
+        call_prefix: &str,
+    ) -> ProviderTurn {
+        ProviderTurn {
+            assistant_text: "observing mixed fast-lane execution".to_owned(),
+            tool_intents: vec![
+                provider_app_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    session_id,
+                    turn_id,
+                    &format!("{call_prefix}-1"),
+                ),
+                provider_app_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    session_id,
+                    turn_id,
+                    &format!("{call_prefix}-2"),
+                ),
+                provider_app_tool_intent(
+                    "session_status",
+                    json!({"session_id": session_id}),
+                    session_id,
+                    turn_id,
+                    &format!("{call_prefix}-3"),
+                ),
+                provider_app_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    session_id,
+                    turn_id,
+                    &format!("{call_prefix}-4"),
+                ),
+                provider_app_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    session_id,
+                    turn_id,
+                    &format!("{call_prefix}-5"),
+                ),
+            ],
+            raw_meta: json!({}),
+        }
+    }
+
+    struct DelayedObservedExecutionDispatcher;
+
+    #[async_trait::async_trait]
+    impl AppToolDispatcher for DelayedObservedExecutionDispatcher {
+        async fn execute_app_tool(
+            &self,
+            session_context: &SessionContext,
+            request: ToolCoreRequest,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            let delay_ms = match request.tool_name.as_str() {
+                "sessions_list" => 25,
+                "session_status" => 10,
+                other => return Err(format!("app_tool_not_found: {other}")),
+            };
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool": request.tool_name,
+                    "session_id": session_context.session_id,
+                }),
+            })
         }
     }
 
@@ -2324,6 +2516,109 @@ mod tests {
         assert_eq!(request["operation"], "click");
 
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn observed_fast_lane_execution_trace_records_batch_and_segment_metrics() {
+        let turn = fast_lane_observed_execution_turn(
+            "session-observed-fast-lane",
+            "turn-observed-fast-lane",
+            "call-observed-fast-lane",
+        );
+        let session_context =
+            SessionContext::root_with_tool_view("session-observed-fast-lane", runtime_tool_view());
+        let dispatcher = DelayedObservedExecutionDispatcher;
+        let engine = TurnEngine::with_parallel_tool_execution(8, 512, true, 2);
+
+        let (result, trace) = engine
+            .execute_turn_in_context_with_trace(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        match result {
+            TurnResult::FinalText(_) => {}
+            other => panic!("expected FinalText, got {other:?}"),
+        }
+
+        let trace = trace.expect("trace should exist");
+        assert_eq!(trace.total_intents, 5);
+        assert_eq!(trace.parallel_execution_enabled, true);
+        assert_eq!(trace.parallel_execution_max_in_flight, 2);
+        assert_eq!(trace.observed_peak_in_flight, 2);
+        assert!(
+            trace.observed_wall_time_ms >= 40,
+            "expected batch wall time to reflect execution, got {}",
+            trace.observed_wall_time_ms
+        );
+        assert_eq!(trace.segments.len(), 3);
+        assert_eq!(
+            trace.segments[0].execution_mode,
+            ToolBatchExecutionMode::Parallel
+        );
+        assert_eq!(trace.segments[0].observed_peak_in_flight, Some(2));
+        assert!(
+            trace.segments[0]
+                .observed_wall_time_ms
+                .expect("parallel segment wall time")
+                >= 20
+        );
+        assert_eq!(
+            trace.segments[1].execution_mode,
+            ToolBatchExecutionMode::Sequential
+        );
+        assert_eq!(trace.segments[1].observed_peak_in_flight, Some(1));
+        assert_eq!(
+            trace.segments[2].execution_mode,
+            ToolBatchExecutionMode::Parallel
+        );
+        assert_eq!(trace.segments[2].observed_peak_in_flight, Some(2));
+    }
+
+    #[tokio::test]
+    async fn observed_fast_lane_execution_treats_single_in_flight_batches_as_sequential() {
+        let turn = fast_lane_observed_execution_turn(
+            "session-observed-fast-lane-single",
+            "turn-observed-fast-lane-single",
+            "call-observed-fast-lane-single",
+        );
+        let session_context = SessionContext::root_with_tool_view(
+            "session-observed-fast-lane-single",
+            runtime_tool_view(),
+        );
+        let dispatcher = DelayedObservedExecutionDispatcher;
+        let engine = TurnEngine::with_parallel_tool_execution(8, 512, true, 1);
+
+        let (_result, trace) = engine
+            .execute_turn_in_context_with_trace(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        let trace = trace.expect("trace should exist");
+        assert_eq!(trace.parallel_execution_max_in_flight, 1);
+        assert_eq!(
+            trace
+                .segments
+                .iter()
+                .filter(|segment| segment.execution_mode == ToolBatchExecutionMode::Parallel)
+                .count(),
+            0
+        );
+        assert!(
+            trace
+                .segments
+                .iter()
+                .all(|segment| segment.execution_mode == ToolBatchExecutionMode::Sequential)
+        );
     }
 
     #[test]

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -11,7 +11,7 @@ use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
 use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc,
@@ -25,16 +25,6 @@ const OPENAI_AUTH_ENV_KEYS: &[&str] = &[
     "OPENAI_API_KEY",
 ];
 const VOLCENGINE_AUTH_ENV_KEYS: &[&str] = &["ARK_API_KEY"];
-
-fn read_http_request_with_timeout(stream: &mut TcpStream, timeout: Duration) -> String {
-    stream.set_nonblocking(false).expect("set stream blocking");
-    stream
-        .set_read_timeout(Some(timeout))
-        .expect("set stream read timeout");
-    let mut request_buf = [0_u8; 8192];
-    let len = stream.read(&mut request_buf).expect("read request");
-    String::from_utf8_lossy(&request_buf[..len]).to_string()
-}
 
 fn build_provider_failover_test_kernel_context(
     agent_id: &str,
@@ -101,6 +91,18 @@ fn next_temp_path(prefix: &str, extension: &str) -> PathBuf {
     ))
 }
 
+fn read_local_provider_request(stream: &mut std::net::TcpStream, deadline: Instant) -> String {
+    stream
+        .set_nonblocking(false)
+        .expect("set accepted stream blocking");
+    stream
+        .set_read_timeout(Some(deadline.saturating_duration_since(Instant::now())))
+        .expect("set accepted stream read timeout");
+    let mut request_buf = [0_u8; 8192];
+    let len = stream.read(&mut request_buf).expect("read request");
+    String::from_utf8_lossy(&request_buf[..len]).to_string()
+}
+
 #[tokio::test]
 async fn provider_auth_ready_accepts_x_api_key_providers() {
     let config = LoongClawConfig {
@@ -162,8 +164,7 @@ async fn fetch_available_models_rejects_missing_volcengine_credentials_before_ne
         while Instant::now() < deadline {
             match listener.accept() {
                 Ok((mut stream, _)) => {
-                    let request =
-                        read_http_request_with_timeout(&mut stream, Duration::from_millis(250));
+                    let request = read_local_provider_request(&mut stream, deadline);
                     requests.push(request);
                     let body = r#"{"error":{"message":"unexpected request"}}"#;
                     let response = format!(
@@ -234,8 +235,7 @@ async fn fetch_available_models_enriches_volcengine_auth_failures_with_ark_guida
             }
             match listener.accept() {
                 Ok((mut stream, _)) => {
-                    let request =
-                        read_http_request_with_timeout(&mut stream, Duration::from_millis(250));
+                    let request = read_local_provider_request(&mut stream, deadline);
                     requests.push(request);
 
                     let body = r#"{"error":{"code":"AuthenticationError","message":"the API key or AK/SK in the request is missing or invalid","type":"Unauthorized"}}"#;

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -92,15 +92,45 @@ fn next_temp_path(prefix: &str, extension: &str) -> PathBuf {
 }
 
 fn read_local_provider_request(stream: &mut std::net::TcpStream, deadline: Instant) -> String {
+    let timeout = deadline
+        .saturating_duration_since(Instant::now())
+        .max(Duration::from_millis(1));
     stream
         .set_nonblocking(false)
         .expect("set accepted stream blocking");
     stream
-        .set_read_timeout(Some(deadline.saturating_duration_since(Instant::now())))
+        .set_read_timeout(Some(timeout))
         .expect("set accepted stream read timeout");
     let mut request_buf = [0_u8; 8192];
     let len = stream.read(&mut request_buf).expect("read request");
     String::from_utf8_lossy(&request_buf[..len]).to_string()
+}
+
+#[test]
+fn read_local_provider_request_accepts_elapsed_deadline() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider listener");
+    let addr = listener.local_addr().expect("local addr");
+    let (written_tx, written_rx) = std::sync::mpsc::channel();
+    let client = std::thread::spawn(move || {
+        let mut stream = std::net::TcpStream::connect(addr).expect("connect local provider");
+        stream
+            .write_all(b"GET /models HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("write local provider request");
+        stream.flush().expect("flush local provider request");
+        written_tx
+            .send(())
+            .expect("notify local provider request write");
+    });
+
+    let (mut stream, _) = listener.accept().expect("accept local provider");
+    written_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("wait for local provider request write");
+
+    let request = read_local_provider_request(&mut stream, Instant::now());
+    assert!(request.starts_with("GET /models HTTP/1.1"));
+
+    client.join().expect("join local provider client");
 }
 
 #[tokio::test]

--- a/docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-design.md
+++ b/docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-design.md
@@ -1,0 +1,205 @@
+# Fast-Lane Observed Execution Diagnostics Design
+
+## Problem
+
+The current fast-lane tool batch event tells operators what LoongClaw planned to
+do:
+
+- whether fast-lane parallel execution was enabled
+- the configured max in-flight limit
+- how intents were segmented into `parallel` or `sequential` batches
+
+That is useful, but still incomplete.
+
+The trace is built before execution starts, so it cannot answer the operational
+questions that matter when debugging parallel tool execution on `dev`:
+
+- did the batch actually execute with concurrency greater than one?
+- what peak concurrency was observed during this run?
+- how long did the batch and each segment take?
+- did a nominally parallel segment effectively degrade to single-flight
+  execution?
+
+There is also one semantic mismatch in the current planner: a segment is labeled
+`parallel` whenever fast-lane parallel execution is enabled and the segment has
+multiple `parallel_safe` intents, even if the configured in-flight cap is `1`.
+That classification overstates what the runtime can actually do.
+
+## Goal
+
+Extend fast-lane batch diagnostics so one persisted event exposes both:
+
+1. configured execution intent
+2. observed execution behavior
+
+This slice should make it possible to compare planned vs actual parallelism from
+the existing event summary and CLI output without redesigning scheduling policy.
+
+## Non-Goals
+
+- adding a new fast-lane health daemon or startup doctor workflow
+- changing safe-lane plan execution
+- changing lane arbitration heuristics
+- adding adaptive concurrency or policy feedback loops
+- introducing new persistence tables or a second event type
+
+## Constraints
+
+- keep the change additive and backward-compatible with existing event history
+- avoid hardcoded thresholds in analytics
+- preserve existing fast-lane event persistence flow
+- keep the implementation rooted in the execution path instead of post-hoc
+  analytics inference
+- minimize change surface outside the fast-lane tool batch path
+
+## Approaches Considered
+
+### Option A: Derive observed behavior only in analytics
+
+Infer actual concurrency from existing segment counts and configured
+`parallel_execution_max_in_flight`.
+
+Pros:
+
+- small analytics-only patch
+
+Cons:
+
+- cannot distinguish configured capability from actual runtime behavior
+- cannot measure elapsed time
+- cannot detect runtime degradation when the configured cap is greater than one
+
+### Option B: Add observed metrics directly to the execution trace
+
+Create the fast-lane trace before execution, then fill observed metrics while
+each segment runs and persist the enriched event through the existing path.
+
+Pros:
+
+- rooted in the real execution boundary
+- keeps one event as the source of truth
+- supports both batch-level and segment-level observed metrics
+- keeps analytics simple and backward-compatible
+
+Cons:
+
+- touches the execution path and tests in multiple layers
+
+### Option C: Emit a second execution-result event after the batch finishes
+
+Keep the existing plan event unchanged and add a new event with observed
+metrics.
+
+Pros:
+
+- preserves a clean separation between plan and execution
+
+Cons:
+
+- duplicates event plumbing
+- complicates summary reconstruction
+- creates ordering and partial-failure edge cases for little practical benefit
+
+## Decision
+
+Choose Option B.
+
+The execution trace should remain the single persisted record for one fast-lane
+tool batch, but it needs to carry observed runtime metrics in addition to
+configured metadata.
+
+## Proposed Model
+
+### Batch-level metrics
+
+Keep the existing configured fields and add:
+
+- `observed_peak_in_flight`
+- `observed_wall_time_ms`
+
+These metrics describe the full batch as executed, not just the planned
+segmentation.
+
+### Segment-level metrics
+
+Keep the existing segment shape and add optional observed fields:
+
+- `observed_peak_in_flight`
+- `observed_wall_time_ms`
+
+Observed fields are optional at the segment level so a partially executed batch
+can still persist a truthful trace when a later segment never starts.
+
+### Execution-mode correction
+
+Update segment classification so a segment is only labeled `parallel` when all
+of the following are true:
+
+- fast-lane parallel execution is enabled
+- the segment contains more than one `parallel_safe` intent
+- the configured `parallel_execution_max_in_flight` is greater than `1`
+
+This keeps planned `execution_mode` aligned with the runtime's effective
+concurrency budget.
+
+## Data Flow
+
+1. Build the batch trace before execution so configured metadata remains stable.
+2. Execute segments in order.
+3. Measure batch elapsed time around the whole execution loop.
+4. For each segment:
+   - measure elapsed time
+   - capture observed peak in-flight concurrency
+   - write those values back into the matching trace segment
+5. Persist the enriched trace through the existing `fast_lane_tool_batch` event.
+6. Extend analytics summary folding to read the new optional fields while
+   remaining compatible with older payloads.
+7. Extend `/fast_lane_summary` to render configured vs observed values clearly.
+
+## Analytics Surface
+
+Add lightweight summary rollups that stay threshold-free:
+
+- latest observed batch peak in-flight
+- latest observed batch wall time
+- aggregate observed batch peak average/max
+- aggregate observed batch wall-time average/max
+- count of degraded parallel segments where a segment planned as `parallel`
+  observed a peak in-flight of `1`
+
+This provides immediate operator value while keeping future health policies free
+to derive their own thresholds later.
+
+## Testing Strategy
+
+1. Add a `turn_engine` test that proves observed concurrency is captured from
+   the real execution path, including mixed parallel and sequential segments.
+2. Add analytics tests for latest and aggregate observed metrics, including
+   degraded parallel segment counting.
+3. Update fast-lane CLI summary tests so the rendered output shows configured vs
+   observed values.
+4. Update conversation integration coverage to ensure persisted batch events
+   include the new fields.
+
+## Risks and Mitigations
+
+### Risk: flakey concurrency assertions
+
+Mitigation:
+
+- use a dedicated test dispatcher with explicit async delays so concurrent
+  overlap is deterministic
+
+### Risk: partial execution traces become misleading on failures
+
+Mitigation:
+
+- keep segment-level observed fields optional
+- record observations immediately when a segment exits, even on failure paths
+
+### Risk: event history compatibility
+
+Mitigation:
+
+- treat observed fields as optional during summary parsing
+- preserve all existing payload fields and event names

--- a/docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-design.md
+++ b/docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-design.md
@@ -183,7 +183,7 @@ to derive their own thresholds later.
 
 ## Risks and Mitigations
 
-### Risk: flakey concurrency assertions
+### Risk: flaky concurrency assertions
 
 Mitigation:
 

--- a/docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-implementation-plan.md
+++ b/docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-implementation-plan.md
@@ -44,7 +44,7 @@ dispatcher and asserts:
 
 **Step 2: Run the targeted test to verify RED**
 
-Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app observed_fast_lane_execution -- --test-threads=1`
+Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app observed_fast_lane_execution -- --test-threads=1`
 Expected: FAIL because observed metrics are not captured yet
 
 ### Task 3: Add failing analytics and CLI summary coverage
@@ -79,9 +79,9 @@ events include the new observed batch and segment fields.
 
 Run:
 
-- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app summarize_fast_lane_tool_batch_events -- --test-threads=1`
-- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app fast_lane_summary -- --test-threads=1`
-- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app persists_fast_lane_tool_batch_event -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app summarize_fast_lane_tool_batch_events -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app fast_lane_summary -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app persists_fast_lane_tool_batch_event -- --test-threads=1`
 
 Expected: FAIL because the new observed fields are not emitted or summarized yet
 
@@ -114,7 +114,7 @@ truthful trace.
 
 **Step 4: Run the targeted trace test to verify GREEN**
 
-Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app observed_fast_lane_execution -- --test-threads=1`
+Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app observed_fast_lane_execution -- --test-threads=1`
 Expected: PASS
 
 ### Task 5: Extend analytics folding and fast-lane summary output
@@ -142,9 +142,9 @@ Assert the observed fields survive the full persistence path.
 
 Run:
 
-- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app summarize_fast_lane_tool_batch_events -- --test-threads=1`
-- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app fast_lane_summary -- --test-threads=1`
-- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app persists_fast_lane_tool_batch_event -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app summarize_fast_lane_tool_batch_events -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app fast_lane_summary -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app persists_fast_lane_tool_batch_event -- --test-threads=1`
 
 Expected: PASS
 
@@ -155,15 +155,15 @@ Expected: PASS
 
 **Step 1: Run focused fast-lane regression coverage**
 
-Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app fast_lane -- --test-threads=1`
+Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test -p loongclaw-app fast_lane -- --test-threads=1`
 Expected: PASS
 
 **Step 2: Run repo-level formatting and all-features verification**
 
 Run:
 
-- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo fmt --all -- --check`
-- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test --workspace --all-features -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo fmt --all -- --check`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home cargo test --workspace --all-features -- --test-threads=1`
 
 Expected: PASS
 

--- a/docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-implementation-plan.md
+++ b/docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-implementation-plan.md
@@ -1,0 +1,178 @@
+# Fast-Lane Observed Execution Diagnostics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend fast-lane tool batch diagnostics so persisted events and CLI summaries expose observed execution concurrency and latency in addition to configured parallel execution metadata.
+
+**Architecture:** Keep the existing `fast_lane_tool_batch` event as the single source of truth, enrich `ToolBatchExecutionTrace` during real execution, correct planned `execution_mode` when the effective in-flight cap is `1`, and extend analytics/CLI summary folding to surface configured-vs-observed comparisons without introducing thresholds or new event types.
+
+**Tech Stack:** Rust, Tokio async execution, serde/JSON analytics folding, CLI summary formatting, memory-sqlite conversation integration tests
+
+---
+
+### Task 1: Write the design and plan artifacts
+
+**Files:**
+- Create: `docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-design.md`
+- Create: `docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-implementation-plan.md`
+
+**Step 1: Verify the design artifact exists**
+
+Run: `test -f docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-design.md`
+Expected: exit 0
+
+**Step 2: Verify the implementation plan artifact exists**
+
+Run: `test -f docs/plans/2026-03-20-fast-lane-observed-execution-diagnostics-implementation-plan.md`
+Expected: exit 0
+
+### Task 2: Add failing trace-level execution coverage
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+
+**Step 1: Add a failing observed-metrics test**
+
+Add a `turn_engine` test that executes a mixed fast-lane batch through a custom
+dispatcher and asserts:
+
+- batch observed peak in-flight is tracked
+- batch observed wall time is populated
+- parallel segments capture observed peak greater than one
+- sequential segments capture observed peak of one
+- `max_in_flight=1` does not classify a segment as planned `parallel`
+
+**Step 2: Run the targeted test to verify RED**
+
+Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app observed_fast_lane_execution -- --test-threads=1`
+Expected: FAIL because observed metrics are not captured yet
+
+### Task 3: Add failing analytics and CLI summary coverage
+
+**Files:**
+- Modify: `crates/app/src/conversation/analytics.rs`
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Add failing analytics tests**
+
+Extend fast-lane analytics tests to assert:
+
+- latest observed peak in-flight and wall time are parsed
+- aggregate observed peak and wall-time rollups are accumulated
+- degraded parallel segments are counted from segment observations
+
+**Step 2: Add failing CLI summary assertions**
+
+Extend fast-lane summary formatting tests to assert:
+
+- configured max in-flight and observed peak are both rendered
+- observed wall-time rollups are rendered
+- latest segment formatting includes observed metrics when present
+
+**Step 3: Add failing conversation persistence assertions**
+
+Extend fast-lane event persistence coverage to assert that persisted batch
+events include the new observed batch and segment fields.
+
+**Step 4: Run the focused test set to verify RED**
+
+Run:
+
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app summarize_fast_lane_tool_batch_events -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app fast_lane_summary -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app persists_fast_lane_tool_batch_event -- --test-threads=1`
+
+Expected: FAIL because the new observed fields are not emitted or summarized yet
+
+### Task 4: Implement observed execution trace capture
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+
+**Step 1: Extend the trace model**
+
+Add observed batch and segment fields and helper methods for event payload
+serialization.
+
+**Step 2: Correct effective parallel classification**
+
+Update segment execution-mode selection so planned `parallel` requires an
+effective in-flight cap greater than one.
+
+**Step 3: Capture observed metrics during execution**
+
+Record:
+
+- batch wall time
+- batch observed peak in-flight
+- per-segment wall time
+- per-segment observed peak in-flight
+
+Do this in the real execution path so partially executed batches still produce a
+truthful trace.
+
+**Step 4: Run the targeted trace test to verify GREEN**
+
+Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app observed_fast_lane_execution -- --test-threads=1`
+Expected: PASS
+
+### Task 5: Extend analytics folding and fast-lane summary output
+
+**Files:**
+- Modify: `crates/app/src/conversation/analytics.rs`
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Extend analytics summary types and parsing**
+
+Add optional/latest and aggregate observed fields while keeping summary parsing
+backward-compatible with older event payloads.
+
+**Step 2: Extend fast-lane CLI rendering**
+
+Render configured-vs-observed execution values clearly and keep the output
+compact enough for operator use.
+
+**Step 3: Extend persisted event assertions**
+
+Assert the observed fields survive the full persistence path.
+
+**Step 4: Run the focused test set to verify GREEN**
+
+Run:
+
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app summarize_fast_lane_tool_batch_events -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app fast_lane_summary -- --test-threads=1`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app persists_fast_lane_tool_batch_event -- --test-threads=1`
+
+Expected: PASS
+
+### Task 6: Run broader verification and prepare clean delivery
+
+**Files:**
+- Review all touched files
+
+**Step 1: Run focused fast-lane regression coverage**
+
+Run: `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test -p loongclaw-app fast_lane -- --test-threads=1`
+Expected: PASS
+
+**Step 2: Run repo-level formatting and all-features verification**
+
+Run:
+
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo fmt --all -- --check`
+- `env HOME=/tmp/loongclaw-test-home USERPROFILE=/tmp/loongclaw-test-home RUSTUP_HOME=/Users/chum/.rustup CARGO_HOME=/Users/chum/.cargo /Users/chum/.cargo/bin/cargo test --workspace --all-features -- --test-threads=1`
+
+Expected: PASS
+
+**Step 3: Inspect final scope**
+
+Run:
+
+- `git status --short`
+- `git diff --stat`
+- `git diff`
+
+Expected: only fast-lane observed diagnostics code, tests, and plan artifacts are changed


### PR DESCRIPTION
## Summary

- Problem: fast-lane traces and `/fast_lane_summary` exposed configured execution shape but not the observed peak concurrency and wall time that actually occurred, and the planned `parallel` label could still appear when the effective in-flight budget had collapsed to `1`.
- Why it matters: operator diagnostics could overstate parallelism and miss the difference between configured intent and observed runtime behavior.
- What changed: persisted observed peak in-flight and wall-time metrics into batch and segment traces, surfaced configured-vs-observed fast-lane diagnostics in analytics rollups and `/fast_lane_summary`, required an effective in-flight budget greater than `1` before labeling a segment as planned `parallel`, and stabilized the Volcengine auth-guidance provider stub used during full verification.
- What did not change (scope boundary): this does not change scheduler or batching policy beyond corrected diagnostics/classification, and it does not add new operator controls.

## Linked Issues

- Closes #369
- Closes #373

## Change Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo test -p loongclaw-app fast_lane -- --test-threads=1
- passed

cargo test -p loongclaw-app provider::tests::fetch_available_models_enriches_volcengine_auth_failures_with_ark_guidance -- --test-threads=1
- passed

cargo test --workspace --all-features -- --test-threads=1
- passed
```

## User-visible / Operator-visible Changes

- `/fast_lane_summary` now shows configured-vs-observed execution diagnostics, including observed peak in-flight and wall-time data.
- segments only report planned `parallel` when the effective in-flight budget is actually greater than `1`.

## Failure Recovery

- Fast rollback or disable path: revert this change to remove the observed diagnostics fields and restore the previous classification/reporting behavior.
- Observable failure symptoms reviewers should watch for: misleading observed-vs-configured metrics, segments still labeled `parallel` when the effective budget is `1`, or regressions in the Volcengine auth-guidance test harness.

## Reviewer Focus

- `crates/app/src/conversation/analytics.rs` and `crates/app/src/conversation/turn_engine.rs` for the observed-metric persistence and parallel-classification rule.
- `crates/app/src/chat.rs` for `/fast_lane_summary` output changes.
- `crates/app/src/provider/tests.rs` for the test-stub stabilization remaining test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observed execution metrics (peak concurrency and elapsed time) to fast-lane batch diagnostics
  * Expanded summary output to display aggregate execution and latency analytics
  * Added tracking of degraded parallel segments

* **Tests**
  * Enhanced tests for new schema version 2 with observed execution metrics
  * Added backward compatibility tests for legacy schema version 1 payloads

* **Documentation**
  * Added design specification for observed execution diagnostics
  * Added implementation plan for observed metrics feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->