### PR TITLE
fix(tools): specify English in tool.search query description

### DIFF
--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1021,7 +1021,7 @@ fn tool_search_definition(descriptor: &ToolDescriptor) -> Value {
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "Natural-language description of the tool capability you need."
+                        "description": "English natural-language description of the tool capability you need."
                     },
                     "limit": {
                         "type": "integer",


### PR DESCRIPTION
## Summary

- Problem: `tool_search` uses ASCII substring matching internally. Chinese queries like "文件搜索" always score 0 and return empty results.
- Why it matters: Chinese-speaking users cannot discover available tools via natural-language queries.
- What changed: Updated the `query` parameter description in the `tool_search` tool schema to explicitly hint that English should be used.
- What did not change (scope boundary): The underlying ASCII substring matching algorithm. A proper translation-layer fix is tracked in issue #401.

## Linked Issues

- Closes #401

## Change Type

- [x] Bug fix

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`

## User-visible / Operator-visible Changes

- Tool discovery via `tool.search` now clearly instructs the model to use English queries, improving results for non-English users who interact in their native language.

## Failure Recovery

- Fast rollback or disable path: Revert the single-line change in `crates/app/src/tools/catalog.rs`.
- Observable failure symptoms reviewers should watch for: None — this only changes a description string.

## Reviewer Focus

- This is a minimal signal-layer fix (schema description). The real fix for non-English query support requires a translation/pinyin matching layer tracked in #401.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the search tool's natural-language capability description must be provided in English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->