### PR TITLE
feat(tools): add file.edit text replacement tool

### DIFF
--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -631,6 +631,17 @@ pub fn tool_catalog() -> ToolCatalog {
             visibility_gate: ToolVisibilityGate::Always,
             provider_definition_builder: file_write_definition,
         });
+        descriptors.push(ToolDescriptor {
+            name: "file.edit",
+            provider_name: "file_edit",
+            aliases: &[],
+            description: "Replace text in a file",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Always,
+            provider_definition_builder: file_edit_definition,
+        });
     }
 
     #[cfg(feature = "tool-shell")]
@@ -1666,6 +1677,41 @@ fn file_write_definition(descriptor: &ToolDescriptor) -> Value {
     })
 }
 
+fn file_edit_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the file (absolute or relative to configured file root)."
+                    },
+                    "old_string": {
+                        "type": "string",
+                        "description": "Literal substring to find. Must be non-empty. \
+                                        Must match exactly once unless replace_all is true."
+                    },
+                    "new_string": {
+                        "type": "string",
+                        "description": "Replacement text."
+                    },
+                    "replace_all": {
+                        "type": "boolean",
+                        "description": "Replace all occurrences instead of requiring a unique match. \
+                                        Zero-match still fails regardless of this flag. Defaults to false."
+                    }
+                },
+                "required": ["path", "old_string", "new_string"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
 fn web_fetch_definition(descriptor: &ToolDescriptor) -> Value {
     json!({
         "type": "function",
@@ -2242,6 +2288,7 @@ fn tool_argument_hint(name: &str) -> &'static str {
         "browser.companion.type" => "session_id:string,selector:string,text:string",
         "file.read" => "path:string,max_bytes?:integer",
         "file.write" => "path:string,content:string,create_dirs?:boolean",
+        "file.edit" => "path:string,old_string:string,new_string:string,replace_all?:boolean",
         "shell.exec" => "command:string,args?:string[]",
         "provider.switch" => "selector?:string",
         "delegate" | "delegate_async" => "task:string,label?:string,timeout_seconds?:integer",
@@ -2310,6 +2357,12 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
             ("content", "string"),
             ("create_dirs", "boolean"),
         ],
+        "file.edit" => &[
+            ("path", "string"),
+            ("old_string", "string"),
+            ("new_string", "string"),
+            ("replace_all", "boolean"),
+        ],
         "shell.exec" => &[("command", "string"), ("args", "array")],
         "provider.switch" => &[("selector", "string")],
         "delegate" | "delegate_async" => &[
@@ -2353,6 +2406,7 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "browser.companion.type" => &["session_id", "selector", "text"],
         "file.read" => &["path"],
         "file.write" => &["path", "content"],
+        "file.edit" => &["path", "old_string", "new_string"],
         "shell.exec" => &["command"],
         "delegate" | "delegate_async" => &["task"],
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
@@ -2392,6 +2446,7 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
         }
         "file.read" => &["file", "read", "filesystem", "repo"],
         "file.write" => &["file", "write", "filesystem"],
+        "file.edit" => &["file", "edit", "filesystem"],
         "shell.exec" => &["shell", "command", "process", "exec"],
         "provider.switch" => &["provider", "switch", "model", "runtime"],
         "delegate" | "delegate_async" => &["session", "delegate", "child"],

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1692,6 +1692,7 @@ fn file_edit_definition(descriptor: &ToolDescriptor) -> Value {
                     },
                     "old_string": {
                         "type": "string",
+                        "minLength": 1,
                         "description": "Literal substring to find. Must be non-empty. \
                                         Must match exactly once unless replace_all is true."
                     },

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -116,6 +116,87 @@ pub(super) fn execute_file_write_tool_with_config(
     }
 }
 
+pub(super) fn execute_file_edit_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    #[cfg(not(feature = "tool-file"))]
+    {
+        let _ = (request, config);
+        return Err("file tool is disabled in this build (enable feature `tool-file`)".to_owned());
+    }
+    #[cfg(feature = "tool-file")]
+    {
+        let payload = request
+            .payload
+            .as_object()
+            .ok_or_else(|| "file.edit payload must be an object".to_owned())?;
+
+        let path = payload
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "file.edit requires payload.path (string)".to_owned())?;
+        let old_string = payload
+            .get("old_string")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "file.edit requires payload.old_string (string)".to_owned())?;
+        let new_string = payload
+            .get("new_string")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "file.edit requires payload.new_string (string)".to_owned())?;
+        let replace_all = payload
+            .get("replace_all")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        // Empty pattern matches every boundary position — reject for a well-defined edit contract.
+        if old_string.is_empty() {
+            return Err("edit_failed: old_string must not be empty".to_owned());
+        }
+
+        let resolved = resolve_safe_file_path_with_config(path, config)?;
+        let content = fs::read_to_string(&resolved)
+            .map_err(|e| format!("failed to read {}: {e}", resolved.display()))?;
+
+        // str::matches() — literal substring, non-overlapping, left-to-right.
+        let match_count = content.matches(old_string).count();
+
+        if match_count == 0 {
+            return Err("edit_failed: old_string not found in file".to_owned());
+        }
+        if match_count > 1 && !replace_all {
+            return Err(format!(
+                "edit_failed: old_string matches {match_count} locations; \
+                 set replace_all:true to replace all occurrences"
+            ));
+        }
+
+        let (updated, replacements_made) = if replace_all {
+            // str::replace uses the same non-overlapping semantics as str::matches.
+            let s = content.replace(old_string, new_string);
+            (s, match_count)
+        } else {
+            // Exactly one match confirmed above.
+            let s = content.replacen(old_string, new_string, 1);
+            (s, 1usize)
+        };
+
+        fs::write(&resolved, updated.as_bytes())
+            .map_err(|e| format!("failed to write {}: {e}", resolved.display()))?;
+
+        Ok(ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "core-tools",
+                "tool_name": request.tool_name,
+                "path": resolved.display().to_string(),
+                "replacements_made": replacements_made,
+                "bytes_written": updated.len(),
+            }),
+        })
+    }
+}
+
 pub(super) fn resolve_safe_file_path_with_config(
     raw: &str,
     config: &super::runtime_config::ToolRuntimeConfig,
@@ -339,6 +420,161 @@ mod tests {
 
         let written = fs::read_to_string(root.join("safe/note.txt")).expect("read written file");
         assert_eq!(written, "hello");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    fn make_edit_request(
+        path: &str,
+        old: &str,
+        new: &str,
+        replace_all: Option<bool>,
+    ) -> ToolCoreRequest {
+        let mut map = serde_json::Map::new();
+        map.insert("path".into(), Value::String(path.to_owned()));
+        map.insert("old_string".into(), Value::String(old.to_owned()));
+        map.insert("new_string".into(), Value::String(new.to_owned()));
+        if let Some(ra) = replace_all {
+            map.insert("replace_all".into(), Value::Bool(ra));
+        }
+        ToolCoreRequest {
+            tool_name: "file.edit".to_owned(),
+            payload: Value::Object(map),
+        }
+    }
+
+    #[test]
+    fn file_edit_single_match_succeeds() {
+        let base = unique_temp_dir("loongclaw-file-edit-single");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        let target = root.join("file.txt");
+        fs::write(&target, "hello world").expect("write");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let result = execute_file_edit_tool_with_config(
+            make_edit_request("file.txt", "hello", "hi", None),
+            &config,
+        );
+        assert!(result.is_ok(), "unexpected error: {result:?}");
+        let outcome = result.unwrap();
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["replacements_made"], 1);
+        assert_eq!(fs::read_to_string(&target).unwrap(), "hi world");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn file_edit_no_match_errors() {
+        let base = unique_temp_dir("loongclaw-file-edit-nomatch");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        fs::write(root.join("file.txt"), "hello world").expect("write");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let err = execute_file_edit_tool_with_config(
+            make_edit_request("file.txt", "nothere", "x", None),
+            &config,
+        )
+        .expect_err("should fail");
+        assert!(err.contains("old_string not found"), "got: {err}");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn file_edit_multiple_match_without_replace_all_errors() {
+        let base = unique_temp_dir("loongclaw-file-edit-multi");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        fs::write(root.join("file.txt"), "a\na\n").expect("write");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let err = execute_file_edit_tool_with_config(
+            make_edit_request("file.txt", "a", "b", None),
+            &config,
+        )
+        .expect_err("should fail");
+        assert!(err.contains("matches 2 locations"), "got: {err}");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn file_edit_replace_all_replaces_all_occurrences() {
+        let base = unique_temp_dir("loongclaw-file-edit-replaceall");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        let target = root.join("file.txt");
+        fs::write(&target, "a\na\na\n").expect("write");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let result = execute_file_edit_tool_with_config(
+            make_edit_request("file.txt", "a", "b", Some(true)),
+            &config,
+        );
+        assert!(result.is_ok(), "unexpected error: {result:?}");
+        let outcome = result.unwrap();
+        assert_eq!(outcome.payload["replacements_made"], 3);
+        assert_eq!(fs::read_to_string(&target).unwrap(), "b\nb\nb\n");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn file_edit_empty_old_string_errors() {
+        let base = unique_temp_dir("loongclaw-file-edit-empty");
+        let root = base.join("root");
+        fs::create_dir_all(&root).expect("create root");
+        fs::write(root.join("file.txt"), "hello").expect("write");
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let err = execute_file_edit_tool_with_config(
+            make_edit_request("file.txt", "", "x", None),
+            &config,
+        )
+        .expect_err("should fail");
+        assert!(err.contains("old_string must not be empty"), "got: {err}");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_edit_rejects_path_escape() {
+        let base = unique_temp_dir("loongclaw-file-edit-escape");
+        let root = base.join("root");
+        let outside = base.join("outside");
+        fs::create_dir_all(&root).expect("create root");
+        fs::create_dir_all(&outside).expect("create outside");
+
+        let outside_file = outside.join("secret.txt");
+        fs::write(&outside_file, "secret content here").expect("write outside");
+        let link = root.join("escape-link");
+        assert!(create_symlink(&outside_file, &link).is_ok());
+
+        let config = ToolRuntimeConfig {
+            file_root: Some(root),
+            ..ToolRuntimeConfig::default()
+        };
+        let err = execute_file_edit_tool_with_config(
+            make_edit_request("escape-link", "secret", "pwned", None),
+            &config,
+        )
+        .expect_err("escape denied");
+
+        assert!(err.starts_with("policy_denied: "));
+        assert!(err.contains("escapes configured file root"));
         let _ = fs::remove_dir_all(base);
     }
 }

--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -135,6 +135,8 @@ pub(super) fn execute_file_edit_tool_with_config(
         let path = payload
             .get("path")
             .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
             .ok_or_else(|| "file.edit requires payload.path (string)".to_owned())?;
         let old_string = payload
             .get("old_string")

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -237,6 +237,24 @@ mod tests {
     }
 
     #[test]
+    fn denies_file_edit_without_capability() {
+        let ext = FilePolicyExtension::new(None);
+        let pack = test_pack();
+        let token = token_with_caps(BTreeSet::from([Capability::InvokeTool]));
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({
+            "tool_name": "file.edit",
+            "payload": {"path": "foo.txt", "old_string": "a", "new_string": "b"}
+        });
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        let result = ext.authorize_extension(&ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            PolicyError::ExtensionDenied { .. }
+        ));
+    }
+
+    #[test]
     fn denies_file_read_without_capability() {
         let ext = FilePolicyExtension::new(None);
         let pack = test_pack();

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -31,7 +31,7 @@ impl FilePolicyExtension {
     fn required_capability(tool_name: &str) -> Option<Capability> {
         match tool_name {
             "file.read" | "claw.migrate" => Some(Capability::FilesystemRead),
-            "file.write" => Some(Capability::FilesystemWrite),
+            "file.write" | "file.edit" => Some(Capability::FilesystemWrite),
             _ => None,
         }
     }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -701,6 +701,7 @@ fn execute_discoverable_tool_core_with_config(
         "shell.exec" => shell::execute_shell_tool_with_config(request, config),
         "file.read" => file::execute_file_read_tool_with_config(request, config),
         "file.write" => file::execute_file_write_tool_with_config(request, config),
+        "file.edit" => file::execute_file_edit_tool_with_config(request, config),
         "provider.switch" => {
             provider_switch::execute_provider_switch_tool_with_config(request, config)
         }
@@ -1744,7 +1745,7 @@ mod tests {
     fn tool_registry_returns_runtime_discoverable_tools_for_default_config() {
         let config = runtime_config::ToolRuntimeConfig::default();
         let entries = tool_registry_with_config(Some(&config));
-        assert_eq!(entries.len(), 23);
+        assert_eq!(entries.len(), 24);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"approval_request_resolve"));
         assert!(names.contains(&"approval_request_status"));
@@ -1757,6 +1758,7 @@ mod tests {
         assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"file.edit"));
         assert!(names.contains(&"provider.switch"));
         assert!(names.contains(&"session_archive"));
         assert!(names.contains(&"session_cancel"));

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -445,7 +445,7 @@ fn required_capabilities_for_tool_name_and_payload(
         "file.read" => {
             caps.insert(Capability::FilesystemRead);
         }
-        "file.write" => {
+        "file.write" | "file.edit" => {
             caps.insert(Capability::FilesystemWrite);
         }
         "claw.migrate" => {
@@ -1790,7 +1790,7 @@ mod tests {
     fn tool_registry_returns_runtime_discoverable_tools_for_default_config_no_websearch() {
         let config = runtime_config::ToolRuntimeConfig::default();
         let entries = tool_registry_with_config(Some(&config));
-        assert_eq!(entries.len(), 22);
+        assert_eq!(entries.len(), 23);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"approval_request_resolve"));
         assert!(names.contains(&"approval_request_status"));
@@ -1803,6 +1803,7 @@ mod tests {
         assert!(names.contains(&"delegate_async"));
         assert!(names.contains(&"file.read"));
         assert!(names.contains(&"file.write"));
+        assert!(names.contains(&"file.edit"));
         assert!(names.contains(&"provider.switch"));
         assert!(names.contains(&"session_archive"));
         assert!(names.contains(&"session_cancel"));
@@ -2193,6 +2194,15 @@ mod tests {
         };
         assert_eq!(
             required_capabilities_for_request(&direct_file_write),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemWrite])
+        );
+
+        let direct_file_edit = ToolCoreRequest {
+            tool_name: "file.edit".to_owned(),
+            payload: json!({"path": "notes.txt", "old_string": "a", "new_string": "b"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_file_edit),
             BTreeSet::from([Capability::InvokeTool, Capability::FilesystemWrite])
         );
 


### PR DESCRIPTION
## Summary

- Problem: `loongclaw` has `file.read` and `file.write` but no precise in-place text replacement tool. Agents must rewrite entire files to make edits, which is fragile and expensive.
- Why it matters: `file.edit` is the most-used tool in coding agent workflows — without it, agents cannot make targeted changes and must fall back to full-file rewrites.
- What changed: Added `file.edit` tool with `old_string`/`new_string` replacement semantics, unique-match validation, path sandboxing, catalog registration, and 6 tests.
- What did not change (scope boundary): No changes to kernel, contracts, protocol, or any existing tool behavior. Auto-install or shell-level integration is out of scope.

## Linked Issues
- Closes #297
- Related #292

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas

Commands and evidence:

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.46s

$ cargo test --workspace --all-features
test tools::file::tests::file_edit_empty_old_string_errors ... ok
test tools::file::tests::file_edit_multiple_match_without_replace_all_errors ... ok
test tools::file::tests::file_edit_no_match_errors ... ok
test tools::file::tests::file_edit_rejects_path_escape ... ok
test tools::file::tests::file_edit_replace_all_replaces_all_occurrences ... ok
test tools::file::tests::file_edit_single_match_succeeds ... ok
test result: ok. 1722 passed; 0 failed; 0 ignored

$ task verify
[fmt] ok
[lint:strict] ok
[check:architecture:strict] passed: architectural boundaries are within configured budgets
[check:dep-graph] PASSED: all workspace edges match architecture contract
```

## User-visible / Operator-visible Changes

New tool available to agents:

```
file.edit(path, old_string, new_string, replace_all?)
```

- `old_string` must be a non-empty literal substring
- Default: must match exactly once — 0 or >1 matches both fail
- `replace_all: true`: replaces all occurrences (0 matches still fails)
- Returns `replacements_made` and `bytes_written` in outcome payload

## Failure Recovery

- Fast rollback or disable path: Revert the 4 changed files. No state is mutated at rest — the tool is purely read-modify-write on a single file per call. Disabling `tool-file` feature removes all file tools including `file.edit`.
- Observable failure symptoms reviewers should watch for: `edit_failed:` prefix in error responses (not found / multiple matches / empty pattern); `policy_denied:` for path escape attempts.

## Reviewer Focus

- `crates/app/src/tools/file.rs` — core logic: empty-string guard, `str::matches()` count, single vs replace_all branch, `replacements_made` vs `match_count` separation
- `crates/app/src/tools/file_policy_ext.rs` — one-line change adding `"file.edit"` to `FilesystemWrite` arm; verify it mirrors `file.write` intent
- `crates/app/src/tools/mod.rs` — dispatch arm + registry count updated from 23 → 24
- `crates/app/src/tools/catalog.rs` — descriptor, JSON Schema description (especially `old_string` / `replace_all` semantics), and all metadata tables


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a file editing tool to find-and-replace text inside files, with optional replace-all behavior.
* **Bug Fixes**
  * Enforced input validation and safety checks to prevent empty matches, unintended multi-replacements, and unauthorized path access.
  * Ensured the tool now requires write permission before running.
* **Tests**
  * Added unit tests covering single/multi replacements, no-match and invalid-input cases, and permission enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->