### PR TITLE
fix(onboard): apply reviewed defaults in non-interactive setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -2894,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1818,7 +1818,7 @@ fn resolve_model_selection(
         if let Some(model) = options.model.as_deref() {
             return Ok(model.trim().to_owned());
         }
-        return Ok(config.provider.configured_model_value());
+        return Ok(resolve_onboarding_model_prompt_default(options, config));
     }
 
     let default_model = resolve_onboarding_model_prompt_default(options, config);
@@ -7811,7 +7811,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_selection_preserves_minimax_auto_non_interactively() {
+    fn resolve_model_selection_applies_minimax_recommended_model_non_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
@@ -7841,8 +7841,8 @@ mod tests {
         .expect("resolve model selection");
 
         assert!(
-            selected == "auto",
-            "non-interactive onboarding should preserve auto for MiniMax instead of silently rewriting the operator config to the reviewed default: {selected:?}"
+            selected == "MiniMax-M2.5",
+            "non-interactive onboarding should use the reviewed provider default for MiniMax instead of carrying auto into preflight: {selected:?}"
         );
     }
 
@@ -7883,7 +7883,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_selection_preserves_deepseek_auto_non_interactively() {
+    fn resolve_model_selection_applies_deepseek_recommended_model_non_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Deepseek;
         config.provider.model = "auto".to_owned();
@@ -7913,8 +7913,8 @@ mod tests {
         .expect("resolve model selection");
 
         assert!(
-            selected == "auto",
-            "non-interactive onboarding should preserve auto for DeepSeek instead of silently rewriting the operator config to the reviewed default: {selected:?}"
+            selected == "deepseek-chat",
+            "non-interactive onboarding should use the reviewed provider default for DeepSeek instead of carrying auto into preflight: {selected:?}"
         );
     }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -865,7 +865,7 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn non_interactive_onboard_preserves_reviewed_auto_when_probe_is_skipped() {
+async fn non_interactive_onboard_applies_reviewed_default_when_probe_is_skipped() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let root = unique_temp_path("non-interactive-reviewed-auto-skip-root");
     std::fs::create_dir_all(&root).expect("create test root");
@@ -890,12 +890,12 @@ async fn non_interactive_onboard_preserves_reviewed_auto_when_probe_is_skipped()
         .expect("load written onboarding config");
     assert_eq!(config.provider.kind, mvp::config::ProviderKind::Deepseek);
     assert_eq!(
-        config.provider.model, "auto",
-        "non-interactive onboarding should preserve model = auto when the operator did not explicitly pin a reviewed provider model"
+        config.provider.model, "deepseek-chat",
+        "non-interactive onboarding should materialize the reviewed provider default so skip-model-probe still leaves a usable explicit model"
     );
     assert!(
-        !raw.contains("model = \"deepseek-chat\""),
-        "skip-model-probe onboarding should not silently rewrite reviewed providers to the reviewed model: {raw}"
+        raw.contains("model = \"deepseek-chat\""),
+        "skip-model-probe onboarding should persist the reviewed model explicitly instead of leaving the config on auto: {raw}"
     );
 }
 
@@ -941,7 +941,7 @@ async fn non_interactive_onboard_allows_explicit_model_probe_warning() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rewriting_config() {
+async fn non_interactive_onboard_applies_reviewed_default_when_probe_fails() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let root = unique_temp_path("non-interactive-reviewed-auto-failure-root");
     std::fs::create_dir_all(&root).expect("create test root");
@@ -960,7 +960,6 @@ async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rew
     config.provider.api_key = Some("test-deepseek-key".to_owned());
     mvp::config::write(Some(output.to_string_lossy().as_ref()), &config, true)
         .expect("write existing config");
-    let original_body = std::fs::read_to_string(&output).expect("read original config");
 
     let mut options = default_non_interactive_onboard_options(&output);
     options.force = true;
@@ -968,21 +967,18 @@ async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rew
 
     let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
     let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
-    let error = crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
         .await
-        .expect_err("reviewed auto-model probe failures should block non-interactive onboarding until the model is pinned explicitly");
+        .expect("reviewed onboarding defaults should let non-interactive onboarding pin a usable explicit model even when catalog probing fails");
 
+    let written = std::fs::read_to_string(&output).expect("read config after onboarding");
     assert!(
-        error.contains("accept reviewed model `deepseek-chat`")
-            && error.contains("provider.model")
-            && error.contains("preferred_models"),
-        "reviewed auto-model probe failures should surface the actionable explicit-model remediation instead of a generic rerun hint: {error}"
+        written.contains("model = \"deepseek-chat\""),
+        "non-interactive onboarding should persist the reviewed model explicitly instead of leaving the provider on auto after a probe warning: {written}"
     );
-    assert_eq!(
-        std::fs::read_to_string(&output).expect("read config after blocked onboard"),
-        original_body,
-        "blocking reviewed auto-model probe failures should leave the existing auto config untouched"
-    );
+    let (_, written_config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(written_config.provider.model, "deepseek-chat");
 
     let requests = server.join().expect("join local provider server");
     assert!(
@@ -991,7 +987,7 @@ async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rew
             request.starts_with("GET /v1/models ")
                 && normalized.contains("authorization: bearer test-deepseek-key")
         }),
-        "reviewed auto-model failures should still attempt the provider model probe before surfacing the actionable remediation: {requests:#?}"
+        "reviewed-default onboarding should still attempt the provider model probe with resolved auth before falling back to the explicit reviewed model: {requests:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -883,7 +883,7 @@ async fn non_interactive_onboard_applies_reviewed_default_when_probe_is_skipped(
         loongclaw_daemon::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
     loongclaw_daemon::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
         .await
-        .expect("skip-model-probe should allow non-interactive onboarding to keep reviewed auto providers on auto");
+        .expect("skip-model-probe should allow non-interactive onboarding to materialize the reviewed default model");
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))


### PR DESCRIPTION
## Summary

- Problem:
  Non-interactive onboarding bypassed the existing reviewed onboarding model policy and preserved `provider.model = "auto"` even for reviewed providers like DeepSeek and MiniMax.
- Why it matters:
  When those providers reject `/models` during setup, onboarding hit a provider-model-probe failure even though the repo already had a reviewed explicit-model recovery path.
- What changed:
  Reused `resolve_onboarding_model_prompt_default()` for non-interactive model selection so the same reviewed default resolution applies in both interactive and non-interactive onboarding. Updated unit and integration coverage to prove reviewed defaults are written explicitly for skipped probe and 401 probe-failure paths.
- What did not change (scope boundary):
  This does not add hidden runtime fallbacks, does not widen the reviewed-provider set, and does not change doctor’s remediation semantics for existing configs that still keep `model = auto`.

## Linked Issues

- Closes #396
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-daemon resolve_model_selection_applies -- --nocapture
- Passed both non-interactive reviewed-default unit tests for DeepSeek and MiniMax.

cargo test -p loongclaw-daemon non_interactive_onboard_applies_reviewed_default --test integration -- --nocapture
- Passed both integration scenarios:
  - skip-model-probe still writes `deepseek-chat`
  - 401 model-probe warning still writes `deepseek-chat`

cargo test -p loongclaw-daemon onboard_cli -- --nocapture
- Passed the full onboarding-focused daemon suite (unit + integration filter).

cargo test -p loongclaw-daemon provider_model_probe_failure_guides_reviewed_default_for_auto_model -- --nocapture
- Passed both onboarding and doctor messaging tests to confirm remediation text stayed aligned.

cargo fmt --all -- --check
- Passed.

cargo test --workspace --locked
- Passed.
```

Before / after:

- Before:
  non-interactive onboarding kept reviewed providers on `model = auto`, so `/models` rejection could still hard-block setup.
- After:
  non-interactive onboarding materializes the reviewed explicit model first, so the same provider policy used by interactive onboarding also unblocks setup without introducing hidden runtime fallback behavior.

Test env note:

- The touched integration tests use the existing environment guards / serialized local test helpers already present in the file (`DetectedEnvironmentGuard`, local probe server, per-test temp paths), so process-global state is restored by the existing test harness patterns.

## User-visible / Operator-visible Changes

- Non-interactive onboarding now writes the reviewed explicit model for providers with a reviewed onboarding default instead of preserving `model = auto`.
- For reviewed providers, setup no longer hard-blocks on `/models` rejection when the existing reviewed explicit model is enough to continue.

## Failure Recovery

- Fast rollback or disable path:
  Revert this commit to restore the old non-interactive `model = auto` behavior.
- Observable failure symptoms reviewers should watch for:
  Non-interactive onboarding unexpectedly overwriting an already explicit `provider.model`, or non-reviewed providers being rewritten away from `auto`.

## Reviewer Focus

- `crates/daemon/src/onboard_cli.rs`
  The non-interactive branch in `resolve_model_selection()` should now reuse the same reviewed-default policy as the interactive path and should still preserve explicit `--model` / explicit config values.
- `crates/daemon/tests/integration/onboard_cli.rs`
  Focus on the skipped-probe and 401-probe flows to confirm we now persist explicit reviewed defaults instead of leaving the config on `auto`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-interactive onboarding to resolve and apply recommended default models instead of preserving placeholder values, ensuring the chosen model is written into the persisted configuration.

* **Tests**
  * Updated non-interactive onboarding tests to expect explicit reviewed-default models, verify persisted config content, and assert probe behavior accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->