### PR TITLE
fix: add provider route diagnostics for transport-style failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
  "loongclaw-kernel",
  "loongclaw-spec",
  "rand 0.9.2",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",

--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ addition to the existing runtime checks. For durable modes (`fanout` or
 `audit summary` when you want a compact kind/count rollup plus last-seen
 fields. Raw `tail` remains a fallback when you need the original JSONL lines.
 
+When provider model probing fails before any HTTP status is returned, `doctor`
+now adds a provider route probe for the active request/models host. That probe
+surfaces the host and port, DNS resolution results, fake-ip-style addresses,
+and a short TCP reachability check so you can separate local proxy/TUN/fake-ip
+instability from true upstream unavailability.
+
 ## Configuration
 
 `loongclaw onboard` uses `provider.api_key` to reference provider credentials, so secrets stay

--- a/crates/app/src/provider/catalog_executor.rs
+++ b/crates/app/src/provider/catalog_executor.rs
@@ -160,10 +160,21 @@ pub(super) async fn fetch_available_models_with_policy(
                     backoff_ms = next_backoff_ms;
                     continue;
                 }
-                return Err(format!(
-                    "provider model-list request failed on attempt {attempt}/{max_attempts}: {error}",
+                let error_message = error.to_string();
+                let mut message = format!(
+                    "provider model-list request failed on attempt {attempt}/{max_attempts}: {error_message}",
                     max_attempts = runtime.request_policy.max_attempts
-                ));
+                );
+                if let Some(route_hint) = transport::render_transport_route_hint(
+                    request_endpoint.as_str(),
+                    error_message.as_str(),
+                    error.is_timeout(),
+                    error.is_connect(),
+                ) {
+                    message.push(' ');
+                    message.push_str(route_hint.as_str());
+                }
+                return Err(message);
             }
             Err(transport::RequestExecutionError::Setup(error)) => {
                 return Err(format!(

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -365,12 +365,23 @@ where
                     backoff_ms = next_backoff_ms;
                     continue;
                 }
+                let error_message = error.to_string();
+                let mut message = format!(
+                    "provider request failed for model `{}` on attempt {attempt}/{max_attempts}: {error_message}",
+                    runtime.model,
+                    max_attempts = runtime.request_policy.max_attempts
+                );
+                if let Some(route_hint) = transport::render_transport_route_hint(
+                    request_endpoint.as_str(),
+                    error_message.as_str(),
+                    error.is_timeout(),
+                    error.is_connect(),
+                ) {
+                    message.push(' ');
+                    message.push_str(route_hint.as_str());
+                }
                 return Err(build_model_request_error(
-                    format!(
-                        "provider request failed for model `{}` on attempt {attempt}/{max_attempts}: {error}",
-                        runtime.model,
-                        max_attempts = runtime.request_policy.max_attempts
-                    ),
+                    message,
                     false,
                     ProviderFailoverReason::TransportFailure,
                     ProviderFailoverStage::TransportFailure,

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -149,6 +149,66 @@ pub(super) fn resolve_request_url(
     Ok(url.replace("<region>", region))
 }
 
+fn request_host_label(url: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    let host = parsed.host_str()?;
+    let port = parsed.port_or_known_default()?;
+    Some(format!("{host}:{port}"))
+}
+
+fn message_looks_like_dns_failure(message: &str) -> bool {
+    message.contains("dns")
+        || message.contains("lookup address")
+        || message.contains("name or service not known")
+        || message.contains("nodename nor servname")
+        || message.contains("temporary failure in name resolution")
+        || message.contains("failed to lookup address information")
+        || message.contains("no such host")
+}
+
+fn message_looks_like_proxy_route_failure(message: &str) -> bool {
+    message.contains("proxy")
+        || message.contains("tunnel")
+        || message.contains("socks")
+        || message.contains("tun")
+}
+
+pub(super) fn render_transport_route_hint(
+    url: &str,
+    error_message: &str,
+    is_timeout: bool,
+    is_connect: bool,
+) -> Option<String> {
+    let host = request_host_label(url)?;
+    let lower = error_message.to_ascii_lowercase();
+
+    if is_timeout {
+        return Some(format!(
+            "request host {host}: the transport timed out before an HTTP response arrived. if you're using a proxy/TUN/fake-ip setup, verify that the route stays healthy for longer-lived requests, then run `loongclaw doctor` to inspect provider route diagnostics"
+        ));
+    }
+
+    if is_connect && message_looks_like_dns_failure(lower.as_str()) {
+        return Some(format!(
+            "request host {host}: dns resolution failed before the request reached the provider. check local dns / proxy / TUN rules, then run `loongclaw doctor` to inspect provider route diagnostics"
+        ));
+    }
+
+    if message_looks_like_proxy_route_failure(lower.as_str()) {
+        return Some(format!(
+            "request host {host}: the transport failed while crossing a proxy/TUN route. verify that the local proxy path is healthy, then run `loongclaw doctor` to inspect provider route diagnostics"
+        ));
+    }
+
+    if is_connect {
+        return Some(format!(
+            "request host {host}: the connection failed before an HTTP status was returned. this usually points to dns, proxy/TUN routing, or another local network-path problem. run `loongclaw doctor` to inspect provider route diagnostics"
+        ));
+    }
+
+    None
+}
+
 pub(super) fn build_request_headers_without_provider_auth(
     provider: &ProviderConfig,
 ) -> CliResult<HeaderMap> {
@@ -506,6 +566,36 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("custom-key")
         );
+    }
+
+    #[test]
+    fn render_transport_route_hint_identifies_dns_failures() {
+        let hint = render_transport_route_hint(
+            "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
+            "dns error: failed to lookup address information: nodename nor servname provided, or not known",
+            false,
+            true,
+        )
+        .expect("dns failure should surface a route hint");
+
+        assert!(hint.contains("ark.cn-beijing.volces.com:443"));
+        assert!(hint.contains("dns"));
+        assert!(hint.contains("loongclaw doctor"));
+    }
+
+    #[test]
+    fn render_transport_route_hint_identifies_proxy_timeout_failures() {
+        let hint = render_transport_route_hint(
+            "https://api.openai.com/v1/chat/completions",
+            "operation timed out",
+            true,
+            false,
+        )
+        .expect("timeouts should surface a route hint");
+
+        assert!(hint.contains("api.openai.com:443"));
+        assert!(hint.contains("proxy"));
+        assert!(hint.contains("TUN"));
     }
 
     #[cfg(feature = "provider-bedrock")]

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -156,8 +156,14 @@ fn request_host_label(url: &str) -> Option<String> {
     Some(format!("{host}:{port}"))
 }
 
+fn message_contains_token(message: &str, token: &str) -> bool {
+    message
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|part| part == token)
+}
+
 fn message_looks_like_dns_failure(message: &str) -> bool {
-    message.contains("dns")
+    message_contains_token(message, "dns")
         || message.contains("lookup address")
         || message.contains("name or service not known")
         || message.contains("nodename nor servname")
@@ -170,7 +176,9 @@ fn message_looks_like_proxy_route_failure(message: &str) -> bool {
     message.contains("proxy")
         || message.contains("tunnel")
         || message.contains("socks")
-        || message.contains("tun")
+        || message_contains_token(message, "tun")
+        || message.contains("utun")
+        || message.contains("tun0")
 }
 
 pub(super) fn render_transport_route_hint(
@@ -596,6 +604,21 @@ mod tests {
         assert!(hint.contains("api.openai.com:443"));
         assert!(hint.contains("proxy"));
         assert!(hint.contains("TUN"));
+    }
+
+    #[test]
+    fn render_transport_route_hint_does_not_treat_tuning_as_proxy_route_failure() {
+        let hint = render_transport_route_hint(
+            "https://api.openai.com/v1/chat/completions",
+            "provider tuning metadata could not be loaded",
+            false,
+            false,
+        );
+
+        assert!(
+            hint.is_none(),
+            "unrelated words like `tuning` should not be classified as proxy/TUN transport failures: {hint:#?}"
+        );
     }
 
     #[cfg(feature = "provider-bedrock")]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -43,6 +43,7 @@ loongclaw-app = { path = "../app", default-features = false }
 loongclaw-spec = { path = "../spec" }
 serde.workspace = true
 serde_json.workspace = true
+reqwest.workspace = true
 tokio.workspace = true
 time.workspace = true
 toml.workspace = true

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -82,7 +82,22 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
                 level: DoctorCheckLevel::Pass,
                 detail: format!("{} model(s) available", models.len()),
             }),
-            Err(error) => checks.push(provider_model_probe_failure_check(&config, error)),
+            Err(error) => {
+                let transport_style_failure =
+                    crate::provider_route_diagnostics::is_transport_style_model_probe_failure(
+                        error.as_str(),
+                    );
+                checks.push(provider_model_probe_failure_check(&config, error));
+                if transport_style_failure
+                    && let Some(route_probe) =
+                        crate::provider_route_diagnostics::collect_provider_route_probe(
+                            &config.provider,
+                        )
+                        .await
+                {
+                    checks.push(provider_route_probe_doctor_check(&route_probe));
+                }
+            }
         }
     }
 
