### PR TITLE
feat: add linux musl release contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ env:
   BIN_NAME: loongclaw
   PACKAGE_NAME: loongclaw
   CROSS_VERSION: "0.2.5"
-  LINUX_X86_64_GLIBC_FLOOR: "2.39"
-  LINUX_ARM64_GLIBC_FLOOR: "2.17"
 
 jobs:
   verify-release:
@@ -160,14 +158,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          case "${{ matrix.target }}" in
-            x86_64-unknown-linux-gnu) max_glibc="${{ env.LINUX_X86_64_GLIBC_FLOOR }}" ;;
-            aarch64-unknown-linux-gnu) max_glibc="${{ env.LINUX_ARM64_GLIBC_FLOOR }}" ;;
-            *)
-              echo "unsupported GNU Linux target for glibc floor verification: ${{ matrix.target }}" >&2
-              exit 1
-              ;;
-          esac
+          . ./scripts/release_artifact_lib.sh
+          max_glibc="$(release_gnu_glibc_floor_for_target "${{ matrix.target }}")"
           ./scripts/check_glibc_floor.sh "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}" "$max_glibc"
 
       - name: Upload packaged artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ env:
   BIN_NAME: loongclaw
   PACKAGE_NAME: loongclaw
   CROSS_VERSION: "0.2.5"
+  LINUX_X86_64_GLIBC_FLOOR: "2.39"
   LINUX_ARM64_GLIBC_FLOOR: "2.17"
 
 jobs:
@@ -72,6 +73,11 @@ jobs:
             ext: ""
             archive: tar.gz
           - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            ext: ""
+            archive: tar.gz
+            install_musl_tools: true
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             ext: ""
             archive: tar.gz
@@ -104,6 +110,10 @@ jobs:
 
       - name: Cache Cargo Artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+
+      - name: Install musl tools
+        if: matrix.install_musl_tools == true
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Install cross (if needed)
         if: matrix.use_cross == true
@@ -145,9 +155,20 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 "dist/$archive").Hash.ToLowerInvariant()
           Set-Content -Path "dist/$archive.sha256" -Value "$hash  $archive"
 
-      - name: Verify glibc floor (Linux ARM64 only)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: ./scripts/check_glibc_floor.sh "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}" "${{ env.LINUX_ARM64_GLIBC_FLOOR }}"
+      - name: Verify glibc floor (Linux GNU targets)
+        if: endsWith(matrix.target, '-unknown-linux-gnu')
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-gnu) max_glibc="${{ env.LINUX_X86_64_GLIBC_FLOOR }}" ;;
+            aarch64-unknown-linux-gnu) max_glibc="${{ env.LINUX_ARM64_GLIBC_FLOOR }}" ;;
+            *)
+              echo "unsupported GNU Linux target for glibc floor verification: ${{ matrix.target }}" >&2
+              exit 1
+              ;;
+          esac
+          ./scripts/check_glibc_floor.sh "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}" "$max_glibc"
 
       - name: Upload packaged artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 ---
 
 <a id="why-loong"></a>
+
 ## Why Loong
 
 We chose **Loong** deliberately.
@@ -86,6 +87,7 @@ and build useful things together, that matters more to us.
 </p>
 
 <a id="product-positioning"></a>
+
 ## Product Positioning
 
 <p align="center">
@@ -99,15 +101,15 @@ baseline with explicit boundaries and room to keep taking shape**. If you only l
 commands like `onboard`, `ask`, or `chat`, you miss the more important story: the codebase already
 contains several layers that matter to teams.
 
-| Core capability | What is already real | Why it matters |
-|-----------------|----------------------|----------------|
-| Governance-native execution | capability tokens, policy decisions, approval requests, and audit events already sit in critical execution paths | this is much closer to a team system than to a single-user demo |
-| Explicit execution planes | `connector`, `runtime`, `tool`, and `memory` are separate kernel planes with symmetric core / extension registration | vertical shaping can replace planes instead of repeatedly rewriting the kernel |
-| Separate control plane | ACP already exists as its own control plane across backend, binding, registry, runtime, analytics, and store modules | future routing, collaboration, and richer agent lifecycle work have a place to live |
-| Shapeable context | the context engine already has `bootstrap`, `ingest`, `after_turn`, `compact_context`, and subagent hooks | context and memory are not hardcoded into a single prompt builder |
-| Runtime-truthful tool surface | the tool catalog carries risk classes, approval modes, and `Runtime / Planned` visibility | what users see is closer to what the system can actually do right now |
-| Migration-aware setup | `onboard` can detect current setup, Codex config, environment, and workspace guidance; the public migration CLI is now `loongclaw migrate` | teams do not have to rebuild configuration and long-lived context from scratch |
-| Multi-surface delivery | beyond CLI, Telegram, Feishu / Lark, and Matrix already exist as runtime-backed surfaces with typed config, routing, and security validation | the product already reaches beyond a local terminal-only experiment |
+| Core capability               | What is already real                                                                                                                         | Why it matters                                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Governance-native execution   | capability tokens, policy decisions, approval requests, and audit events already sit in critical execution paths                             | this is much closer to a team system than to a single-user demo                     |
+| Explicit execution planes     | `connector`, `runtime`, `tool`, and `memory` are separate kernel planes with symmetric core / extension registration                         | vertical shaping can replace planes instead of repeatedly rewriting the kernel      |
+| Separate control plane        | ACP already exists as its own control plane across backend, binding, registry, runtime, analytics, and store modules                         | future routing, collaboration, and richer agent lifecycle work have a place to live |
+| Shapeable context             | the context engine already has `bootstrap`, `ingest`, `after_turn`, `compact_context`, and subagent hooks                                    | context and memory are not hardcoded into a single prompt builder                   |
+| Runtime-truthful tool surface | the tool catalog carries risk classes, approval modes, and `Runtime / Planned` visibility                                                    | what users see is closer to what the system can actually do right now               |
+| Migration-aware setup         | `onboard` can detect current setup, Codex config, environment, and workspace guidance; the public migration CLI is now `loongclaw migrate`   | teams do not have to rebuild configuration and long-lived context from scratch      |
+| Multi-surface delivery        | beyond CLI, Telegram, Feishu / Lark, and Matrix already exist as runtime-backed surfaces with typed config, routing, and security validation | the product already reaches beyond a local terminal-only experiment                 |
 
 That is why we increasingly describe LoongClaw as an early foundation for vertical agents. The
 governance boundary, extension boundary, and delivery boundary are already visible today.
@@ -127,6 +129,7 @@ goal is not only to connect models to chat surfaces, but to grow a base layer th
 bridge digital systems and real-world action.
 
 <a id="why-teams-build-on-loongclaw"></a>
+
 ## Why Teams Build On LoongClaw
 
 If you place LoongClaw against a few common AI-agent product shapes, it sits between a runnable
@@ -135,20 +138,21 @@ solving team problems earlier instead of postponing them.
 
 ### Design-Orientation Comparison
 
-| Design orientation | Assistant-first products | Framework-first products | LoongClaw |
-|--------------------|--------------------------|--------------------------|-----------|
-| Starting point | optimize single-user chat experience first | offer a flexible but relatively empty builder layer first | ship a runnable baseline while bringing in team-facing boundaries early |
-| Governance | often added through perimeter systems later | possible, but usually requires extra integration work | policy, approval, and audit are modeled inside critical execution paths |
-| Extension model | often grows through plugins and scripts later | highly flexible, but each team may rebuild its own stack | extend through planes, adapters, packs, and channels with clearer boundaries |
-| Delivery surfaces | often stop at CLI or a single chat UI | often thin on built-in delivery surfaces | CLI, Telegram, Feishu / Lark, and Matrix are already real delivery surfaces |
-| Vertical evolution | can stall at being "a better assistant" | can stall at "you can build it yourself" | aims to keep shaping vertical agents on top of a stable Rust base |
-| Long-term edge | usually software-assistant-centric | usually orchestration-centric | leaves room for hardware, robotics, and embodied intelligence over time |
+| Design orientation | Assistant-first products                      | Framework-first products                                  | LoongClaw                                                                    |
+| ------------------ | --------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Starting point     | optimize single-user chat experience first    | offer a flexible but relatively empty builder layer first | ship a runnable baseline while bringing in team-facing boundaries early      |
+| Governance         | often added through perimeter systems later   | possible, but usually requires extra integration work     | policy, approval, and audit are modeled inside critical execution paths      |
+| Extension model    | often grows through plugins and scripts later | highly flexible, but each team may rebuild its own stack  | extend through planes, adapters, packs, and channels with clearer boundaries |
+| Delivery surfaces  | often stop at CLI or a single chat UI         | often thin on built-in delivery surfaces                  | CLI, Telegram, Feishu / Lark, and Matrix are already real delivery surfaces  |
+| Vertical evolution | can stall at being "a better assistant"       | can stall at "you can build it yourself"                  | aims to keep shaping vertical agents on top of a stable Rust base            |
+| Long-term edge     | usually software-assistant-centric            | usually orchestration-centric                             | leaves room for hardware, robotics, and embodied intelligence over time      |
 
 <p align="center">
   <img src="assets/readme/loongclaw-foundation-diagram.svg" alt="LoongClaw foundation diagram" width="100%" />
 </p>
 
 <a id="quick-start"></a>
+
 ## Quick Start
 
 ### Install Script
@@ -156,12 +160,23 @@ solving team problems earlier instead of postponing them.
 The install script prefers the matching GitHub Release binary, verifies its SHA256 checksum,
 installs `loongclaw`, and can drop you straight into guided onboarding.
 
+On Linux x86_64, the installer now treats GNU and musl as distinct release artifacts:
+
+- it prefers `x86_64-unknown-linux-gnu` when the host glibc satisfies the declared GNU floor
+- it falls back to `x86_64-unknown-linux-musl` when glibc is too old or cannot be detected
+- you can override the default with `--target-libc gnu|musl` or `LOONGCLAW_INSTALL_TARGET_LIBC`
+
 <details>
 <summary>Linux / macOS</summary>
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts/install.sh | bash -s -- --onboard
 ```
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts/install.sh | bash -s -- --target-libc musl
+```
+
 </details>
 
 <details>
