### PR TITLE
feat(conversation): add tool loop safety gates (global counter + consecutive same-tool warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -2893,9 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/app/src/config/conversation.rs
+++ b/crates/app/src/config/conversation.rs
@@ -212,6 +212,10 @@ pub struct ConversationTurnLoopConfig {
     pub max_followup_tool_payload_chars_total: usize,
     #[serde(default = "default_turn_loop_max_discovery_followup_rounds")]
     pub max_discovery_followup_rounds: usize,
+    #[serde(default = "default_turn_loop_max_total_tool_calls")]
+    pub max_total_tool_calls: usize,
+    #[serde(default = "default_turn_loop_max_consecutive_same_tool")]
+    pub max_consecutive_same_tool: usize,
 }
 
 impl Default for ConversationTurnLoopConfig {
@@ -226,6 +230,8 @@ impl Default for ConversationTurnLoopConfig {
             max_followup_tool_payload_chars_total:
                 default_turn_loop_max_followup_tool_payload_chars_total(),
             max_discovery_followup_rounds: default_turn_loop_max_discovery_followup_rounds(),
+            max_total_tool_calls: default_turn_loop_max_total_tool_calls(),
+            max_consecutive_same_tool: default_turn_loop_max_consecutive_same_tool(),
         }
     }
 }
@@ -472,6 +478,14 @@ const fn default_turn_loop_max_followup_tool_payload_chars_total() -> usize {
 
 const fn default_turn_loop_max_discovery_followup_rounds() -> usize {
     2
+}
+
+const fn default_turn_loop_max_total_tool_calls() -> usize {
+    200
+}
+
+const fn default_turn_loop_max_consecutive_same_tool() -> usize {
+    10
 }
 
 const fn default_fast_lane_max_tool_steps_per_turn() -> usize {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -4739,7 +4739,7 @@ async fn handle_turn_with_runtime_tool_search_requests_a_followup_provider_turn(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn handle_turn_with_runtime_honors_max_total_tool_calls_before_tool_dispatch() {
+async fn handle_turn_with_runtime_blocks_only_when_next_round_would_exceed_max_total_tool_calls() {
     use crate::test_support::TurnTestHarness;
 
     let harness = TurnTestHarness::new();
@@ -4759,8 +4759,14 @@ async fn handle_turn_with_runtime_honors_max_total_tool_calls_before_tool_dispat
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
-                assistant_text: "I found the tool, now I can continue.".to_owned(),
-                tool_intents: Vec::new(),
+                assistant_text: "I should search one more time before continuing.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-tool-search-breaker",
+                    "turn-tool-search-breaker",
+                    "call-tool-search-breaker-2",
+                )],
                 raw_meta: Value::Null,
             }),
         ],
