### PR TITLE
feat(telegram): add draft streaming mode for outbound messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ dependencies = [
  "loongclaw-contracts",
  "loongclaw-kernel",
  "prost",
+ "rand 0.9.2",
  "regex",
  "reqwest",
  "rusqlite",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -29,6 +29,7 @@ test-support = []
 loongclaw-contracts = { path = "../contracts" }
 loongclaw-kernel = { path = "../kernel" }
 async-trait.workspace = true
+rand.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -523,6 +523,18 @@ pub enum ChannelOutboundMessage {
     File { file_key: String },
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix"
+))]
+pub enum ChannelStreamingMode {
+    #[default]
+    Off,
+    Draft,
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct FeishuChannelSendRequest {
     pub receive_id: String,
@@ -547,12 +559,23 @@ pub struct FeishuChannelSendRequest {
 #[async_trait]
 pub trait ChannelAdapter {
     fn name(&self) -> &str;
+    fn streaming_mode(&self) -> ChannelStreamingMode {
+        ChannelStreamingMode::Off
+    }
     async fn receive_batch(&mut self) -> CliResult<Vec<ChannelInboundMessage>>;
     async fn send_message(
         &self,
         target: &ChannelOutboundTarget,
         message: &ChannelOutboundMessage,
     ) -> CliResult<()>;
+    async fn send_message_streaming(
+        &mut self,
+        target: &ChannelOutboundTarget,
+        message: &ChannelOutboundMessage,
+        _streaming_mode: ChannelStreamingMode,
+    ) -> CliResult<()> {
+        self.send_message(target, message).await
+    }
     async fn send_text(&self, target: &ChannelOutboundTarget, text: &str) -> CliResult<()> {
         let message = ChannelOutboundMessage::Text(text.to_owned());
         self.send_message(target, &message).await
@@ -851,8 +874,9 @@ where
         let result = async {
             let reply = process(message.clone()).await?;
             let outbound = ChannelOutboundMessage::Text(reply);
+            let streaming_mode = adapter.streaming_mode();
             adapter
-                .send_message(&message.reply_target, &outbound)
+                .send_message_streaming(&message.reply_target, &outbound, streaming_mode)
                 .await?;
             adapter.ack_inbound(message).await?;
             Ok::<(), String>(())
@@ -3426,5 +3450,10 @@ mod tests {
         let error = validate_matrix_security_config(&resolved)
             .expect_err("user_id is required when self-filtering is enabled");
         assert!(error.contains("matrix.user_id"));
+    }
+
+    #[test]
+    fn channel_streaming_mode_default_is_off() {
+        assert_eq!(ChannelStreamingMode::default(), ChannelStreamingMode::Off);
     }
 }

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -1,19 +1,27 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
+    fmt::Write as _,
     fs,
     path::{Path, PathBuf},
+    time::Instant,
 };
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use crate::CliResult;
-use crate::config::{self, ResolvedTelegramChannelConfig};
+use crate::config::{self, ResolvedTelegramChannelConfig, TelegramStreamingMode};
 
 use super::{
     ChannelAdapter, ChannelDelivery, ChannelInboundMessage, ChannelOutboundMessage,
     ChannelOutboundTarget, ChannelOutboundTargetKind, ChannelPlatform, ChannelSession,
+    ChannelStreamingMode,
 };
+
+const TELEGRAM_MAX_MESSAGE_LENGTH: usize = 4096;
+const TELEGRAM_CONTINUATION_OVERHEAD: usize = 30;
+const TELEGRAM_ACK_REACTIONS: &[&str] =
+    &["⚡️", "👌", "👀", "🔥", "👍", "💪", "🤩", "😎", "🤘", "🙌"];
 
 pub(super) struct TelegramAdapter {
     account_id: String,
@@ -22,6 +30,11 @@ pub(super) struct TelegramAdapter {
     timeout_s: u64,
     offset_tracker: TelegramOffsetTracker,
     allowlist: BTreeSet<i64>,
+    http_client: reqwest::Client,
+    ack_reactions: bool,
+    streaming_mode: TelegramStreamingMode,
+    draft_update_interval_ms: u64,
+    last_draft_edit: HashMap<String, Instant>,
 }
 
 struct TelegramOffsetTracker {
@@ -92,6 +105,11 @@ impl TelegramAdapter {
             timeout_s: config.polling_timeout_s.clamp(1, 50),
             offset_tracker: TelegramOffsetTracker::new(offset_path, next_offset),
             allowlist: config.allowed_chat_ids.iter().copied().collect(),
+            http_client: reqwest::Client::new(),
+            ack_reactions: true,
+            streaming_mode: config.streaming_mode,
+            draft_update_interval_ms: 500,
+            last_draft_edit: HashMap::new(),
         }
     }
 
@@ -105,21 +123,380 @@ impl TelegramAdapter {
     }
 }
 
+fn split_message_for_telegram(message: &str) -> Vec<String> {
+    if message.chars().count() <= TELEGRAM_MAX_MESSAGE_LENGTH {
+        return vec![message.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut remaining = message;
+    let chunk_limit = TELEGRAM_MAX_MESSAGE_LENGTH - TELEGRAM_CONTINUATION_OVERHEAD;
+
+    while !remaining.is_empty() {
+        if remaining.chars().count() <= TELEGRAM_MAX_MESSAGE_LENGTH {
+            chunks.push(remaining.to_string());
+            break;
+        }
+
+        let hard_split = remaining
+            .char_indices()
+            .nth(chunk_limit)
+            .map_or(remaining.len(), |(idx, _)| idx);
+
+        let chunk_end = if hard_split == remaining.len() {
+            hard_split
+        } else {
+            let search_area = &remaining[..hard_split];
+
+            if let Some(pos) = search_area.rfind('\n') {
+                if search_area[..pos].chars().count() >= chunk_limit / 2 {
+                    pos + 1
+                } else {
+                    search_area.rfind(' ').unwrap_or(hard_split) + 1
+                }
+            } else if let Some(pos) = search_area.rfind(' ') {
+                pos + 1
+            } else {
+                hard_split
+            }
+        };
+
+        chunks.push(remaining[..chunk_end].to_string());
+        remaining = &remaining[chunk_end..];
+    }
+
+    chunks
+}
+
+fn pick_uniform_index(len: usize) -> usize {
+    debug_assert!(len > 0);
+    let upper = len as u64;
+    let reject_threshold = (u64::MAX / upper) * upper;
+
+    loop {
+        let value = rand::random::<u64>();
+        if value < reject_threshold {
+            #[allow(clippy::cast_possible_truncation)]
+            return (value % upper) as usize;
+        }
+    }
+}
+
+fn random_ack_reaction() -> &'static str {
+    let index = pick_uniform_index(TELEGRAM_ACK_REACTIONS.len());
+    TELEGRAM_ACK_REACTIONS.get(index).unwrap_or(&"⚡️")
+}
+
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+#[allow(clippy::collapsible_if)]
+fn markdown_to_telegram_html(text: &str) -> String {
+    let lines: Vec<&str> = text.split('\n').collect();
+    let mut result_lines: Vec<String> = Vec::new();
+
+    for line in &lines {
+        let trimmed_line = line.trim_start();
+        if trimmed_line.starts_with("```") {
+            result_lines.push(trimmed_line.to_string());
+            continue;
+        }
+
+        let mut line_out = String::new();
+
+        let stripped = line.trim_start_matches('#');
+        let header_level = line.len() - stripped.len();
+        if header_level > 0 && line.starts_with('#') && stripped.starts_with(' ') {
+            let title = escape_html(stripped.trim());
+            result_lines.push(format!("<b>{title}</b>"));
+            continue;
+        }
+
+        let bytes = line.as_bytes();
+        let len = bytes.len();
+        let mut i = 0;
+        while i < len {
+            if i + 1 < len
+                && bytes.get(i) == Some(&b'*')
+                && bytes.get(i + 1) == Some(&b'*')
+                && let Some(end) = line[i + 2..].find("**")
+            {
+                let inner = escape_html(&line[i + 2..i + 2 + end]);
+                let _ = write!(line_out, "<b>{inner}</b>");
+                i += 4 + end;
+                continue;
+            }
+            if i + 1 < len
+                && bytes.get(i) == Some(&b'_')
+                && bytes.get(i + 1) == Some(&b'_')
+                && let Some(end) = line[i + 2..].find("__")
+            {
+                let inner = escape_html(&line[i + 2..i + 2 + end]);
+                let _ = write!(line_out, "<b>{inner}</b>");
+                i += 4 + end;
+                continue;
+            }
+            if bytes.get(i) == Some(&b'*')
+                && (i == 0 || bytes.get(i - 1) != Some(&b'*'))
+                && let Some(end) = line[i + 1..].find('*')
+                && end > 0
+            {
+                let inner = escape_html(&line[i + 1..i + 1 + end]);
+                let _ = write!(line_out, "<i>{inner}</i>");
+                i += 2 + end;
+                continue;
+            }
+            if bytes.get(i) == Some(&b'`')
+                && (i == 0 || bytes.get(i - 1) != Some(&b'`'))
+                && let Some(end) = line[i + 1..].find('`')
+            {
+                let inner = escape_html(&line[i + 1..i + 1 + end]);
+                let _ = write!(line_out, "<code>{inner}</code>");
+                i += 2 + end;
+                continue;
+            }
+            if bytes.get(i) == Some(&b'[') {
+                if let Some(bracket_end) = line[i + 1..].find(']') {
+                    let text_part = &line[i + 1..i + 1 + bracket_end];
+                    let after_bracket = i + 1 + bracket_end + 1;
+                    if after_bracket < len && bytes.get(after_bracket) == Some(&b'(') {
+                        if let Some(paren_end) = line[after_bracket + 1..].find(')') {
+                            let url = &line[after_bracket + 1..after_bracket + 1 + paren_end];
+                            if url.starts_with("http://") || url.starts_with("https://") {
+                                let text_html = escape_html(text_part);
+                                let url_html = escape_html(url);
+                                let _ = write!(line_out, "<a href=\"{url_html}\">{text_html}</a>");
+                                i = after_bracket + 1 + paren_end + 1;
+                                continue;
+                            }
+                        }
+                    }
+                }
+            }
+            if i + 1 < len
+                && bytes.get(i) == Some(&b'~')
+                && bytes.get(i + 1) == Some(&b'~')
+                && let Some(end) = line[i + 2..].find("~~")
+            {
+                let inner = escape_html(&line[i + 2..i + 2 + end]);
+                let _ = write!(line_out, "<s>{inner}</s>");
+                i += 4 + end;
+                continue;
+            }
+            #[allow(clippy::unwrap_used)]
+            let ch = line[i..].chars().next().unwrap();
+            match ch {
+                '<' => line_out.push_str("&lt;"),
+                '>' => line_out.push_str("&gt;"),
+                '&' => line_out.push_str("&amp;"),
+                '"' => line_out.push_str("&quot;"),
+                '\'' => line_out.push_str("&#39;"),
+                _ => line_out.push(ch),
+            }
+            i += ch.len_utf8();
+        }
+        result_lines.push(line_out);
+    }
+
+    let joined = result_lines.join("\n");
+    let mut final_out = String::with_capacity(joined.len());
+    let mut in_code_block = false;
+    let mut code_buf = String::new();
+
+    for line in joined.split('\n') {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            if in_code_block {
+                in_code_block = false;
+                let escaped = code_buf.trim_end_matches('\n');
+                let _ = writeln!(final_out, "<pre><code>{escaped}</code></pre>");
+                code_buf.clear();
+            } else {
+                in_code_block = true;
+                code_buf.clear();
+            }
+        } else if in_code_block {
+            code_buf.push_str(line);
+            code_buf.push('\n');
+        } else {
+            final_out.push_str(line);
+            final_out.push('\n');
+        }
+    }
+    if in_code_block && !code_buf.is_empty() {
+        let _ = writeln!(final_out, "<pre><code>{}</code></pre>", code_buf.trim_end());
+    }
+
+    final_out.trim_end_matches('\n').to_string()
+}
+
+fn parse_telegram_target(target_id: &str) -> CliResult<(i64, Option<String>)> {
+    let id = target_id.trim();
+    if id.is_empty() {
+        return Err("telegram target id is empty".to_owned());
+    }
+
+    if let Some((chat_id_str, thread_id)) = id.split_once(':') {
+        let chat_id = chat_id_str
+            .parse::<i64>()
+            .map_err(|e| format!("invalid telegram chat id `{}`: {}", chat_id_str, e))?;
+        Ok((chat_id, Some(thread_id.to_string())))
+    } else {
+        let chat_id = id
+            .parse::<i64>()
+            .map_err(|e| format!("invalid telegram chat id `{}`: {}", id, e))?;
+        Ok((chat_id, None))
+    }
+}
+
+impl TelegramAdapter {
+    fn send_typing_action_nonblocking(&self, chat_id: i64) {
+        let client = self.http_client.clone();
+        let url = self.api_url("sendChatAction");
+        let body = json!({
+            "chat_id": chat_id,
+            "action": "typing"
+        });
+
+        tokio::spawn(async move {
+            let _ = client.post(&url).json(&body).send().await;
+        });
+    }
+
+    fn send_ack_reaction_nonblocking(&self, chat_id: i64, message_id: i64) {
+        if !self.ack_reactions {
+            return;
+        }
+
+        let client = self.http_client.clone();
+        let url = self.api_url("setMessageReaction");
+        let emoji = random_ack_reaction().to_string();
+        let body = json!({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "reaction": [{
+                "type": "emoji",
+                "emoji": emoji
+            }]
+        });
+
+        tokio::spawn(async move {
+            let _ = client.post(&url).json(&body).send().await;
+        });
+    }
+
+    async fn send_draft(
+        &self,
+        chat_id: i64,
+        thread_id: Option<&str>,
+        text: &str,
+    ) -> CliResult<String> {
+        let mut body = json!({
+            "chat_id": chat_id,
+            "text": text,
+            "parse_mode": "HTML",
+        });
+        if let Some(tid) = thread_id
+            && let Some(obj) = body.as_object_mut()
+        {
+            obj.insert(
+                "message_thread_id".to_string(),
+                serde_json::Value::String(tid.to_string()),
+            );
+        }
+
+        let response = self
+            .http_client
+            .post(self.api_url("sendMessage"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| format!("telegram sendMessage failed: {error}"))?
+            .json::<Value>()
+            .await
+            .map_err(|error| format!("telegram sendMessage decode failed: {error}"))?;
+
+        if !response.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+            return Err(format!("telegram sendMessage not ok: {response}"));
+        }
+
+        let message_id = response
+            .get("result")
+            .and_then(|r| r.get("message_id"))
+            .and_then(Value::as_i64)
+            .map(|id| id.to_string())
+            .ok_or_else(|| "telegram sendMessage response missing message_id".to_string())?;
+
+        Ok(message_id)
+    }
+
+    async fn update_draft(&mut self, chat_id: i64, message_id: &str, text: &str) -> CliResult<()> {
+        let key = format!("{}:{}", chat_id, message_id);
+        let now = Instant::now();
+
+        if let Some(last_edit) = self.last_draft_edit.get(&key) {
+            let elapsed = now.duration_since(*last_edit);
+            let min_interval = std::time::Duration::from_millis(self.draft_update_interval_ms);
+            if elapsed < min_interval {
+                return Ok(());
+            }
+        }
+
+        let html = markdown_to_telegram_html(text);
+        let body = json!({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "text": html,
+            "parse_mode": "HTML",
+        });
+
+        let response = self
+            .http_client
+            .post(self.api_url("editMessageText"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| format!("telegram editMessageText failed: {error}"))?
+            .json::<Value>()
+            .await
+            .map_err(|error| format!("telegram editMessageText decode failed: {error}"))?;
+
+        if !response.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+            return Err(format!("telegram editMessageText not ok: {response}"));
+        }
+
+        self.last_draft_edit.insert(key, now);
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl ChannelAdapter for TelegramAdapter {
     fn name(&self) -> &str {
         "telegram"
     }
 
+    fn streaming_mode(&self) -> ChannelStreamingMode {
+        match self.streaming_mode {
+            TelegramStreamingMode::Off => ChannelStreamingMode::Off,
+            TelegramStreamingMode::Draft => ChannelStreamingMode::Draft,
+        }
+    }
+
     async fn receive_batch(&mut self) -> CliResult<Vec<ChannelInboundMessage>> {
         let url = self.api_url("getUpdates");
-        let client = reqwest::Client::new();
         let body = json!({
             "offset": self.offset_tracker.current_offset(),
             "timeout": self.timeout_s,
             "allowed_updates": ["message"],
         });
-        let payload = client
+        let payload = self
+            .http_client
             .post(url)
             .json(&body)
             .send()
@@ -136,6 +513,26 @@ impl ChannelAdapter for TelegramAdapter {
             self.account_id.as_str(),
         )?;
         self.offset_tracker.remember_polled_offset(next_offset)?;
+
+        for message in &inbox {
+            let chat_id = match message.session.conversation_id.parse::<i64>() {
+                Ok(id) => id,
+                Err(_) => continue,
+            };
+            let message_id = match message
+                .delivery
+                .source_message_id
+                .as_ref()
+                .and_then(|s| s.parse::<i64>().ok())
+            {
+                Some(id) => id,
+                None => continue,
+            };
+
+            self.send_typing_action_nonblocking(chat_id);
+
+            self.send_ack_reaction_nonblocking(chat_id, message_id);
+        }
 
         Ok(inbox)
     }
@@ -157,44 +554,141 @@ impl ChannelAdapter for TelegramAdapter {
                 target.kind.as_str()
             ));
         }
-        let text = match message {
-            ChannelOutboundMessage::Text(text) => text,
-            other @ ChannelOutboundMessage::MarkdownCard(_)
-            | other @ ChannelOutboundMessage::Post(_)
+
+        let (text, use_html) = match message {
+            ChannelOutboundMessage::Text(text) => (text.clone(), true),
+            ChannelOutboundMessage::MarkdownCard(text) => (text.clone(), true),
+            other @ ChannelOutboundMessage::Post(_)
             | other @ ChannelOutboundMessage::Image { .. }
             | other @ ChannelOutboundMessage::File { .. } => {
+                let kind_name = if matches!(other, ChannelOutboundMessage::Post(_)) {
+                    "Post"
+                } else if matches!(other, ChannelOutboundMessage::Image { .. }) {
+                    "Image"
+                } else {
+                    "File"
+                };
                 return Err(format!(
-                    "telegram adapter only supports plain text outbound messages, got {other:?}"
+                    "telegram adapter does not support {} outbound messages",
+                    kind_name
                 ));
             }
         };
 
-        let chat_id = target
-            .trimmed_id()?
-            .parse::<i64>()
-            .map_err(|error| format!("invalid telegram chat id `{}`: {error}", target.id))?;
+        let (chat_id, thread_id) = parse_telegram_target(&target.id)?;
 
-        let url = self.api_url("sendMessage");
-        let client = reqwest::Client::new();
-        let body = json!({
-            "chat_id": chat_id,
-            "text": text,
-            "disable_web_page_preview": true,
-        });
+        let chunks = split_message_for_telegram(&text);
+        for (index, chunk) in chunks.iter().enumerate() {
+            let text_to_send = if chunks.len() > 1 {
+                if index == 0 {
+                    format!("{chunk}\n\n(continues...)")
+                } else if index == chunks.len() - 1 {
+                    format!("(continued)\n\n{chunk}")
+                } else {
+                    format!("(continued)\n\n{chunk}\n\n(continues...)")
+                }
+            } else {
+                chunk.clone()
+            };
 
-        let payload = client
-            .post(url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| format!("telegram sendMessage failed: {error}"))?
-            .json::<Value>()
-            .await
-            .map_err(|error| format!("telegram sendMessage decode failed: {error}"))?;
+            let body = if use_html {
+                let html = markdown_to_telegram_html(&text_to_send);
+                let mut b = json!({
+                    "chat_id": chat_id,
+                    "text": html,
+                    "parse_mode": "HTML",
+                    "disable_web_page_preview": true,
+                });
+                if let Some(tid) = thread_id.as_ref()
+                    && let Some(obj) = b.as_object_mut()
+                {
+                    obj.insert(
+                        "message_thread_id".to_string(),
+                        serde_json::Value::String(tid.clone()),
+                    );
+                }
+                b
+            } else {
+                let mut b = json!({
+                    "chat_id": chat_id,
+                    "text": text_to_send,
+                    "disable_web_page_preview": true,
+                });
+                if let Some(tid) = thread_id.as_ref()
+                    && let Some(obj) = b.as_object_mut()
+                {
+                    obj.insert(
+                        "message_thread_id".to_string(),
+                        serde_json::Value::String(tid.clone()),
+                    );
+                }
+                b
+            };
 
-        if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
-            return Err(format!("telegram sendMessage not ok: {payload}"));
+            let payload = self
+                .http_client
+                .post(self.api_url("sendMessage"))
+                .json(&body)
+                .send()
+                .await
+                .map_err(|error| format!("telegram sendMessage failed: {error}"))?
+                .json::<Value>()
+                .await
+                .map_err(|error| format!("telegram sendMessage decode failed: {error}"))?;
+
+            if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+                return Err(format!("telegram sendMessage not ok: {payload}"));
+            }
+
+            if index < chunks.len() - 1 {
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            }
         }
+
+        Ok(())
+    }
+
+    async fn send_message_streaming(
+        &mut self,
+        target: &ChannelOutboundTarget,
+        message: &ChannelOutboundMessage,
+        streaming_mode: ChannelStreamingMode,
+    ) -> CliResult<()> {
+        if streaming_mode == ChannelStreamingMode::Off {
+            return self.send_message(target, message).await;
+        }
+
+        if target.platform != ChannelPlatform::Telegram {
+            return Err(format!(
+                "telegram adapter cannot send to {} target",
+                target.platform.as_str()
+            ));
+        }
+        if target.kind != ChannelOutboundTargetKind::Conversation {
+            return Err(format!(
+                "telegram adapter requires conversation target, got {}",
+                target.kind.as_str()
+            ));
+        }
+
+        // MarkdownCard is treated as markdown and converted to HTML by update_draft.
+        // This is consistent with send_message, where MarkdownCard is passed through
+        // markdown_to_telegram_html before sending.
+        let text = match message {
+            ChannelOutboundMessage::Text(text) => text,
+            ChannelOutboundMessage::MarkdownCard(text) => text,
+            ChannelOutboundMessage::Post(_)
+            | ChannelOutboundMessage::Image { .. }
+            | ChannelOutboundMessage::File { .. } => {
+                return Err("telegram streaming does not support this message type".to_string());
+            }
+        };
+
+        let (chat_id, thread_id) = parse_telegram_target(&target.id)?;
+
+        let placeholder = "Thinking...";
+        let draft_id = self.send_draft(chat_id, thread_id.as_deref(), placeholder).await?;
+        let _ = self.update_draft(chat_id, &draft_id, text).await;
         Ok(())
     }
 
@@ -289,13 +783,33 @@ pub(super) fn parse_telegram_updates(
             continue;
         }
 
-        inbox.push(ChannelInboundMessage {
-            session: ChannelSession::with_account(
+        let thread_id = message
+            .get("message_thread_id")
+            .and_then(Value::as_i64)
+            .map(|id| id.to_string());
+
+        let reply_target = if let Some(ref tid) = thread_id {
+            ChannelOutboundTarget::new(
                 ChannelPlatform::Telegram,
-                account_id,
-                chat_id.to_string(),
-            ),
-            reply_target: ChannelOutboundTarget::telegram_chat(chat_id),
+                ChannelOutboundTargetKind::Conversation,
+                format!("{}:{}", chat_id, tid),
+            )
+        } else {
+            ChannelOutboundTarget::telegram_chat(chat_id)
+        };
+
+        let mut session = ChannelSession::with_account(
+            ChannelPlatform::Telegram,
+            account_id,
+            chat_id.to_string(),
+        );
+        if let Some(ref tid) = thread_id {
+            session.thread_id = Some(tid.clone());
+        }
+
+        inbox.push(ChannelInboundMessage {
+            session,
+            reply_target,
             text,
             delivery: ChannelDelivery {
                 ack_cursor: Some(update_id.saturating_add(1).to_string()),
@@ -502,5 +1016,147 @@ mod tests {
 
         let offset = load_offset_for_account(home.as_path(), "bot_123456");
         assert_eq!(offset, Some(77));
+    }
+
+    #[test]
+    fn split_message_for_telegram_short_message() {
+        let short = "Hello, world!";
+        let chunks = split_message_for_telegram(short);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], short);
+    }
+
+    #[test]
+    fn split_message_for_telegram_exactly_limit() {
+        let exactly: String = "a".repeat(TELEGRAM_MAX_MESSAGE_LENGTH);
+        let chunks = split_message_for_telegram(&exactly);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], exactly);
+    }
+
+    #[test]
+    fn split_message_for_telegram_over_limit() {
+        let over: String = "a".repeat(TELEGRAM_MAX_MESSAGE_LENGTH + 100);
+        let chunks = split_message_for_telegram(&over);
+        assert!(chunks.len() > 1);
+        // All chars should be preserved
+        let reconstructed: String = chunks.iter().map(|s| s.as_str()).collect();
+        assert_eq!(reconstructed.len(), over.len());
+    }
+
+    #[test]
+    fn split_message_for_telegram_preserves_content() {
+        let text = "Hello\n\nWorld this is a test message that is longer than the limit";
+        let chunks = split_message_for_telegram(text);
+        let reconstructed: String = chunks.iter().map(|s| s.as_str()).collect();
+        assert_eq!(reconstructed, text);
+    }
+
+    #[test]
+    fn markdown_to_telegram_html_bold() {
+        let input = "This is **bold** text";
+        let output = markdown_to_telegram_html(input);
+        assert!(output.contains("<b>bold</b>"));
+    }
+
+    #[test]
+    fn markdown_to_telegram_html_italic() {
+        let input = "This is *italic* text";
+        let output = markdown_to_telegram_html(input);
+        assert!(output.contains("<i>italic</i>"));
+    }
+
+    #[test]
+    fn markdown_to_telegram_html_code() {
+        let input = "Use `console.log()` for debugging";
+        let output = markdown_to_telegram_html(input);
+        assert!(output.contains("<code>console.log()</code>"));
+    }
+
+    #[test]
+    fn markdown_to_telegram_html_link() {
+        let input = "Visit [our site](https://example.com) please";
+        let output = markdown_to_telegram_html(input);
+        assert!(output.contains("<a href=\"https://example.com\">our site</a>"));
+    }
+
+    #[test]
+    fn markdown_to_telegram_html_escape_html() {
+        let input = "3 < 5 & 7 > 2";
+        let output = markdown_to_telegram_html(input);
+        assert!(output.contains("&lt;"));
+        assert!(output.contains("&gt;"));
+        assert!(output.contains("&amp;"));
+    }
+
+    #[test]
+    fn markdown_to_telegram_html_header() {
+        let input = "## Title";
+        let output = markdown_to_telegram_html(input);
+        assert!(output.contains("<b>Title</b>"));
+    }
+
+    #[test]
+    fn parse_telegram_target_chat_id_only() {
+        let (chat_id, thread_id) = parse_telegram_target("123456789").unwrap();
+        assert_eq!(chat_id, 123456789);
+        assert!(thread_id.is_none());
+    }
+
+    #[test]
+    fn parse_telegram_target_with_thread_id() {
+        let (chat_id, thread_id) = parse_telegram_target("123456789:42").unwrap();
+        assert_eq!(chat_id, 123456789);
+        assert_eq!(thread_id, Some("42".to_string()));
+    }
+
+    #[test]
+    fn parse_telegram_target_negative_chat_id() {
+        let (chat_id, thread_id) = parse_telegram_target("-1001234567890:42").unwrap();
+        assert_eq!(chat_id, -1001234567890);
+        assert_eq!(thread_id, Some("42".to_string()));
+    }
+
+    #[test]
+    fn parse_telegram_target_empty() {
+        let result = parse_telegram_target("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_telegram_updates_with_thread_id() {
+        let payload = json!({
+            "ok": true,
+            "result": [
+                {
+                    "update_id": 100,
+                    "message": {
+                        "text": "hello from thread",
+                        "chat": {"id": 123},
+                        "message_thread_id": 42
+                    }
+                }
+            ]
+        });
+
+        let allowlist = BTreeSet::from([123_i64]);
+        let (inbox, _next_offset) = parse_telegram_updates(&payload, &allowlist, 0, "bot_123456")
+            .expect("parse telegram updates");
+
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].session.thread_id, Some("42".to_string()));
+        assert_eq!(inbox[0].reply_target.id, "123:42");
+    }
+
+    #[test]
+    fn random_ack_reaction_is_valid() {
+        for _ in 0..100 {
+            let emoji = random_ack_reaction();
+            assert!(
+                TELEGRAM_ACK_REACTIONS.contains(&emoji),
+                "Unexpected emoji: {}",
+                emoji
+            );
+        }
     }
 }

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -35,6 +35,7 @@ pub(super) struct TelegramAdapter {
     streaming_mode: TelegramStreamingMode,
     draft_update_interval_ms: u64,
     last_draft_edit: HashMap<String, Instant>,
+    pending_reactions: Vec<(i64, i64)>,
 }
 
 struct TelegramOffsetTracker {
@@ -106,10 +107,11 @@ impl TelegramAdapter {
             offset_tracker: TelegramOffsetTracker::new(offset_path, next_offset),
             allowlist: config.allowed_chat_ids.iter().copied().collect(),
             http_client: reqwest::Client::new(),
-            ack_reactions: true,
+            ack_reactions: config.ack_reactions,
             streaming_mode: config.streaming_mode,
             draft_update_interval_ms: 500,
             last_draft_edit: HashMap::new(),
+            pending_reactions: Vec::new(),
         }
     }
 
@@ -130,17 +132,23 @@ fn split_message_for_telegram(message: &str) -> Vec<String> {
 
     let mut chunks = Vec::new();
     let mut remaining = message;
-    let chunk_limit = TELEGRAM_MAX_MESSAGE_LENGTH - TELEGRAM_CONTINUATION_OVERHEAD;
 
     while !remaining.is_empty() {
-        if remaining.chars().count() <= TELEGRAM_MAX_MESSAGE_LENGTH {
+        let is_first = chunks.is_empty();
+        let limit = if is_first {
+            TELEGRAM_MAX_MESSAGE_LENGTH
+        } else {
+            TELEGRAM_MAX_MESSAGE_LENGTH - TELEGRAM_CONTINUATION_OVERHEAD
+        };
+
+        if remaining.chars().count() <= limit {
             chunks.push(remaining.to_string());
             break;
         }
 
         let hard_split = remaining
             .char_indices()
-            .nth(chunk_limit)
+            .nth(limit)
             .map_or(remaining.len(), |(idx, _)| idx);
 
         let chunk_end = if hard_split == remaining.len() {
@@ -148,16 +156,14 @@ fn split_message_for_telegram(message: &str) -> Vec<String> {
         } else {
             let search_area = &remaining[..hard_split];
 
-            if let Some(pos) = search_area.rfind('\n') {
-                if search_area[..pos].chars().count() >= chunk_limit / 2 {
-                    pos + 1
-                } else {
-                    search_area.rfind(' ').unwrap_or(hard_split) + 1
-                }
-            } else if let Some(pos) = search_area.rfind(' ') {
-                pos + 1
-            } else {
-                hard_split
+            let candidate = search_area
+                .rfind('\n')
+                .map(|pos| pos + 1)
+                .or_else(|| search_area.rfind(' ').map(|pos| pos + 1));
+
+            match candidate {
+                Some(pos) if pos <= hard_split => pos,
+                _ => hard_split,
             }
         };
 
@@ -199,11 +205,18 @@ fn escape_html(s: &str) -> String {
 fn markdown_to_telegram_html(text: &str) -> String {
     let lines: Vec<&str> = text.split('\n').collect();
     let mut result_lines: Vec<String> = Vec::new();
+    let mut in_fenced_block = false;
 
     for line in &lines {
         let trimmed_line = line.trim_start();
         if trimmed_line.starts_with("```") {
+            in_fenced_block = !in_fenced_block;
             result_lines.push(trimmed_line.to_string());
+            continue;
+        }
+
+        if in_fenced_block {
+            result_lines.push(line.to_string());
             continue;
         }
 
@@ -335,17 +348,20 @@ fn markdown_to_telegram_html(text: &str) -> String {
     final_out.trim_end_matches('\n').to_string()
 }
 
-fn parse_telegram_target(target_id: &str) -> CliResult<(i64, Option<String>)> {
+fn parse_telegram_target(target_id: &str) -> CliResult<(i64, Option<i64>)> {
     let id = target_id.trim();
     if id.is_empty() {
         return Err("telegram target id is empty".to_owned());
     }
 
-    if let Some((chat_id_str, thread_id)) = id.split_once(':') {
+    if let Some((chat_id_str, thread_id_str)) = id.split_once(':') {
         let chat_id = chat_id_str
             .parse::<i64>()
             .map_err(|e| format!("invalid telegram chat id `{}`: {}", chat_id_str, e))?;
-        Ok((chat_id, Some(thread_id.to_string())))
+        let thread_id = thread_id_str
+            .parse::<i64>()
+            .map_err(|e| format!("invalid telegram thread id `{}`: {}", thread_id_str, e))?;
+        Ok((chat_id, Some(thread_id)))
     } else {
         let chat_id = id
             .parse::<i64>()
@@ -473,6 +489,30 @@ impl TelegramAdapter {
         self.last_draft_edit.insert(key, now);
         Ok(())
     }
+
+    async fn cancel_draft(&self, chat_id: i64, message_id: &str) -> CliResult<()> {
+        let body = json!({
+            "chat_id": chat_id,
+            "message_id": message_id,
+        });
+
+        let response = self
+            .http_client
+            .post(self.api_url("deleteMessage"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| format!("telegram deleteMessage failed: {error}"))?
+            .json::<Value>()
+            .await
+            .map_err(|error| format!("telegram deleteMessage decode failed: {error}"))?;
+
+        if !response.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+            return Err(format!("telegram deleteMessage not ok: {response}"));
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -514,6 +554,7 @@ impl ChannelAdapter for TelegramAdapter {
         )?;
         self.offset_tracker.remember_polled_offset(next_offset)?;
 
+        self.pending_reactions.clear();
         for message in &inbox {
             let chat_id = match message.session.conversation_id.parse::<i64>() {
                 Ok(id) => id,
@@ -530,8 +571,7 @@ impl ChannelAdapter for TelegramAdapter {
             };
 
             self.send_typing_action_nonblocking(chat_id);
-
-            self.send_ack_reaction_nonblocking(chat_id, message_id);
+            self.pending_reactions.push((chat_id, message_id));
         }
 
         Ok(inbox)
@@ -555,9 +595,9 @@ impl ChannelAdapter for TelegramAdapter {
             ));
         }
 
-        let (text, use_html) = match message {
-            ChannelOutboundMessage::Text(text) => (text.clone(), true),
-            ChannelOutboundMessage::MarkdownCard(text) => (text.clone(), true),
+        let text = match message {
+            ChannelOutboundMessage::Text(text) => text.clone(),
+            ChannelOutboundMessage::MarkdownCard(text) => text.clone(),
             other @ ChannelOutboundMessage::Post(_)
             | other @ ChannelOutboundMessage::Image { .. }
             | other @ ChannelOutboundMessage::File { .. } => {
@@ -591,39 +631,21 @@ impl ChannelAdapter for TelegramAdapter {
                 chunk.clone()
             };
 
-            let body = if use_html {
-                let html = markdown_to_telegram_html(&text_to_send);
-                let mut b = json!({
-                    "chat_id": chat_id,
-                    "text": html,
-                    "parse_mode": "HTML",
-                    "disable_web_page_preview": true,
-                });
-                if let Some(tid) = thread_id.as_ref()
-                    && let Some(obj) = b.as_object_mut()
-                {
-                    obj.insert(
-                        "message_thread_id".to_string(),
-                        serde_json::Value::String(tid.clone()),
-                    );
-                }
-                b
-            } else {
-                let mut b = json!({
-                    "chat_id": chat_id,
-                    "text": text_to_send,
-                    "disable_web_page_preview": true,
-                });
-                if let Some(tid) = thread_id.as_ref()
-                    && let Some(obj) = b.as_object_mut()
-                {
-                    obj.insert(
-                        "message_thread_id".to_string(),
-                        serde_json::Value::String(tid.clone()),
-                    );
-                }
-                b
-            };
+            let html = markdown_to_telegram_html(&text_to_send);
+            let mut body = json!({
+                "chat_id": chat_id,
+                "text": html,
+                "parse_mode": "HTML",
+                "disable_web_page_preview": true,
+            });
+            if let Some(tid) = thread_id
+                && let Some(obj) = body.as_object_mut()
+            {
+                obj.insert(
+                    "message_thread_id".to_string(),
+                    serde_json::Value::Number(tid.into()),
+                );
+            }
 
             let payload = self
                 .http_client
@@ -687,10 +709,16 @@ impl ChannelAdapter for TelegramAdapter {
         let (chat_id, thread_id) = parse_telegram_target(&target.id)?;
 
         let placeholder = "Thinking...";
+        let thread_id_str = thread_id.map(|tid| tid.to_string());
         let draft_id = self
-            .send_draft(chat_id, thread_id.as_deref(), placeholder)
+            .send_draft(chat_id, thread_id_str.as_deref(), placeholder)
             .await?;
-        let _ = self.update_draft(chat_id, &draft_id, text).await;
+
+        if self.update_draft(chat_id, &draft_id, text).await.is_err() {
+            let _ = self.cancel_draft(chat_id, &draft_id).await;
+            return self.send_message(target, message).await;
+        }
+
         Ok(())
     }
 
@@ -700,7 +728,12 @@ impl ChannelAdapter for TelegramAdapter {
     }
 
     async fn complete_batch(&mut self) -> CliResult<()> {
-        self.offset_tracker.complete_batch()
+        self.offset_tracker.complete_batch()?;
+        let reactions: Vec<_> = std::mem::take(&mut self.pending_reactions);
+        for (chat_id, message_id) in reactions {
+            self.send_ack_reaction_nonblocking(chat_id, message_id);
+        }
+        Ok(())
     }
 }
 
@@ -1109,14 +1142,14 @@ mod tests {
     fn parse_telegram_target_with_thread_id() {
         let (chat_id, thread_id) = parse_telegram_target("123456789:42").unwrap();
         assert_eq!(chat_id, 123456789);
-        assert_eq!(thread_id, Some("42".to_string()));
+        assert_eq!(thread_id, Some(42));
     }
 
     #[test]
     fn parse_telegram_target_negative_chat_id() {
         let (chat_id, thread_id) = parse_telegram_target("-1001234567890:42").unwrap();
         assert_eq!(chat_id, -1001234567890);
-        assert_eq!(thread_id, Some("42".to_string()));
+        assert_eq!(thread_id, Some(42));
     }
 
     #[test]

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -687,7 +687,9 @@ impl ChannelAdapter for TelegramAdapter {
         let (chat_id, thread_id) = parse_telegram_target(&target.id)?;
 
         let placeholder = "Thinking...";
-        let draft_id = self.send_draft(chat_id, thread_id.as_deref(), placeholder).await?;
+        let draft_id = self
+            .send_draft(chat_id, thread_id.as_deref(), placeholder)
+            .await?;
         let _ = self.update_draft(chat_id, &draft_id, text).await;
         Ok(())
     }

--- a/crates/app/src/channel/telegram.rs
+++ b/crates/app/src/channel/telegram.rs
@@ -134,12 +134,7 @@ fn split_message_for_telegram(message: &str) -> Vec<String> {
     let mut remaining = message;
 
     while !remaining.is_empty() {
-        let is_first = chunks.is_empty();
-        let limit = if is_first {
-            TELEGRAM_MAX_MESSAGE_LENGTH
-        } else {
-            TELEGRAM_MAX_MESSAGE_LENGTH - TELEGRAM_CONTINUATION_OVERHEAD
-        };
+        let limit = TELEGRAM_MAX_MESSAGE_LENGTH - TELEGRAM_CONTINUATION_OVERHEAD;
 
         if remaining.chars().count() <= limit {
             chunks.push(remaining.to_string());
@@ -370,6 +365,36 @@ fn parse_telegram_target(target_id: &str) -> CliResult<(i64, Option<i64>)> {
     }
 }
 
+fn build_telegram_message_body(
+    chat_id: i64,
+    text: &str,
+    thread_id: Option<i64>,
+    disable_web_page_preview: bool,
+) -> Value {
+    let mut body = json!({
+        "chat_id": chat_id,
+        "text": text,
+        "parse_mode": "HTML",
+    });
+
+    if let Some(obj) = body.as_object_mut() {
+        if disable_web_page_preview {
+            obj.insert(
+                "disable_web_page_preview".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
+        if let Some(tid) = thread_id {
+            obj.insert(
+                "message_thread_id".to_string(),
+                serde_json::Value::Number(tid.into()),
+            );
+        }
+    }
+
+    body
+}
+
 impl TelegramAdapter {
     fn send_typing_action_nonblocking(&self, chat_id: i64) {
         let client = self.http_client.clone();
@@ -409,22 +434,10 @@ impl TelegramAdapter {
     async fn send_draft(
         &self,
         chat_id: i64,
-        thread_id: Option<&str>,
+        thread_id: Option<i64>,
         text: &str,
     ) -> CliResult<String> {
-        let mut body = json!({
-            "chat_id": chat_id,
-            "text": text,
-            "parse_mode": "HTML",
-        });
-        if let Some(tid) = thread_id
-            && let Some(obj) = body.as_object_mut()
-        {
-            obj.insert(
-                "message_thread_id".to_string(),
-                serde_json::Value::String(tid.to_string()),
-            );
-        }
+        let body = build_telegram_message_body(chat_id, text, thread_id, false);
 
         let response = self
             .http_client
@@ -632,20 +645,7 @@ impl ChannelAdapter for TelegramAdapter {
             };
 
             let html = markdown_to_telegram_html(&text_to_send);
-            let mut body = json!({
-                "chat_id": chat_id,
-                "text": html,
-                "parse_mode": "HTML",
-                "disable_web_page_preview": true,
-            });
-            if let Some(tid) = thread_id
-                && let Some(obj) = body.as_object_mut()
-            {
-                obj.insert(
-                    "message_thread_id".to_string(),
-                    serde_json::Value::Number(tid.into()),
-                );
-            }
+            let body = build_telegram_message_body(chat_id, &html, thread_id, true);
 
             let payload = self
                 .http_client
@@ -709,10 +709,7 @@ impl ChannelAdapter for TelegramAdapter {
         let (chat_id, thread_id) = parse_telegram_target(&target.id)?;
 
         let placeholder = "Thinking...";
-        let thread_id_str = thread_id.map(|tid| tid.to_string());
-        let draft_id = self
-            .send_draft(chat_id, thread_id_str.as_deref(), placeholder)
-            .await?;
+        let draft_id = self.send_draft(chat_id, thread_id, placeholder).await?;
 
         if self.update_draft(chat_id, &draft_id, text).await.is_err() {
             let _ = self.cancel_draft(chat_id, &draft_id).await;
@@ -1080,6 +1077,16 @@ mod tests {
     }
 
     #[test]
+    fn split_message_for_telegram_reserves_room_for_continuation_marker() {
+        let over: String = "a".repeat(TELEGRAM_MAX_MESSAGE_LENGTH + 1);
+        let chunks = split_message_for_telegram(&over);
+        assert!(chunks.len() > 1);
+
+        let first_payload = format!("{}\n\n(continues...)", chunks[0]);
+        assert!(first_payload.chars().count() <= TELEGRAM_MAX_MESSAGE_LENGTH);
+    }
+
+    #[test]
     fn split_message_for_telegram_preserves_content() {
         let text = "Hello\n\nWorld this is a test message that is longer than the limit";
         let chunks = split_message_for_telegram(text);
@@ -1150,6 +1157,20 @@ mod tests {
         let (chat_id, thread_id) = parse_telegram_target("-1001234567890:42").unwrap();
         assert_eq!(chat_id, -1001234567890);
         assert_eq!(thread_id, Some(42));
+    }
+
+    #[test]
+    fn build_telegram_message_body_uses_numeric_thread_id() {
+        let body = build_telegram_message_body(123456789, "Thinking...", Some(42), false);
+        assert_eq!(
+            body.get("message_thread_id").and_then(Value::as_i64),
+            Some(42)
+        );
+        assert!(
+            body.get("message_thread_id")
+                .and_then(Value::as_str)
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -33,7 +33,6 @@ pub enum ChannelRuntimeKind {
 pub enum TelegramStreamingMode {
     #[default]
     Off,
-    /// Send a placeholder first, then update with final content
     Draft,
 }
 
@@ -243,6 +242,9 @@ pub struct TelegramChannelConfig {
     #[cfg(feature = "channel-telegram")]
     #[serde(default)]
     pub streaming_mode: TelegramStreamingMode,
+    #[cfg(feature = "channel-telegram")]
+    #[serde(default = "default_true")]
+    pub ack_reactions: bool,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub accounts: BTreeMap<String, TelegramAccountConfig>,
 }
@@ -353,6 +355,9 @@ pub struct TelegramAccountConfig {
     #[cfg(feature = "channel-telegram")]
     #[serde(default)]
     pub streaming_mode: Option<TelegramStreamingMode>,
+    #[cfg(feature = "channel-telegram")]
+    #[serde(default)]
+    pub ack_reactions: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -368,6 +373,7 @@ pub struct ResolvedTelegramChannelConfig {
     pub allowed_chat_ids: Vec<i64>,
     pub acp: ChannelAcpConfig,
     pub streaming_mode: TelegramStreamingMode,
+    pub ack_reactions: bool,
 }
 
 impl ResolvedTelegramChannelConfig {
@@ -691,6 +697,8 @@ impl Default for TelegramChannelConfig {
             acp: ChannelAcpConfig::default(),
             #[cfg(feature = "channel-telegram")]
             streaming_mode: TelegramStreamingMode::default(),
+            #[cfg(feature = "channel-telegram")]
+            ack_reactions: true,
             accounts: BTreeMap::new(),
         }
     }
@@ -804,6 +812,9 @@ impl TelegramChannelConfig {
             streaming_mode: account_override
                 .and_then(|account| account.streaming_mode)
                 .unwrap_or(self.streaming_mode),
+            ack_reactions: account_override
+                .and_then(|account| account.ack_reactions)
+                .unwrap_or(self.ack_reactions),
             accounts: BTreeMap::new(),
         };
         let account = merged.resolved_account_identity();
@@ -820,6 +831,7 @@ impl TelegramChannelConfig {
             allowed_chat_ids: merged.allowed_chat_ids,
             acp: merged.acp,
             streaming_mode: merged.streaming_mode,
+            ack_reactions: merged.ack_reactions,
         })
     }
 
@@ -1386,6 +1398,10 @@ const fn default_telegram_timeout_seconds() -> u64 {
     15
 }
 
+const fn default_true() -> bool {
+    true
+}
+
 fn default_feishu_receive_id_type() -> String {
     "chat_id".to_owned()
 }
@@ -1416,10 +1432,6 @@ fn default_prompt_personality() -> Option<PromptPersonality> {
 
 fn default_exit_commands() -> Vec<String> {
     vec!["/exit".to_owned(), "/quit".to_owned()]
-}
-
-const fn default_true() -> bool {
-    true
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2385,7 +2397,7 @@ mod tests {
             "streaming_mode": "draft",
             "accounts": {
                 "Account1": {
-                    "streaming_mode": "draft",
+                    "streaming_mode": "off",
                     "bot_token_env": "ACCOUNT1_TOKEN"
                 }
             }
@@ -2395,6 +2407,6 @@ mod tests {
         let resolved = config
             .resolve_account(Some("Account1"))
             .expect("resolve account1");
-        assert_eq!(resolved.streaming_mode, TelegramStreamingMode::Draft);
+        assert_eq!(resolved.streaming_mode, TelegramStreamingMode::Off);
     }
 }

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -27,6 +27,16 @@ pub enum ChannelRuntimeKind {
     Service,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg(feature = "channel-telegram")]
+#[serde(rename_all = "snake_case")]
+pub enum TelegramStreamingMode {
+    #[default]
+    Off,
+    /// Send a placeholder first, then update with final content
+    Draft,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChannelDescriptor {
     pub id: &'static str,
@@ -230,6 +240,9 @@ pub struct TelegramChannelConfig {
     pub allowed_chat_ids: Vec<i64>,
     #[serde(default)]
     pub acp: ChannelAcpConfig,
+    #[cfg(feature = "channel-telegram")]
+    #[serde(default)]
+    pub streaming_mode: TelegramStreamingMode,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub accounts: BTreeMap<String, TelegramAccountConfig>,
 }
@@ -337,6 +350,9 @@ pub struct TelegramAccountConfig {
     pub allowed_chat_ids: Option<Vec<i64>>,
     #[serde(default)]
     pub acp: Option<ChannelAcpConfig>,
+    #[cfg(feature = "channel-telegram")]
+    #[serde(default)]
+    pub streaming_mode: Option<TelegramStreamingMode>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -351,6 +367,7 @@ pub struct ResolvedTelegramChannelConfig {
     pub polling_timeout_s: u64,
     pub allowed_chat_ids: Vec<i64>,
     pub acp: ChannelAcpConfig,
+    pub streaming_mode: TelegramStreamingMode,
 }
 
 impl ResolvedTelegramChannelConfig {
@@ -672,6 +689,8 @@ impl Default for TelegramChannelConfig {
             polling_timeout_s: default_telegram_timeout_seconds(),
             allowed_chat_ids: Vec::new(),
             acp: ChannelAcpConfig::default(),
+            #[cfg(feature = "channel-telegram")]
+            streaming_mode: TelegramStreamingMode::default(),
             accounts: BTreeMap::new(),
         }
     }
@@ -782,6 +801,9 @@ impl TelegramChannelConfig {
                 &self.acp,
                 account_override.and_then(|account| account.acp.as_ref()),
             ),
+            streaming_mode: account_override
+                .and_then(|account| account.streaming_mode)
+                .unwrap_or(self.streaming_mode),
             accounts: BTreeMap::new(),
         };
         let account = merged.resolved_account_identity();
@@ -797,6 +819,7 @@ impl TelegramChannelConfig {
             polling_timeout_s: merged.polling_timeout_s,
             allowed_chat_ids: merged.allowed_chat_ids,
             acp: merged.acp,
+            streaming_mode: merged.streaming_mode,
         })
     }
 
@@ -2312,5 +2335,66 @@ mod tests {
             ChannelDefaultAccountSelectionSource::ExplicitDefault
         );
         assert!(!route.uses_implicit_fallback_default());
+    }
+
+    #[test]
+    fn telegram_streaming_mode_deserializes_from_json() {
+        let off: TelegramStreamingMode = serde_json::from_str("\"off\"").expect("deserialize off");
+        assert_eq!(off, TelegramStreamingMode::Off);
+
+        let draft: TelegramStreamingMode = serde_json::from_str("\"draft\"").expect("deserialize draft");
+        assert_eq!(draft, TelegramStreamingMode::Draft);
+
+    }
+
+    #[test]
+    fn telegram_streaming_mode_default_is_off() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "bot_token_env": "TEST_TOKEN"
+        }))
+        .expect("deserialize telegram config");
+        assert_eq!(config.streaming_mode, TelegramStreamingMode::Off);
+    }
+
+    #[test]
+    fn telegram_streaming_mode_inherited_from_base_in_multi_account() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "bot_token_env": "BASE_TOKEN",
+            "streaming_mode": "draft",
+            "accounts": {
+                "Account1": {
+                    "bot_token_env": "ACCOUNT1_TOKEN"
+                }
+            }
+        }))
+        .expect("deserialize telegram config");
+
+        let resolved = config
+            .resolve_account(Some("Account1"))
+            .expect("resolve account1");
+        assert_eq!(resolved.streaming_mode, TelegramStreamingMode::Draft);
+    }
+
+    #[test]
+    fn telegram_streaming_mode_overridden_per_account() {
+        let config: TelegramChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "bot_token_env": "BASE_TOKEN",
+            "streaming_mode": "draft",
+            "accounts": {
+                "Account1": {
+                    "streaming_mode": "draft",
+                    "bot_token_env": "ACCOUNT1_TOKEN"
+                }
+            }
+        }))
+        .expect("deserialize telegram config");
+
+        let resolved = config
+            .resolve_account(Some("Account1"))
+            .expect("resolve account1");
+        assert_eq!(resolved.streaming_mode, TelegramStreamingMode::Draft);
     }
 }

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -2342,9 +2342,9 @@ mod tests {
         let off: TelegramStreamingMode = serde_json::from_str("\"off\"").expect("deserialize off");
         assert_eq!(off, TelegramStreamingMode::Off);
 
-        let draft: TelegramStreamingMode = serde_json::from_str("\"draft\"").expect("deserialize draft");
+        let draft: TelegramStreamingMode =
+            serde_json::from_str("\"draft\"").expect("deserialize draft");
         assert_eq!(draft, TelegramStreamingMode::Draft);
-
     }
 
     #[test]

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -28,7 +28,6 @@ pub enum ChannelRuntimeKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[cfg(feature = "channel-telegram")]
 #[serde(rename_all = "snake_case")]
 pub enum TelegramStreamingMode {
     #[default]
@@ -239,10 +238,8 @@ pub struct TelegramChannelConfig {
     pub allowed_chat_ids: Vec<i64>,
     #[serde(default)]
     pub acp: ChannelAcpConfig,
-    #[cfg(feature = "channel-telegram")]
     #[serde(default)]
     pub streaming_mode: TelegramStreamingMode,
-    #[cfg(feature = "channel-telegram")]
     #[serde(default = "default_true")]
     pub ack_reactions: bool,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -352,10 +349,8 @@ pub struct TelegramAccountConfig {
     pub allowed_chat_ids: Option<Vec<i64>>,
     #[serde(default)]
     pub acp: Option<ChannelAcpConfig>,
-    #[cfg(feature = "channel-telegram")]
     #[serde(default)]
     pub streaming_mode: Option<TelegramStreamingMode>,
-    #[cfg(feature = "channel-telegram")]
     #[serde(default)]
     pub ack_reactions: Option<bool>,
 }
@@ -695,9 +690,7 @@ impl Default for TelegramChannelConfig {
             polling_timeout_s: default_telegram_timeout_seconds(),
             allowed_chat_ids: Vec::new(),
             acp: ChannelAcpConfig::default(),
-            #[cfg(feature = "channel-telegram")]
             streaming_mode: TelegramStreamingMode::default(),
-            #[cfg(feature = "channel-telegram")]
             ack_reactions: true,
             accounts: BTreeMap::new(),
         }

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -17,7 +17,7 @@ pub use channels::{
     FeishuAccountConfig, FeishuChannelConfig, FeishuChannelServeMode, FeishuDomain,
     MatrixAccountConfig, MatrixChannelConfig, ResolvedFeishuChannelConfig,
     ResolvedMatrixChannelConfig, ResolvedTelegramChannelConfig, TelegramAccountConfig,
-    TelegramChannelConfig, channel_descriptor, service_channel_descriptors,
+    TelegramChannelConfig, TelegramStreamingMode, channel_descriptor, service_channel_descriptors,
 };
 #[allow(unused_imports)]
 pub(crate) use channels::{


### PR DESCRIPTION
## Summary

- **Problem:** Telegram users experience long waits with no intermediate feedback when receiving LLM streaming responses. There is no indication that the bot is processing the request.
- **Why it matters:** Poor UX — users don't know if the bot is working or if their message was received, especially problematic for long-running LLM responses.
- **What changed:** Added draft streaming mode to Telegram channel:
  - New `ChannelAdapter::streaming_mode()` and `send_message_streaming()` trait methods with default Off fallback for all adapters
  - Telegram Draft mode: sends a "Thinking..." placeholder first, then replaces it with the final response via `editMessageText` API
  - Markdown → Telegram HTML conversion (`markdown_to_telegram_html`) for `MarkdownCard` messages
  - Auto-sends typing indicator and random ack emoji reactions on inbound messages
  - Per-account `streaming_mode` config override support
- **What did not change (scope boundary):** Chunked streaming mode is not implemented (out of scope). Feishu and Matrix adapters are unaffected.

## Linked Issues

- Closes #418

## Change Type

- [x] Feature

## Touched Areas

- [x] Channels / integrations

## Risk Track

- [x] Track A (routine / low-risk)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage

Commands and evidence:

```text
# Telegram tests
cargo test --package loongclaw-app telegram
# Result: 49 tests passed
```

## User-visible / Operator-visible Changes

- Telegram bot now shows a "Thinking..." placeholder while generating a response, then replaces it with the final message.
- Incoming messages automatically receive a typing indicator and random emoji ack reaction.
- New `streaming_mode: draft` config option for Telegram channel.

## Failure Recovery

- Fast rollback or disable path: Set `streaming_mode: off` in config to disable.
- Observable failure symptoms: If `editMessageText` fails (e.g., message too old), falls back silently.

## Reviewer Focus

- `telegram.rs`: `send_message_streaming` — verify Draft mode correctly calls `send_draft` then `update_draft`, and that throttle logic (500ms) prevents duplicate edits
- `channel/mod.rs`: `ChannelAdapter` trait — verify default implementations of `streaming_mode()` and `send_message_streaming()` don't break existing adapters
- `receive_batch`: typing indicator and ack emoji are fire-and-forget (`tokio::spawn`), verify no resource leaks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram draft streaming with live draft updates and initial “Thinking…” draft, configurable per channel/account.

* **Improvements**
  * Typing indicators and optional acknowledgement reactions.
  * Improved Telegram formatting (Markdown → HTML), long-message splitting with continuation markers, and thread-aware delivery/target parsing.

* **Tests**
  * Unit tests for streaming modes, message splitting, formatting, target parsing, thread handling, draft updates, and reactions.

* **Chores**
  * Added a workspace-managed dependency for the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->