### PR TITLE
feat: finish external skills metadata, migration, and fetch lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "tokio-tungstenite",
  "toml",
  "wait-timeout",
+ "which",
 ]
 
 [[package]]
@@ -4173,6 +4174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ ed25519-dalek = "2.2"
 wasmtime = { version = "42.0.1", default-features = false, features = ["std", "runtime", "cranelift"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
+which = "8"
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -470,11 +470,40 @@ loongclaw migrate --mode plan_many --input ~/legacy-claws
 loongclaw migrate --mode apply_selected --input ~/legacy-claws \
   --source-id openclaw --output ~/.loongclaw/config.toml --force
 
+# Apply one selected source and bridge installable local external skills
+loongclaw migrate --mode apply_selected --input ~/legacy-claws \
+  --source-id openclaw --output ~/.loongclaw/config.toml \
+  --apply-external-skills-plan --force
+
 # Roll back the most recent migration
 loongclaw migrate --mode rollback_last_apply --output ~/.loongclaw/config.toml
 ```
 
-Deeper migration modes also exist, including `merge_profiles` for multi-source profile merging and `map_external_skills` for external-skills artifact mapping.
+Deeper migration modes also exist, including `merge_profiles` for multi-source profile merging and `map_external_skills` for external-skills artifact mapping. The bridge remains opt-in: prompt/profile import still works by default, while `--apply-external-skills-plan` adds installable local skill directories to the managed runtime without replacing unrelated managed skills.
+
+<a id="manage-external-skills"></a>
+## Manage External Skills
+
+LoongClaw's external-skills runtime is operator-visible now instead of staying hidden behind migration helpers.
+
+```bash
+# Inspect resolved managed, user, and project skills with eligibility + invocation metadata
+loongclaw skills list
+loongclaw skills info release-guard
+
+# Download a remote skill package under the external-skills policy boundary
+loongclaw skills fetch https://skills.sh/release-guard.tgz --approve-download
+
+# Download and sync a remote package into the managed runtime in one step
+loongclaw skills fetch https://skills.sh/release-guard.tgz \
+  --approve-download --install --replace
+```
+
+`loongclaw skills list` and `loongclaw skills info` surface per-skill metadata such as
+`invocation_policy`, required env or binaries, required runtime config gates, and declared tool
+restrictions. `loongclaw skills fetch --install --replace` gives operators a thin update path over
+the existing managed install lifecycle without bypassing the same runtime policy checks that govern
+downloads and installed skill execution.
 
 <a id="core-capabilities"></a>
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -54,6 +54,7 @@ axum = { workspace = true, optional = true }
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
 wait-timeout = "0.2"
+tempfile = "3"
 which.workspace = true
 regex = { workspace = true, optional = true }
 prost = { version = "0.13", optional = true }
@@ -61,7 +62,6 @@ rustls = { version = "0.23", default-features = false, features = ["ring"], opti
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"], optional = true }
 
 [dev-dependencies]
-tempfile = "3"
 axum.workspace = true
 
 [lints]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -54,6 +54,7 @@ axum = { workspace = true, optional = true }
 aes = { version = "0.8", optional = true }
 cbc = { version = "0.1", optional = true }
 wait-timeout = "0.2"
+which.workspace = true
 regex = { workspace = true, optional = true }
 prost = { version = "0.13", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }

--- a/crates/app/src/migration/mod.rs
+++ b/crates/app/src/migration/mod.rs
@@ -621,7 +621,7 @@ fn external_skill_probe_roots(input_path: &Path) -> Vec<PathBuf> {
 
 fn external_skill_warning(artifact: &ExternalSkillArtifact) -> String {
     format!(
-        "detected external skills artifact `{}` ({}); LoongClaw imports prompt/profile content but does not auto-install the runtime, so use the explicit external skills lifecycle (`fetch` -> `install` -> `list` -> `invoke`) when you want the skill available in chat",
+        "detected external skills artifact `{}` ({}); LoongClaw imports prompt/profile content by default, and installable local skills can be bridged into the managed runtime with `loongclaw migrate --mode apply_selected --apply-external-skills-plan` or the explicit external skills lifecycle (`fetch` -> `install` -> `list` -> `invoke`)",
         artifact.path.display(),
         artifact.kind.as_id()
     )
@@ -1297,6 +1297,8 @@ mod tests {
             kind: ExternalSkillArtifactKind::SkillsDir,
             path: PathBuf::from("/tmp/demo/skills"),
         });
+        assert!(warning.contains("apply_selected"));
+        assert!(warning.contains("apply-external-skills-plan"));
         assert!(warning.contains("fetch"));
         assert!(warning.contains("install"));
         assert!(warning.contains("invoke"));

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -346,123 +346,133 @@ pub fn apply_import_selection(
         }
     };
 
-    if request.apply_external_skills_plan {
-        let input_path = request
-            .external_skills_input_path
-            .as_deref()
-            .ok_or_else(|| {
-                "apply_external_skills_plan requires external_skills_input_path".to_owned()
-            })?;
-        let mapping = plan_external_skill_mapping(input_path);
-        external_skill_artifact_count = mapping.artifacts.len();
-        external_skill_entries_applied = apply_external_skill_mapping(&mut config, &mapping);
-        external_skill_managed_installs = bridge_installable_external_skills(
-            &mut config,
-            &request.output_path,
-            input_path,
-            &mapping,
-        )?;
-        warnings.extend(mapping.warnings.clone());
-        external_skill_mapping = Some(mapping);
-    }
-    dedup_strings_in_place(&mut warnings);
-
-    let state_dir = migration_state_dir(&request.output_path);
-    fs::create_dir_all(&state_dir).map_err(|error| {
-        format!(
-            "failed to create migration state directory {}: {error}",
-            state_dir.display()
-        )
-    })?;
-    let session_id = import_session_id();
-    let backup_path = backup_path_for_output(&request.output_path, &state_dir, &session_id);
-    let manifest_path = manifest_path_for_output(&request.output_path, &state_dir);
-    let output_preexisted = request.output_path.exists();
-    if output_preexisted {
-        fs::copy(&request.output_path, &backup_path).map_err(|error| {
-            format!(
-                "failed to write import backup {}: {error}",
-                backup_path.display()
-            )
-        })?;
-    } else {
-        fs::write(&backup_path, "").map_err(|error| {
-            format!(
-                "failed to initialize import backup {}: {error}",
-                backup_path.display()
-            )
-        })?;
-    }
-
-    let output_string = request.output_path.display().to_string();
-    let written_output_path = match crate::config::write(Some(&output_string), &config, true) {
-        Ok(path) => path,
-        Err(error) => {
-            if let Err(rollback_error) = rollback_bridged_external_skills(
-                &config,
+    let mut backup_context: Option<(PathBuf, bool)> = None;
+    let persist_result = (|| -> CliResult<(PathBuf, PathBuf, PathBuf, Option<PathBuf>)> {
+        if request.apply_external_skills_plan {
+            let input_path = request
+                .external_skills_input_path
+                .as_deref()
+                .ok_or_else(|| {
+                    "apply_external_skills_plan requires external_skills_input_path".to_owned()
+                })?;
+            let mapping = plan_external_skill_mapping(input_path);
+            external_skill_artifact_count = mapping.artifacts.len();
+            external_skill_entries_applied = apply_external_skill_mapping(&mut config, &mapping);
+            external_skill_managed_installs = bridge_installable_external_skills(
+                &mut config,
                 &request.output_path,
-                request.external_skills_input_path.as_deref(),
+                input_path,
+                &mapping,
+            )?;
+            warnings.extend(mapping.warnings.clone());
+            external_skill_mapping = Some(mapping);
+        }
+        dedup_strings_in_place(&mut warnings);
+
+        let state_dir = migration_state_dir(&request.output_path);
+        fs::create_dir_all(&state_dir).map_err(|error| {
+            format!(
+                "failed to create migration state directory {}: {error}",
+                state_dir.display()
+            )
+        })?;
+        let session_id = import_session_id();
+        let backup_path = backup_path_for_output(&request.output_path, &state_dir, &session_id);
+        let manifest_path = manifest_path_for_output(&request.output_path, &state_dir);
+        let output_preexisted = request.output_path.exists();
+        if output_preexisted {
+            fs::copy(&request.output_path, &backup_path).map_err(|error| {
+                format!(
+                    "failed to write import backup {}: {error}",
+                    backup_path.display()
+                )
+            })?;
+        } else {
+            fs::write(&backup_path, "").map_err(|error| {
+                format!(
+                    "failed to initialize import backup {}: {error}",
+                    backup_path.display()
+                )
+            })?;
+        }
+        backup_context = Some((backup_path.clone(), output_preexisted));
+
+        let output_string = request.output_path.display().to_string();
+        let written_output_path = crate::config::write(Some(&output_string), &config, true)?;
+        let external_skills_manifest_path = if let Some(mapping) = external_skill_mapping.as_ref() {
+            let external_path =
+                external_skills_manifest_path_for_output(&request.output_path, &state_dir);
+            let external_manifest = build_external_skills_apply_manifest(
+                &written_output_path,
+                mapping,
+                config.external_skills.resolved_install_root().as_deref(),
                 &external_skill_managed_installs,
-            ) {
-                return Err(format!(
-                    "persist migrated config {} failed: {error}; external skills bridge rollback also failed: {rollback_error}",
-                    request.output_path.display()
+            );
+            let body = serde_json::to_vec_pretty(&external_manifest)
+                .map_err(|error| format!("failed to encode external skills manifest: {error}"))?;
+            fs::write(&external_path, body).map_err(|error| {
+                format!(
+                    "failed to write external skills manifest {}: {error}",
+                    external_path.display()
+                )
+            })?;
+            Some(external_path)
+        } else {
+            None
+        };
+
+        let manifest = ImportApplyManifest {
+            session_id,
+            selected_primary_source: selected_primary_source_id.clone(),
+            merged_sources: merged_source_ids.clone(),
+            prompt_owner_source: prompt_owner_source_id.clone(),
+            output_path: written_output_path.display().to_string(),
+            backup_path: backup_path.display().to_string(),
+            output_preexisted,
+            warnings: warnings.clone(),
+            unresolved_conflicts,
+            external_skill_artifact_count,
+            external_skill_entries_applied,
+            external_skill_managed_install_count: external_skill_managed_installs.len(),
+            external_skill_managed_skill_ids: external_skill_managed_installs
+                .iter()
+                .map(|skill| skill.skill_id.clone())
+                .collect(),
+            external_skills_manifest_path: external_skills_manifest_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
+        };
+        let manifest_body = serde_json::to_vec_pretty(&manifest)
+            .map_err(|error| format!("failed to encode import manifest: {error}"))?;
+        fs::write(&manifest_path, manifest_body).map_err(|error| {
+            format!(
+                "failed to write import manifest {}: {error}",
+                manifest_path.display()
+            )
+        })?;
+
+        Ok((
+            written_output_path,
+            backup_path,
+            manifest_path,
+            external_skills_manifest_path,
+        ))
+    })();
+
+    let (written_output_path, backup_path, manifest_path, external_skills_manifest_path) =
+        match persist_result {
+            Ok(result) => result,
+            Err(error) => {
+                return Err(finalize_apply_import_selection_failure(
+                    error,
+                    &config,
+                    &request.output_path,
+                    request.external_skills_input_path.as_deref(),
+                    &external_skill_managed_installs,
+                    backup_context.as_ref(),
                 ));
             }
-            return Err(error);
-        }
-    };
-    let external_skills_manifest_path = if let Some(mapping) = external_skill_mapping.as_ref() {
-        let external_path =
-            external_skills_manifest_path_for_output(&request.output_path, &state_dir);
-        let external_manifest = build_external_skills_apply_manifest(
-            &written_output_path,
-            mapping,
-            config.external_skills.resolved_install_root().as_deref(),
-            &external_skill_managed_installs,
-        );
-        let body = serde_json::to_vec_pretty(&external_manifest)
-            .map_err(|error| format!("failed to encode external skills manifest: {error}"))?;
-        fs::write(&external_path, body).map_err(|error| {
-            format!(
-                "failed to write external skills manifest {}: {error}",
-                external_path.display()
-            )
-        })?;
-        Some(external_path)
-    } else {
-        None
-    };
-
-    let manifest = ImportApplyManifest {
-        session_id,
-        selected_primary_source: selected_primary_source_id.clone(),
-        merged_sources: merged_source_ids.clone(),
-        prompt_owner_source: prompt_owner_source_id.clone(),
-        output_path: written_output_path.display().to_string(),
-        backup_path: backup_path.display().to_string(),
-        output_preexisted,
-        warnings: warnings.clone(),
-        unresolved_conflicts,
-        external_skill_artifact_count,
-        external_skill_entries_applied,
-        external_skill_managed_install_count: external_skill_managed_installs.len(),
-        external_skill_managed_skill_ids: external_skill_managed_installs
-            .iter()
-            .map(|skill| skill.skill_id.clone())
-            .collect(),
-        external_skills_manifest_path: external_skills_manifest_path
-            .as_ref()
-            .map(|path| path.display().to_string()),
-    };
-    let manifest_body = serde_json::to_vec_pretty(&manifest)
-        .map_err(|error| format!("failed to encode import manifest: {error}"))?;
-    fs::write(&manifest_path, manifest_body).map_err(|error| {
-        format!(
-            "failed to write import manifest {}: {error}",
-            manifest_path.display()
-        )
-    })?;
+        };
 
     Ok(ApplyImportSelectionResult {
         output_path: written_output_path,
@@ -528,28 +538,47 @@ fn bridge_installable_external_skills(
             )
         });
         let install = match install_outcome {
-            Ok(outcome) => match parse_external_skills_install_outcome(&outcome) {
-                Ok(install) => install,
-                Err(error) => {
-                    if let Err(rollback_error) = rollback_bridged_external_skills(
-                        config,
-                        output_path,
-                        Some(input_path),
-                        &installed,
-                    ) {
-                        return Err(format!(
-                            "{error}; external skills bridge rollback also failed: {rollback_error}"
-                        ));
+            Ok(outcome) => {
+                let current_skill_id = outcome
+                    .payload
+                    .get("skill_id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned);
+                match parse_external_skills_install_outcome(&outcome) {
+                    Ok(install) => install,
+                    Err(error) => {
+                        let mut rollback_ids = installed_skill_ids(&installed);
+                        if let Some(skill_id) = current_skill_id.as_ref() {
+                            rollback_ids.push(skill_id.clone());
+                        }
+                        let error = if current_skill_id.is_none() {
+                            format!(
+                                "{error}; external skills install payload was missing `skill_id`, so the most recent bridged install may require manual cleanup"
+                            )
+                        } else {
+                            error
+                        };
+                        if let Err(rollback_error) = rollback_bridged_external_skill_ids(
+                            config,
+                            output_path,
+                            Some(input_path),
+                            &rollback_ids,
+                        ) {
+                            return Err(format!(
+                                "{error}; external skills bridge rollback also failed: {rollback_error}"
+                            ));
+                        }
+                        return Err(error);
                     }
-                    return Err(error);
                 }
-            },
+            }
             Err(error) => {
-                if let Err(rollback_error) = rollback_bridged_external_skills(
+                let rollback_ids = installed_skill_ids(&installed);
+                if let Err(rollback_error) = rollback_bridged_external_skill_ids(
                     config,
                     output_path,
                     Some(input_path),
-                    &installed,
+                    &rollback_ids,
                 ) {
                     return Err(format!(
                         "{error}; external skills bridge rollback also failed: {rollback_error}"
@@ -639,13 +668,68 @@ fn required_string(payload: &serde_json::Value, key: &str) -> CliResult<String> 
         .ok_or_else(|| format!("external skills install payload missing `{key}`"))
 }
 
-fn rollback_bridged_external_skills(
+fn restore_output_from_backup(
+    output_path: &Path,
+    backup_path: &Path,
+    output_preexisted: bool,
+) -> CliResult<()> {
+    if output_preexisted {
+        fs::copy(backup_path, output_path).map_err(|error| {
+            format!(
+                "failed to restore config {} from backup {}: {error}",
+                output_path.display(),
+                backup_path.display()
+            )
+        })?;
+    } else if output_path.exists() {
+        fs::remove_file(output_path).map_err(|error| {
+            format!(
+                "failed to remove partial config {} after rollback: {error}",
+                output_path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn finalize_apply_import_selection_failure(
+    error: String,
     config: &crate::config::LoongClawConfig,
     output_path: &Path,
     input_path: Option<&Path>,
     installs: &[ExternalSkillsInstalledSkill],
+    backup_context: Option<&(PathBuf, bool)>,
+) -> String {
+    let mut message = error;
+    if let Err(rollback_error) =
+        rollback_bridged_external_skills(config, output_path, input_path, installs)
+    {
+        message =
+            format!("{message}; external skills bridge rollback also failed: {rollback_error}");
+    }
+    if let Some((backup_path, output_preexisted)) = backup_context
+        && let Err(restore_error) =
+            restore_output_from_backup(output_path, backup_path, *output_preexisted)
+    {
+        message = format!("{message}; config restore also failed: {restore_error}");
+    }
+    message
+}
+
+fn installed_skill_ids(installs: &[ExternalSkillsInstalledSkill]) -> Vec<String> {
+    installs
+        .iter()
+        .map(|install| install.skill_id.clone())
+        .collect()
+}
+
+fn rollback_bridged_external_skill_ids(
+    config: &crate::config::LoongClawConfig,
+    output_path: &Path,
+    input_path: Option<&Path>,
+    skill_ids: &[String],
 ) -> CliResult<()> {
-    if installs.is_empty() {
+    if skill_ids.is_empty() {
         return Ok(());
     }
 
@@ -654,24 +738,35 @@ fn rollback_bridged_external_skills(
         output_path,
         input_path.unwrap_or(output_path),
     );
-    for install in installs.iter().rev() {
+    for skill_id in skill_ids.iter().rev() {
         crate::tools::execute_tool_core_with_config(
             ToolCoreRequest {
                 tool_name: "external_skills.remove".to_owned(),
                 payload: json!({
-                    "skill_id": install.skill_id,
+                    "skill_id": skill_id,
                 }),
             },
             &runtime,
         )
         .map_err(|error| {
-            format!(
-                "remove bridged external skill `{}` failed during rollback: {error}",
-                install.skill_id
-            )
+            format!("remove bridged external skill `{skill_id}` failed during rollback: {error}")
         })?;
     }
     Ok(())
+}
+
+fn rollback_bridged_external_skills(
+    config: &crate::config::LoongClawConfig,
+    output_path: &Path,
+    input_path: Option<&Path>,
+    installs: &[ExternalSkillsInstalledSkill],
+) -> CliResult<()> {
+    rollback_bridged_external_skill_ids(
+        config,
+        output_path,
+        input_path,
+        &installed_skill_ids(installs),
+    )
 }
 
 fn build_external_skills_apply_manifest(
@@ -1533,6 +1628,69 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
+    #[test]
+    fn apply_import_selection_rolls_back_bridged_external_skills_when_state_dir_setup_fails() {
+        let root = unique_temp_dir("loongclaw-import-apply-managed-external-skills-state-dir");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n",
+        );
+        write_file(
+            &root,
+            ".codex/skills/release-guard/SKILL.md",
+            "# Release Guard\n\nUse this skill when release discipline matters.\n",
+        );
+
+        let output_path = root.join("loongclaw.toml");
+        let mut baseline = crate::config::LoongClawConfig::default();
+        baseline.external_skills.install_root =
+            Some(root.join("managed-skills").display().to_string());
+        let baseline_body = crate::config::render(&baseline).expect("render baseline config");
+        fs::write(&output_path, &baseline_body).expect("write baseline config");
+
+        let state_dir = migration_state_dir(&output_path);
+        fs::write(&state_dir, "occupied").expect("occupy migration state path with file");
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let error = apply_import_selection(&ApplyImportSelection {
+            discovery,
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::SelectedSingleSource {
+                source_id: "openclaw".to_owned(),
+            },
+            apply_external_skills_plan: true,
+            external_skills_input_path: Some(root.clone()),
+        })
+        .expect_err("state dir setup failure should abort apply");
+
+        assert!(
+            error.contains("failed to create migration state directory"),
+            "expected state dir setup failure, got: {error}"
+        );
+        assert!(
+            !root.join("managed-skills").join("release-guard").exists(),
+            "rollback should remove bridged installs when setup fails before config write"
+        );
+        assert_eq!(
+            fs::read_to_string(&output_path).expect("read preserved baseline config"),
+            baseline_body,
+            "state dir setup failures should not mutate the output config"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     #[cfg(unix)]
     #[test]
     fn apply_import_selection_rolls_back_bridged_external_skills_when_config_write_fails() {
@@ -1598,6 +1756,74 @@ mod tests {
         cleanup_permissions.set_mode(0o600);
         fs::set_permissions(&output_path, cleanup_permissions)
             .expect("restore output permissions for cleanup");
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn apply_import_selection_restores_config_and_rolls_back_bridged_external_skills_when_external_manifest_write_fails()
+     {
+        let root = unique_temp_dir("loongclaw-import-apply-managed-external-skills-manifest");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n",
+        );
+        write_file(
+            &root,
+            ".codex/skills/release-guard/SKILL.md",
+            "# Release Guard\n\nUse this skill when release discipline matters.\n",
+        );
+
+        let output_path = root.join("loongclaw.toml");
+        let mut baseline = crate::config::LoongClawConfig::default();
+        baseline.external_skills.install_root =
+            Some(root.join("managed-skills").display().to_string());
+        let baseline_body = crate::config::render(&baseline).expect("render baseline config");
+        fs::write(&output_path, &baseline_body).expect("write baseline config");
+
+        let state_dir = migration_state_dir(&output_path);
+        fs::create_dir_all(&state_dir).expect("create migration state directory");
+        let external_manifest_path =
+            external_skills_manifest_path_for_output(&output_path, &state_dir);
+        fs::create_dir_all(&external_manifest_path)
+            .expect("occupy external manifest path with directory");
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let error = apply_import_selection(&ApplyImportSelection {
+            discovery,
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::SelectedSingleSource {
+                source_id: "openclaw".to_owned(),
+            },
+            apply_external_skills_plan: true,
+            external_skills_input_path: Some(root.clone()),
+        })
+        .expect_err("external manifest write failure should abort apply");
+
+        assert!(
+            error.contains("failed to write external skills manifest"),
+            "expected external manifest write failure, got: {error}"
+        );
+        assert!(
+            !root.join("managed-skills").join("release-guard").exists(),
+            "rollback should remove bridged installs when manifest writing fails"
+        );
+        assert_eq!(
+            fs::read_to_string(&output_path).expect("read restored config"),
+            baseline_body,
+            "post-write failures should restore the previous config from backup"
+        );
+
         fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
-    io::ErrorKind,
+    io::{ErrorKind, Write},
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -410,7 +410,7 @@ pub fn apply_import_selection(
             );
             let body = serde_json::to_vec_pretty(&external_manifest)
                 .map_err(|error| format!("failed to encode external skills manifest: {error}"))?;
-            fs::write(&external_path, body).map_err(|error| {
+            write_bytes_atomically(&external_path, &body).map_err(|error| {
                 format!(
                     "failed to write external skills manifest {}: {error}",
                     external_path.display()
@@ -444,7 +444,7 @@ pub fn apply_import_selection(
         };
         let manifest_body = serde_json::to_vec_pretty(&manifest)
             .map_err(|error| format!("failed to encode import manifest: {error}"))?;
-        fs::write(&manifest_path, manifest_body).map_err(|error| {
+        write_bytes_atomically(&manifest_path, &manifest_body).map_err(|error| {
             format!(
                 "failed to write import manifest {}: {error}",
                 manifest_path.display()
@@ -497,6 +497,25 @@ pub fn apply_import_selection(
 fn dedup_strings_in_place(values: &mut Vec<String>) {
     let mut seen = BTreeSet::new();
     values.retain(|value| seen.insert(value.clone()));
+}
+
+fn write_bytes_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    write_bytes_atomically_with(path, |file| {
+        file.write_all(bytes)?;
+        file.sync_all()
+    })
+}
+
+fn write_bytes_atomically_with<F>(path: &Path, writer: F) -> std::io::Result<()>
+where
+    F: FnOnce(&mut fs::File) -> std::io::Result<()>,
+{
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let mut staged = tempfile::NamedTempFile::new_in(parent)?;
+    writer(staged.as_file_mut())?;
+    staged.as_file_mut().sync_all()?;
+    staged.persist(path).map_err(|error| error.error)?;
+    Ok(())
 }
 
 fn bridge_installable_external_skills(
@@ -656,7 +675,9 @@ fn installable_external_skill_probe_rank(
     probe_roots: &[PathBuf],
     artifact: &super::ExternalSkillArtifact,
 ) -> usize {
-    let Some(probe_root) = installable_external_skill_probe_root(artifact) else {
+    let Some(probe_root) = installable_external_skill_probe_root(artifact)
+        .map(|root| root.canonicalize().unwrap_or(root))
+    else {
         return probe_roots.len();
     };
     probe_roots
@@ -1230,6 +1251,30 @@ mod tests {
     }
 
     #[test]
+    fn write_bytes_atomically_preserves_existing_file_when_staged_write_fails() {
+        let root = unique_temp_dir("loongclaw-import-atomic-write-failure");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let target = root.join("manifest.json");
+        let baseline = br#"{"status":"old"}"#;
+        fs::write(&target, baseline).expect("write baseline manifest");
+
+        let error = write_bytes_atomically_with(&target, |_file| {
+            Err(std::io::Error::other("forced staged write failure"))
+        })
+        .expect_err("staged write failure should surface an error");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            fs::read(&target).expect("read preserved manifest"),
+            baseline,
+            "staged write failures should preserve the previous manifest body"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
     fn discover_import_sources_returns_ranked_candidates_from_fixture_root() {
         let root = unique_temp_dir("loongclaw-import-discovery-ranked");
         fs::create_dir_all(&root).expect("create fixture root");
@@ -1743,6 +1788,55 @@ mod tests {
                     .expect("canonicalize winning root")
             ],
             "duplicate installable skill ids should collapse to the highest-precedence import root"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn collect_installable_external_skill_roots_honors_probe_precedence_for_noncanonical_artifacts()
+    {
+        let root = unique_temp_dir("loongclaw-import-noncanonical-probe-precedence");
+        fs::create_dir_all(&root).expect("create fixture root");
+        fs::create_dir_all(root.join("workspace")).expect("create workspace root");
+
+        write_file(
+            &root,
+            "skills/release-guard-root/SKILL.md",
+            "---\nname: release-guard\ndescription: root winner.\n---\n\n# release guard\n",
+        );
+        write_file(
+            &root,
+            "workspace/skills/release-guard-workspace/SKILL.md",
+            "---\nname: release-guard\ndescription: workspace fallback.\n---\n\n# release guard\n",
+        );
+
+        let mapping = crate::migration::ExternalSkillMappingPlan {
+            input_path: root.join("workspace/.."),
+            artifacts: vec![
+                crate::migration::ExternalSkillArtifact {
+                    kind: crate::migration::ExternalSkillArtifactKind::SkillsDir,
+                    path: root.join("workspace/../skills"),
+                },
+                crate::migration::ExternalSkillArtifact {
+                    kind: crate::migration::ExternalSkillArtifactKind::SkillsDir,
+                    path: root.join("workspace/skills"),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let roots = collect_installable_external_skill_roots(&mapping)
+            .expect("duplicate skill ids should still resolve deterministically");
+
+        assert_eq!(
+            roots,
+            vec![
+                root.join("skills/release-guard-root")
+                    .canonicalize()
+                    .expect("canonicalize winning root")
+            ],
+            "probe-root precedence should still prefer the input root when artifact paths are noncanonical"
         );
 
         fs::remove_dir_all(&root).ok();

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -6,7 +6,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use loongclaw_contracts::ToolCoreRequest;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::CliResult;
 
@@ -96,6 +98,8 @@ pub struct ApplyImportSelectionResult {
     pub warnings: Vec<String>,
     pub external_skill_artifact_count: usize,
     pub external_skill_entries_applied: usize,
+    pub external_skill_managed_install_count: usize,
+    pub external_skill_managed_skill_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,6 +118,10 @@ struct ImportApplyManifest {
     #[serde(default)]
     external_skill_entries_applied: usize,
     #[serde(default)]
+    external_skill_managed_install_count: usize,
+    #[serde(default)]
+    external_skill_managed_skill_ids: Vec<String>,
+    #[serde(default)]
     external_skills_manifest_path: Option<String>,
 }
 
@@ -126,6 +134,8 @@ struct ExternalSkillsApplyManifest {
     declared_skills: Vec<String>,
     locked_skills: Vec<String>,
     resolved_skills: Vec<String>,
+    managed_install_root: Option<String>,
+    installed_skills: Vec<ExternalSkillsInstalledSkill>,
     warnings: Vec<String>,
 }
 
@@ -133,6 +143,16 @@ struct ExternalSkillsApplyManifest {
 struct ExternalSkillsApplyArtifact {
     kind: String,
     path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ExternalSkillsInstalledSkill {
+    skill_id: String,
+    source_kind: String,
+    source_path: String,
+    install_path: String,
+    skill_md_path: String,
+    sha256: String,
 }
 
 pub fn discover_import_sources(
@@ -272,6 +292,7 @@ pub fn apply_import_selection(
     let mut warnings = Vec::new();
     let mut external_skill_artifact_count = 0usize;
     let mut external_skill_entries_applied = 0usize;
+    let mut external_skill_managed_installs = Vec::new();
     let mut external_skill_mapping = None;
     let (merged_source_ids, prompt_owner_source_id, unresolved_conflicts) = match &request.mode {
         ImportSelectionMode::RecommendedSingleSource { .. }
@@ -335,6 +356,12 @@ pub fn apply_import_selection(
         let mapping = plan_external_skill_mapping(input_path);
         external_skill_artifact_count = mapping.artifacts.len();
         external_skill_entries_applied = apply_external_skill_mapping(&mut config, &mapping);
+        external_skill_managed_installs = bridge_installable_external_skills(
+            &mut config,
+            &request.output_path,
+            input_path,
+            &mapping,
+        )?;
         warnings.extend(mapping.warnings.clone());
         external_skill_mapping = Some(mapping);
     }
@@ -368,11 +395,32 @@ pub fn apply_import_selection(
     }
 
     let output_string = request.output_path.display().to_string();
-    let written_output_path = crate::config::write(Some(&output_string), &config, true)?;
+    let written_output_path = match crate::config::write(Some(&output_string), &config, true) {
+        Ok(path) => path,
+        Err(error) => {
+            if let Err(rollback_error) = rollback_bridged_external_skills(
+                &config,
+                &request.output_path,
+                request.external_skills_input_path.as_deref(),
+                &external_skill_managed_installs,
+            ) {
+                return Err(format!(
+                    "persist migrated config {} failed: {error}; external skills bridge rollback also failed: {rollback_error}",
+                    request.output_path.display()
+                ));
+            }
+            return Err(error);
+        }
+    };
     let external_skills_manifest_path = if let Some(mapping) = external_skill_mapping.as_ref() {
         let external_path =
             external_skills_manifest_path_for_output(&request.output_path, &state_dir);
-        let external_manifest = build_external_skills_apply_manifest(&written_output_path, mapping);
+        let external_manifest = build_external_skills_apply_manifest(
+            &written_output_path,
+            mapping,
+            config.external_skills.resolved_install_root().as_deref(),
+            &external_skill_managed_installs,
+        );
         let body = serde_json::to_vec_pretty(&external_manifest)
             .map_err(|error| format!("failed to encode external skills manifest: {error}"))?;
         fs::write(&external_path, body).map_err(|error| {
@@ -398,6 +446,11 @@ pub fn apply_import_selection(
         unresolved_conflicts,
         external_skill_artifact_count,
         external_skill_entries_applied,
+        external_skill_managed_install_count: external_skill_managed_installs.len(),
+        external_skill_managed_skill_ids: external_skill_managed_installs
+            .iter()
+            .map(|skill| skill.skill_id.clone())
+            .collect(),
         external_skills_manifest_path: external_skills_manifest_path
             .as_ref()
             .map(|path| path.display().to_string()),
@@ -423,6 +476,11 @@ pub fn apply_import_selection(
         warnings,
         external_skill_artifact_count,
         external_skill_entries_applied,
+        external_skill_managed_install_count: external_skill_managed_installs.len(),
+        external_skill_managed_skill_ids: external_skill_managed_installs
+            .into_iter()
+            .map(|skill| skill.skill_id)
+            .collect(),
     })
 }
 
@@ -431,9 +489,196 @@ fn dedup_strings_in_place(values: &mut Vec<String>) {
     values.retain(|value| seen.insert(value.clone()));
 }
 
+fn bridge_installable_external_skills(
+    config: &mut crate::config::LoongClawConfig,
+    output_path: &Path,
+    input_path: &Path,
+    mapping: &super::ExternalSkillMappingPlan,
+) -> CliResult<Vec<ExternalSkillsInstalledSkill>> {
+    let installable_roots = collect_installable_external_skill_roots(mapping)?;
+    if installable_roots.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let install_root = config
+        .external_skills
+        .resolved_install_root()
+        .unwrap_or_else(|| default_external_skills_install_root(output_path));
+    config.external_skills.enabled = true;
+    if config.external_skills.install_root.is_none() {
+        config.external_skills.install_root = Some(install_root.display().to_string());
+    }
+
+    let tool_runtime = build_external_skills_bridge_runtime(config, output_path, input_path);
+    let mut installed = Vec::new();
+    for skill_root in installable_roots {
+        let install_outcome = crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.install".to_owned(),
+                payload: json!({
+                    "path": skill_root.display().to_string(),
+                }),
+            },
+            &tool_runtime,
+        )
+        .map_err(|error| {
+            format!(
+                "bridge install for external skill source {} failed: {error}",
+                skill_root.display()
+            )
+        });
+        let install = match install_outcome {
+            Ok(outcome) => match parse_external_skills_install_outcome(&outcome) {
+                Ok(install) => install,
+                Err(error) => {
+                    if let Err(rollback_error) = rollback_bridged_external_skills(
+                        config,
+                        output_path,
+                        Some(input_path),
+                        &installed,
+                    ) {
+                        return Err(format!(
+                            "{error}; external skills bridge rollback also failed: {rollback_error}"
+                        ));
+                    }
+                    return Err(error);
+                }
+            },
+            Err(error) => {
+                if let Err(rollback_error) = rollback_bridged_external_skills(
+                    config,
+                    output_path,
+                    Some(input_path),
+                    &installed,
+                ) {
+                    return Err(format!(
+                        "{error}; external skills bridge rollback also failed: {rollback_error}"
+                    ));
+                }
+                return Err(error);
+            }
+        };
+        installed.push(install);
+    }
+
+    Ok(installed)
+}
+
+fn collect_installable_external_skill_roots(
+    mapping: &super::ExternalSkillMappingPlan,
+) -> CliResult<Vec<PathBuf>> {
+    let mut roots = Vec::new();
+    let mut seen = BTreeSet::new();
+    for artifact in &mapping.artifacts {
+        if !matches!(
+            artifact.kind,
+            super::ExternalSkillArtifactKind::CodexSkillsDir
+                | super::ExternalSkillArtifactKind::ClaudeSkillsDir
+                | super::ExternalSkillArtifactKind::SkillsDir
+        ) {
+            continue;
+        }
+        for root in crate::tools::discover_installable_external_skill_roots(&artifact.path)? {
+            let canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
+            if seen.insert(canonical.display().to_string()) {
+                roots.push(canonical);
+            }
+        }
+    }
+    roots.sort();
+    Ok(roots)
+}
+
+fn default_external_skills_install_root(output_path: &Path) -> PathBuf {
+    output_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .join("external-skills-installed")
+}
+
+fn build_external_skills_bridge_runtime(
+    config: &crate::config::LoongClawConfig,
+    output_path: &Path,
+    input_path: &Path,
+) -> crate::tools::runtime_config::ToolRuntimeConfig {
+    let mut runtime = crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        config,
+        Some(output_path),
+    );
+    runtime.file_root = Some(resolve_external_skills_bridge_file_root(input_path));
+    runtime
+}
+
+fn resolve_external_skills_bridge_file_root(input_path: &Path) -> PathBuf {
+    if input_path.is_file() {
+        input_path.parent().unwrap_or(Path::new(".")).to_path_buf()
+    } else {
+        input_path.to_path_buf()
+    }
+}
+
+fn parse_external_skills_install_outcome(
+    outcome: &loongclaw_contracts::ToolCoreOutcome,
+) -> CliResult<ExternalSkillsInstalledSkill> {
+    let payload = &outcome.payload;
+    Ok(ExternalSkillsInstalledSkill {
+        skill_id: required_string(payload, "skill_id")?,
+        source_kind: required_string(payload, "source_kind")?,
+        source_path: required_string(payload, "source_path")?,
+        install_path: required_string(payload, "install_path")?,
+        skill_md_path: required_string(payload, "skill_md_path")?,
+        sha256: required_string(payload, "sha256")?,
+    })
+}
+
+fn required_string(payload: &serde_json::Value, key: &str) -> CliResult<String> {
+    payload
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| format!("external skills install payload missing `{key}`"))
+}
+
+fn rollback_bridged_external_skills(
+    config: &crate::config::LoongClawConfig,
+    output_path: &Path,
+    input_path: Option<&Path>,
+    installs: &[ExternalSkillsInstalledSkill],
+) -> CliResult<()> {
+    if installs.is_empty() {
+        return Ok(());
+    }
+
+    let runtime = build_external_skills_bridge_runtime(
+        config,
+        output_path,
+        input_path.unwrap_or(output_path),
+    );
+    for install in installs.iter().rev() {
+        crate::tools::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "external_skills.remove".to_owned(),
+                payload: json!({
+                    "skill_id": install.skill_id,
+                }),
+            },
+            &runtime,
+        )
+        .map_err(|error| {
+            format!(
+                "remove bridged external skill `{}` failed during rollback: {error}",
+                install.skill_id
+            )
+        })?;
+    }
+    Ok(())
+}
+
 fn build_external_skills_apply_manifest(
     output_path: &Path,
     mapping: &super::ExternalSkillMappingPlan,
+    managed_install_root: Option<&Path>,
+    installed_skills: &[ExternalSkillsInstalledSkill],
 ) -> ExternalSkillsApplyManifest {
     ExternalSkillsApplyManifest {
         output_path: output_path.display().to_string(),
@@ -450,6 +695,8 @@ fn build_external_skills_apply_manifest(
         declared_skills: mapping.declared_skills.clone(),
         locked_skills: mapping.locked_skills.clone(),
         resolved_skills: mapping.resolved_skills.clone(),
+        managed_install_root: managed_install_root.map(|path| path.display().to_string()),
+        installed_skills: installed_skills.to_vec(),
         warnings: mapping.warnings.clone(),
     }
 }
@@ -781,6 +1028,8 @@ fn import_session_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::{
         fs,
         path::{Path, PathBuf},
@@ -1193,6 +1442,14 @@ mod tests {
             .expect("profile note should be present");
         assert!(profile_note.contains("Imported External Skills Artifacts"));
         assert!(profile_note.contains("kind=skills_catalog"));
+        assert!(
+            !merged_config.external_skills.enabled,
+            "metadata-only external skills imports should not enable the managed runtime"
+        );
+        assert_eq!(
+            result.external_skill_managed_install_count, 0,
+            "no installable skill roots were present in this fixture"
+        );
         let external_manifest = result
             .external_skills_manifest_path
             .as_ref()
@@ -1202,6 +1459,145 @@ mod tests {
             "external skills manifest should be written"
         );
 
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn apply_import_selection_bridges_installable_external_skills_into_managed_runtime() {
+        let root = unique_temp_dir("loongclaw-import-apply-managed-external-skills");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n",
+        );
+        write_file(
+            &root,
+            ".codex/skills/release-guard/SKILL.md",
+            "# Release Guard\n\nUse this skill when release discipline matters.\n",
+        );
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let output_path = root.join("loongclaw.toml");
+
+        let result = apply_import_selection(&ApplyImportSelection {
+            discovery,
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::SelectedSingleSource {
+                source_id: "openclaw".to_owned(),
+            },
+            apply_external_skills_plan: true,
+            external_skills_input_path: Some(root.clone()),
+        })
+        .expect("apply should succeed");
+
+        let output_string = output_path.display().to_string();
+        let (_, merged_config) =
+            crate::config::load(Some(&output_string)).expect("load merged config");
+        assert!(
+            merged_config.external_skills.enabled,
+            "applying the external skills bridge should enable the managed runtime"
+        );
+        assert_eq!(result.external_skill_managed_install_count, 1);
+        assert_eq!(
+            result.external_skill_managed_skill_ids,
+            vec!["release-guard".to_owned()]
+        );
+        assert!(
+            result.external_skill_entries_applied >= 1,
+            "profile-note import metadata should still be recorded"
+        );
+        let expected_install_root = root.join("external-skills-installed");
+        let expected_install_root_string = expected_install_root.display().to_string();
+        assert_eq!(
+            merged_config.external_skills.install_root.as_deref(),
+            Some(expected_install_root_string.as_str())
+        );
+        assert!(
+            expected_install_root
+                .join("release-guard")
+                .join("SKILL.md")
+                .exists(),
+            "installable imported skills should bridge into managed installs"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_import_selection_rolls_back_bridged_external_skills_when_config_write_fails() {
+        let root = unique_temp_dir("loongclaw-import-apply-managed-external-skills-rollback");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        let openclaw_root = root.join("openclaw-workspace");
+        fs::create_dir_all(&openclaw_root).expect("create openclaw root");
+        write_file(
+            &openclaw_root,
+            "SOUL.md",
+            "# Soul\n\nPrefer direct answers and keep OpenClaw style concise.\n",
+        );
+        write_file(
+            &openclaw_root,
+            "IDENTITY.md",
+            "# Identity\n\n- role: release copilot\n",
+        );
+        write_file(
+            &root,
+            ".codex/skills/release-guard/SKILL.md",
+            "# Release Guard\n\nUse this skill when release discipline matters.\n",
+        );
+
+        let output_path = root.join("readonly-loongclaw.toml");
+        let mut baseline = crate::config::LoongClawConfig::default();
+        baseline.external_skills.install_root =
+            Some(root.join("managed-skills").display().to_string());
+        let rendered = crate::config::render(&baseline).expect("render baseline config");
+        fs::write(&output_path, rendered).expect("write baseline config");
+        let mut readonly_permissions = fs::metadata(&output_path)
+            .expect("read output metadata")
+            .permissions();
+        readonly_permissions.set_mode(0o400);
+        fs::set_permissions(&output_path, readonly_permissions)
+            .expect("make output file read only");
+
+        let discovery = discover_import_sources(&root, DiscoveryOptions::default())
+            .expect("discovery should succeed");
+        let error = apply_import_selection(&ApplyImportSelection {
+            discovery,
+            output_path: output_path.clone(),
+            mode: ImportSelectionMode::SelectedSingleSource {
+                source_id: "openclaw".to_owned(),
+            },
+            apply_external_skills_plan: true,
+            external_skills_input_path: Some(root.clone()),
+        })
+        .expect_err("read-only config path should fail to persist");
+
+        assert!(
+            error.contains("failed to write config file"),
+            "expected config write failure, got: {error}"
+        );
+        assert!(
+            !root.join("managed-skills").join("release-guard").exists(),
+            "rollback should remove bridged managed installs after config persistence failure"
+        );
+
+        let mut cleanup_permissions = fs::metadata(&output_path)
+            .expect("read output metadata for cleanup")
+            .permissions();
+        cleanup_permissions.set_mode(0o600);
+        fs::set_permissions(&output_path, cleanup_permissions)
+            .expect("restore output permissions for cleanup");
         fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/app/src/migration/orchestrator.rs
+++ b/crates/app/src/migration/orchestrator.rs
@@ -593,29 +593,111 @@ fn bridge_installable_external_skills(
     Ok(installed)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InstallableExternalSkillCandidate {
+    root: PathBuf,
+    probe_rank: usize,
+    root_rank: usize,
+}
+
 fn collect_installable_external_skill_roots(
     mapping: &super::ExternalSkillMappingPlan,
 ) -> CliResult<Vec<PathBuf>> {
-    let mut roots = Vec::new();
+    let probe_roots = super::external_skill_probe_roots(&mapping.input_path)
+        .into_iter()
+        .map(|root| root.canonicalize().unwrap_or(root))
+        .collect::<Vec<_>>();
+    let mut winners = BTreeMap::new();
     let mut seen = BTreeSet::new();
     for artifact in &mapping.artifacts {
-        if !matches!(
-            artifact.kind,
-            super::ExternalSkillArtifactKind::CodexSkillsDir
-                | super::ExternalSkillArtifactKind::ClaudeSkillsDir
-                | super::ExternalSkillArtifactKind::SkillsDir
-        ) {
+        let Some(root_rank) = installable_external_skill_root_rank(artifact.kind) else {
             continue;
-        }
+        };
+        let probe_rank = installable_external_skill_probe_rank(&probe_roots, artifact);
         for root in crate::tools::discover_installable_external_skill_roots(&artifact.path)? {
             let canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
-            if seen.insert(canonical.display().to_string()) {
-                roots.push(canonical);
+            if !seen.insert(canonical.clone()) {
+                continue;
+            }
+            let skill_id = crate::tools::resolve_installable_external_skill_id(&canonical)?;
+            let candidate = InstallableExternalSkillCandidate {
+                root: canonical,
+                probe_rank,
+                root_rank,
+            };
+            match winners.get(&skill_id) {
+                Some(current)
+                    if !installable_external_skill_candidate_wins(&candidate, current) => {}
+                _ => {
+                    winners.insert(skill_id, candidate);
+                }
             }
         }
     }
-    roots.sort();
-    Ok(roots)
+    let mut candidates = winners.into_values().collect::<Vec<_>>();
+    candidates.sort_by(compare_installable_external_skill_candidates);
+    Ok(candidates
+        .into_iter()
+        .map(|candidate| candidate.root)
+        .collect())
+}
+
+fn installable_external_skill_root_rank(kind: super::ExternalSkillArtifactKind) -> Option<usize> {
+    match kind {
+        super::ExternalSkillArtifactKind::CodexSkillsDir => Some(1),
+        super::ExternalSkillArtifactKind::ClaudeSkillsDir => Some(2),
+        super::ExternalSkillArtifactKind::SkillsDir => Some(3),
+        super::ExternalSkillArtifactKind::SkillsCatalog
+        | super::ExternalSkillArtifactKind::SkillsLock => None,
+    }
+}
+
+fn installable_external_skill_probe_rank(
+    probe_roots: &[PathBuf],
+    artifact: &super::ExternalSkillArtifact,
+) -> usize {
+    let Some(probe_root) = installable_external_skill_probe_root(artifact) else {
+        return probe_roots.len();
+    };
+    probe_roots
+        .iter()
+        .position(|candidate| candidate == &probe_root)
+        .unwrap_or(probe_roots.len())
+}
+
+fn installable_external_skill_probe_root(
+    artifact: &super::ExternalSkillArtifact,
+) -> Option<PathBuf> {
+    match artifact.kind {
+        super::ExternalSkillArtifactKind::CodexSkillsDir
+        | super::ExternalSkillArtifactKind::ClaudeSkillsDir => artifact
+            .path
+            .parent()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf),
+        super::ExternalSkillArtifactKind::SkillsDir => {
+            artifact.path.parent().map(Path::to_path_buf)
+        }
+        super::ExternalSkillArtifactKind::SkillsCatalog
+        | super::ExternalSkillArtifactKind::SkillsLock => None,
+    }
+}
+
+fn installable_external_skill_candidate_wins(
+    left: &InstallableExternalSkillCandidate,
+    right: &InstallableExternalSkillCandidate,
+) -> bool {
+    compare_installable_external_skill_candidates(left, right).is_lt()
+}
+
+fn compare_installable_external_skill_candidates(
+    left: &InstallableExternalSkillCandidate,
+    right: &InstallableExternalSkillCandidate,
+) -> std::cmp::Ordering {
+    left.probe_rank
+        .cmp(&right.probe_rank)
+        .then_with(|| left.root_rank.cmp(&right.root_rank))
+        .then_with(|| left.root.cmp(&right.root))
 }
 
 fn default_external_skills_install_root(output_path: &Path) -> PathBuf {
@@ -1623,6 +1705,44 @@ mod tests {
                 .join("SKILL.md")
                 .exists(),
             "installable imported skills should bridge into managed installs"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn collect_installable_external_skill_roots_prefers_highest_precedence_duplicate_skill_ids() {
+        let root = unique_temp_dir("loongclaw-import-duplicate-installable-skill-ids");
+        fs::create_dir_all(&root).expect("create fixture root");
+
+        write_file(
+            &root,
+            ".codex/skills/release-guard-codex/SKILL.md",
+            "---\nname: release-guard\ndescription: codex winner.\n---\n\n# release guard\n",
+        );
+        write_file(
+            &root,
+            ".claude/skills/release-guard-claude/SKILL.md",
+            "---\nname: release-guard\ndescription: claude fallback.\n---\n\n# release guard\n",
+        );
+        write_file(
+            &root,
+            "skills/release-guard-project/SKILL.md",
+            "---\nname: release-guard\ndescription: project fallback.\n---\n\n# release guard\n",
+        );
+
+        let mapping = super::plan_external_skill_mapping(&root);
+        let roots = collect_installable_external_skill_roots(&mapping)
+            .expect("duplicate skill ids should still resolve deterministically");
+
+        assert_eq!(
+            roots,
+            vec![
+                root.join(".codex/skills/release-guard-codex")
+                    .canonicalize()
+                    .expect("canonicalize winning root")
+            ],
+            "duplicate installable skill ids should collapse to the highest-precedence import root"
         );
 
         fs::remove_dir_all(&root).ok();

--- a/crates/app/src/tools/claw_migrate.rs
+++ b/crates/app/src/tools/claw_migrate.rs
@@ -381,6 +381,8 @@ fn apply_selection_result_payload(result: &migration::ApplyImportSelectionResult
         "unresolved_conflicts": result.unresolved_conflicts,
         "external_skill_artifact_count": result.external_skill_artifact_count,
         "external_skill_entries_applied": result.external_skill_entries_applied,
+        "external_skill_managed_install_count": result.external_skill_managed_install_count,
+        "external_skill_managed_skill_ids": result.external_skill_managed_skill_ids,
         "warnings": result.warnings,
     })
 }

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -2782,6 +2782,8 @@ fn policy_payload(policy: &super::runtime_config::ExternalSkillsRuntimePolicy) -
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
 
@@ -3598,6 +3600,63 @@ mod tests {
             .expect_err("missing env requirements should reject invocation");
             assert!(env_error.contains("missing env `LOONGCLAW_MISSING_TOKEN`"));
 
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_marks_non_executable_required_bin_as_ineligible() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-bin-eligibility");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let mut home = ScopedHomeFixture::new("loongclaw-ext-skill-bin-eligibility-home");
+            let bin_dir = unique_temp_dir("loongclaw-ext-skill-bin-eligibility-bin");
+            fs::create_dir_all(&bin_dir).expect("create fake bin dir");
+
+            let fake_bin = bin_dir.join("release-check");
+            fs::write(&fake_bin, "#!/bin/sh\nexit 0\n").expect("write fake binary");
+            let mut permissions = fs::metadata(&fake_bin)
+                .expect("read fake binary metadata")
+                .permissions();
+            permissions.set_mode(0o644);
+            fs::set_permissions(&fake_bin, permissions)
+                .expect("mark fake binary as non-executable");
+
+            home.set_env("PATH", &bin_dir);
+            write_file(
+                &home.path,
+                ".agents/skills/bin-gated/SKILL.md",
+                "---\nrequired_bins:\n- release-check\n---\n\n# Bin Gated\n\nNeeds a real executable on PATH.\n",
+            );
+            let config = managed_runtime_config(&root);
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed");
+            let listed_skill = list_outcome.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "bin-gated")
+                .cloned()
+                .expect("bin-gated skill should be listed");
+            assert_eq!(listed_skill["eligibility"]["eligible"], json!(false));
+            assert!(
+                listed_skill["eligibility"]["issues"]
+                    .as_array()
+                    .expect("eligibility issues should be an array")
+                    .iter()
+                    .any(|issue| issue.as_str() == Some("missing binary `release-check`")),
+                "non-executable files on PATH must not satisfy required_bins"
+            );
+
+            fs::remove_dir_all(&bin_dir).ok();
             fs::remove_dir_all(&root).ok();
         });
     }
@@ -4814,6 +4873,77 @@ mod tests {
             );
 
             fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn list_skips_missing_managed_installs_instead_of_failing_discovery() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-discovery-broken-managed");
+            let home = unique_temp_dir("loongclaw-ext-skill-discovery-broken-managed-home");
+            fs::create_dir_all(&root).expect("create fixture root");
+            fs::create_dir_all(&home).expect("create home root");
+
+            write_file(
+                &root,
+                "source/broken-managed/SKILL.md",
+                "# Broken Managed\n\nThis managed install will be removed after indexing.\n",
+            );
+            write_file(
+                &home,
+                ".agents/skills/user-only/SKILL.md",
+                "# User Only\n\nKeep discovery alive when managed state is broken.\n",
+            );
+
+            let config = managed_runtime_config(&root);
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("HOME", &home);
+
+            crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/broken-managed"
+                    }),
+                },
+                &config,
+            )
+            .expect("install should succeed");
+
+            fs::remove_dir_all(
+                root.join("external-skills-installed")
+                    .join("broken-managed"),
+            )
+            .expect("remove managed install to simulate broken index entry");
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("broken managed installs should be skipped during discovery");
+
+            assert!(
+                list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "user-only" && skill["scope"] == "user"),
+                "healthy user skills should remain discoverable when a managed install is missing"
+            );
+            assert!(
+                !list_outcome.payload["skills"]
+                    .as_array()
+                    .expect("skills should be an array")
+                    .iter()
+                    .any(|skill| skill["skill_id"] == "broken-managed"),
+                "broken managed installs should be dropped from discovery output"
+            );
+
+            fs::remove_dir_all(&root).ok();
+            fs::remove_dir_all(&home).ok();
         });
     }
 

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -165,7 +165,12 @@ struct SkillFrontmatter {
     invocation_policy: Option<SkillInvocationPolicy>,
     #[serde(default, alias = "requires_env")]
     required_env: Vec<String>,
-    #[serde(default, alias = "requires_bin", alias = "requires_bins", alias = "requires_commands")]
+    #[serde(
+        default,
+        alias = "requires_bin",
+        alias = "requires_bins",
+        alias = "requires_commands"
+    )]
     required_bins: Vec<String>,
     #[serde(default, alias = "requires_paths")]
     required_paths: Vec<String>,
@@ -1618,8 +1623,10 @@ fn parse_skill_frontmatter(skill_markdown: &str) -> Result<SkillFrontmatter, Str
     for line in lines {
         let trimmed = line.trim();
         if trimmed == "---" {
-            let raw = raw_frontmatter.join("
-");
+            let raw = raw_frontmatter.join(
+                "
+",
+            );
             if raw.trim().is_empty() {
                 return Ok(SkillFrontmatter::default());
             }
@@ -3470,37 +3477,38 @@ mod tests {
                 .find(|skill| skill["skill_id"] == "release-guard")
                 .cloned()
                 .expect("release-guard should be listed");
-            assert_eq!(listed_skill["metadata"]["invocation_policy"], "both");
-            assert_eq!(
-                listed_skill["metadata"]["allowed_tools"],
-                json!(["shell.exec"])
+            assert!(
+                listed_skill.get("metadata").is_none(),
+                "model list should not expose operator metadata: {listed_skill:?}"
             );
-            assert_eq!(
-                listed_skill["metadata"]["blocked_tools"],
-                json!(["web.fetch"])
-            );
-            assert_eq!(listed_skill["eligibility"]["eligible"], json!(true));
 
-            let inspect_outcome = crate::tools::execute_tool_core_with_config(
-                ToolCoreRequest {
-                    tool_name: "external_skills.inspect".to_owned(),
-                    payload: json!({
-                        "skill_id": "release-guard"
-                    }),
-                },
-                &config,
-            )
-            .expect("inspect should succeed");
+            let operator_list = execute_external_skills_operator_list_tool_with_config(&config)
+                .expect("operator list should succeed");
+            let operator_skill = operator_list.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "release-guard")
+                .cloned()
+                .expect("release-guard should be listed for operators");
+            assert_eq!(operator_skill["invocation_policy"], "both");
+            assert_eq!(operator_skill["allowed_tools"], json!(["shell.exec"]));
+            assert_eq!(operator_skill["blocked_tools"], json!(["web.fetch"]));
+            assert_eq!(operator_skill["eligibility"]["available"], json!(true));
+
+            let inspect_outcome =
+                execute_external_skills_operator_inspect_tool_with_config("release-guard", &config)
+                    .expect("operator inspect should succeed");
             assert_eq!(
-                inspect_outcome.payload["skill"]["metadata"]["required_env"],
+                inspect_outcome.payload["skill"]["required_env"],
                 json!(["LOONGCLAW_RELEASE_GUARD_TOKEN"])
             );
             assert_eq!(
-                inspect_outcome.payload["skill"]["metadata"]["required_config"],
+                inspect_outcome.payload["skill"]["required_config"],
                 json!(["external_skills.enabled"])
             );
             assert_eq!(
-                inspect_outcome.payload["skill"]["eligibility"]["eligible"],
+                inspect_outcome.payload["skill"]["eligibility"]["available"],
                 json!(true)
             );
 
@@ -3519,7 +3527,7 @@ mod tests {
                 "both"
             );
             assert_eq!(
-                invoke_outcome.payload["eligibility"]["eligible"],
+                invoke_outcome.payload["eligibility"]["available"],
                 json!(true)
             );
             assert!(
@@ -3552,22 +3560,16 @@ mod tests {
             );
             let config = managed_runtime_config(&root);
 
-            let list_outcome = crate::tools::execute_tool_core_with_config(
-                ToolCoreRequest {
-                    tool_name: "external_skills.list".to_owned(),
-                    payload: json!({}),
-                },
-                &config,
-            )
-            .expect("list should succeed");
-            let env_gated = list_outcome.payload["skills"]
+            let operator_list = execute_external_skills_operator_list_tool_with_config(&config)
+                .expect("operator list should succeed");
+            let env_gated = operator_list.payload["skills"]
                 .as_array()
                 .expect("skills should be an array")
                 .iter()
                 .find(|skill| skill["skill_id"] == "env-gated")
                 .cloned()
-                .expect("env-gated should be listed");
-            assert_eq!(env_gated["eligibility"]["eligible"], json!(false));
+                .expect("env-gated should be listed for operators");
+            assert_eq!(env_gated["eligibility"]["available"], json!(false));
             assert!(
                 env_gated["eligibility"]["issues"]
                     .as_array()
@@ -3598,7 +3600,7 @@ mod tests {
                 &config,
             )
             .expect_err("missing env requirements should reject invocation");
-            assert!(env_error.contains("missing env `LOONGCLAW_MISSING_TOKEN`"));
+            assert!(env_error.contains("LOONGCLAW_MISSING_TOKEN"));
 
             fs::remove_dir_all(&root).ok();
         });
@@ -3631,22 +3633,16 @@ mod tests {
             );
             let config = managed_runtime_config(&root);
 
-            let list_outcome = crate::tools::execute_tool_core_with_config(
-                ToolCoreRequest {
-                    tool_name: "external_skills.list".to_owned(),
-                    payload: json!({}),
-                },
-                &config,
-            )
-            .expect("list should succeed");
-            let listed_skill = list_outcome.payload["skills"]
+            let operator_list = execute_external_skills_operator_list_tool_with_config(&config)
+                .expect("operator list should succeed");
+            let listed_skill = operator_list.payload["skills"]
                 .as_array()
                 .expect("skills should be an array")
                 .iter()
                 .find(|skill| skill["skill_id"] == "bin-gated")
                 .cloned()
-                .expect("bin-gated skill should be listed");
-            assert_eq!(listed_skill["eligibility"]["eligible"], json!(false));
+                .expect("bin-gated skill should be listed for operators");
+            assert_eq!(listed_skill["eligibility"]["available"], json!(false));
             assert!(
                 listed_skill["eligibility"]["issues"]
                     .as_array()

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -89,6 +89,10 @@ struct DiscoveredSkillEntry {
     required_env: Vec<String>,
     required_bin: Vec<String>,
     required_paths: Vec<String>,
+    invocation_policy: SkillInvocationPolicy,
+    required_config: Vec<String>,
+    allowed_tools: Vec<String>,
+    blocked_tools: Vec<String>,
     eligibility: SkillEligibility,
 }
 
@@ -131,26 +135,46 @@ enum SkillModelVisibility {
     Hidden,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+enum SkillInvocationPolicy {
+    #[default]
+    Model,
+    #[serde(alias = "user", alias = "operator")]
+    Manual,
+    Both,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 struct SkillEligibility {
     available: bool,
+    eligible: bool,
     missing_env: Vec<String>,
     missing_bin: Vec<String>,
     missing_paths: Vec<String>,
+    issues: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct SkillFrontmatter {
     name: Option<String>,
     description: Option<String>,
     #[serde(default)]
-    requires_env: Vec<String>,
-    #[serde(default, alias = "requires_bins", alias = "requires_commands")]
-    requires_bin: Vec<String>,
-    #[serde(default)]
-    requires_paths: Vec<String>,
-    #[serde(default)]
     model_visibility: SkillModelVisibility,
+    #[serde(default)]
+    invocation_policy: Option<SkillInvocationPolicy>,
+    #[serde(default, alias = "requires_env")]
+    required_env: Vec<String>,
+    #[serde(default, alias = "requires_bin", alias = "requires_bins", alias = "requires_commands")]
+    required_bins: Vec<String>,
+    #[serde(default, alias = "requires_paths")]
+    required_paths: Vec<String>,
+    #[serde(default)]
+    required_config: Vec<String>,
+    #[serde(default)]
+    allowed_tools: Vec<String>,
+    #[serde(default)]
+    blocked_tools: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -825,6 +849,22 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
     let skill = resolve_discovered_skill(&inventory, skill_id)?;
     ensure_skill_access_for_audience(&skill, SkillAudience::Model)?;
     let instructions = load_discovered_skill_markdown(config, &skill)?;
+    if !skill.eligibility.available {
+        return Err(format!(
+            "external skill `{skill_id}` is not eligible in the current runtime: {}",
+            skill.eligibility.issues.join("; ")
+        ));
+    }
+    if matches!(skill.invocation_policy, SkillInvocationPolicy::Manual) {
+        return Err(format!(
+            "external skill `{skill_id}` is marked invocation_policy=manual and cannot be invoked through external_skills.invoke"
+        ));
+    }
+    let invocation_policy_id = invocation_policy_id(skill.invocation_policy);
+    let tool_restrictions_suffix = render_tool_restrictions_suffix(
+        skill.allowed_tools.as_slice(),
+        skill.blocked_tools.as_slice(),
+    );
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
@@ -838,9 +878,13 @@ pub(super) fn execute_external_skills_invoke_tool_with_config(
             "install_path": skill.install_path,
             "skill_md_path": skill.skill_md_path,
             "instructions": instructions,
+            "metadata": metadata_payload_from_skill(&skill),
+            "eligibility": skill.eligibility,
             "invocation_summary": format!(
-                "Loaded external skill `{}`. Apply the instructions in `SKILL.md` before continuing the task.",
-                skill_id
+                "Loaded external skill `{}` with invocation_policy={}. Apply the instructions in `SKILL.md` before continuing the task{}.",
+                skill_id,
+                invocation_policy_id,
+                tool_restrictions_suffix
             ),
         }),
     })
@@ -1025,28 +1069,6 @@ impl ExternalSkillsPolicyOverride {
             || self.require_download_approval.is_some()
             || self.allowed_domains.is_some()
             || self.blocked_domains.is_some()
-    }
-}
-
-impl SkillEligibility {
-    fn ready() -> Self {
-        Self {
-            available: true,
-            ..Self::default()
-        }
-    }
-
-    fn with_missing(
-        missing_env: Vec<String>,
-        missing_bin: Vec<String>,
-        missing_paths: Vec<String>,
-    ) -> Self {
-        Self {
-            available: missing_env.is_empty() && missing_bin.is_empty() && missing_paths.is_empty(),
-            missing_env,
-            missing_bin,
-            missing_paths,
-        }
     }
 }
 
@@ -1412,6 +1434,10 @@ fn find_skill_roots(root: &Path) -> Result<Vec<PathBuf>, String> {
     Ok(roots)
 }
 
+pub(crate) fn discover_installable_skill_roots(root: &Path) -> Result<Vec<PathBuf>, String> {
+    find_skill_roots(root)
+}
+
 fn visit_skill_roots(root: &Path, roots: &mut Vec<PathBuf>) -> Result<(), String> {
     let metadata = fs::symlink_metadata(root).map_err(|error| {
         format!(
@@ -1592,7 +1618,8 @@ fn parse_skill_frontmatter(skill_markdown: &str) -> Result<SkillFrontmatter, Str
     for line in lines {
         let trimmed = line.trim();
         if trimmed == "---" {
-            let raw = raw_frontmatter.join("\n");
+            let raw = raw_frontmatter.join("
+");
             if raw.trim().is_empty() {
                 return Ok(SkillFrontmatter::default());
             }
@@ -1625,12 +1652,18 @@ fn parse_skill_frontmatter(skill_markdown: &str) -> Result<SkillFrontmatter, Str
 fn normalize_skill_frontmatter(frontmatter: &mut SkillFrontmatter) {
     frontmatter.name = normalize_optional_metadata_string(frontmatter.name.take());
     frontmatter.description = normalize_optional_metadata_string(frontmatter.description.take());
-    frontmatter.requires_env =
-        normalize_metadata_string_list(std::mem::take(&mut frontmatter.requires_env));
-    frontmatter.requires_bin =
-        normalize_metadata_string_list(std::mem::take(&mut frontmatter.requires_bin));
-    frontmatter.requires_paths =
-        normalize_metadata_string_list(std::mem::take(&mut frontmatter.requires_paths));
+    frontmatter.required_env =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.required_env));
+    frontmatter.required_bins =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.required_bins));
+    frontmatter.required_paths =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.required_paths));
+    frontmatter.required_config =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.required_config));
+    frontmatter.allowed_tools =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.allowed_tools));
+    frontmatter.blocked_tools =
+        normalize_metadata_string_list(std::mem::take(&mut frontmatter.blocked_tools));
 }
 
 fn normalize_optional_metadata_string(value: Option<String>) -> Option<String> {
@@ -1704,6 +1737,9 @@ fn build_discovered_skill_entry(
             skill_md_path
         )
     })?;
+    let invocation_policy = frontmatter
+        .invocation_policy
+        .unwrap_or(SkillInvocationPolicy::Model);
     let eligibility = evaluate_skill_eligibility(config, &frontmatter);
     Ok(DiscoveredSkillEntry {
         display_name: derive_skill_display_name_with_frontmatter(
@@ -1720,9 +1756,13 @@ fn build_discovered_skill_entry(
         active,
         install_path,
         model_visibility: frontmatter.model_visibility,
-        required_env: frontmatter.requires_env.clone(),
-        required_bin: frontmatter.requires_bin.clone(),
-        required_paths: frontmatter.requires_paths.clone(),
+        required_env: frontmatter.required_env.clone(),
+        required_bin: frontmatter.required_bins.clone(),
+        required_paths: frontmatter.required_paths.clone(),
+        invocation_policy,
+        required_config: frontmatter.required_config.clone(),
+        allowed_tools: frontmatter.allowed_tools.clone(),
+        blocked_tools: frontmatter.blocked_tools.clone(),
         eligibility,
         skill_id,
     })
@@ -1733,32 +1773,66 @@ fn evaluate_skill_eligibility(
     frontmatter: &SkillFrontmatter,
 ) -> SkillEligibility {
     let missing_env = frontmatter
-        .requires_env
+        .required_env
         .iter()
         .filter(|name| !env_var_is_present(name))
         .cloned()
         .collect::<Vec<_>>();
     let missing_bin = frontmatter
-        .requires_bin
+        .required_bins
         .iter()
-        .filter(|command| !command_on_path(command))
+        .filter(|command| !command_exists(command))
         .cloned()
         .collect::<Vec<_>>();
     let missing_paths = frontmatter
-        .requires_paths
+        .required_paths
         .iter()
         .filter(|path| !required_path_exists(config, path))
         .cloned()
         .collect::<Vec<_>>();
-    if missing_env.is_empty() && missing_bin.is_empty() && missing_paths.is_empty() {
-        SkillEligibility::ready()
-    } else {
-        SkillEligibility::with_missing(missing_env, missing_bin, missing_paths)
+
+    let mut issues = missing_env
+        .iter()
+        .map(|env_name| format!("missing env `{env_name}`"))
+        .collect::<Vec<_>>();
+    issues.extend(
+        missing_bin
+            .iter()
+            .map(|binary| format!("missing binary `{binary}`")),
+    );
+    issues.extend(
+        missing_paths
+            .iter()
+            .map(|path| format!("missing path `{path}`")),
+    );
+    for selector in &frontmatter.required_config {
+        match runtime_config_selector_enabled(config, selector) {
+            Some(true) => {}
+            Some(false) => issues.push(format!("config gate `{selector}` is disabled")),
+            None => issues.push(format!("unsupported config gate `{selector}`")),
+        }
+    }
+    let available = issues.is_empty();
+    SkillEligibility {
+        available,
+        eligible: available,
+        missing_env,
+        missing_bin,
+        missing_paths,
+        issues,
     }
 }
 
 fn env_var_is_present(name: &str) -> bool {
     std::env::var_os(name).is_some_and(|value| !value.is_empty())
+}
+
+fn command_exists(binary: &str) -> bool {
+    let candidate = binary.trim();
+    if candidate.is_empty() {
+        return false;
+    }
+    which::which(candidate).is_ok()
 }
 
 fn serialize_skill_entry_for_audience(
@@ -1783,37 +1857,6 @@ fn serialize_skill_entries_for_audience(
                 .map(DiscoveredSkillModelView::from)
                 .collect::<Vec<_>>()
         ),
-    }
-}
-
-fn command_on_path(command: &str) -> bool {
-    let Some(path_env) = std::env::var_os("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path_env).any(|dir| {
-        command_candidates(command)
-            .into_iter()
-            .map(|candidate| dir.join(candidate))
-            .any(|candidate| command_candidate_is_executable(&candidate))
-    })
-}
-
-fn command_candidate_is_executable(candidate: &Path) -> bool {
-    let Ok(metadata) = fs::metadata(candidate) else {
-        return false;
-    };
-    if !metadata.is_file() {
-        return false;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        metadata.permissions().mode() & 0o111 != 0
-    }
-    #[cfg(not(unix))]
-    {
-        true
     }
 }
 
@@ -1881,23 +1924,6 @@ fn blocked_candidate_precedes_discovered(
         candidate.root_rank,
         &candidate.entry.source_path,
     ) != Ordering::Greater
-}
-
-fn command_candidates(command: &str) -> Vec<String> {
-    #[cfg(windows)]
-    {
-        vec![
-            command.to_owned(),
-            format!("{command}.exe"),
-            format!("{command}.cmd"),
-            format!("{command}.bat"),
-            format!("{command}.com"),
-        ]
-    }
-    #[cfg(not(windows))]
-    {
-        vec![command.to_owned()]
-    }
 }
 
 fn required_path_exists(config: &super::runtime_config::ToolRuntimeConfig, raw: &str) -> bool {
@@ -2226,6 +2252,62 @@ fn discover_skill_inventory(
     });
     Ok(inventory)
 }
+
+fn metadata_payload_from_skill(skill: &DiscoveredSkillEntry) -> Value {
+    json!({
+        "model_visibility": skill.model_visibility,
+        "invocation_policy": skill.invocation_policy,
+        "required_env": skill.required_env,
+        "required_bins": skill.required_bin,
+        "required_paths": skill.required_paths,
+        "required_config": skill.required_config,
+        "allowed_tools": skill.allowed_tools,
+        "blocked_tools": skill.blocked_tools,
+    })
+}
+
+fn runtime_config_selector_enabled(
+    config: &super::runtime_config::ToolRuntimeConfig,
+    selector: &str,
+) -> Option<bool> {
+    match selector.trim().to_ascii_lowercase().as_str() {
+        "external_skills.enabled" | "tools.external_skills.enabled" => {
+            Some(config.external_skills.enabled)
+        }
+        "browser.enabled" | "tools.browser.enabled" => Some(config.browser.enabled),
+        "browser_companion.enabled" | "tools.browser_companion.enabled" => {
+            Some(config.browser_companion.enabled)
+        }
+        "delegate.enabled" | "tools.delegate.enabled" => Some(config.delegate_enabled),
+        "messages.enabled" | "tools.messages.enabled" => Some(config.messages_enabled),
+        "sessions.enabled" | "tools.sessions.enabled" => Some(config.sessions_enabled),
+        "web.enabled" | "tools.web.enabled" | "web_fetch.enabled" | "tools.web_fetch.enabled" => {
+            Some(config.web_fetch.enabled)
+        }
+        "web_search.enabled" | "tools.web_search.enabled" => Some(config.web_search.enabled),
+        _ => None,
+    }
+}
+
+fn invocation_policy_id(policy: SkillInvocationPolicy) -> &'static str {
+    match policy {
+        SkillInvocationPolicy::Model => "model",
+        SkillInvocationPolicy::Manual => "manual",
+        SkillInvocationPolicy::Both => "both",
+    }
+}
+
+fn render_tool_restrictions_suffix(allowed_tools: &[String], blocked_tools: &[String]) -> String {
+    let mut fragments = Vec::new();
+    if !allowed_tools.is_empty() {
+        fragments.push(format!(" allowed_tools={}", allowed_tools.join(",")));
+    }
+    if !blocked_tools.is_empty() {
+        fragments.push(format!(" blocked_tools={}", blocked_tools.join(",")));
+    }
+    fragments.concat()
+}
+
 #[cfg(test)]
 pub(super) fn installed_skill_snapshot_lines_with_config(
     config: &super::runtime_config::ToolRuntimeConfig,
@@ -2774,6 +2856,10 @@ mod tests {
             let mut env = crate::test_support::ScopedEnv::new();
             env.set("HOME", &path);
             Self { _env: env, path }
+        }
+
+        fn set_env(&mut self, key: &'static str, value: impl AsRef<std::ffi::OsStr>) {
+            self._env.set(key, value);
         }
     }
 
@@ -3348,6 +3434,169 @@ mod tests {
                     .expect("instructions should be text")
                     .contains("Demo Skill")
             );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn inspect_and_invoke_surface_skill_metadata_contract() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-metadata-contract");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let mut home = ScopedHomeFixture::new("loongclaw-ext-skill-metadata-contract-home");
+            home.set_env("LOONGCLAW_RELEASE_GUARD_TOKEN", "present");
+            write_file(
+                &home.path,
+                ".agents/skills/release-guard/SKILL.md",
+                "---\nname: release-guard\ndescription: Guard release discipline.\ninvocation_policy: both\nrequired_env:\n- LOONGCLAW_RELEASE_GUARD_TOKEN\nrequired_bins:\n- sh\nrequired_config:\n- external_skills.enabled\nallowed_tools:\n- shell.exec\nblocked_tools:\n- web.fetch\n---\n\n# Release Guard\n\nPrefer release checklists.\n",
+            );
+            let config = managed_runtime_config(&root);
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed");
+            let listed_skill = list_outcome.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "release-guard")
+                .cloned()
+                .expect("release-guard should be listed");
+            assert_eq!(listed_skill["metadata"]["invocation_policy"], "both");
+            assert_eq!(
+                listed_skill["metadata"]["allowed_tools"],
+                json!(["shell.exec"])
+            );
+            assert_eq!(
+                listed_skill["metadata"]["blocked_tools"],
+                json!(["web.fetch"])
+            );
+            assert_eq!(listed_skill["eligibility"]["eligible"], json!(true));
+
+            let inspect_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.inspect".to_owned(),
+                    payload: json!({
+                        "skill_id": "release-guard"
+                    }),
+                },
+                &config,
+            )
+            .expect("inspect should succeed");
+            assert_eq!(
+                inspect_outcome.payload["skill"]["metadata"]["required_env"],
+                json!(["LOONGCLAW_RELEASE_GUARD_TOKEN"])
+            );
+            assert_eq!(
+                inspect_outcome.payload["skill"]["metadata"]["required_config"],
+                json!(["external_skills.enabled"])
+            );
+            assert_eq!(
+                inspect_outcome.payload["skill"]["eligibility"]["eligible"],
+                json!(true)
+            );
+
+            let invoke_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "release-guard"
+                    }),
+                },
+                &config,
+            )
+            .expect("invoke should succeed");
+            assert_eq!(
+                invoke_outcome.payload["metadata"]["invocation_policy"],
+                "both"
+            );
+            assert_eq!(
+                invoke_outcome.payload["eligibility"]["eligible"],
+                json!(true)
+            );
+            assert!(
+                invoke_outcome.payload["invocation_summary"]
+                    .as_str()
+                    .expect("invocation summary should be text")
+                    .contains("allowed_tools=shell.exec"),
+                "tool restrictions should surface in invocation summary"
+            );
+
+            fs::remove_dir_all(&root).ok();
+        });
+    }
+
+    #[test]
+    fn invoke_rejects_manual_or_ineligible_skill_metadata_contracts() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-metadata-contract-reject");
+            fs::create_dir_all(&root).expect("create fixture root");
+            let home = ScopedHomeFixture::new("loongclaw-ext-skill-metadata-contract-reject-home");
+            write_file(
+                &home.path,
+                ".agents/skills/manual-only/SKILL.md",
+                "---\ninvocation_policy: manual\n---\n\n# Manual Only\n\nUse this skill only for operator-driven checks.\n",
+            );
+            write_file(
+                &home.path,
+                ".agents/skills/env-gated/SKILL.md",
+                "---\nrequired_env:\n- LOONGCLAW_MISSING_TOKEN\n---\n\n# Env Gated\n\nNeeds a token before it can run.\n",
+            );
+            let config = managed_runtime_config(&root);
+
+            let list_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.list".to_owned(),
+                    payload: json!({}),
+                },
+                &config,
+            )
+            .expect("list should succeed");
+            let env_gated = list_outcome.payload["skills"]
+                .as_array()
+                .expect("skills should be an array")
+                .iter()
+                .find(|skill| skill["skill_id"] == "env-gated")
+                .cloned()
+                .expect("env-gated should be listed");
+            assert_eq!(env_gated["eligibility"]["eligible"], json!(false));
+            assert!(
+                env_gated["eligibility"]["issues"]
+                    .as_array()
+                    .expect("eligibility issues should be an array")
+                    .iter()
+                    .any(|issue| issue.as_str() == Some("missing env `LOONGCLAW_MISSING_TOKEN`"))
+            );
+
+            let manual_error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "manual-only"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("manual-only skills should reject model invocation");
+            assert!(manual_error.contains("invocation_policy=manual"));
+
+            let env_error = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.invoke".to_owned(),
+                    payload: json!({
+                        "skill_id": "env-gated"
+                    }),
+                },
+                &config,
+            )
+            .expect_err("missing env requirements should reject invocation");
+            assert!(env_error.contains("missing env `LOONGCLAW_MISSING_TOKEN`"));
 
             fs::remove_dir_all(&root).ok();
         });

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -145,6 +145,9 @@ enum SkillInvocationPolicy {
     Both,
 }
 
+/// `available` and `eligible` currently move together because a skill is only
+/// runnable when its local prerequisites are present. Keep both fields so
+/// operator-facing output can distinguish policy from current availability later.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 struct SkillEligibility {
     available: bool,
@@ -1443,6 +1446,11 @@ pub(crate) fn discover_installable_skill_roots(root: &Path) -> Result<Vec<PathBu
     find_skill_roots(root)
 }
 
+pub(crate) fn resolve_installable_skill_id(root: &Path) -> Result<String, String> {
+    let skill_markdown = load_directory_skill_markdown(root)?;
+    Ok(derive_skill_id_from_markdown(root, skill_markdown.as_str()))
+}
+
 fn visit_skill_roots(root: &Path, roots: &mut Vec<PathBuf>) -> Result<(), String> {
     let metadata = fs::symlink_metadata(root).map_err(|error| {
         format!(
@@ -1775,6 +1783,8 @@ fn build_discovered_skill_entry(
     })
 }
 
+// This currently answers both "can run right now" and "eligible to run" so
+// operator output stays explicit without silently inventing separate semantics.
 fn evaluate_skill_eligibility(
     config: &super::runtime_config::ToolRuntimeConfig,
     frontmatter: &SkillFrontmatter,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -102,6 +102,10 @@ pub(crate) fn discover_installable_external_skill_roots(
     external_skills::discover_installable_skill_roots(root)
 }
 
+pub(crate) fn resolve_installable_external_skill_id(root: &Path) -> Result<String, String> {
+    external_skills::resolve_installable_skill_id(root)
+}
+
 tokio::task_local! {
     static TRUSTED_INTERNAL_TOOL_PAYLOAD_TASK: bool;
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -96,6 +96,12 @@ pub fn external_skills_operator_inspect_with_config(
     external_skills::execute_external_skills_operator_inspect_tool_with_config(skill_id, config)
 }
 
+pub(crate) fn discover_installable_external_skill_roots(
+    root: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    external_skills::discover_installable_skill_roots(root)
+}
+
 tokio::task_local! {
     static TRUSTED_INTERNAL_TOOL_PAYLOAD_TASK: bool;
 }
@@ -12588,6 +12594,11 @@ mod tests {
             "# Identity\n\n- role: release copilot\n- tone: steady\n",
         );
         write_file(&root, "SKILLS.md", "# Skills\n\n- custom/skill-a\n");
+        write_file(
+            &root,
+            ".codex/skills/release-guard/SKILL.md",
+            "# Release Guard\n\nUse this skill when release discipline matters.\n",
+        );
 
         let output_path = root.join("loongclaw.toml");
 
@@ -12613,11 +12624,19 @@ mod tests {
         assert_eq!(outcome.status, "ok");
         assert_eq!(
             outcome.payload["result"]["external_skill_artifact_count"],
-            1
+            2
         );
         assert_eq!(
             outcome.payload["result"]["external_skill_entries_applied"],
-            3
+            6
+        );
+        assert_eq!(
+            outcome.payload["result"]["external_skill_managed_install_count"],
+            1
+        );
+        assert_eq!(
+            outcome.payload["result"]["external_skill_managed_skill_ids"],
+            json!(["release-guard"])
         );
         assert!(
             outcome.payload["result"]["external_skills_manifest_path"]
@@ -12627,6 +12646,13 @@ mod tests {
         );
         let raw = fs::read_to_string(&output_path).expect("read output config");
         assert!(raw.contains("Imported External Skills Artifacts"));
+        assert!(
+            root.join("external-skills-installed")
+                .join("release-guard")
+                .join("SKILL.md")
+                .exists(),
+            "claw.migrate should bridge installable local skills into the managed runtime"
+        );
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -384,7 +384,7 @@ pub enum Commands {
     },
     #[command(
         about = "Preview or apply legacy claw migration explicitly",
-        long_about = "Power-user migration flow for discovering, previewing, or applying legacy claw nativeization explicitly.\n\nUse this when you want exact CLI control over migration mode selection and output handling for older claw-family workspaces. If you want the guided path, use `loongclaw onboard` instead.\n\nMode quick reference:\n- discover, plan_many, recommend_primary, merge_profiles, map_external_skills: require `--input`\n- plan: requires `--input`; `--output` is optional preview target\n- apply: requires `--input` and `--output`\n- apply_selected: requires `--input` and `--output`; use `--source-id` to pin one discovered source\n- rollback_last_apply: requires `--output`"
+        long_about = "Power-user migration flow for discovering, previewing, or applying legacy claw nativeization explicitly.\n\nUse this when you want exact CLI control over migration mode selection and output handling for older claw-family workspaces. If you want the guided path, use `loongclaw onboard` instead.\n\nMode quick reference:\n- discover, plan_many, recommend_primary, merge_profiles, map_external_skills: require `--input`\n- plan: requires `--input`; `--output` is optional preview target\n- apply: requires `--input` and `--output`\n- apply_selected: requires `--input` and `--output`; use `--source-id` to pin one discovered source, and `--apply-external-skills-plan` to bridge installable local external skills into the managed runtime\n- rollback_last_apply: requires `--output`"
     )]
     Migrate {
         /// Path to the legacy claw workspace or root to inspect
@@ -411,10 +411,10 @@ pub enum Commands {
         /// Explicit primary source id when safe profile merge is enabled
         #[arg(long)]
         primary_source_id: Option<String>,
-        /// Apply the planned external skills mapping during apply_selected
+        /// Bridge installable local external skills into the managed runtime during apply_selected
         #[arg(long, default_value_t = false)]
         apply_external_skills_plan: bool,
-        /// Overwrite an existing target config when the selected mode writes output
+        /// Overwrite an existing target config path instead of stopping for manual review
         #[arg(long, default_value_t = false)]
         force: bool,
     },

--- a/crates/daemon/src/migrate_cli.rs
+++ b/crates/daemon/src/migrate_cli.rs
@@ -603,6 +603,25 @@ fn render_apply_selected_outcome(
             .and_then(Value::as_u64)
             .unwrap_or(0)
     );
+    println!(
+        "- managed external skills bridged: {}",
+        result
+            .get("external_skill_managed_install_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+    );
+    if let Some(bridged_skill_ids) = result
+        .get("external_skill_managed_skill_ids")
+        .and_then(Value::as_array)
+    {
+        let bridged = bridged_skill_ids
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>();
+        if !bridged.is_empty() {
+            println!("- bridged skill ids: {}", bridged.join(", "));
+        }
+    }
     if let Some(manifest_path) = result
         .get("external_skills_manifest_path")
         .and_then(Value::as_str)

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -1149,7 +1149,8 @@ fn render_skill_summary_line(skill: &Value) -> String {
         .get("model_visibility")
         .and_then(Value::as_str)
         .or_else(|| {
-            skill.get("metadata")
+            skill
+                .get("metadata")
                 .and_then(|value| value.get("model_visibility"))
                 .and_then(Value::as_str)
         })
@@ -1157,7 +1158,8 @@ fn render_skill_summary_line(skill: &Value) -> String {
     let eligible = skill
         .get("eligibility")
         .and_then(|value| {
-            value.get("available")
+            value
+                .get("available")
                 .and_then(Value::as_bool)
                 .or_else(|| value.get("eligible").and_then(Value::as_bool))
         })
@@ -1166,7 +1168,8 @@ fn render_skill_summary_line(skill: &Value) -> String {
         .get("invocation_policy")
         .and_then(Value::as_str)
         .or_else(|| {
-            skill.get("metadata")
+            skill
+                .get("metadata")
                 .and_then(|value| value.get("invocation_policy"))
                 .and_then(Value::as_str)
         })

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -12,6 +12,22 @@ pub enum SkillsCommands {
     /// Inspect one resolved external skill
     #[command(visible_alias = "inspect")]
     Info { skill_id: String },
+    /// Download an external skill package and optionally sync it into the managed runtime
+    Fetch {
+        url: String,
+        #[arg(long)]
+        save_as: Option<String>,
+        #[arg(long)]
+        max_bytes: Option<usize>,
+        #[arg(long, default_value_t = false)]
+        approve_download: bool,
+        #[arg(long, default_value_t = false)]
+        install: bool,
+        #[arg(long)]
+        skill_id: Option<String>,
+        #[arg(long, default_value_t = false)]
+        replace: bool,
+    },
     /// Install a managed external skill from a local directory or archive
     Install {
         path: String,
@@ -109,6 +125,7 @@ pub fn execute_skills_command(options: SkillsCommandOptions) -> CliResult<Skills
         }
         command @ (SkillsCommands::List
         | SkillsCommands::Info { .. }
+        | SkillsCommands::Fetch { .. }
         | SkillsCommands::Install { .. }
         | SkillsCommands::InstallBundled { .. }
         | SkillsCommands::Remove { .. }) => {
@@ -146,6 +163,25 @@ fn execute_non_policy_skills_command(
                 &tool_runtime_config,
             )
         }
+        SkillsCommands::Fetch {
+            url,
+            save_as,
+            max_bytes,
+            approve_download,
+            install,
+            skill_id,
+            replace,
+        } => execute_fetch_command(
+            resolved_path,
+            config,
+            &url,
+            save_as.as_deref(),
+            max_bytes,
+            approve_download,
+            install,
+            skill_id.as_deref(),
+            replace,
+        ),
         SkillsCommands::InstallBundled { skill_id, replace } => {
             execute_install_bundled_skill_command(resolved_path, config, &skill_id, replace)
         }
@@ -176,22 +212,17 @@ fn build_skills_tool_request(command: SkillsCommands) -> CliResult<ToolCoreReque
                 "skill_id": skill_id,
             }),
         }),
+        SkillsCommands::Fetch { .. } => {
+            Err("skills fetch requests are handled directly by the daemon CLI".to_owned())
+        }
         SkillsCommands::Install {
             path,
             skill_id,
             replace,
-        } => {
-            let mut payload = Map::new();
-            payload.insert("path".to_owned(), json!(path));
-            payload.insert("replace".to_owned(), json!(replace));
-            if let Some(skill_id) = skill_id {
-                payload.insert("skill_id".to_owned(), json!(skill_id));
-            }
-            Ok(ToolCoreRequest {
-                tool_name: "external_skills.install".to_owned(),
-                payload: Value::Object(payload),
-            })
-        }
+        } => Ok(ToolCoreRequest {
+            tool_name: "external_skills.install".to_owned(),
+            payload: build_install_payload(&path, skill_id.as_deref(), replace),
+        }),
         SkillsCommands::InstallBundled { .. } | SkillsCommands::EnableBrowserPreview { .. } => {
             Err("bundled skills install requests are handled directly by the daemon CLI".to_owned())
         }
@@ -204,6 +235,101 @@ fn build_skills_tool_request(command: SkillsCommands) -> CliResult<ToolCoreReque
         SkillsCommands::Policy { .. } => {
             Err("skills policy requests are handled directly by the daemon CLI".to_owned())
         }
+    }
+}
+
+fn execute_fetch_command(
+    resolved_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+    url: &str,
+    save_as: Option<&str>,
+    max_bytes: Option<usize>,
+    approve_download: bool,
+    install: bool,
+    skill_id: Option<&str>,
+    replace: bool,
+) -> CliResult<ToolCoreOutcome> {
+    if !install {
+        if skill_id.is_some() {
+            return Err("skills fetch --skill-id requires --install".to_owned());
+        }
+        if replace {
+            return Err("skills fetch --replace requires --install".to_owned());
+        }
+    }
+
+    let tool_runtime_config = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        config,
+        Some(resolved_path),
+    );
+    let fetch_request = build_fetch_tool_request(url, save_as, max_bytes, approve_download);
+    let fetch_outcome =
+        mvp::tools::execute_tool_core_with_config(fetch_request, &tool_runtime_config)?;
+    let fetched = fetch_outcome.payload;
+
+    let installed = if install {
+        let saved_path = fetched
+            .get("saved_path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "external skills fetch payload missing `saved_path`".to_owned())?;
+        let install_request = build_install_request(saved_path, skill_id, replace);
+        Some(
+            mvp::tools::execute_tool_core_with_config(install_request, &tool_runtime_config)?
+                .payload,
+        )
+    } else {
+        None
+    };
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "daemon-cli",
+            "tool_name": "skills.fetch",
+            "sync_applied": install,
+            "fetched": fetched,
+            "installed": installed,
+        }),
+    })
+}
+
+fn build_fetch_tool_request(
+    url: &str,
+    save_as: Option<&str>,
+    max_bytes: Option<usize>,
+    approve_download: bool,
+) -> ToolCoreRequest {
+    let mut payload = Map::new();
+    payload.insert("url".to_owned(), json!(url));
+    if let Some(save_as) = save_as {
+        payload.insert("save_as".to_owned(), json!(save_as));
+    }
+    if let Some(max_bytes) = max_bytes {
+        payload.insert("max_bytes".to_owned(), json!(max_bytes));
+    }
+    if approve_download {
+        payload.insert("approval_granted".to_owned(), json!(true));
+    }
+    ToolCoreRequest {
+        tool_name: "external_skills.fetch".to_owned(),
+        payload: Value::Object(payload),
+    }
+}
+
+fn build_install_payload(path: &str, skill_id: Option<&str>, replace: bool) -> Value {
+    let mut payload = Map::new();
+    payload.insert("path".to_owned(), json!(path));
+    payload.insert("replace".to_owned(), json!(replace));
+    if let Some(skill_id) = skill_id {
+        payload.insert("skill_id".to_owned(), json!(skill_id));
+    }
+    Value::Object(payload)
+}
+
+fn build_install_request(path: &str, skill_id: Option<&str>, replace: bool) -> ToolCoreRequest {
+    ToolCoreRequest {
+        tool_name: "external_skills.install".to_owned(),
+        payload: build_install_payload(path, skill_id, replace),
     }
 }
 
@@ -525,11 +651,90 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                 }
             }
         }
+        "skills.fetch" => {
+            let fetched = payload
+                .get("fetched")
+                .and_then(Value::as_object)
+                .ok_or_else(|| "skills fetch payload missing `fetched` object".to_owned())?;
+            lines.push(format!(
+                "saved_path={}",
+                fetched
+                    .get("saved_path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("-")
+            ));
+            lines.push(format!(
+                "bytes_downloaded={}",
+                fetched
+                    .get("bytes_downloaded")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0)
+            ));
+            lines.push(format!(
+                "sha256={}",
+                fetched.get("sha256").and_then(Value::as_str).unwrap_or("-")
+            ));
+            lines.push(format!(
+                "approval_required={}",
+                fetched
+                    .get("approval_required")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+            lines.push(format!(
+                "approval_granted={}",
+                fetched
+                    .get("approval_granted")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            ));
+            let sync_applied = payload
+                .get("sync_applied")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            lines.push(format!("sync_applied={sync_applied}"));
+            if sync_applied {
+                let installed = payload
+                    .get("installed")
+                    .and_then(Value::as_object)
+                    .ok_or_else(|| "skills fetch payload missing `installed` object".to_owned())?;
+                lines.push(format!(
+                    "installed skill_id={}",
+                    installed
+                        .get("skill_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("-")
+                ));
+                lines.push(format!(
+                    "display_name={}",
+                    installed
+                        .get("display_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("-")
+                ));
+                lines.push(format!(
+                    "install_path={}",
+                    installed
+                        .get("install_path")
+                        .and_then(Value::as_str)
+                        .unwrap_or("-")
+                ));
+                lines.push(format!(
+                    "replaced={}",
+                    installed
+                        .get("replaced")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                ));
+            }
+        }
         "external_skills.inspect" => {
             let skill = payload
                 .get("skill")
                 .and_then(Value::as_object)
                 .ok_or_else(|| "skills info payload missing `skill` object".to_owned())?;
+            let metadata = skill.get("metadata").and_then(Value::as_object);
+            let eligibility = skill.get("eligibility").and_then(Value::as_object);
             lines.push(format!(
                 "skill_id={}",
                 skill.get("skill_id").and_then(Value::as_str).unwrap_or("-")
@@ -554,51 +759,59 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                 skill
                     .get("model_visibility")
                     .and_then(Value::as_str)
+                    .or_else(|| {
+                        metadata
+                            .and_then(|value| value.get("model_visibility"))
+                            .and_then(Value::as_str)
+                    })
                     .unwrap_or("visible")
             ));
             lines.push(format!(
                 "eligible={}",
-                skill
-                    .get("eligibility")
-                    .and_then(|eligibility| eligibility.get("available"))
-                    .and_then(Value::as_bool)
+                eligibility
+                    .and_then(|value| {
+                        value
+                            .get("available")
+                            .and_then(Value::as_bool)
+                            .or_else(|| value.get("eligible").and_then(Value::as_bool))
+                    })
                     .unwrap_or(true)
             ));
             lines.push(format!(
                 "required_env={}",
-                render_string_list(skill.get("required_env"))
+                render_string_list(
+                    skill
+                        .get("required_env")
+                        .or_else(|| metadata.and_then(|value| value.get("required_env")))
+                )
             ));
             lines.push(format!(
                 "required_bin={}",
-                render_string_list(skill.get("required_bin"))
+                render_string_list(
+                    skill
+                        .get("required_bin")
+                        .or_else(|| metadata.and_then(|value| value.get("required_bins")))
+                )
             ));
             lines.push(format!(
                 "required_paths={}",
-                render_string_list(skill.get("required_paths"))
+                render_string_list(
+                    skill
+                        .get("required_paths")
+                        .or_else(|| metadata.and_then(|value| value.get("required_paths")))
+                )
             ));
             lines.push(format!(
                 "missing_env={}",
-                render_string_list(
-                    skill
-                        .get("eligibility")
-                        .and_then(|eligibility| eligibility.get("missing_env"))
-                )
+                render_string_list(eligibility.and_then(|value| value.get("missing_env")))
             ));
             lines.push(format!(
                 "missing_bin={}",
-                render_string_list(
-                    skill
-                        .get("eligibility")
-                        .and_then(|eligibility| eligibility.get("missing_bin"))
-                )
+                render_string_list(eligibility.and_then(|value| value.get("missing_bin")))
             ));
             lines.push(format!(
                 "missing_paths={}",
-                render_string_list(
-                    skill
-                        .get("eligibility")
-                        .and_then(|eligibility| eligibility.get("missing_paths"))
-                )
+                render_string_list(eligibility.and_then(|value| value.get("missing_paths")))
             ));
             lines.push(format!(
                 "source_path={}",
@@ -625,6 +838,18 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                 "sha256={}",
                 skill.get("sha256").and_then(Value::as_str).unwrap_or("-")
             ));
+            lines.push(format!(
+                "invocation_policy={}",
+                skill
+                    .get("invocation_policy")
+                    .and_then(Value::as_str)
+                    .or_else(|| {
+                        metadata
+                            .and_then(|value| value.get("invocation_policy"))
+                            .and_then(Value::as_str)
+                    })
+                    .unwrap_or("model")
+            ));
             lines.push("instructions_preview:".to_owned());
             lines.push(
                 payload
@@ -633,6 +858,60 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                     .unwrap_or("-")
                     .to_owned(),
             );
+            render_string_section(
+                &mut lines,
+                "eligibility_issues:",
+                eligibility.and_then(|value| value.get("issues")),
+                "skills info payload missing `skill.eligibility.issues` array",
+            )?;
+            render_string_section(
+                &mut lines,
+                "required_env:",
+                skill
+                    .get("required_env")
+                    .or_else(|| metadata.and_then(|value| value.get("required_env"))),
+                "skills info payload missing `skill.required_env` array",
+            )?;
+            render_string_section(
+                &mut lines,
+                "required_bins:",
+                skill
+                    .get("required_bin")
+                    .or_else(|| metadata.and_then(|value| value.get("required_bins"))),
+                "skills info payload missing `skill.required_bin` array",
+            )?;
+            render_string_section(
+                &mut lines,
+                "required_paths:",
+                skill
+                    .get("required_paths")
+                    .or_else(|| metadata.and_then(|value| value.get("required_paths"))),
+                "skills info payload missing `skill.required_paths` array",
+            )?;
+            render_string_section(
+                &mut lines,
+                "required_config:",
+                skill
+                    .get("required_config")
+                    .or_else(|| metadata.and_then(|value| value.get("required_config"))),
+                "skills info payload missing `skill.required_config` array",
+            )?;
+            render_string_section(
+                &mut lines,
+                "allowed_tools:",
+                skill
+                    .get("allowed_tools")
+                    .or_else(|| metadata.and_then(|value| value.get("allowed_tools"))),
+                "skills info payload missing `skill.allowed_tools` array",
+            )?;
+            render_string_section(
+                &mut lines,
+                "blocked_tools:",
+                skill
+                    .get("blocked_tools")
+                    .or_else(|| metadata.and_then(|value| value.get("blocked_tools"))),
+                "skills info payload missing `skill.blocked_tools` array",
+            )?;
             let shadowed = payload
                 .get("shadowed_skills")
                 .and_then(Value::as_array)
@@ -869,13 +1148,30 @@ fn render_skill_summary_line(skill: &Value) -> String {
     let model_visibility = skill
         .get("model_visibility")
         .and_then(Value::as_str)
+        .or_else(|| {
+            skill.get("metadata")
+                .and_then(|value| value.get("model_visibility"))
+                .and_then(Value::as_str)
+        })
         .unwrap_or("visible");
     let eligible = skill
         .get("eligibility")
-        .and_then(|eligibility| eligibility.get("available"))
-        .and_then(Value::as_bool)
+        .and_then(|value| {
+            value.get("available")
+                .and_then(Value::as_bool)
+                .or_else(|| value.get("eligible").and_then(Value::as_bool))
+        })
         .unwrap_or(true);
+    let invocation_policy = skill
+        .get("invocation_policy")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            skill.get("metadata")
+                .and_then(|value| value.get("invocation_policy"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("model");
     format!(
-        "{skill_id} [{active}] scope={scope} model_visibility={model_visibility} eligible={eligible} display_name={display_name} summary={summary}"
+        "{skill_id} [{active}] scope={scope} model_visibility={model_visibility} eligible={eligible} invocation_policy={invocation_policy} display_name={display_name} summary={summary}"
     )
 }

--- a/crates/daemon/tests/integration/migrate_cli.rs
+++ b/crates/daemon/tests/integration/migrate_cli.rs
@@ -245,6 +245,11 @@ fn run_migrate_cli_apply_selected_mode_can_apply_external_skill_plan() {
         "SKILLS.md",
         "# Skills\n\n- custom/skill-a\n",
     );
+    write_file(
+        &discovery_root,
+        ".codex/skills/release-guard/SKILL.md",
+        "# Release Guard\n\nUse this skill when release discipline matters.\n",
+    );
 
     let output_path = output_root.join("selected-external.toml");
     loongclaw_daemon::migrate_cli::run_migrate_cli(
@@ -266,12 +271,24 @@ fn run_migrate_cli_apply_selected_mode_can_apply_external_skill_plan() {
     let raw = fs::read_to_string(&output_path).expect("read generated config");
     assert!(raw.contains("Imported External Skills Artifacts"));
     assert!(raw.contains("kind=skills_catalog"));
+    assert!(
+        raw.contains("enabled = true"),
+        "bridged installs should enable external skills in the written config"
+    );
     let external_manifest_path = output_root
         .join(".loongclaw-migration")
         .join("selected-external.toml.external-skills.json");
     assert!(
         external_manifest_path.exists(),
         "apply_selected mode should write external skills manifest"
+    );
+    assert!(
+        output_root
+            .join("external-skills-installed")
+            .join("release-guard")
+            .join("SKILL.md")
+            .exists(),
+        "apply_selected mode should bridge installable local skills into the managed runtime"
     );
 
     fs::remove_dir_all(&discovery_root).ok();

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -1714,16 +1714,15 @@ fn render_skills_cli_text_surfaces_skill_contract_details() {
                         "install_path": "/tmp/managed/release-guard",
                         "skill_md_path": "/tmp/managed/release-guard/SKILL.md",
                         "sha256": "abc123",
-                        "metadata": {
-                            "invocation_policy": "manual",
-                            "required_env": ["LOONGCLAW_RELEASE_GUARD_TOKEN"],
-                            "required_bins": ["sh"],
-                            "required_config": ["external_skills.enabled"],
-                            "allowed_tools": ["shell.exec"],
-                            "blocked_tools": ["web.fetch"]
-                        },
+                        "invocation_policy": "manual",
+                        "required_env": ["LOONGCLAW_RELEASE_GUARD_TOKEN"],
+                        "required_bin": ["sh"],
+                        "required_paths": [],
+                        "required_config": ["external_skills.enabled"],
+                        "allowed_tools": ["shell.exec"],
+                        "blocked_tools": ["web.fetch"],
                         "eligibility": {
-                            "eligible": false,
+                            "available": false,
                             "issues": ["missing env `LOONGCLAW_RELEASE_GUARD_TOKEN`"]
                         }
                     },

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -148,6 +148,7 @@ fn skills_install_cli_parses_global_flags_after_subcommand() {
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Fetch { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
                     ..
@@ -194,6 +195,7 @@ fn skills_install_bundled_cli_parses_global_flags_after_subcommand() {
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Fetch { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
                     ..
@@ -236,6 +238,7 @@ fn skills_enable_browser_preview_cli_parses_global_flags_after_subcommand() {
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Fetch { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. }
@@ -301,6 +304,7 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
             },
             other @ loongclaw_daemon::skills_cli::SkillsCommands::List
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
+            | other @ loongclaw_daemon::skills_cli::SkillsCommands::Fetch { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
@@ -312,6 +316,127 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
         },
         other => panic!("unexpected command parsed: {other:?}"),
     }
+}
+
+#[test]
+fn skills_fetch_cli_parses_install_flags_after_subcommand() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "skills",
+        "fetch",
+        "https://skills.sh/demo.tgz",
+        "--save-as",
+        "release-guard.tgz",
+        "--max-bytes",
+        "2048",
+        "--approve-download",
+        "--install",
+        "--skill-id",
+        "release-guard",
+        "--replace",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("skills fetch CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            match command {
+                loongclaw_daemon::skills_cli::SkillsCommands::Fetch {
+                    url,
+                    save_as,
+                    max_bytes,
+                    approve_download,
+                    install,
+                    skill_id,
+                    replace,
+                } => {
+                    assert_eq!(url, "https://skills.sh/demo.tgz");
+                    assert_eq!(save_as.as_deref(), Some("release-guard.tgz"));
+                    assert_eq!(max_bytes, Some(2048));
+                    assert!(approve_download);
+                    assert!(install);
+                    assert_eq!(skill_id.as_deref(), Some("release-guard"));
+                    assert!(replace);
+                }
+                other @ loongclaw_daemon::skills_cli::SkillsCommands::List
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::EnableBrowserPreview {
+                    ..
+                }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Remove { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Policy { .. } => {
+                    panic!("unexpected skills subcommand parsed: {other:?}")
+                }
+            }
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn execute_skills_command_fetch_rejects_install_options_without_install_flag() {
+    let root = unique_temp_dir("loongclaw-skills-cli-fetch-validate");
+    let _env = SkillsCliEnvironmentGuard::set(&[]);
+    let config_path = write_external_skills_config(&root, true);
+
+    let error = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Fetch {
+                url: "https://skills.sh/demo.tgz".to_owned(),
+                save_as: None,
+                max_bytes: None,
+                approve_download: true,
+                install: false,
+                skill_id: Some("release-guard".to_owned()),
+                replace: true,
+            },
+        },
+    )
+    .expect_err("fetch should reject install-only flags without --install");
+
+    assert!(error.contains("--install"));
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn execute_skills_command_fetch_propagates_runtime_policy_errors() {
+    let root = unique_temp_dir("loongclaw-skills-cli-fetch-policy");
+    let _env = SkillsCliEnvironmentGuard::set(&[]);
+    let config_path = write_external_skills_config(&root, true);
+
+    let error = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Fetch {
+                url: "https://skills.sh/demo.tgz".to_owned(),
+                save_as: None,
+                max_bytes: None,
+                approve_download: false,
+                install: false,
+                skill_id: None,
+                replace: false,
+            },
+        },
+    )
+    .expect_err("fetch should surface approval gating before network access");
+
+    assert!(error.contains("requires explicit authorization"));
+
+    fs::remove_dir_all(&root).ok();
 }
 
 #[test]
@@ -1569,6 +1694,90 @@ fn execute_skills_command_policy_set_rejects_invalid_domain_rules() {
     assert!(reloaded.external_skills.blocked_domains.is_empty());
 
     fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn render_skills_cli_text_surfaces_skill_contract_details() {
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(
+        &loongclaw_daemon::skills_cli::SkillsCommandExecution {
+            resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+            outcome: kernel::ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: serde_json::json!({
+                    "tool_name": "external_skills.inspect",
+                    "skill": {
+                        "skill_id": "release-guard",
+                        "display_name": "Release Guard",
+                        "scope": "managed",
+                        "active": true,
+                        "source_path": "/tmp/managed/release-guard",
+                        "install_path": "/tmp/managed/release-guard",
+                        "skill_md_path": "/tmp/managed/release-guard/SKILL.md",
+                        "sha256": "abc123",
+                        "metadata": {
+                            "invocation_policy": "manual",
+                            "required_env": ["LOONGCLAW_RELEASE_GUARD_TOKEN"],
+                            "required_bins": ["sh"],
+                            "required_config": ["external_skills.enabled"],
+                            "allowed_tools": ["shell.exec"],
+                            "blocked_tools": ["web.fetch"]
+                        },
+                        "eligibility": {
+                            "eligible": false,
+                            "issues": ["missing env `LOONGCLAW_RELEASE_GUARD_TOKEN`"]
+                        }
+                    },
+                    "instructions_preview": "Prefer release checklists.",
+                    "shadowed_skills": []
+                }),
+            },
+        },
+    )
+    .expect("inspect payload should render");
+
+    assert!(rendered.contains("eligible=false"));
+    assert!(rendered.contains("invocation_policy=manual"));
+    assert!(rendered.contains("eligibility_issues:"));
+    assert!(rendered.contains("required_env:"));
+    assert!(rendered.contains("allowed_tools:"));
+    assert!(rendered.contains("blocked_tools:"));
+}
+
+#[test]
+fn render_skills_cli_text_surfaces_fetch_sync_summary() {
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(
+        &loongclaw_daemon::skills_cli::SkillsCommandExecution {
+            resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+            outcome: kernel::ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: serde_json::json!({
+                    "tool_name": "skills.fetch",
+                    "sync_applied": true,
+                    "fetched": {
+                        "saved_path": "/tmp/downloads/release-guard.tgz",
+                        "bytes_downloaded": 512,
+                        "sha256": "feedface",
+                        "approval_required": true,
+                        "approval_granted": true
+                    },
+                    "installed": {
+                        "skill_id": "release-guard",
+                        "display_name": "Release Guard",
+                        "install_path": "/tmp/managed/release-guard",
+                        "replaced": true
+                    }
+                }),
+            },
+        },
+    )
+    .expect("fetch payload should render");
+
+    assert!(rendered.contains("saved_path=/tmp/downloads/release-guard.tgz"));
+    assert!(rendered.contains("bytes_downloaded=512"));
+    assert!(rendered.contains("sha256=feedface"));
+    assert!(rendered.contains("sync_applied=true"));
+    assert!(rendered.contains("installed skill_id=release-guard"));
+    assert!(rendered.contains("replaced=true"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Problem:
  issue #159 still lacked the remaining skills-platform slices after the earlier discovery/operator CLI work: a constrained per-skill metadata contract, an explicit migration-to-managed-install bridge, and a minimal operator-facing remote fetch/install/update path.
- Why it matters:
  without these pieces, external skills remained only partially productized: operators could inspect local skills, but could not carry imported skills into the managed runtime, diagnose eligibility from a stable contract, or use a supported fetch/install sync path.
- What changed:
  exposed the public root `loongclaw migrate` entrypoint; made `migrate --mode apply_selected --apply-external-skills-plan` bridge installable imported skill roots into the managed runtime with deterministic install-root selection, manifest reporting, and rollback on config persistence failure; extended `SKILL.md` frontmatter support with `invocation_policy`, `required_env`, `required_bins`, `required_config`, `allowed_tools`, and `blocked_tools`; surfaced resolved metadata and eligibility through `external_skills.list|inspect|invoke` and `loongclaw skills list|info`; added `loongclaw skills fetch` with optional `--install --skill-id --replace`; updated migration warnings and README operator docs.
- What did not change (scope boundary):
  this PR does not add a full remote registry index or a background sync daemon. `skills fetch --install --replace` is intentionally the thin operator-facing lifecycle on top of the existing managed runtime primitives.

## Linked Issues

- Closes #159
- Related #393

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Tools
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] Kernel / policy / approvals
- [ ] Providers / routing
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  migration apply can now enable external skills and bridge imported local skills into a managed install root, and external skill invocation now fails closed when the resolved contract says the skill is manual-only or currently ineligible.
- Rollout / guardrails:
  the migration bridge stays opt-in behind `--apply-external-skills-plan`; operator-facing `skills list|info` exposes eligibility and contract details; `skills fetch` rejects install-only flags unless `--install` is explicit.
- Rollback path:
  revert this PR, or use `loongclaw migrate --mode rollback_last_apply` for the latest migration apply and remove managed skills with `loongclaw skills remove` if needed.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- passed

git diff --check
- passed

CARGO_TARGET_DIR=<tmp-target> cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed

CARGO_TARGET_DIR=<tmp-target> cargo test --workspace --locked
- passed

CARGO_TARGET_DIR=<tmp-target> cargo test --workspace --all-features --locked
- passed

CARGO_TARGET_DIR=<tmp-target> cargo test -p loongclaw-daemon skills_cli -- --nocapture
- passed

CARGO_TARGET_DIR=<tmp-target> cargo test -p loongclaw-daemon migrate_cli -- --nocapture
- passed

CARGO_TARGET_DIR=<tmp-target> cargo test -p loongclaw-app inspect_and_invoke_surface_skill_metadata_contract -- --nocapture
- passed

CARGO_TARGET_DIR=<tmp-target> cargo test -p loongclaw-app invoke_rejects_manual_or_ineligible_skill_metadata_contracts -- --nocapture
- passed

CARGO_TARGET_DIR=<tmp-target> cargo test -p loongclaw-app apply_import_selection_ -- --nocapture
- passed
```

## User-visible / Operator-visible Changes

- `loongclaw migrate` is now a public root entrypoint, and `--apply-external-skills-plan` can bridge imported local skills into managed installs instead of stopping at audit artifacts.
- `loongclaw skills list|info` now surfaces per-skill invocation policy, requirement gates, declared tool restrictions, and eligibility diagnostics.
- `loongclaw skills fetch --install --replace` provides a minimal operator sync/update path over the existing managed install lifecycle.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR, use `loongclaw migrate --mode rollback_last_apply` for the latest migration apply, or disable/remove external skills through the existing runtime/CLI controls.
- Observable failure symptoms reviewers should watch for:
  a migration apply unexpectedly enables external skills, a bridged install is left behind after a failed config write, or `skills fetch` accepts install/replace flags without explicit install intent.

## Reviewer Focus

- review the migration bridge and rollback seams in `crates/app/src/migration/orchestrator.rs`, especially install-root selection, manifest capture, and cleanup when config persistence fails.
- review the metadata contract parsing and eligibility enforcement in `crates/app/src/tools/external_skills.rs`, especially how invocation policy and requirement gates surface to both runtime payloads and operator debugging.
- review the operator-facing lifecycle in `crates/daemon/src/skills_cli.rs` and `crates/daemon/src/migrate_cli.rs`, especially the validation around `skills fetch --install --replace` and the updated human-readable output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Migrate CLI with an opt-in bridge to install local external skills; Skills Fetch command to download (with explicit approval) and optionally install/replace skills. CLI outputs and JSON now include managed install counts/IDs.
  * External-skill listing/inspect/invoke surfaces per-skill metadata, eligibility, invocation policy, required env/bins/paths, and tool allow/block rules; invocations blocked when ineligible or manual-only.

* **Bug Fixes**
  * Migration persistence is guarded with rollback and config restoration on failure.

* **Documentation**
  * Expanded migration and external-skills docs with examples and operator workflows.

* **Tests**
  * New and updated integration/unit tests covering CLI parsing, fetch/install flows, eligibility, and rollback behavior.

* **Chores**
  * Workspace dependency and package dependency adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->