### PR TITLE
kernel: align shared execution security tiers across runtime lanes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,6 +2096,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "futures-util",
+ "loongclaw-contracts",
  "loongclaw-kernel",
  "loongclaw-protocol",
  "reqwest",

--- a/crates/app/src/tools/browser.rs
+++ b/crates/app/src/tools/browser.rs
@@ -916,6 +916,7 @@ mod tests {
             &config,
         )
         .expect("browser.extract links should succeed");
+        assert_eq!(links.payload["execution_tier"], json!("restricted"));
         assert_eq!(links.payload["links"][0]["text"], json!("Continue"));
 
         let selector_text = execute_browser_tool_with_config(
@@ -931,6 +932,7 @@ mod tests {
             &config,
         )
         .expect("browser.extract selector_text should succeed");
+        assert_eq!(selector_text.payload["execution_tier"], json!("restricted"));
         assert_eq!(selector_text.payload["items"], json!(["Alpha", "Beta"]));
         handle.join().expect("server thread");
     }

--- a/crates/app/src/tools/browser.rs
+++ b/crates/app/src/tools/browser.rs
@@ -106,7 +106,13 @@ fn execute_browser_open(
     let max_bytes = parse_max_bytes(payload, config.web_fetch.max_bytes, "browser.open")?;
     let client = build_browser_client(config)?;
     let page = fetch_browser_page(&client, raw_url.as_str(), max_bytes, config)?;
-    let response_payload = browser_page_payload("browser.open", &session_id, &page, None);
+    let response_payload = browser_page_payload(
+        "browser.open",
+        &session_id,
+        &page,
+        None,
+        config.browser_execution_security_tier().as_str(),
+    );
     store_browser_session(
         scope_id,
         session_id,
@@ -154,6 +160,7 @@ fn execute_browser_extract(
         BrowserExtractMode::PageText => json!({
             "adapter": "core-tools",
             "tool_name": "browser.extract",
+            "execution_tier": config.browser_execution_security_tier().as_str(),
             "session_id": session_id,
             "mode": mode.as_str(),
             "final_url": page.final_url,
@@ -163,6 +170,7 @@ fn execute_browser_extract(
         BrowserExtractMode::Title => json!({
             "adapter": "core-tools",
             "tool_name": "browser.extract",
+            "execution_tier": config.browser_execution_security_tier().as_str(),
             "session_id": session_id,
             "mode": mode.as_str(),
             "final_url": page.final_url,
@@ -171,6 +179,7 @@ fn execute_browser_extract(
         BrowserExtractMode::Links => json!({
             "adapter": "core-tools",
             "tool_name": "browser.extract",
+            "execution_tier": config.browser_execution_security_tier().as_str(),
             "session_id": session_id,
             "mode": mode.as_str(),
             "final_url": page.final_url,
@@ -194,6 +203,7 @@ fn execute_browser_extract(
             json!({
                 "adapter": "core-tools",
                 "tool_name": "browser.extract",
+                "execution_tier": config.browser_execution_security_tier().as_str(),
                 "session_id": session_id,
                 "mode": mode.as_str(),
                 "final_url": page.final_url,
@@ -251,6 +261,7 @@ fn execute_browser_click(
             "text": selected_link.text,
             "url": selected_link.url,
         })),
+        config.browser_execution_security_tier().as_str(),
     );
     store_browser_session(
         scope_id,
@@ -500,10 +511,12 @@ fn browser_page_payload(
     session_id: &str,
     page: &BrowserPage,
     clicked_link: Option<Value>,
+    execution_tier: &str,
 ) -> Value {
     json!({
         "adapter": "core-tools",
         "tool_name": tool_name,
+        "execution_tier": execution_tier,
         "session_id": session_id,
         "requested_url": page.requested_url,
         "final_url": page.final_url,
@@ -862,6 +875,7 @@ mod tests {
                 .expect("session id")
                 .starts_with("browser-")
         );
+        assert_eq!(outcome.payload["execution_tier"], json!("restricted"));
         assert_eq!(outcome.payload["title"], json!("Fixture Home"));
         assert!(
             outcome.payload["page_text"]
@@ -946,6 +960,7 @@ mod tests {
         )
         .expect("browser.click should succeed");
 
+        assert_eq!(clicked.payload["execution_tier"], json!("restricted"));
         assert_eq!(clicked.payload["title"], json!("Next Page"));
         assert_eq!(clicked.payload["clicked_link"]["id"], json!(1));
         assert!(

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -473,6 +473,7 @@ fn execute_browser_companion_request(
         payload: json!({
             "adapter": "browser-companion",
             "tool_name": request.tool_name,
+            "execution_tier": policy.execution_security_tier().as_str(),
             "operation": operation.protocol_name(),
             "action_class": operation.action_class(),
             "session_id": session_id,
@@ -594,6 +595,9 @@ mod tests {
         sync::atomic::{AtomicBool, AtomicUsize, Ordering},
         time::Duration,
     };
+
+    use loongclaw_contracts::ToolCoreRequest;
+    use serde_json::{Value, json};
 
     struct BrokenWriter;
 
@@ -719,5 +723,53 @@ mod tests {
     fn pause_before_browser_companion_spawn_retry_succeeds_without_runtime() {
         super::pause_before_browser_companion_spawn_retry(Duration::ZERO)
             .expect("pause should work without a tokio runtime");
+    }
+
+    struct OkRunner;
+
+    impl super::BrowserCompanionRunner for OkRunner {
+        fn invoke(
+            &self,
+            _command: &str,
+            _timeout_seconds: u64,
+            _request: &super::BrowserCompanionProtocolRequest,
+        ) -> Result<Value, String> {
+            Ok(json!({
+                "navigated": true,
+            }))
+        }
+    }
+
+    #[test]
+    fn browser_companion_session_start_reports_balanced_execution_tier() {
+        let request = ToolCoreRequest {
+            tool_name: "browser.companion.session.start".to_owned(),
+            payload: json!({}),
+        };
+        let payload = request
+            .payload
+            .as_object()
+            .expect("browser companion payload object")
+            .clone();
+        let policy = super::super::runtime_config::BrowserCompanionRuntimePolicy {
+            enabled: true,
+            ready: true,
+            command: Some("browser-companion".to_owned()),
+            expected_version: Some("1.5.0".to_owned()),
+            timeout_seconds: 5,
+        };
+
+        let outcome = super::execute_browser_companion_request(
+            request,
+            &payload,
+            "test-scope",
+            &policy,
+            &OkRunner,
+            true,
+        )
+        .expect("browser companion session start should succeed");
+
+        assert_eq!(outcome.payload["execution_tier"], json!("balanced"));
+        assert_eq!(outcome.payload["action_class"], json!("read"));
     }
 }

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -771,5 +771,31 @@ mod tests {
 
         assert_eq!(outcome.payload["execution_tier"], json!("balanced"));
         assert_eq!(outcome.payload["action_class"], json!("read"));
+        let session_id = outcome.payload["session_id"]
+            .as_str()
+            .expect("session id in payload")
+            .to_owned();
+
+        let stop_request = ToolCoreRequest {
+            tool_name: "browser.companion.session.stop".to_owned(),
+            payload: json!({"session_id": &session_id}),
+        };
+        let stop_payload = stop_request
+            .payload
+            .as_object()
+            .expect("browser companion stop payload object")
+            .clone();
+        let stopped = super::execute_browser_companion_request(
+            stop_request,
+            &stop_payload,
+            "test-scope",
+            &policy,
+            &OkRunner,
+            true,
+        )
+        .expect("browser companion session stop should succeed");
+
+        assert_eq!(stopped.payload["session_id"], json!(session_id));
+        assert_eq!(stopped.payload["operation"], json!("session.stop"));
     }
 }

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use loongclaw_contracts::ExecutionSecurityTier;
 use serde::{Deserialize, Serialize};
 
 use super::shell_policy_ext::ShellPolicyDefault;
@@ -112,6 +113,14 @@ impl Default for BrowserRuntimePolicy {
     }
 }
 
+impl BrowserRuntimePolicy {
+    #[must_use]
+    pub const fn execution_security_tier(&self) -> ExecutionSecurityTier {
+        let _ = self;
+        ExecutionSecurityTier::Restricted
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserCompanionRuntimePolicy {
     pub enabled: bool,
@@ -137,6 +146,15 @@ impl BrowserCompanionRuntimePolicy {
     #[must_use]
     pub fn is_runtime_ready(&self) -> bool {
         self.enabled && self.ready && self.command.is_some()
+    }
+
+    #[must_use]
+    pub fn execution_security_tier(&self) -> ExecutionSecurityTier {
+        if self.is_runtime_ready() {
+            ExecutionSecurityTier::Balanced
+        } else {
+            ExecutionSecurityTier::Restricted
+        }
     }
 }
 
@@ -666,6 +684,16 @@ impl ToolRuntimeConfig {
 
         lines.push("Treat these as enforced limits for this child session.".to_owned());
         Some(lines.join("\n"))
+    }
+
+    #[must_use]
+    pub const fn browser_execution_security_tier(&self) -> ExecutionSecurityTier {
+        self.browser.execution_security_tier()
+    }
+
+    #[must_use]
+    pub fn browser_companion_execution_security_tier(&self) -> ExecutionSecurityTier {
+        self.browser_companion.execution_security_tier()
     }
 }
 

--- a/crates/contracts/src/execution_security_types.rs
+++ b/crates/contracts/src/execution_security_types.rs
@@ -1,0 +1,28 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionSecurityTier {
+    Restricted,
+    Balanced,
+    Trusted,
+}
+
+impl ExecutionSecurityTier {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Restricted => "restricted",
+            Self::Balanced => "balanced",
+            Self::Trusted => "trusted",
+        }
+    }
+}
+
+impl fmt::Display for ExecutionSecurityTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -4,6 +4,7 @@ mod audit_types;
 mod clock;
 mod contracts;
 mod errors;
+mod execution_security_types;
 mod fault;
 mod memory_types;
 mod namespace;
@@ -23,6 +24,7 @@ pub use errors::{
     AuditError, ConnectorError, HarnessError, IntegrationError, KernelError, MemoryPlaneError,
     PackError, PolicyError, RuntimePlaneError, ToolPlaneError,
 };
+pub use execution_security_types::ExecutionSecurityTier;
 pub use fault::Fault;
 pub use memory_types::{
     MemoryCoreOutcome, MemoryCoreRequest, MemoryExtensionOutcome, MemoryExtensionRequest,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1874,6 +1874,22 @@ mod runtime_snapshot_restore_spec_tests {
             "literal-secret",
         ));
     }
+
+    #[test]
+    fn runtime_snapshot_tool_runtime_json_reports_browser_execution_tiers() {
+        let mut runtime = mvp::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime.browser_companion.enabled = true;
+        runtime.browser_companion.ready = true;
+        runtime.browser_companion.command = Some("browser-companion".to_owned());
+
+        let json = runtime_snapshot_tool_runtime_json(&runtime);
+
+        assert_eq!(json["browser"]["execution_tier"], json!("restricted"));
+        assert_eq!(
+            json["browser_companion"]["execution_tier"],
+            json!("balanced")
+        );
+    }
 }
 
 fn runtime_snapshot_artifact_metadata_now(
@@ -3517,16 +3533,20 @@ pub fn render_runtime_snapshot_text(snapshot: &RuntimeSnapshotCliState) -> Strin
         snapshot.tool_runtime.delegate_enabled
     ));
     lines.push(format!(
-        "tool_runtime browser enabled={} max_sessions={} max_links={} max_text_chars={}",
+        "tool_runtime browser enabled={} tier={} max_sessions={} max_links={} max_text_chars={}",
         snapshot.tool_runtime.browser.enabled,
+        snapshot.tool_runtime.browser_execution_security_tier(),
         snapshot.tool_runtime.browser.max_sessions,
         snapshot.tool_runtime.browser.max_links,
         snapshot.tool_runtime.browser.max_text_chars
     ));
     lines.push(format!(
-        "tool_runtime browser_companion enabled={} ready={} command={} expected_version={}",
+        "tool_runtime browser_companion enabled={} ready={} tier={} command={} expected_version={}",
         snapshot.tool_runtime.browser_companion.enabled,
         snapshot.tool_runtime.browser_companion.ready,
+        snapshot
+            .tool_runtime
+            .browser_companion_execution_security_tier(),
         snapshot
             .tool_runtime
             .browser_companion
@@ -3720,6 +3740,7 @@ fn runtime_snapshot_tool_runtime_json(
         "delegate_enabled": runtime.delegate_enabled,
         "browser": {
             "enabled": runtime.browser.enabled,
+            "execution_tier": runtime.browser_execution_security_tier().as_str(),
             "max_sessions": runtime.browser.max_sessions,
             "max_links": runtime.browser.max_links,
             "max_text_chars": runtime.browser.max_text_chars,
@@ -3727,6 +3748,7 @@ fn runtime_snapshot_tool_runtime_json(
         "browser_companion": {
             "enabled": runtime.browser_companion.enabled,
             "ready": runtime.browser_companion.ready,
+            "execution_tier": runtime.browser_companion_execution_security_tier().as_str(),
             "command": runtime.browser_companion.command,
             "expected_version": runtime.browser_companion.expected_version,
         },

--- a/crates/daemon/tests/integration/spec_runtime_bridge/mod.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/mod.rs
@@ -16,6 +16,7 @@ const HTTP_JSON_RUNTIME_BASE_KEYS: &[&str] = &[
 const PROCESS_STDIO_RUNTIME_BASE_KEYS: &[&str] = &[
     "args",
     "command",
+    "execution_tier",
     "executor",
     "protocol_capabilities",
     "protocol_required_capability",
@@ -128,6 +129,14 @@ fn snapshot_protocol_context() -> ConnectorProtocolContext {
     context
 }
 
+fn balanced_process_stdio_policy() -> BridgeRuntimePolicy {
+    BridgeRuntimePolicy {
+        execute_process_stdio: true,
+        allowed_process_commands: BTreeSet::from(["cat".to_owned()]),
+        ..BridgeRuntimePolicy::default()
+    }
+}
+
 #[test]
 fn bridge_http_json_runtime_evidence_snapshots_stable() {
     let context = snapshot_protocol_context();
@@ -236,8 +245,10 @@ fn bridge_http_json_runtime_evidence_snapshots_stable() {
 #[test]
 fn bridge_process_stdio_runtime_evidence_snapshots_stable() {
     let context = snapshot_protocol_context();
+    let runtime_policy = balanced_process_stdio_policy();
     let base = process_stdio_runtime_evidence(
         &context,
+        runtime_policy.process_stdio_execution_security_tier(),
         "cat",
         &["/tmp/input.txt".to_owned()],
         5_000,
@@ -249,6 +260,7 @@ fn bridge_process_stdio_runtime_evidence_snapshots_stable() {
         json!({
             "executor":"process_stdio_local",
             "transport_kind":"json_line",
+            "execution_tier":"balanced",
             "command":"cat",
             "args":["/tmp/input.txt"],
             "timeout_ms":5000,
@@ -262,6 +274,7 @@ fn bridge_process_stdio_runtime_evidence_snapshots_stable() {
 
     let execution = process_stdio_runtime_evidence(
         &context,
+        runtime_policy.process_stdio_execution_security_tier(),
         "cat",
         &["/tmp/input.txt".to_owned()],
         5_000,
@@ -290,6 +303,7 @@ fn bridge_process_stdio_runtime_evidence_snapshots_stable() {
         json!({
             "executor":"process_stdio_local",
             "transport_kind":"json_line",
+            "execution_tier":"balanced",
             "command":"cat",
             "args":["/tmp/input.txt"],
             "timeout_ms":5000,

--- a/crates/spec/Cargo.toml
+++ b/crates/spec/Cargo.toml
@@ -12,6 +12,7 @@ test-support = ["test-hooks"]
 [dependencies]
 async-trait.workspace = true
 kernel = { package = "loongclaw-kernel", path = "../kernel" }
+loongclaw-contracts = { path = "../contracts" }
 loongclaw-protocol = { path = "../protocol" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/spec/src/spec_bridge_runtime_evidence.inc.rs
+++ b/crates/spec/src/spec_bridge_runtime_evidence.inc.rs
@@ -95,6 +95,7 @@ pub fn http_json_runtime_evidence(
 pub struct ProcessStdioRuntimeBase {
     pub executor: &'static str,
     pub transport_kind: &'static str,
+    pub execution_tier: ExecutionSecurityTier,
     pub command: String,
     pub args: Vec<String>,
     pub timeout_ms: u64,
@@ -131,6 +132,7 @@ pub struct ProcessStdioRuntimeExecution {
 
 pub fn process_stdio_runtime_evidence(
     context: &ConnectorProtocolContext,
+    execution_tier: ExecutionSecurityTier,
     command: &str,
     args: &[String],
     timeout_ms: u64,
@@ -140,6 +142,7 @@ pub fn process_stdio_runtime_evidence(
     let base = ProcessStdioRuntimeBase {
         executor: EXECUTOR,
         transport_kind: "json_line",
+        execution_tier,
         command: command.to_owned(),
         args: args.to_vec(),
         timeout_ms,

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -21,6 +21,7 @@ use kernel::{
     ToolCoreRequest, ToolExtensionAdapter, ToolExtensionOutcome, ToolExtensionRequest,
     VerticalPackManifest,
 };
+use loongclaw_contracts::ExecutionSecurityTier;
 use loongclaw_protocol::{
     OutboundFrame, PROTOCOL_VERSION, ProtocolRouter, RouteAuthorizationRequest,
 };
@@ -726,6 +727,23 @@ pub struct BridgeRuntimePolicy {
     pub wasm_require_hash_pin: bool,
     pub wasm_required_sha256_by_plugin: BTreeMap<String, String>,
     pub enforce_execution_success: bool,
+}
+
+impl BridgeRuntimePolicy {
+    #[must_use]
+    pub fn process_stdio_execution_security_tier(&self) -> ExecutionSecurityTier {
+        if self.execute_process_stdio && !self.allowed_process_commands.is_empty() {
+            ExecutionSecurityTier::Balanced
+        } else {
+            ExecutionSecurityTier::Restricted
+        }
+    }
+
+    #[must_use]
+    pub const fn wasm_execution_security_tier(&self) -> ExecutionSecurityTier {
+        let _ = self;
+        ExecutionSecurityTier::Restricted
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1510,6 +1528,19 @@ pub async fn maybe_execute_bridge(
 
 include!("spec_bridge_protocol.inc.rs");
 
+fn with_execution_security_tier(
+    mut runtime: Value,
+    execution_tier: ExecutionSecurityTier,
+) -> Value {
+    if let Some(object) = runtime.as_object_mut() {
+        object.insert(
+            "execution_tier".to_owned(),
+            Value::String(execution_tier.to_string()),
+        );
+    }
+    runtime
+}
+
 fn normalize_allowed_wasm_path_prefixes(prefixes: &[PathBuf]) -> Vec<PathBuf> {
     prefixes
         .iter()
@@ -1670,6 +1701,7 @@ pub fn execute_wasm_component_bridge(
     command: &ConnectorCommand,
     runtime_policy: &BridgeRuntimePolicy,
 ) -> Value {
+    let execution_tier = runtime_policy.wasm_execution_security_tier();
     let artifact_path = match resolve_wasm_component_artifact_path(provider, &channel.endpoint) {
         Ok(path) => path,
         Err(reason) => {
@@ -1685,10 +1717,13 @@ pub fn execute_wasm_component_bridge(
             execution["reason"] = Value::String(format!(
                 "failed to canonicalize wasm artifact path: {error}"
             ));
-            execution["runtime"] = json!({
-                "executor": "wasmtime_module",
-                "artifact_path": artifact_path.display().to_string(),
-            });
+            execution["runtime"] = with_execution_security_tier(
+                json!({
+                    "executor": "wasmtime_module",
+                    "artifact_path": artifact_path.display().to_string(),
+                }),
+                execution_tier,
+            );
             return execution;
         }
     };
@@ -1703,14 +1738,17 @@ pub fn execute_wasm_component_bridge(
         execution["status"] = Value::String("blocked".to_owned());
         execution["reason"] =
             Value::String("wasm artifact path is outside runtime allowed_path_prefixes".to_owned());
-        execution["runtime"] = json!({
-            "executor": "wasmtime_module",
-            "artifact_path": artifact_path.display().to_string(),
-            "allowed_path_prefixes": normalized_allowed_prefixes
-                .iter()
-                .map(|path| path.display().to_string())
-                .collect::<Vec<_>>(),
-        });
+        execution["runtime"] = with_execution_security_tier(
+            json!({
+                "executor": "wasmtime_module",
+                "artifact_path": artifact_path.display().to_string(),
+                "allowed_path_prefixes": normalized_allowed_prefixes
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>(),
+            }),
+            execution_tier,
+        );
         return execution;
     }
 
@@ -1720,10 +1758,13 @@ pub fn execute_wasm_component_bridge(
             execution["status"] = Value::String("failed".to_owned());
             execution["reason"] =
                 Value::String(format!("failed to read wasm artifact metadata: {error}"));
-            execution["runtime"] = json!({
-                "executor": "wasmtime_module",
-                "artifact_path": artifact_path.display().to_string(),
-            });
+            execution["runtime"] = with_execution_security_tier(
+                json!({
+                    "executor": "wasmtime_module",
+                    "artifact_path": artifact_path.display().to_string(),
+                }),
+                execution_tier,
+            );
             return execution;
         }
     };
@@ -1734,10 +1775,13 @@ pub fn execute_wasm_component_bridge(
         execution["status"] = Value::String("blocked".to_owned());
         execution["reason"] =
             Value::String("wasm artifact path must reference a regular file".to_owned());
-        execution["runtime"] = json!({
-            "executor": "wasmtime_module",
-            "artifact_path": artifact_path.display().to_string(),
-        });
+        execution["runtime"] = with_execution_security_tier(
+            json!({
+                "executor": "wasmtime_module",
+                "artifact_path": artifact_path.display().to_string(),
+            }),
+            execution_tier,
+        );
         return execution;
     }
 
@@ -1749,12 +1793,15 @@ pub fn execute_wasm_component_bridge(
             "wasm artifact size {} exceeds runtime max_component_bytes {limit}",
             module_size_bytes
         ));
-        execution["runtime"] = json!({
-            "executor": "wasmtime_module",
-            "artifact_path": artifact_path.display().to_string(),
-            "module_size_bytes": module_size_bytes,
-            "max_component_bytes": limit,
-        });
+        execution["runtime"] = with_execution_security_tier(
+            json!({
+                "executor": "wasmtime_module",
+                "artifact_path": artifact_path.display().to_string(),
+                "module_size_bytes": module_size_bytes,
+                "max_component_bytes": limit,
+            }),
+            execution_tier,
+        );
         return execution;
     }
 
@@ -1767,25 +1814,28 @@ pub fn execute_wasm_component_bridge(
         Err(reason) => {
             execution["status"] = Value::String("blocked".to_owned());
             execution["reason"] = Value::String(reason);
-            execution["runtime"] = json!({
-                "executor": "wasmtime_module",
-                "artifact_path": artifact_path.display().to_string(),
-                "export": export_name,
-                "operation": command.operation,
-                "payload": command.payload,
-                "module_size_bytes": module_size_bytes,
-                "fuel_limit": runtime_policy.wasm_fuel_limit,
-                "cache_hit": false,
-                "cache_miss": true,
-                "cache_evicted_entries": 0,
-                "cache_entries": 0,
-                "cache_capacity": cache_capacity,
-                "cache_total_module_bytes": 0,
-                "cache_max_bytes": cache_max_bytes,
-                "cache_inserted": false,
-                "integrity_check_required": true,
-                "integrity_check_passed": false,
-            });
+            execution["runtime"] = with_execution_security_tier(
+                json!({
+                    "executor": "wasmtime_module",
+                    "artifact_path": artifact_path.display().to_string(),
+                    "export": export_name,
+                    "operation": command.operation,
+                    "payload": command.payload,
+                    "module_size_bytes": module_size_bytes,
+                    "fuel_limit": runtime_policy.wasm_fuel_limit,
+                    "cache_hit": false,
+                    "cache_miss": true,
+                    "cache_evicted_entries": 0,
+                    "cache_entries": 0,
+                    "cache_capacity": cache_capacity,
+                    "cache_total_module_bytes": 0,
+                    "cache_max_bytes": cache_max_bytes,
+                    "cache_inserted": false,
+                    "integrity_check_required": true,
+                    "integrity_check_passed": false,
+                }),
+                execution_tier,
+            );
             return execution;
         }
     };
@@ -1806,23 +1856,26 @@ pub fn execute_wasm_component_bridge(
                 Err(error) => {
                     execution["status"] = Value::String("failed".to_owned());
                     execution["reason"] = Value::String(error);
-                    execution["runtime"] = json!({
-                        "executor": "wasmtime_module",
-                        "artifact_path": artifact_path.display().to_string(),
-                        "export": export_name,
-                        "operation": command.operation,
-                        "payload": command.payload,
-                        "module_size_bytes": module_size_bytes,
-                        "fuel_limit": runtime_policy.wasm_fuel_limit,
-                        "cache_hit": false,
-                        "cache_miss": true,
-                        "cache_evicted_entries": 0,
-                        "cache_entries": 0,
-                        "cache_capacity": cache_capacity,
-                        "cache_total_module_bytes": 0,
-                        "cache_max_bytes": cache_max_bytes,
-                        "cache_inserted": false,
-                    });
+                    execution["runtime"] = with_execution_security_tier(
+                        json!({
+                            "executor": "wasmtime_module",
+                            "artifact_path": artifact_path.display().to_string(),
+                            "export": export_name,
+                            "operation": command.operation,
+                            "payload": command.payload,
+                            "module_size_bytes": module_size_bytes,
+                            "fuel_limit": runtime_policy.wasm_fuel_limit,
+                            "cache_hit": false,
+                            "cache_miss": true,
+                            "cache_evicted_entries": 0,
+                            "cache_entries": 0,
+                            "cache_capacity": cache_capacity,
+                            "cache_total_module_bytes": 0,
+                            "cache_max_bytes": cache_max_bytes,
+                            "cache_inserted": false,
+                        }),
+                        execution_tier,
+                    );
                     return execution;
                 }
             };
@@ -1837,12 +1890,15 @@ pub fn execute_wasm_component_bridge(
                     "wasm artifact size {} exceeds runtime max_component_bytes {limit}",
                     module_size_bytes
                 ));
-                execution["runtime"] = json!({
-                    "executor": "wasmtime_module",
-                    "artifact_path": artifact_path.display().to_string(),
-                    "module_size_bytes": module_size_bytes,
-                    "max_component_bytes": limit,
-                });
+                execution["runtime"] = with_execution_security_tier(
+                    json!({
+                        "executor": "wasmtime_module",
+                        "artifact_path": artifact_path.display().to_string(),
+                        "module_size_bytes": module_size_bytes,
+                        "max_component_bytes": limit,
+                    }),
+                    execution_tier,
+                );
                 return execution;
             }
 
@@ -1853,15 +1909,18 @@ pub fn execute_wasm_component_bridge(
                     execution["reason"] = Value::String(format!(
                         "wasm artifact sha256 mismatch: expected {expected}, actual {actual}"
                     ));
-                    execution["runtime"] = json!({
-                        "executor": "wasmtime_module",
-                        "artifact_path": artifact_path.display().to_string(),
-                        "module_size_bytes": module_size_bytes,
-                        "expected_sha256": expected,
-                        "artifact_sha256": actual,
-                        "integrity_check_required": true,
-                        "integrity_check_passed": false,
-                    });
+                    execution["runtime"] = with_execution_security_tier(
+                        json!({
+                            "executor": "wasmtime_module",
+                            "artifact_path": artifact_path.display().to_string(),
+                            "module_size_bytes": module_size_bytes,
+                            "expected_sha256": expected,
+                            "artifact_sha256": actual,
+                            "integrity_check_required": true,
+                            "integrity_check_passed": false,
+                        }),
+                        execution_tier,
+                    );
                     return execution;
                 }
                 Some(actual)
@@ -1889,7 +1948,40 @@ pub fn execute_wasm_component_bridge(
                             Err(reason) => {
                                 execution["status"] = Value::String("failed".to_owned());
                                 execution["reason"] = Value::String(reason);
-                                execution["runtime"] = json!({
+                                execution["runtime"] = with_execution_security_tier(
+                                    json!({
+                                        "executor": "wasmtime_module",
+                                        "artifact_path": artifact_path.display().to_string(),
+                                        "export": export_name,
+                                        "operation": command.operation,
+                                        "payload": command.payload,
+                                        "module_size_bytes": module_size_bytes,
+                                        "fuel_limit": runtime_policy.wasm_fuel_limit,
+                                        "cache_hit": false,
+                                        "cache_miss": true,
+                                        "cache_evicted_entries": 0,
+                                        "cache_entries": 0,
+                                        "cache_capacity": cache_capacity,
+                                        "cache_total_module_bytes": 0,
+                                        "cache_max_bytes": cache_max_bytes,
+                                        "cache_inserted": false,
+                                    }),
+                                    execution_tier,
+                                );
+                                return execution;
+                            }
+                        };
+                    let cache_lookup = match insert_cached_wasm_module(
+                        refreshed_cache_key,
+                        compiled.clone(),
+                        module_size_bytes,
+                    ) {
+                        Ok(lookup) => lookup,
+                        Err(reason) => {
+                            execution["status"] = Value::String("failed".to_owned());
+                            execution["reason"] = Value::String(reason);
+                            execution["runtime"] = with_execution_security_tier(
+                                json!({
                                     "executor": "wasmtime_module",
                                     "artifact_path": artifact_path.display().to_string(),
                                     "export": export_name,
@@ -1905,36 +1997,9 @@ pub fn execute_wasm_component_bridge(
                                     "cache_total_module_bytes": 0,
                                     "cache_max_bytes": cache_max_bytes,
                                     "cache_inserted": false,
-                                });
-                                return execution;
-                            }
-                        };
-                    let cache_lookup = match insert_cached_wasm_module(
-                        refreshed_cache_key,
-                        compiled.clone(),
-                        module_size_bytes,
-                    ) {
-                        Ok(lookup) => lookup,
-                        Err(reason) => {
-                            execution["status"] = Value::String("failed".to_owned());
-                            execution["reason"] = Value::String(reason);
-                            execution["runtime"] = json!({
-                                "executor": "wasmtime_module",
-                                "artifact_path": artifact_path.display().to_string(),
-                                "export": export_name,
-                                "operation": command.operation,
-                                "payload": command.payload,
-                                "module_size_bytes": module_size_bytes,
-                                "fuel_limit": runtime_policy.wasm_fuel_limit,
-                                "cache_hit": false,
-                                "cache_miss": true,
-                                "cache_evicted_entries": 0,
-                                "cache_entries": 0,
-                                "cache_capacity": cache_capacity,
-                                "cache_total_module_bytes": 0,
-                                "cache_max_bytes": cache_max_bytes,
-                                "cache_inserted": false,
-                            });
+                                }),
+                                execution_tier,
+                            );
                             return execution;
                         }
                     };
@@ -1943,23 +2008,26 @@ pub fn execute_wasm_component_bridge(
                 Err(reason) => {
                     execution["status"] = Value::String("failed".to_owned());
                     execution["reason"] = Value::String(reason);
-                    execution["runtime"] = json!({
-                        "executor": "wasmtime_module",
-                        "artifact_path": artifact_path.display().to_string(),
-                        "export": export_name,
-                        "operation": command.operation,
-                        "payload": command.payload,
-                        "module_size_bytes": module_size_bytes,
-                        "fuel_limit": runtime_policy.wasm_fuel_limit,
-                        "cache_hit": false,
-                        "cache_miss": true,
-                        "cache_evicted_entries": 0,
-                        "cache_entries": 0,
-                        "cache_capacity": cache_capacity,
-                        "cache_total_module_bytes": 0,
-                        "cache_max_bytes": cache_max_bytes,
-                        "cache_inserted": false,
-                    });
+                    execution["runtime"] = with_execution_security_tier(
+                        json!({
+                            "executor": "wasmtime_module",
+                            "artifact_path": artifact_path.display().to_string(),
+                            "export": export_name,
+                            "operation": command.operation,
+                            "payload": command.payload,
+                            "module_size_bytes": module_size_bytes,
+                            "fuel_limit": runtime_policy.wasm_fuel_limit,
+                            "cache_hit": false,
+                            "cache_miss": true,
+                            "cache_evicted_entries": 0,
+                            "cache_entries": 0,
+                            "cache_capacity": cache_capacity,
+                            "cache_total_module_bytes": 0,
+                            "cache_max_bytes": cache_max_bytes,
+                            "cache_inserted": false,
+                        }),
+                        execution_tier,
+                    );
                     return execution;
                 }
             }
@@ -1967,23 +2035,26 @@ pub fn execute_wasm_component_bridge(
         Err(reason) => {
             execution["status"] = Value::String("failed".to_owned());
             execution["reason"] = Value::String(reason);
-            execution["runtime"] = json!({
-                "executor": "wasmtime_module",
-                "artifact_path": artifact_path.display().to_string(),
-                "export": export_name,
-                "operation": command.operation,
-                "payload": command.payload,
-                "module_size_bytes": module_size_bytes,
-                "fuel_limit": runtime_policy.wasm_fuel_limit,
-                "cache_hit": false,
-                "cache_miss": true,
-                "cache_evicted_entries": 0,
-                "cache_entries": 0,
-                "cache_capacity": cache_capacity,
-                "cache_total_module_bytes": 0,
-                "cache_max_bytes": cache_max_bytes,
-                "cache_inserted": false,
-            });
+            execution["runtime"] = with_execution_security_tier(
+                json!({
+                    "executor": "wasmtime_module",
+                    "artifact_path": artifact_path.display().to_string(),
+                    "export": export_name,
+                    "operation": command.operation,
+                    "payload": command.payload,
+                    "module_size_bytes": module_size_bytes,
+                    "fuel_limit": runtime_policy.wasm_fuel_limit,
+                    "cache_hit": false,
+                    "cache_miss": true,
+                    "cache_evicted_entries": 0,
+                    "cache_entries": 0,
+                    "cache_capacity": cache_capacity,
+                    "cache_total_module_bytes": 0,
+                    "cache_max_bytes": cache_max_bytes,
+                    "cache_inserted": false,
+                }),
+                execution_tier,
+            );
             return execution;
         }
     };
@@ -2021,54 +2092,60 @@ pub fn execute_wasm_component_bridge(
     match run_result {
         Ok(consumed_fuel) => {
             execution["status"] = Value::String("executed".to_owned());
-            execution["runtime"] = json!({
-                "executor": "wasmtime_module",
-                "artifact_path": artifact_path.display().to_string(),
-                "export": export_name,
-                "operation": command.operation,
-                "payload": command.payload,
-                "module_size_bytes": module_size_bytes,
-                "fuel_limit": runtime_policy.wasm_fuel_limit,
-                "fuel_consumed": consumed_fuel,
-                "cache_hit": cache_lookup.hit,
-                "cache_miss": !cache_lookup.hit,
-                "cache_evicted_entries": cache_lookup.evicted_entries,
-                "cache_entries": cache_lookup.cache_len,
-                "cache_capacity": cache_lookup.cache_capacity,
-                "cache_total_module_bytes": cache_lookup.cache_total_module_bytes,
-                "cache_max_bytes": cache_lookup.cache_max_bytes,
-                "cache_inserted": cache_lookup.inserted,
-                "expected_sha256": expected_sha256,
-                "artifact_sha256": cached_module.artifact_sha256.clone(),
-                "integrity_check_required": expected_sha256.is_some(),
-                "integrity_check_passed": expected_sha256.is_none() || cached_module.artifact_sha256.is_some(),
-            });
+            execution["runtime"] = with_execution_security_tier(
+                json!({
+                    "executor": "wasmtime_module",
+                    "artifact_path": artifact_path.display().to_string(),
+                    "export": export_name,
+                    "operation": command.operation,
+                    "payload": command.payload,
+                    "module_size_bytes": module_size_bytes,
+                    "fuel_limit": runtime_policy.wasm_fuel_limit,
+                    "fuel_consumed": consumed_fuel,
+                    "cache_hit": cache_lookup.hit,
+                    "cache_miss": !cache_lookup.hit,
+                    "cache_evicted_entries": cache_lookup.evicted_entries,
+                    "cache_entries": cache_lookup.cache_len,
+                    "cache_capacity": cache_lookup.cache_capacity,
+                    "cache_total_module_bytes": cache_lookup.cache_total_module_bytes,
+                    "cache_max_bytes": cache_lookup.cache_max_bytes,
+                    "cache_inserted": cache_lookup.inserted,
+                    "expected_sha256": expected_sha256,
+                    "artifact_sha256": cached_module.artifact_sha256.clone(),
+                    "integrity_check_required": expected_sha256.is_some(),
+                    "integrity_check_passed": expected_sha256.is_none() || cached_module.artifact_sha256.is_some(),
+                }),
+                execution_tier,
+            );
             execution
         }
         Err(reason) => {
             execution["status"] = Value::String("failed".to_owned());
             execution["reason"] = Value::String(reason);
-            execution["runtime"] = json!({
-                "executor": "wasmtime_module",
-                "artifact_path": artifact_path.display().to_string(),
-                "export": export_name,
-                "operation": command.operation,
-                "payload": command.payload,
-                "module_size_bytes": module_size_bytes,
-                "fuel_limit": runtime_policy.wasm_fuel_limit,
-                "cache_hit": cache_lookup.hit,
-                "cache_miss": !cache_lookup.hit,
-                "cache_evicted_entries": cache_lookup.evicted_entries,
-                "cache_entries": cache_lookup.cache_len,
-                "cache_capacity": cache_lookup.cache_capacity,
-                "cache_total_module_bytes": cache_lookup.cache_total_module_bytes,
-                "cache_max_bytes": cache_lookup.cache_max_bytes,
-                "cache_inserted": cache_lookup.inserted,
-                "expected_sha256": expected_sha256,
-                "artifact_sha256": cached_module.artifact_sha256.clone(),
-                "integrity_check_required": expected_sha256.is_some(),
-                "integrity_check_passed": expected_sha256.is_none() || cached_module.artifact_sha256.is_some(),
-            });
+            execution["runtime"] = with_execution_security_tier(
+                json!({
+                    "executor": "wasmtime_module",
+                    "artifact_path": artifact_path.display().to_string(),
+                    "export": export_name,
+                    "operation": command.operation,
+                    "payload": command.payload,
+                    "module_size_bytes": module_size_bytes,
+                    "fuel_limit": runtime_policy.wasm_fuel_limit,
+                    "cache_hit": cache_lookup.hit,
+                    "cache_miss": !cache_lookup.hit,
+                    "cache_evicted_entries": cache_lookup.evicted_entries,
+                    "cache_entries": cache_lookup.cache_len,
+                    "cache_capacity": cache_lookup.cache_capacity,
+                    "cache_total_module_bytes": cache_lookup.cache_total_module_bytes,
+                    "cache_max_bytes": cache_lookup.cache_max_bytes,
+                    "cache_inserted": cache_lookup.inserted,
+                    "expected_sha256": expected_sha256,
+                    "artifact_sha256": cached_module.artifact_sha256.clone(),
+                    "integrity_check_required": expected_sha256.is_some(),
+                    "integrity_check_passed": expected_sha256.is_none() || cached_module.artifact_sha256.is_some(),
+                }),
+                execution_tier,
+            );
             execution
         }
     }
@@ -2663,7 +2740,11 @@ impl MemoryExtensionAdapter for VectorIndexMemoryExtension {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, path::Path, sync::Arc};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        path::Path,
+        sync::Arc,
+    };
     #[cfg(unix)]
     use std::{
         fs,
@@ -2680,8 +2761,9 @@ mod tests {
         parse_wasm_signals_based_traps,
     };
     use super::{
-        BridgeRuntimePolicy, CoreToolRuntime, WasmModuleCache, build_wasm_module_cache_key,
-        compile_wasm_module, normalize_sha256_pin, resolve_expected_wasm_sha256,
+        BridgeRuntimePolicy, ConnectorProtocolContext, CoreToolRuntime, WasmModuleCache,
+        build_wasm_module_cache_key, compile_wasm_module, normalize_sha256_pin,
+        process_stdio_runtime_evidence, resolve_expected_wasm_sha256,
     };
     use kernel::{CoreToolAdapter, ToolCoreOutcome, ToolCoreRequest};
     use serde_json::json;
@@ -2853,6 +2935,94 @@ mod tests {
         let error = resolve_expected_wasm_sha256(&provider, &policy)
             .expect_err("metadata/policy conflict should be rejected");
         assert!(error.contains("between provider metadata"));
+    }
+
+    #[test]
+    fn process_stdio_runtime_evidence_reports_balanced_execution_tier() {
+        let provider = provider_with_metadata(BTreeMap::new());
+        let channel = kernel::ChannelConfig {
+            channel_id: "channel-x".to_owned(),
+            endpoint: "stdio://connector".to_owned(),
+            provider_id: provider.provider_id.clone(),
+            enabled: true,
+            metadata: BTreeMap::new(),
+        };
+        let command = kernel::ConnectorCommand {
+            connector_name: "connector-x".to_owned(),
+            operation: "call".to_owned(),
+            required_capabilities: BTreeSet::new(),
+            payload: json!({}),
+        };
+        let mut context =
+            ConnectorProtocolContext::from_connector_command(&provider, &channel, &command);
+        super::authorize_connector_protocol_context(&mut context)
+            .expect("protocol context should authorize");
+
+        let runtime = process_stdio_runtime_evidence(
+            &context,
+            BridgeRuntimePolicy {
+                execute_process_stdio: true,
+                allowed_process_commands: BTreeSet::from(["demo-connector".to_owned()]),
+                ..BridgeRuntimePolicy::default()
+            }
+            .process_stdio_execution_security_tier(),
+            "demo-connector",
+            &["--serve".to_owned()],
+            5_000,
+            super::ProcessStdioRuntimeEvidenceKind::BaseOnly,
+        );
+
+        assert_eq!(runtime["execution_tier"], json!("balanced"));
+    }
+
+    #[test]
+    fn execute_wasm_component_bridge_reports_restricted_execution_tier() {
+        let unique = format!(
+            "loongclaw-wasm-tier-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        );
+        let root = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&root).expect("create temp wasm root");
+        let wasm_path = root.join("fixture.wasm");
+        std::fs::write(&wasm_path, EMPTY_WASM_MODULE).expect("write wasm fixture");
+
+        let provider = provider_with_metadata(BTreeMap::from([
+            ("component".to_owned(), wasm_path.display().to_string()),
+            ("plugin_id".to_owned(), "plugin-a".to_owned()),
+        ]));
+        let channel = kernel::ChannelConfig {
+            channel_id: "channel-wasm".to_owned(),
+            endpoint: "local://fixture".to_owned(),
+            provider_id: provider.provider_id.clone(),
+            enabled: true,
+            metadata: BTreeMap::new(),
+        };
+        let command = kernel::ConnectorCommand {
+            connector_name: "connector-x".to_owned(),
+            operation: "call".to_owned(),
+            required_capabilities: BTreeSet::new(),
+            payload: json!({}),
+        };
+        let runtime_policy = BridgeRuntimePolicy {
+            execute_wasm_component: true,
+            wasm_allowed_path_prefixes: vec![root.clone()],
+            ..BridgeRuntimePolicy::default()
+        };
+
+        let execution = super::execute_wasm_component_bridge(
+            json!({"status": "planned"}),
+            &provider,
+            &channel,
+            &command,
+            &runtime_policy,
+        );
+
+        assert_eq!(execution["runtime"]["execution_tier"], json!("restricted"));
+        let _ = std::fs::remove_file(&wasm_path);
+        let _ = std::fs::remove_dir(&root);
     }
 
     #[test]

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -1707,6 +1707,12 @@ pub fn execute_wasm_component_bridge(
         Err(reason) => {
             execution["status"] = Value::String("blocked".to_owned());
             execution["reason"] = Value::String(reason);
+            execution["runtime"] = with_execution_security_tier(
+                json!({
+                    "executor": "wasmtime_module",
+                }),
+                execution_tier,
+            );
             return execution;
         }
     };
@@ -3023,6 +3029,44 @@ mod tests {
         assert_eq!(execution["runtime"]["execution_tier"], json!("restricted"));
         let _ = std::fs::remove_file(&wasm_path);
         let _ = std::fs::remove_dir(&root);
+    }
+
+    #[test]
+    fn execute_wasm_component_bridge_reports_runtime_on_artifact_resolution_failure() {
+        let provider = provider_with_metadata(BTreeMap::new());
+        let channel = kernel::ChannelConfig {
+            channel_id: "channel-wasm".to_owned(),
+            endpoint: "local://fixture".to_owned(),
+            provider_id: provider.provider_id.clone(),
+            enabled: true,
+            metadata: BTreeMap::new(),
+        };
+        let command = kernel::ConnectorCommand {
+            connector_name: "connector-x".to_owned(),
+            operation: "call".to_owned(),
+            required_capabilities: BTreeSet::new(),
+            payload: json!({}),
+        };
+        let runtime_policy = BridgeRuntimePolicy {
+            execute_wasm_component: true,
+            ..BridgeRuntimePolicy::default()
+        };
+
+        let execution = super::execute_wasm_component_bridge(
+            json!({"status": "planned"}),
+            &provider,
+            &channel,
+            &command,
+            &runtime_policy,
+        );
+
+        assert_eq!(execution["status"], json!("blocked"));
+        assert_eq!(
+            execution["reason"],
+            json!("wasm_component execution requires component artifact path")
+        );
+        assert_eq!(execution["runtime"]["executor"], json!("wasmtime_module"));
+        assert_eq!(execution["runtime"]["execution_tier"], json!("restricted"));
     }
 
     #[test]

--- a/crates/spec/src/spec_runtime/process_stdio_bridge.rs
+++ b/crates/spec/src/spec_runtime/process_stdio_bridge.rs
@@ -59,6 +59,7 @@ pub async fn execute_process_stdio_bridge(
         execution["reason"] = Value::String(format!("process_stdio {reason}"));
         execution["runtime"] = process_stdio_runtime_evidence(
             &protocol_context,
+            runtime_policy.process_stdio_execution_security_tier(),
             &program,
             &args,
             timeout_ms,
@@ -90,6 +91,7 @@ pub async fn execute_process_stdio_bridge(
             }
             execution["runtime"] = process_stdio_runtime_evidence(
                 &protocol_context,
+                runtime_policy.process_stdio_execution_security_tier(),
                 &program,
                 &args,
                 timeout_ms,
@@ -109,6 +111,7 @@ pub async fn execute_process_stdio_bridge(
             execution["reason"] = Value::String(reason);
             execution["runtime"] = process_stdio_runtime_evidence(
                 &protocol_context,
+                runtime_policy.process_stdio_execution_security_tier(),
                 &program,
                 &args,
                 timeout_ms,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,7 +106,8 @@ Remaining deliverables:
   - CPU budget refinement
   - memory limits
   - timeout/termination policy
-- process bridge sandbox profile tiers (`restricted`, `balanced`, `trusted`)
+- process bridge sandbox profile tiers (`restricted`, `balanced`, `trusted`) aligned with the
+  shared execution-tier contract used by browser and WASM evidence surfaces
 - hot-reload lifecycle hooks:
   - pre-load validation
   - rollback-on-failure
@@ -438,6 +439,13 @@ risks growing its own security semantics and evidence model.
 
 Trade-off: the first slice should standardize the contract, not attempt a giant all-lane sandbox
 rewrite.
+
+Current first-slice mapping:
+
+- `restricted` - built-in browser lane and the current WASM component runtime lane
+- `balanced` - allowlisted `process_stdio` bridge execution and the managed browser companion when
+  its runtime gate is open
+- `trusted` - reserved for future explicit high-trust runtime lanes rather than assumed by default
 
 ### D9: First-party workflow packs on hardened primitives
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -67,6 +67,24 @@ CapabilityToken → PolicyEngine → PolicyExtensionChain → Execution → Audi
 - Trade-off: corporate proxy-only egress is not currently supported for these web tools because a proxy hop would weaken the same-host assumptions behind the private-address guard
 - If proxy-aware web tooling is added later, it should preserve the same SSRF guarantees rather than silently bypassing them
 
+### Shared Execution Security Tiers
+
+LoongClaw now uses one shared execution-tier vocabulary across the process, browser, and WASM
+lanes. The first slice standardizes the contract and the emitted evidence; it does not attempt a
+full sandbox rewrite for every lane at once.
+
+| Tier | Meaning | Current lane mapping |
+|------|---------|----------------------|
+| `restricted` | tightly bounded execution intended for untrusted or heavily constrained work | built-in browser tools and the current WASM component runtime lane |
+| `balanced` | richer operator-governed execution with explicit readiness or allowlist gates | allowlisted `process_stdio` bridge execution and the managed browser companion when its runtime gate is open |
+| `trusted` | reserved for future explicit high-trust execution lanes | no default lane maps here yet |
+
+Current evidence surfaces that emit or expose this vocabulary:
+
+- `process_stdio` bridge runtime evidence now includes `execution_tier`
+- WASM bridge runtime evidence now includes `execution_tier`
+- browser tool payloads and runtime snapshots now include `execution_tier`
+
 ### Compile-Time Constraints
 
 25 workspace clippy denies prevent common agent anti-patterns. See [Harness Engineering](design-docs/harness-engineering.md) for the full list.

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-18T10:08:59Z
+- Generated at: 2026-03-20T11:48:08Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,7 +11,7 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3020 | 3600 | 580 | 47 | 65 | 18 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 301 | 1000 | 699 | 8 | 20 | 12 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 312 | 650 | 338 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
@@ -39,7 +39,7 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=3020 functions=47 -->
+<!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=301 functions=8 -->
 <!-- arch-hotspot key=memory_mod lines=312 functions=15 -->


### PR DESCRIPTION
## Summary

- Problem: execution security semantics were drifting across `process_stdio`, built-in browser tools, browser companion flows, and the wasm component bridge because the repository did not expose one shared execution-tier contract.
- Why it matters: operators and runtime authors could not rely on one vocabulary or one evidence surface when comparing risk posture across lanes, which weakens review, audit, and future rollout work.
- What changed: added a shared `ExecutionSecurityTier` contract in `loongclaw-contracts`, mapped current browser / browser companion / `process_stdio` / wasm defaults onto it, and surfaced the same tier through runtime evidence, tool payloads, runtime snapshots, tests, and docs.
- What did not change (scope boundary): this does not attempt a full sandbox rewrite, expand unrelated lane capabilities, or redefine existing bounded checks that were already correct.

## Linked Issues

- Closes #266
- Related #267

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [x] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this changes operator-visible policy and evidence semantics across runtime lanes, so drift or partial rollout would be confusing even if functional behavior stayed correct.
- Rollout / guardrails: the change keeps the rollout intentionally narrow by introducing the shared contract first, mapping only existing defaults, and extending evidence surfaces instead of broadening execution permissions.
- Rollback path: revert this commit to drop the shared tier contract and restore the prior per-lane evidence shape.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
env CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/loongclaw-issue266-target-clippy2 <redacted-cargo> fmt --all -- --check
  passed

env CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/loongclaw-issue266-target-clippy2 <redacted-cargo> clippy --workspace --all-targets --all-features -- -D warnings
  passed

env CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/loongclaw-issue266-target-clippy2 <redacted-cargo> test --workspace --locked
  passed

env CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/loongclaw-issue266-target-clippy2 <redacted-cargo> test --workspace --all-features --locked
  passed
```

## User-visible / Operator-visible Changes

- runtime evidence for `process_stdio` and wasm bridge execution now includes a shared `execution_tier`
- browser and browser companion tool payloads now expose the same `execution_tier`
- runtime snapshot text and json now show browser and browser companion execution tiers

## Failure Recovery

- Fast rollback or disable path: revert this branch or drop the new `ExecutionSecurityTier` contract wiring from the affected lanes.
- Observable failure symptoms reviewers should watch for: missing `execution_tier` fields in runtime evidence or snapshot output, unexpected tier values for browser or browser companion readiness states, or snapshot tests drifting from the documented mapping.

## Reviewer Focus

- confirm the shared contract lives at the contracts layer rather than reintroducing per-lane drift
- inspect `BridgeRuntimePolicy` tier derivation and wasm evidence wrapping for partial coverage gaps
- inspect browser and daemon runtime snapshot surfaces to confirm operator-facing output stays aligned with the documented mapping


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool and bridge executions now include an execution_tier in their outcomes and runtime evidence.
  * Added a three-tier execution security model: restricted, balanced, trusted.
  * Runtime snapshots and runtime evidence consistently surface execution_tier for browser, companion, WASM, and process bridges.

* **Tests**
  * Updated tests to assert expected execution_tier values across affected flows.

* **Documentation**
  * Security and roadmap docs updated with execution tier definitions and mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->