@@ -172,6 +187,7 @@ $script = Join-Path $env:TEMP "loongclaw-install.ps1"
 Invoke-WebRequest https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts/install.ps1 -OutFile $script
 pwsh $script -Onboard
 ```
+
 </details>
 
 ### Build From Source
@@ -190,6 +206,7 @@ pwsh ./scripts/install.ps1 -Source -Onboard
 ```bash
 cargo install --path crates/daemon
 ```
+
 </details>
 
 ### Shell Completion
@@ -221,6 +238,7 @@ loongclaw completions powershell >> $PROFILE
 ```elvish
 loongclaw completions elvish >> ~/.config/elvish/rc.elv
 ```
+
 </details>
 
 ### First Success Path
@@ -425,6 +443,7 @@ Further references:
 - `loongclaw validate-config --config ~/.loongclaw/config.toml --json`
 
 <a id="migrate-existing-setup"></a>
+
 ## Migrate Existing Setup from Other Claws or Agents
 
 LoongClaw does not assume teams should start from zero.
@@ -454,6 +473,7 @@ loongclaw migrate --mode rollback_last_apply --output ~/.loongclaw/config.toml
 Deeper migration modes also exist, including `merge_profiles` for multi-source profile merging and `map_external_skills` for external-skills artifact mapping.
 
 <a id="core-capabilities"></a>
+
 ## Core Capabilities
 
 ### Governance And Controlled Execution
@@ -501,15 +521,15 @@ contracts (leaf -- zero internal deps)
 └── daemon (binary) --> all of the above
 ```
 
-| Crate | Role |
-|-------|------|
-| `contracts` | Stable shared ABI surface |
-| `kernel` | Policy, audit, capability, pack, and governance core |
-| `protocol` | Typed transport and routing contracts |
-| `app` | Providers, tools, channels, memory, and conversation runtime |
-| `spec` | Deterministic execution specs |
-| `bench` | Benchmark harness and gates |
-| `daemon` | Runnable CLI binary and operator-facing commands |
+| Crate       | Role                                                         |
+| ----------- | ------------------------------------------------------------ |
+| `contracts` | Stable shared ABI surface                                    |
+| `kernel`    | Policy, audit, capability, pack, and governance core         |
+| `protocol`  | Typed transport and routing contracts                        |
+| `app`       | Providers, tools, channels, memory, and conversation runtime |
+| `spec`      | Deterministic execution specs                                |
+| `bench`     | Benchmark harness and gates                                  |
+| `daemon`    | Runnable CLI binary and operator-facing commands             |
 
 Three design rules matter most:
 
@@ -531,21 +551,23 @@ Some ecosystem pieces are still better described as architecture direction than 
 For the full layered execution model, see [ARCHITECTURE.md](ARCHITECTURE.md) and [Layered Kernel Design](docs/design-docs/layered-kernel-design.md).
 
 <a id="documentation"></a>
+
 ## Documentation
 
-| Document | Description |
-|----------|-------------|
-| [Architecture](ARCHITECTURE.md) | Crate map and layered execution overview |
-| [Core Beliefs](docs/design-docs/core-beliefs.md) | Core engineering principles |
-| [Roadmap](docs/ROADMAP.md) | Stage-based milestones and direction |
-| [Product Sense](docs/PRODUCT_SENSE.md) | Current product contract and user journey |
-| [Product Specs](docs/product-specs/index.md) | User-facing requirements for onboarding, ask, doctor, channels, and memory |
+| Document                                                    | Description                                                                                                 |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [Architecture](ARCHITECTURE.md)                             | Crate map and layered execution overview                                                                    |
+| [Core Beliefs](docs/design-docs/core-beliefs.md)            | Core engineering principles                                                                                 |
+| [Roadmap](docs/ROADMAP.md)                                  | Stage-based milestones and direction                                                                        |
+| [Product Sense](docs/PRODUCT_SENSE.md)                      | Current product contract and user journey                                                                   |
+| [Product Specs](docs/product-specs/index.md)                | User-facing requirements for onboarding, ask, doctor, channels, and memory                                  |
 | [Contribution Areas](docs/references/contribution-areas.md) | The kinds of design, engineering, docs, and community help that would make the biggest difference right now |
-| [Reliability](docs/RELIABILITY.md) | Build and kernel invariants |
-| [Security](SECURITY.md) | Security policy and disclosure path |
-| [Changelog](CHANGELOG.md) | Release history |
+| [Reliability](docs/RELIABILITY.md)                          | Build and kernel invariants                                                                                 |
+| [Security](SECURITY.md)                                     | Security policy and disclosure path                                                                         |
+| [Changelog](CHANGELOG.md)                                   | Release history                                                                                             |
 
 <a id="contributing"></a>
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.

--- a/docs/plans/2026-03-20-linux-musl-release-contract-design.md
+++ b/docs/plans/2026-03-20-linux-musl-release-contract-design.md
@@ -1,0 +1,304 @@
+# Linux Musl Release Contract Design
+
+## Context
+
+As of 2026-03-20, the latest public GitHub release is `v0.1.0-alpha.2`. The
+published Linux asset is still GNU-only, and a Debian 12 reproduction confirms
+that the shipped `x86_64-unknown-linux-gnu` binary requires `GLIBC_2.38` and
+`GLIBC_2.39` while Debian 12 provides glibc 2.36.
+
+The current product code reflects that same contract:
+
+- `scripts/release_artifact_lib.sh` resolves Linux targets only to GNU triples
+- `scripts/install.sh` downloads only the resolved GNU archive for Linux
+- `.github/workflows/release.yml` publishes GNU Linux artifacts only
+- product docs do not explain a Linux libc compatibility contract
+
+This means the reported failure is not a one-off packaging mistake. It is a
+contract gap between the public installer surface and the actual Linux runtime
+compatibility envelope.
+
+## Problem
+
+LoongClaw currently treats Linux as if a single GNU release binary were
+universally installable.
+
+That assumption is false:
+
+1. Debian 12 and other older-glibc systems can receive an unusable binary
+   through the default install path.
+2. The installer has no libc-aware selection or fallback path once a Linux arch
+   is resolved.
+3. The release workflow names Linux artifacts by architecture only, not by libc
+   variant, so the public contract is underspecified.
+4. The repository has a glibc-floor check mechanism, but it is not surfaced as
+   installer selection data for Linux x86_64.
+
+This is a correctness and release-contract issue, not just a documentation
+problem.
+
+## Chosen Slice
+
+Take the smallest complete contract fix instead of trying to solve all Linux
+distribution packaging at once:
+
+1. Publish dual Linux artifacts for x86_64:
+   `x86_64-unknown-linux-gnu` and `x86_64-unknown-linux-musl`.
+2. Keep the implementation structure multi-arch ready, but defer `aarch64`
+   musl publishing to follow-up work.
+3. Teach the Bash installer to choose GNU only when the host glibc is present
+   and new enough for the published GNU artifact; otherwise choose musl.
+4. Add an explicit user override for Linux libc selection.
+5. Make the release helper, workflow, tests, and docs speak the same libc-aware
+   contract.
+
+This fixes the Debian 12 class of failures without expanding into package
+managers, auto-update, or a broader Linux packaging redesign.
+
+## Approaches Considered
+
+### Approach A: Dual Linux artifacts plus libc-aware installer selection
+
+Publish GNU and musl Linux archives, keep GNU as the preferred path when the
+host can run it, and fall back to musl otherwise.
+
+Pros:
+
+- fixes the confirmed Debian 12 failure path
+- preserves GNU binaries for hosts where they already work well
+- keeps the public contract explicit and testable
+- scales naturally to future `aarch64` musl support
+
+Cons:
+
+- adds a second Linux artifact to the release workflow
+- requires deterministic glibc detection and override behavior
+
+### Approach B: Musl-first Linux installs
+
+Publish both artifacts but default all Linux installs to musl unless the user
+explicitly requests GNU.
+
+Pros:
+
+- simplest installer behavior
+- maximizes compatibility by default
+
+Cons:
+
+- changes the primary runtime profile for all Linux users
+- hides GNU compatibility drift instead of making it explicit
+
+### Approach C: GNU-only rebuild on an older glibc baseline
+
+Keep one Linux artifact and move the GNU build to an older baseline so Debian 12
+works without musl.
+
+Pros:
+
+- no new installer selection logic
+- single Linux asset remains simple
+
+Cons:
+
+- still leaves Linux tied to one libc contract
+- harder to guarantee across release infrastructure drift
+- does not provide a compatibility escape hatch when GNU floor changes again
+
+### Recommendation
+
+Choose Approach A.
+
+The issue is a missing Linux artifact contract, not merely a bad single build.
+Dual artifacts plus libc-aware selection closes the compatibility gap while
+keeping the release surface explicit.
+
+## Design
+
+### 1. Public Linux artifact contract
+
+The public release surface should distinguish Linux assets by libc, not only by
+architecture.
+
+First-pass Linux artifacts:
+
+- `x86_64-unknown-linux-gnu`
+- `x86_64-unknown-linux-musl`
+
+Non-Linux targets remain unchanged. Linux `aarch64` stays GNU-only in this
+patch, but helper interfaces and workflow matrix entries should be structured so
+adding `aarch64-unknown-linux-musl` later is a data extension rather than a
+design rewrite.
+
+Archive and checksum naming stay explicit by full target triple:
+
+- `loongclaw-<tag>-x86_64-unknown-linux-gnu.tar.gz`
+- `loongclaw-<tag>-x86_64-unknown-linux-musl.tar.gz`
+- matching `.sha256` files for each
+
+No generic `linux.tar.gz` alias should be introduced in this slice.
+
+### 2. Shared Linux target and libc metadata
+
+`scripts/release_artifact_lib.sh` should become the single source of truth for
+Linux release-asset selection metadata.
+
+It should grow libc-aware helpers rather than forcing the installer to invent
+selection rules privately. The exact helper names can be chosen during
+implementation, but the shared contract needs to cover:
+
+- the supported Linux libc variants for a given architecture
+- the default GNU target triple for a Linux architecture
+- the musl fallback triple for a Linux architecture when supported
+- the minimum supported glibc version for GNU Linux targets that the installer
+  may auto-select
+
+For this first slice:
+
+- Linux x86_64 exposes GNU plus musl variants
+- Linux aarch64 exposes GNU only
+- Windows and macOS behavior is unchanged
+
+The standalone Bash installer must remain self-contained. If it cannot source
+`release_artifact_lib.sh` from a repository checkout, it should continue to
+carry a mirrored fallback implementation of the same libc-aware helpers.
+
+### 3. Installer selection model
+
+The Bash installer remains the Linux bootstrap path. PowerShell continues to
+cover Windows only and should not grow Linux behavior in this patch.
+
+Linux selection order:
+
+1. If the user provides an explicit libc override, honor it.
+2. Otherwise, detect whether glibc is present on the host and determine its
+   version.
+3. If glibc is present and meets the minimum supported version for the GNU
+   target, download GNU.
+4. If glibc is absent, unreadable, unparsable, or too old, download musl.
+
+User override:
+
+- add a public Bash flag `--target-libc gnu|musl`
+- add matching environment variable `LOONGCLAW_INSTALL_TARGET_LIBC`
+- reject unsupported combinations with a precise error
+- if the override requests GNU on a host whose detected glibc is too old, fail
+  before download with a precise compatibility message instead of knowingly
+  installing an unusable binary
+
+Detection behavior must fail closed toward musl. The installer should not guess
+GNU when host libc state is ambiguous.
+
+This model intentionally avoids downloading and probing both archives at
+runtime. The decision is made from host detection plus shared release metadata.
+For host detection, prefer a direct glibc version probe such as
+`getconf GNU_LIBC_VERSION` when available, then fall back to parsing
+`ldd --version`; if neither produces a trustworthy glibc version, treat the
+host as musl/unknown and select musl.
+
+### 4. GNU glibc floor contract
+
+The installer can only prefer GNU safely if the GNU artifact has an explicit
+maximum required glibc version.
+
+The release workflow already has a floor-check mechanism through
+`scripts/check_glibc_floor.sh`. This slice should extend that existing pattern
+instead of introducing a new release-time ABI check path.
+
+Concretely:
+
+- define an explicit GNU glibc floor for Linux x86_64 in the release workflow
+- keep the existing GNU glibc floor contract for Linux aarch64
+- verify GNU Linux artifacts against those declared floors during release builds
+- expose the same floor values to installer selection through the shared helper
+  library
+
+That keeps release-time verification and install-time selection aligned. If a
+GNU artifact exceeds its declared floor, the release should fail before publish.
+
+### 5. Release workflow changes
+
+`.github/workflows/release.yml` should publish both Linux x86_64 variants.
+
+Required workflow changes:
+
+- add `x86_64-unknown-linux-musl` to the build matrix
+- keep `x86_64-unknown-linux-gnu` in the matrix
+- continue packaging archives and checksums by full target triple
+- ensure the publish step uploads both Linux artifacts
+- keep completions generation deterministic by using a known release binary; the
+  existing GNU x86_64 path can stay the source as long as that artifact remains
+  in the matrix
+
+The workflow should also fail clearly when a declared Linux variant is missing a
+packaged archive or checksum.
+
+## Testing Strategy
+
+Follow TDD for the implementation, but the contract requires these verification
+layers:
+
+1. shared helper tests:
+   - Linux target-to-libc resolution
+   - archive/checksum naming for musl targets
+   - explicit GNU glibc floor metadata for supported GNU Linux targets
+2. Bash installer tests:
+   - GNU chosen when host glibc satisfies the configured floor
+   - musl chosen when host glibc is too old
+   - musl chosen when glibc detection is unavailable or unparsable
+   - explicit override forcing GNU or musl
+   - precise failure when an overridden or auto-selected asset does not exist
+3. release workflow checks:
+   - GNU floor checks for GNU Linux artifacts
+   - musl artifact packaging and checksum publication
+4. reproducible compatibility evidence:
+   - a Debian 12 default install path should resolve to musl instead of
+     producing a runtime `GLIBC_* not found` failure
+
+## Product Docs
+
+Linux install documentation should explicitly describe the shipped contract:
+
+- LoongClaw publishes GNU and musl Linux artifacts where available
+- the Bash installer prefers GNU only on hosts that satisfy the declared glibc
+  floor
+- otherwise the installer falls back to musl
+- users can override the selection when they need a specific libc variant
+
+Docs should also avoid implying that all Linux artifacts are interchangeable.
+
+## Non-Goals
+
+- shipping Linux musl for `aarch64` in this first patch
+- changing macOS or Windows install behavior
+- adding package-manager distribution
+- adding auto-update / self-update
+- introducing release manifests or indirection layers beyond the existing asset
+  naming model
+- redesigning PowerShell install behavior for non-Windows targets
+
+## Risks
+
+- Musl builds may expose Rust or native dependency issues not present in current
+  GNU builds. Mitigation: fail the release workflow hard on missing or broken
+  musl artifacts.
+- Glibc detection can become brittle across Linux environments. Mitigation: keep
+  detection minimal and deterministic, and default uncertain cases to musl.
+- Shared helper duplication between repository-backed and standalone installer
+  paths can drift. Mitigation: keep fallback helper functions narrow and cover
+  them in shell tests.
+- GNU floor metadata can drift from actual build output. Mitigation: reuse the
+  existing `check_glibc_floor.sh` enforcement path in release CI.
+
+## Acceptance Criteria
+
+- Public releases publish both `x86_64-unknown-linux-gnu` and
+  `x86_64-unknown-linux-musl` archives with matching checksums.
+- The Bash installer auto-selects GNU only when the host glibc satisfies the
+  declared GNU floor; otherwise it installs musl.
+- Linux users can explicitly override the libc variant through a supported
+  installer surface.
+- A Debian 12 default install path no longer ends in a runtime
+  `GLIBC_2.38` / `GLIBC_2.39` failure from the chosen artifact.
+- Release helpers, release workflow, installer behavior, and docs describe the
+  same libc-aware Linux contract.

