### PR TITLE
fix(file): clear error message when path is a directory not a file

### DIFF
--- a/crates/app/src/tools/file.rs
+++ b/crates/app/src/tools/file.rs
@@ -38,6 +38,12 @@ pub(super) fn execute_file_read_tool_with_config(
             .min(8 * 1_048_576) as usize;
 
         let resolved = resolve_safe_file_path_with_config(target, config)?;
+        if resolved.is_dir() {
+            return Err(format!(
+                "path '{}' is a directory, not a file",
+                resolved.display()
+            ));
+        }
         let bytes = fs::read(&resolved)
             .map_err(|error| format!("failed to read file {}: {error}", resolved.display()))?;
         let clipped = bytes.len() > max_bytes;


### PR DESCRIPTION
## Summary

- **Problem**: When a user invokes `file.read` with a directory path in `loongclaw chat`, `fs::read()` returns an "Is a directory" error, causing AI-generated confusing messages like "The file `demo.txt` could not be read" or "was not found", making it hard for users to understand the real issue.

- **Why it matters**: Unclear error messages lead to user confusion and wasted debugging time, especially when users mistakenly use their `file_root` directory as a file path.

- **What changed**: Added an `is_dir()` check before `fs::read()` in `file.read`. When the path is a directory, a clear error is returned: `"path 'X' is a directory, not a file"`.

- **What did not change (scope boundary)**: Only improves `file.read` error messaging; no changes to capability checks, path security logic, or `file.write`/`file.edit`.

## Linked Issues

- Closes #417
- Related #196 (security hardening for capability bypass on fallback path — separate work)

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --package loongclaw-app --all-targets --all-features -- -D warnings`
- [x] `cargo test --package loongclaw-app --lib tools::file` — 26 tests passed
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`

Commands and evidence:

```text
cargo fmt --all -- --check         # passed
cargo clippy --package loongclaw-app --all-targets --all-features -- -D warnings  # passed
cargo test --package loongclaw-app --lib tools::file  # 26 passed, 0 failed
```

## User-visible / Operator-visible Changes

- `file.read` now returns a clear error when given a directory path: `"path '/some/path' is a directory, not a file"` instead of the raw `fs::read` error.

## Failure Recovery

- **Fast rollback or disable path**: `git revert <commit>`
- **Observable failure symptoms reviewers should watch for**: None — only improves error messaging, no changes to any success path.

## Reviewer Focus

- `crates/app/src/tools/file.rs:40-47` — confirm `is_dir()` check is correctly placed after `resolve_safe_file_path_with_config` and before `fs::read`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File reading tool now properly rejects directory paths with a clear error message instead of attempting to read them as files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->