### PR TITLE
fix(chat): graceful onboarding prompt when running chat without config

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -38,6 +38,7 @@ use super::memory;
 use super::memory::runtime_config::MemoryRuntimeConfig;
 
 pub const DEFAULT_FIRST_PROMPT: &str = "Summarize this repository and suggest the best next step.";
+const TEST_ONBOARD_EXECUTABLE_ENV: &str = "LOONGCLAW_TEST_ONBOARD_EXECUTABLE";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CliChatOptions {
@@ -66,16 +67,38 @@ fn append_onboard_target_args(
     }
 }
 
+fn resolve_onboard_executable_path() -> CliResult<PathBuf> {
+    if cfg!(debug_assertions)
+        && let Some(executable_path) = std::env::var_os(TEST_ONBOARD_EXECUTABLE_ENV)
+    {
+        return Ok(PathBuf::from(executable_path));
+    }
+
+    std::env::current_exe()
+        .map_err(|error| format!("failed to resolve current executable: {error}"))
+}
+
+fn build_onboard_command_for_executable(
+    executable_path: PathBuf,
+    config_path: Option<&str>,
+    resolved_config_path: &Path,
+) -> std::process::Command {
+    let mut command = std::process::Command::new(executable_path);
+    command.arg("onboard");
+    append_onboard_target_args(&mut command, config_path, resolved_config_path);
+    command
+}
+
 fn build_onboard_command(
     config_path: Option<&str>,
     resolved_config_path: &Path,
 ) -> CliResult<std::process::Command> {
-    let current_exe = std::env::current_exe()
-        .map_err(|error| format!("failed to resolve current executable: {error}"))?;
-    let mut command = std::process::Command::new(current_exe);
-    command.arg("onboard");
-    append_onboard_target_args(&mut command, config_path, resolved_config_path);
-    Ok(command)
+    let executable_path = resolve_onboard_executable_path()?;
+    Ok(build_onboard_command_for_executable(
+        executable_path,
+        config_path,
+        resolved_config_path,
+    ))
 }
 
 fn format_onboard_command_hint(config_path: Option<&str>, resolved_config_path: &Path) -> String {
@@ -1657,6 +1680,7 @@ fn format_average(sum: u64, samples: u32) -> String {
 mod tests {
     use super::*;
     use crate::conversation::ConversationRuntimeBinding;
+    use std::ffi::OsStr;
     use std::path::PathBuf;
     #[cfg(feature = "memory-sqlite")]
     use std::{
@@ -1706,6 +1730,51 @@ mod tests {
     #[test]
     fn cli_chat_options_keep_automatic_routing_without_explicit_acp_inputs() {
         assert!(!CliChatOptions::default().requests_explicit_acp());
+    }
+
+    #[test]
+    fn build_onboard_command_defaults_to_current_executable() {
+        let expected_executable = std::env::current_exe().expect("current executable");
+        let command =
+            build_onboard_command(None, Path::new("/tmp/loongclaw.toml")).expect("onboard command");
+
+        assert_eq!(command.get_program(), expected_executable.as_os_str());
+        assert_eq!(
+            command
+                .get_args()
+                .map(|argument| argument.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["onboard".to_owned()]
+        );
+    }
+
+    #[test]
+    fn build_onboard_command_forwards_explicit_config_path_to_output() {
+        let command = build_onboard_command_for_executable(
+            PathBuf::from("/tmp/loongclaw"),
+            Some("custom.toml"),
+            Path::new("/tmp/custom.toml"),
+        );
+
+        assert_eq!(command.get_program(), OsStr::new("/tmp/loongclaw"));
+        assert_eq!(
+            command
+                .get_args()
+                .map(|argument| argument.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec![
+                "onboard".to_owned(),
+                "--output".to_owned(),
+                "/tmp/custom.toml".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn onboard_command_hint_preserves_explicit_config_path() {
+        let hint = format_onboard_command_hint(Some("custom.toml"), Path::new("/tmp/custom.toml"));
+
+        assert_eq!(hint, "loongclaw onboard --output /tmp/custom.toml");
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -118,8 +118,13 @@ pub async fn run_cli_chat(
         let input = input.trim().to_ascii_lowercase();
 
         if read > 0 && matches!(input.as_str(), "y" | "yes") {
-            let exit_status = std::process::Command::new("loongclaw")
-                .arg("onboard")
+            let mut onboard = std::process::Command::new("loongclaw");
+            onboard.arg("onboard");
+            if config_path.is_some() {
+                onboard.arg("--output").arg(&resolved_config_path);
+            }
+
+            let exit_status = onboard
                 .spawn()
                 .map_err(|e| format!("failed to spawn onboard: {e}"))?
                 .wait()

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -99,19 +99,25 @@ pub async fn run_cli_chat(
     let resolved_config_path = config_path
         .map(config::expand_path)
         .unwrap_or_else(config::default_config_path);
+    let config_exists = resolved_config_path.try_exists().map_err(|error| {
+        format!(
+            "failed to access config path {}: {error}",
+            resolved_config_path.display()
+        )
+    })?;
 
-    if !resolved_config_path.exists() {
+    if !config_exists {
         println!("Welcome to LoongClaw!");
         println!();
         println!("No configuration found. Would you like to run the setup wizard now? [Y/n]");
 
         let mut input = String::new();
-        io::stdin()
+        let read = io::stdin()
             .read_line(&mut input)
             .map_err(|e| format!("read stdin failed: {e}"))?;
-        let input = input.trim().to_lowercase();
+        let input = input.trim().to_ascii_lowercase();
 
-        if input.is_empty() || input == "y" || input == "yes" {
+        if read > 0 && matches!(input.as_str(), "y" | "yes") {
             let exit_status = std::process::Command::new("loongclaw")
                 .arg("onboard")
                 .spawn()

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -56,6 +56,37 @@ impl CliChatOptions {
     }
 }
 
+fn append_onboard_target_args(
+    command: &mut std::process::Command,
+    config_path: Option<&str>,
+    resolved_config_path: &Path,
+) {
+    if config_path.is_some() {
+        command.arg("--output").arg(resolved_config_path);
+    }
+}
+
+fn build_onboard_command(
+    config_path: Option<&str>,
+    resolved_config_path: &Path,
+) -> CliResult<std::process::Command> {
+    let current_exe = std::env::current_exe()
+        .map_err(|error| format!("failed to resolve current executable: {error}"))?;
+    let mut command = std::process::Command::new(current_exe);
+    command.arg("onboard");
+    append_onboard_target_args(&mut command, config_path, resolved_config_path);
+    Ok(command)
+}
+
+fn format_onboard_command_hint(config_path: Option<&str>, resolved_config_path: &Path) -> String {
+    let mut command = String::from("loongclaw onboard");
+    if config_path.is_some() {
+        command.push_str(" --output ");
+        command.push_str(&resolved_config_path.display().to_string());
+    }
+    command
+}
+
 struct CliTurnRuntime {
     resolved_path: PathBuf,
     config: LoongClawConfig,
@@ -107,6 +138,7 @@ pub async fn run_cli_chat(
     })?;
 
     if !config_exists {
+        let onboard_hint = format_onboard_command_hint(config_path, &resolved_config_path);
         println!("Welcome to LoongClaw!");
         println!();
         println!("No configuration found. Would you like to run the setup wizard now? [Y/n]");
@@ -118,11 +150,7 @@ pub async fn run_cli_chat(
         let input = input.trim().to_ascii_lowercase();
 
         if read > 0 && matches!(input.as_str(), "y" | "yes") {
-            let mut onboard = std::process::Command::new("loongclaw");
-            onboard.arg("onboard");
-            if config_path.is_some() {
-                onboard.arg("--output").arg(&resolved_config_path);
-            }
+            let mut onboard = build_onboard_command(config_path, &resolved_config_path)?;
 
             let exit_status = onboard
                 .spawn()
@@ -134,7 +162,7 @@ pub async fn run_cli_chat(
                 return Err(format!("onboard exited with code {:?}", exit_status.code()));
             }
         } else {
-            println!("You can run 'loongclaw onboard' later to get started.");
+            println!("You can run '{onboard_hint}' later to get started.");
         }
         return Ok(());
     }

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -96,6 +96,38 @@ pub async fn run_cli_chat(
     session_hint: Option<&str>,
     options: &CliChatOptions,
 ) -> CliResult<()> {
+    let resolved_config_path = config_path
+        .map(config::expand_path)
+        .unwrap_or_else(config::default_config_path);
+
+    if !resolved_config_path.exists() {
+        println!("Welcome to LoongClaw!");
+        println!();
+        println!("No configuration found. Would you like to run the setup wizard now? [Y/n]");
+
+        let mut input = String::new();
+        io::stdin()
+            .read_line(&mut input)
+            .map_err(|e| format!("read stdin failed: {e}"))?;
+        let input = input.trim().to_lowercase();
+
+        if input.is_empty() || input == "y" || input == "yes" {
+            let exit_status = std::process::Command::new("loongclaw")
+                .arg("onboard")
+                .spawn()
+                .map_err(|e| format!("failed to spawn onboard: {e}"))?
+                .wait()
+                .map_err(|e| format!("failed to wait for onboard: {e}"))?;
+
+            if !exit_status.success() {
+                return Err(format!("onboard exited with code {:?}", exit_status.code()));
+            }
+        } else {
+            println!("You can run 'loongclaw onboard' later to get started.");
+        }
+        return Ok(());
+    }
+
     let runtime =
         initialize_cli_turn_runtime(config_path, session_hint, options, "cli-chat").await?;
     print_cli_chat_startup(&runtime, options)?;

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -1,7 +1,6 @@
 #![cfg(unix)]
 
 use super::*;
-use std::ffi::{OsStr, OsString};
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -22,16 +21,6 @@ fn unique_temp_path(label: &str) -> PathBuf {
         "loongclaw-chat-cli-{label}-{}-{nanos}-{counter}",
         std::process::id(),
     ))
-}
-
-fn prepend_path(dir: &Path) -> OsString {
-    let original_path = std::env::var_os("PATH").unwrap_or_default();
-    let mut path_value = dir.as_os_str().to_os_string();
-    if !original_path.is_empty() {
-        path_value.push(OsStr::new(":"));
-        path_value.push(original_path);
-    }
-    path_value
 }
 
 fn render_output(bytes: &[u8]) -> String {
@@ -64,15 +53,8 @@ struct ChatCliFixture {
     _lock: MutexGuard<'static, ()>,
     root: PathBuf,
     home_dir: PathBuf,
-    bin_dir: PathBuf,
-    chat_binary_path: PathBuf,
+    onboard_binary_path: PathBuf,
     onboard_log_path: PathBuf,
-}
-
-#[derive(Clone, Copy)]
-enum PathMode {
-    IncludeFixtureBinDir,
-    Empty,
 }
 
 impl ChatCliFixture {
@@ -81,54 +63,34 @@ impl ChatCliFixture {
         let root = unique_temp_path(label);
         let home_dir = root.join("home");
         let bin_dir = root.join("bin");
-        let chat_binary_path = bin_dir.join("loongclaw");
+        let onboard_binary_path = bin_dir.join("fake-onboard");
         std::fs::create_dir_all(&home_dir).expect("create fixture home");
         std::fs::create_dir_all(&bin_dir).expect("create fixture bin");
-        std::fs::copy(env!("CARGO_BIN_EXE_loongclaw"), &chat_binary_path)
-            .expect("copy loongclaw chat binary");
-        let mut permissions = std::fs::metadata(&chat_binary_path)
-            .expect("copied loongclaw metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&chat_binary_path, permissions)
-            .expect("mark copied loongclaw executable");
         Self {
             _lock: lock,
             home_dir,
-            bin_dir,
-            chat_binary_path,
+            onboard_binary_path,
             onboard_log_path: root.join("fake-onboard.log"),
             root,
         }
     }
 
-    fn swap_chat_binary_with_fake_onboard(&self, exit_code: i32) {
-        let staged_binary_path = self.bin_dir.join("loongclaw.chat");
-        if !staged_binary_path.exists() {
-            std::fs::rename(&self.chat_binary_path, &staged_binary_path)
-                .expect("stage copied loongclaw binary");
-        }
-
+    fn install_fake_onboard(&self, exit_code: i32) {
         let script = format!(
             "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit {exit_code}\n",
             self.onboard_log_path.display()
         );
-        std::fs::write(&self.chat_binary_path, script).expect("write fake loongclaw script");
-        let mut permissions = std::fs::metadata(&self.chat_binary_path)
+        std::fs::write(&self.onboard_binary_path, script).expect("write fake loongclaw script");
+        let mut permissions = std::fs::metadata(&self.onboard_binary_path)
             .expect("fake loongclaw metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(&self.chat_binary_path, permissions)
+        std::fs::set_permissions(&self.onboard_binary_path, permissions)
             .expect("mark fake loongclaw executable");
     }
 
     fn run_chat_command(&self, config_path: Option<&Path>, stdin_bytes: Option<&[u8]>) -> Output {
-        self.run_chat_command_with_fake_onboard(
-            config_path,
-            stdin_bytes,
-            None,
-            PathMode::IncludeFixtureBinDir,
-        )
+        self.run_chat_command_with_fake_onboard(config_path, stdin_bytes, None)
     }
 
     fn run_chat_command_with_fake_onboard(
@@ -136,9 +98,8 @@ impl ChatCliFixture {
         config_path: Option<&Path>,
         stdin_bytes: Option<&[u8]>,
         fake_onboard_exit_code: Option<i32>,
-        path_mode: PathMode,
     ) -> Output {
-        let mut command = Command::new(&self.chat_binary_path);
+        let mut command = Command::new(env!("CARGO_BIN_EXE_loongclaw"));
         command
             .arg("chat")
             .current_dir(&self.root)
@@ -148,22 +109,18 @@ impl ChatCliFixture {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        match path_mode {
-            PathMode::IncludeFixtureBinDir => {
-                command.env("PATH", prepend_path(&self.bin_dir));
-            }
-            PathMode::Empty => {
-                command.env("PATH", "");
-            }
-        }
         if let Some(config_path) = config_path {
             command.arg("--config").arg(config_path);
         }
+        if let Some(exit_code) = fake_onboard_exit_code {
+            self.install_fake_onboard(exit_code);
+            command.env(
+                "LOONGCLAW_TEST_ONBOARD_EXECUTABLE",
+                &self.onboard_binary_path,
+            );
+        }
 
         let mut child = command.spawn().expect("spawn chat cli");
-        if let Some(exit_code) = fake_onboard_exit_code {
-            self.swap_chat_binary_with_fake_onboard(exit_code);
-        }
         if let Some(stdin_bytes) = stdin_bytes {
             child
                 .stdin
@@ -190,12 +147,7 @@ impl Drop for ChatCliFixture {
 #[test]
 fn chat_without_config_runs_onboard_for_explicit_yes() {
     let fixture = ChatCliFixture::new("explicit-yes");
-    let output = fixture.run_chat_command_with_fake_onboard(
-        None,
-        Some(b"yes\n"),
-        Some(0),
-        PathMode::IncludeFixtureBinDir,
-    );
+    let output = fixture.run_chat_command_with_fake_onboard(None, Some(b"yes\n"), Some(0));
     let stdout = render_output(&output.stdout);
     let stderr = render_output(&output.stderr);
 
@@ -219,12 +171,8 @@ fn chat_without_config_forwards_explicit_config_path_to_onboard() {
     let fixture = ChatCliFixture::new("explicit-config");
     let explicit_config = fixture.root.join("custom-config.toml");
 
-    let output = fixture.run_chat_command_with_fake_onboard(
-        Some(&explicit_config),
-        Some(b"y\n"),
-        Some(0),
-        PathMode::IncludeFixtureBinDir,
-    );
+    let output =
+        fixture.run_chat_command_with_fake_onboard(Some(&explicit_config), Some(b"y\n"), Some(0));
     let stdout = render_output(&output.stdout);
     let stderr = render_output(&output.stderr);
     let onboard_log = fixture.onboard_log();
@@ -320,12 +268,7 @@ fn chat_without_config_treats_eof_as_decline() {
 #[test]
 fn chat_without_config_reports_onboard_failure() {
     let fixture = ChatCliFixture::new("onboard-failure");
-    let output = fixture.run_chat_command_with_fake_onboard(
-        None,
-        Some(b"y\n"),
-        Some(7),
-        PathMode::IncludeFixtureBinDir,
-    );
+    let output = fixture.run_chat_command_with_fake_onboard(None, Some(b"y\n"), Some(7));
     let stdout = render_output(&output.stdout);
     let stderr = render_output(&output.stderr);
 
@@ -337,26 +280,6 @@ fn chat_without_config_reports_onboard_failure() {
     assert!(
         stderr.contains("error: onboard exited with code Some(7)"),
         "stderr should surface the subprocess failure: {stderr:?}"
-    );
-}
-
-#[test]
-fn chat_without_config_reexecutes_current_binary_for_onboard() {
-    let fixture = ChatCliFixture::new("current-exe-reexec");
-
-    let output =
-        fixture.run_chat_command_with_fake_onboard(None, Some(b"y\n"), Some(0), PathMode::Empty);
-    let stdout = render_output(&output.stdout);
-    let stderr = render_output(&output.stderr);
-
-    assert!(
-        output.status.success(),
-        "re-executing onboard through current_exe should not depend on PATH, stdout={stdout:?}, stderr={stderr:?}"
-    );
-    assert!(
-        fixture.onboard_log().contains("onboard"),
-        "accepting onboarding should re-execute the current binary: {:?}",
-        fixture.onboard_log()
     );
 }
 

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -1,0 +1,268 @@
+#![cfg(unix)]
+
+use super::*;
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::MutexGuard;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static CHAT_CLI_TEMP_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_temp_path(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let counter = CHAT_CLI_TEMP_PATH_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "loongclaw-chat-cli-{label}-{}-{nanos}-{counter}",
+        std::process::id(),
+    ))
+}
+
+fn prepend_path(dir: &Path) -> OsString {
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut path_value = dir.as_os_str().to_os_string();
+    if !original_path.is_empty() {
+        path_value.push(OsStr::new(":"));
+        path_value.push(original_path);
+    }
+    path_value
+}
+
+fn render_output(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+struct PermissionsResetGuard {
+    path: PathBuf,
+    permissions: std::fs::Permissions,
+}
+
+impl PermissionsResetGuard {
+    fn new(path: &Path) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            permissions: std::fs::metadata(path)
+                .expect("metadata for permission reset")
+                .permissions(),
+        }
+    }
+}
+
+impl Drop for PermissionsResetGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::set_permissions(&self.path, self.permissions.clone());
+    }
+}
+
+struct ChatCliFixture {
+    _lock: MutexGuard<'static, ()>,
+    root: PathBuf,
+    home_dir: PathBuf,
+    bin_dir: PathBuf,
+    onboard_log_path: PathBuf,
+}
+
+impl ChatCliFixture {
+    fn new(label: &str) -> Self {
+        let lock = lock_daemon_test_environment();
+        let root = unique_temp_path(label);
+        let home_dir = root.join("home");
+        let bin_dir = root.join("bin");
+        std::fs::create_dir_all(&home_dir).expect("create fixture home");
+        std::fs::create_dir_all(&bin_dir).expect("create fixture bin");
+        Self {
+            _lock: lock,
+            home_dir,
+            bin_dir,
+            onboard_log_path: root.join("fake-onboard.log"),
+            root,
+        }
+    }
+
+    fn install_fake_loongclaw(&self, exit_code: i32) {
+        let script_path = self.bin_dir.join("loongclaw");
+        let script = format!(
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit {exit_code}\n",
+            self.onboard_log_path.display()
+        );
+        std::fs::write(&script_path, script).expect("write fake loongclaw script");
+        let mut permissions = std::fs::metadata(&script_path)
+            .expect("fake loongclaw metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script_path, permissions)
+            .expect("mark fake loongclaw executable");
+    }
+
+    fn run_chat_command(&self, config_path: Option<&Path>, stdin_bytes: Option<&[u8]>) -> Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_loongclaw"));
+        command
+            .arg("chat")
+            .current_dir(&self.root)
+            .env("HOME", &self.home_dir)
+            .env("PATH", prepend_path(&self.bin_dir))
+            .env_remove("LOONGCLAW_CONFIG_PATH")
+            .env_remove("USERPROFILE")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(config_path) = config_path {
+            command.arg("--config").arg(config_path);
+        }
+
+        let mut child = command.spawn().expect("spawn chat cli");
+        if let Some(stdin_bytes) = stdin_bytes {
+            child
+                .stdin
+                .as_mut()
+                .expect("chat stdin")
+                .write_all(stdin_bytes)
+                .expect("write chat stdin");
+        }
+        drop(child.stdin.take());
+        child.wait_with_output().expect("wait for chat cli output")
+    }
+
+    fn onboard_log(&self) -> String {
+        std::fs::read_to_string(&self.onboard_log_path).unwrap_or_default()
+    }
+}
+
+impl Drop for ChatCliFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn chat_without_config_runs_onboard_for_explicit_yes() {
+    let fixture = ChatCliFixture::new("explicit-yes");
+    fixture.install_fake_loongclaw(0);
+
+    let output = fixture.run_chat_command(None, Some(b"yes\n"));
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "explicit yes should succeed, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("Welcome to LoongClaw!"),
+        "missing-config onboarding flow should greet the user: {stdout:?}"
+    );
+    assert!(
+        fixture.onboard_log().contains("onboard"),
+        "explicit yes should invoke `loongclaw onboard`: {:?}",
+        fixture.onboard_log()
+    );
+}
+
+#[test]
+fn chat_without_config_treats_blank_line_as_decline() {
+    let fixture = ChatCliFixture::new("blank-line");
+    fixture.install_fake_loongclaw(0);
+
+    let output = fixture.run_chat_command(None, Some(b"\n"));
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "blank input should exit cleanly, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        fixture.onboard_log().is_empty(),
+        "blank input should not auto-run onboarding: {:?}",
+        fixture.onboard_log()
+    );
+    assert!(
+        stdout.contains("You can run 'loongclaw onboard' later to get started."),
+        "blank input should leave a follow-up hint: {stdout:?}"
+    );
+}
+
+#[test]
+fn chat_without_config_treats_eof_as_decline() {
+    let fixture = ChatCliFixture::new("eof");
+    fixture.install_fake_loongclaw(0);
+
+    let output = fixture.run_chat_command(None, None);
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "eof should exit cleanly, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        fixture.onboard_log().is_empty(),
+        "eof should not auto-run onboarding: {:?}",
+        fixture.onboard_log()
+    );
+    assert!(
+        stdout.contains("You can run 'loongclaw onboard' later to get started."),
+        "eof should still leave the follow-up hint: {stdout:?}"
+    );
+}
+
+#[test]
+fn chat_without_config_reports_onboard_failure() {
+    let fixture = ChatCliFixture::new("onboard-failure");
+    fixture.install_fake_loongclaw(7);
+
+    let output = fixture.run_chat_command(None, Some(b"y\n"));
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "failing onboard should bubble up as a cli error, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stderr.contains("error: onboard exited with code Some(7)"),
+        "stderr should surface the subprocess failure: {stderr:?}"
+    );
+}
+
+#[test]
+fn chat_without_config_surfaces_config_path_access_errors() {
+    let fixture = ChatCliFixture::new("config-access-error");
+    fixture.install_fake_loongclaw(0);
+
+    let blocked_dir = fixture.root.join("blocked");
+    std::fs::create_dir_all(&blocked_dir).expect("create blocked directory");
+    let _reset_guard = PermissionsResetGuard::new(&blocked_dir);
+    let mut permissions = std::fs::metadata(&blocked_dir)
+        .expect("blocked directory metadata")
+        .permissions();
+    permissions.set_mode(0o000);
+    std::fs::set_permissions(&blocked_dir, permissions).expect("lock blocked directory");
+    let blocked_config = blocked_dir.join("loongclaw.toml");
+
+    let output = fixture.run_chat_command(Some(&blocked_config), None);
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "config access errors should not fall into onboarding, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stderr.contains("failed to access config path"),
+        "stderr should report the path access failure: {stderr:?}"
+    );
+    assert!(
+        fixture.onboard_log().is_empty(),
+        "path access errors should not invoke onboarding: {:?}",
+        fixture.onboard_log()
+    );
+}

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -165,6 +165,31 @@ fn chat_without_config_runs_onboard_for_explicit_yes() {
 }
 
 #[test]
+fn chat_without_config_forwards_explicit_config_path_to_onboard() {
+    let fixture = ChatCliFixture::new("explicit-config");
+    fixture.install_fake_loongclaw(0);
+    let explicit_config = fixture.root.join("custom-config.toml");
+
+    let output = fixture.run_chat_command(Some(&explicit_config), Some(b"y\n"));
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+    let onboard_log = fixture.onboard_log();
+
+    assert!(
+        output.status.success(),
+        "explicit config path should still succeed, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        onboard_log.contains("onboard --output"),
+        "explicit config path should be forwarded to onboarding output args: {onboard_log:?}"
+    );
+    assert!(
+        onboard_log.contains(&explicit_config.display().to_string()),
+        "explicit config path should be passed through to onboarding: {onboard_log:?}"
+    );
+}
+
+#[test]
 fn chat_without_config_treats_blank_line_as_decline() {
     let fixture = ChatCliFixture::new("blank-line");
     fixture.install_fake_loongclaw(0);

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -65,7 +65,14 @@ struct ChatCliFixture {
     root: PathBuf,
     home_dir: PathBuf,
     bin_dir: PathBuf,
+    chat_binary_path: PathBuf,
     onboard_log_path: PathBuf,
+}
+
+#[derive(Clone, Copy)]
+enum PathMode {
+    IncludeFixtureBinDir,
+    Empty,
 }
 
 impl ChatCliFixture {
@@ -74,49 +81,89 @@ impl ChatCliFixture {
         let root = unique_temp_path(label);
         let home_dir = root.join("home");
         let bin_dir = root.join("bin");
+        let chat_binary_path = bin_dir.join("loongclaw");
         std::fs::create_dir_all(&home_dir).expect("create fixture home");
         std::fs::create_dir_all(&bin_dir).expect("create fixture bin");
+        std::fs::copy(env!("CARGO_BIN_EXE_loongclaw"), &chat_binary_path)
+            .expect("copy loongclaw chat binary");
+        let mut permissions = std::fs::metadata(&chat_binary_path)
+            .expect("copied loongclaw metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&chat_binary_path, permissions)
+            .expect("mark copied loongclaw executable");
         Self {
             _lock: lock,
             home_dir,
             bin_dir,
+            chat_binary_path,
             onboard_log_path: root.join("fake-onboard.log"),
             root,
         }
     }
 
-    fn install_fake_loongclaw(&self, exit_code: i32) {
-        let script_path = self.bin_dir.join("loongclaw");
+    fn swap_chat_binary_with_fake_onboard(&self, exit_code: i32) {
+        let staged_binary_path = self.bin_dir.join("loongclaw.chat");
+        if !staged_binary_path.exists() {
+            std::fs::rename(&self.chat_binary_path, &staged_binary_path)
+                .expect("stage copied loongclaw binary");
+        }
+
         let script = format!(
             "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit {exit_code}\n",
             self.onboard_log_path.display()
         );
-        std::fs::write(&script_path, script).expect("write fake loongclaw script");
-        let mut permissions = std::fs::metadata(&script_path)
+        std::fs::write(&self.chat_binary_path, script).expect("write fake loongclaw script");
+        let mut permissions = std::fs::metadata(&self.chat_binary_path)
             .expect("fake loongclaw metadata")
             .permissions();
         permissions.set_mode(0o755);
-        std::fs::set_permissions(&script_path, permissions)
+        std::fs::set_permissions(&self.chat_binary_path, permissions)
             .expect("mark fake loongclaw executable");
     }
 
     fn run_chat_command(&self, config_path: Option<&Path>, stdin_bytes: Option<&[u8]>) -> Output {
-        let mut command = Command::new(env!("CARGO_BIN_EXE_loongclaw"));
+        self.run_chat_command_with_fake_onboard(
+            config_path,
+            stdin_bytes,
+            None,
+            PathMode::IncludeFixtureBinDir,
+        )
+    }
+
+    fn run_chat_command_with_fake_onboard(
+        &self,
+        config_path: Option<&Path>,
+        stdin_bytes: Option<&[u8]>,
+        fake_onboard_exit_code: Option<i32>,
+        path_mode: PathMode,
+    ) -> Output {
+        let mut command = Command::new(&self.chat_binary_path);
         command
             .arg("chat")
             .current_dir(&self.root)
             .env("HOME", &self.home_dir)
-            .env("PATH", prepend_path(&self.bin_dir))
             .env_remove("LOONGCLAW_CONFIG_PATH")
             .env_remove("USERPROFILE")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        match path_mode {
+            PathMode::IncludeFixtureBinDir => {
+                command.env("PATH", prepend_path(&self.bin_dir));
+            }
+            PathMode::Empty => {
+                command.env("PATH", "");
+            }
+        }
         if let Some(config_path) = config_path {
             command.arg("--config").arg(config_path);
         }
 
         let mut child = command.spawn().expect("spawn chat cli");
+        if let Some(exit_code) = fake_onboard_exit_code {
+            self.swap_chat_binary_with_fake_onboard(exit_code);
+        }
         if let Some(stdin_bytes) = stdin_bytes {
             child
                 .stdin
@@ -143,9 +190,12 @@ impl Drop for ChatCliFixture {
 #[test]
 fn chat_without_config_runs_onboard_for_explicit_yes() {
     let fixture = ChatCliFixture::new("explicit-yes");
-    fixture.install_fake_loongclaw(0);
-
-    let output = fixture.run_chat_command(None, Some(b"yes\n"));
+    let output = fixture.run_chat_command_with_fake_onboard(
+        None,
+        Some(b"yes\n"),
+        Some(0),
+        PathMode::IncludeFixtureBinDir,
+    );
     let stdout = render_output(&output.stdout);
     let stderr = render_output(&output.stderr);
 
@@ -167,10 +217,14 @@ fn chat_without_config_runs_onboard_for_explicit_yes() {
 #[test]
 fn chat_without_config_forwards_explicit_config_path_to_onboard() {
     let fixture = ChatCliFixture::new("explicit-config");
-    fixture.install_fake_loongclaw(0);
     let explicit_config = fixture.root.join("custom-config.toml");
 
-    let output = fixture.run_chat_command(Some(&explicit_config), Some(b"y\n"));
+    let output = fixture.run_chat_command_with_fake_onboard(
+        Some(&explicit_config),
+        Some(b"y\n"),
+        Some(0),
+        PathMode::IncludeFixtureBinDir,
+    );
     let stdout = render_output(&output.stdout);
     let stderr = render_output(&output.stderr);
     let onboard_log = fixture.onboard_log();
@@ -190,9 +244,36 @@ fn chat_without_config_forwards_explicit_config_path_to_onboard() {
 }
 
 #[test]
+fn chat_without_config_decline_hint_preserves_explicit_config_path() {
+    let fixture = ChatCliFixture::new("decline-explicit-config");
+    let explicit_config = fixture.root.join("custom-config.toml");
+
+    let output = fixture.run_chat_command(Some(&explicit_config), Some(b"\n"));
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+    let expected_hint = format!(
+        "You can run 'loongclaw onboard --output {}' later to get started.",
+        explicit_config.display()
+    );
+
+    assert!(
+        output.status.success(),
+        "declining with an explicit config path should still exit cleanly, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        fixture.onboard_log().is_empty(),
+        "declining should not spawn onboarding: {:?}",
+        fixture.onboard_log()
+    );
+    assert!(
+        stdout.contains(&expected_hint),
+        "decline hint should preserve the explicit config path: {stdout:?}"
+    );
+}
+
+#[test]
 fn chat_without_config_treats_blank_line_as_decline() {
     let fixture = ChatCliFixture::new("blank-line");
-    fixture.install_fake_loongclaw(0);
 
     let output = fixture.run_chat_command(None, Some(b"\n"));
     let stdout = render_output(&output.stdout);
@@ -216,7 +297,6 @@ fn chat_without_config_treats_blank_line_as_decline() {
 #[test]
 fn chat_without_config_treats_eof_as_decline() {
     let fixture = ChatCliFixture::new("eof");
-    fixture.install_fake_loongclaw(0);
 
     let output = fixture.run_chat_command(None, None);
     let stdout = render_output(&output.stdout);
@@ -240,9 +320,12 @@ fn chat_without_config_treats_eof_as_decline() {
 #[test]
 fn chat_without_config_reports_onboard_failure() {
     let fixture = ChatCliFixture::new("onboard-failure");
-    fixture.install_fake_loongclaw(7);
-
-    let output = fixture.run_chat_command(None, Some(b"y\n"));
+    let output = fixture.run_chat_command_with_fake_onboard(
+        None,
+        Some(b"y\n"),
+        Some(7),
+        PathMode::IncludeFixtureBinDir,
+    );
     let stdout = render_output(&output.stdout);
     let stderr = render_output(&output.stderr);
 
@@ -258,9 +341,28 @@ fn chat_without_config_reports_onboard_failure() {
 }
 
 #[test]
+fn chat_without_config_reexecutes_current_binary_for_onboard() {
+    let fixture = ChatCliFixture::new("current-exe-reexec");
+
+    let output =
+        fixture.run_chat_command_with_fake_onboard(None, Some(b"y\n"), Some(0), PathMode::Empty);
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "re-executing onboard through current_exe should not depend on PATH, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        fixture.onboard_log().contains("onboard"),
+        "accepting onboarding should re-execute the current binary: {:?}",
+        fixture.onboard_log()
+    );
+}
+
+#[test]
 fn chat_without_config_surfaces_config_path_access_errors() {
     let fixture = ChatCliFixture::new("config-access-error");
-    fixture.install_fake_loongclaw(0);
 
     let blocked_dir = fixture.root.join("blocked");
     std::fs::create_dir_all(&blocked_dir).expect("create blocked directory");

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -24,6 +24,7 @@ fn validation_diagnostic_with_severity(
 
 mod acp;
 mod architecture;
+mod chat_cli;
 mod cli_tests;
 mod doctor_feishu;
 mod feishu_cli;


### PR DESCRIPTION
## Summary

- **Problem**: When users run `loongclaw chat` without a config file, they see technical error messages exposing internal details (file paths, os error 2), causing confusion.
- **Why it matters**: New users or users with deleted configs see cryptic errors on first try, potentially thinking the tool is broken.
- **What changed**: Added a config existence check at the `run_cli_chat` entry point. When no config is found, displays a friendly welcome message and prompts the user to run the onboard wizard, spawning a subprocess to execute it.
- **What did not change (scope boundary)**: Core `config::load()` function unchanged; `loongclaw ask` command behavior unchanged.

## Linked Issues

- Closes #399

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas

Commands and evidence:

```text
cargo fmt --all -- --check  # passed
cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings  # passed
```

## User-visible / Operator-visible Changes

- `loongclaw chat` without config shows a friendly welcome message and "Would you like to run the setup wizard now? [Y/n]" prompt
- User selects Y -> automatically runs `loongclaw onboard`, exits after onboard completes (does not re-enter chat)
- User selects n -> shows hint message and exits with code 0

## Failure Recovery

- Fast rollback or disable path: Revert this commit to restore original behavior
- Observable failure symptoms reviewers should watch for: N/A (only affects the no-config path of chat command)

## Reviewer Focus

- `crates/app/src/chat.rs` lines 99-129: New config check and onboard guidance logic
- Confirm exit code handling is correct (returns 0 on user cancel, error on onboard failure)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI expands and checks config path at startup; if missing, prompts to run onboarding, launches onboarding on acceptance (forwards explicit config path) or defers setup without starting chat.
* **Bug Fixes**
  * Onboarding subprocess failures and inaccessible config paths now produce clear error exit codes and messages.
* **Tests**
  * Added integration tests covering prompts, argument forwarding, subprocess failures, EOF/blank input, and permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->