--- a/docs/plans/2026-03-20-linux-musl-release-contract-implementation-plan.md
+++ b/docs/plans/2026-03-20-linux-musl-release-contract-implementation-plan.md
@@ -1,0 +1,220 @@
+# Linux Musl Release Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a Linux x86_64 GNU plus musl release contract so Debian 12 class hosts install a usable binary by default.
+
+**Architecture:** Extend the shared shell release helper with libc-aware Linux metadata, drive Bash installer selection from that helper plus host glibc detection, then publish the extra musl artifact in the release workflow and sync docs to the new contract.
+
+**Tech Stack:** Bash, GitHub Actions YAML, Markdown docs, existing shell regression tests.
+
+---
+
+## Chunk 1: Shared Release Metadata
+
+### Task 1: Add failing helper coverage for Linux libc variants
+
+**Files:**
+- Modify: `scripts/test_release_artifact_lib.sh`
+- Modify: `scripts/test_install_sh.sh`
+- Modify: `tasks/todo.md`
+
+- [ ] **Step 1: Add failing helper assertions for musl-aware Linux metadata**
+
+Add checks for:
+- `x86_64-unknown-linux-musl` archive and checksum naming
+- Linux x86_64 supported libc variants
+- Linux x86_64 GNU floor metadata
+- Linux aarch64 remaining GNU-only in the first slice
+
+- [ ] **Step 2: Run helper test to verify it fails**
+
+Run: `bash scripts/test_release_artifact_lib.sh`
+Expected: FAIL because the helper only knows GNU Linux targets today.
+
+- [ ] **Step 3: Update `tasks/todo.md` implementation checklist**
+
+Record the helper-first execution order and the failing-test evidence.
+
+### Task 2: Implement libc-aware release helper metadata
+
+**Files:**
+- Modify: `scripts/release_artifact_lib.sh`
+- Modify: `scripts/test_release_artifact_lib.sh`
+
+- [ ] **Step 1: Add shared Linux libc helper functions**
+
+Implement narrow helpers for:
+- supported libc variants per Linux architecture
+- target triple resolution by Linux arch + libc
+- default GNU floor lookup for supported GNU Linux targets
+
+- [ ] **Step 2: Keep existing naming helpers compatible**
+
+Preserve current archive/checksum/binary naming semantics and make musl targets round-trip through the same helpers.
+
+- [ ] **Step 3: Re-run helper test to verify it passes**
+
+Run: `bash scripts/test_release_artifact_lib.sh`
+Expected: PASS
+
+## Chunk 2: Installer Selection and Safety
+
+### Task 3: Add failing installer coverage for libc auto-selection
+
+**Files:**
+- Modify: `scripts/test_install_sh.sh`
+- Modify: `tasks/todo.md`
+
+- [ ] **Step 1: Add failing installer scenarios**
+
+Cover:
+- GNU selected when host glibc satisfies the configured floor
+- musl selected when host glibc is too old
+- musl selected when glibc detection is unavailable
+- `--target-libc gnu|musl` and `LOONGCLAW_INSTALL_TARGET_LIBC`
+- forced GNU on an unsupported glibc host fails before download
+
+- [ ] **Step 2: Run installer test to verify it fails**
+
+Run: `bash scripts/test_install_sh.sh`
+Expected: FAIL because the installer currently resolves only one GNU Linux target and has no libc override or detection logic.
+
+### Task 4: Implement Bash installer libc selection
+
+**Files:**
+- Modify: `scripts/install.sh`
+- Modify: `scripts/release_artifact_lib.sh`
+- Modify: `scripts/test_install_sh.sh`
+
+- [ ] **Step 1: Add Linux libc override parsing**
+
+Implement:
+- `--target-libc gnu|musl`
+- `LOONGCLAW_INSTALL_TARGET_LIBC`
+- precise validation errors for unsupported combinations
+
+- [ ] **Step 2: Add glibc detection helpers**
+
+Prefer:
+- `getconf GNU_LIBC_VERSION`
+- fallback to `ldd --version`
+- unresolved or untrustworthy detection defaults to musl
+
+- [ ] **Step 3: Resolve Linux target through the shared helper**
+
+Keep non-Linux behavior unchanged and make standalone-installer fallback helpers mirror the repository helper contract.
+
+- [ ] **Step 4: Fail early for explicit incompatible GNU override**
+
+If the user forces GNU and the detected glibc floor is too old, return a compatibility error before download.
+
+- [ ] **Step 5: Re-run installer regression test**
+
+Run: `bash scripts/test_install_sh.sh`
+Expected: PASS
+
+## Chunk 3: Release Workflow and Docs
+
+### Task 5: Add the musl release artifact to the publish workflow
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `scripts/test_release_artifact_lib.sh`
+
+- [ ] **Step 1: Extend the release matrix**
+
+Add:
+- `x86_64-unknown-linux-musl`
+- explicit x86_64 GNU glibc floor env alongside existing Linux ARM64 floor
+
+- [ ] **Step 2: Keep release verification aligned**
+
+Ensure:
+- GNU floor checks apply to GNU Linux artifacts only
+- musl artifact packaging uploads archive + checksum
+- CI shell syntax/regression coverage stays green for the touched scripts
+
+- [ ] **Step 3: Run targeted shell regression checks**
+
+Run: `bash scripts/test_release_artifact_lib.sh`
+Expected: PASS
+
+Run: `bash scripts/test_install_sh.sh`
+Expected: PASS
+
+### Task 6: Sync public docs to the libc-aware Linux contract
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/product-specs/installation.md`
+- Modify: `tasks/todo.md`
+
+- [ ] **Step 1: Update README install wording**
+
+Document that Linux installs:
+- publish GNU and musl artifacts where available
+- prefer GNU on compatible glibc hosts
+- fall back to musl otherwise
+- allow explicit override
+
+- [ ] **Step 2: Update product-spec acceptance wording**
+
+Reflect the shipped libc-aware Linux behavior without changing macOS or Windows contract language.
+
+- [ ] **Step 3: Update task tracker with implementation results**
+
+Record the executed checks and any residual follow-up such as future `aarch64` musl work.
+
+## Chunk 4: Verification and Delivery
+
+### Task 7: Run targeted verification gates
+
+**Files:**
+- No file changes required
+
+- [ ] **Step 1: Run shell regression suite**
+
+Run: `bash scripts/test_release_artifact_lib.sh`
+Expected: PASS
+
+Run: `bash scripts/test_install_sh.sh`
+Expected: PASS
+
+Run: `bash scripts/test_check_glibc_floor.sh`
+Expected: PASS
+
+- [ ] **Step 2: Run diff hygiene**
+
+Run: `git diff --check`
+Expected: PASS
+
+### Task 8: Run repo verification and document known unrelated failures
+
+**Files:**
+- Modify: `tasks/todo.md`
+
+- [ ] **Step 1: Run canonical verification**
+
+Run: `task verify`
+Expected: PASS except for pre-existing unrelated repo gate failures, if any.
+
+- [ ] **Step 2: If `task verify` fails for an unrelated baseline issue, capture it explicitly**
+
+Current known candidate:
+- `cargo deny` advisory `RUSTSEC-2026-0049` on `rustls-webpki 0.103.9`
+
+- [ ] **Step 3: Commit implementation in logical slices**
+
+Suggested commit order:
+- helper + tests
+- installer + tests
+- workflow + docs
+
+- [ ] **Step 4: Final review summary**
+
+Capture:
+- what changed
+- what was verified
+- what remains intentionally out of scope (`aarch64` musl)

--- a/docs/product-specs/installation.md
+++ b/docs/product-specs/installation.md
@@ -13,6 +13,9 @@ or `chat` without reverse-engineering release or source workflows.
 - [x] The bootstrap installer prefers GitHub Release binaries, verifies their
       SHA256 checksums, and installs the matching `loongclaw` binary when a
       release exists for the requested version.
+- [x] Linux x86_64 release artifacts distinguish GNU and musl variants, and the
+      Bash installer auto-selects GNU only when the host satisfies the declared
+      GNU glibc floor; otherwise it falls back to musl.
 - [x] If the repository has not published a matching release yet, the installer
       fails with an explicit next action instead of constructing a misleading or
       broken download URL.
@@ -20,6 +23,8 @@ or `chat` without reverse-engineering release or source workflows.
       the explicit `--source` fallback from a local checkout.
 - [x] The install path can hand users directly into `loongclaw onboard` after a
       successful install.
+- [x] Linux users can explicitly override the libc variant when they need a
+      specific GNU or musl artifact.
 
 ## Out of Scope
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,17 +75,21 @@ else
 
   release_supported_linux_libcs_for_arch() {
     local arch
-    arch="$(release_normalize_linux_arch "${1:?arch is required}")"
+    arch="$(release_normalize_linux_arch "${1:?arch is required}")" || return 1
 
     case "$arch" in
       x86_64) printf 'gnu\nmusl\n' ;;
       aarch64) printf 'gnu\n' ;;
+      *)
+        echo "unsupported Linux architecture: ${1}" >&2
+        return 1
+        ;;
     esac
   }
 
   release_linux_target_for_arch_and_libc() {
     local arch libc
-    arch="$(release_normalize_linux_arch "${1:?arch is required}")"
+    arch="$(release_normalize_linux_arch "${1:?arch is required}")" || return 1
     libc="$(printf '%s' "${2:?libc is required}" | tr '[:upper:]' '[:lower:]')"
 
     case "$arch:$libc" in
@@ -327,7 +331,7 @@ parse_glibc_version() {
 }
 
 detect_host_glibc_version() {
-  local output version
+  local output normalized_output version
 
   if command -v getconf >/dev/null 2>&1; then
     if output="$(getconf GNU_LIBC_VERSION 2>/dev/null)"; then
@@ -341,10 +345,14 @@ detect_host_glibc_version() {
 
   if command -v ldd >/dev/null 2>&1; then
     if output="$(ldd --version 2>&1 | head -n 1)"; then
-      version="$(parse_glibc_version "$output" || true)"
-      if [[ -n "$version" ]]; then
-        printf '%s\n' "$version"
-        return 0
+      normalized_output="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+      if [[ "$normalized_output" != *musl* ]] && \
+        [[ "$normalized_output" == *glibc* || "$normalized_output" == *"gnu libc"* || "$normalized_output" == *"gnu c library"* ]]; then
+        version="$(parse_glibc_version "$output" || true)"
+        if [[ -n "$version" ]]; then
+          printf '%s\n' "$version"
+          return 0
+        fi
       fi
     fi
   fi
@@ -352,10 +360,57 @@ detect_host_glibc_version() {
   return 1
 }
 
+compare_versions() {
+  local actual="${1:?actual version is required}"
+  local minimum="${2:?minimum version is required}"
+  local IFS=.
+  local -a actual_parts=() minimum_parts=()
+  local len i a m
+
+  read -r -a actual_parts <<< "$actual"
+  read -r -a minimum_parts <<< "$minimum"
+
+  len="${#actual_parts[@]}"
+  if (( ${#minimum_parts[@]} > len )); then
+    len="${#minimum_parts[@]}"
+  fi
+
+  for (( i = 0; i < len; i++ )); do
+    a="${actual_parts[i]:-0}"
+    m="${minimum_parts[i]:-0}"
+    [[ "$a" =~ ^[0-9]+$ ]] || a=0
+    [[ "$m" =~ ^[0-9]+$ ]] || m=0
+
+    if (( 10#$a > 10#$m )); then
+      return 0
+    fi
+    if (( 10#$a < 10#$m )); then
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+supports_sort_version() {
+  local sorted
+  if ! sorted="$(printf '2.9\n2.10\n' | sort -V 2>/dev/null)"; then
+    return 1
+  fi
+
+  [[ "$sorted" == $'2.9\n2.10' ]]
+}
+
 version_at_least() {
   local actual="${1:?actual version is required}"
   local minimum="${2:?minimum version is required}"
-  [[ "$(printf '%s\n%s\n' "$minimum" "$actual" | sort -V | head -n 1)" == "$minimum" ]]
+
+  if supports_sort_version; then
+    [[ "$(printf '%s\n%s\n' "$minimum" "$actual" | sort -V | head -n 1)" == "$minimum" ]]
+    return $?
+  fi
+
+  compare_versions "$actual" "$minimum"
 }
 
 release_target_for_install() {
@@ -415,7 +470,17 @@ release_target_for_install() {
     return 0
   fi
 
-  printf '%s\n' "$gnu_target"
+  if [[ -n "${detected_glibc:-}" ]]; then
+    printf 'error: %s requires glibc >= %s but the host reports %s; no musl release artifact is published for %s; use --source instead\n' \
+      "$gnu_target" \
+      "$required_glibc" \
+      "$detected_glibc" \
+      "$normalized_arch" >&2
+  else
+    printf 'error: could not detect a compatible glibc on the host and no musl release artifact is published for %s; use --source instead\n' \
+      "$normalized_arch" >&2
+  fi
+  exit 1
 }
 
 install_from_source() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,13 +3,14 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: ./scripts/install.sh [--prefix <dir>] [--onboard] [--version <tag>] [--source]
+Usage: ./scripts/install.sh [--prefix <dir>] [--onboard] [--version <tag>] [--source] [--target-libc <gnu|musl>]
 
 Options:
   --prefix <dir>   Install directory for loongclaw (default: $HOME/.local/bin)
   --onboard        Run `loongclaw onboard` after install
   --version <tag>  Release tag to install (default: latest)
   --source         Build from local source instead of downloading a release binary
+  --target-libc    Override Linux libc target selection (`gnu` or `musl`)
   -h, --help       Show this help
 USAGE
 }
@@ -57,6 +58,60 @@ else
     esac
   }
 
+  release_normalize_linux_arch() {
+    local arch="${1:?arch is required}"
+    local normalized_arch
+    normalized_arch="$(printf '%s' "$arch" | tr '[:upper:]' '[:lower:]')"
+
+    case "$normalized_arch" in
+      x86_64|amd64) printf 'x86_64\n' ;;
+      arm64|aarch64) printf 'aarch64\n' ;;
+      *)
+        echo "unsupported Linux architecture: ${arch}" >&2
+        return 1
+        ;;
+    esac
+  }
+
+  release_supported_linux_libcs_for_arch() {
+    local arch
+    arch="$(release_normalize_linux_arch "${1:?arch is required}")"
+
+    case "$arch" in
+      x86_64) printf 'gnu\nmusl\n' ;;
+      aarch64) printf 'gnu\n' ;;
+    esac
+  }
+
+  release_linux_target_for_arch_and_libc() {
+    local arch libc
+    arch="$(release_normalize_linux_arch "${1:?arch is required}")"
+    libc="$(printf '%s' "${2:?libc is required}" | tr '[:upper:]' '[:lower:]')"
+
+    case "$arch:$libc" in
+      x86_64:gnu) printf 'x86_64-unknown-linux-gnu\n' ;;
+      x86_64:musl) printf 'x86_64-unknown-linux-musl\n' ;;
+      aarch64:gnu) printf 'aarch64-unknown-linux-gnu\n' ;;
+      *)
+        echo "unsupported Linux architecture/libc combination: ${arch}/${libc}" >&2
+        return 1
+        ;;
+    esac
+  }
+
+  release_gnu_glibc_floor_for_target() {
+    local target="${1:?target is required}"
+
+    case "$target" in
+      x86_64-unknown-linux-gnu) printf '2.39\n' ;;
+      aarch64-unknown-linux-gnu) printf '2.17\n' ;;
+      *)
+        echo "unsupported GNU Linux target for glibc floor lookup: ${target}" >&2
+        return 1
+        ;;
+    esac
+  }
+
   release_target_for_platform() {
     local platform="${1:?platform is required}"
     local arch="${2:?arch is required}"
@@ -67,14 +122,7 @@ else
 
     case "$normalized_platform" in
       LINUX)
-        case "$normalized_arch" in
-          x86_64|amd64) printf 'x86_64-unknown-linux-gnu\n' ;;
-          arm64|aarch64) printf 'aarch64-unknown-linux-gnu\n' ;;
-          *)
-            echo "unsupported Linux architecture: ${arch}" >&2
-            return 1
-            ;;
-        esac
+        release_linux_target_for_arch_and_libc "$normalized_arch" "gnu"
         ;;
       DARWIN)
         case "$normalized_arch" in
@@ -109,6 +157,7 @@ install_source=0
 release_version="${LOONGCLAW_INSTALL_VERSION:-latest}"
 release_repo="${LOONGCLAW_INSTALL_REPO:-loongclaw-ai/loongclaw}"
 release_base_url="${LOONGCLAW_INSTALL_RELEASE_BASE_URL:-https://github.com/${release_repo}/releases}"
+target_libc="${LOONGCLAW_INSTALL_TARGET_LIBC:-auto}"
 package_name="loongclaw"
 bin_name="loongclaw"
 
@@ -137,6 +186,14 @@ while [[ $# -gt 0 ]]; do
     --source)
       install_source=1
       shift
+      ;;
+    --target-libc)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --target-libc requires 'gnu' or 'musl'" >&2
+        exit 2
+      fi
+      target_libc="$2"
+      shift 2
       ;;
     -h|--help)
       usage
@@ -242,6 +299,125 @@ lowercase_value() {
   printf '%s' "${1:?value is required}" | tr '[:upper:]' '[:lower:]'
 }
 
+normalize_target_libc() {
+  local raw="${1:-auto}"
+  local normalized
+  normalized="$(lowercase_value "$raw")"
+
+  case "$normalized" in
+    auto|"") printf 'auto\n' ;;
+    gnu|musl) printf '%s\n' "$normalized" ;;
+    *)
+      echo "error: unsupported --target-libc value: ${raw} (expected gnu or musl)" >&2
+      exit 2
+      ;;
+  esac
+}
+
+parse_glibc_version() {
+  local input="${1:-}"
+  local parsed
+
+  parsed="$(printf '%s\n' "$input" | grep -oE '[0-9]+(\.[0-9]+){1,2}' | head -n 1 || true)"
+  if [[ -n "$parsed" ]]; then
+    printf '%s\n' "$parsed"
+    return 0
+  fi
+  return 1
+}
+
+detect_host_glibc_version() {
+  local output version
+
+  if command -v getconf >/dev/null 2>&1; then
+    if output="$(getconf GNU_LIBC_VERSION 2>/dev/null)"; then
+      version="$(parse_glibc_version "$output" || true)"
+      if [[ -n "$version" ]]; then
+        printf '%s\n' "$version"
+        return 0
+      fi
+    fi
+  fi
+
+  if command -v ldd >/dev/null 2>&1; then
+    if output="$(ldd --version 2>&1 | head -n 1)"; then
+      version="$(parse_glibc_version "$output" || true)"
+      if [[ -n "$version" ]]; then
+        printf '%s\n' "$version"
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
+}
+
+version_at_least() {
+  local actual="${1:?actual version is required}"
+  local minimum="${2:?minimum version is required}"
+  [[ "$(printf '%s\n%s\n' "$minimum" "$actual" | sort -V | head -n 1)" == "$minimum" ]]
+}
+
+release_target_for_install() {
+  local platform="${1:?platform is required}"
+  local arch="${2:?arch is required}"
+  local requested_libc="${3:?requested_libc is required}"
+  local normalized_platform normalized_libc normalized_arch gnu_target musl_target required_glibc detected_glibc
+
+  normalized_platform="$(printf '%s' "$platform" | tr '[:lower:]' '[:upper:]')"
+  normalized_libc="$(normalize_target_libc "$requested_libc")"
+
+  if [[ "$normalized_platform" != "LINUX" ]]; then
+    if [[ "$normalized_libc" != "auto" ]]; then
+      echo "error: --target-libc is only supported for Linux installs" >&2
+      exit 2
+    fi
+    release_target_for_platform "$platform" "$arch"
+    return 0
+  fi
+
+  normalized_arch="$(release_normalize_linux_arch "$arch")"
+  gnu_target="$(release_linux_target_for_arch_and_libc "$normalized_arch" "gnu")"
+
+  if [[ "$normalized_libc" == "gnu" ]]; then
+    if ! detected_glibc="$(detect_host_glibc_version)"; then
+      echo "error: explicit GNU install requires detectable glibc on the host; use --target-libc musl instead" >&2
+      exit 1
+    fi
+    required_glibc="$(release_gnu_glibc_floor_for_target "$gnu_target")"
+    if ! version_at_least "$detected_glibc" "$required_glibc"; then
+      printf 'error: %s requires glibc >= %s but the host reports %s; use --target-libc musl instead\n' \
+        "$gnu_target" \
+        "$required_glibc" \
+        "$detected_glibc" >&2
+      exit 1
+    fi
+    printf '%s\n' "$gnu_target"
+    return 0
+  fi
+
+  if [[ "$normalized_libc" == "musl" ]]; then
+    release_linux_target_for_arch_and_libc "$normalized_arch" "musl"
+    return 0
+  fi
+
+  if detected_glibc="$(detect_host_glibc_version)"; then
+    required_glibc="$(release_gnu_glibc_floor_for_target "$gnu_target")"
+    if version_at_least "$detected_glibc" "$required_glibc"; then
+      printf '%s\n' "$gnu_target"
+      return 0
+    fi
+  fi
+
+  musl_target="$(release_linux_target_for_arch_and_libc "$normalized_arch" "musl" || true)"
+  if [[ -n "$musl_target" ]]; then
+    printf '%s\n' "$musl_target"
+    return 0
+  fi
+
+  printf '%s\n' "$gnu_target"
+}
+
 install_from_source() {
   local repo_root source_binary
   require_command "cargo" "Install Rust first: https://rustup.rs"
@@ -282,7 +458,7 @@ install_from_release() {
 
   host_platform="$(uname -s)"
   host_arch="$(uname -m)"
-  target="$(release_target_for_platform "${host_platform}" "${host_arch}")"
+  target="$(release_target_for_install "${host_platform}" "${host_arch}" "${target_libc}")"
   target_tag="$(normalize_release_tag "${release_version}")"
   if [[ "${target_tag}" == "latest" ]]; then
     target_tag="$(resolve_latest_release_tag)"

--- a/scripts/release_artifact_lib.sh
+++ b/scripts/release_artifact_lib.sh
@@ -61,17 +61,21 @@ release_normalize_linux_arch() {
 
 release_supported_linux_libcs_for_arch() {
   local arch
-  arch="$(release_normalize_linux_arch "${1:?arch is required}")"
+  arch="$(release_normalize_linux_arch "${1:?arch is required}")" || return 1
 
   case "$arch" in
     x86_64) printf 'gnu\nmusl\n' ;;
     aarch64) printf 'gnu\n' ;;
+    *)
+      echo "unsupported Linux architecture: ${1}" >&2
+      return 1
+      ;;
   esac
 }
 
 release_linux_target_for_arch_and_libc() {
   local arch libc
-  arch="$(release_normalize_linux_arch "${1:?arch is required}")"
+  arch="$(release_normalize_linux_arch "${1:?arch is required}")" || return 1
   libc="$(printf '%s' "${2:?libc is required}" | tr '[:upper:]' '[:lower:]')"
 
   case "$arch:$libc" in

--- a/scripts/release_artifact_lib.sh
+++ b/scripts/release_artifact_lib.sh
@@ -44,6 +44,60 @@ release_binary_name_for_target() {
   esac
 }
 
+release_normalize_linux_arch() {
+  local arch="${1:?arch is required}"
+  local normalized_arch
+  normalized_arch="$(printf '%s' "$arch" | tr '[:upper:]' '[:lower:]')"
+
+  case "$normalized_arch" in
+    x86_64|amd64) printf 'x86_64\n' ;;
+    arm64|aarch64) printf 'aarch64\n' ;;
+    *)
+      echo "unsupported Linux architecture: ${arch}" >&2
+      return 1
+      ;;
+  esac
+}
+
+release_supported_linux_libcs_for_arch() {
+  local arch
+  arch="$(release_normalize_linux_arch "${1:?arch is required}")"
+
+  case "$arch" in
+    x86_64) printf 'gnu\nmusl\n' ;;
+    aarch64) printf 'gnu\n' ;;
+  esac
+}
+
+release_linux_target_for_arch_and_libc() {
+  local arch libc
+  arch="$(release_normalize_linux_arch "${1:?arch is required}")"
+  libc="$(printf '%s' "${2:?libc is required}" | tr '[:upper:]' '[:lower:]')"
+
+  case "$arch:$libc" in
+    x86_64:gnu) printf 'x86_64-unknown-linux-gnu\n' ;;
+    x86_64:musl) printf 'x86_64-unknown-linux-musl\n' ;;
+    aarch64:gnu) printf 'aarch64-unknown-linux-gnu\n' ;;
+    *)
+      echo "unsupported Linux architecture/libc combination: ${arch}/${libc}" >&2
+      return 1
+      ;;
+  esac
+}
+
+release_gnu_glibc_floor_for_target() {
+  local target="${1:?target is required}"
+
+  case "$target" in
+    x86_64-unknown-linux-gnu) printf '2.39\n' ;;
+    aarch64-unknown-linux-gnu) printf '2.17\n' ;;
+    *)
+      echo "unsupported GNU Linux target for glibc floor lookup: ${target}" >&2
+      return 1
+      ;;
+  esac
+}
+
 release_target_for_platform() {
   local platform="${1:?platform is required}"
   local arch="${2:?arch is required}"
@@ -54,14 +108,7 @@ release_target_for_platform() {
 
   case "$normalized_platform" in
     LINUX)
-      case "$normalized_arch" in
-        x86_64|amd64) printf 'x86_64-unknown-linux-gnu\n' ;;
-        arm64|aarch64) printf 'aarch64-unknown-linux-gnu\n' ;;
-        *)
-          echo "unsupported Linux architecture: ${arch}" >&2
-          return 1
-          ;;
-      esac
+      release_linux_target_for_arch_and_libc "$normalized_arch" "gnu"
       ;;
     DARWIN)
       case "$normalized_arch" in

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -530,6 +530,8 @@ run_standalone_linux_arm64_install_rejects_missing_glibc_test() {
   cp "$SCRIPT_UNDER_TEST" "$standalone_script"
   chmod +x "$standalone_script"
   make_uname_stub_bin "$fixture" "Linux" "aarch64"
+  make_getconf_stub_bin "$fixture" "__FAIL__"
+  make_ldd_stub_bin "$fixture" "__FAIL__"
 
   if (
     cd "$fixture"

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -164,9 +164,46 @@ if [[ "$response" == "__FAIL__" ]]; then
   exit 1
 fi
 
-printf '%s\n' "$response"
+  printf '%s\n' "$response"
 EOF
   chmod +x "$fixture/fake-bin/ldd"
+}
+
+make_sort_stub_bin() {
+  local fixture="$1"
+  local mode="$2"
+  mkdir -p "$fixture/fake-bin"
+  cat >"$fixture/fake-bin/sort" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$mode" == "__FAIL_VERSION__" ]]; then
+  for arg in "\$@"; do
+    if [[ "\$arg" == "-V" || "\$arg" == "--version-sort" ]]; then
+      echo "sort: unrecognized option '\$arg'" >&2
+      exit 1
+    fi
+  done
+fi
+
+exec /usr/bin/sort "\$@"
+EOF
+  chmod +x "$fixture/fake-bin/sort"
+}
+
+source_install_functions() {
+  local shim
+  shim="$(mktemp)"
+  awk '
+    /^prefix="\$\{HOME\}\/\.local\/bin"/ { skip = 1; next }
+    skip && !/^require_command\(\) \{/ { next }
+    /^require_command\(\) \{/ { skip = 0 }
+    /^if \[\[ "\$\{install_source\}" -eq 1 \]\]; then$/ { exit }
+    { print }
+  ' "$SCRIPT_UNDER_TEST" >"$shim"
+  # shellcheck disable=SC1090
+  . "$shim"
+  rm -f "$shim"
 }
 
 run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test() {
@@ -289,6 +326,132 @@ run_linux_x86_64_explicit_gnu_override_rejects_old_glibc_test() {
   assert_contains "$output_file" "requires glibc"
 }
 
+run_version_at_least_falls_back_when_sort_version_is_unavailable_test() {
+  local fixture
+  fixture="$(mktemp -d)"
+  trap 'rm -rf "$fixture"' RETURN
+  make_sort_stub_bin "$fixture" "__FAIL_VERSION__"
+
+  if ! (
+    PATH="$fixture/fake-bin:$PATH"
+    source_install_functions
+    version_at_least "2.39" "2.39"
+  ); then
+    echo "expected version_at_least to succeed even when sort -V is unavailable" >&2
+    exit 1
+  fi
+}
+
+run_version_at_least_rejects_older_version_with_sort_version_test() {
+  if (
+    source_install_functions
+    version_at_least "2.16" "2.17"
+  ); then
+    echo "expected version_at_least to reject older versions when sort -V is available" >&2
+    exit 1
+  fi
+}
+
+run_detect_host_glibc_version_rejects_musl_ldd_output_test() {
+  if (
+    source_install_functions
+    getconf() { return 1; }
+    ldd() { printf 'musl libc (x86_64) Version 1.2.5\n'; }
+    detect_host_glibc_version >/dev/null
+  ); then
+    echo "expected detect_host_glibc_version to reject musl ldd output" >&2
+    exit 1
+  fi
+}
+
+run_release_target_for_install_rejects_arm64_old_glibc_without_musl_test() {
+  local output_file
+  output_file="$(mktemp)"
+  trap 'rm -f "$output_file"' RETURN
+
+  if (
+    source_install_functions
+    detect_host_glibc_version() { printf '2.16\n'; }
+    release_target_for_install "Linux" "aarch64" "auto" >"$output_file" 2>&1
+  ); then
+    echo "expected release_target_for_install to reject GNU-only arm64 installs on an unsupported glibc host" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "no musl release artifact is published for aarch64"
+}
+
+run_linux_x86_64_prefers_gnu_when_sort_version_is_unavailable_test() {
+  local fixture install_dir output_file installed_output
+  fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/linux-gnu-no-sort-v.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64"
+  make_getconf_stub_bin "$fixture" "glibc 2.39"
+  make_sort_stub_bin "$fixture" "__FAIL_VERSION__"
+
+  (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_contains "$output_file" "x86_64-unknown-linux-gnu"
+  installed_output="$("$install_dir/loongclaw")"
+  if [[ "$installed_output" != "gnu-binary" ]]; then
+    echo "expected GNU artifact to be installed without sort -V support but got '$installed_output'" >&2
+    exit 1
+  fi
+}
+
+run_linux_x86_64_explicit_gnu_override_rejects_musl_ldd_output_test() {
+  local fixture output_file
+  fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  output_file="$fixture/linux-gnu-override-musl-ldd.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64"
+  make_getconf_stub_bin "$fixture" "__FAIL__"
+  make_ldd_stub_bin "$fixture" "musl libc (x86_64) Version 1.2.5"
+
+  if (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --target-libc gnu --prefix "$fixture/install" >"$output_file" 2>&1
+  ); then
+    echo "expected install.sh to reject a GNU override when only musl ldd output is available" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "explicit GNU install requires detectable glibc"
+}
+
+run_linux_arm64_auto_rejects_old_glibc_without_musl_artifact_test() {
+  local fixture output_file
+  fixture="$(make_release_fixture "v0.1.2" "aarch64-unknown-linux-gnu" "arm64-gnu-binary")"
+  trap 'rm -rf "$fixture"' RETURN
+  output_file="$fixture/linux-arm64-old-glibc.out"
+  make_uname_stub_bin "$fixture" "Linux" "aarch64"
+  make_getconf_stub_bin "$fixture" "glibc 2.16"
+
+  if (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$fixture/install" >"$output_file" 2>&1
+  ); then
+    echo "expected install.sh to reject GNU-only arm64 installs on an unsupported glibc host" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "no musl release artifact is published for aarch64"
+}
+
 run_release_override_install_and_onboard_test() {
   local fixture install_dir output_file marker
   fixture="$(make_release_fixture "v0.1.2")"
@@ -357,7 +520,7 @@ run_missing_release_guidance_test() {
   assert_contains "$output_file" "bash scripts/install.sh --source --onboard"
 }
 
-run_standalone_linux_arm64_install_test() {
+run_standalone_linux_arm64_install_rejects_missing_glibc_test() {
   local fixture install_dir output_file standalone_script
   fixture="$(make_release_fixture "v0.1.2" "aarch64-unknown-linux-gnu")"
   trap 'rm -rf "$fixture"' RETURN
@@ -368,25 +531,36 @@ run_standalone_linux_arm64_install_test() {
   chmod +x "$standalone_script"
   make_uname_stub_bin "$fixture" "Linux" "aarch64"
 
-  (
+  if (
     cd "$fixture"
     PATH="$fixture/fake-bin:$PATH" \
       LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
       bash "$standalone_script" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
-  )
+  ); then
+    echo "expected standalone install.sh to reject GNU-only arm64 installs without detectable glibc" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
 
-  [[ -x "$install_dir/loongclaw" ]]
-  assert_contains "$output_file" "Installed loongclaw"
+  assert_contains "$output_file" "could not detect a compatible glibc on the host"
+  assert_contains "$output_file" "no musl release artifact is published for aarch64"
 }
 
 run_release_override_install_and_onboard_test
 run_checksum_mismatch_fails_test
 run_missing_release_guidance_test
 run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test
+run_version_at_least_falls_back_when_sort_version_is_unavailable_test
+run_version_at_least_rejects_older_version_with_sort_version_test
+run_detect_host_glibc_version_rejects_musl_ldd_output_test
+run_release_target_for_install_rejects_arm64_old_glibc_without_musl_test
+run_linux_x86_64_prefers_gnu_when_sort_version_is_unavailable_test
 run_linux_x86_64_falls_back_to_musl_when_glibc_is_too_old_test
 run_linux_x86_64_falls_back_to_musl_when_glibc_detection_fails_test
 run_linux_x86_64_explicit_musl_override_test
 run_linux_x86_64_explicit_gnu_override_rejects_old_glibc_test
-run_standalone_linux_arm64_install_test
+run_linux_x86_64_explicit_gnu_override_rejects_musl_ldd_output_test
+run_linux_arm64_auto_rejects_old_glibc_without_musl_artifact_test
+run_standalone_linux_arm64_install_rejects_missing_glibc_test
 
 echo "install.sh smoke checks passed"

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -29,33 +29,46 @@ host_target() {
 }
 
 make_release_fixture() {
-  local fixture tag target archive_name checksum_name binary_name archive_path checksum_path release_dir
+  local fixture
   fixture="$(mktemp -d)"
-  tag="${1:-v0.1.2}"
-  target="${2:-$(host_target)}"
+  write_release_fixture_asset \
+    "$fixture" \
+    "${1:-v0.1.2}" \
+    "${2:-$(host_target)}" \
+    "${3:-fixture-binary}"
+  printf '%s\n' "$fixture"
+}
+
+write_release_fixture_asset() {
+  local fixture tag target binary_label archive_name checksum_name binary_name archive_path checksum_path release_dir staging_dir
+  fixture="${1:?fixture is required}"
+  tag="${2:-v0.1.2}"
+  target="${3:-$(host_target)}"
+  binary_label="${4:-fixture-binary}"
   archive_name="$(release_archive_name "loongclaw" "$tag" "$target")"
   checksum_name="$(release_archive_checksum_name "loongclaw" "$tag" "$target")"
   binary_name="$(release_binary_name_for_target "loongclaw" "$target")"
   release_dir="$fixture/releases/download/$tag"
-  mkdir -p "$release_dir" "$fixture/staging"
+  staging_dir="$fixture/staging/$target"
+  mkdir -p "$release_dir" "$staging_dir"
 
-  cat >"$fixture/staging/$binary_name" <<'EOF'
+  cat >"$staging_dir/$binary_name" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "onboard" ]]; then
-  printf 'onboard\n' >> "${ONBOARD_MARKER:?}"
+if [[ "\${1:-}" == "onboard" ]]; then
+  printf 'onboard\n' >> "\${ONBOARD_MARKER:?}"
 fi
-printf 'fixture-binary\n'
+printf '%s\n' "$binary_label"
 EOF
-  chmod +x "$fixture/staging/$binary_name"
+  chmod +x "$staging_dir/$binary_name"
 
   archive_path="$release_dir/$archive_name"
   case "$archive_name" in
     *.tar.gz)
-      tar -C "$fixture/staging" -czf "$archive_path" "$binary_name"
+      tar -C "$staging_dir" -czf "$archive_path" "$binary_name"
       ;;
     *.zip)
-      (cd "$fixture/staging" && zip -q "$archive_path" "$binary_name")
+      (cd "$staging_dir" && zip -q "$archive_path" "$binary_name")
       ;;
     *)
       echo "unsupported archive format in fixture: $archive_name" >&2
@@ -65,7 +78,14 @@ EOF
 
   checksum_path="$release_dir/$checksum_name"
   printf '%s  %s\n' "$(sha256_file "$archive_path")" "$archive_name" >"$checksum_path"
+}
 
+make_linux_dual_libc_fixture() {
+  local fixture tag
+  fixture="$(mktemp -d)"
+  tag="${1:-v0.1.2}"
+  write_release_fixture_asset "$fixture" "$tag" "x86_64-unknown-linux-gnu" "gnu-binary"
+  write_release_fixture_asset "$fixture" "$tag" "x86_64-unknown-linux-musl" "musl-binary"
   printf '%s\n' "$fixture"
 }
 
@@ -108,6 +128,165 @@ case "\${1:-}" in
 esac
 EOF
   chmod +x "$fixture/fake-bin/uname"
+}
+
+make_getconf_stub_bin() {
+  local fixture="$1"
+  local response="$2"
+  mkdir -p "$fixture/fake-bin"
+  cat >"$fixture/fake-bin/getconf" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" != "GNU_LIBC_VERSION" ]]; then
+  echo "unexpected getconf invocation: \$*" >&2
+  exit 1
+fi
+
+if [[ "$response" == "__FAIL__" ]]; then
+  exit 1
+fi
+
+printf '%s\n' "$response"
+EOF
+  chmod +x "$fixture/fake-bin/getconf"
+}
+
+make_ldd_stub_bin() {
+  local fixture="$1"
+  local response="$2"
+  mkdir -p "$fixture/fake-bin"
+  cat >"$fixture/fake-bin/ldd" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$response" == "__FAIL__" ]]; then
+  exit 1
+fi
+
+printf '%s\n' "$response"
+EOF
+  chmod +x "$fixture/fake-bin/ldd"
+}
+
+run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test() {
+  local fixture install_dir output_file installed_output
+  fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/linux-gnu.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64"
+  make_getconf_stub_bin "$fixture" "glibc 2.39"
+
+  (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_contains "$output_file" "x86_64-unknown-linux-gnu"
+  installed_output="$("$install_dir/loongclaw")"
+  if [[ "$installed_output" != "gnu-binary" ]]; then
+    echo "expected GNU artifact to be installed but got '$installed_output'" >&2
+    exit 1
+  fi
+}
+
+run_linux_x86_64_falls_back_to_musl_when_glibc_is_too_old_test() {
+  local fixture install_dir output_file installed_output
+  fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/linux-musl-old-glibc.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64"
+  make_getconf_stub_bin "$fixture" "glibc 2.36"
+
+  (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_contains "$output_file" "x86_64-unknown-linux-musl"
+  installed_output="$("$install_dir/loongclaw")"
+  if [[ "$installed_output" != "musl-binary" ]]; then
+    echo "expected musl fallback artifact to be installed but got '$installed_output'" >&2
+    exit 1
+  fi
+}
+
+run_linux_x86_64_falls_back_to_musl_when_glibc_detection_fails_test() {
+  local fixture install_dir output_file installed_output
+  fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/linux-musl-no-glibc.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64"
+  make_getconf_stub_bin "$fixture" "__FAIL__"
+  make_ldd_stub_bin "$fixture" "__FAIL__"
+
+  (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_contains "$output_file" "x86_64-unknown-linux-musl"
+  installed_output="$("$install_dir/loongclaw")"
+  if [[ "$installed_output" != "musl-binary" ]]; then
+    echo "expected musl fallback artifact to be installed but got '$installed_output'" >&2
+    exit 1
+  fi
+}
+
+run_linux_x86_64_explicit_musl_override_test() {
+  local fixture install_dir output_file installed_output
+  fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/linux-musl-override.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64"
+  make_getconf_stub_bin "$fixture" "glibc 2.39"
+
+  (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      LOONGCLAW_INSTALL_TARGET_LIBC="musl" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_contains "$output_file" "x86_64-unknown-linux-musl"
+  installed_output="$("$install_dir/loongclaw")"
+  if [[ "$installed_output" != "musl-binary" ]]; then
+    echo "expected musl override artifact to be installed but got '$installed_output'" >&2
+    exit 1
+  fi
+}
+
+run_linux_x86_64_explicit_gnu_override_rejects_old_glibc_test() {
+  local fixture output_file
+  fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  output_file="$fixture/linux-gnu-override-old-glibc.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64"
+  make_getconf_stub_bin "$fixture" "glibc 2.36"
+
+  if (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --target-libc gnu --prefix "$fixture/install" >"$output_file" 2>&1
+  ); then
+    echo "expected install.sh to reject a GNU override on an unsupported glibc host" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "requires glibc"
 }
 
 run_release_override_install_and_onboard_test() {
@@ -203,6 +382,11 @@ run_standalone_linux_arm64_install_test() {
 run_release_override_install_and_onboard_test
 run_checksum_mismatch_fails_test
 run_missing_release_guidance_test
+run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test
+run_linux_x86_64_falls_back_to_musl_when_glibc_is_too_old_test
+run_linux_x86_64_falls_back_to_musl_when_glibc_detection_fails_test
+run_linux_x86_64_explicit_musl_override_test
+run_linux_x86_64_explicit_gnu_override_rejects_old_glibc_test
 run_standalone_linux_arm64_install_test
 
 echo "install.sh smoke checks passed"

--- a/scripts/test_release_artifact_lib.sh
+++ b/scripts/test_release_artifact_lib.sh
@@ -123,6 +123,11 @@ EOF
     exit 1
   fi
 
+  if release_supported_linux_libcs_for_arch "ppc64le" >/dev/null 2>&1; then
+    echo "expected release_supported_linux_libcs_for_arch to reject unsupported host arch" >&2
+    exit 1
+  fi
+
   release_trace_path_matches_contract \
     "v0.1.2" \
     "020e2a67" \

--- a/scripts/test_release_artifact_lib.sh
+++ b/scripts/test_release_artifact_lib.sh
@@ -57,17 +57,44 @@ EOF
     "loongclaw-v0.1.2-aarch64-unknown-linux-gnu.tar.gz" \
     "$(release_archive_name "loongclaw" "v0.1.2" "aarch64-unknown-linux-gnu")"
   assert_equals \
+    "loongclaw-v0.1.2-x86_64-unknown-linux-musl.tar.gz" \
+    "$(release_archive_name "loongclaw" "v0.1.2" "x86_64-unknown-linux-musl")"
+  assert_equals \
     "loongclaw-v0.1.2-x86_64-pc-windows-msvc.zip" \
     "$(release_archive_name "loongclaw" "v0.1.2" "x86_64-pc-windows-msvc")"
   assert_equals \
     "loongclaw-v0.1.2-x86_64-pc-windows-msvc.zip.sha256" \
     "$(release_archive_checksum_name "loongclaw" "v0.1.2" "x86_64-pc-windows-msvc")"
   assert_equals \
+    "loongclaw-v0.1.2-x86_64-unknown-linux-musl.tar.gz.sha256" \
+    "$(release_archive_checksum_name "loongclaw" "v0.1.2" "x86_64-unknown-linux-musl")"
+  assert_equals \
     "x86_64-unknown-linux-gnu" \
     "$(release_target_for_platform "Linux" "x86_64")"
   assert_equals \
     "aarch64-unknown-linux-gnu" \
     "$(release_target_for_platform "Linux" "arm64")"
+  assert_equals \
+    $'gnu\nmusl' \
+    "$(release_supported_linux_libcs_for_arch "x86_64")"
+  assert_equals \
+    "gnu" \
+    "$(release_supported_linux_libcs_for_arch "aarch64")"
+  assert_equals \
+    "x86_64-unknown-linux-musl" \
+    "$(release_linux_target_for_arch_and_libc "x86_64" "musl")"
+  assert_equals \
+    "x86_64-unknown-linux-gnu" \
+    "$(release_linux_target_for_arch_and_libc "x86_64" "gnu")"
+  assert_equals \
+    "aarch64-unknown-linux-gnu" \
+    "$(release_linux_target_for_arch_and_libc "aarch64" "gnu")"
+  assert_equals \
+    "2.39" \
+    "$(release_gnu_glibc_floor_for_target "x86_64-unknown-linux-gnu")"
+  assert_equals \
+    "2.17" \
+    "$(release_gnu_glibc_floor_for_target "aarch64-unknown-linux-gnu")"
   assert_equals \
     "x86_64-apple-darwin" \
     "$(release_target_for_platform "Darwin" "x86_64")"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -78,6 +78,11 @@ change against the repo's existing shell and release gates.
   unsupported-arch failure propagation in the release helper, musl-aware glibc
   detection, `sort -V` fallback coverage, GNU-only arch rejection when no musl
   artifact exists, and shared glibc floor lookup in the release workflow.
+- 2026-03-21: After the review-follow-up push, GitHub Actions exposed one
+  Linux-only test harness gap in the standalone installer regression: the copied
+  installer still saw the host runner's real glibc via `getconf`/`ldd`. The
+  fix was test-only and narrow: stub both commands to fail so the test actually
+  exercises the intended "glibc unavailable" path on CI.
 
 ## Review / Results
 
@@ -108,3 +113,7 @@ change against the repo's existing shell and release gates.
   fixes. The standalone copied-installer regression now intentionally fails on
   GNU-only `aarch64` when no compatible glibc can be detected, matching the
   reviewed contract instead of silently installing an unusable binary.
+- 2026-03-21: CI parity follow-up passed:
+  the exact governance regression-test bundle from `.github/workflows/ci.yml`
+  now passes locally after stubbing `getconf` and `ldd` in the standalone
+  Linux `aarch64` test, and `task verify` remains green.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -25,6 +25,9 @@ change against the repo's existing shell and release gates.
       green on this branch.
 - [x] Clear the newly surfaced `cargo audit` advisories in `aws-lc-sys` so PR
       Security checks pass.
+- [x] Address the remaining PR review threads around Linux libc detection,
+      version comparison portability, GNU-only fallback safety, and workflow
+      glibc floor reuse.
 
 ## Progress Notes
 
@@ -70,6 +73,11 @@ change against the repo's existing shell and release gates.
   update `aws-lc-rs 1.16.1 -> 1.16.2` and `aws-lc-sys 0.38.0 -> 0.39.0`,
   matching the advisory remediation without changing application code or
   release-contract behavior.
+- 2026-03-21: Reviewed each open PR bot thread against the shipped shell path,
+  reproduced the valid failures locally, and kept the fixes narrow: explicit
+  unsupported-arch failure propagation in the release helper, musl-aware glibc
+  detection, `sort -V` fallback coverage, GNU-only arch rejection when no musl
+  artifact exists, and shared glibc floor lookup in the release workflow.
 
 ## Review / Results
 
@@ -92,3 +100,11 @@ change against the repo's existing shell and release gates.
 - 2026-03-21: Security follow-up verification passed:
   `cargo audit`, `cargo deny check advisories bans sources`, and full
   `task verify` are green after the AWS-LC lockfile update.
+- 2026-03-21: Review follow-up verification passed:
+  `bash scripts/test_release_artifact_lib.sh`,
+  `bash scripts/test_install_sh.sh`,
+  `bash scripts/test_check_glibc_floor.sh`,
+  `git diff --check`, and full `task verify` are green after the review-thread
+  fixes. The standalone copied-installer regression now intentionally fails on
+  GNU-only `aarch64` when no compatible glibc can be detected, matching the
+  reviewed contract instead of silently installing an unusable binary.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -18,9 +18,11 @@ change against the repo's existing shell and release gates.
 - [x] Write `docs/plans/2026-03-20-linux-musl-release-contract-implementation-plan.md`.
 - [x] Add failing helper and installer coverage for libc-aware Linux behavior.
 - [x] Implement shared release-helper metadata, installer selection, and release
-  workflow updates for Linux `x86_64` GNU plus musl artifacts.
+      workflow updates for Linux `x86_64` GNU plus musl artifacts.
 - [x] Update public install docs to describe auto-selection and manual override.
 - [x] Run targeted shell regression checks and repo verification.
+- [x] Clear the pre-existing `cargo deny` advisory gate so `task verify` can go
+      green on this branch.
 
 ## Progress Notes
 
@@ -55,6 +57,10 @@ change against the repo's existing shell and release gates.
   glibc floor checks only to GNU Linux targets.
 - 2026-03-20: Updated `README.md` and `docs/product-specs/installation.md` so
   the public contract matches the shipped installer behavior.
+- 2026-03-21: Cleared the repo-wide verification blocker with a narrow lockfile
+  update from `rustls-webpki 0.103.9` to `0.103.10`, matching the
+  `RUSTSEC-2026-0049` remediation guidance without widening the dependency
+  surface beyond the affected crate.
 
 ## Review / Results
 
@@ -70,3 +76,7 @@ change against the repo's existing shell and release gates.
   `RUSTSEC-2026-0049` in `rustls-webpki 0.103.9`.
 - 2026-03-20: Intentional first-pass scope remains Linux `x86_64`; `aarch64`
   musl support is left as a follow-up matrix extension.
+- 2026-03-21: Follow-up verification passed after the lockfile bump:
+  `cargo deny check advisories` and full `task verify` are green on this
+  branch. Remaining `cargo deny` output is warning-only duplicate/license noise,
+  not a failing advisory gate.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23,6 +23,8 @@ change against the repo's existing shell and release gates.
 - [x] Run targeted shell regression checks and repo verification.
 - [x] Clear the pre-existing `cargo deny` advisory gate so `task verify` can go
       green on this branch.
+- [x] Clear the newly surfaced `cargo audit` advisories in `aws-lc-sys` so PR
+      Security checks pass.
 
 ## Progress Notes
 
@@ -61,6 +63,13 @@ change against the repo's existing shell and release gates.
   update from `rustls-webpki 0.103.9` to `0.103.10`, matching the
   `RUSTSEC-2026-0049` remediation guidance without widening the dependency
   surface beyond the affected crate.
+- 2026-03-21: Reproduced the PR Security failure locally with `cargo audit`,
+  which surfaced `RUSTSEC-2026-0044` and `RUSTSEC-2026-0048` through
+  `aws-lc-sys 0.38.0` via `aws-lc-rs 1.16.1`.
+- 2026-03-21: Cleared the Security gate with the narrow compatible lockfile
+  update `aws-lc-rs 1.16.1 -> 1.16.2` and `aws-lc-sys 0.38.0 -> 0.39.0`,
+  matching the advisory remediation without changing application code or
+  release-contract behavior.
 
 ## Review / Results
 
@@ -80,3 +89,6 @@ change against the repo's existing shell and release gates.
   `cargo deny check advisories` and full `task verify` are green on this
   branch. Remaining `cargo deny` output is warning-only duplicate/license noise,
   not a failing advisory gate.
+- 2026-03-21: Security follow-up verification passed:
+  `cargo audit`, `cargo deny check advisories bans sources`, and full
+  `task verify` are green after the AWS-LC lockfile update.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,8 +2,9 @@
 
 ## Objective
 
-Write, review, and commit the approved design for Linux GNU plus musl release
-artifacts with libc-aware installer selection.
+Ship the approved Linux GNU plus musl release contract for `x86_64`, wire the
+Bash installer to choose a compatible libc variant by default, and verify the
+change against the repo's existing shell and release gates.
 
 ## Checklist
 
@@ -12,8 +13,14 @@ artifacts with libc-aware installer selection.
 - [x] Align the spec location and format with existing `docs/plans` documents.
 - [x] Write `docs/plans/2026-03-20-linux-musl-release-contract-design.md`.
 - [x] Perform a local review pass for contract gaps and scope drift.
-- [ ] Commit the spec and task tracker updates.
-- [ ] Ask for user review before writing the implementation plan.
+- [x] Commit the approved design and ask for user review.
+- [x] Post a concise implementation update to GitHub issue `#310`.
+- [x] Write `docs/plans/2026-03-20-linux-musl-release-contract-implementation-plan.md`.
+- [x] Add failing helper and installer coverage for libc-aware Linux behavior.
+- [x] Implement shared release-helper metadata, installer selection, and release
+  workflow updates for Linux `x86_64` GNU plus musl artifacts.
+- [x] Update public install docs to describe auto-selection and manual override.
+- [x] Run targeted shell regression checks and repo verification.
 
 ## Progress Notes
 
