### PR TITLE
fix(test): rearrange `use`s to resolve `test` compile errors and warns

### DIFF
--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -1713,7 +1713,8 @@ mod tests {
     #[cfg(unix)]
     use std::path::{Path, PathBuf};
     #[cfg(unix)]
-    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
     use crate::config::{AcpBackendProfilesConfig, AcpConfig, AcpxBackendConfig, LoongClawConfig};

--- a/crates/app/src/feishu/token_store.rs
+++ b/crates/app/src/feishu/token_store.rs
@@ -544,7 +544,6 @@ fn unix_ts_now() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;

--- a/crates/app/src/feishu/token_store.rs
+++ b/crates/app/src/feishu/token_store.rs
@@ -544,6 +544,7 @@ fn unix_ts_now() -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;

--- a/crates/app/src/feishu/token_store.rs
+++ b/crates/app/src/feishu/token_store.rs
@@ -544,6 +544,7 @@ fn unix_ts_now() -> i64 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 


### PR DESCRIPTION
## Summary

- Problem:
- Why it matters: Tests don't pass compilation on Windows
- What changed: `use`s' order and cfg
- What did not change (scope boundary): outside tests
## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [ ] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo clippy --workspace --all-targets --all-features -- -D warnings
    Checking loongclaw-contracts v0.1.0-alpha.2 (D:\Code\loongclaw\crates\contracts)
    Checking loongclaw-protocol v0.1.0-alpha.2 (D:\Code\loongclaw\crates\protocol)
   Compiling loongclaw-app v0.1.0-alpha.2 (D:\Code\loongclaw\crates\app)
    Checking loongclaw-kernel v0.1.0-alpha.2 (D:\Code\loongclaw\crates\kernel)
    Checking loongclaw-spec v0.1.0-alpha.2 (D:\Code\loongclaw\crates\spec)
    Checking loongclaw-bench v0.1.0-alpha.2 (D:\Code\loongclaw\crates\bench)
    Checking loongclaw-daemon v0.1.0-alpha.2 (D:\Code\loongclaw\crates\daemon)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 43.97s
```

## User-visible / Operator-visible Changes

- None, or describe the exact change: None

## Failure Recovery

- Fast rollback or disable path: None
- Observable failure symptoms reviewers should watch for: None

## Reviewer Focus

- Point reviewers at the files, edge cases, or risk seams that deserve the most attention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minor internal test portability and import cleanup to streamline platform-specific test compilation and maintainability. No user-facing behavior or public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->