### PR TITLE
fix(onboard): apply reviewed defaults in non-interactive setup

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1818,7 +1818,7 @@ fn resolve_model_selection(
         if let Some(model) = options.model.as_deref() {
             return Ok(model.trim().to_owned());
         }
-        return Ok(config.provider.configured_model_value());
+        return Ok(resolve_onboarding_model_prompt_default(options, config));
     }
 
     let default_model = resolve_onboarding_model_prompt_default(options, config);
@@ -7811,7 +7811,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_selection_preserves_minimax_auto_non_interactively() {
+    fn resolve_model_selection_applies_minimax_recommended_model_non_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
@@ -7841,8 +7841,8 @@ mod tests {
         .expect("resolve model selection");
 
         assert!(
-            selected == "auto",
-            "non-interactive onboarding should preserve auto for MiniMax instead of silently rewriting the operator config to the reviewed default: {selected:?}"
+            selected == "MiniMax-M2.5",
+            "non-interactive onboarding should use the reviewed provider default for MiniMax instead of carrying auto into preflight: {selected:?}"
         );
     }
 
@@ -7883,7 +7883,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_selection_preserves_deepseek_auto_non_interactively() {
+    fn resolve_model_selection_applies_deepseek_recommended_model_non_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Deepseek;
         config.provider.model = "auto".to_owned();
@@ -7913,8 +7913,8 @@ mod tests {
         .expect("resolve model selection");
 
         assert!(
-            selected == "auto",
-            "non-interactive onboarding should preserve auto for DeepSeek instead of silently rewriting the operator config to the reviewed default: {selected:?}"
+            selected == "deepseek-chat",
+            "non-interactive onboarding should use the reviewed provider default for DeepSeek instead of carrying auto into preflight: {selected:?}"
         );
     }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -865,7 +865,7 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn non_interactive_onboard_preserves_reviewed_auto_when_probe_is_skipped() {
+async fn non_interactive_onboard_applies_reviewed_default_when_probe_is_skipped() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let root = unique_temp_path("non-interactive-reviewed-auto-skip-root");
     std::fs::create_dir_all(&root).expect("create test root");
@@ -890,12 +890,12 @@ async fn non_interactive_onboard_preserves_reviewed_auto_when_probe_is_skipped()
         .expect("load written onboarding config");
     assert_eq!(config.provider.kind, mvp::config::ProviderKind::Deepseek);
     assert_eq!(
-        config.provider.model, "auto",
-        "non-interactive onboarding should preserve model = auto when the operator did not explicitly pin a reviewed provider model"
+        config.provider.model, "deepseek-chat",
+        "non-interactive onboarding should materialize the reviewed provider default so skip-model-probe still leaves a usable explicit model"
     );
     assert!(
-        !raw.contains("model = \"deepseek-chat\""),
-        "skip-model-probe onboarding should not silently rewrite reviewed providers to the reviewed model: {raw}"
+        raw.contains("model = \"deepseek-chat\""),
+        "skip-model-probe onboarding should persist the reviewed model explicitly instead of leaving the config on auto: {raw}"
     );
 }
 
@@ -941,7 +941,7 @@ async fn non_interactive_onboard_allows_explicit_model_probe_warning() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rewriting_config() {
+async fn non_interactive_onboard_applies_reviewed_default_when_probe_fails() {
     let _env_guard = DetectedEnvironmentGuard::without_detected_environment();
     let root = unique_temp_path("non-interactive-reviewed-auto-failure-root");
     std::fs::create_dir_all(&root).expect("create test root");
@@ -960,7 +960,6 @@ async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rew
     config.provider.api_key = Some("test-deepseek-key".to_owned());
     mvp::config::write(Some(output.to_string_lossy().as_ref()), &config, true)
         .expect("write existing config");
-    let original_body = std::fs::read_to_string(&output).expect("read original config");
 
     let mut options = default_non_interactive_onboard_options(&output);
     options.force = true;
@@ -968,21 +967,18 @@ async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rew
 
     let mut ui = ScriptedOnboardUi::new(std::iter::empty::<String>());
     let context = crate::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
-    let error = crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
+    crate::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
         .await
-        .expect_err("reviewed auto-model probe failures should block non-interactive onboarding until the model is pinned explicitly");
+        .expect("reviewed onboarding defaults should let non-interactive onboarding pin a usable explicit model even when catalog probing fails");
 
+    let written = std::fs::read_to_string(&output).expect("read config after onboarding");
     assert!(
-        error.contains("accept reviewed model `deepseek-chat`")
-            && error.contains("provider.model")
-            && error.contains("preferred_models"),
-        "reviewed auto-model probe failures should surface the actionable explicit-model remediation instead of a generic rerun hint: {error}"
+        written.contains("model = \"deepseek-chat\""),
+        "non-interactive onboarding should persist the reviewed model explicitly instead of leaving the provider on auto after a probe warning: {written}"
     );
-    assert_eq!(
-        std::fs::read_to_string(&output).expect("read config after blocked onboard"),
-        original_body,
-        "blocking reviewed auto-model probe failures should leave the existing auto config untouched"
-    );
+    let (_, written_config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
+        .expect("load written onboarding config");
+    assert_eq!(written_config.provider.model, "deepseek-chat");
 
     let requests = server.join().expect("join local provider server");
     assert!(
@@ -991,7 +987,7 @@ async fn non_interactive_onboard_reports_reviewed_auto_probe_failure_without_rew
             request.starts_with("GET /v1/models ")
                 && normalized.contains("authorization: bearer test-deepseek-key")
         }),
-        "reviewed auto-model failures should still attempt the provider model probe before surfacing the actionable remediation: {requests:#?}"
+        "reviewed-default onboarding should still attempt the provider model probe with resolved auth before falling back to the explicit reviewed model: {requests:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -883,7 +883,7 @@ async fn non_interactive_onboard_applies_reviewed_default_when_probe_is_skipped(
         loongclaw_daemon::onboard_cli::OnboardRuntimeContext::new_for_tests(80, None, None);
     loongclaw_daemon::onboard_cli::run_onboard_cli_with_ui(options, &mut ui, &context)
         .await
-        .expect("skip-model-probe should allow non-interactive onboarding to keep reviewed auto providers on auto");
+        .expect("skip-model-probe should allow non-interactive onboarding to materialize the reviewed default model");
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))


### PR DESCRIPTION
## Summary

- Problem:
  Non-interactive onboarding bypassed the existing reviewed onboarding model policy and preserved `provider.model = "auto"` even for reviewed providers like DeepSeek and MiniMax.
- Why it matters:
  When those providers reject `/models` during setup, onboarding still hard-blocked even though the repo already had a reviewed explicit-model recovery path.
- What changed:
  Reused `resolve_onboarding_model_prompt_default()` for non-interactive model selection so the same reviewed default resolution now applies in both interactive and non-interactive onboarding. Updated unit and integration coverage to prove reviewed defaults are written explicitly for skipped-probe and 401 probe-failure paths. Also refreshed one stale integration-test panic message so failure output matches the new behavior.
- What did not change (scope boundary):
  This does not add hidden runtime fallbacks, does not widen the reviewed-provider set, and does not change doctor’s remediation semantics for existing configs that still keep `model = auto`.

## Linked Issues

- Closes #396
- Related #398

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-daemon resolve_model_selection_applies -- --nocapture
- Passed both non-interactive reviewed-default unit tests for DeepSeek and MiniMax on the clean replacement branch.

cargo test -p loongclaw-daemon non_interactive_onboard_applies_reviewed_default --test integration -- --nocapture
- Passed both integration scenarios:
  - skip-model-probe still writes `deepseek-chat`
  - 401 model-probe warning still writes `deepseek-chat`
```

Before / after:

- Before:
  non-interactive onboarding kept reviewed providers on `model = auto`, so `/models` rejection could still hard-block setup.
- After:
  non-interactive onboarding materializes the reviewed explicit model first, so the same provider policy used by interactive onboarding also unblocks setup without introducing hidden runtime fallback behavior.

Test env note:

- The touched integration tests use the existing environment guards / serialized local test helpers already present in the file (`DetectedEnvironmentGuard`, local probe server, per-test temp paths), so process-global state is restored by the existing test harness patterns.

## User-visible / Operator-visible Changes

- Non-interactive onboarding now writes the reviewed explicit model for providers with a reviewed onboarding default instead of preserving `model = auto`.
- For reviewed providers, setup no longer hard-blocks on `/models` rejection when the existing reviewed explicit model is enough to continue.

## Failure Recovery

- Fast rollback or disable path:
  Revert the onboarding fix commit to restore the old non-interactive `model = auto` behavior.
- Observable failure symptoms reviewers should watch for:
  Non-interactive onboarding unexpectedly overwriting an already explicit `provider.model`, or non-reviewed providers being rewritten away from `auto`.

## Reviewer Focus

- `crates/daemon/src/onboard_cli.rs`
  The non-interactive branch in `resolve_model_selection()` should now reuse the same reviewed-default policy as the interactive path and should still preserve explicit `--model` / explicit config values.
- `crates/daemon/tests/integration/onboard_cli.rs`
  Focus on the skipped-probe and 401-probe flows to confirm we now persist explicit reviewed defaults instead of leaving the config on `auto`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved model selection during setup: when no specific model is chosen, the system now uses each provider's recommended default model instead of a generic "auto" setting, providing clearer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->