@@ -29,9 +36,37 @@ artifacts with libc-aware installer selection.
 - 2026-03-20: Wrote the design doc in `docs/plans` and tightened the contract
   around explicit GNU override behavior, glibc detection order, and shared
   helper ownership.
+- 2026-03-20: Posted the agreed rollout direction to GitHub issue `#310` with a
+  concise summary of the Debian 12 repro, dual-artifact contract, installer
+  fallback rule, and first-pass `x86_64` scope.
+- 2026-03-20: Wrote the implementation plan in `docs/plans` and executed it
+  helper-first: add failing tests, implement shared libc metadata, then wire the
+  installer selection logic and release workflow.
+- 2026-03-20: Added release-helper coverage for Linux musl archive/checksum
+  naming, supported libc variants, and GNU glibc floor metadata; the first run
+  failed as expected before `release_supported_linux_libcs_for_arch` and related
+  helpers were implemented.
+- 2026-03-20: Added installer regression coverage for GNU preference on
+  supported glibc, musl fallback on old or unreadable glibc, and explicit
+  `gnu|musl` override behavior; the first run failed until the installer learned
+  host glibc detection and target selection.
+- 2026-03-20: Extended the release workflow to publish
+  `x86_64-unknown-linux-musl`, install `musl-tools` for that target, and apply
+  glibc floor checks only to GNU Linux targets.
+- 2026-03-20: Updated `README.md` and `docs/product-specs/installation.md` so
+  the public contract matches the shipped installer behavior.
 
 ## Review / Results
 