@@ -1210,6 +1225,26 @@ fn provider_transport_doctor_check(provider: &mvp::config::ProviderConfig) -> Do
     }
 }
 
+fn provider_route_probe_doctor_check(
+    probe: &crate::provider_route_diagnostics::ProviderRouteProbe,
+) -> DoctorCheck {
+    DoctorCheck {
+        name: crate::provider_route_diagnostics::PROVIDER_ROUTE_PROBE_CHECK_NAME.to_owned(),
+        level: match probe.level {
+            crate::provider_route_diagnostics::ProviderRouteProbeLevel::Pass => {
+                DoctorCheckLevel::Pass
+            }
+            crate::provider_route_diagnostics::ProviderRouteProbeLevel::Warn => {
+                DoctorCheckLevel::Warn
+            }
+            crate::provider_route_diagnostics::ProviderRouteProbeLevel::Fail => {
+                DoctorCheckLevel::Fail
+            }
+        },
+        detail: probe.detail.clone(),
+    }
+}
+
 fn provider_credentials_doctor_check(
     config: &mvp::config::LoongClawConfig,
     has_provider_credentials: bool,
@@ -1248,6 +1283,16 @@ fn provider_model_probe_failure_check(
     error: String,
 ) -> DoctorCheck {
     let provider_prefix = crate::provider_presentation::active_provider_detail_label(config);
+    if crate::provider_route_diagnostics::is_transport_style_model_probe_failure(error.as_str()) {
+        return DoctorCheck {
+            name: "provider model probe".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: format!(
+                "{provider_prefix}: {} ({error}); runtime could not verify the provider route. inspect the provider route probe below and retry once dns / proxy / TUN routing is stable",
+                crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER
+            ),
+        };
+    }
     let auth_style_failure = mvp::provider::is_auth_style_failure_message(error.as_str());
     let append_region_hint = |mut detail: String| {
         if auth_style_failure && let Some(hint) = config.provider.region_endpoint_failure_hint() {
@@ -1483,61 +1528,101 @@ fn build_doctor_next_steps_with_path_env(
     if checks.iter().any(|check| {
         check.name == "provider model probe"
             && check.level != DoctorCheckLevel::Pass
-            && check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
+            && (check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
+                || check.detail.contains(
+                    crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER,
+                ))
     }) {
-        let provider_model_probe_auth_failure = checks.iter().any(|check| {
+        let provider_model_probe_transport_failure = checks.iter().any(|check| {
             check.name == "provider model probe"
                 && check.level != DoctorCheckLevel::Pass
-                && check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
-                && mvp::provider::is_auth_style_failure_message(check.detail.as_str())
+                && check.detail.contains(
+                    crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER,
+                )
         });
-        match config.provider.model_catalog_probe_recovery() {
-            mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
-                recommended_onboarding_model: Some(model),
-            } => {
+        if provider_model_probe_transport_failure {
+            if checks.iter().any(|check| {
+                check.name == crate::provider_route_diagnostics::PROVIDER_ROUTE_PROBE_CHECK_NAME
+                    && check.level != DoctorCheckLevel::Pass
+            }) {
                 push_unique_step(
                     &mut steps,
                     format!(
-                        "Rerun onboarding and accept reviewed model `{model}`: {rerun_onboard_command}"
+                        "Fix the active provider route (DNS / proxy / TUN), then re-run diagnostics: {rerun_command}"
                     ),
                 );
+                if checks.iter().any(|check| {
+                    check.name == crate::provider_route_diagnostics::PROVIDER_ROUTE_PROBE_CHECK_NAME
+                        && check.detail.contains("fake-ip-style")
+                }) {
+                    push_unique_step(
+                        &mut steps,
+                        "If the provider host should bypass proxying, add it to your direct/bypass rules; otherwise keep the fake-ip/TUN proxy healthy before retrying.".to_owned(),
+                    );
+                }
+            } else {
                 push_unique_step(
                     &mut steps,
                     format!(
-                        "Or set `provider.model` / `preferred_models` explicitly, then re-run diagnostics: {rerun_command}"
-                    ),
-                );
-            }
-            mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
-                recommended_onboarding_model: None,
-            } => {
-                push_unique_step(
-                    &mut steps,
-                    format!(
-                        "Set `provider.model` / `preferred_models` explicitly, then re-run diagnostics: {rerun_command}"
-                    ),
-                );
-            }
-            mvp::config::ModelCatalogProbeRecovery::ExplicitModel(_)
-            | mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(_) => {
-                push_unique_step(
-                    &mut steps,
-                    format!(
-                        "Retry provider probe only after credentials are ready: {rerun_command}"
-                    ),
-                );
-                push_unique_step(
-                    &mut steps,
-                    format!(
-                        "If your provider blocks model listing during setup, retry with: {rerun_command} --skip-model-probe"
+                        "Re-run diagnostics after checking the active provider route: {rerun_command}"
                     ),
                 );
             }
-        }
-        if provider_model_probe_auth_failure
-            && let Some(hint) = config.provider.region_endpoint_failure_hint()
-        {
-            push_unique_step(&mut steps, hint);
+        } else {
+            let provider_model_probe_auth_failure = checks.iter().any(|check| {
+                check.name == "provider model probe"
+                    && check.level != DoctorCheckLevel::Pass
+                    && check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
+                    && mvp::provider::is_auth_style_failure_message(check.detail.as_str())
+            });
+            match config.provider.model_catalog_probe_recovery() {
+                mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+                    recommended_onboarding_model: Some(model),
+                } => {
+                    push_unique_step(
+                        &mut steps,
+                        format!(
+                            "Rerun onboarding and accept reviewed model `{model}`: {rerun_onboard_command}"
+                        ),
+                    );
+                    push_unique_step(
+                        &mut steps,
+                        format!(
+                            "Or set `provider.model` / `preferred_models` explicitly, then re-run diagnostics: {rerun_command}"
+                        ),
+                    );
+                }
+                mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+                    recommended_onboarding_model: None,
+                } => {
+                    push_unique_step(
+                        &mut steps,
+                        format!(
+                            "Set `provider.model` / `preferred_models` explicitly, then re-run diagnostics: {rerun_command}"
+                        ),
+                    );
+                }
+                mvp::config::ModelCatalogProbeRecovery::ExplicitModel(_)
+                | mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(_) => {
+                    push_unique_step(
+                        &mut steps,
+                        format!(
+                            "Retry provider probe only after credentials are ready: {rerun_command}"
+                        ),
+                    );
+                    push_unique_step(
+                        &mut steps,
+                        format!(
+                            "If your provider blocks model listing during setup, retry with: {rerun_command} --skip-model-probe"
+                        ),
+                    );
+                }
+            }
+            if provider_model_probe_auth_failure
+                && let Some(hint) = config.provider.region_endpoint_failure_hint()
+            {
+                push_unique_step(&mut steps, hint);
+            }
         }
     }
 
@@ -2063,6 +2148,30 @@ mod tests {
         assert!(
             check.detail.contains("explicitly configured"),
             "doctor should explain that explicit-model runtime may still work when catalog probing fails: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_transport_failure_prioritizes_route_guidance() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.model = "custom-explicit-model".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider model-list request failed on attempt 3/3: operation timed out".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(
+            check
+                .detail
+                .contains(crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER),
+            "transport probe failures should use the route-focused marker: {check:#?}"
+        );
+        assert!(
+            !check.detail.contains("provider.model"),
+            "transport probe failures should not suggest model-selection repair when the route is the real blocker: {check:#?}"
         );
     }
 
@@ -3235,6 +3344,48 @@ mod tests {
                 step == "If your provider blocks model listing during setup, retry with: loongclaw doctor --config '/tmp/loongclaw.toml' --skip-model-probe"
             }),
             "warn-level preferred-model recovery should still keep the skip-model-probe escape hatch visible: {next_steps:#?}"
+        );
+    }
+
+    #[test]
+    fn build_doctor_next_steps_guides_provider_route_probe_repairs() {
+        let checks = vec![
+            DoctorCheck {
+                name: "provider model probe".to_owned(),
+                level: DoctorCheckLevel::Fail,
+                detail:
+                    "OpenAI [openai]: model catalog transport failed (provider model-list request failed on attempt 3/3: operation timed out)"
+                        .to_owned(),
+            },
+            DoctorCheck {
+                name: "provider route probe".to_owned(),
+                level: DoctorCheckLevel::Warn,
+                detail:
+                    "request/models host api.openai.com:443: dns resolved to 198.18.0.2 (fake-ip-style); tcp connect ok. the route currently depends on local fake-ip/TUN interception."
+                        .to_owned(),
+            },
+        ];
+
+        let next_steps = build_doctor_next_steps_with_path_env(
+            &checks,
+            Path::new("/tmp/loongclaw.toml"),
+            &mvp::config::LoongClawConfig::default(),
+            false,
+            Some(std::ffi::OsStr::new("")),
+        );
+
+        assert!(
+            next_steps.iter().any(|step| {
+                step.contains("provider route")
+                    && step.contains("loongclaw doctor --config '/tmp/loongclaw.toml'")
+            }),
+            "route-probe findings should produce a concrete diagnostics rerun step: {next_steps:#?}"
+        );
+        assert!(
+            next_steps.iter().any(|step| {
+                step.contains("fake-ip") || step.contains("direct/bypass") || step.contains("proxy")
+            }),
+            "route-probe findings should explain how to repair proxy/fake-ip routing instead of leaving recovery implicit: {next_steps:#?}"
         );
     }
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1288,7 +1288,7 @@ fn provider_model_probe_failure_check(
             name: "provider model probe".to_owned(),
             level: DoctorCheckLevel::Fail,
             detail: format!(
-                "{provider_prefix}: {} ({error}); runtime could not verify the provider route. inspect the provider route probe below and retry once dns / proxy / TUN routing is stable",
+                "{provider_prefix}: {} ({error}); runtime could not verify the provider route. inspect provider route diagnostics and retry once dns / proxy / TUN routing is stable",
                 crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER
             ),
         };
@@ -2172,6 +2172,10 @@ mod tests {
         assert!(
             !check.detail.contains("provider.model"),
             "transport probe failures should not suggest model-selection repair when the route is the real blocker: {check:#?}"
+        );
+        assert!(
+            !check.detail.contains("below"),
+            "doctor should not promise a later route-probe section that may not exist when collection is unavailable: {check:#?}"
         );
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -52,6 +52,7 @@ pub mod next_actions;
 pub mod onboard_cli;
 pub mod onboard_presentation;
 pub mod provider_presentation;
+mod provider_route_diagnostics;
 pub mod runtime_capability_cli;
 pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2250,7 +2250,22 @@ async fn run_preflight_checks(
                 detail: format!("{} model(s) available", models.len()),
                 non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
             }),
-            Err(error) => checks.push(provider_model_probe_failure_check(config, error)),
+            Err(error) => {
+                let transport_style_failure =
+                    crate::provider_route_diagnostics::is_transport_style_model_probe_failure(
+                        error.as_str(),
+                    );
+                checks.push(provider_model_probe_failure_check(config, error));
+                if transport_style_failure
+                    && let Some(route_probe) =
+                        crate::provider_route_diagnostics::collect_provider_route_probe(
+                            &config.provider,
+                        )
+                        .await
+                {
+                    checks.push(provider_route_probe_preflight_check(&route_probe));
+                }
+            }
         }
     }
 
@@ -2293,6 +2308,17 @@ fn provider_model_probe_failure_check(
     error: String,
 ) -> OnboardCheck {
     let provider_prefix = provider_check_detail_prefix(config);
+    if crate::provider_route_diagnostics::is_transport_style_model_probe_failure(error.as_str()) {
+        return OnboardCheck {
+            name: "provider model probe",
+            level: OnboardCheckLevel::Fail,
+            detail: format!(
+                "{provider_prefix}: {} ({error}); runtime could not verify the provider route. inspect the provider route probe below and retry once dns / proxy / TUN routing is stable",
+                crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER
+            ),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+        };
+    }
     let auth_style_failure = mvp::provider::is_auth_style_failure_message(error.as_str());
     let append_region_hint = |mut detail: String| {
         if auth_style_failure && let Some(hint) = config.provider.region_endpoint_failure_hint() {
@@ -2474,6 +2500,27 @@ fn provider_transport_check(config: &mvp::config::LoongClawConfig) -> OnboardChe
             mvp::config::ProviderTransportReadinessLevel::Unsupported => OnboardCheckLevel::Fail,
         },
         detail: readiness.detail,
+        non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+    }
+}
+
+fn provider_route_probe_preflight_check(
+    probe: &crate::provider_route_diagnostics::ProviderRouteProbe,
+) -> OnboardCheck {
+    OnboardCheck {
+        name: crate::provider_route_diagnostics::PROVIDER_ROUTE_PROBE_CHECK_NAME,
+        level: match probe.level {
+            crate::provider_route_diagnostics::ProviderRouteProbeLevel::Pass => {
+                OnboardCheckLevel::Pass
+            }
+            crate::provider_route_diagnostics::ProviderRouteProbeLevel::Warn => {
+                OnboardCheckLevel::Warn
+            }
+            crate::provider_route_diagnostics::ProviderRouteProbeLevel::Fail => {
+                OnboardCheckLevel::Fail
+            }
+        },
+        detail: probe.detail.clone(),
         non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
     }
 }
@@ -6840,6 +6887,30 @@ mod tests {
         assert!(
             check.detail.contains("explicitly configured"),
             "explicit-model probe failures should explain that catalog discovery is advisory: {check:#?}"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_transport_failure_prioritizes_route_guidance() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.model = "custom-explicit-model".to_owned();
+
+        let check = provider_model_probe_failure_check(
+            &config,
+            "provider model-list request failed on attempt 3/3: operation timed out".to_owned(),
+        );
+
+        assert_eq!(check.name, "provider model probe");
+        assert_eq!(check.level, OnboardCheckLevel::Fail);
+        assert!(
+            check
+                .detail
+                .contains(crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER),
+            "transport probe failures should use the route-focused marker during onboarding: {check:#?}"
+        );
+        assert!(
+            !check.detail.contains("provider.model"),
+            "transport probe failures should not suggest model-selection repair when the route is the real blocker: {check:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2313,7 +2313,7 @@ fn provider_model_probe_failure_check(
             name: "provider model probe",
             level: OnboardCheckLevel::Fail,
             detail: format!(
-                "{provider_prefix}: {} ({error}); runtime could not verify the provider route. inspect the provider route probe below and retry once dns / proxy / TUN routing is stable",
+                "{provider_prefix}: {} ({error}); runtime could not verify the provider route. inspect provider route diagnostics and retry once dns / proxy / TUN routing is stable",
                 crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER
             ),
             non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
@@ -2420,8 +2420,23 @@ fn non_interactive_preflight_failure_message(checks: &[OnboardCheck]) -> String 
     let detail = checks
         .iter()
         .find(|check| check.level == OnboardCheckLevel::Fail)
-        .map(|check| check.detail.as_str())
-        .unwrap_or("preflight checks failed");
+        .map(|check| {
+            let mut detail = check.detail.clone();
+            if check.name == "provider model probe"
+                && check.detail.contains(
+                    crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER,
+                )
+                && let Some(route_probe) = checks.iter().find(|candidate| {
+                    candidate.name
+                        == crate::provider_route_diagnostics::PROVIDER_ROUTE_PROBE_CHECK_NAME
+                })
+            {
+                detail.push_str(" provider route probe: ");
+                detail.push_str(route_probe.detail.as_str());
+            }
+            detail
+        })
+        .unwrap_or_else(|| "preflight checks failed".to_owned());
     format!("onboard preflight failed: {detail}")
 }
 
@@ -6912,6 +6927,10 @@ mod tests {
             !check.detail.contains("provider.model"),
             "transport probe failures should not suggest model-selection repair when the route is the real blocker: {check:#?}"
         );
+        assert!(
+            !check.detail.contains("below"),
+            "transport probe failures should not promise a later probe section that may not exist in non-interactive output: {check:#?}"
+        );
     }
 
     #[test]
@@ -7121,6 +7140,40 @@ mod tests {
         assert!(
             message.contains("provider.model"),
             "non-interactive onboarding should preserve the explicit remediation from the failing check: {message}"
+        );
+    }
+
+    #[test]
+    fn non_interactive_preflight_failure_message_appends_provider_route_probe_detail_for_transport_failures()
+     {
+        let checks = vec![
+            OnboardCheck {
+                name: "provider model probe",
+                level: OnboardCheckLevel::Fail,
+                detail:
+                    "OpenAI [openai]: model catalog transport failed (provider model-list request failed on attempt 3/3: operation timed out); runtime could not verify the provider route. inspect provider route diagnostics and retry once dns / proxy / TUN routing is stable"
+                        .to_owned(),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+            },
+            OnboardCheck {
+                name: "provider route probe",
+                level: OnboardCheckLevel::Warn,
+                detail:
+                    "request/models host api.openai.com:443: dns resolved to 198.18.0.2 (fake-ip-style); tcp connect ok via 198.18.0.2. the route currently depends on local fake-ip/TUN interception, so intermittent long-request failures usually point to proxy health or direct/bypass rules."
+                        .to_owned(),
+                non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+            },
+        ];
+
+        let message = non_interactive_preflight_failure_message(&checks);
+
+        assert!(
+            message.contains("provider route probe"),
+            "non-interactive onboarding should mention the collected provider route probe when transport diagnostics are available: {message}"
+        );
+        assert!(
+            message.contains("fake-ip-style"),
+            "non-interactive onboarding should include the route-probe detail instead of dropping it behind the first failing check: {message}"
         );
     }
 

--- a/crates/daemon/src/provider_route_diagnostics.rs
+++ b/crates/daemon/src/provider_route_diagnostics.rs
@@ -1,0 +1,374 @@
+use std::net::IpAddr;
+
+use loongclaw_app as mvp;
+
+#[cfg(not(test))]
+use std::collections::{BTreeMap, BTreeSet};
+#[cfg(not(test))]
+use std::net::SocketAddr;
+#[cfg(not(test))]
+use std::time::Duration;
+#[cfg(not(test))]
+use tokio::net::{TcpStream, lookup_host};
+#[cfg(not(test))]
+use tokio::time::timeout;
+
+pub(crate) const PROVIDER_ROUTE_PROBE_CHECK_NAME: &str = "provider route probe";
+pub(crate) const MODEL_CATALOG_TRANSPORT_FAILED_MARKER: &str = "model catalog transport failed";
+
+#[cfg(not(test))]
+const ROUTE_PROBE_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(not(test))]
+const ROUTE_PROBE_CONNECT_ADDRESS_LIMIT: usize = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProviderRouteProbeLevel {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProviderRouteProbe {
+    pub(crate) level: ProviderRouteProbeLevel,
+    pub(crate) detail: String,
+}
+
+#[cfg(not(test))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderRouteTarget {
+    label: String,
+    host: String,
+    port: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderRouteObservation {
+    label: String,
+    host: String,
+    port: u16,
+    resolved_addrs: Result<Vec<IpAddr>, String>,
+    connect_result: Option<Result<IpAddr, String>>,
+}
+
+pub(crate) fn is_transport_style_model_probe_failure(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    let looks_like_model_probe_transport = lower.contains("model-list request failed on attempt")
+        || lower.contains("model-list request setup failed on attempt");
+    let looks_like_route_issue = lower.contains("dns")
+        || lower.contains("lookup address")
+        || lower.contains("name or service not known")
+        || lower.contains("nodename nor servname")
+        || lower.contains("temporary failure in name resolution")
+        || lower.contains("failed to lookup address information")
+        || lower.contains("no such host")
+        || lower.contains("timed out")
+        || lower.contains("proxy")
+        || lower.contains("tunnel")
+        || lower.contains("tun")
+        || lower.contains("connect")
+        || lower.contains("connection");
+    looks_like_model_probe_transport && looks_like_route_issue
+}
+
+#[cfg(test)]
+pub(crate) async fn collect_provider_route_probe(
+    provider: &mvp::config::ProviderConfig,
+) -> Option<ProviderRouteProbe> {
+    let _ = provider;
+    None
+}
+
+#[cfg(not(test))]
+pub(crate) async fn collect_provider_route_probe(
+    provider: &mvp::config::ProviderConfig,
+) -> Option<ProviderRouteProbe> {
+    let targets = provider_route_targets(provider);
+    if targets.is_empty() {
+        return None;
+    }
+
+    let mut observations = Vec::with_capacity(targets.len());
+    for target in &targets {
+        observations.push(probe_route_target(target).await);
+    }
+
+    Some(summarize_provider_route_probe(&observations))
+}
+
+#[cfg(not(test))]
+fn provider_route_targets(provider: &mvp::config::ProviderConfig) -> Vec<ProviderRouteTarget> {
+    let mut grouped = BTreeMap::<(String, u16), Vec<&'static str>>::new();
+    push_provider_route_target(&mut grouped, "request", provider.endpoint().as_str());
+    push_provider_route_target(&mut grouped, "models", provider.models_endpoint().as_str());
+
+    grouped
+        .into_iter()
+        .map(|((host, port), labels)| ProviderRouteTarget {
+            label: labels.join("/"),
+            host,
+            port,
+        })
+        .collect()
+}
+
+#[cfg(not(test))]
+fn push_provider_route_target(
+    grouped: &mut BTreeMap<(String, u16), Vec<&'static str>>,
+    label: &'static str,
+    url: &str,
+) {
+    let Some(target) = parse_provider_route_target(url) else {
+        return;
+    };
+    let entry = grouped.entry((target.host, target.port)).or_default();
+    if !entry.contains(&label) {
+        entry.push(label);
+    }
+}
+
+#[cfg(not(test))]
+fn parse_provider_route_target(url: &str) -> Option<ProviderRouteTarget> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    let host = parsed.host_str()?.to_owned();
+    let port = parsed.port_or_known_default()?;
+    Some(ProviderRouteTarget {
+        label: "request".to_owned(),
+        host,
+        port,
+    })
+}
+
+#[cfg(not(test))]
+async fn probe_route_target(target: &ProviderRouteTarget) -> ProviderRouteObservation {
+    let resolved_addrs = lookup_host((target.host.as_str(), target.port))
+        .await
+        .map(|addrs| {
+            let mut unique = BTreeSet::new();
+            for addr in addrs {
+                unique.insert(addr.ip());
+            }
+            unique.into_iter().collect::<Vec<_>>()
+        })
+        .map_err(|error| error.to_string());
+    let connect_result = match &resolved_addrs {
+        Ok(addrs) => probe_route_connectivity(addrs, target.port).await,
+        Err(_) => None,
+    };
+
+    ProviderRouteObservation {
+        label: target.label.clone(),
+        host: target.host.clone(),
+        port: target.port,
+        resolved_addrs,
+        connect_result,
+    }
+}
+
+#[cfg(not(test))]
+async fn probe_route_connectivity(addrs: &[IpAddr], port: u16) -> Option<Result<IpAddr, String>> {
+    if addrs.is_empty() {
+        return None;
+    }
+
+    let mut last_error = None;
+    for addr in addrs.iter().take(ROUTE_PROBE_CONNECT_ADDRESS_LIMIT) {
+        let socket = SocketAddr::new(*addr, port);
+        match timeout(ROUTE_PROBE_CONNECT_TIMEOUT, TcpStream::connect(socket)).await {
+            Ok(Ok(stream)) => {
+                drop(stream);
+                return Some(Ok(*addr));
+            }
+            Ok(Err(error)) => last_error = Some(error.to_string()),
+            Err(_) => {
+                last_error = Some(format!(
+                    "timed out after {}s",
+                    ROUTE_PROBE_CONNECT_TIMEOUT.as_secs()
+                ));
+            }
+        }
+    }
+
+    Some(Err(
+        last_error.unwrap_or_else(|| "connection failed".to_owned())
+    ))
+}
+
+fn summarize_provider_route_probe(observations: &[ProviderRouteObservation]) -> ProviderRouteProbe {
+    let mut level = ProviderRouteProbeLevel::Pass;
+    let mut details = Vec::with_capacity(observations.len());
+
+    for observation in observations {
+        let (observation_level, detail) = summarize_route_observation(observation);
+        level = combine_probe_levels(level, observation_level);
+        details.push(detail);
+    }
+
+    ProviderRouteProbe {
+        level,
+        detail: details.join(" "),
+    }
+}
+
+fn summarize_route_observation(
+    observation: &ProviderRouteObservation,
+) -> (ProviderRouteProbeLevel, String) {
+    let target = format!(
+        "{} host {}:{}",
+        observation.label, observation.host, observation.port
+    );
+    match &observation.resolved_addrs {
+        Err(error) => (
+            ProviderRouteProbeLevel::Fail,
+            format!(
+                "{target}: dns lookup failed ({error}). check local dns or proxy/TUN rules before retrying."
+            ),
+        ),
+        Ok(addrs) if addrs.is_empty() => (
+            ProviderRouteProbeLevel::Fail,
+            format!(
+                "{target}: dns lookup returned no addresses. check local dns or proxy/TUN rules before retrying."
+            ),
+        ),
+        Ok(addrs) => {
+            let rendered_addrs = render_probe_addresses(addrs);
+            let fake_ip_style = addrs.iter().any(is_likely_fake_ip_addr);
+            match observation.connect_result.as_ref() {
+                Some(Ok(connected_ip)) if fake_ip_style => (
+                    ProviderRouteProbeLevel::Warn,
+                    format!(
+                        "{target}: dns resolved to {rendered_addrs} (fake-ip-style); tcp connect ok via {connected_ip}. the route currently depends on local fake-ip/TUN interception, so intermittent long-request failures usually point to proxy health or direct/bypass rules."
+                    ),
+                ),
+                Some(Ok(connected_ip)) => (
+                    ProviderRouteProbeLevel::Pass,
+                    format!(
+                        "{target}: dns resolved to {rendered_addrs}; tcp connect ok via {connected_ip}. basic route reachability looks healthy right now, so the earlier transport failure is more likely upstream or transient proxy instability."
+                    ),
+                ),
+                Some(Err(error)) if fake_ip_style => (
+                    ProviderRouteProbeLevel::Fail,
+                    format!(
+                        "{target}: dns resolved to {rendered_addrs} (fake-ip-style); tcp connect failed ({error}). the fake-ip/TUN route is not healthy enough to reach the provider right now."
+                    ),
+                ),
+                Some(Err(error)) => (
+                    ProviderRouteProbeLevel::Fail,
+                    format!(
+                        "{target}: dns resolved to {rendered_addrs}; tcp connect failed ({error}). the provider host is not reachable from the current route."
+                    ),
+                ),
+                None => (
+                    ProviderRouteProbeLevel::Fail,
+                    format!(
+                        "{target}: dns resolved to {rendered_addrs}, but no tcp connectivity probe could be completed."
+                    ),
+                ),
+            }
+        }
+    }
+}
+
+fn combine_probe_levels(
+    left: ProviderRouteProbeLevel,
+    right: ProviderRouteProbeLevel,
+) -> ProviderRouteProbeLevel {
+    match (left, right) {
+        (ProviderRouteProbeLevel::Fail, _) | (_, ProviderRouteProbeLevel::Fail) => {
+            ProviderRouteProbeLevel::Fail
+        }
+        (ProviderRouteProbeLevel::Warn, _) | (_, ProviderRouteProbeLevel::Warn) => {
+            ProviderRouteProbeLevel::Warn
+        }
+        _ => ProviderRouteProbeLevel::Pass,
+    }
+}
+
+fn render_probe_addresses(addrs: &[IpAddr]) -> String {
+    let rendered = addrs
+        .iter()
+        .take(4)
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    if addrs.len() > rendered.len() {
+        format!(
+            "{} (+{} more)",
+            rendered.join(", "),
+            addrs.len() - rendered.len()
+        )
+    } else {
+        rendered.join(", ")
+    }
+}
+
+fn is_likely_fake_ip_addr(addr: &IpAddr) -> bool {
+    match addr {
+        // 198.18.0.0/15 is the RFC 2544 benchmark range and is commonly reused by fake-ip resolvers.
+        IpAddr::V4(ipv4) => {
+            let [first, second, _, _] = ipv4.octets();
+            first == 198 && (second == 18 || second == 19)
+        }
+        IpAddr::V6(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn transport_style_model_probe_failure_detection_ignores_status_errors() {
+        assert!(!is_transport_style_model_probe_failure(
+            "provider returned status 401 on attempt 3/3"
+        ));
+        assert!(is_transport_style_model_probe_failure(
+            "provider model-list request failed on attempt 3/3: operation timed out"
+        ));
+    }
+
+    #[test]
+    fn summarize_provider_route_probe_reports_dns_failures() {
+        let probe = summarize_provider_route_probe(&[ProviderRouteObservation {
+            label: "request/models".to_owned(),
+            host: "api.openai.com".to_owned(),
+            port: 443,
+            resolved_addrs: Err("no such host".to_owned()),
+            connect_result: None,
+        }]);
+
+        assert_eq!(probe.level, ProviderRouteProbeLevel::Fail);
+        assert!(probe.detail.contains("dns lookup failed"));
+        assert!(probe.detail.contains("proxy/TUN"));
+    }
+
+    #[test]
+    fn summarize_provider_route_probe_warns_for_fake_ip_style_dns() {
+        let probe = summarize_provider_route_probe(&[ProviderRouteObservation {
+            label: "request/models".to_owned(),
+            host: "ark.cn-beijing.volces.com".to_owned(),
+            port: 443,
+            resolved_addrs: Ok(vec![IpAddr::V4(Ipv4Addr::new(198, 18, 0, 2))]),
+            connect_result: Some(Ok(IpAddr::V4(Ipv4Addr::new(198, 18, 0, 2)))),
+        }]);
+
+        assert_eq!(probe.level, ProviderRouteProbeLevel::Warn);
+        assert!(probe.detail.contains("fake-ip-style"));
+        assert!(probe.detail.contains("direct/bypass"));
+    }
+
+    #[test]
+    fn summarize_provider_route_probe_reports_connect_failures() {
+        let probe = summarize_provider_route_probe(&[ProviderRouteObservation {
+            label: "request".to_owned(),
+            host: "api.openai.com".to_owned(),
+            port: 443,
+            resolved_addrs: Ok(vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))]),
+            connect_result: Some(Err("timed out after 2s".to_owned())),
+        }]);
+
+        assert_eq!(probe.level, ProviderRouteProbeLevel::Fail);
+        assert!(probe.detail.contains("tcp connect failed"));
+        assert!(probe.detail.contains("not reachable"));
+    }
+}