@@ -4785,9 +4791,9 @@ async fn handle_turn_with_runtime_honors_max_total_tool_calls_before_tool_dispat
 
     assert_eq!(
         reply,
-        "tool_loop_circuit_breaker: reached 1/1 tool calls this turn. Do you want to continue? Reply to resume."
+        "tool_loop_circuit_breaker: would exceed 2/1 tool calls this turn. Do you want to continue? Reply to resume."
     );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
     assert_eq!(
         *runtime
             .completion_calls
@@ -4802,6 +4808,13 @@ async fn handle_turn_with_runtime_honors_max_total_tool_calls_before_tool_dispat
     assert_eq!(visible_turns[0].1, "user");
     assert_eq!(visible_turns[1].1, "assistant");
     assert_eq!(visible_turns[1].2, reply);
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 2);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -4739,6 +4739,151 @@ async fn handle_turn_with_runtime_tool_search_requests_a_followup_provider_turn(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_honors_max_total_tool_calls_before_tool_dispatch() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-tool-search-breaker",
+                    "turn-tool-search-breaker",
+                    "call-tool-search-breaker",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "I found the tool, now I can continue.".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let mut config = test_config();
+    config.conversation.turn_loop.max_total_tool_calls = 1;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-tool-search-breaker",
+            "search for the right tool, then read and summarize note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+        )
+        .await
+        .expect("tool loop breaker should return a synthetic reply");
+
+    assert_eq!(
+        reply,
+        "tool_loop_circuit_breaker: reached 1/1 tool calls this turn. Do you want to continue? Reply to resume."
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let visible_turns = persisted_visible_turns(&persisted);
+    assert_eq!(visible_turns.len(), 2);
+    assert_eq!(visible_turns[0].1, "user");
+    assert_eq!(visible_turns[1].1, "assistant");
+    assert_eq!(visible_turns[1].2, reply);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_includes_same_tool_warning_in_followup_provider_round() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-tool-search-warning",
+                    "turn-tool-search-warning",
+                    "call-tool-search-warning-1",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "I should search again before continuing.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-tool-search-warning",
+                    "turn-tool-search-warning",
+                    "call-tool-search-warning-2",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "I should stop and ask before continuing.".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    );
+
+    let mut config = test_config();
+    config.conversation.turn_loop.max_consecutive_same_tool = 2;
+    config.conversation.turn_loop.max_discovery_followup_rounds = 3;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-tool-search-warning",
+            "search for the right tool, then read and summarize note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+        )
+        .await
+        .expect("same-tool warning path should still return a reply");
+
+    assert_eq!(reply, "I should stop and ask before continuing.");
+
+    let requested_turn_messages = runtime
+        .turn_requested_messages
+        .lock()
+        .expect("turn request lock")
+        .clone();
+    assert_eq!(requested_turn_messages.len(), 3);
+    assert!(
+        requested_turn_messages[2].iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_loop_warning]\nconsecutive_same_tool:")
+                    })
+        }),
+        "third provider turn should receive the repeated-tool warning in coordinator followup context: {requested_turn_messages:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_turn_with_runtime_tool_search_raw_request_still_uses_followup_provider_turn() {
     use crate::test_support::TurnTestHarness;
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -88,8 +88,8 @@ use super::turn_shared::{
     build_tool_driven_followup_tail, build_tool_loop_guard_tail,
     decide_provider_turn_request_action, format_approval_required_reply, next_conversation_turn_id,
     reduce_followup_payload_for_model, request_completion_with_raw_fallback,
-    tool_driven_followup_payload, tool_result_contains_truncation_signal,
-    user_requested_raw_tool_output,
+    tool_driven_followup_payload, tool_loop_circuit_breaker_reply,
+    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::recovery::{
@@ -952,12 +952,7 @@ impl ProviderTurnLoopState {
         next_tool_calls: usize,
     ) -> Option<String> {
         let prospective_total = self.total_tool_calls.saturating_add(next_tool_calls);
-        (prospective_total >= policy.max_total_tool_calls).then(|| {
-            format!(
-                "tool_loop_circuit_breaker: reached {}/{} tool calls this turn. Do you want to continue? Reply to resume.",
-                prospective_total, policy.max_total_tool_calls
-            )
-        })
+        tool_loop_circuit_breaker_reply(prospective_total, policy.max_total_tool_calls)
     }
 
     fn observe_turn(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -85,10 +85,11 @@ use super::turn_engine::{
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
     ToolDrivenFollowupPayload, ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
-    build_tool_driven_followup_tail, decide_provider_turn_request_action,
-    format_approval_required_reply, next_conversation_turn_id, reduce_followup_payload_for_model,
-    request_completion_with_raw_fallback, tool_driven_followup_payload,
-    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
+    build_tool_driven_followup_tail, build_tool_loop_guard_tail,
+    decide_provider_turn_request_action, format_approval_required_reply, next_conversation_turn_id,
+    reduce_followup_payload_for_model, request_completion_with_raw_fallback,
+    tool_driven_followup_payload, tool_result_contains_truncation_signal,
+    user_requested_raw_tool_output,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::recovery::{
@@ -913,11 +914,107 @@ impl ProviderTurnLaneExecution {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ProviderTurnLoopPolicy {
+    max_total_tool_calls: usize,
+    max_consecutive_same_tool: usize,
+}
+
+impl ProviderTurnLoopPolicy {
+    fn from_config(config: &LoongClawConfig) -> Self {
+        let turn_loop = &config.conversation.turn_loop;
+        Self {
+            max_total_tool_calls: turn_loop.max_total_tool_calls.max(1),
+            max_consecutive_same_tool: turn_loop.max_consecutive_same_tool.max(1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ProviderTurnLoopState {
+    total_tool_calls: usize,
+    consecutive_same_tool: usize,
+    last_tool_name: Option<String>,
+    warned_same_tool_key: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum ProviderTurnLoopVerdict {
+    Continue,
+    InjectWarning { reason: String },
+    HardStop { reason: String },
+}
+
+impl ProviderTurnLoopState {
+    fn circuit_breaker_reply(
+        &self,
+        policy: &ProviderTurnLoopPolicy,
+        next_tool_calls: usize,
+    ) -> Option<String> {
+        let prospective_total = self.total_tool_calls.saturating_add(next_tool_calls);
+        (prospective_total >= policy.max_total_tool_calls).then(|| {
+            format!(
+                "tool_loop_circuit_breaker: reached {}/{} tool calls this turn. Do you want to continue? Reply to resume.",
+                prospective_total, policy.max_total_tool_calls
+            )
+        })
+    }
+
+    fn observe_turn(
+        &mut self,
+        policy: &ProviderTurnLoopPolicy,
+        turn: &ProviderTurn,
+    ) -> Option<ProviderTurnLoopVerdict> {
+        let tool_intent_count = turn.tool_intents.len();
+        self.total_tool_calls = self.total_tool_calls.saturating_add(tool_intent_count);
+        if tool_intent_count == 0 {
+            self.warned_same_tool_key = None;
+            return None;
+        }
+
+        let tool_name_signature = provider_turn_tool_name_signature(&turn.tool_intents);
+        if self.last_tool_name.as_deref() == Some(tool_name_signature.as_str()) {
+            self.consecutive_same_tool += 1;
+        } else {
+            self.last_tool_name = Some(tool_name_signature.clone());
+            self.consecutive_same_tool = 1;
+            self.warned_same_tool_key = None;
+        }
+
+        if self.consecutive_same_tool < policy.max_consecutive_same_tool {
+            self.warned_same_tool_key = None;
+            return Some(ProviderTurnLoopVerdict::Continue);
+        }
+
+        let reason_key = format!("consecutive_same_tool:{tool_name_signature}");
+        let reason = format!(
+            "consecutive_same_tool: {tool_name_signature} called {} times in a row (limit={})",
+            self.consecutive_same_tool, policy.max_consecutive_same_tool
+        );
+
+        if self.warned_same_tool_key.as_deref() == Some(reason_key.as_str()) {
+            Some(ProviderTurnLoopVerdict::HardStop { reason })
+        } else {
+            self.warned_same_tool_key = Some(reason_key);
+            Some(ProviderTurnLoopVerdict::InjectWarning { reason })
+        }
+    }
+}
+
+fn provider_turn_tool_name_signature(intents: &[ToolIntent]) -> String {
+    intents
+        .iter()
+        .map(|intent| intent.tool_name.trim())
+        .collect::<Vec<_>>()
+        .join("||")
+}
+
 #[derive(Debug, Clone)]
 struct ProviderTurnContinuePhase {
     request: TurnCheckpointRequest,
     lane_execution: ProviderTurnLaneExecution,
     reply_phase: ToolDrivenReplyPhase,
+    loop_verdict: Option<ProviderTurnLoopVerdict>,
     followup_config: LoongClawConfig,
     ingress: Option<ConversationIngressContext>,
 }
@@ -926,6 +1023,7 @@ impl ProviderTurnContinuePhase {
     fn new(
         tool_intents: usize,
         lane_execution: ProviderTurnLaneExecution,
+        loop_verdict: Option<ProviderTurnLoopVerdict>,
         followup_config: LoongClawConfig,
         ingress: Option<&ConversationIngressContext>,
     ) -> Self {
@@ -934,6 +1032,7 @@ impl ProviderTurnContinuePhase {
             request: TurnCheckpointRequest::Continue { tool_intents },
             lane_execution,
             reply_phase,
+            loop_verdict,
             followup_config,
             ingress: ingress.cloned(),
         }
@@ -964,12 +1063,28 @@ impl ProviderTurnContinuePhase {
         }
     }
 
+    fn loop_warning_reason(&self) -> Option<&str> {
+        match self.loop_verdict.as_ref() {
+            Some(ProviderTurnLoopVerdict::InjectWarning { reason }) => Some(reason.as_str()),
+            _ => None,
+        }
+    }
+
+    fn hard_stop_reason(&self) -> Option<&str> {
+        match self.loop_verdict.as_ref() {
+            Some(ProviderTurnLoopVerdict::HardStop { reason }) => Some(reason.as_str()),
+            _ => None,
+        }
+    }
+
     async fn resolve<R: ConversationRuntime + ?Sized>(
         &self,
         runtime: &R,
         session_id: &str,
         preparation: &ProviderTurnPreparation,
         user_input: &str,
+        turn_loop_policy: &ProviderTurnLoopPolicy,
+        turn_loop_state: &mut ProviderTurnLoopState,
         remaining_provider_rounds: usize,
         binding: ConversationRuntimeBinding<'_>,
     ) -> ResolvedProviderTurn {
@@ -980,6 +1095,8 @@ impl ProviderTurnContinuePhase {
             preparation,
             self,
             user_input,
+            turn_loop_policy,
+            turn_loop_state,
             remaining_provider_rounds,
             binding,
             self.ingress.as_ref(),
@@ -2272,16 +2389,31 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
     binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
 ) -> ResolvedProviderTurn {
+    let turn_loop_policy = ProviderTurnLoopPolicy::from_config(config);
+    let mut turn_loop_state = ProviderTurnLoopState::default();
+
     match decide_provider_turn_request_action(result, error_mode) {
         ProviderTurnRequestAction::Continue { turn } => {
             let turn =
                 scope_provider_turn_tool_intents(turn, session_id, preparation.turn_id.as_str());
+            if let Some(reply) =
+                turn_loop_state.circuit_breaker_reply(&turn_loop_policy, turn.tool_intents.len())
+            {
+                return build_turn_loop_circuit_breaker_resolved_turn(
+                    preparation,
+                    user_input,
+                    turn.tool_intents.len(),
+                    reply,
+                );
+            }
             let continue_phase = prepare_provider_turn_continue_phase(
                 config,
                 runtime,
                 session_id,
                 preparation,
                 turn,
+                &turn_loop_policy,
+                &mut turn_loop_state,
                 binding,
                 ingress,
             )
@@ -2292,6 +2424,8 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
                     session_id,
                     preparation,
                     user_input,
+                    &turn_loop_policy,
+                    &mut turn_loop_state,
                     config
                         .conversation
                         .turn_loop
@@ -2334,12 +2468,32 @@ fn scope_provider_turn_tool_intents(
     turn
 }
 
+fn build_turn_loop_circuit_breaker_resolved_turn(
+    preparation: &ProviderTurnPreparation,
+    user_input: &str,
+    tool_intents: usize,
+    reply: String,
+) -> ResolvedProviderTurn {
+    let checkpoint = build_resolved_provider_checkpoint(
+        preparation,
+        user_input,
+        Some(reply.as_str()),
+        TurnCheckpointRequest::Continue { tool_intents },
+        None,
+        None,
+        TurnFinalizationCheckpoint::persist_reply(ReplyPersistenceMode::Success),
+    );
+    ResolvedProviderTurn::persist_reply(reply, checkpoint)
+}
+
 async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
     session_id: &str,
     preparation: &ProviderTurnPreparation,
     turn: ProviderTurn,
+    turn_loop_policy: &ProviderTurnLoopPolicy,
+    turn_loop_state: &mut ProviderTurnLoopState,
     binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
 ) -> ProviderTurnContinuePhase {
@@ -2354,9 +2508,16 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
         ingress,
     )
     .await;
+    let loop_verdict = turn_loop_state.observe_turn(turn_loop_policy, &turn);
     let followup_config =
         ConversationTurnCoordinator::reload_followup_provider_config_after_tool_turn(config, &turn);
-    ProviderTurnContinuePhase::new(tool_intents, lane_execution, followup_config, ingress)
+    ProviderTurnContinuePhase::new(
+        tool_intents,
+        lane_execution,
+        loop_verdict,
+        followup_config,
+        ingress,
+    )
 }
 
 async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
@@ -2366,6 +2527,8 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     preparation: &ProviderTurnPreparation,
     continue_phase: &ProviderTurnContinuePhase,
     user_input: &str,
+    turn_loop_policy: &ProviderTurnLoopPolicy,
+    turn_loop_state: &mut ProviderTurnLoopState,
     remaining_provider_rounds: usize,
     binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
@@ -2376,6 +2539,12 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
             raw_reply: String,
             payload: ToolDrivenFollowupPayload,
             requires_completion_pass: bool,
+            loop_warning_reason: Option<String>,
+        },
+        GuardFollowup {
+            raw_reply: String,
+            reason: String,
+            latest_tool_payload: Option<ToolDrivenFollowupPayload>,
         },
     }
 
@@ -2412,18 +2581,28 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
 
         let reply_decision = match current_continue_phase.reply_phase.decision() {
             ToolDrivenReplyBaseDecision::FinalizeDirect { reply } => {
-                if current_continue_phase
+                let latest_tool_payload = tool_driven_followup_payload(
+                    current_continue_phase.lane_execution.had_tool_intents,
+                    &current_continue_phase.lane_execution.turn_result,
+                );
+                if let Some(reason) = current_continue_phase.hard_stop_reason() {
+                    ReplyLoopDecision::GuardFollowup {
+                        raw_reply: reply.clone(),
+                        reason: reason.to_owned(),
+                        latest_tool_payload,
+                    }
+                } else if current_continue_phase
                     .lane_execution
                     .requires_provider_turn_followup
-                    && let Some(payload) = tool_driven_followup_payload(
-                        current_continue_phase.lane_execution.had_tool_intents,
-                        &current_continue_phase.lane_execution.turn_result,
-                    )
+                    && let Some(payload) = latest_tool_payload
                 {
                     ReplyLoopDecision::Followup {
                         raw_reply: reply.clone(),
                         payload,
                         requires_completion_pass: false,
+                        loop_warning_reason: current_continue_phase
+                            .loop_warning_reason()
+                            .map(ToOwned::to_owned),
                     }
                 } else {
                     ReplyLoopDecision::FinalizeDirect(reply.clone())
@@ -2432,11 +2611,24 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
             ToolDrivenReplyBaseDecision::RequireFollowup {
                 raw_reply,
                 payload: followup,
-            } => ReplyLoopDecision::Followup {
-                raw_reply: raw_reply.clone(),
-                payload: followup.clone(),
-                requires_completion_pass: true,
-            },
+            } => {
+                if let Some(reason) = current_continue_phase.hard_stop_reason() {
+                    ReplyLoopDecision::GuardFollowup {
+                        raw_reply: raw_reply.clone(),
+                        reason: reason.to_owned(),
+                        latest_tool_payload: Some(followup.clone()),
+                    }
+                } else {
+                    ReplyLoopDecision::Followup {
+                        raw_reply: raw_reply.clone(),
+                        payload: followup.clone(),
+                        requires_completion_pass: true,
+                        loop_warning_reason: current_continue_phase
+                            .loop_warning_reason()
+                            .map(ToOwned::to_owned),
+                    }
+                }
+            }
         };
 
         match reply_decision {
@@ -2448,8 +2640,9 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                 raw_reply,
                 payload: followup,
                 requires_completion_pass,
+                loop_warning_reason,
             } => {
-                let follow_up_messages = build_turn_reply_followup_messages(
+                let follow_up_messages = build_turn_reply_followup_messages_with_warning(
                     &current_preparation.session.messages,
                     current_continue_phase
                         .lane_execution
@@ -2457,6 +2650,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                         .as_str(),
                     followup.clone(),
                     user_input,
+                    loop_warning_reason.as_deref(),
                 );
                 if current_continue_phase
                     .lane_execution
@@ -2543,12 +2737,24 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                 kernel_ctx,
                             )
                             .await;
+                            if let Some(reply) = turn_loop_state
+                                .circuit_breaker_reply(turn_loop_policy, turn.tool_intents.len())
+                            {
+                                return build_turn_loop_circuit_breaker_resolved_turn(
+                                    preparation,
+                                    user_input,
+                                    turn.tool_intents.len(),
+                                    reply,
+                                );
+                            }
                             current_continue_phase = prepare_provider_turn_continue_phase(
                                 &current_continue_phase.followup_config,
                                 runtime,
                                 session_id,
                                 &followup_preparation,
                                 turn,
+                                turn_loop_policy,
+                                turn_loop_state,
                                 binding,
                                 ingress,
                             )
@@ -2603,6 +2809,33 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                     current_continue_phase.checkpoint(preparation, user_input, raw_reply.as_str());
                 return ResolvedProviderTurn::persist_reply(raw_reply, checkpoint);
             }
+            ReplyLoopDecision::GuardFollowup {
+                raw_reply,
+                reason,
+                latest_tool_payload,
+            } => {
+                let guard_messages = build_turn_reply_guard_messages(
+                    &current_preparation.session.messages,
+                    current_continue_phase
+                        .lane_execution
+                        .assistant_preface
+                        .as_str(),
+                    reason.as_str(),
+                    latest_tool_payload.as_ref(),
+                    user_input,
+                );
+                let reply = request_completion_with_raw_fallback(
+                    runtime,
+                    &current_continue_phase.followup_config,
+                    &guard_messages,
+                    binding,
+                    raw_reply.as_str(),
+                )
+                .await;
+                let checkpoint =
+                    current_continue_phase.checkpoint(preparation, user_input, reply.as_str());
+                return ResolvedProviderTurn::persist_reply(reply, checkpoint);
+            }
         }
     }
 }
@@ -2639,18 +2872,53 @@ fn format_analytics_turn_checkpoint_progress_status(
     }
 }
 
+#[cfg(test)]
 fn build_turn_reply_followup_messages(
     base_messages: &[Value],
     assistant_preface: &str,
     followup: ToolDrivenFollowupPayload,
     user_input: &str,
 ) -> Vec<Value> {
+    build_turn_reply_followup_messages_with_warning(
+        base_messages,
+        assistant_preface,
+        followup,
+        user_input,
+        None,
+    )
+}
+
+fn build_turn_reply_followup_messages_with_warning(
+    base_messages: &[Value],
+    assistant_preface: &str,
+    followup: ToolDrivenFollowupPayload,
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+) -> Vec<Value> {
     let mut messages = base_messages.to_vec();
     messages.extend(build_tool_driven_followup_tail(
         assistant_preface,
         &followup,
         user_input,
-        None,
+        loop_warning_reason,
+        |label, text| reduce_followup_payload_for_model(label, text).into_owned(),
+    ));
+    messages
+}
+
+fn build_turn_reply_guard_messages(
+    base_messages: &[Value],
+    assistant_preface: &str,
+    reason: &str,
+    latest_tool_payload: Option<&ToolDrivenFollowupPayload>,
+    user_input: &str,
+) -> Vec<Value> {
+    let mut messages = base_messages.to_vec();
+    messages.extend(build_tool_loop_guard_tail(
+        assistant_preface,
+        reason,
+        user_input,
+        latest_tool_payload.map(ToolDrivenFollowupPayload::message_context),
         |label, text| reduce_followup_payload_for_model(label, text).into_owned(),
     ));
     messages
@@ -7142,6 +7410,7 @@ mod tests {
                     source: SafeLaneFailureRouteSource::SessionGovernor,
                 }),
             },
+            None,
             config,
             None,
         );
@@ -7352,6 +7621,7 @@ mod tests {
                 turn_result: TurnResult::FinalText("hello there".to_owned()),
                 safe_lane_terminal_route: None,
             },
+            None,
             LoongClawConfig::default(),
             None,
         );

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -33,6 +33,7 @@ struct TurnLoopSessionState {
     last_raw_reply: String,
     loop_supervisor: ToolLoopSupervisor,
     followup_payload_budget: FollowupPayloadBudget,
+    total_tool_calls: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -175,6 +176,28 @@ impl ConversationTurnLoop {
                 &mut session.loop_supervisor,
             )
             .await;
+
+            // Global circuit breaker: count tool calls dispatched this round and terminate
+            // if the cumulative per-turn limit is reached.
+            session.total_tool_calls += turn.tool_intents.len();
+            if session.total_tool_calls >= policy.max_total_tool_calls {
+                return apply_turn_loop_terminal_action(
+                    runtime,
+                    session_id,
+                    user_input,
+                    TurnLoopTerminalAction::PersistReply {
+                        reply: format!(
+                            "tool_loop_circuit_breaker: reached {}/{} tool calls this turn. \
+                             Do you want to continue? Reply to resume.",
+                            session.total_tool_calls, policy.max_total_tool_calls
+                        ),
+                        persistence_mode: ReplyPersistenceMode::Success,
+                    },
+                    binding,
+                )
+                .await;
+            }
+
             let reply_phase = evaluation.reply_phase(session.raw_tool_output_requested);
             if let Some(raw_reply) = reply_phase.raw_reply() {
                 session.last_raw_reply = raw_reply.to_owned();
@@ -309,6 +332,7 @@ fn initialize_turn_loop_session(
             policy.max_followup_tool_payload_chars,
             policy.max_followup_tool_payload_chars_total,
         ),
+        total_tool_calls: 0,
     }
 }
 
@@ -644,6 +668,8 @@ struct TurnLoopPolicy {
     max_same_tool_failure_rounds: usize,
     max_followup_tool_payload_chars: usize,
     max_followup_tool_payload_chars_total: usize,
+    max_total_tool_calls: usize,
+    max_consecutive_same_tool: usize,
 }
 
 impl TurnLoopPolicy {
@@ -659,6 +685,8 @@ impl TurnLoopPolicy {
             max_followup_tool_payload_chars_total: turn_loop
                 .max_followup_tool_payload_chars_total
                 .max(1),
+            max_total_tool_calls: turn_loop.max_total_tool_calls.max(1),
+            max_consecutive_same_tool: turn_loop.max_consecutive_same_tool.max(1),
         }
     }
 }
@@ -669,6 +697,8 @@ struct ToolLoopSupervisor {
     last_pattern_streak: usize,
     warned_reason_key: Option<String>,
     recent_rounds: VecDeque<ToolLoopObservation>,
+    consecutive_same_tool: usize,
+    last_tool_name: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -702,6 +732,31 @@ impl ToolLoopSupervisor {
         outcome_fingerprint: &str,
         failed: bool,
     ) -> ToolLoopSupervisorVerdict {
+        // Consecutive same-tool-name detection (tool-name only, not full signature).
+        // Fires at exactly max_consecutive_same_tool occurrences (>= threshold).
+        if self.last_tool_name.as_deref() == Some(tool_name_signature) {
+            self.consecutive_same_tool += 1;
+        } else {
+            self.last_tool_name = Some(tool_name_signature.to_owned());
+            self.consecutive_same_tool = 1;
+        }
+        if self.consecutive_same_tool >= policy.max_consecutive_same_tool {
+            let reason = LoopDetectionReason {
+                key: format!("consecutive_same_tool:{tool_name_signature}"),
+                text: format!(
+                    "consecutive_same_tool: {tool_name_signature} called {} times in a row \
+                     (limit={})",
+                    self.consecutive_same_tool, policy.max_consecutive_same_tool
+                ),
+            };
+            return if self.warned_reason_key.as_deref() == Some(reason.key.as_str()) {
+                ToolLoopSupervisorVerdict::HardStop { reason: reason.text }
+            } else {
+                self.warned_reason_key = Some(reason.key);
+                ToolLoopSupervisorVerdict::InjectWarning { reason: reason.text }
+            };
+        }
+
         let pattern = format!("{tool_signature}::{outcome_fingerprint}");
         if self.last_pattern.as_deref() == Some(pattern.as_str()) {
             self.last_pattern_streak += 1;
@@ -1599,5 +1654,61 @@ mod tests {
                 panic!("unexpected propagated error terminal action: {error}");
             }
         }
+    }
+
+    fn test_policy_with_consecutive_limit(limit: usize) -> TurnLoopPolicy {
+        TurnLoopPolicy {
+            max_rounds: 100,
+            max_tool_steps_per_round: 1,
+            max_repeated_tool_call_rounds: 100,
+            max_ping_pong_cycles: 100,
+            max_same_tool_failure_rounds: 100,
+            max_followup_tool_payload_chars: 8_000,
+            max_followup_tool_payload_chars_total: 20_000,
+            max_total_tool_calls: 200,
+            max_consecutive_same_tool: limit,
+        }
+    }
+
+    fn observe(supervisor: &mut ToolLoopSupervisor, policy: &TurnLoopPolicy, tool_name: &str) -> ToolLoopSupervisorVerdict {
+        supervisor.observe_round(policy, tool_name, tool_name, "ok", false)
+    }
+
+    #[test]
+    fn consecutive_same_tool_injects_warning_at_threshold() {
+        let policy = test_policy_with_consecutive_limit(3);
+        let mut supervisor = ToolLoopSupervisor::default();
+
+        // First two calls: below threshold
+        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::Continue));
+        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::Continue));
+        // Third call: hits threshold (>= 3) → InjectWarning
+        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::InjectWarning { .. }));
+    }
+
+    #[test]
+    fn consecutive_same_tool_hard_stops_on_repeat_warning() {
+        let policy = test_policy_with_consecutive_limit(3);
+        let mut supervisor = ToolLoopSupervisor::default();
+
+        // Get to threshold
+        observe(&mut supervisor, &policy, "shell.exec");
+        observe(&mut supervisor, &policy, "shell.exec");
+        observe(&mut supervisor, &policy, "shell.exec"); // InjectWarning
+        // Same pattern again → HardStop
+        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::HardStop { .. }));
+    }
+
+    #[test]
+    fn consecutive_same_tool_resets_on_tool_name_change() {
+        let policy = test_policy_with_consecutive_limit(3);
+        let mut supervisor = ToolLoopSupervisor::default();
+
+        observe(&mut supervisor, &policy, "shell.exec");
+        observe(&mut supervisor, &policy, "shell.exec");
+        // Switch tool — resets consecutive counter
+        assert!(matches!(observe(&mut supervisor, &policy, "file.read"), ToolLoopSupervisorVerdict::Continue));
+        // Back to shell.exec — should start fresh, not trigger warning
+        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::Continue));
     }
 }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -166,6 +166,28 @@ impl ConversationTurnLoop {
                 }
             };
 
