### PR TITLE
feat: enforce external skill manifest visibility and eligibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -2894,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tar",
  "tempfile",
@@ -3081,6 +3082,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3677,6 +3691,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -32,6 +32,7 @@ async-trait.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml = "0.9"
 toml = { workspace = true, optional = true }
 reqwest.workspace = true
 scraper = { version = "0.26", optional = true }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -981,7 +981,7 @@ mod tests {
         let user_prompt = messages[2]["content"]
             .as_str()
             .expect("user prompt should exist");
-        assert!(user_prompt.contains("managed external skill"));
+        assert!(user_prompt.contains("external skill"));
         assert!(user_prompt.contains("Original request:\nsummarize note.md"));
     }
 

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -14,7 +14,7 @@ use crate::CliResult;
 
 pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
-pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "A managed external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
+pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "An external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
 
 const FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS: usize = 384;
@@ -607,7 +607,7 @@ fn summarize_shell_output_preview(value: Option<&Value>) -> (String, usize, bool
 
 pub fn build_external_skill_system_message(skill_context: &ExternalSkillInvokeContext) -> String {
     format!(
-        "Managed external skill `{}` ({}) is now active for this task. Treat the following `SKILL.md` content as trusted runtime guidance until superseded.\n\n{}",
+        "External skill `{}` ({}) is now active for this task. Treat the following `SKILL.md` content as trusted runtime guidance until superseded.\n\n{}",
         skill_context.skill_id, skill_context.display_name, skill_context.instructions
     )
 }
@@ -620,7 +620,7 @@ pub fn build_external_skill_followup_user_prompt(
     let mut sections = vec![
         EXTERNAL_SKILL_FOLLOWUP_PROMPT.to_owned(),
         format!(
-            "Loaded managed external skill:\n- id: {}\n- name: {}",
+            "Loaded external skill:\n- id: {}\n- name: {}",
             skill_context.skill_id, skill_context.display_name
         ),
     ];

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -1631,15 +1631,13 @@ fn normalize_optional_metadata_string(value: Option<String>) -> Option<String> {
 }
 
 fn normalize_metadata_string_list(values: Vec<String>) -> Vec<String> {
-    let mut normalized = values
+    values
         .into_iter()
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
         .collect::<BTreeSet<_>>()
         .into_iter()
-        .collect::<Vec<_>>();
-    normalized.sort();
-    normalized
+        .collect()
 }
 
 fn skill_content_lines(skill_markdown: &str) -> impl Iterator<Item = &str> {

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
     fs,
     io::{ErrorKind, Read},
@@ -159,10 +160,20 @@ struct DiscoveredSkillCandidate {
     root_rank: usize,
 }
 
+#[derive(Debug, Clone)]
+struct BlockedSkillCandidate {
+    skill_id: String,
+    scope: DiscoveredSkillScope,
+    probe_rank: usize,
+    root_rank: usize,
+    source_path: String,
+    error: String,
+}
+
 #[derive(Debug, Clone, Default)]
-struct ManagedSkillDiscovery {
+struct SkillCandidateDiscovery {
     candidates: Vec<DiscoveredSkillCandidate>,
-    blocked_skill_errors: BTreeMap<String, String>,
+    blocked_candidates: Vec<BlockedSkillCandidate>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -838,7 +849,6 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
 pub(crate) fn execute_external_skills_operator_list_tool_with_config(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    require_enabled_runtime_policy(config)?;
     execute_external_skills_list_for_audience(
         "external_skills.list".to_owned(),
         config,
@@ -850,7 +860,6 @@ pub(crate) fn execute_external_skills_operator_inspect_tool_with_config(
     skill_id: &str,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    require_enabled_runtime_policy(config)?;
     execute_external_skills_inspect_for_audience(
         "external_skills.inspect".to_owned(),
         config,
@@ -1808,6 +1817,72 @@ fn command_candidate_is_executable(candidate: &Path) -> bool {
     }
 }
 
+fn compare_candidate_priority(
+    left_scope: DiscoveredSkillScope,
+    left_probe_rank: usize,
+    left_root_rank: usize,
+    left_source_path: &str,
+    right_scope: DiscoveredSkillScope,
+    right_probe_rank: usize,
+    right_root_rank: usize,
+    right_source_path: &str,
+) -> Ordering {
+    left_scope
+        .precedence_rank()
+        .cmp(&right_scope.precedence_rank())
+        .then_with(|| left_probe_rank.cmp(&right_probe_rank))
+        .then_with(|| left_root_rank.cmp(&right_root_rank))
+        .then_with(|| left_source_path.cmp(right_source_path))
+}
+
+fn compare_discovered_skill_candidates(
+    left: &DiscoveredSkillCandidate,
+    right: &DiscoveredSkillCandidate,
+) -> Ordering {
+    compare_candidate_priority(
+        left.entry.scope,
+        left.probe_rank,
+        left.root_rank,
+        &left.entry.source_path,
+        right.entry.scope,
+        right.probe_rank,
+        right.root_rank,
+        &right.entry.source_path,
+    )
+}
+
+fn compare_blocked_skill_candidates(
+    left: &BlockedSkillCandidate,
+    right: &BlockedSkillCandidate,
+) -> Ordering {
+    compare_candidate_priority(
+        left.scope,
+        left.probe_rank,
+        left.root_rank,
+        &left.source_path,
+        right.scope,
+        right.probe_rank,
+        right.root_rank,
+        &right.source_path,
+    )
+}
+
+fn blocked_candidate_precedes_discovered(
+    blocked: &BlockedSkillCandidate,
+    candidate: &DiscoveredSkillCandidate,
+) -> bool {
+    compare_candidate_priority(
+        blocked.scope,
+        blocked.probe_rank,
+        blocked.root_rank,
+        &blocked.source_path,
+        candidate.entry.scope,
+        candidate.probe_rank,
+        candidate.root_rank,
+        &candidate.entry.source_path,
+    ) != Ordering::Greater
+}
+
 fn command_candidates(command: &str) -> Vec<String> {
     #[cfg(windows)]
     {
@@ -2073,12 +2148,15 @@ fn discover_skill_inventory(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<SkillDiscoveryInventory, String> {
     let managed = discover_managed_skill_candidates(config)?;
+    let user = discover_user_skill_candidates(config)?;
+    let project = discover_project_skill_candidates(config)?;
+
     let mut grouped = BTreeMap::<String, Vec<DiscoveredSkillCandidate>>::new();
     for candidate in managed
         .candidates
         .into_iter()
-        .chain(discover_user_skill_candidates(config)?)
-        .chain(discover_project_skill_candidates(config)?)
+        .chain(user.candidates)
+        .chain(project.candidates)
     {
         grouped
             .entry(candidate.entry.skill_id.clone())
@@ -2086,23 +2164,45 @@ fn discover_skill_inventory(
             .push(candidate);
     }
 
-    let mut inventory = SkillDiscoveryInventory {
-        blocked_skill_errors: managed.blocked_skill_errors,
-        ..SkillDiscoveryInventory::default()
-    };
-    for (skill_id, mut candidates) in grouped {
-        if inventory.blocked_skill_errors.contains_key(&skill_id) {
+    let mut blocked_grouped = BTreeMap::<String, Vec<BlockedSkillCandidate>>::new();
+    for blocked in managed
+        .blocked_candidates
+        .into_iter()
+        .chain(user.blocked_candidates)
+        .chain(project.blocked_candidates)
+    {
+        blocked_grouped
+            .entry(blocked.skill_id.clone())
+            .or_default()
+            .push(blocked);
+    }
+
+    let mut inventory = SkillDiscoveryInventory::default();
+    let skill_ids = grouped
+        .keys()
+        .chain(blocked_grouped.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for skill_id in skill_ids {
+        let mut candidates = grouped.remove(&skill_id).unwrap_or_default();
+        let mut blocked_candidates = blocked_grouped.remove(&skill_id).unwrap_or_default();
+        candidates.sort_by(compare_discovered_skill_candidates);
+        blocked_candidates.sort_by(compare_blocked_skill_candidates);
+
+        if let Some(blocked) = blocked_candidates.first()
+            && candidates
+                .first()
+                .is_none_or(|candidate| blocked_candidate_precedes_discovered(blocked, candidate))
+        {
+            inventory
+                .blocked_skill_errors
+                .insert(skill_id, blocked.error.clone());
             continue;
         }
-        candidates.sort_by(|left, right| {
-            left.entry
-                .scope
-                .precedence_rank()
-                .cmp(&right.entry.scope.precedence_rank())
-                .then_with(|| left.probe_rank.cmp(&right.probe_rank))
-                .then_with(|| left.root_rank.cmp(&right.root_rank))
-                .then_with(|| left.entry.source_path.cmp(&right.entry.source_path))
-        });
+
+        if candidates.is_empty() {
+            continue;
+        }
 
         let winner = candidates.remove(0);
         inventory.skills.push(winner.entry);
@@ -2157,33 +2257,41 @@ pub(super) fn installed_skill_snapshot_lines_with_config(
 
 fn discover_managed_skill_candidates(
     config: &super::runtime_config::ToolRuntimeConfig,
-) -> Result<ManagedSkillDiscovery, String> {
+) -> Result<SkillCandidateDiscovery, String> {
     let install_root = resolve_install_root(config);
     let index = load_installed_skill_index(&install_root)?;
-    let mut discovery = ManagedSkillDiscovery::default();
+    let mut discovery = SkillCandidateDiscovery::default();
     for entry in index.skills {
         let skill_id = entry.skill_id.clone();
+        let source_path = entry.source_path.clone();
         let entry = match rehydrate_installed_skill_entry(&install_root, entry) {
             Ok(entry) => entry,
             Err(error) => {
-                discovery
-                    .blocked_skill_errors
-                    .entry(skill_id)
-                    .or_insert(error);
+                discovery.blocked_candidates.push(BlockedSkillCandidate {
+                    skill_id,
+                    scope: DiscoveredSkillScope::Managed,
+                    probe_rank: 0,
+                    root_rank: 0,
+                    source_path,
+                    error,
+                });
                 continue;
             }
         };
         let entry = match build_managed_discovered_skill_entry(config, entry) {
             Ok(entry) => entry,
             Err(error) => {
-                discovery
-                    .blocked_skill_errors
-                    .entry(skill_id)
-                    .or_insert(error);
+                discovery.blocked_candidates.push(BlockedSkillCandidate {
+                    skill_id,
+                    scope: DiscoveredSkillScope::Managed,
+                    probe_rank: 0,
+                    root_rank: 0,
+                    source_path,
+                    error,
+                });
                 continue;
             }
         };
-        discovery.blocked_skill_errors.remove(&skill_id);
         discovery.candidates.push(DiscoveredSkillCandidate {
             probe_rank: 0,
             root_rank: 0,
@@ -2195,9 +2303,9 @@ fn discover_managed_skill_candidates(
 
 fn discover_user_skill_candidates(
     config: &super::runtime_config::ToolRuntimeConfig,
-) -> Result<Vec<DiscoveredSkillCandidate>, String> {
+) -> Result<SkillCandidateDiscovery, String> {
     let Some(home_root) = user_home_dir() else {
-        return Ok(Vec::new());
+        return Ok(SkillCandidateDiscovery::default());
     };
     discover_scoped_skill_candidates(
         config,
@@ -2209,7 +2317,7 @@ fn discover_user_skill_candidates(
 
 fn discover_project_skill_candidates(
     config: &super::runtime_config::ToolRuntimeConfig,
-) -> Result<Vec<DiscoveredSkillCandidate>, String> {
+) -> Result<SkillCandidateDiscovery, String> {
     discover_scoped_skill_candidates(
         config,
         &project_discovery_probe_roots(config),
@@ -2223,8 +2331,8 @@ fn discover_scoped_skill_candidates(
     probe_roots: &[PathBuf],
     scope: DiscoveredSkillScope,
     dir_specs: &[(&str, usize)],
-) -> Result<Vec<DiscoveredSkillCandidate>, String> {
-    let mut candidates = Vec::new();
+) -> Result<SkillCandidateDiscovery, String> {
+    let mut discovery = SkillCandidateDiscovery::default();
     let mut seen = BTreeSet::new();
     for (probe_rank, probe_root) in probe_roots.iter().enumerate() {
         for (relative_dir, root_rank) in dir_specs {
@@ -2240,7 +2348,17 @@ fn discover_scoped_skill_candidates(
                 }
                 let skill_markdown = match load_directory_skill_markdown(&skill_root) {
                     Ok(skill_markdown) => skill_markdown,
-                    Err(_) => continue,
+                    Err(error) => {
+                        discovery.blocked_candidates.push(BlockedSkillCandidate {
+                            skill_id: derive_skill_id(&skill_root),
+                            scope,
+                            probe_rank,
+                            root_rank: *root_rank,
+                            source_path: skill_root.display().to_string(),
+                            error,
+                        });
+                        continue;
+                    }
                 };
                 let skill_id = derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str());
                 let entry = match build_discovered_skill_entry(
@@ -2249,15 +2367,25 @@ fn discover_scoped_skill_candidates(
                     "directory".to_owned(),
                     skill_root.display().to_string(),
                     key,
-                    skill_id,
+                    skill_id.clone(),
                     skill_markdown.as_str(),
                     true,
                     None,
                 ) {
                     Ok(entry) => entry,
-                    Err(_) => continue,
+                    Err(error) => {
+                        discovery.blocked_candidates.push(BlockedSkillCandidate {
+                            skill_id,
+                            scope,
+                            probe_rank,
+                            root_rank: *root_rank,
+                            source_path: skill_root.display().to_string(),
+                            error,
+                        });
+                        continue;
+                    }
                 };
-                candidates.push(DiscoveredSkillCandidate {
+                discovery.candidates.push(DiscoveredSkillCandidate {
                     probe_rank,
                     root_rank: *root_rank,
                     entry,
@@ -2265,7 +2393,7 @@ fn discover_scoped_skill_candidates(
             }
         }
     }
-    Ok(candidates)
+    Ok(discovery)
 }
 
 fn project_discovery_probe_roots(
@@ -3687,6 +3815,83 @@ mod tests {
             cleanup_perms.set_mode(0o644);
             fs::set_permissions(&unreadable_path, cleanup_perms).ok();
             fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_surface_fails_closed_when_unreadable_user_winner_has_project_fallback() {
+        with_managed_runtime_test(|| {
+            use std::os::unix::fs::PermissionsExt;
+
+            let root = unique_temp_dir("loongclaw-ext-skill-unreadable-user-winner");
+            let home = unique_temp_dir("loongclaw-ext-skill-unreadable-user-winner-home");
+            fs::create_dir_all(&root).expect("create fixture root");
+            fs::create_dir_all(&home).expect("create home root");
+            write_file(
+                &root,
+                ".agents/skills/demo-skill/SKILL.md",
+                "---\nname: demo-skill\ndescription: project fallback should stay blocked.\n---\n\nProject fallback instructions.\n",
+            );
+            write_file(
+                &home,
+                ".agents/skills/demo-skill/SKILL.md",
+                "---\nname: demo-skill\ndescription: unreadable user winner.\n---\n\nBroken user instructions.\n",
+            );
+
+            let unreadable_path = home.join(".agents/skills/demo-skill/SKILL.md");
+            let mut perms = fs::metadata(&unreadable_path)
+                .expect("read metadata")
+                .permissions();
+            perms.set_mode(0o000);
+            fs::set_permissions(&unreadable_path, perms).expect("set unreadable permissions");
+
+            let config = managed_runtime_config(&root);
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("HOME", &home);
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed when the higher-precedence local winner is unreadable");
+
+            assert!(
+                list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .all(|skill| skill["skill_id"] != "demo-skill"),
+                "provider surface should fail closed instead of promoting the project fallback: {}",
+                list_outcome.payload
+            );
+
+            let error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "demo-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("invoke should report the unreadable higher-precedence local winner");
+            assert!(
+                error.contains("failed to read external skill source")
+                    || error.contains("failed to inspect external skill source"),
+                "expected unreadable local winner error, got: {error}"
+            );
+
+            let mut cleanup_perms = fs::metadata(&unreadable_path)
+                .expect("read metadata for cleanup")
+                .permissions();
+            cleanup_perms.set_mode(0o644);
+            fs::set_permissions(&unreadable_path, cleanup_perms).ok();
+            fs::remove_dir_all(&root).ok();
+            fs::remove_dir_all(&home).ok();
         });
     }
 

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -11,6 +11,7 @@ use flate2::read::GzDecoder;
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
+use serde_yaml::Value as YamlValue;
 use sha2::{Digest, Sha256};
 use tar::Archive;
 
@@ -83,12 +84,41 @@ struct DiscoveredSkillEntry {
     sha256: String,
     active: bool,
     install_path: Option<String>,
+    model_visibility: SkillModelVisibility,
+    required_env: Vec<String>,
+    required_bin: Vec<String>,
+    required_paths: Vec<String>,
+    eligibility: SkillEligibility,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+enum SkillModelVisibility {
+    #[default]
+    Visible,
+    Hidden,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+struct SkillEligibility {
+    available: bool,
+    missing_env: Vec<String>,
+    missing_bin: Vec<String>,
+    missing_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
 struct SkillFrontmatter {
     name: Option<String>,
     description: Option<String>,
+    #[serde(default)]
+    requires_env: Vec<String>,
+    #[serde(default, alias = "requires_bins", alias = "requires_commands")]
+    requires_bin: Vec<String>,
+    #[serde(default)]
+    requires_paths: Vec<String>,
+    #[serde(default)]
+    model_visibility: SkillModelVisibility,
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +132,12 @@ struct DiscoveredSkillCandidate {
 struct SkillDiscoveryInventory {
     skills: Vec<DiscoveredSkillEntry>,
     shadowed_skills: Vec<DiscoveredSkillEntry>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillAudience {
+    Model,
+    Operator,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -692,16 +728,7 @@ pub(super) fn execute_external_skills_list_tool_with_config(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     require_enabled_runtime_policy(config)?;
-    let inventory = discover_skill_inventory(config)?;
-    Ok(ToolCoreOutcome {
-        status: "ok".to_owned(),
-        payload: json!({
-            "adapter": "core-tools",
-            "tool_name": request.tool_name,
-            "skills": inventory.skills,
-            "shadowed_skills": inventory.shadowed_skills,
-        }),
-    })
+    execute_external_skills_list_for_audience(request.tool_name, config, SkillAudience::Model)
 }
 
 pub(super) fn execute_external_skills_inspect_tool_with_config(
@@ -720,24 +747,12 @@ pub(super) fn execute_external_skills_inspect_tool_with_config(
         .ok_or_else(|| "external_skills.inspect requires payload.skill_id".to_owned())?;
 
     require_enabled_runtime_policy(config)?;
-
-    let inventory = discover_skill_inventory(config)?;
-    let skill = resolve_discovered_skill(&inventory, skill_id)?;
-    let instructions = load_discovered_skill_markdown(config, &skill)?;
-    Ok(ToolCoreOutcome {
-        status: "ok".to_owned(),
-        payload: json!({
-            "adapter": "core-tools",
-            "tool_name": request.tool_name,
-            "skill": skill,
-            "instructions_preview": build_preview(instructions.as_str(), 240),
-            "shadowed_skills": inventory
-                .shadowed_skills
-                .into_iter()
-                .filter(|entry| entry.skill_id == skill_id)
-                .collect::<Vec<_>>(),
-        }),
-    })
+    execute_external_skills_inspect_for_audience(
+        request.tool_name,
+        config,
+        skill_id,
+        SkillAudience::Model,
+    )
 }
 
 pub(super) fn execute_external_skills_invoke_tool_with_config(
@@ -757,12 +772,9 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
 
     require_enabled_runtime_policy(config)?;
 
-    let skill = resolve_discovered_skill(&discover_skill_inventory(config)?, skill_id)?;
-    if !skill.active {
-        return Err(format!(
-            "external skill `{skill_id}` is installed but inactive"
-        ));
-    }
+    let inventory = discover_skill_inventory(config)?;
+    let skill = resolve_discovered_skill(&inventory, skill_id)?;
+    ensure_skill_access_for_audience(&skill, SkillAudience::Model)?;
     let instructions = load_discovered_skill_markdown(config, &skill)?;
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -783,6 +795,30 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
             ),
         }),
     })
+}
+
+pub(crate) fn execute_external_skills_operator_list_tool_with_config(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    require_enabled_runtime_policy(config)?;
+    execute_external_skills_list_for_audience(
+        "external_skills.list".to_owned(),
+        config,
+        SkillAudience::Operator,
+    )
+}
+
+pub(crate) fn execute_external_skills_operator_inspect_tool_with_config(
+    skill_id: &str,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    require_enabled_runtime_policy(config)?;
+    execute_external_skills_inspect_for_audience(
+        "external_skills.inspect".to_owned(),
+        config,
+        skill_id,
+        SkillAudience::Operator,
+    )
 }
 
 pub(super) fn execute_external_skills_remove_tool_with_config(
@@ -830,6 +866,51 @@ pub(super) fn execute_external_skills_remove_tool_with_config(
             "tool_name": request.tool_name,
             "skill_id": skill_id,
             "removed": true,
+        }),
+    })
+}
+
+fn execute_external_skills_list_for_audience(
+    tool_name: String,
+    config: &super::runtime_config::ToolRuntimeConfig,
+    audience: SkillAudience,
+) -> Result<ToolCoreOutcome, String> {
+    let inventory = discover_skill_inventory(config)?;
+    let filtered = filter_inventory_for_audience(inventory, audience);
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": tool_name,
+            "skills": filtered.skills,
+            "shadowed_skills": filtered.shadowed_skills,
+        }),
+    })
+}
+
+fn execute_external_skills_inspect_for_audience(
+    tool_name: String,
+    config: &super::runtime_config::ToolRuntimeConfig,
+    skill_id: &str,
+    audience: SkillAudience,
+) -> Result<ToolCoreOutcome, String> {
+    let inventory = discover_skill_inventory(config)?;
+    let skill = resolve_discovered_skill(&inventory, skill_id)?;
+    ensure_skill_access_for_audience(&skill, audience)?;
+    let instructions = load_discovered_skill_markdown(config, &skill)?;
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": tool_name,
+            "skill": skill,
+            "instructions_preview": build_preview(instructions.as_str(), 240),
+            "shadowed_skills": inventory
+                .shadowed_skills
+                .into_iter()
+                .filter(|entry| entry.skill_id == skill_id)
+                .filter(|entry| skill_is_visible_to_audience(entry, audience))
+                .collect::<Vec<_>>(),
         }),
     })
 }
@@ -894,6 +975,28 @@ impl ExternalSkillsPolicyOverride {
             || self.require_download_approval.is_some()
             || self.allowed_domains.is_some()
             || self.blocked_domains.is_some()
+    }
+}
+
+impl SkillEligibility {
+    fn ready() -> Self {
+        Self {
+            available: true,
+            ..Self::default()
+        }
+    }
+
+    fn with_missing(
+        missing_env: Vec<String>,
+        missing_bin: Vec<String>,
+        missing_paths: Vec<String>,
+    ) -> Self {
+        Self {
+            available: missing_env.is_empty() && missing_bin.is_empty() && missing_paths.is_empty(),
+            missing_env,
+            missing_bin,
+            missing_paths,
+        }
     }
 }
 
@@ -1334,6 +1437,8 @@ fn derive_skill_id(root: &Path) -> String {
 
 fn derive_skill_id_from_markdown(root: &Path, skill_markdown: &str) -> String {
     parse_skill_frontmatter(skill_markdown)
+        .ok()
+        .unwrap_or_default()
         .name
         .as_deref()
         .and_then(|name| normalize_skill_id(name).ok())
@@ -1371,7 +1476,17 @@ fn normalize_skill_id(raw: &str) -> Result<String, String> {
 }
 
 fn derive_skill_display_name(skill_markdown: &str, fallback: &str) -> String {
-    let frontmatter = parse_skill_frontmatter(skill_markdown);
+    let frontmatter = parse_skill_frontmatter(skill_markdown)
+        .ok()
+        .unwrap_or_default();
+    derive_skill_display_name_with_frontmatter(skill_markdown, &frontmatter, fallback)
+}
+
+fn derive_skill_display_name_with_frontmatter(
+    skill_markdown: &str,
+    frontmatter: &SkillFrontmatter,
+    fallback: &str,
+) -> String {
     // Prefer the visible document title when present so operator-facing listings match
     // the heading the skill author chose to present in SKILL.md.
     for line in skill_content_lines(skill_markdown) {
@@ -1383,20 +1498,29 @@ fn derive_skill_display_name(skill_markdown: &str, fallback: &str) -> String {
             }
         }
     }
-    if let Some(name) = frontmatter.name
+    if let Some(name) = frontmatter.name.as_deref()
         && !name.is_empty()
     {
-        return name;
+        return name.to_owned();
     }
     fallback.to_owned()
 }
 
 fn derive_skill_summary(skill_markdown: &str) -> String {
-    let frontmatter = parse_skill_frontmatter(skill_markdown);
-    if let Some(description) = frontmatter.description
+    let frontmatter = parse_skill_frontmatter(skill_markdown)
+        .ok()
+        .unwrap_or_default();
+    derive_skill_summary_with_frontmatter(skill_markdown, &frontmatter)
+}
+
+fn derive_skill_summary_with_frontmatter(
+    skill_markdown: &str,
+    frontmatter: &SkillFrontmatter,
+) -> String {
+    if let Some(description) = frontmatter.description.as_deref()
         && !description.is_empty()
     {
-        return build_preview(description.as_str(), 120);
+        return build_preview(description, 120);
     }
     for line in skill_content_lines(skill_markdown) {
         let trimmed = line.trim();
@@ -1408,41 +1532,73 @@ fn derive_skill_summary(skill_markdown: &str) -> String {
     "No summary provided.".to_owned()
 }
 
-fn parse_skill_frontmatter(skill_markdown: &str) -> SkillFrontmatter {
+fn parse_skill_frontmatter(skill_markdown: &str) -> Result<SkillFrontmatter, String> {
     let mut lines = skill_markdown.lines();
     if lines.next().map(str::trim) != Some("---") {
-        return SkillFrontmatter::default();
+        return Ok(SkillFrontmatter::default());
     }
 
-    let mut frontmatter = SkillFrontmatter::default();
+    let mut raw_frontmatter = Vec::new();
     for line in lines {
         let trimmed = line.trim();
         if trimmed == "---" {
-            break;
+            let raw = raw_frontmatter.join("\n");
+            if raw.trim().is_empty() {
+                return Ok(SkillFrontmatter::default());
+            }
+            let parsed = serde_yaml::from_str::<YamlValue>(&raw)
+                .map_err(|error| format!("failed to parse YAML: {error}"))?;
+            let mut frontmatter = match parsed {
+                YamlValue::Null => SkillFrontmatter::default(),
+                YamlValue::Mapping(_) => serde_yaml::from_value(parsed).map_err(|error| {
+                    format!("failed to decode supported metadata fields: {error}")
+                })?,
+                YamlValue::Bool(_)
+                | YamlValue::Number(_)
+                | YamlValue::String(_)
+                | YamlValue::Sequence(_)
+                | YamlValue::Tagged(_) => {
+                    return Err(
+                        "frontmatter must decode to a YAML mapping of scalar or list fields"
+                            .to_owned(),
+                    );
+                }
+            };
+            normalize_skill_frontmatter(&mut frontmatter);
+            return Ok(frontmatter);
         }
-        if let Some(value) = parse_frontmatter_scalar(trimmed, "name") {
-            frontmatter.name = Some(value);
-            continue;
-        }
-        if let Some(value) = parse_frontmatter_scalar(trimmed, "description") {
-            frontmatter.description = Some(value);
-        }
+        raw_frontmatter.push(line);
     }
-    frontmatter
+    Err("frontmatter is missing a closing `---` delimiter".to_owned())
 }
 
-fn parse_frontmatter_scalar(line: &str, key: &str) -> Option<String> {
-    let raw = line.strip_prefix(key)?.strip_prefix(':')?.trim();
-    let unquoted = raw
-        .strip_prefix('"')
-        .and_then(|value| value.strip_suffix('"'))
-        .or_else(|| {
-            raw.strip_prefix('\'')
-                .and_then(|value| value.strip_suffix('\''))
-        })
-        .unwrap_or(raw)
-        .trim();
-    (!unquoted.is_empty()).then(|| unquoted.to_owned())
+fn normalize_skill_frontmatter(frontmatter: &mut SkillFrontmatter) {
+    frontmatter.name = normalize_optional_metadata_string(frontmatter.name.take());
+    frontmatter.description = normalize_optional_metadata_string(frontmatter.description.take());
+    frontmatter.requires_env =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.requires_env));
+    frontmatter.requires_bin =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.requires_bin));
+    frontmatter.requires_paths =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.requires_paths));
+}
+
+fn normalize_optional_metadata_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn normalize_metadata_string_list(values: Vec<String>) -> Vec<String> {
+    let mut normalized = values
+        .into_iter()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
 }
 
 fn skill_content_lines(skill_markdown: &str) -> impl Iterator<Item = &str> {
@@ -1463,6 +1619,220 @@ fn skill_content_lines(skill_markdown: &str) -> impl Iterator<Item = &str> {
         }
         true
     })
+}
+
+fn build_managed_discovered_skill_entry(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    entry: InstalledSkillEntry,
+) -> Result<DiscoveredSkillEntry, String> {
+    let skill_markdown = load_managed_skill_markdown(&entry)?;
+    build_discovered_skill_entry(
+        config,
+        DiscoveredSkillScope::Managed,
+        entry.source_kind,
+        entry.source_path,
+        entry.skill_md_path,
+        entry.skill_id,
+        skill_markdown.as_str(),
+        entry.active,
+        Some(entry.install_path),
+    )
+}
+
+fn build_discovered_skill_entry(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    scope: DiscoveredSkillScope,
+    source_kind: String,
+    source_path: String,
+    skill_md_path: String,
+    skill_id: String,
+    skill_markdown: &str,
+    active: bool,
+    install_path: Option<String>,
+) -> Result<DiscoveredSkillEntry, String> {
+    let frontmatter = parse_skill_frontmatter(skill_markdown).map_err(|error| {
+        format!(
+            "invalid external skill frontmatter in {}: {error}",
+            skill_md_path
+        )
+    })?;
+    let eligibility = evaluate_skill_eligibility(config, &frontmatter);
+    Ok(DiscoveredSkillEntry {
+        display_name: derive_skill_display_name_with_frontmatter(
+            skill_markdown,
+            &frontmatter,
+            skill_id.as_str(),
+        ),
+        summary: derive_skill_summary_with_frontmatter(skill_markdown, &frontmatter),
+        scope,
+        source_kind,
+        source_path,
+        skill_md_path,
+        sha256: format!("{:x}", Sha256::digest(skill_markdown.as_bytes())),
+        active,
+        install_path,
+        model_visibility: frontmatter.model_visibility,
+        required_env: frontmatter.requires_env.clone(),
+        required_bin: frontmatter.requires_bin.clone(),
+        required_paths: frontmatter.requires_paths.clone(),
+        eligibility,
+        skill_id,
+    })
+}
+
+fn evaluate_skill_eligibility(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    frontmatter: &SkillFrontmatter,
+) -> SkillEligibility {
+    let missing_env = frontmatter
+        .requires_env
+        .iter()
+        .filter(|name| !env_var_is_present(name))
+        .cloned()
+        .collect::<Vec<_>>();
+    let missing_bin = frontmatter
+        .requires_bin
+        .iter()
+        .filter(|command| !command_on_path(command))
+        .cloned()
+        .collect::<Vec<_>>();
+    let missing_paths = frontmatter
+        .requires_paths
+        .iter()
+        .filter(|path| !required_path_exists(config, path))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing_env.is_empty() && missing_bin.is_empty() && missing_paths.is_empty() {
+        SkillEligibility::ready()
+    } else {
+        SkillEligibility::with_missing(missing_env, missing_bin, missing_paths)
+    }
+}
+
+fn env_var_is_present(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|value| !value.is_empty())
+}
+
+fn command_on_path(command: &str) -> bool {
+    let Some(path_env) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path_env).any(|dir| {
+        command_candidates(command)
+            .into_iter()
+            .map(|candidate| dir.join(candidate))
+            .any(|candidate| candidate.is_file())
+    })
+}
+
+fn command_candidates(command: &str) -> Vec<String> {
+    #[cfg(windows)]
+    {
+        vec![
+            command.to_owned(),
+            format!("{command}.exe"),
+            format!("{command}.cmd"),
+            format!("{command}.bat"),
+            format!("{command}.com"),
+        ]
+    }
+    #[cfg(not(windows))]
+    {
+        vec![command.to_owned()]
+    }
+}
+
+fn required_path_exists(config: &super::runtime_config::ToolRuntimeConfig, raw: &str) -> bool {
+    resolve_required_path(config, raw).exists()
+}
+
+fn resolve_required_path(config: &super::runtime_config::ToolRuntimeConfig, raw: &str) -> PathBuf {
+    let candidate = PathBuf::from(raw);
+    if candidate.is_absolute() {
+        return candidate;
+    }
+    config
+        .file_root
+        .clone()
+        .or_else(|| project_discovery_root(config))
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+        .join(candidate)
+}
+
+fn filter_inventory_for_audience(
+    inventory: SkillDiscoveryInventory,
+    audience: SkillAudience,
+) -> SkillDiscoveryInventory {
+    match audience {
+        SkillAudience::Operator => inventory,
+        SkillAudience::Model => SkillDiscoveryInventory {
+            skills: inventory
+                .skills
+                .into_iter()
+                .filter(|entry| skill_is_visible_to_audience(entry, audience))
+                .collect(),
+            shadowed_skills: inventory
+                .shadowed_skills
+                .into_iter()
+                .filter(|entry| skill_is_visible_to_audience(entry, audience))
+                .collect(),
+        },
+    }
+}
+
+fn skill_is_visible_to_audience(entry: &DiscoveredSkillEntry, audience: SkillAudience) -> bool {
+    match audience {
+        SkillAudience::Operator => true,
+        SkillAudience::Model => {
+            entry.active
+                && entry.model_visibility == SkillModelVisibility::Visible
+                && entry.eligibility.available
+        }
+    }
+}
+
+fn ensure_skill_access_for_audience(
+    skill: &DiscoveredSkillEntry,
+    audience: SkillAudience,
+) -> Result<(), String> {
+    if audience == SkillAudience::Operator {
+        return Ok(());
+    }
+    if skill_is_visible_to_audience(skill, audience) {
+        return Ok(());
+    }
+
+    let mut blockers = Vec::new();
+    if !skill.active {
+        blockers.push("a higher-precedence resolved skill is inactive".to_owned());
+    }
+    if skill.model_visibility == SkillModelVisibility::Hidden {
+        blockers.push("the skill is operator-only and hidden from the model surface".to_owned());
+    }
+    if !skill.eligibility.missing_env.is_empty() {
+        blockers.push(format!(
+            "missing env vars: {}",
+            skill.eligibility.missing_env.join(", ")
+        ));
+    }
+    if !skill.eligibility.missing_bin.is_empty() {
+        blockers.push(format!(
+            "missing commands on PATH: {}",
+            skill.eligibility.missing_bin.join(", ")
+        ));
+    }
+    if !skill.eligibility.missing_paths.is_empty() {
+        blockers.push(format!(
+            "missing required paths: {}",
+            skill.eligibility.missing_paths.join(", ")
+        ));
+    }
+
+    Err(format!(
+        "external skill `{}` is not available on the provider surface: {}",
+        skill.skill_id,
+        blockers.join("; ")
+    ))
 }
 
 fn build_preview(content: &str, max_chars: usize) -> String {
@@ -1621,7 +1991,7 @@ fn discover_skill_inventory(
     let mut grouped = BTreeMap::<String, Vec<DiscoveredSkillCandidate>>::new();
     for candidate in discover_managed_skill_candidates(config)?
         .into_iter()
-        .chain(discover_user_skill_candidates()?)
+        .chain(discover_user_skill_candidates(config)?)
         .chain(discover_project_skill_candidates(config)?)
     {
         grouped
@@ -1642,11 +2012,7 @@ fn discover_skill_inventory(
                 .then_with(|| left.entry.source_path.cmp(&right.entry.source_path))
         });
 
-        let winner_index = candidates
-            .iter()
-            .position(|candidate| candidate.entry.active)
-            .unwrap_or(0);
-        let winner = candidates.remove(winner_index);
+        let winner = candidates.remove(0);
         inventory.skills.push(winner.entry);
         inventory
             .shadowed_skills
@@ -1685,9 +2051,14 @@ pub(super) fn installed_skill_snapshot_lines_with_config(
             if !entry.active {
                 return None;
             }
-            rehydrate_installed_skill_entry(&install_root, entry)
-                .ok()
-                .map(|entry| format!("- {}: {}", entry.skill_id, INSTALLED_SKILL_SNAPSHOT_HINT))
+            let rehydrated = rehydrate_installed_skill_entry(&install_root, entry).ok()?;
+            let discovered = build_managed_discovered_skill_entry(config, rehydrated).ok()?;
+            skill_is_visible_to_audience(&discovered, SkillAudience::Model).then(|| {
+                format!(
+                    "- {}: {}",
+                    discovered.skill_id, INSTALLED_SKILL_SNAPSHOT_HINT
+                )
+            })
         })
         .collect())
 }
@@ -1705,28 +2076,20 @@ fn discover_managed_skill_candidates(
             Ok(DiscoveredSkillCandidate {
                 probe_rank: 0,
                 root_rank: 0,
-                entry: DiscoveredSkillEntry {
-                    skill_id: entry.skill_id,
-                    display_name: entry.display_name,
-                    summary: entry.summary,
-                    scope: DiscoveredSkillScope::Managed,
-                    source_kind: entry.source_kind,
-                    source_path: entry.source_path,
-                    skill_md_path: entry.skill_md_path,
-                    sha256: entry.sha256,
-                    active: entry.active,
-                    install_path: Some(entry.install_path),
-                },
+                entry: build_managed_discovered_skill_entry(config, entry)?,
             })
         })
         .collect()
 }
 
-fn discover_user_skill_candidates() -> Result<Vec<DiscoveredSkillCandidate>, String> {
+fn discover_user_skill_candidates(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<DiscoveredSkillCandidate>, String> {
     let Some(home_root) = user_home_dir() else {
         return Ok(Vec::new());
     };
     discover_scoped_skill_candidates(
+        config,
         &[home_root],
         DiscoveredSkillScope::User,
         &USER_DISCOVERY_DIRS,
@@ -1737,6 +2100,7 @@ fn discover_project_skill_candidates(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<Vec<DiscoveredSkillCandidate>, String> {
     discover_scoped_skill_candidates(
+        config,
         &project_discovery_probe_roots(config),
         DiscoveredSkillScope::Project,
         &PROJECT_DISCOVERY_DIRS,
@@ -1744,6 +2108,7 @@ fn discover_project_skill_candidates(
 }
 
 fn discover_scoped_skill_candidates(
+    config: &super::runtime_config::ToolRuntimeConfig,
     probe_roots: &[PathBuf],
     scope: DiscoveredSkillScope,
     dir_specs: &[(&str, usize)],
@@ -1762,26 +2127,29 @@ fn discover_scoped_skill_candidates(
                 if !seen.insert(key.clone()) {
                     continue;
                 }
-                let skill_markdown = load_directory_skill_markdown(&skill_root)?;
+                let skill_markdown = match load_directory_skill_markdown(&skill_root) {
+                    Ok(skill_markdown) => skill_markdown,
+                    Err(_) => continue,
+                };
                 let skill_id = derive_skill_id_from_markdown(&skill_root, skill_markdown.as_str());
+                let entry = match build_discovered_skill_entry(
+                    config,
+                    scope,
+                    "directory".to_owned(),
+                    skill_root.display().to_string(),
+                    key,
+                    skill_id,
+                    skill_markdown.as_str(),
+                    true,
+                    None,
+                ) {
+                    Ok(entry) => entry,
+                    Err(_) => continue,
+                };
                 candidates.push(DiscoveredSkillCandidate {
                     probe_rank,
                     root_rank: *root_rank,
-                    entry: DiscoveredSkillEntry {
-                        skill_id: skill_id.clone(),
-                        display_name: derive_skill_display_name(
-                            skill_markdown.as_str(),
-                            skill_id.as_str(),
-                        ),
-                        summary: derive_skill_summary(skill_markdown.as_str()),
-                        scope,
-                        source_kind: "directory".to_owned(),
-                        source_path: skill_root.display().to_string(),
-                        skill_md_path: key,
-                        sha256: format!("{:x}", Sha256::digest(skill_markdown.as_bytes())),
-                        active: true,
-                        install_path: None,
-                    },
+                    entry,
                 });
             }
         }
@@ -3055,6 +3423,269 @@ mod tests {
             )
             .expect("list should succeed after remove");
             assert_eq!(list_outcome.payload["skills"], json!([]));
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn provider_surface_does_not_fall_back_when_managed_winner_is_inactive() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-inactive-winner");
+            let home = unique_temp_dir("loongclaw-ext-skill-inactive-winner-home");
+            fs::create_dir_all(&root).expect("create fixture root");
+            fs::create_dir_all(&home).expect("create home root");
+            write_file(
+                &root,
+                "source/demo-skill/SKILL.md",
+                "# Managed Demo Skill\n\nManaged winner should keep precedence even when inactive.\n",
+            );
+            write_file(
+                &home,
+                ".agents/skills/demo-skill/SKILL.md",
+                "---\nname: demo-skill\ndescription: user fallback should stay shadowed.\n---\n\n# User Demo Skill\n\nDo not silently take over.\n",
+            );
+
+            let config = managed_runtime_config(&root);
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("HOME", &home);
+
+            crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/demo-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect("install should succeed");
+
+            let install_root = root.join("external-skills-installed");
+            let index_path = install_root.join("index.json");
+            let mut index: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&index_path).expect("read index"))
+                    .expect("parse index");
+            index["skills"][0]["active"] = json!(false);
+            fs::write(
+                &index_path,
+                serde_json::to_string_pretty(&index).expect("encode index"),
+            )
+            .expect("write tampered index");
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed even when managed winner is inactive");
+            assert!(
+                !list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "demo-skill"),
+                "provider surface should not fall back to lower-scope duplicates: {}",
+                list_outcome.payload
+            );
+
+            let error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "demo-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("invoke should reject inactive managed winners");
+            assert!(
+                error.contains("inactive"),
+                "expected inactive winner error, got: {error}"
+            );
+
+            fs::remove_dir_all(&root).ok();
+            fs::remove_dir_all(&home).ok();
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_surface_skips_unreadable_local_skills_without_failing_discovery() {
+        with_managed_runtime_test(|| {
+            use std::os::unix::fs::PermissionsExt;
+
+            let root = unique_temp_dir("loongclaw-ext-skill-unreadable-discovery");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let _home = ScopedHomeFixture::new("loongclaw-ext-skill-unreadable-discovery-home");
+            write_file(
+                &root,
+                ".agents/skills/healthy-skill/SKILL.md",
+                "---\nname: healthy-skill\ndescription: healthy project skill.\n---\n\nHealthy skill instructions.\n",
+            );
+            write_file(
+                &root,
+                ".agents/skills/broken-skill/SKILL.md",
+                "---\nname: broken-skill\ndescription: unreadable project skill.\n---\n\nBroken skill instructions.\n",
+            );
+
+            let unreadable_path = root.join(".agents/skills/broken-skill/SKILL.md");
+            let mut perms = fs::metadata(&unreadable_path)
+                .expect("read metadata")
+                .permissions();
+            perms.set_mode(0o000);
+            fs::set_permissions(&unreadable_path, perms).expect("set unreadable permissions");
+
+            let config = managed_runtime_config(&root);
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed when one discovered skill is unreadable");
+
+            let skills = list_outcome.payload["skills"]
+                .as_array()
+                .expect("skills should be an array");
+            assert!(
+                skills
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "healthy-skill"),
+                "healthy project skill should remain discoverable: {skills:?}"
+            );
+            assert!(
+                skills
+                    .iter()
+                    .all(|skill| skill["skill_id"] != "broken-skill"),
+                "unreadable skill should be skipped instead of failing discovery: {skills:?}"
+            );
+
+            let mut cleanup_perms = fs::metadata(&unreadable_path)
+                .expect("read metadata for cleanup")
+                .permissions();
+            cleanup_perms.set_mode(0o644);
+            fs::set_permissions(&unreadable_path, cleanup_perms).ok();
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn provider_surface_hides_model_hidden_skills_and_snapshot_auto_exposure() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-model-hidden");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let _home = ScopedHomeFixture::new("loongclaw-ext-skill-model-hidden-home");
+            write_file(
+                &root,
+                "source/demo-skill/SKILL.md",
+                "---\nname: demo-skill\ndescription: operator-only managed skill.\nmodel_visibility: hidden\n---\n\n# Demo Skill\n\nHide this skill from the model surface.\n",
+            );
+            let config = managed_runtime_config(&root);
+
+            crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/demo-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect("install should succeed");
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed");
+            assert!(
+                !list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "demo-skill"),
+                "model-hidden skills should stay off the provider-visible surface: {}",
+                list_outcome.payload
+            );
+
+            let error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "demo-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("invoke should reject model-hidden skills on the provider surface");
+            assert!(
+                error.contains("operator-only") || error.contains("model"),
+                "expected model-hidden error, got: {error}"
+            );
+
+            let lines = installed_skill_snapshot_lines_with_config(&config)
+                .expect("snapshot should succeed");
+            assert!(
+                lines.is_empty(),
+                "model-hidden skills should not be auto-exposed in installed snapshots: {lines:?}"
+            );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn provider_surface_hides_skills_with_missing_required_env() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-required-env");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let _home = ScopedHomeFixture::new("loongclaw-ext-skill-required-env-home");
+            write_file(
+                &root,
+                ".agents/skills/env-guarded/SKILL.md",
+                "---\nname: env-guarded\ndescription: requires an explicit env var.\nrequires_env:\n  - DEMO_SKILL_TOKEN\n---\n\n# Env Guarded Skill\n\nOnly run when the token exists.\n",
+            );
+            let config = managed_runtime_config(&root);
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed");
+            assert!(
+                !list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "env-guarded"),
+                "skills with missing required env should stay hidden from provider list: {}",
+                list_outcome.payload
+            );
+
+            let error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "env-guarded"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("invoke should reject skills with missing required env");
+            assert!(
+                error.contains("DEMO_SKILL_TOKEN"),
+                "expected missing env variable in error, got: {error}"
+            );
 
             fs::remove_dir_all(&root).ok();
         });

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -91,6 +91,37 @@ struct DiscoveredSkillEntry {
     eligibility: SkillEligibility,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct DiscoveredSkillModelView {
+    skill_id: String,
+    display_name: String,
+    summary: String,
+    scope: DiscoveredSkillScope,
+    source_kind: String,
+    source_path: String,
+    skill_md_path: String,
+    sha256: String,
+    active: bool,
+    install_path: Option<String>,
+}
+
+impl From<DiscoveredSkillEntry> for DiscoveredSkillModelView {
+    fn from(entry: DiscoveredSkillEntry) -> Self {
+        Self {
+            skill_id: entry.skill_id,
+            display_name: entry.display_name,
+            summary: entry.summary,
+            scope: entry.scope,
+            source_kind: entry.source_kind,
+            source_path: entry.source_path,
+            skill_md_path: entry.skill_md_path,
+            sha256: entry.sha256,
+            active: entry.active,
+            install_path: entry.install_path,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 enum SkillModelVisibility {
@@ -129,9 +160,16 @@ struct DiscoveredSkillCandidate {
 }
 
 #[derive(Debug, Clone, Default)]
+struct ManagedSkillDiscovery {
+    candidates: Vec<DiscoveredSkillCandidate>,
+    blocked_skill_errors: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
 struct SkillDiscoveryInventory {
     skills: Vec<DiscoveredSkillEntry>,
     shadowed_skills: Vec<DiscoveredSkillEntry>,
+    blocked_skill_errors: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -882,8 +920,8 @@ fn execute_external_skills_list_for_audience(
         payload: json!({
             "adapter": "core-tools",
             "tool_name": tool_name,
-            "skills": filtered.skills,
-            "shadowed_skills": filtered.shadowed_skills,
+            "skills": serialize_skill_entries_for_audience(filtered.skills, audience),
+            "shadowed_skills": serialize_skill_entries_for_audience(filtered.shadowed_skills, audience),
         }),
     })
 }
@@ -903,14 +941,17 @@ fn execute_external_skills_inspect_for_audience(
         payload: json!({
             "adapter": "core-tools",
             "tool_name": tool_name,
-            "skill": skill,
+            "skill": serialize_skill_entry_for_audience(skill, audience),
             "instructions_preview": build_preview(instructions.as_str(), 240),
-            "shadowed_skills": inventory
-                .shadowed_skills
-                .into_iter()
-                .filter(|entry| entry.skill_id == skill_id)
-                .filter(|entry| skill_is_visible_to_audience(entry, audience))
-                .collect::<Vec<_>>(),
+            "shadowed_skills": serialize_skill_entries_for_audience(
+                inventory
+                    .shadowed_skills
+                    .into_iter()
+                    .filter(|entry| entry.skill_id == skill_id)
+                    .filter(|entry| skill_is_visible_to_audience(entry, audience))
+                    .collect::<Vec<_>>(),
+                audience,
+            ),
         }),
     })
 }
@@ -1713,6 +1754,31 @@ fn env_var_is_present(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|value| !value.is_empty())
 }
 
+fn serialize_skill_entry_for_audience(
+    entry: DiscoveredSkillEntry,
+    audience: SkillAudience,
+) -> Value {
+    match audience {
+        SkillAudience::Operator => json!(entry),
+        SkillAudience::Model => json!(DiscoveredSkillModelView::from(entry)),
+    }
+}
+
+fn serialize_skill_entries_for_audience(
+    entries: Vec<DiscoveredSkillEntry>,
+    audience: SkillAudience,
+) -> Value {
+    match audience {
+        SkillAudience::Operator => json!(entries),
+        SkillAudience::Model => json!(
+            entries
+                .into_iter()
+                .map(DiscoveredSkillModelView::from)
+                .collect::<Vec<_>>()
+        ),
+    }
+}
+
 fn command_on_path(command: &str) -> bool {
     let Some(path_env) = std::env::var_os("PATH") else {
         return false;
@@ -1721,8 +1787,27 @@ fn command_on_path(command: &str) -> bool {
         command_candidates(command)
             .into_iter()
             .map(|candidate| dir.join(candidate))
-            .any(|candidate| candidate.is_file())
+            .any(|candidate| command_candidate_is_executable(&candidate))
     })
+}
+
+fn command_candidate_is_executable(candidate: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(candidate) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 fn command_candidates(command: &str) -> Vec<String> {
@@ -1776,6 +1861,7 @@ fn filter_inventory_for_audience(
                 .into_iter()
                 .filter(|entry| skill_is_visible_to_audience(entry, audience))
                 .collect(),
+            blocked_skill_errors: inventory.blocked_skill_errors,
         },
     }
 }
@@ -1988,8 +2074,10 @@ fn installed_skill_by_id(
 fn discover_skill_inventory(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<SkillDiscoveryInventory, String> {
+    let managed = discover_managed_skill_candidates(config)?;
     let mut grouped = BTreeMap::<String, Vec<DiscoveredSkillCandidate>>::new();
-    for candidate in discover_managed_skill_candidates(config)?
+    for candidate in managed
+        .candidates
         .into_iter()
         .chain(discover_user_skill_candidates(config)?)
         .chain(discover_project_skill_candidates(config)?)
@@ -2000,8 +2088,14 @@ fn discover_skill_inventory(
             .push(candidate);
     }
 
-    let mut inventory = SkillDiscoveryInventory::default();
-    for mut candidates in grouped.into_values() {
+    let mut inventory = SkillDiscoveryInventory {
+        blocked_skill_errors: managed.blocked_skill_errors,
+        ..SkillDiscoveryInventory::default()
+    };
+    for (skill_id, mut candidates) in grouped {
+        if inventory.blocked_skill_errors.contains_key(&skill_id) {
+            continue;
+        }
         candidates.sort_by(|left, right| {
             left.entry
                 .scope
@@ -2065,21 +2159,40 @@ pub(super) fn installed_skill_snapshot_lines_with_config(
 
 fn discover_managed_skill_candidates(
     config: &super::runtime_config::ToolRuntimeConfig,
-) -> Result<Vec<DiscoveredSkillCandidate>, String> {
+) -> Result<ManagedSkillDiscovery, String> {
     let install_root = resolve_install_root(config);
     let index = load_installed_skill_index(&install_root)?;
-    index
-        .skills
-        .into_iter()
-        .map(|entry| {
-            let entry = rehydrate_installed_skill_entry(&install_root, entry)?;
-            Ok(DiscoveredSkillCandidate {
-                probe_rank: 0,
-                root_rank: 0,
-                entry: build_managed_discovered_skill_entry(config, entry)?,
-            })
-        })
-        .collect()
+    let mut discovery = ManagedSkillDiscovery::default();
+    for entry in index.skills {
+        let skill_id = entry.skill_id.clone();
+        let entry = match rehydrate_installed_skill_entry(&install_root, entry) {
+            Ok(entry) => entry,
+            Err(error) => {
+                discovery
+                    .blocked_skill_errors
+                    .entry(skill_id)
+                    .or_insert(error);
+                continue;
+            }
+        };
+        let entry = match build_managed_discovered_skill_entry(config, entry) {
+            Ok(entry) => entry,
+            Err(error) => {
+                discovery
+                    .blocked_skill_errors
+                    .entry(skill_id)
+                    .or_insert(error);
+                continue;
+            }
+        };
+        discovery.blocked_skill_errors.remove(&skill_id);
+        discovery.candidates.push(DiscoveredSkillCandidate {
+            probe_rank: 0,
+            root_rank: 0,
+            entry,
+        });
+    }
+    Ok(discovery)
 }
 
 fn discover_user_skill_candidates(
@@ -2211,12 +2324,18 @@ fn resolve_discovered_skill(
     inventory: &SkillDiscoveryInventory,
     skill_id: &str,
 ) -> Result<DiscoveredSkillEntry, String> {
-    inventory
+    if let Some(skill) = inventory
         .skills
         .iter()
         .find(|entry| entry.skill_id == skill_id)
         .cloned()
-        .ok_or_else(|| format!("external skill `{skill_id}` is not available"))
+    {
+        return Ok(skill);
+    }
+    if let Some(error) = inventory.blocked_skill_errors.get(skill_id) {
+        return Err(error.clone());
+    }
+    Err(format!("external skill `{skill_id}` is not available"))
 }
 
 fn load_discovered_skill_markdown(
@@ -3688,6 +3807,290 @@ mod tests {
             );
 
             fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn model_surface_redacts_operator_only_skill_metadata() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-model-redaction");
+            fs::create_dir_all(&root).expect("create fixture root");
+            write_file(
+                &root,
+                ".agents/skills/demo-skill/SKILL.md",
+                "---\nname: demo-skill\ndescription: eligible project skill.\nrequires_env:\n  - DEMO_SKILL_TOKEN\nrequires_bin:\n  - sh\nrequires_paths:\n  - fixtures/present.txt\n---\n\n# Demo Skill\n\nOnly expose model-safe metadata on the provider surface.\n",
+            );
+            write_file(&root, "fixtures/present.txt", "present");
+            let config = managed_runtime_config(&root);
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("DEMO_SKILL_TOKEN", "present");
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("model list should succeed");
+            let model_skill = list_outcome.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "demo-skill")
+                .expect("model list should include demo-skill");
+            assert!(
+                model_skill.get("model_visibility").is_none(),
+                "model list should not expose visibility internals: {model_skill:?}"
+            );
+            assert!(
+                model_skill.get("required_env").is_none(),
+                "model list should not expose required_env: {model_skill:?}"
+            );
+            assert!(
+                model_skill.get("required_bin").is_none(),
+                "model list should not expose required_bin: {model_skill:?}"
+            );
+            assert!(
+                model_skill.get("required_paths").is_none(),
+                "model list should not expose required_paths: {model_skill:?}"
+            );
+            assert!(
+                model_skill.get("eligibility").is_none(),
+                "model list should not expose eligibility diagnostics: {model_skill:?}"
+            );
+
+            let operator_list = execute_external_skills_operator_list_tool_with_config(&config)
+                .expect("operator list should succeed");
+            let operator_skill = operator_list.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "demo-skill")
+                .expect("operator list should include demo-skill");
+            assert_eq!(operator_skill["model_visibility"], "visible");
+            assert_eq!(operator_skill["required_env"], json!(["DEMO_SKILL_TOKEN"]));
+            assert_eq!(operator_skill["required_bin"], json!(["sh"]));
+            assert_eq!(
+                operator_skill["required_paths"],
+                json!(["fixtures/present.txt"])
+            );
+            assert_eq!(operator_skill["eligibility"]["available"], true);
+
+            let inspect_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.inspect".to_owned(),
+                    payload: json!({
+                        "skill_id": "demo-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect("model inspect should succeed");
+            let model_inspect_skill = inspect_outcome.payload["skill"]
+                .as_object()
+                .expect("inspect skill should be an object");
+            assert!(
+                !model_inspect_skill.contains_key("model_visibility"),
+                "model inspect should not expose visibility internals: {model_inspect_skill:?}"
+            );
+            assert!(
+                !model_inspect_skill.contains_key("required_env"),
+                "model inspect should not expose required_env: {model_inspect_skill:?}"
+            );
+            assert!(
+                !model_inspect_skill.contains_key("required_bin"),
+                "model inspect should not expose required_bin: {model_inspect_skill:?}"
+            );
+            assert!(
+                !model_inspect_skill.contains_key("required_paths"),
+                "model inspect should not expose required_paths: {model_inspect_skill:?}"
+            );
+            assert!(
+                !model_inspect_skill.contains_key("eligibility"),
+                "model inspect should not expose eligibility diagnostics: {model_inspect_skill:?}"
+            );
+
+            let operator_inspect =
+                execute_external_skills_operator_inspect_tool_with_config("demo-skill", &config)
+                    .expect("operator inspect should succeed");
+            assert_eq!(
+                operator_inspect.payload["skill"]["required_env"],
+                json!(["DEMO_SKILL_TOKEN"])
+            );
+            assert_eq!(
+                operator_inspect.payload["skill"]["required_bin"],
+                json!(["sh"])
+            );
+            assert_eq!(
+                operator_inspect.payload["skill"]["required_paths"],
+                json!(["fixtures/present.txt"])
+            );
+            assert_eq!(
+                operator_inspect.payload["skill"]["eligibility"]["available"],
+                true
+            );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_surface_hides_skills_with_non_executable_required_commands() {
+        with_managed_runtime_test(|| {
+            use std::os::unix::fs::PermissionsExt;
+
+            let root = unique_temp_dir("loongclaw-ext-skill-required-bin-exec");
+            fs::create_dir_all(root.join("bin")).expect("create bin dir");
+            write_file(
+                &root,
+                ".agents/skills/bin-guarded/SKILL.md",
+                "---\nname: bin-guarded\ndescription: requires an executable command.\nrequires_bin:\n  - demo-bin\n---\n\n# Bin Guarded\n\nOnly run when the command is executable.\n",
+            );
+            write_file(&root, "bin/demo-bin", "#!/bin/sh\necho guarded\n");
+            let command_path = root.join("bin/demo-bin");
+            let mut perms = fs::metadata(&command_path)
+                .expect("read command metadata")
+                .permissions();
+            perms.set_mode(0o644);
+            fs::set_permissions(&command_path, perms).expect("set non-executable permissions");
+
+            let config = managed_runtime_config(&root);
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("PATH", root.join("bin").as_os_str());
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed");
+            assert!(
+                !list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "bin-guarded"),
+                "skills with non-executable required commands should stay hidden: {}",
+                list_outcome.payload
+            );
+
+            let error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "bin-guarded"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("invoke should reject non-executable required commands");
+            assert!(
+                error.contains("demo-bin"),
+                "expected missing command in error, got: {error}"
+            );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn provider_surface_skips_broken_managed_installs_without_failing_discovery() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-broken-managed-discovery");
+            let home = unique_temp_dir("loongclaw-ext-skill-broken-managed-discovery-home");
+            fs::create_dir_all(&root).expect("create fixture root");
+            fs::create_dir_all(&home).expect("create home root");
+            write_file(
+                &root,
+                "source/healthy-skill/SKILL.md",
+                "---\nname: healthy-skill\ndescription: healthy managed skill.\n---\n\nHealthy managed skill instructions.\n",
+            );
+            write_file(
+                &home,
+                ".agents/skills/broken-skill/SKILL.md",
+                "---\nname: broken-skill\ndescription: lower-precedence fallback should stay shadowed.\n---\n\nDo not silently fall back.\n",
+            );
+            let config = managed_runtime_config(&root);
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("HOME", &home);
+
+            crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/healthy-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect("healthy managed install should succeed");
+
+            let install_root = root.join("external-skills-installed");
+            let mut index =
+                load_installed_skill_index(&install_root).expect("load managed skill index");
+            index.skills.push(InstalledSkillEntry {
+                skill_id: "broken-skill".to_owned(),
+                display_name: "Broken Skill".to_owned(),
+                summary: "broken managed skill".to_owned(),
+                source_kind: "directory".to_owned(),
+                source_path: root.join("source/broken-skill").display().to_string(),
+                install_path: install_root.join("broken-skill").display().to_string(),
+                skill_md_path: install_root
+                    .join("broken-skill/SKILL.md")
+                    .display()
+                    .to_string(),
+                sha256: "deadbeef".to_owned(),
+                installed_at_unix: 0,
+                active: true,
+            });
+            persist_installed_skill_index(&install_root, &mut index)
+                .expect("persist index with broken managed entry");
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed when one managed install is broken");
+            let skills = list_outcome.payload["skills"]
+                .as_array()
+                .expect("skills should be an array");
+            assert!(
+                skills
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "healthy-skill"),
+                "healthy managed skill should remain discoverable: {skills:?}"
+            );
+            assert!(
+                skills
+                    .iter()
+                    .all(|skill| skill["skill_id"] != "broken-skill"),
+                "broken managed skill should fail closed instead of falling back: {skills:?}"
+            );
+
+            let error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "broken-skill"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("broken managed install should not fall back to user scope");
+            assert!(
+                error.contains("failed to inspect managed external skill install"),
+                "expected managed install error, got: {error}"
+            );
+
+            fs::remove_dir_all(&root).ok();
+            fs::remove_dir_all(&home).ok();
         });
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -83,6 +83,19 @@ pub fn normalize_external_skill_domain_rule(raw: &str) -> Result<String, String>
     normalize_external_skills_domain_rule(raw)
 }
 
+pub fn external_skills_operator_list_with_config(
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    external_skills::execute_external_skills_operator_list_tool_with_config(config)
+}
+
+pub fn external_skills_operator_inspect_with_config(
+    skill_id: &str,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    external_skills::execute_external_skills_operator_inspect_tool_with_config(skill_id, config)
+}
+
 tokio::task_local! {
     static TRUSTED_INTERNAL_TOOL_PAYLOAD_TASK: bool;
 }

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -127,13 +127,29 @@ fn execute_non_policy_skills_command(
     command: SkillsCommands,
 ) -> CliResult<ToolCoreOutcome> {
     match command {
+        SkillsCommands::List => {
+            let tool_runtime_config =
+                mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+                    config,
+                    Some(resolved_path),
+                );
+            mvp::tools::external_skills_operator_list_with_config(&tool_runtime_config)
+        }
+        SkillsCommands::Info { skill_id } => {
+            let tool_runtime_config =
+                mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+                    config,
+                    Some(resolved_path),
+                );
+            mvp::tools::external_skills_operator_inspect_with_config(
+                &skill_id,
+                &tool_runtime_config,
+            )
+        }
         SkillsCommands::InstallBundled { skill_id, replace } => {
             execute_install_bundled_skill_command(resolved_path, config, &skill_id, replace)
         }
-        command @ (SkillsCommands::List
-        | SkillsCommands::Info { .. }
-        | SkillsCommands::Install { .. }
-        | SkillsCommands::Remove { .. }) => {
+        command @ (SkillsCommands::Install { .. } | SkillsCommands::Remove { .. }) => {
             let tool_runtime_config =
                 mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
                     config,
@@ -534,6 +550,57 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                 skill.get("active").and_then(Value::as_bool).unwrap_or(true)
             ));
             lines.push(format!(
+                "model_visibility={}",
+                skill
+                    .get("model_visibility")
+                    .and_then(Value::as_str)
+                    .unwrap_or("visible")
+            ));
+            lines.push(format!(
+                "eligible={}",
+                skill
+                    .get("eligibility")
+                    .and_then(|eligibility| eligibility.get("available"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            ));
+            lines.push(format!(
+                "required_env={}",
+                render_string_list(skill.get("required_env"))
+            ));
+            lines.push(format!(
+                "required_bin={}",
+                render_string_list(skill.get("required_bin"))
+            ));
+            lines.push(format!(
+                "required_paths={}",
+                render_string_list(skill.get("required_paths"))
+            ));
+            lines.push(format!(
+                "missing_env={}",
+                render_string_list(
+                    skill
+                        .get("eligibility")
+                        .and_then(|eligibility| eligibility.get("missing_env"))
+                )
+            ));
+            lines.push(format!(
+                "missing_bin={}",
+                render_string_list(
+                    skill
+                        .get("eligibility")
+                        .and_then(|eligibility| eligibility.get("missing_bin"))
+                )
+            ));
+            lines.push(format!(
+                "missing_paths={}",
+                render_string_list(
+                    skill
+                        .get("eligibility")
+                        .and_then(|eligibility| eligibility.get("missing_paths"))
+                )
+            ));
+            lines.push(format!(
                 "source_path={}",
                 skill
                     .get("source_path")
@@ -799,5 +866,16 @@ fn render_skill_summary_line(skill: &Value) -> String {
         .and_then(Value::as_str)
         .unwrap_or("-");
     let summary = skill.get("summary").and_then(Value::as_str).unwrap_or("-");
-    format!("{skill_id} [{active}] scope={scope} display_name={display_name} summary={summary}")
+    let model_visibility = skill
+        .get("model_visibility")
+        .and_then(Value::as_str)
+        .unwrap_or("visible");
+    let eligible = skill
+        .get("eligibility")
+        .and_then(|eligibility| eligibility.get("available"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    format!(
+        "{skill_id} [{active}] scope={scope} model_visibility={model_visibility} eligible={eligible} display_name={display_name} summary={summary}"
+    )
 }

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -1157,6 +1157,57 @@ fn execute_skills_command_list_keeps_inactive_managed_winner_visible_to_operator
 }
 
 #[test]
+fn execute_skills_command_operator_inspection_still_works_when_runtime_is_disabled() {
+    let root = unique_temp_dir("loongclaw-skills-cli-runtime-disabled");
+    let home = unique_temp_dir("loongclaw-skills-cli-runtime-disabled-home");
+    let config_path = write_external_skills_config(&root, false);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        ".agents/skills/demo-skill/SKILL.md",
+        "---\nname: demo-skill\ndescription: project skill should stay inspectable while runtime is disabled.\n---\n\n# Demo Skill\n\nDisabled runtime should still allow operator inspection.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    let list = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+        },
+    )
+    .expect("skills list should remain available for operator inspection");
+    let demo_skill = list.outcome.payload["skills"]
+        .as_array()
+        .expect("skills should be an array")
+        .iter()
+        .find(|skill| skill["skill_id"] == "demo-skill")
+        .expect("operator list should include project skills even when runtime is disabled");
+    assert_eq!(demo_skill["scope"], "project");
+
+    let info = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Info {
+                skill_id: "demo-skill".to_owned(),
+            },
+        },
+    )
+    .expect("skills info should remain available for operator inspection");
+    assert_eq!(info.outcome.payload["skill"]["scope"], "project");
+    assert!(
+        info.outcome.payload["instructions_preview"]
+            .as_str()
+            .expect("instructions preview should be text")
+            .contains("Disabled runtime should still allow operator inspection")
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
 fn execute_skills_command_installs_bundled_browser_companion_preview() {
     let root = unique_temp_dir("loongclaw-skills-cli-bundled-install");
     let _env = SkillsCliEnvironmentGuard::set(&[]);

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -1000,6 +1000,163 @@ fn execute_skills_command_list_prefers_nearest_project_ancestor_for_duplicate_sk
 }
 
 #[test]
+fn execute_skills_command_list_shows_operator_only_and_ineligible_skill_metadata() {
+    let root = unique_temp_dir("loongclaw-skills-cli-manifest");
+    let home = unique_temp_dir("loongclaw-skills-cli-manifest-home");
+    let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        "source/demo-skill/SKILL.md",
+        "---\nname: demo-skill\ndescription: operator-only demo skill.\nmodel_visibility: hidden\nrequires_env:\n  - DEMO_SKILL_TOKEN\n---\n\n# Demo Skill\n\nOperator should still be able to inspect this skill.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: false,
+            },
+        },
+    )
+    .expect("skills install should succeed");
+
+    let list = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+        },
+    )
+    .expect("skills list should succeed");
+    let demo_skill = list.outcome.payload["skills"]
+        .as_array()
+        .expect("skills should be an array")
+        .iter()
+        .find(|skill| skill["skill_id"] == "demo-skill")
+        .expect("operator CLI should keep operator-only skills visible");
+    assert_eq!(demo_skill["scope"], "managed");
+    assert_eq!(demo_skill["model_visibility"], "hidden");
+    assert_eq!(demo_skill["eligibility"]["available"], false);
+    assert_eq!(
+        demo_skill["eligibility"]["missing_env"],
+        serde_json::json!(["DEMO_SKILL_TOKEN"])
+    );
+
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(&list)
+        .expect("text rendering should succeed");
+    assert!(
+        rendered.contains("model_visibility=hidden"),
+        "CLI text should explain model visibility to operators: {rendered}"
+    );
+    assert!(
+        rendered.contains("eligible=false"),
+        "CLI text should explain eligibility state to operators: {rendered}"
+    );
+
+    let info = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Info {
+                skill_id: "demo-skill".to_owned(),
+            },
+        },
+    )
+    .expect("skills info should succeed for operator-only skills");
+    assert_eq!(info.outcome.payload["skill"]["model_visibility"], "hidden");
+    assert_eq!(
+        info.outcome.payload["skill"]["eligibility"]["available"],
+        false
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn execute_skills_command_list_keeps_inactive_managed_winner_visible_to_operator() {
+    let root = unique_temp_dir("loongclaw-skills-cli-inactive-winner");
+    let home = unique_temp_dir("loongclaw-skills-cli-inactive-winner-home");
+    let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        "source/demo-skill/SKILL.md",
+        "# Managed Demo Skill\n\nManaged winner should stay visible to the operator.\n",
+    );
+    write_file(
+        &home,
+        ".agents/skills/demo-skill/SKILL.md",
+        "---\nname: demo-skill\ndescription: user fallback should stay shadowed.\n---\n\n# User Demo Skill\n\nDo not silently take over.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: false,
+            },
+        },
+    )
+    .expect("skills install should succeed");
+
+    let index_path = root.join("managed-skills").join("index.json");
+    let mut index: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&index_path).expect("read index"))
+            .expect("parse index");
+    index["skills"][0]["active"] = serde_json::json!(false);
+    fs::write(
+        &index_path,
+        serde_json::to_string_pretty(&index).expect("encode index"),
+    )
+    .expect("write index");
+
+    let list = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::List,
+        },
+    )
+    .expect("skills list should succeed");
+    let demo_skill = list.outcome.payload["skills"]
+        .as_array()
+        .expect("skills should be an array")
+        .iter()
+        .find(|skill| skill["skill_id"] == "demo-skill")
+        .expect("operator CLI should keep the inactive managed winner visible");
+    assert_eq!(demo_skill["scope"], "managed");
+    assert_eq!(demo_skill["active"], false);
+    assert!(
+        list.outcome.payload["shadowed_skills"]
+            .as_array()
+            .expect("shadowed skills should be an array")
+            .iter()
+            .any(|skill| skill["skill_id"] == "demo-skill" && skill["scope"] == "user"),
+        "lower-scope duplicate should remain shadowed for operator debugging"
+    );
+
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(&list)
+        .expect("text rendering should succeed");
+    assert!(
+        rendered.contains("demo-skill [inactive]"),
+        "CLI text should make inactive winners obvious: {rendered}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
 fn execute_skills_command_installs_bundled_browser_companion_preview() {
     let root = unique_temp_dir("loongclaw-skills-cli-bundled-install");
     let _env = SkillsCliEnvironmentGuard::set(&[]);

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -1010,7 +1010,10 @@ fn execute_skills_command_list_shows_operator_only_and_ineligible_skill_metadata
         "source/demo-skill/SKILL.md",
         "---\nname: demo-skill\ndescription: operator-only demo skill.\nmodel_visibility: hidden\nrequires_env:\n  - DEMO_SKILL_TOKEN\n---\n\n# Demo Skill\n\nOperator should still be able to inspect this skill.\n",
     );
-    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+    let _env = SkillsCliEnvironmentGuard::set(&[
+        ("HOME", Some(home.to_string_lossy().as_ref())),
+        ("DEMO_SKILL_TOKEN", None),
+    ]);
 
     loongclaw_daemon::skills_cli::execute_skills_command(
         loongclaw_daemon::skills_cli::SkillsCommandOptions {
@@ -1113,7 +1116,13 @@ fn execute_skills_command_list_keeps_inactive_managed_winner_visible_to_operator
     let mut index: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&index_path).expect("read index"))
             .expect("parse index");
-    index["skills"][0]["active"] = serde_json::json!(false);
+    let managed_entry = index["skills"]
+        .as_array_mut()
+        .expect("index skills should be an array")
+        .iter_mut()
+        .find(|skill| skill["skill_id"] == "demo-skill")
+        .expect("managed demo-skill entry should exist");
+    managed_entry["active"] = serde_json::json!(false);
     fs::write(
         &index_path,
         serde_json::to_string_pretty(&index).expect("encode index"),


### PR DESCRIPTION
## Summary

- Problem:
  external skills still lacked a real metadata contract for model visibility and runtime eligibility, and the current discovery path could silently fall back to lower-scope duplicates when a higher-precedence managed skill was inactive.
- Why it matters:
  without a hard eligibility and visibility contract, the provider surface can expose skills the model should not see, operators cannot reliably debug why a skill is unavailable, and precedence drift can mask the real managed winner.
- What changed:
  added yaml-backed `SKILL.md` metadata parsing for `model_visibility`, `requires_env`, `requires_bin`, and `requires_paths`; evaluated eligibility during discovery; kept strict managed > user > project precedence; filtered the model/provider surface to active + visible + eligible skills only; exposed full resolved metadata and eligibility diagnostics through `loongclaw skills list|info`; added regression coverage for inactive winners, unreadable local skills, hidden skills, and missing env gates.
- What did not change (scope boundary):
  this PR does not add the migration-to-install bridge or registry/update/sync workflows, so issue #159 remains open for those follow-up slices.

## Linked Issues

- Closes #n/a
- Related #159

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  provider-visible skills now obey manifest visibility and eligibility gates, so previously callable inactive or misconfigured skills will stop surfacing to the model and instead fail closed with an explicit reason.
- Rollout / guardrails:
  operator-facing `loongclaw skills list|info` still exposes the resolved winner, shadowed duplicates, and missing requirement diagnostics so breakage is inspectable instead of silent.
- Rollback path:
  revert this PR, or disable external skills at runtime with the existing policy surface if an urgent rollback is needed.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed after formatting the updated files

git diff --check
- passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed

env CARGO_TARGET_DIR=/tmp/loongclaw-issue159-target <redacted-cargo> test --workspace --locked
- passed

env CARGO_TARGET_DIR=/tmp/loongclaw-issue159-target <redacted-cargo> test --workspace --all-features --locked
- passed

cargo test -p loongclaw-app provider_surface_
- passed during focused regression verification

cargo test -p loongclaw-daemon execute_skills_command_list_
- passed during focused cli regression verification
```

## User-visible / Operator-visible Changes

- models now only see external skills that are active, `model_visibility: visible`, and currently eligible for the runtime environment
- operators can inspect hidden or ineligible skills through `loongclaw skills list|info`, including missing env vars, commands, and paths
- strict discovery precedence is preserved even when the managed winner is inactive, so lower-scope duplicates stay shadowed instead of silently taking over

## Failure Recovery

- Fast rollback or disable path:
  revert this PR or turn off external skills with the existing runtime policy controls.
- Observable failure symptoms reviewers should watch for:
  a skill that used to appear on the provider surface now disappears because it is hidden, inactive, or missing requirements; the operator CLI should show the exact blocker instead of a silent fallback.

## Reviewer Focus

- review the audience split and precedence handling in `crates/app/src/tools/external_skills.rs`, especially the no-fallback behavior for inactive managed winners and the unreadable-local-skill skip path
- review the operator CLI output changes in `crates/daemon/src/skills_cli.rs` and the new integration coverage in `crates/daemon/tests/integration/skills_cli.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill visibility and eligibility controls with model-specific gating and requirement specs (env, binaries, paths).
  * Operator-focused tools for listing and inspecting external skills; model/operator outputs redact/retain different details.
  * Improved discovery precedence, fail-closed handling for unreadable candidates, and auto-exposure that respects visibility.

* **CLI**
  * Enhanced CLI output to show visibility, eligibility, and missing requirements.

* **Style**
  * Simplified prompts from "managed external skill" to "external skill".

* **Tests**
  * Added integration tests covering operator-facing discovery and inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->