--- a/docs/product-specs/doctor.md
+++ b/docs/product-specs/doctor.md
@@ -30,6 +30,10 @@ can recover a broken setup without reverse-engineering runtime internals.
 - [ ] When `tools.browser_companion.enabled=true`, doctor surfaces companion
       install/runtime readiness as warnings with concrete repair steps instead
       of turning the optional managed lane into a hard core-runtime failure.
+- [ ] When provider model probing fails before any HTTP status is returned,
+      doctor surfaces request/models host route diagnostics, including DNS
+      results, fake-ip-style address detection, and a short TCP reachability
+      probe with concrete repair guidance.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- Problem: transport-style provider failures were usually surfaced as generic `transport_failure` reports, which hid whether the actual blocker was DNS resolution, a fake-ip/TUN route, proxy instability, or basic host reachability.
- Why it matters: the current failure path made doctor, onboard, and runtime point users toward model-selection recovery even when the provider route itself was the real blocker.
- What changed: added shared provider route diagnostics for request/models hosts, appended route-aware runtime transport hints, taught doctor/onboard to classify transport-style model probe failures separately, and documented the new behavior.
- What did not change (scope boundary): this does not add automatic machine-level network reconfiguration, a hosted relay path, or a broad provider runtime refactor.

## Linked Issues

