### PR TITLE
fix: harden onboarding credential env handling

### DIFF
--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -152,6 +152,12 @@ async fn fetch_available_models_rejects_missing_volcengine_credentials_before_ne
         while Instant::now() < deadline {
             match listener.accept() {
                 Ok((mut stream, _)) => {
+                    stream
+                        .set_nonblocking(false)
+                        .expect("set request stream blocking");
+                    stream
+                        .set_read_timeout(Some(Duration::from_millis(250)))
+                        .expect("set request stream read timeout");
                     let mut request_buf = [0_u8; 8192];
                     let len = stream.read(&mut request_buf).expect("read request");
                     let request = String::from_utf8_lossy(&request_buf[..len]).to_string();
@@ -225,6 +231,12 @@ async fn fetch_available_models_enriches_volcengine_auth_failures_with_ark_guida
             }
             match listener.accept() {
                 Ok((mut stream, _)) => {
+                    stream
+                        .set_nonblocking(false)
+                        .expect("set request stream blocking");
+                    stream
+                        .set_read_timeout(Some(Duration::from_millis(250)))
+                        .expect("set request stream read timeout");
                     let mut request_buf = [0_u8; 8192];
                     let len = stream.read(&mut request_buf).expect("read request");
                     let request = String::from_utf8_lossy(&request_buf[..len]).to_string();

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1909,40 +1909,61 @@ fn resolve_api_key_env_selection(
     ui: &mut impl OnboardUi,
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
+    let explicit_selection = if let Some(api_key_env) = options.api_key_env.as_deref() {
+        if is_explicit_onboard_clear_input(api_key_env) {
+            return Ok(String::new());
+        }
+        let trimmed = api_key_env.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(validate_selected_provider_credential_env(config, trimmed)?)
+        }
+    } else {
+        None
+    };
+
     if options.non_interactive {
-        if let Some(api_key_env) = options.api_key_env.as_deref() {
-            if is_explicit_onboard_clear_input(api_key_env) {
-                return Ok(String::new());
-            }
-            let trimmed = api_key_env.trim();
-            if !trimmed.is_empty() {
-                return Ok(trimmed.to_owned());
+        return Ok(explicit_selection.unwrap_or(default_api_key_env));
+    }
+    let initial = explicit_selection
+        .as_deref()
+        .unwrap_or(default_api_key_env.as_str());
+    let example_env_name = provider_credential_env_hint(&config.provider)
+        .unwrap_or_else(|| "PROVIDER_API_KEY".to_owned());
+    loop {
+        print_lines(
+            ui,
+            render_api_key_env_selection_screen_lines_with_style(
+                config,
+                default_api_key_env.as_str(),
+                initial,
+                guided_prompt_path,
+                context.render_width,
+                true,
+            ),
+        )?;
+        let value = ui.prompt_with_default("Credential env var name", initial)?;
+        if is_explicit_onboard_clear_input(&value) {
+            return Ok(String::new());
+        }
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Ok(String::new());
+        }
+        match validate_selected_provider_credential_env(config, trimmed) {
+            Ok(validated) => return Ok(validated),
+            Err(error) => {
+                print_message(ui, error)?;
+                print_message(
+                    ui,
+                    format!(
+                        "enter the environment variable name only, for example {example_env_name}, or type :clear to remove the env binding"
+                    ),
+                )?;
             }
         }
-        return Ok(default_api_key_env);
     }
-    let initial = options
-        .api_key_env
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(default_api_key_env.as_str());
-    print_lines(
-        ui,
-        render_api_key_env_selection_screen_lines_with_style(
-            config,
-            default_api_key_env.as_str(),
-            initial,
-            guided_prompt_path,
-            context.render_width,
-            true,
-        ),
-    )?;
-    let value = ui.prompt_with_default("Credential env var", initial)?;
-    if is_explicit_onboard_clear_input(&value) {
-        return Ok(String::new());
-    }
-    Ok(value.trim().to_owned())
 }
 
 fn apply_selected_api_key_env(
@@ -2191,6 +2212,9 @@ async fn run_preflight_checks(
     skip_model_probe: bool,
 ) -> Vec<OnboardCheck> {
     let mut checks = Vec::new();
+    if let Some(validation_check) = config_validation_check(config) {
+        checks.push(validation_check);
+    }
     let credential_check = provider_credential_check(config);
     let has_credentials = credential_check.level == OnboardCheckLevel::Pass;
     checks.push(credential_check);
@@ -2234,6 +2258,15 @@ async fn run_preflight_checks(
     checks.extend(collect_channel_preflight_checks(config));
 
     checks
+}
+
+fn config_validation_check(config: &mvp::config::LoongClawConfig) -> Option<OnboardCheck> {
+    config.validate().err().map(|detail| OnboardCheck {
+        name: "config validation",
+        level: OnboardCheckLevel::Fail,
+        detail,
+        non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+    })
 }
 
 fn provider_check_detail_prefix(config: &mvp::config::LoongClawConfig) -> String {
@@ -2472,6 +2505,20 @@ pub fn provider_credential_env_hint(provider: &mvp::config::ProviderConfig) -> O
     provider_credential_env_hints(provider).into_iter().next()
 }
 
+fn validate_selected_provider_credential_env(
+    config: &mvp::config::LoongClawConfig,
+    selected_env_name: &str,
+) -> CliResult<String> {
+    let trimmed = selected_env_name.trim();
+    if trimmed.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut candidate = config.clone();
+    apply_selected_api_key_env(&mut candidate.provider, trimmed.to_owned());
+    candidate.validate().map(|_| trimmed.to_owned())
+}
+
 pub fn preferred_provider_credential_env_binding(
     provider: &mvp::config::ProviderConfig,
 ) -> Option<ProviderCredentialEnvBinding> {
@@ -2600,16 +2647,34 @@ fn push_provider_credential_env_hint(hints: &mut Vec<String>, maybe_env_name: Op
     }
 }
 
-fn normalize_provider_credential_env_name(raw: &str) -> Option<String> {
+fn provider_credential_env_name_is_safe(raw: &str) -> bool {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
+        return false;
+    }
+
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.api_key = None;
+    config.provider.api_key_env = Some(trimmed.to_owned());
+    config.validate().is_ok()
+}
+
+fn normalize_provider_credential_env_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || !provider_credential_env_name_is_safe(trimmed) {
         return None;
     }
     Some(trimmed.to_owned())
 }
 
 fn render_provider_credential_source_value(raw: Option<&str>) -> Option<String> {
-    normalize_provider_credential_env_name(raw?).map(|env_name| format!("${{{env_name}}}"))
+    let trimmed = raw?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    normalize_provider_credential_env_name(trimmed)
+        .map(|env_name| format!("${{{env_name}}}"))
+        .or_else(|| Some("environment variable".to_owned()))
 }
 
 pub fn preferred_api_key_env_default(config: &mvp::config::LoongClawConfig) -> String {
@@ -4179,10 +4244,10 @@ fn render_api_key_env_selection_default_hint_line(
     suggested_env: &str,
     prompt_default: &str,
 ) -> String {
-    let prompt_default = render_provider_credential_source_value(Some(prompt_default))
-        .unwrap_or_else(|| prompt_default.trim().to_owned());
-    let suggested_env = render_provider_credential_source_value(Some(suggested_env))
-        .unwrap_or_else(|| suggested_env.trim().to_owned());
+    let prompt_default =
+        render_provider_credential_source_value(Some(prompt_default)).unwrap_or_default();
+    let suggested_env =
+        render_provider_credential_source_value(Some(suggested_env)).unwrap_or_default();
     let current_env =
         configured_provider_credential_env_binding(&config.provider).and_then(|binding| {
             render_provider_credential_source_value(Some(binding.env_name.as_str()))
@@ -5267,12 +5332,15 @@ fn render_api_key_env_selection_screen_lines_with_style(
         context_lines.push(format!("- suggested source: {suggested_source}"));
     }
 
+    let example_env_name = provider_credential_env_hint(&config.provider)
+        .unwrap_or_else(|| "PROVIDER_API_KEY".to_owned());
     let mut hint_lines = vec![render_api_key_env_selection_default_hint_line(
         config,
         default_api_key_env,
         prompt_default,
     )];
     hint_lines.push("- enter an env var name, not the secret value itself".to_owned());
+    hint_lines.push(format!("- example: {example_env_name}"));
     if prompt_default.trim().is_empty() {
         if provider_has_inline_credential(&config.provider) {
             hint_lines.push("- leave this blank to keep inline credentials".to_owned());
@@ -6646,6 +6714,27 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn run_preflight_checks_fail_for_invalid_provider_credential_env_value() {
+        let secret = "sk-live-direct-secret-value";
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Openai;
+        config.provider.api_key_env = Some(secret.to_owned());
+        config.provider.api_key = None;
+
+        let checks = run_preflight_checks(&config, true).await;
+
+        assert!(
+            checks.iter().any(|check| {
+                check.name == "config validation"
+                    && check.level == OnboardCheckLevel::Fail
+                    && check.detail.contains("provider.api_key_env")
+                    && !check.detail.contains(secret)
+            }),
+            "preflight should fail fast on invalid provider credential env values without echoing the secret: {checks:#?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn browser_companion_onboard_preflight_warns_when_runtime_gate_is_closed() {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
         let temp_dir = browser_companion_temp_dir("runtime-gate");
@@ -6947,6 +7036,44 @@ mod tests {
     }
 
     #[test]
+    fn preferred_api_key_env_default_ignores_invalid_configured_secret_literal() {
+        let secret = "sk-live-direct-secret-value";
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Openai;
+        config.provider.api_key_env = Some(secret.to_owned());
+
+        let default_env = preferred_api_key_env_default(&config);
+
+        assert_eq!(
+            default_env, "OPENAI_CODEX_OAUTH_TOKEN",
+            "invalid configured credential env values should fall back to the provider's safe onboarding default instead of being reused as the interactive prompt default"
+        );
+        assert!(
+            !default_env.contains(secret),
+            "prompt defaults must never echo the rejected secret-like value"
+        );
+    }
+
+    #[test]
+    fn build_onboarding_success_summary_does_not_echo_invalid_credential_env_value() {
+        let secret = "sk-live-direct-secret-value";
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Openai;
+        config.provider.api_key_env = Some(secret.to_owned());
+
+        let summary =
+            build_onboarding_success_summary(Path::new("/tmp/loongclaw.toml"), &config, None);
+        let credential = summary
+            .credential
+            .expect("summary should still describe the configured credential lane");
+
+        assert!(
+            !credential.value.contains(secret),
+            "success summary must never echo invalid secret-like env input: {credential:#?}"
+        );
+    }
+
+    #[test]
     fn resolve_api_key_env_selection_accepts_explicit_clear_token_in_interactive_mode() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Openai;
@@ -6979,6 +7106,82 @@ mod tests {
         assert!(
             selected.is_empty(),
             "typing :clear should explicitly clear the api-key env selection instead of persisting the literal token: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_api_key_env_selection_reprompts_after_secret_literal_interactively() {
+        let secret = "sk-live-direct-secret-value";
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Openai;
+        let mut ui = TestOnboardUi::with_inputs([secret, "OPENAI_API_KEY"]);
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_api_key_env_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            "OPENAI_API_KEY".to_owned(),
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("interactive credential selection should reprompt on invalid secret-like input");
+
+        assert_eq!(
+            selected, "OPENAI_API_KEY",
+            "interactive onboarding should reject secret-like input and keep asking for an env var name"
+        );
+    }
+
+    #[test]
+    fn resolve_api_key_env_selection_rejects_secret_literal_non_interactively() {
+        let secret = "sk-live-direct-secret-value";
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Openai;
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let error = resolve_api_key_env_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: true,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: Some(secret.to_owned()),
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            "OPENAI_API_KEY".to_owned(),
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect_err("non-interactive onboarding should reject secret-like env selections");
+
+        assert!(
+            error.contains("provider.api_key_env"),
+            "the validation error should identify the bad field: {error}"
+        );
+        assert!(
+            !error.contains(secret),
+            "non-interactive validation must not echo the secret-like input: {error}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1311,6 +1311,7 @@ pub async fn run_onboard_cli_with_ui(
     }
 
     let checks = run_preflight_checks(&config, options.skip_model_probe).await;
+    let config_validation_failure = config_validation_failure_message(&checks);
 
     let credential_ok = checks
         .iter()
@@ -1331,6 +1332,9 @@ pub async fn run_onboard_cli_with_ui(
         });
 
     if options.non_interactive {
+        if let Some(message) = config_validation_failure {
+            return Err(message);
+        }
         if !credential_ok {
             let credential_hint = provider_credential_env_hint(&config.provider)
                 .unwrap_or_else(|| "PROVIDER_API_KEY".to_owned());
@@ -1358,6 +1362,9 @@ pub async fn run_onboard_cli_with_ui(
                 true,
             ),
         )?;
+        if let Some(message) = config_validation_failure {
+            return Err(message);
+        }
         if (has_failures || has_warnings)
             && !ui.prompt_confirm(
                 crate::onboard_presentation::preflight_confirm_prompt(),
@@ -2392,6 +2399,13 @@ fn non_interactive_preflight_failure_message(checks: &[OnboardCheck]) -> String 
     format!("onboard preflight failed: {detail}")
 }
 
+fn config_validation_failure_message(checks: &[OnboardCheck]) -> Option<String> {
+    checks
+        .iter()
+        .find(|check| check.name == "config validation" && check.level == OnboardCheckLevel::Fail)
+        .map(|check| format!("onboard preflight failed: {}", check.detail))
+}
+
 pub fn provider_credential_check(config: &mvp::config::LoongClawConfig) -> OnboardCheck {
     let provider = &config.provider;
     let provider_prefix = provider_check_detail_prefix(config);
@@ -2675,6 +2689,34 @@ fn render_provider_credential_source_value(raw: Option<&str>) -> Option<String> 
     normalize_provider_credential_env_name(trimmed)
         .map(|env_name| format!("${{{env_name}}}"))
         .or_else(|| Some("environment variable".to_owned()))
+}
+
+fn render_configured_provider_credential_source_value(
+    provider: &mvp::config::ProviderConfig,
+) -> Option<String> {
+    provider
+        .oauth_access_token_env
+        .as_deref()
+        .and_then(|value| render_provider_credential_source_value(Some(value)))
+        .or_else(|| {
+            provider
+                .api_key_env
+                .as_deref()
+                .and_then(|value| render_provider_credential_source_value(Some(value)))
+        })
+}
+
+fn provider_has_configured_credential_env(provider: &mvp::config::ProviderConfig) -> bool {
+    provider
+        .oauth_access_token_env
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+        || provider
+            .api_key_env
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
 }
 
 pub fn preferred_api_key_env_default(config: &mvp::config::LoongClawConfig) -> String {
@@ -5319,10 +5361,7 @@ fn render_api_key_env_selection_screen_lines_with_style(
         "- provider: {}",
         crate::provider_presentation::guided_provider_label(config.provider.kind)
     )];
-    if let Some(current_env) = configured_provider_credential_env_binding(&config.provider)
-        .and_then(|binding| {
-            render_provider_credential_source_value(Some(binding.env_name.as_str()))
-        })
+    if let Some(current_env) = render_configured_provider_credential_source_value(&config.provider)
     {
         context_lines.push(format!("- current source: {current_env}"));
     }
@@ -5764,14 +5803,10 @@ fn summarize_provider_credential(
             value: "inline oauth token".to_owned(),
         });
     }
-    if let Some(oauth_env) = provider
-        .oauth_access_token_env
-        .as_deref()
-        .and_then(|value| render_provider_credential_source_value(Some(value)))
-    {
+    if let Some(configured_env) = render_configured_provider_credential_source_value(provider) {
         return Some(OnboardingCredentialSummary {
             label: "credential source",
-            value: oauth_env,
+            value: configured_env,
         });
     }
     if provider
@@ -5797,7 +5832,7 @@ fn summarize_provider_credential(
 
 fn provider_supports_blank_api_key_env(config: &mvp::config::LoongClawConfig) -> bool {
     provider_has_inline_credential(&config.provider)
-        || configured_provider_credential_env_binding(&config.provider).is_some()
+        || provider_has_configured_credential_env(&config.provider)
 }
 
 fn prompt_import_candidate_choice(
@@ -7019,6 +7054,30 @@ mod tests {
     }
 
     #[test]
+    fn config_validation_failure_message_only_matches_config_validation_failures() {
+        let checks = vec![
+            OnboardCheck {
+                name: "provider credentials",
+                level: OnboardCheckLevel::Fail,
+                detail: "credentials missing".to_owned(),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+            },
+            OnboardCheck {
+                name: "config validation",
+                level: OnboardCheckLevel::Fail,
+                detail: "provider.api_key_env must be an environment variable name".to_owned(),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+            },
+        ];
+
+        assert_eq!(
+            config_validation_failure_message(&checks),
+            Some("onboard preflight failed: provider.api_key_env must be an environment variable name".to_owned()),
+            "config validation failures should be surfaced as terminal preflight errors"
+        );
+    }
+
+    #[test]
     fn provider_credential_check_adds_volcengine_auth_guidance_when_missing() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::VolcengineCoding;
@@ -7067,6 +7126,10 @@ mod tests {
             .credential
             .expect("summary should still describe the configured credential lane");
 
+        assert_eq!(
+            credential.value, "environment variable",
+            "success summary should redact invalid configured env pointers instead of inventing a provider default binding"
+        );
         assert!(
             !credential.value.contains(secret),
             "success summary must never echo invalid secret-like env input: {credential:#?}"

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4387,6 +4387,37 @@ fn onboard_api_key_env_screen_wraps_progress_line_on_narrow_width() {
 }
 
 #[test]
+fn onboard_api_key_env_screen_redacts_invalid_current_source_and_keeps_clear_hint() {
+    let secret = "sk-live-direct-secret-value";
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.kind = mvp::config::ProviderKind::Openai;
+    config.provider.api_key_env = Some(secret.to_owned());
+
+    let lines = loongclaw_daemon::onboard_cli::render_api_key_env_selection_screen_lines(
+        &config,
+        "OPENAI_API_KEY",
+        80,
+    );
+
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "- current source: environment variable"),
+        "credential-env screen should redact invalid configured env pointers instead of hiding them or inventing defaults: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "- type :clear to clear the configured credential env"),
+        "credential-env screen should still offer the clear token when the configured env pointer is present but redacted: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.contains(secret)),
+        "credential-env screen must never echo the invalid secret-like configured env pointer: {lines:#?}"
+    );
+}
+
+#[test]
 fn onboard_system_prompt_screen_explains_blank_behavior() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.cli.system_prompt = "be terse and code-focused".to_owned();
@@ -6573,6 +6604,38 @@ fn onboard_review_lines_surface_region_endpoint_note_for_minimax() {
         lines.iter().any(|line| line.contains("api.minimaxi.com"))
             && lines.iter().any(|line| line.contains("api.minimax.io")),
         "review screen should show the current and alternate MiniMax regional endpoints: {lines:#?}"
+    );
+}
+
+#[test]
+fn onboard_review_lines_redact_invalid_configured_credential_env_value() {
+    let secret = "sk-live-direct-secret-value";
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.provider.kind = mvp::config::ProviderKind::Openai;
+    config.provider.api_key_env = Some(secret.to_owned());
+
+    let lines = loongclaw_daemon::onboard_cli::render_onboard_review_lines_with_guidance(
+        &config,
+        None,
+        &[],
+        80,
+    );
+
+    assert!(
+        lines
+            .iter()
+            .any(|line| line == "- credential source: environment variable"),
+        "review screen should redact invalid configured env pointers instead of inventing a provider default binding: {lines:#?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .all(|line| line != "- credential source: ${OPENAI_CODEX_OAUTH_TOKEN}"),
+        "review screen should not replace an invalid configured env pointer with the provider default binding: {lines:#?}"
+    );
+    assert!(
+        lines.iter().all(|line| !line.contains(secret)),
+        "review screen must never echo the invalid secret-like configured env pointer: {lines:#?}"
     );
 }
 

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -24,6 +24,9 @@ next.
       explicit `Esc` cancellation hint before any config write.
 - [ ] Interactive fixed-choice prompts use terminal-native selection widgets
       with arrow-key navigation instead of raw numeric or exact-string entry.
+- [ ] The credential-source step asks for an environment variable name,
+      rejects pasted secret literals or shell assignment syntax, and never
+      echoes rejected secret-like input in review or success output.
 - [ ] When provider credentials are already available and catalog discovery
       succeeds, model selection offers a searchable model list while still
       allowing a manual custom model override.


### PR DESCRIPTION
## Summary

- Problem:
  onboarding accepted secret-like credential input where it expected an env var name, then carried that bad value into review and success output instead of failing early.
- Why it matters:
  this could leak credential material back to the terminal, leave users with an invalid config state, and make the onboarding flow look successful when the credential binding was already broken.
- What changed:
  onboarding now validates credential env selections against config validation before accepting them, reprompts interactively on secret-like input, rejects the same input non-interactively, adds a preflight config validation gate, avoids reusing or echoing invalid secret-like values in prompt defaults and summaries, updates the onboarding spec, and hardens the local provider test harness that surfaced a socket race during full validation.
- What did not change (scope boundary):
  this does not change provider auth semantics, secret storage policy, or unrelated onboarding decisions outside credential env binding validation and presentation.

## Linked Issues

- Closes #344
- Related #344

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed

cargo test -p loongclaw-app fetch_available_models_ -- --nocapture
- passed after hardening the local listener test harness against a nonblocking socket read race

cargo test --workspace --locked
- passed

cargo test --workspace --all-features --locked
- passed

manual review:
- reviewed the onboarding credential env flow for explicit input, fallback defaults, review rendering, success summary rendering, and preflight validation behavior
- updated docs/product-specs/onboarding.md to document the stricter acceptance rule for credential env bindings

regression coverage added in crates/daemon/src/onboard_cli.rs:
- invalid credential env rejected during preflight
- invalid configured secret-like env not reused as prompt default
- success summary does not echo invalid secret-like env input
- interactive onboarding reprompts on secret-like input
- non-interactive onboarding rejects secret-like input cleanly
```

## User-visible / Operator-visible Changes

- onboarding now accepts only env var names for credential bindings, fails earlier on invalid bindings, and avoids echoing secret-like input back in onboarding review or success output

## Failure Recovery

- Fast rollback or disable path:
  revert this commit to restore the previous onboarding credential env behavior
- Observable failure symptoms reviewers should watch for:
  onboarding rejecting a valid env var name, missing provider-specific env suggestions, or preflight surfacing unexpected config validation failures for valid credential bindings

## Reviewer Focus

- focus on `crates/daemon/src/onboard_cli.rs` around credential env selection, preflight validation ordering, and summary rendering
- verify the new tests cover explicit input, fallback defaults, and non-echo behavior without weakening existing onboarding flows
- spot-check `crates/app/src/provider/tests.rs` to confirm the test-only socket change is limited to local harness reliability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation of environment variable names during credential setup with improved error messages and examples.
  * Added safeguards to prevent accidental input of secret literals or shell syntax during onboarding.
  * Strengthened preflight checks for credential configuration validity.

* **Tests**
  * Updated test infrastructure for credential validation scenarios.

* **Documentation**
  * Updated onboarding specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->