+            // Global circuit breaker: prospective check before dispatching tools.
+            // Trips if adding this round's intents would reach the per-turn limit,
+            // ensuring no tools from this round are executed after the cap is hit.
+            let prospective_total = session.total_tool_calls + turn.tool_intents.len();
+            if prospective_total >= policy.max_total_tool_calls {
+                return apply_turn_loop_terminal_action(
+                    runtime,
+                    session_id,
+                    user_input,
+                    TurnLoopTerminalAction::PersistReply {
+                        reply: format!(
+                            "tool_loop_circuit_breaker: reached {}/{} tool calls this turn. \
+                             Do you want to continue? Reply to resume.",
+                            prospective_total, policy.max_total_tool_calls
+                        ),
+                        persistence_mode: ReplyPersistenceMode::Success,
+                    },
+                    binding,
+                )
+                .await;
+            }
+
             let evaluation = evaluate_round_kernel(
                 config,
                 &policy,
@@ -177,26 +199,7 @@ impl ConversationTurnLoop {
             )
             .await;
 
-            // Global circuit breaker: count tool calls dispatched this round and terminate
-            // if the cumulative per-turn limit is reached.
             session.total_tool_calls += turn.tool_intents.len();
-            if session.total_tool_calls >= policy.max_total_tool_calls {
-                return apply_turn_loop_terminal_action(
-                    runtime,
-                    session_id,
-                    user_input,
-                    TurnLoopTerminalAction::PersistReply {
-                        reply: format!(
-                            "tool_loop_circuit_breaker: reached {}/{} tool calls this turn. \
-                             Do you want to continue? Reply to resume.",
-                            session.total_tool_calls, policy.max_total_tool_calls
-                        ),
-                        persistence_mode: ReplyPersistenceMode::Success,
-                    },
-                    binding,
-                )
-                .await;
-            }
 
             let reply_phase = evaluation.reply_phase(session.raw_tool_output_requested);
             if let Some(raw_reply) = reply_phase.raw_reply() {
@@ -749,6 +752,22 @@ impl ToolLoopSupervisor {
                     self.consecutive_same_tool, policy.max_consecutive_same_tool
                 ),
             };
+            // Update pattern history before returning so other detectors see this round.
+            let pattern = format!("{tool_signature}::{outcome_fingerprint}");
+            if self.last_pattern.as_deref() == Some(pattern.as_str()) {
+                self.last_pattern_streak += 1;
+            } else {
+                self.last_pattern = Some(pattern.clone());
+                self.last_pattern_streak = 1;
+            }
+            self.recent_rounds.push_back(ToolLoopObservation {
+                pattern,
+                tool_name_signature: tool_name_signature.to_owned(),
+                failed,
+            });
+            if self.recent_rounds.len() > Self::MAX_RECENT_ROUNDS {
+                self.recent_rounds.pop_front();
+            }
             return if self.warned_reason_key.as_deref() == Some(reason.key.as_str()) {
                 ToolLoopSupervisorVerdict::HardStop {
                     reason: reason.text,

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -169,7 +169,9 @@ impl ConversationTurnLoop {
             // Global circuit breaker: prospective check before dispatching tools.
             // Trips if adding this round's intents would reach the per-turn limit,
             // ensuring no tools from this round are executed after the cap is hit.
-            let prospective_total = session.total_tool_calls.saturating_add(turn.tool_intents.len());
+            let prospective_total = session
+                .total_tool_calls
+                .saturating_add(turn.tool_intents.len());
             if prospective_total >= policy.max_total_tool_calls {
                 return apply_turn_loop_terminal_action(
                     runtime,

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -201,7 +201,7 @@ impl ConversationTurnLoop {
             )
             .await;
 
-            session.total_tool_calls += turn.tool_intents.len();
+            session.total_tool_calls = prospective_total;
 
             let reply_phase = evaluation.reply_phase(session.raw_tool_output_requested);
             if let Some(raw_reply) = reply_phase.raw_reply() {
@@ -1757,5 +1757,25 @@ mod tests {
             observe(&mut supervisor, &policy, "shell.exec"),
             ToolLoopSupervisorVerdict::Continue
         ));
+    }
+
+    #[test]
+    fn global_circuit_breaker_trips_when_prospective_total_reaches_limit() {
+        // Mirrors the prospective check in handle_turn_with_runtime:
+        //   let prospective_total = session.total_tool_calls.saturating_add(turn.tool_intents.len());
+        //   if prospective_total >= policy.max_total_tool_calls { ... }
+        let max = 200usize;
+
+        // At 198 with 3 incoming intents: 201 >= 200 → breaker fires
+        assert!(198usize.saturating_add(3) >= max);
+
+        // At 197 with 2 incoming intents: 199 < 200 → breaker does not fire
+        assert!(197usize.saturating_add(2) < max);
+
+        // Exact boundary: 199 + 1 = 200 >= 200 → fires
+        assert!(199usize.saturating_add(1) >= max);
+
+        // Saturating: usize::MAX + 1 does not overflow, still >= max
+        assert!(usize::MAX.saturating_add(1) >= max);
     }
 }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -20,7 +20,7 @@ use super::turn_shared::{
     ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
     build_tool_loop_guard_tail, decide_provider_turn_request_action,
     reduce_followup_payload_for_model, request_completion_with_raw_fallback,
-    user_requested_raw_tool_output,
+    tool_loop_circuit_breaker_reply, user_requested_raw_tool_output,
 };
 
 #[derive(Default)]
@@ -167,22 +167,20 @@ impl ConversationTurnLoop {
             };
 
             // Global circuit breaker: prospective check before dispatching tools.
-            // Trips if adding this round's intents would reach the per-turn limit,
-            // ensuring no tools from this round are executed after the cap is hit.
+            // Trips if adding this round's intents would exceed the per-turn limit,
+            // ensuring the configured max remains inclusive for executed tool calls.
             let prospective_total = session
                 .total_tool_calls
                 .saturating_add(turn.tool_intents.len());
-            if prospective_total >= policy.max_total_tool_calls {
+            if let Some(reply) =
+                tool_loop_circuit_breaker_reply(prospective_total, policy.max_total_tool_calls)
+            {
                 return apply_turn_loop_terminal_action(
                     runtime,
                     session_id,
                     user_input,
                     TurnLoopTerminalAction::PersistReply {
-                        reply: format!(
-                            "tool_loop_circuit_breaker: reached {}/{} tool calls this turn. \
-                             Do you want to continue? Reply to resume.",
-                            prospective_total, policy.max_total_tool_calls
-                        ),
+                        reply,
                         persistence_mode: ReplyPersistenceMode::Success,
                     },
                     binding,
@@ -1717,7 +1715,7 @@ mod tests {
             observe(&mut supervisor, &policy, "shell.exec"),
             ToolLoopSupervisorVerdict::Continue
         ));
-        // Third call: hits threshold (>= 3) → InjectWarning
+        // Third call: hits threshold (>= 3) -> InjectWarning
         assert!(matches!(
             observe(&mut supervisor, &policy, "shell.exec"),
             ToolLoopSupervisorVerdict::InjectWarning { .. }
@@ -1733,7 +1731,7 @@ mod tests {
         observe(&mut supervisor, &policy, "shell.exec");
         observe(&mut supervisor, &policy, "shell.exec");
         observe(&mut supervisor, &policy, "shell.exec"); // InjectWarning
-        // Same pattern again → HardStop
+        // Same pattern again -> HardStop
         assert!(matches!(
             observe(&mut supervisor, &policy, "shell.exec"),
             ToolLoopSupervisorVerdict::HardStop { .. }
@@ -1747,12 +1745,12 @@ mod tests {
 
         observe(&mut supervisor, &policy, "shell.exec");
         observe(&mut supervisor, &policy, "shell.exec");
-        // Switch tool — resets consecutive counter
+        // Switch tool - resets consecutive counter
         assert!(matches!(
             observe(&mut supervisor, &policy, "file.read"),
             ToolLoopSupervisorVerdict::Continue
         ));
-        // Back to shell.exec — should start fresh, not trigger warning
+        // Back to shell.exec - should start fresh, not trigger warning
         assert!(matches!(
             observe(&mut supervisor, &policy, "shell.exec"),
             ToolLoopSupervisorVerdict::Continue
@@ -1760,22 +1758,14 @@ mod tests {
     }
 
     #[test]
-    fn global_circuit_breaker_trips_when_prospective_total_reaches_limit() {
-        // Mirrors the prospective check in handle_turn_with_runtime:
-        //   let prospective_total = session.total_tool_calls.saturating_add(turn.tool_intents.len());
-        //   if prospective_total >= policy.max_total_tool_calls { ... }
-        let max = 200usize;
-
-        // At 198 with 3 incoming intents: 201 >= 200 → breaker fires
-        assert!(198usize.saturating_add(3) >= max);
-
-        // At 197 with 2 incoming intents: 199 < 200 → breaker does not fire
-        assert!(197usize.saturating_add(2) < max);
-
-        // Exact boundary: 199 + 1 = 200 >= 200 → fires
-        assert!(199usize.saturating_add(1) >= max);
-
-        // Saturating: usize::MAX + 1 does not overflow, still >= max
-        assert!(usize::MAX.saturating_add(1) >= max);
+    fn global_circuit_breaker_allows_reaching_limit_and_trips_only_above_it() {
+        assert_eq!(tool_loop_circuit_breaker_reply(200, 200), None);
+        assert_eq!(
+            tool_loop_circuit_breaker_reply(201, 200).as_deref(),
+            Some(
+                "tool_loop_circuit_breaker: would exceed 201/200 tool calls this turn. Do you want to continue? Reply to resume."
+            )
+        );
+        assert!(tool_loop_circuit_breaker_reply(usize::MAX, 200).is_some());
     }
 }

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -169,7 +169,7 @@ impl ConversationTurnLoop {
             // Global circuit breaker: prospective check before dispatching tools.
             // Trips if adding this round's intents would reach the per-turn limit,
             // ensuring no tools from this round are executed after the cap is hit.
-            let prospective_total = session.total_tool_calls + turn.tool_intents.len();
+            let prospective_total = session.total_tool_calls.saturating_add(turn.tool_intents.len());
             if prospective_total >= policy.max_total_tool_calls {
                 return apply_turn_loop_terminal_action(
                     runtime,

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -750,10 +750,14 @@ impl ToolLoopSupervisor {
                 ),
             };
             return if self.warned_reason_key.as_deref() == Some(reason.key.as_str()) {
-                ToolLoopSupervisorVerdict::HardStop { reason: reason.text }
+                ToolLoopSupervisorVerdict::HardStop {
+                    reason: reason.text,
+                }
             } else {
                 self.warned_reason_key = Some(reason.key);
-                ToolLoopSupervisorVerdict::InjectWarning { reason: reason.text }
+                ToolLoopSupervisorVerdict::InjectWarning {
+                    reason: reason.text,
+                }
             };
         }
 
@@ -1670,7 +1674,11 @@ mod tests {
         }
     }
 
-    fn observe(supervisor: &mut ToolLoopSupervisor, policy: &TurnLoopPolicy, tool_name: &str) -> ToolLoopSupervisorVerdict {
+    fn observe(
+        supervisor: &mut ToolLoopSupervisor,
+        policy: &TurnLoopPolicy,
+        tool_name: &str,
+    ) -> ToolLoopSupervisorVerdict {
         supervisor.observe_round(policy, tool_name, tool_name, "ok", false)
     }
 
@@ -1680,10 +1688,19 @@ mod tests {
         let mut supervisor = ToolLoopSupervisor::default();
 
         // First two calls: below threshold
-        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::Continue));
-        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::Continue));
+        assert!(matches!(
+            observe(&mut supervisor, &policy, "shell.exec"),
+            ToolLoopSupervisorVerdict::Continue
+        ));
+        assert!(matches!(
+            observe(&mut supervisor, &policy, "shell.exec"),
+            ToolLoopSupervisorVerdict::Continue
+        ));
         // Third call: hits threshold (>= 3) → InjectWarning
-        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::InjectWarning { .. }));
+        assert!(matches!(
+            observe(&mut supervisor, &policy, "shell.exec"),
+            ToolLoopSupervisorVerdict::InjectWarning { .. }
+        ));
     }
 
     #[test]
@@ -1696,7 +1713,10 @@ mod tests {
         observe(&mut supervisor, &policy, "shell.exec");
         observe(&mut supervisor, &policy, "shell.exec"); // InjectWarning
         // Same pattern again → HardStop
-        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::HardStop { .. }));
+        assert!(matches!(
+            observe(&mut supervisor, &policy, "shell.exec"),
+            ToolLoopSupervisorVerdict::HardStop { .. }
+        ));
     }
 
     #[test]
@@ -1707,8 +1727,14 @@ mod tests {
         observe(&mut supervisor, &policy, "shell.exec");
         observe(&mut supervisor, &policy, "shell.exec");
         // Switch tool — resets consecutive counter
-        assert!(matches!(observe(&mut supervisor, &policy, "file.read"), ToolLoopSupervisorVerdict::Continue));
+        assert!(matches!(
+            observe(&mut supervisor, &policy, "file.read"),
+            ToolLoopSupervisorVerdict::Continue
+        ));
         // Back to shell.exec — should start fresh, not trigger warning
-        assert!(matches!(observe(&mut supervisor, &policy, "shell.exec"), ToolLoopSupervisorVerdict::Continue));
+        assert!(matches!(
+            observe(&mut supervisor, &policy, "shell.exec"),
+            ToolLoopSupervisorVerdict::Continue
+        ));
     }
 }

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -31,6 +31,18 @@ pub fn next_conversation_turn_id() -> String {
     format!("turn-{nanos:x}-{seq:x}")
 }
 
+pub fn tool_loop_circuit_breaker_reply(
+    prospective_total: usize,
+    max_total_tool_calls: usize,
+) -> Option<String> {
+    (prospective_total > max_total_tool_calls).then(|| {
+        format!(
+            "tool_loop_circuit_breaker: would exceed {}/{} tool calls this turn. Do you want to continue? Reply to resume.",
+            prospective_total, max_total_tool_calls
+        )
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolDrivenFollowupPayload {
     ToolResult { text: String },


### PR DESCRIPTION
## Summary

- Problem: Agents stuck in infinite tool loops burn tokens and run up significant API costs with no automatic stop.
- Why it matters: Without a safety gate, a runaway agent can exhaust a user's API budget silently. This is a P0 MVP blocker.
- What changed: Added two safety gates to the conversation turn loop — (1) a global tool call counter that circuit-breaks and asks the user to continue when the per-turn limit is reached, and (2) a consecutive same-tool-name detector that injects a warning (then hard-stops) when the same tool is called N times in a row.
- What did not change (scope boundary): No changes to existing detectors (`check_no_progress`, `check_ping_pong`, `check_failure_streak`), kernel policy, or provider routing. Ping-pong detection remains P1 out of scope.

## Linked Issues

- Closes #299
- Related #292

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values

Commands and evidence:

```text
$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.39s

$ cargo test --workspace --all-features
test result: ok. 1748 passed; 0 failed; 0 ignored

New tests added:
  consecutive_same_tool_injects_warning_at_threshold ... ok
  consecutive_same_tool_hard_stops_on_repeat_warning ... ok
  consecutive_same_tool_resets_on_tool_name_change ... ok

Config before: ConversationTurnLoopConfig had no global counter or consecutive-tool fields.
Config after:
  max_total_tool_calls: usize  (default: 200)
  max_consecutive_same_tool: usize  (default: 10)
Both fields are additive with serde defaults — zero breaking change for existing configs.
```

## User-visible / Operator-visible Changes

Two new configurable thresholds in `conversation.turn_loop`:

| Field | Default | Behavior |
|-------|---------|----------|
| `max_total_tool_calls` | 200 | When cumulative tool calls this turn reach the limit, the turn terminates with: "Do you want to continue? Reply to resume." |
| `max_consecutive_same_tool` | 10 | When the same tool name is called N times in a row, injects a warning into the next AI prompt; repeating the same warning key triggers a hard stop. |

## Failure Recovery

- Fast rollback or disable path: Set `max_total_tool_calls` and `max_consecutive_same_tool` to large values (e.g., 999999) in config to effectively disable both gates without a code change.
- Observable failure symptoms reviewers should watch for: Circuit breaker firing prematurely on legitimate multi-step tasks where the same tool is correctly called many times (e.g., `file.read` in a large refactor). If so, raise `max_consecutive_same_tool` in operator config.

## Reviewer Focus

- `crates/app/src/conversation/turn_loop.rs` — `observe_round()`: consecutive detection fires before existing pattern checks; verify it does not shadow `check_no_progress` for cases where the full signature also matches.
- `handle_turn_with_runtime()`: global counter increments `turn.tool_intents.len()` after `evaluate_round_kernel()` — counts intents dispatched, not successfully completed. Confirm this is the desired semantics.
- `crates/app/src/config/conversation.rs` — both new fields have `serde(default)` so existing config files without these keys continue to work unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-wide tool-usage limits: configurable total tool calls (default 200) and consecutive same-tool calls (default 10).
  * Warning emitted when consecutive-tool threshold is reached; hard stop enforced on subsequent repeats.

* **Tests**
  * Added unit tests for warning behavior, hard-stop behavior, and counter reset when tool changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->