-- 2026-03-20: Local review completed. The main gap was explicit override safety:
-  the spec now requires the installer to fail early when `gnu` is forced on a
-  host that does not meet the declared GNU glibc floor.
+- 2026-03-20: Local design review completed. The main gap was explicit override
+  safety: the final contract requires the installer to fail early when `gnu` is
+  forced on a host that does not meet the declared GNU glibc floor.
+- 2026-03-20: Targeted verification passed:
+  `bash scripts/test_release_artifact_lib.sh`,
+  `bash scripts/test_install_sh.sh`,
+  `bash scripts/test_check_glibc_floor.sh`, and `git diff --check`.
+- 2026-03-20: `task verify` completed all relevant build/test checks for this
+  change and failed only on the pre-existing unrelated `cargo deny` advisory
+  `RUSTSEC-2026-0049` in `rustls-webpki 0.103.9`.
+- 2026-03-20: Intentional first-pass scope remains Linux `x86_64`; `aarch64`
+  musl support is left as a follow-up matrix extension.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,37 @@
+# Linux Musl Release Contract Tasks
+
+## Objective
+
+Write, review, and commit the approved design for Linux GNU plus musl release
+artifacts with libc-aware installer selection.
+
+## Checklist
+
+- [x] Inspect current installer, release helper, and release workflow behavior.
+- [x] Confirm the Debian 12 failure mode and current public release contract.
+- [x] Align the spec location and format with existing `docs/plans` documents.
+- [x] Write `docs/plans/2026-03-20-linux-musl-release-contract-design.md`.
+- [x] Perform a local review pass for contract gaps and scope drift.
+- [ ] Commit the spec and task tracker updates.
+- [ ] Ask for user review before writing the implementation plan.
+
+## Progress Notes
+
+- 2026-03-20: Confirmed the current Linux release contract is GNU-only in
+  `scripts/release_artifact_lib.sh`, `scripts/install.sh`, and
+  `.github/workflows/release.yml`.
+- 2026-03-20: Confirmed the Bash installer is the Linux path; `install.ps1`
+  remains Windows-only, so the first musl slice stays in the Bash/shared helper
+  contract.
+- 2026-03-20: Confirmed the release workflow already enforces a Linux ARM64
+  glibc floor through `scripts/check_glibc_floor.sh`, which can be extended for
+  explicit GNU floor metadata instead of inventing a second mechanism.
+- 2026-03-20: Wrote the design doc in `docs/plans` and tightened the contract
+  around explicit GNU override behavior, glibc detection order, and shared
+  helper ownership.
+
+## Review / Results
+
+- 2026-03-20: Local review completed. The main gap was explicit override safety:
+  the spec now requires the installer to fail early when `gnu` is forced on a
+  host that does not meet the declared GNU glibc floor.


### PR DESCRIPTION
## Summary
- add explicit Linux `x86_64` GNU and musl release metadata plus the musl release artifact in the publish workflow
- teach the Bash installer to prefer GNU only when the host glibc satisfies the declared floor, otherwise fall back to musl, with `--target-libc` and `LOONGCLAW_INSTALL_TARGET_LIBC` override support
- update install docs and bump `rustls-webpki` to `0.103.10` so the branch is back to a green `cargo deny` / `task verify` baseline

Refs #310.

## Test Plan
- `bash scripts/test_release_artifact_lib.sh`
- `bash scripts/test_install_sh.sh`
- `bash scripts/test_check_glibc_floor.sh`
- `cargo deny check advisories`
- `task verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added musl release variant for Linux x86_64 alongside GNU.
  * Installer auto-detects host glibc and selects GNU when compatible, otherwise falls back to musl.
  * Added --target-libc CLI flag and LOONGCLAW_INSTALL_TARGET_LIBC override to force GNU or musl.

* **Documentation**
  * Updated README and installation docs to explain GNU vs musl artifacts, selection rules, and override usage.

* **Tests**
  * Expanded installer and release tests covering GNU/musl selection and glibc checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->