### PR TITLE
fix(feishu): install a rustls provider before websocket tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
+ "rustls",
  "scraper",
  "serde",
  "serde_json",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 default = ["channel-cli", "channel-telegram", "channel-feishu", "channel-matrix", "config-toml", "memory-sqlite", "feishu-integration", "tool-shell", "tool-file", "tool-browser", "tool-webfetch", "tool-websearch", "provider-openai", "provider-anthropic", "provider-bedrock", "provider-volcengine"]
 channel-cli = []
 channel-telegram = []
-channel-feishu = ["dep:axum", "dep:aes", "dep:cbc", "dep:prost", "dep:tokio-tungstenite", "feishu-integration"]
+channel-feishu = ["dep:axum", "dep:aes", "dep:cbc", "dep:prost", "dep:rustls", "dep:tokio-tungstenite", "feishu-integration"]
 channel-matrix = []
 provider-openai = []
 provider-anthropic = []
@@ -54,6 +54,7 @@ cbc = { version = "0.1", optional = true }
 wait-timeout = "0.2"
 regex = { workspace = true, optional = true }
 prost = { version = "0.13", optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"], optional = true }
 
 [dev-dependencies]

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use axum::http::StatusCode;
@@ -34,6 +34,16 @@ const FRAME_TYPE_CONTROL: i32 = 0;
 const FRAME_TYPE_DATA: i32 = 1;
 const DEFAULT_WS_RECONNECT_INTERVAL_S: u64 = 120;
 const DEFAULT_WS_PING_INTERVAL_S: u64 = 120;
+
+fn ensure_feishu_websocket_rustls_provider() {
+    static RUSTLS_PROVIDER_INIT: OnceLock<()> = OnceLock::new();
+
+    RUSTLS_PROVIDER_INIT.get_or_init(|| {
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        }
+    });
+}
 
 #[derive(Clone, PartialEq, prost::Message)]
 struct FeishuWsHeader {
@@ -246,6 +256,10 @@ async fn run_feishu_websocket_session(
         .unwrap_or(DEFAULT_WS_PING_INTERVAL_S)
         .max(1);
 
+    // Feishu already uses reqwest's ring-backed rustls path for HTTP calls in the same flow.
+    // Install the same process default once so websocket TLS does not panic when other crates
+    // also link rustls with aws-lc-rs enabled.
+    ensure_feishu_websocket_rustls_provider();
     let (mut stream, _) = connect_async(parsed_url.as_str())
         .await
         .map_err(|error| format!("connect Feishu websocket failed: {error}"))?;
@@ -741,6 +755,83 @@ mod tests {
             !error.to_string().contains("TLS support not compiled in"),
             "wss support must be compiled in for Feishu websocket mode: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn feishu_websocket_wss_session_surfaces_tls_errors_without_panicking() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let (provider_base_url, provider_server) =
+            spawn_mock_provider_server(provider_requests.clone()).await;
+        let (feishu_base_url, feishu_server) =
+            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_ws_tls_1").await;
+
+        let config = test_websocket_config(&provider_base_url, &feishu_base_url);
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve websocket feishu account");
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before websocket tls test");
+        let kernel_ctx =
+            bootstrap_test_kernel_context("feishu-websocket-wss-test", DEFAULT_TOKEN_TTL_S)
+                .expect("bootstrap kernel context");
+        let runtime = Arc::new(
+            ChannelOperationRuntimeTracker::start(
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+            )
+            .await
+            .expect("start runtime tracker"),
+        );
+        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock tls listener");
+        let address = listener.local_addr().expect("mock tls listener addr");
+        let accept_task = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.expect("accept mock tls socket");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            drop(socket);
+        });
+
+        let session_url = format!("wss://{address}/events?service_id=42");
+        let session_join = tokio::time::timeout(
+            Duration::from_secs(5),
+            tokio::spawn(async move {
+                run_feishu_websocket_session(
+                    &state,
+                    session_url.as_str(),
+                    &FeishuWsEndpointClientConfig::default(),
+                )
+                .await
+            }),
+        )
+        .await
+        .expect("wss session should not hang");
+        let session_error = session_join
+            .expect("wss session should return a recoverable error instead of panicking")
+            .expect_err("plain tcp listener should not complete a tls websocket session");
+        assert!(
+            session_error.starts_with("connect Feishu websocket failed:"),
+            "unexpected websocket tls session result: {session_error}"
+        );
+        assert!(
+            !session_error
+                .contains("Could not automatically determine the process-level CryptoProvider"),
+            "wss session should not panic when rustls has multiple providers enabled: {session_error}"
+        );
+
+        accept_task.abort();
+        let _ = accept_task.await;
+        provider_server.abort();
+        feishu_server.abort();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Problem: `loongclaw feishu-serve` can panic in the Feishu websocket TLS path when `rustls` is compiled with both `aws-lc-rs` and `ring`, and `tokio-tungstenite` reaches `ClientConfig::builder()` before any process-default provider is installed.
- Why it matters: the Feishu websocket path crashes the process instead of surfacing a recoverable connection error, which blocks normal startup on both macOS and Ubuntu.
- What changed:
  - add a `channel-feishu`-scoped optional `rustls` dependency with the `ring` feature enabled
  - install `ring` as the process-default `rustls` provider once before `connect_async(...)`
  - add a regression test that reaches the WSS TLS handshake path and asserts we return an error instead of panicking
- What did not change (scope boundary): this does not rewrite the broader `rustls` dependency graph or change Feishu HTTP behavior outside the websocket path.

## Linked Issues

- Closes #381
- Closes #383

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: not applicable; this change does not alter config/env fallbacks or defaults
- [x] If tests mutate process-global env: not applicable; the regression test does not mutate env vars, and the process-global `rustls` provider install matches the production websocket path

Commands and evidence:

```text
cargo tree -i rustls -e features | rg 'rustls v|aws-smithy-http-client|reqwest|tokio-tungstenite|feature "aws|feature "ring'
# confirmed the mixed-provider graph: aws-smithy-http-client brings aws-lc-rs while reqwest/tokio-tungstenite bring ring

cargo fmt --all -- --check
# passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
# passed

cargo test -p loongclaw-app feishu_websocket_wss_session_surfaces_tls_errors_without_panicking
# passed; the websocket tls path now returns a recoverable error instead of panicking

cargo test --workspace --locked
# passed

cargo test --workspace --all-features --locked
# passed
```

## User-visible / Operator-visible Changes

- `loongclaw feishu-serve` no longer panics when the Feishu websocket TLS path is initialized in a mixed-provider `rustls` build; failed TLS setup now surfaces as a normal connection error.

## Failure Recovery

- Fast rollback or disable path: revert this commit, or temporarily avoid the websocket serve path and use the non-websocket Feishu flow while investigating.
- Observable failure symptoms reviewers should watch for: unexpected websocket TLS initialization errors or any regressions caused by the process-global `rustls` provider being installed earlier in process lifetime.

## Reviewer Focus

- Please focus on the `rustls` provider initialization in `crates/app/src/channel/feishu/websocket.rs` and the regression test that exercises the WSS TLS handshake path without relying on a real TLS server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved WebSocket TLS connection stability by ensuring proper cryptographic provider initialization before establishing connections.
  * Enhanced error handling for WebSocket TLS failures, allowing connections to fail gracefully with meaningful error messages instead of unexpected hangs.

* **Tests**
  * Added comprehensive test coverage for WebSocket TLS error scenarios to prevent regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->