### PR TITLE
fix: allow blank enter to keep onboarding prompt addendum

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -58,6 +58,9 @@ pub trait OnboardUi {
     fn print_line(&mut self, line: &str) -> CliResult<()>;
     fn prompt_with_default(&mut self, label: &str, default: &str) -> CliResult<String>;
     fn prompt_required(&mut self, label: &str) -> CliResult<String>;
+    fn prompt_allow_empty(&mut self, label: &str) -> CliResult<String> {
+        self.prompt_required(label)
+    }
     fn prompt_confirm(&mut self, message: &str, default: bool) -> CliResult<bool>;
     fn select_one(
         &mut self,
@@ -355,6 +358,13 @@ impl OnboardUi for StdioOnboardUi {
         prompt_required_stdio(self.stdio_line_reader(), label)
     }
 
+    fn prompt_allow_empty(&mut self, label: &str) -> CliResult<String> {
+        if rich_prompt_ui_available() {
+            return prompt_allow_empty_rich(label);
+        }
+        prompt_required_stdio(self.stdio_line_reader(), label)
+    }
+
     fn prompt_confirm(&mut self, message: &str, default: bool) -> CliResult<bool> {
         if rich_prompt_ui_available() {
             return prompt_confirm_rich(message, default);
@@ -513,12 +523,16 @@ fn map_rich_prompt_error(action: &str, error: DialoguerError) -> String {
 
 fn prompt_with_default_rich(label: &str, default: &str) -> CliResult<String> {
     let term = rich_prompt_term();
+    prompt_with_default_rich_on(&term, label, default)
+}
+
+fn prompt_with_default_rich_on(term: &Term, label: &str, default: &str) -> CliResult<String> {
     let theme = rich_prompt_theme();
     let value = Input::<String>::with_theme(&theme)
         .with_prompt(label)
         .default(default.to_owned())
         .report(false)
-        .interact_text_on(&term)
+        .interact_text_on(term)
         .map_err(|error| map_rich_prompt_error("interactive prompt", error))?;
     let value = ensure_onboard_input_not_cancelled(value)?;
     let trimmed = value.trim();
@@ -530,11 +544,32 @@ fn prompt_with_default_rich(label: &str, default: &str) -> CliResult<String> {
 
 fn prompt_required_rich(label: &str) -> CliResult<String> {
     let term = rich_prompt_term();
+    prompt_required_rich_on(&term, label)
+}
+
+fn prompt_required_rich_on(term: &Term, label: &str) -> CliResult<String> {
     let theme = rich_prompt_theme();
     let value = Input::<String>::with_theme(&theme)
         .with_prompt(label)
         .report(false)
-        .interact_text_on(&term)
+        .interact_text_on(term)
+        .map_err(|error| map_rich_prompt_error("interactive prompt", error))?;
+    let value = ensure_onboard_input_not_cancelled(value)?;
+    Ok(value.trim().to_owned())
+}
+
+fn prompt_allow_empty_rich(label: &str) -> CliResult<String> {
+    let term = rich_prompt_term();
+    prompt_allow_empty_rich_on(&term, label)
+}
+
+fn prompt_allow_empty_rich_on(term: &Term, label: &str) -> CliResult<String> {
+    let theme = rich_prompt_theme();
+    let value = Input::<String>::with_theme(&theme)
+        .with_prompt(label)
+        .allow_empty(true)
+        .report(false)
+        .interact_text_on(term)
         .map_err(|error| map_rich_prompt_error("interactive prompt", error))?;
     let value = ensure_onboard_input_not_cancelled(value)?;
     Ok(value.trim().to_owned())
@@ -807,7 +842,7 @@ fn prompt_optional(
     label: &str,
     current: Option<&str>,
 ) -> CliResult<Option<String>> {
-    let value = ui.prompt_required(label)?;
+    let value = ui.prompt_allow_empty(label)?;
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Ok(current
@@ -7388,6 +7423,73 @@ mod tests {
             selected,
             SystemPromptSelection::Set("prefer concise code reviews".to_owned()),
             "using the prompt default should still apply a prefilled system prompt override"
+        );
+    }
+
+    #[test]
+    fn resolve_prompt_addendum_selection_keeps_current_addendum_when_blank_input_is_used() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.cli.system_prompt_addendum = Some("Keep answers direct.".to_owned());
+        let mut ui = TestOnboardUi::with_inputs([""]);
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_prompt_addendum_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve prompt addendum selection");
+
+        assert_eq!(
+            selected.as_deref(),
+            Some("Keep answers direct."),
+            "blank optional input should keep the current addendum"
+        );
+    }
+
+    #[test]
+    fn resolve_prompt_addendum_selection_clears_current_addendum_when_dash_input_is_used() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.cli.system_prompt_addendum = Some("Keep answers direct.".to_owned());
+        let mut ui = TestOnboardUi::with_inputs(["-"]);
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_prompt_addendum_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve prompt addendum selection");
+
+        assert_eq!(
+            selected, None,
+            "typing '-' should still clear the current addendum"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -6424,6 +6424,18 @@ mod tests {
         }
     }
 
+    struct AllowEmptyOnlyTestUi {
+        inputs: VecDeque<String>,
+    }
+
+    impl AllowEmptyOnlyTestUi {
+        fn with_inputs(inputs: impl IntoIterator<Item = impl Into<String>>) -> Self {
+            Self {
+                inputs: inputs.into_iter().map(Into::into).collect(),
+            }
+        }
+    }
+
     fn browser_companion_temp_dir(label: &str) -> PathBuf {
         static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
         let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
@@ -6569,6 +6581,42 @@ mod tests {
                     default.ok_or_else(|| "missing test input for required selection".to_owned())
                 }
             }
+        }
+    }
+
+    impl OnboardUi for AllowEmptyOnlyTestUi {
+        fn print_line(&mut self, _line: &str) -> CliResult<()> {
+            Ok(())
+        }
+
+        fn prompt_with_default(&mut self, _label: &str, _default: &str) -> CliResult<String> {
+            Err("test expected prompt_allow_empty instead of prompt_with_default".to_owned())
+        }
+
+        fn prompt_required(&mut self, _label: &str) -> CliResult<String> {
+            Err("test expected prompt_allow_empty instead of prompt_required".to_owned())
+        }
+
+        fn prompt_allow_empty(&mut self, _label: &str) -> CliResult<String> {
+            let value = self
+                .inputs
+                .pop_front()
+                .ok_or_else(|| "missing allow-empty test input".to_owned())?;
+            Ok(ensure_onboard_input_not_cancelled(value)?.trim().to_owned())
+        }
+
+        fn prompt_confirm(&mut self, _message: &str, _default: bool) -> CliResult<bool> {
+            Err("test expected prompt_allow_empty instead of prompt_confirm".to_owned())
+        }
+
+        fn select_one(
+            &mut self,
+            _label: &str,
+            _options: &[SelectOption],
+            _default: Option<usize>,
+            _interaction_mode: SelectInteractionMode,
+        ) -> CliResult<usize> {
+            Err("test expected prompt_allow_empty instead of select_one".to_owned())
         }
     }
 
@@ -7457,6 +7505,71 @@ mod tests {
             selected.as_deref(),
             Some("Keep answers direct."),
             "blank optional input should keep the current addendum"
+        );
+    }
+
+    #[test]
+    fn resolve_prompt_addendum_selection_uses_allow_empty_prompt_path_for_blank_first_run_input() {
+        let config = mvp::config::LoongClawConfig::default();
+        let mut ui = AllowEmptyOnlyTestUi::with_inputs([""]);
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_prompt_addendum_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve prompt addendum selection");
+
+        assert_eq!(
+            selected, None,
+            "blank first-run optional input should preserve the absence of an addendum"
+        );
+    }
+
+    #[test]
+    fn resolve_prompt_addendum_selection_uses_allow_empty_prompt_path_for_clear_input() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.cli.system_prompt_addendum = Some("Keep answers direct.".to_owned());
+        let mut ui = AllowEmptyOnlyTestUi::with_inputs(["-"]);
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_prompt_addendum_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            &mut ui,
+            &context,
+        )
+        .expect("resolve prompt addendum selection");
+
+        assert_eq!(
+            selected, None,
+            "allow-empty prompt handling should still respect the explicit clear token"
         );
     }
 


### PR DESCRIPTION
## Summary

- Problem:
  interactive onboarding treated the step 5 prompt addendum field as required input in the attended terminal flow, so pressing Enter on a blank line never advanced even though the screen said blank input would keep the current addendum.
- Why it matters:
  first-run onboarding could block at step 5 and contradicted its own operator guidance.
- What changed:
  split allow-empty prompt handling from required prompt handling in the onboarding ui abstraction, route optional prompt addendum input through the allow-empty path, and add regression coverage for keeping or clearing the current addendum.
- What did not change (scope boundary):
  required prompt behavior for the rest of onboarding stays unchanged, and `-` still remains the explicit clear action for the addendum field.

## Linked Issues

- Closes #350
- Related # none

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
CARGO_TARGET_DIR=<isolated-target-dir> CARGO_BUILD_JOBS=4 cargo fmt --all -- --check
CARGO_TARGET_DIR=<isolated-target-dir> CARGO_BUILD_JOBS=4 cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=<isolated-target-dir> CARGO_BUILD_JOBS=4 cargo test --workspace --locked
CARGO_TARGET_DIR=<isolated-target-dir> CARGO_BUILD_JOBS=4 cargo test --workspace --all-features --locked
CARGO_TARGET_DIR=<isolated-target-dir> CARGO_BUILD_JOBS=4 cargo test -p loongclaw-daemon prompt_addendum

manual attended-terminal verification:
- ran `loongclaw onboard --accept-risk` in an isolated tty-backed config home
- chose `Start fresh`
- accepted the default provider / model / credential source / personality
- pressed blank Enter at `step 5 of 7 · prompt addendum`
- confirmed the flow advanced to `step 6 of 7 · memory profile`
```

## User-visible / Operator-visible Changes

- pressing Enter on a blank prompt addendum input now keeps the current addendum and continues onboarding as the screen text promises.

## Failure Recovery

- Fast rollback or disable path:
  revert this commit to restore the previous onboarding prompt behavior.
- Observable failure symptoms reviewers should watch for:
  optional onboarding prompts unexpectedly rejecting blank input, or required prompts unexpectedly accepting blank input.

## Reviewer Focus

- `crates/daemon/src/onboard_cli.rs`
- confirm the new allow-empty path is only used for optional prompt handling
- confirm the regression tests cover both "keep current addendum" and explicit clear behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional prompts now accept empty input to preserve current values or keep absence on first run.
  * Dash input (`-`) can clear optional prompt values.
  * Prompts use an enhanced, richer display when available with graceful fallback to the standard prompt.

* **Tests**
  * Added test coverage for optional prompt behavior, blank input handling, and explicit clear via `-`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->