### PR TITLE
fix feishu websocket endpoint discovery negative reconnect count

### DIFF
--- a/crates/app/src/feishu/client.rs
+++ b/crates/app/src/feishu/client.rs
@@ -75,7 +75,7 @@ pub struct FeishuUserInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct FeishuWsEndpointClientConfig {
     #[serde(rename = "ReconnectCount", default)]
-    pub reconnect_count: Option<u64>,
+    pub reconnect_count: Option<i64>,
     #[serde(rename = "ReconnectInterval", default)]
     pub reconnect_interval_s: Option<u64>,
     #[serde(rename = "ReconnectNonce", default)]
@@ -1143,6 +1143,47 @@ mod tests {
                 .reconnect_interval_s,
             Some(7)
         );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn get_websocket_endpoint_accepts_negative_reconnect_count() {
+        let router = Router::new().route(
+            "/callback/ws/endpoint",
+            post(|| async {
+                Json(serde_json::json!({
+                    "code": 0,
+                    "msg": "ok",
+                    "data": {
+                        "URL": "wss://example.feishu.cn/ws?service_id=42",
+                        "ClientConfig": {
+                            "ReconnectCount": -1,
+                            "ReconnectInterval": 7,
+                            "PingInterval": 15
+                        }
+                    }
+                }))
+            }),
+        );
+        let (base_url, server) = spawn_mock_feishu_server(router).await;
+        let client = FeishuClient::new(base_url, "cli_xxx", "secret_xxx", 20).expect("client");
+
+        let endpoint = client
+            .get_websocket_endpoint()
+            .await
+            .expect("negative reconnect counts from Feishu should not break endpoint discovery");
+        let config_json = serde_json::to_value(
+            endpoint
+                .client_config
+                .expect("client config from websocket endpoint response"),
+        )
+        .expect("serialize websocket client config");
+
+        assert_eq!(endpoint.url, "wss://example.feishu.cn/ws?service_id=42");
+        assert_eq!(config_json["ReconnectCount"], serde_json::json!(-1));
+        assert_eq!(config_json["ReconnectInterval"], serde_json::json!(7));
+        assert_eq!(config_json["PingInterval"], serde_json::json!(15));
 
         server.abort();
     }


### PR DESCRIPTION
## Summary

- Problem: real Feishu websocket endpoint responses can return `ClientConfig.ReconnectCount = -1`, but endpoint discovery modeled that field as unsigned and rejected the payload before websocket startup.
- Why it matters: valid upstream responses failed during endpoint discovery, so Feishu websocket sessions could not start even though the server response was correct.
- What changed: `FeishuWsEndpointClientConfig.reconnect_count` now accepts signed values, and regression coverage exercises the real endpoint payload shape including `-1`.
- What did not change (scope boundary): this does not change websocket reconnect policy semantics beyond accepting the provider contract shape, and it does not change unrelated channel routing or provider auth behavior.

## Linked Issues

- Closes #376
- Related #340
- Related #274

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

cargo test -p loongclaw-app feishu::client::tests::get_websocket_endpoint_ -- --nocapture
- passed

cargo test -p loongclaw-app channel::feishu::websocket::tests::feishu_websocket_session_reaches_provider_and_replies -- --exact
- passed

cargo clippy -p loongclaw-app --lib --tests -- -D warnings
- passed

cargo test --workspace --locked
- hit the same unrelated existing provider failure already reproduced on the unmodified branch:
  provider::tests::fetch_available_models_enriches_volcengine_auth_failures_with_ark_guidance
  failed locally with a loopback `WouldBlock` / request-send error and did not touch the Feishu websocket path changed here
```

## User-visible / Operator-visible Changes

- Feishu websocket endpoint discovery now accepts the real upstream `ReconnectCount = -1` payload instead of failing before websocket startup.

## Failure Recovery

- Fast rollback or disable path: revert this change to restore the previous endpoint-shape parsing.
- Observable failure symptoms reviewers should watch for: valid Feishu endpoint responses still failing discovery, negative reconnect counts being rejected, or malformed payloads being accepted too loosely.

## Reviewer Focus

- `crates/app/src/feishu/client.rs` for the signed reconnect-count model and the regression coverage around the real endpoint payload shape.