- Closes #338
- Related #338

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-app render_transport_route_hint_identifies_ -- --nocapture
cargo test -p loongclaw-daemon provider_model_probe_transport_failure_prioritizes_route_guidance -- --nocapture
cargo test -p loongclaw-daemon route_probe -- --nocapture
cargo test -p loongclaw-daemon transport_style_model_probe_failure_detection_ignores_status_errors -- --nocapture
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked

all commands passed in the issue worktree after fixing the transport-style probe classification path and the shared route diagnostics module.
```

## User-visible / Operator-visible Changes

- `loongclaw doctor` and onboarding now surface provider route probe details for transport-style model probe failures, including the active host, DNS results, fake-ip-style detection, and a short TCP reachability check.
- runtime request/model-list transport failures now append route-aware guidance instead of leaving users with a generic transport failure.
- doctor recovery guidance now keeps model-selection steps for real catalog/auth issues and prefers route repair guidance when the route is the blocker.

## Failure Recovery

- Fast rollback or disable path: revert commit `221c0bfb` to remove the route diagnostics layer and restore the prior generic transport failure flow.
- Observable failure symptoms reviewers should watch for: unexpected route-probe noise on non-transport failures, missing provider model recovery steps on genuine auth/catalog failures, or overly broad transport hinting in runtime errors.

## Reviewer Focus

- review `crates/daemon/src/provider_route_diagnostics.rs` for the route-probe scope and fake-ip heuristics.
- review `crates/daemon/src/doctor_cli.rs` and `crates/daemon/src/onboard_cli.rs` for the transport-style model probe split so route failures do not fall back to model-selection guidance.
- review `crates/app/src/provider/transport.rs` plus the runtime executors for the appended transport hints and error-message boundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doctor now provides enhanced diagnostics when provider connectivity fails, including network route analysis, DNS resolution status, and TCP connectivity checks to help identify network or proxy issues.

* **Documentation**
  * Updated documentation with provider route diagnostics specifications and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->