### PR TITLE
feat: add durable safe-lane context compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2855,7 +2855,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3193,7 +3193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3293,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -3318,7 +3318,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4191,7 +4191,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -22,7 +22,7 @@ tool-shell = []
 tool-file = []
 tool-browser = ["dep:scraper"]
 tool-webfetch = []
-tool-websearch = ["dep:regex"]
+tool-websearch = []
 test-support = []
 
 [dependencies]
@@ -56,7 +56,7 @@ cbc = { version = "0.1", optional = true }
 wait-timeout = "0.2"
 tempfile = "3"
 which.workspace = true
-regex = { workspace = true, optional = true }
+regex.workspace = true
 prost = { version = "0.13", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"], optional = true }

--- a/crates/app/src/config/conversation.rs
+++ b/crates/app/src/config/conversation.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+const fn default_compact_preserve_recent_turns() -> usize {
+    6
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ConversationConfig {
     #[serde(default)]
@@ -12,6 +16,8 @@ pub struct ConversationConfig {
     pub compact_min_messages: Option<usize>,
     #[serde(default)]
     pub compact_trigger_estimated_tokens: Option<usize>,
+    #[serde(default = "default_compact_preserve_recent_turns")]
+    pub compact_preserve_recent_turns: usize,
     #[serde(default = "default_true")]
     pub compact_fail_open: bool,
     #[serde(default)]
@@ -120,6 +126,7 @@ impl Default for ConversationConfig {
             compact_enabled: default_true(),
             compact_min_messages: None,
             compact_trigger_estimated_tokens: None,
+            compact_preserve_recent_turns: default_compact_preserve_recent_turns(),
             compact_fail_open: default_true(),
             turn_loop: ConversationTurnLoopConfig::default(),
             hybrid_lane_enabled: default_true(),
@@ -269,6 +276,10 @@ impl ConversationConfig {
             .filter(|value| *value > 0)
     }
 
+    pub fn compact_preserve_recent_turns(&self) -> usize {
+        self.compact_preserve_recent_turns.max(1)
+    }
+
     pub fn should_compact(&self, message_count: usize) -> bool {
         self.should_compact_with_estimate(message_count, None)
     }
@@ -284,17 +295,17 @@ impl ConversationConfig {
 
         let min_messages = self.compact_min_messages();
         let trigger_tokens = self.compact_trigger_estimated_tokens();
+
         if min_messages.is_none() && trigger_tokens.is_none() {
-            return true;
+            return false;
         }
 
-        let message_threshold_hit = min_messages.is_some_and(|min| message_count >= min);
-        let token_threshold_hit = match (trigger_tokens, estimated_tokens) {
-            (Some(threshold), Some(tokens)) => tokens >= threshold,
-            _ => false,
-        };
+        let messages_triggered = min_messages.is_some_and(|threshold| message_count >= threshold);
+        let tokens_triggered = trigger_tokens
+            .zip(estimated_tokens)
+            .is_some_and(|(threshold, actual)| actual >= threshold);
 
-        message_threshold_hit || token_threshold_hit
+        messages_triggered || tokens_triggered
     }
 
     pub fn compaction_fail_open(&self) -> bool {

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -2112,6 +2112,7 @@ system = " LuCid "
 compact_enabled = true
 compact_min_messages = 6
 compact_trigger_estimated_tokens = 120
+compact_preserve_recent_turns = 4
 compact_fail_open = false
 "#;
         let parsed =
@@ -2122,6 +2123,7 @@ compact_fail_open = false
             parsed.conversation.compact_trigger_estimated_tokens(),
             Some(120)
         );
+        assert_eq!(parsed.conversation.compact_preserve_recent_turns(), 4);
         assert!(!parsed.conversation.compaction_fail_open());
         assert!(!parsed.conversation.should_compact(5));
         assert!(parsed.conversation.should_compact(6));
@@ -2138,14 +2140,31 @@ compact_fail_open = false
     }
 
     #[test]
-    fn conversation_compaction_defaults_are_backward_compatible() {
+    fn conversation_compaction_defaults_require_explicit_thresholds() {
         let config = ConversationConfig::default();
         assert!(config.turn_middleware_ids().is_empty());
         assert!(config.compact_enabled);
         assert!(config.compaction_fail_open());
+        assert_eq!(config.compact_preserve_recent_turns(), 6);
         assert_eq!(config.compact_trigger_estimated_tokens(), None);
-        assert!(config.should_compact(0));
-        assert!(config.should_compact_with_estimate(0, None));
+        assert!(!config.should_compact(0));
+        assert!(!config.should_compact_with_estimate(0, None));
+        assert!(!config.should_compact_with_estimate(100, Some(10_000)));
+    }
+
+    #[test]
+    fn conversation_compaction_enabled_without_thresholds_does_not_trigger() {
+        let config = ConversationConfig {
+            compact_enabled: true,
+            compact_min_messages: None,
+            compact_trigger_estimated_tokens: None,
+            compact_fail_open: true,
+            context_engine: None,
+            ..ConversationConfig::default()
+        };
+
+        assert!(!config.should_compact(1));
+        assert!(!config.should_compact_with_estimate(100, Some(10_000)));
     }
 
     #[test]

--- a/crates/app/src/conversation/compaction.rs
+++ b/crates/app/src/conversation/compaction.rs
@@ -1,0 +1,205 @@
+use crate::memory::WindowTurn;
+
+const SUMMARY_MAX_RENDERED_TURNS: usize = 4;
+const SUMMARY_TURN_EXCERPT_CHARS: usize = 96;
+const PRIOR_COMPACTED_SUMMARY_PLACEHOLDER: &str = "[prior compacted summary]";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompactPolicy {
+    preserve_recent_turns: usize,
+}
+
+impl CompactPolicy {
+    pub fn new(preserve_recent_turns: usize) -> Self {
+        Self {
+            preserve_recent_turns,
+        }
+    }
+}
+
+pub fn compact_window(turns: &[WindowTurn], policy: CompactPolicy) -> Option<Vec<WindowTurn>> {
+    let preserve = policy.preserve_recent_turns.min(turns.len());
+    if turns.len() <= preserve {
+        return None;
+    }
+
+    let split_at = turns.len() - preserve;
+    let (older, recent) = turns.split_at(split_at);
+    if older.len() == 1 && older.first().is_some_and(is_compacted_summary_turn) {
+        return None;
+    }
+
+    let summary = WindowTurn {
+        role: "user".to_owned(),
+        content: format!(
+            "Compacted {} earlier turns\n{}",
+            older.len(),
+            render_summary(older)
+        ),
+        ts: older.last().and_then(|turn| turn.ts),
+    };
+
+    let mut compacted = Vec::with_capacity(recent.len() + 1);
+    compacted.push(summary);
+    compacted.extend_from_slice(recent);
+    Some(compacted)
+}
+
+fn render_summary(turns: &[WindowTurn]) -> String {
+    let all_lines = turns
+        .iter()
+        .flat_map(render_summary_lines)
+        .collect::<Vec<_>>();
+    let mut selected_indices = all_lines
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, line)| line.is_user.then_some(idx))
+        .take(SUMMARY_MAX_RENDERED_TURNS)
+        .collect::<Vec<_>>();
+    if selected_indices.len() < SUMMARY_MAX_RENDERED_TURNS {
+        let remaining = SUMMARY_MAX_RENDERED_TURNS - selected_indices.len();
+        selected_indices.extend(
+            all_lines
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, line)| (!line.is_user).then_some(idx))
+                .take(remaining),
+        );
+    }
+    selected_indices.sort_unstable();
+
+    let mut lines = selected_indices
+        .into_iter()
+        .filter_map(|idx| all_lines.get(idx).map(|line| line.text.clone()))
+        .collect::<Vec<_>>();
+    let omitted_turns = all_lines.len().saturating_sub(lines.len());
+    if omitted_turns > 0 {
+        lines.push(format!("... {} earlier turns omitted", omitted_turns));
+    }
+    lines.join("\n")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderedSummaryLine {
+    text: String,
+    is_user: bool,
+}
+
+fn render_summary_lines(turn: &WindowTurn) -> Vec<RenderedSummaryLine> {
+    if is_internal_assistant_event_turn(turn) {
+        return Vec::new();
+    }
+
+    if turn.content.trim_start().starts_with("Compacted ") {
+        let lines = extract_prior_summary_lines(&turn.content);
+        if !lines.is_empty() {
+            return lines;
+        }
+        return vec![RenderedSummaryLine {
+            text: format!("{}: {}", turn.role, PRIOR_COMPACTED_SUMMARY_PLACEHOLDER),
+            is_user: turn.role == "user",
+        }];
+    }
+
+    vec![RenderedSummaryLine {
+        text: format!("{}: {}", turn.role, summarize_turn_content(&turn.content)),
+        is_user: turn.role == "user",
+    }]
+}
+
+fn is_compacted_summary_turn(turn: &WindowTurn) -> bool {
+    turn.content.trim_start().starts_with("Compacted ")
+}
+
+fn is_internal_assistant_event_turn(turn: &WindowTurn) -> bool {
+    if turn.role != "assistant" {
+        return false;
+    }
+
+    let parsed = match serde_json::from_str::<serde_json::Value>(&turn.content) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    matches!(
+        parsed.get("type").and_then(serde_json::Value::as_str),
+        Some("conversation_event" | "tool_decision" | "tool_outcome")
+    )
+}
+
+fn summarize_turn_content(content: &str) -> String {
+    let normalized = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    trim_to_chars(&normalized, SUMMARY_TURN_EXCERPT_CHARS)
+}
+
+fn extract_prior_summary_lines(content: &str) -> Vec<RenderedSummaryLine> {
+    content
+        .split_once('\n')
+        .map(|(_, body)| body)
+        .unwrap_or_default()
+        .lines()
+        .filter_map(normalize_prior_summary_line)
+        .collect()
+}
+
+fn normalize_prior_summary_line(line: &str) -> Option<RenderedSummaryLine> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with("... ") {
+        return None;
+    }
+
+    let (role, content) = strip_repeated_summary_role_prefixes(trimmed);
+    if role == "assistant" && is_internal_assistant_summary_content(content) {
+        return None;
+    }
+
+    Some(RenderedSummaryLine {
+        text: format!(
+            "{role}: {}",
+            trim_to_chars(content, SUMMARY_TURN_EXCERPT_CHARS)
+        ),
+        is_user: role == "user",
+    })
+}
+
+fn strip_repeated_summary_role_prefixes(mut line: &str) -> (&str, &str) {
+    let mut role = "user";
+    loop {
+        if let Some(rest) = line.strip_prefix("user:") {
+            role = "user";
+            line = rest.trim_start();
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("assistant:") {
+            role = "assistant";
+            line = rest.trim_start();
+            continue;
+        }
+        break;
+    }
+    (role, line)
+}
+
+fn is_internal_assistant_summary_content(content: &str) -> bool {
+    let parsed = match serde_json::from_str::<serde_json::Value>(content) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    matches!(
+        parsed.get("type").and_then(serde_json::Value::as_str),
+        Some("conversation_event" | "tool_decision" | "tool_outcome")
+    )
+}
+
+fn trim_to_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_owned();
+    }
+
+    if max_chars <= 3 {
+        return value.chars().take(max_chars).collect();
+    }
+
+    let mut trimmed = value.chars().take(max_chars - 3).collect::<String>();
+    trimmed.push_str("...");
+    trimmed
+}

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 #[cfg(feature = "memory-sqlite")]
 use loongclaw_contracts::Capability;
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::config::LoongClawConfig;
 use crate::{CliResult, KernelContext};
@@ -10,6 +10,8 @@ use crate::{CliResult, KernelContext};
 use crate::memory;
 use std::collections::BTreeSet;
 
+#[cfg(feature = "memory-sqlite")]
+use super::compaction::{CompactPolicy, compact_window};
 use super::runtime_binding::ConversationRuntimeBinding;
 
 pub const CONTEXT_ENGINE_API_VERSION: u16 = 1;
@@ -299,6 +301,25 @@ pub struct DefaultContextEngine;
 #[derive(Default)]
 pub struct LegacyContextEngine;
 
+#[cfg(feature = "memory-sqlite")]
+struct CompactionWindowSnapshot {
+    turns: Vec<memory::WindowTurn>,
+    turn_count: Option<usize>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl CompactionWindowSnapshot {
+    fn is_complete_session_snapshot(&self) -> bool {
+        matches!(self.turn_count, Some(turn_count) if turn_count == self.turns.len())
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+enum PersistMemoryWindowOutcome {
+    Persisted,
+    Conflict,
+}
+
 #[async_trait]
 impl ConversationContextEngine for DefaultContextEngine {
     fn id(&self) -> &'static str {
@@ -307,10 +328,69 @@ impl ConversationContextEngine for DefaultContextEngine {
 
     fn metadata(&self) -> ContextEngineMetadata {
         #[cfg(feature = "memory-sqlite")]
-        let capabilities = [ContextEngineCapability::KernelMemoryWindowRead];
+        let capabilities = [
+            ContextEngineCapability::KernelMemoryWindowRead,
+            ContextEngineCapability::ContextCompaction,
+        ];
         #[cfg(not(feature = "memory-sqlite"))]
         let capabilities: [ContextEngineCapability; 0] = [];
         ContextEngineMetadata::new("default", capabilities)
+    }
+
+    async fn compact_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        _messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            const MAX_COMPACTION_CONFLICT_RETRIES: usize = 3;
+
+            for _ in 0..MAX_COMPACTION_CONFLICT_RETRIES {
+                let has_summary_checkpoint = load_memory_context_entries(session_id, kernel_ctx)
+                    .await?
+                    .into_iter()
+                    .any(|entry| entry.kind == memory::MemoryContextKind::Summary);
+                if has_summary_checkpoint {
+                    return Ok(());
+                }
+
+                let snapshot = load_memory_window_snapshot(config, session_id, kernel_ctx).await?;
+                // Fail closed when compaction cannot see the complete persisted session.
+                if !snapshot.is_complete_session_snapshot() {
+                    return Ok(());
+                }
+                let preserve_recent_turns = config
+                    .conversation
+                    .compact_preserve_recent_turns()
+                    .min(config.memory.sliding_window.saturating_sub(1));
+                if preserve_recent_turns == 0 {
+                    return Ok(());
+                }
+                let Some(compacted) =
+                    compact_window(&snapshot.turns, CompactPolicy::new(preserve_recent_turns))
+                else {
+                    return Ok(());
+                };
+
+                match persist_memory_window(session_id, &compacted, snapshot.turn_count, kernel_ctx)
+                    .await?
+                {
+                    PersistMemoryWindowOutcome::Persisted => return Ok(()),
+                    PersistMemoryWindowOutcome::Conflict => continue,
+                }
+            }
+
+            Err("context compaction aborted after repeated concurrent turn updates".to_owned())
+        }
+
+        #[cfg(not(feature = "memory-sqlite"))]
+        {
+            let _ = (config, session_id, kernel_ctx);
+            Ok(())
+        }
     }
 
     async fn assemble_messages(
@@ -412,6 +492,113 @@ async fn load_memory_window(
             ts: Some(turn.ts),
         })
         .collect())
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_memory_window_snapshot(
+    config: &LoongClawConfig,
+    session_id: &str,
+    kernel_ctx: &KernelContext,
+) -> CliResult<CompactionWindowSnapshot> {
+    const MAX_COMPACTION_WINDOW_TURNS: usize = 512;
+
+    let request = loongclaw_contracts::MemoryCoreRequest {
+        operation: memory::MEMORY_OP_WINDOW.to_owned(),
+        payload: json!({
+            "session_id": session_id,
+            "limit": MAX_COMPACTION_WINDOW_TURNS,
+            "allow_extended_limit": true,
+        }),
+    };
+    let caps = BTreeSet::from([Capability::MemoryRead]);
+    let outcome = kernel_ctx
+        .kernel
+        .execute_memory_core(
+            kernel_ctx.pack_id(),
+            &kernel_ctx.token,
+            &caps,
+            None,
+            request,
+        )
+        .await
+        .map_err(|error| format!("load memory window via kernel failed: {error}"))?;
+
+    if outcome.status != "ok" {
+        return Err(format!(
+            "load memory window via kernel returned non-ok status: {}",
+            outcome.status
+        ));
+    }
+
+    let _ = config;
+    Ok(CompactionWindowSnapshot {
+        turns: memory::decode_window_turns(&outcome.payload),
+        turn_count: memory::decode_window_turn_count(&outcome.payload),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_memory_context_entries(
+    session_id: &str,
+    kernel_ctx: &KernelContext,
+) -> CliResult<Vec<memory::MemoryContextEntry>> {
+    let request = memory::build_read_context_request(session_id);
+    let caps = BTreeSet::from([Capability::MemoryRead]);
+    let outcome = kernel_ctx
+        .kernel
+        .execute_memory_core(
+            kernel_ctx.pack_id(),
+            &kernel_ctx.token,
+            &caps,
+            None,
+            request,
+        )
+        .await
+        .map_err(|error| format!("load memory context via kernel failed: {error}"))?;
+
+    if outcome.status != "ok" {
+        return Err(format!(
+            "load memory context via kernel returned non-ok status: {}",
+            outcome.status
+        ));
+    }
+
+    Ok(memory::decode_memory_context_entries(&outcome.payload))
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn persist_memory_window(
+    session_id: &str,
+    turns: &[memory::WindowTurn],
+    expected_turn_count: Option<usize>,
+    kernel_ctx: &KernelContext,
+) -> CliResult<PersistMemoryWindowOutcome> {
+    let request = memory::build_replace_turns_request_with_expectation(
+        session_id,
+        turns,
+        expected_turn_count,
+    );
+    let caps = BTreeSet::from([Capability::MemoryWrite]);
+    let outcome = kernel_ctx
+        .kernel
+        .execute_memory_core(
+            kernel_ctx.pack_id(),
+            &kernel_ctx.token,
+            &caps,
+            None,
+            request,
+        )
+        .await
+        .map_err(|error| format!("persist compacted memory window via kernel failed: {error}"))?;
+
+    match outcome.status.as_str() {
+        "ok" => Ok(PersistMemoryWindowOutcome::Persisted),
+        "conflict" => Ok(PersistMemoryWindowOutcome::Conflict),
+        _ => Err(format!(
+            "persist compacted memory window via kernel returned non-ok status: {}",
+            outcome.status
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics;
+mod compaction;
 mod context_engine;
 mod context_engine_registry;
 mod ingress;

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2538,12 +2538,15 @@ async fn handle_turn_with_runtime_success_with_kernel_runs_lifecycle_hooks() {
         vec![json!({"role": "system", "content": "sys"})],
         Ok("assistant-reply".to_owned()),
     );
+    let mut config = test_config();
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = crate::context::bootstrap_test_kernel_context("test-handle-turn-success", 60)
         .expect("bootstrap kernel context");
     let reply = coordinator
         .handle_turn_with_runtime(
-            &test_config(),
+            &config,
             "session-1",
             "hello",
             ProviderErrorMode::Propagate,
@@ -4234,6 +4237,8 @@ async fn handle_turn_with_runtime_compaction_error_is_ignored_when_fail_open() {
     );
     runtime.compact_result = Err("compact failure".to_owned());
     let mut config = test_config();
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
     config.conversation.compact_fail_open = true;
 
     let coordinator = ConversationTurnCoordinator::new();
@@ -4263,6 +4268,8 @@ async fn handle_turn_with_runtime_compaction_error_propagates_when_fail_closed()
     );
     runtime.compact_result = Err("compact failure".to_owned());
     let mut config = test_config();
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
     config.conversation.compact_fail_open = false;
 
     let coordinator = ConversationTurnCoordinator::new();
@@ -10545,6 +10552,92 @@ fn build_kernel_context_with_raw_window_payload(
     (ctx, invocations)
 }
 
+fn build_kernel_context_with_compaction_conflict(
+    audit: Arc<InMemoryAuditSink>,
+) -> (KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::MemoryWrite, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+
+    let invocations = Arc::new(Mutex::new(Vec::new()));
+    let adapter = ConflictOnFirstReplaceMemoryAdapter {
+        invocations: invocations.clone(),
+        state: Mutex::new(ConflictOnFirstReplaceState::default()),
+    };
+    kernel.register_core_memory_adapter(adapter);
+    kernel
+        .set_default_core_memory_adapter("test-memory-conflict-retry")
+        .expect("set default memory adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    (ctx, invocations)
+}
+
+fn build_kernel_context_with_incomplete_compaction_snapshot(
+    audit: Arc<InMemoryAuditSink>,
+    window_turns: Value,
+    turn_count: usize,
+) -> (KernelContext, Arc<Mutex<Vec<MemoryCoreRequest>>>) {
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::MemoryWrite, Capability::MemoryRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+
+    let invocations = Arc::new(Mutex::new(Vec::new()));
+    kernel.register_core_memory_adapter(IncompleteCompactionSnapshotMemoryAdapter {
+        invocations: invocations.clone(),
+        window_turns,
+        turn_count,
+    });
+    kernel
+        .set_default_core_memory_adapter("test-memory-incomplete-compaction-snapshot")
+        .expect("set default memory adapter");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    (ctx, invocations)
+}
+
 #[cfg(feature = "memory-sqlite")]
 fn prepare_discovery_first_summary_test(
     db_scope: &str,
@@ -10712,6 +10805,165 @@ impl CoreMemoryAdapter for RawWindowPayloadMemoryAdapter {
             status: "ok".to_owned(),
             payload: json!({}),
         })
+    }
+}
+
+struct ConflictOnFirstReplaceState {
+    turn_count: usize,
+    window_turns: Vec<Value>,
+    conflict_emitted: bool,
+}
+
+impl Default for ConflictOnFirstReplaceState {
+    fn default() -> Self {
+        Self {
+            turn_count: 6,
+            window_turns: vec![
+                json!({"role": "user", "content": "ask 1", "ts": 1}),
+                json!({"role": "assistant", "content": "reply 1", "ts": 2}),
+                json!({"role": "user", "content": "ask 2", "ts": 3}),
+                json!({"role": "assistant", "content": "reply 2", "ts": 4}),
+                json!({"role": "user", "content": "recent ask", "ts": 5}),
+                json!({"role": "assistant", "content": "recent reply", "ts": 6}),
+            ],
+            conflict_emitted: false,
+        }
+    }
+}
+
+struct ConflictOnFirstReplaceMemoryAdapter {
+    invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+    state: Mutex<ConflictOnFirstReplaceState>,
+}
+
+#[async_trait]
+impl CoreMemoryAdapter for ConflictOnFirstReplaceMemoryAdapter {
+    fn name(&self) -> &str {
+        "test-memory-conflict-retry"
+    }
+
+    async fn execute_core_memory(
+        &self,
+        request: MemoryCoreRequest,
+    ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+        self.invocations
+            .lock()
+            .expect("invocations lock")
+            .push(request.clone());
+
+        let mut state = self.state.lock().expect("conflict state lock");
+        match request.operation.as_str() {
+            crate::memory::MEMORY_OP_READ_CONTEXT => Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({"entries": []}),
+            }),
+            crate::memory::MEMORY_OP_WINDOW => Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "turns": state.window_turns.clone(),
+                    "turn_count": state.turn_count,
+                }),
+            }),
+            crate::memory::MEMORY_OP_REPLACE_TURNS => {
+                let expected_turn_count = request
+                    .payload
+                    .get("expected_turn_count")
+                    .and_then(Value::as_u64)
+                    .map(|value| value as usize);
+
+                if !state.conflict_emitted {
+                    state.turn_count += 1;
+                    let concurrent_ts = state.turn_count as i64;
+                    state.window_turns.push(json!({
+                        "role": "user",
+                        "content": "concurrent ask",
+                        "ts": concurrent_ts,
+                    }));
+                    state.conflict_emitted = true;
+                    return Ok(MemoryCoreOutcome {
+                        status: "conflict".to_owned(),
+                        payload: json!({
+                            "expected_turn_count": expected_turn_count,
+                            "actual_turn_count": state.turn_count,
+                        }),
+                    });
+                }
+
+                if expected_turn_count != Some(state.turn_count) {
+                    return Ok(MemoryCoreOutcome {
+                        status: "conflict".to_owned(),
+                        payload: json!({
+                            "expected_turn_count": expected_turn_count,
+                            "actual_turn_count": state.turn_count,
+                        }),
+                    });
+                }
+
+                let turns = request
+                    .payload
+                    .get("turns")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                state.turn_count = turns.len();
+                state.window_turns = turns;
+                Ok(MemoryCoreOutcome {
+                    status: "ok".to_owned(),
+                    payload: json!({
+                        "replaced_turns": state.turn_count,
+                    }),
+                })
+            }
+            _ => Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            }),
+        }
+    }
+}
+
+struct IncompleteCompactionSnapshotMemoryAdapter {
+    invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
+    window_turns: Value,
+    turn_count: usize,
+}
+
+#[async_trait]
+impl CoreMemoryAdapter for IncompleteCompactionSnapshotMemoryAdapter {
+    fn name(&self) -> &str {
+        "test-memory-incomplete-compaction-snapshot"
+    }
+
+    async fn execute_core_memory(
+        &self,
+        request: MemoryCoreRequest,
+    ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
+        self.invocations
+            .lock()
+            .expect("invocations lock")
+            .push(request.clone());
+
+        match request.operation.as_str() {
+            crate::memory::MEMORY_OP_READ_CONTEXT => Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({"entries": []}),
+            }),
+            crate::memory::MEMORY_OP_WINDOW => Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "turns": self.window_turns.clone(),
+                    "turn_count": self.turn_count,
+                }),
+            }),
+            crate::memory::MEMORY_OP_REPLACE_TURNS => Err(MemoryPlaneError::Execution(
+                "replace_turns should not run when the compaction snapshot is incomplete"
+                    .to_owned(),
+            )),
+            _ => Ok(MemoryCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({}),
+            }),
+        }
     }
 }
 
@@ -17296,6 +17548,1028 @@ async fn durable_turn_checkpoint_repair_persists_failed_terminal_checkpoint_then
             .len(),
         1,
         "finalized durable checkpoint must not trigger another compaction"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[test]
+fn compact_window_preserves_recent_turns_and_summarizes_history() {
+    use super::compaction::{CompactPolicy, compact_window};
+
+    let turns = vec![
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "ask 1".into(),
+            ts: Some(1),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "reply 1".into(),
+            ts: Some(2),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "ask 2".into(),
+            ts: Some(3),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "reply 2".into(),
+            ts: Some(4),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "recent ask".into(),
+            ts: Some(5),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "recent reply".into(),
+            ts: Some(6),
+        },
+    ];
+
+    let compacted = compact_window(&turns, CompactPolicy::new(2)).expect("should compact");
+
+    assert_eq!(compacted.len(), 3);
+    assert_eq!(compacted[0].role, "user");
+    assert!(compacted[0].content.contains("Compacted 4 earlier turns"));
+    assert_eq!(compacted[1].content, "recent ask");
+    assert_eq!(compacted[2].content, "recent reply");
+}
+
+#[test]
+fn compact_window_skips_small_histories() {
+    use super::compaction::{CompactPolicy, compact_window};
+
+    let turns = vec![
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "short".into(),
+            ts: Some(1),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "reply".into(),
+            ts: Some(2),
+        },
+    ];
+
+    assert!(compact_window(&turns, CompactPolicy::new(2)).is_none());
+}
+
+#[test]
+fn compact_window_skips_recompacting_single_prior_summary() {
+    use super::compaction::{CompactPolicy, compact_window};
+
+    let turns = vec![
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "Compacted 4 earlier turns\nuser: ask 1".into(),
+            ts: Some(4),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "recent ask".into(),
+            ts: Some(5),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "recent reply".into(),
+            ts: Some(6),
+        },
+    ];
+
+    assert!(compact_window(&turns, CompactPolicy::new(2)).is_none());
+}
+
+#[test]
+fn compact_window_bounds_summary_content_and_prior_summaries() {
+    use super::compaction::{CompactPolicy, compact_window};
+
+    let prior_summary = format!("Compacted 9 earlier turns\nuser: {}", "history ".repeat(64));
+    let long_payload = "payload ".repeat(96);
+    let turns = vec![
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: prior_summary,
+            ts: Some(1),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: long_payload.clone(),
+            ts: Some(2),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: long_payload.clone(),
+            ts: Some(3),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: long_payload.clone(),
+            ts: Some(4),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: long_payload,
+            ts: Some(5),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "recent ask".into(),
+            ts: Some(6),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "recent reply".into(),
+            ts: Some(7),
+        },
+    ];
+
+    let compacted = compact_window(&turns, CompactPolicy::new(2)).expect("should compact");
+    let summary = &compacted[0].content;
+
+    assert!(summary.contains("history"));
+    assert!(summary.contains("earlier turns omitted"));
+    assert!(
+        summary.len() < 512,
+        "summary should stay bounded: {}",
+        summary.len()
+    );
+    assert_eq!(compacted[1].content, "recent ask");
+    assert_eq!(compacted[2].content, "recent reply");
+}
+
+#[test]
+fn compact_window_retains_prior_summary_details_across_repeated_compaction() {
+    use super::compaction::{CompactPolicy, compact_window};
+
+    let prior_summary = "Compacted 1 earlier turns\nuser: For this test, remember these facts exactly: - codename: NIMBUS-17 - owner: Mina - budget: 47";
+    let turns = vec![
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: prior_summary.into(),
+            ts: Some(1),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "ack-1".into(),
+            ts: Some(2),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "Add these facts too: - launch month: October - fallback code: RIVER-9".into(),
+            ts: Some(3),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "ack-2".into(),
+            ts: Some(4),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "recent ask".into(),
+            ts: Some(5),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "recent reply".into(),
+            ts: Some(6),
+        },
+    ];
+
+    let compacted = compact_window(&turns, CompactPolicy::new(2)).expect("should compact");
+    let summary = &compacted[0].content;
+
+    assert!(summary.contains("NIMBUS-17"));
+    assert!(summary.contains("Mina"));
+    assert!(summary.contains("47"));
+    assert!(summary.contains("October"));
+    assert!(summary.contains("RIVER-9"));
+    assert!(
+        !summary.contains("[prior compacted summary]"),
+        "repeated compaction should retain prior summary details: {summary}"
+    );
+}
+
+#[test]
+fn compact_window_prioritizes_user_fact_turns_when_summary_budget_is_limited() {
+    use super::compaction::{CompactPolicy, compact_window};
+
+    let turns = vec![
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "codename: NIMBUS-17 owner: Mina budget: 47".into(),
+            ts: Some(1),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "ack-1".into(),
+            ts: Some(2),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "launch month: October fallback code: RIVER-9".into(),
+            ts: Some(3),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "ack-2".into(),
+            ts: Some(4),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "escalation contact: Owen".into(),
+            ts: Some(5),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "ack-3".into(),
+            ts: Some(6),
+        },
+        crate::memory::WindowTurn {
+            role: "user".into(),
+            content: "recent ask".into(),
+            ts: Some(7),
+        },
+        crate::memory::WindowTurn {
+            role: "assistant".into(),
+            content: "recent reply".into(),
+            ts: Some(8),
+        },
+    ];
+
+    let compacted = compact_window(&turns, CompactPolicy::new(2)).expect("should compact");
+    let summary = &compacted[0].content;
+
+    assert!(summary.contains("NIMBUS-17"));
+    assert!(summary.contains("October"));
+    assert!(summary.contains("RIVER-9"));
+    assert!(summary.contains("Owen"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn default_context_engine_metadata_advertises_context_compaction() {
+    use super::context_engine::{
+        ContextEngineCapability, ConversationContextEngine, DefaultContextEngine,
+    };
+
+    let engine = DefaultContextEngine;
+    let metadata = engine.metadata();
+
+    assert!(
+        metadata
+            .capabilities
+            .contains(&ContextEngineCapability::KernelMemoryWindowRead)
+    );
+    assert!(
+        metadata
+            .capabilities
+            .contains(&ContextEngineCapability::ContextCompaction)
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_compact_context_rewrites_persisted_window() {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let mut config = test_config();
+    let db_path = unique_memory_sqlite_path("default-context-engine-compaction");
+    let _ = std::fs::remove_file(&db_path);
+    config.memory.sqlite_path = db_path.clone();
+    config.memory.sliding_window = 32;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let kernel_ctx =
+        test_kernel_context_with_memory("test-default-context-engine-compaction", &memory_config);
+    let session_id = "default-context-engine-compaction";
+
+    for (role, content) in [
+        ("user", "ask 1"),
+        ("assistant", "reply 1"),
+        ("user", "ask 2"),
+        ("assistant", "reply 2"),
+        ("user", "ask 3"),
+        ("assistant", "reply 3"),
+        ("user", "recent ask"),
+        ("assistant", "recent reply"),
+    ] {
+        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+            .expect("seed turns should succeed");
+    }
+
+    let engine = DefaultContextEngine;
+    engine
+        .compact_context(&config, session_id, &[], &kernel_ctx)
+        .await
+        .expect("default engine compaction should succeed");
+
+    let turns = crate::memory::window_direct(session_id, 32, &memory_config)
+        .expect("window load should succeed");
+
+    assert_eq!(turns.len(), 7);
+    assert_eq!(turns[0].role, "user");
+    assert!(turns[0].content.contains("Compacted 2 earlier turns"));
+    assert_eq!(turns[1].content, "ask 2");
+    assert_eq!(turns[2].content, "reply 2");
+    assert_eq!(turns[5].content, "recent ask");
+    assert_eq!(turns[6].content, "recent reply");
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_compact_context_compacts_full_session_but_assembles_within_sliding_window()
+ {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let mut config = test_config();
+    let db_path = unique_memory_sqlite_path("default-context-engine-compaction-clamp");
+    let _ = std::fs::remove_file(&db_path);
+    config.memory.sqlite_path = db_path.clone();
+    config.memory.sliding_window = 4;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-default-context-engine-compaction-clamp",
+        &memory_config,
+    );
+    let session_id = "default-context-engine-compaction-clamp";
+
+    for (role, content) in [
+        ("user", "ask 1"),
+        ("assistant", "reply 1"),
+        ("user", "ask 2"),
+        ("assistant", "reply 2"),
+        ("user", "recent ask"),
+        ("assistant", "recent reply"),
+    ] {
+        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+            .expect("seed turns should succeed");
+    }
+
+    let engine = DefaultContextEngine;
+    engine
+        .compact_context(&config, session_id, &[], &kernel_ctx)
+        .await
+        .expect("default engine compaction should succeed");
+
+    let turns = crate::memory::window_direct(session_id, 32, &memory_config)
+        .expect("window load should succeed");
+    assert_eq!(turns.len(), 4);
+    assert_eq!(turns[0].role, "user");
+    assert!(turns[0].content.contains("Compacted 3 earlier turns"));
+    assert_eq!(turns[1].content, "reply 2");
+    assert_eq!(turns[2].content, "recent ask");
+    assert_eq!(turns[3].content, "recent reply");
+
+    let messages = engine
+        .assemble_messages(
+            &config,
+            session_id,
+            false,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("assemble messages should preserve summary inside sliding window");
+    assert_eq!(messages.len(), 4);
+    assert!(
+        messages[0]["content"]
+            .as_str()
+            .expect("summary content")
+            .contains("Compacted 3 earlier turns")
+    );
+    assert_eq!(
+        messages[3]["content"]
+            .as_str()
+            .expect("recent reply content"),
+        "recent reply"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_compact_context_rewrites_from_full_session_snapshot() {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let mut config = test_config();
+    let db_path =
+        unique_memory_sqlite_path("default-context-engine-compaction-full-session-snapshot");
+    let _ = std::fs::remove_file(&db_path);
+    config.memory.sqlite_path = db_path.clone();
+    config.memory.sliding_window = 4;
+    config.conversation.compact_preserve_recent_turns = 2;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-default-context-engine-compaction-full-session-snapshot",
+        &memory_config,
+    );
+    let session_id = "default-context-engine-compaction-full-session-snapshot";
+
+    for (role, content) in [
+        ("user", "turn 1"),
+        ("assistant", "turn 2"),
+        ("user", "turn 3"),
+        ("assistant", "turn 4"),
+        ("user", "turn 5"),
+        ("assistant", "turn 6"),
+        ("user", "turn 7"),
+        ("assistant", "turn 8"),
+        ("user", "turn 9"),
+        ("assistant", "turn 10"),
+    ] {
+        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+            .expect("seed turns should succeed");
+    }
+
+    let engine = DefaultContextEngine;
+    engine
+        .compact_context(&config, session_id, &[], &kernel_ctx)
+        .await
+        .expect("default engine compaction should succeed");
+
+    let turns = crate::memory::window_direct(session_id, 32, &memory_config)
+        .expect("window load should succeed");
+    assert_eq!(turns.len(), 3);
+    assert_eq!(turns[0].role, "user");
+    assert!(turns[0].content.contains("Compacted 8 earlier turns"));
+    assert!(turns[0].content.contains("turn 1"));
+    assert_eq!(turns[1].content, "turn 9");
+    assert_eq!(turns[2].content, "turn 10");
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_compact_context_summarizes_visible_history_not_checkpoint_noise() {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let mut config = test_config();
+    let db_path = unique_memory_sqlite_path("default-context-engine-compaction-visible-history");
+    let _ = std::fs::remove_file(&db_path);
+    config.memory.sqlite_path = db_path.clone();
+    config.memory.sliding_window = 32;
+    config.conversation.compact_preserve_recent_turns = 2;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-default-context-engine-compaction-visible-history",
+        &memory_config,
+    );
+    let session_id = "default-context-engine-compaction-visible-history";
+    let checkpoint_event = crate::memory::build_conversation_event_content(
+        "turn_checkpoint",
+        json!({
+            "stage": "finalized",
+            "checkpoint": {
+                "lane": {
+                    "lane": "safe",
+                    "result_kind": "final_reply",
+                },
+            },
+        }),
+    );
+
+    for (role, content) in [
+        (
+            "user",
+            "For this test, remember these facts exactly:\n- codename: NIMBUS-17\n- owner: Mina\n- budget: 47",
+        ),
+        ("assistant", "ack-1"),
+        ("assistant", checkpoint_event.as_str()),
+        (
+            "user",
+            "Add these facts too:\n- launch month: October\n- fallback code: RIVER-9",
+        ),
+        ("assistant", "ack-2"),
+        ("assistant", checkpoint_event.as_str()),
+        ("user", "recent ask"),
+        ("assistant", "recent reply"),
+    ] {
+        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+            .expect("seed turns should succeed");
+    }
+
+    let engine = DefaultContextEngine;
+    engine
+        .compact_context(&config, session_id, &[], &kernel_ctx)
+        .await
+        .expect("default engine compaction should succeed");
+
+    let messages = engine
+        .assemble_messages(
+            &config,
+            session_id,
+            false,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("assemble messages should preserve visible history");
+    let summary = messages[0]["content"].as_str().expect("summary content");
+
+    assert!(summary.contains("NIMBUS-17"));
+    assert!(summary.contains("Mina"));
+    assert!(summary.contains("47"));
+    assert!(summary.contains("October"));
+    assert!(summary.contains("RIVER-9"));
+    assert!(
+        !summary.contains("turn_checkpoint"),
+        "summary should exclude internal checkpoint payloads: {summary}"
+    );
+    assert!(
+        !summary.contains("conversation_event"),
+        "summary should exclude internal event envelopes: {summary}"
+    );
+    assert_eq!(messages[1]["content"], json!("recent ask"));
+    assert_eq!(messages[2]["content"], json!("recent reply"));
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_compact_context_retries_conflict_and_preserves_concurrent_turn() {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (kernel_ctx, invocations) = build_kernel_context_with_compaction_conflict(audit);
+    let mut config = test_config();
+    config.memory.sliding_window = 32;
+    config.conversation.compact_preserve_recent_turns = 3;
+
+    let engine = DefaultContextEngine;
+    engine
+        .compact_context(
+            &config,
+            "default-context-engine-conflict-retry",
+            &[],
+            &kernel_ctx,
+        )
+        .await
+        .expect("default engine compaction should retry conflict and succeed");
+
+    let captured = invocations.lock().expect("invocations lock").clone();
+    let replace_requests = captured
+        .iter()
+        .filter(|request| request.operation == crate::memory::MEMORY_OP_REPLACE_TURNS)
+        .collect::<Vec<_>>();
+    let window_requests = captured
+        .iter()
+        .filter(|request| request.operation == crate::memory::MEMORY_OP_WINDOW)
+        .collect::<Vec<_>>();
+
+    assert_eq!(window_requests.len(), 2);
+    for request in &window_requests {
+        assert_eq!(request.payload["allow_extended_limit"], json!(true));
+        assert_eq!(request.payload["limit"], json!(512));
+    }
+    assert_eq!(replace_requests.len(), 2);
+    assert_eq!(replace_requests[0].payload["expected_turn_count"], 6);
+    assert_eq!(replace_requests[1].payload["expected_turn_count"], 7);
+    assert!(
+        replace_requests[1].payload["turns"]
+            .as_array()
+            .expect("replacement turns payload")
+            .iter()
+            .any(|turn| turn["content"] == "concurrent ask"),
+        "retry should preserve the turn appended during the conflict window"
+    );
+    assert!(
+        replace_requests[1].payload["turns"]
+            .as_array()
+            .expect("replacement turns payload")
+            .iter()
+            .any(|turn| turn["content"] == "recent ask"),
+        "retry should preserve the most recent user turn as well as the concurrent append"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_compact_context_skips_incomplete_extended_snapshot() {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let window_turns = json!(
+        (1..=512)
+            .map(|turn| {
+                let role = if turn % 2 == 0 { "assistant" } else { "user" };
+                json!({
+                    "role": role,
+                    "content": format!("turn {turn}"),
+                    "ts": turn,
+                })
+            })
+            .collect::<Vec<_>>()
+    );
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let (kernel_ctx, invocations) =
+        build_kernel_context_with_incomplete_compaction_snapshot(audit, window_turns, 513);
+    let mut config = test_config();
+    config.memory.sliding_window = 32;
+
+    let engine = DefaultContextEngine;
+    engine
+        .compact_context(
+            &config,
+            "default-context-engine-incomplete-compaction-snapshot",
+            &[],
+            &kernel_ctx,
+        )
+        .await
+        .expect("default engine should skip incomplete compaction snapshots");
+
+    let captured = invocations.lock().expect("invocations lock").clone();
+    let window_requests = captured
+        .iter()
+        .filter(|request| request.operation == crate::memory::MEMORY_OP_WINDOW)
+        .collect::<Vec<_>>();
+    let replace_requests = captured
+        .iter()
+        .filter(|request| request.operation == crate::memory::MEMORY_OP_REPLACE_TURNS)
+        .collect::<Vec<_>>();
+
+    assert_eq!(window_requests.len(), 1);
+    assert_eq!(
+        window_requests[0].payload["allow_extended_limit"],
+        json!(true)
+    );
+    assert_eq!(window_requests[0].payload["limit"], json!(512));
+    assert!(
+        replace_requests.is_empty(),
+        "compaction should fail closed instead of rewriting from an incomplete snapshot"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_compact_context_preserves_existing_summarized_history() {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let mut config = test_config();
+    let db_path = unique_memory_sqlite_path("default-context-engine-preserve-summary-history");
+    let _ = std::fs::remove_file(&db_path);
+    config.memory.sqlite_path = db_path.clone();
+    config.memory.profile = MemoryProfile::WindowPlusSummary;
+    config.memory.sliding_window = 2;
+    config.conversation.compact_preserve_recent_turns = 1;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-default-context-engine-preserve-summary-history",
+        &memory_config,
+    );
+    let session_id = "default-context-engine-preserve-summary-history";
+
+    for (role, content) in [
+        ("user", "turn 1"),
+        ("assistant", "turn 2"),
+        ("user", "turn 3"),
+        ("assistant", "turn 4"),
+    ] {
+        crate::memory::append_turn_direct(session_id, role, content, &memory_config)
+            .expect("seed turns should succeed");
+    }
+
+    let before = crate::provider::build_messages_for_session(&config, session_id, false)
+        .expect("provider history before compaction");
+    assert!(
+        before.iter().any(|message| {
+            message["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("turn 1"))
+        }),
+        "precondition: summarized history should include the earliest turn"
+    );
+
+    let engine = DefaultContextEngine;
+    engine
+        .compact_context(&config, session_id, &[], &kernel_ctx)
+        .await
+        .expect("default engine compaction should succeed");
+
+    let after = crate::provider::build_messages_for_session(&config, session_id, false)
+        .expect("provider history after compaction");
+    assert!(
+        after.iter().any(|message| {
+            message["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("turn 1"))
+        }),
+        "compaction should preserve preexisting summarized history"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct DefaultCompactingRuntime {
+    inner: FakeRuntime,
+    context_runtime: DefaultConversationRuntime,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl DefaultCompactingRuntime {
+    fn new(inner: FakeRuntime) -> Self {
+        Self {
+            inner,
+            context_runtime: DefaultConversationRuntime::default(),
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl ConversationRuntime for DefaultCompactingRuntime {
+    async fn build_messages(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        tool_view: &crate::tools::ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<Vec<Value>> {
+        self.context_runtime
+            .build_messages(
+                config,
+                session_id,
+                include_system_prompt,
+                tool_view,
+                binding,
+            )
+            .await
+    }
+
+    async fn request_completion(
+        &self,
+        config: &LoongClawConfig,
+        messages: &[Value],
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<String> {
+        self.inner
+            .request_completion(config, messages, binding)
+            .await
+    }
+
+    async fn request_turn(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
+        messages: &[Value],
+        tool_view: &crate::tools::ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<ProviderTurn> {
+        self.inner
+            .request_turn(config, session_id, turn_id, messages, tool_view, binding)
+            .await
+    }
+
+    async fn request_turn_streaming(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
+        messages: &[Value],
+        tool_view: &crate::tools::ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+        on_token: crate::provider::StreamingTokenCallback,
+    ) -> CliResult<ProviderTurn> {
+        self.inner
+            .request_turn_streaming(
+                config, session_id, turn_id, messages, tool_view, binding, on_token,
+            )
+            .await
+    }
+
+    async fn persist_turn(
+        &self,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<()> {
+        self.inner
+            .persist_turn(session_id, role, content, binding)
+            .await
+    }
+
+    async fn after_turn(
+        &self,
+        session_id: &str,
+        user_input: &str,
+        assistant_reply: &str,
+        messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.inner
+            .after_turn(
+                session_id,
+                user_input,
+                assistant_reply,
+                messages,
+                kernel_ctx,
+            )
+            .await
+    }
+
+    async fn compact_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        messages: &[Value],
+        kernel_ctx: &KernelContext,
+    ) -> CliResult<()> {
+        self.context_runtime
+            .compact_context(config, session_id, messages, kernel_ctx)
+            .await
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_persists_completed_compaction_checkpoint_when_default_context_engine_compacts_history()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "default-engine-compaction")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 32;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+    config.conversation.compact_fail_open = false;
+
+    let session_id = "session-turn-checkpoint-default-engine-compaction";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    for (role, content) in [
+        ("user", "ask 1"),
+        ("assistant", "reply 1"),
+        ("user", "ask 2"),
+        ("assistant", "reply 2"),
+        ("user", "ask 3"),
+        ("assistant", "reply 3"),
+        ("user", "recent ask"),
+        ("assistant", "recent reply"),
+    ] {
+        crate::memory::append_turn_direct(session_id, role, content, &mem_config)
+            .expect("seed turn should succeed");
+    }
+
+    let runtime = DefaultCompactingRuntime::new(
+        FakeRuntime::with_turns_and_completions(
+            vec![],
+            vec![Ok(ProviderTurn {
+                assistant_text: "fresh reply".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            })],
+            vec![],
+        )
+        .with_durable_memory_config(mem_config.clone()),
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context_with_memory(
+        "test-turn-checkpoint-default-engine-compaction",
+        &mem_config,
+    );
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            session_id,
+            "latest ask",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("turn should succeed with durable compaction");
+    assert_eq!(reply, "fresh reply");
+
+    let turns =
+        crate::memory::window_direct(session_id, 32, &mem_config).expect("load compacted turns");
+    let assistant_contents = turns
+        .iter()
+        .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))
+        .collect::<Vec<_>>();
+    let checkpoint_summary = summarize_turn_checkpoint_events(assistant_contents.iter().copied());
+    assert_eq!(checkpoint_summary.checkpoint_events, 2);
+    assert_eq!(
+        checkpoint_summary.latest_stage,
+        Some(TurnCheckpointStage::Finalized)
+    );
+    assert_eq!(
+        checkpoint_summary.latest_compaction,
+        Some(TurnCheckpointProgressStatus::Completed)
+    );
+
+    let prompt_messages = DefaultConversationRuntime::default()
+        .build_messages(
+            &config,
+            session_id,
+            true,
+            &crate::tools::runtime_tool_view_for_config(&config.tools),
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("load prompt history after compaction");
+    assert!(prompt_messages.iter().any(|message| {
+        message["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("Compacted "))
+    }));
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_persists_failed_open_compaction_checkpoint_when_compaction_fails()
+{
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-turn-checkpoint", "compaction-failed-open")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 16;
+    config.conversation.compact_enabled = true;
+    config.conversation.compact_min_messages = Some(1);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+    config.conversation.compact_fail_open = true;
+
+    let session_id = "session-turn-checkpoint-compaction-failed-open";
+    let mem_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    crate::memory::append_turn_direct(session_id, "user", "hello", &mem_config)
+        .expect("persist user turn");
+    crate::memory::append_turn_direct(session_id, "assistant", "assistant-reply", &mem_config)
+        .expect("persist assistant turn");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "hello"}),
+            json!({"role": "assistant", "content": "assistant-reply"}),
+        ],
+        vec![Ok(ProviderTurn {
+            assistant_text: "assistant-reply-2".to_owned(),
+            tool_intents: vec![],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_durable_memory_config(mem_config.clone())
+    .with_compact_result(Err("compact failure".to_owned()));
+    let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx =
+        test_kernel_context_with_memory("test-turn-checkpoint-compaction-failed-open", &mem_config);
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            session_id,
+            "hello again",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("fail-open compaction should keep turn successful");
+    assert_eq!(reply, "assistant-reply-2");
+    assert_eq!(runtime.compact_calls.lock().expect("compact lock").len(), 1);
+
+    let turns =
+        crate::memory::window_direct(session_id, 16, &mem_config).expect("load fail-open turns");
+    let assistant_contents = turns
+        .iter()
+        .filter_map(|turn| (turn.role == "assistant").then_some(turn.content.as_str()))
+        .collect::<Vec<_>>();
+    let checkpoint_summary = summarize_turn_checkpoint_events(assistant_contents.iter().copied());
+    assert_eq!(checkpoint_summary.checkpoint_events, 2);
+    assert_eq!(
+        checkpoint_summary.latest_stage,
+        Some(TurnCheckpointStage::Finalized)
+    );
+    assert_eq!(
+        checkpoint_summary.latest_compaction,
+        Some(TurnCheckpointProgressStatus::FailedOpen)
     );
 
     let _ = std::fs::remove_file(&db_path);

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -21,32 +21,6 @@ const FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS: usize = 384;
 const SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS: usize = 384;
 const SHELL_FOLLOWUP_STDIO_OMISSION_MARKER: &str = "\n[... omitted ...]\n";
 
-/// Strips <think>...</think> tags from model response text to prevent
-/// internal reasoning chains from leaking to user-facing output.
-/// This handles both standard think tags and case-insensitive variants.
-#[allow(clippy::expect_used)]
-fn strip_think_tags(text: &str) -> String {
-    use regex::Regex;
-    static BALANCED_THINK_TAG_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-        // Match <think> ... </think> tags (case-insensitive, multiline)
-        Regex::new(r"(?is)<think>.*?</think>").expect("static regex should always compile")
-    });
-    static OPEN_THINK_TAG_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-        // Match an unterminated <think> tag through end-of-string.
-        Regex::new(r"(?is)<think>.*$").expect("static regex should always compile")
-    });
-    static CLOSE_THINK_TAG_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-        // Match any stray closing </think> tag.
-        Regex::new(r"(?i)</think>").expect("static regex should always compile")
-    });
-
-    let without_balanced_tags = BALANCED_THINK_TAG_RE.replace_all(text, "");
-    let without_open_tags = OPEN_THINK_TAG_RE.replace_all(&without_balanced_tags, "");
-    CLOSE_THINK_TAG_RE
-        .replace_all(&without_open_tags, "")
-        .to_string()
-}
-
 pub fn next_conversation_turn_id() -> String {
     static NEXT_CONVERSATION_TURN_SEQ: AtomicU64 = AtomicU64::new(1);
     let seq = NEXT_CONVERSATION_TURN_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -270,15 +244,10 @@ impl<'a> ToolDrivenReplyKernel<'a> {
         match self.turn_result {
             TurnResult::FinalText(text)
             | TurnResult::StreamingText(text)
-            | TurnResult::StreamingDone(text) => {
-                let trimmed_reply = text.trim();
-                let cleaned_reply = strip_think_tags(trimmed_reply);
-                let cleaned_reply = cleaned_reply.trim().to_owned();
-                Some(join_non_empty_lines(&[
-                    self.assistant_preface,
-                    cleaned_reply.as_str(),
-                ]))
-            }
+            | TurnResult::StreamingDone(text) => Some(join_non_empty_lines(&[
+                self.assistant_preface,
+                text.as_str(),
+            ])),
             TurnResult::NeedsApproval(requirement) => Some(format_approval_required_reply(
                 self.assistant_preface,
                 requirement,
@@ -338,11 +307,10 @@ pub fn compose_assistant_reply(
         TurnResult::FinalText(text)
         | TurnResult::StreamingText(text)
         | TurnResult::StreamingDone(text) => {
-            let cleaned_text = strip_think_tags(text.trim());
             if had_tool_intents {
-                join_non_empty_lines(&[assistant_preface, cleaned_text.as_str()])
+                join_non_empty_lines(&[assistant_preface, text.as_str()])
             } else {
-                cleaned_text.trim().to_string()
+                text
             }
         }
         TurnResult::NeedsApproval(requirement) => {
@@ -1091,19 +1059,6 @@ mod tests {
             Some(ToolDrivenFollowupPayload::ToolResult {
                 text: "tool output".to_owned(),
             })
-        );
-    }
-
-    #[test]
-    fn tool_driven_reply_kernel_strips_think_tags_from_raw_reply() {
-        let result = TurnResult::FinalText(
-            "<think>internal reasoning</think>\nvisible tool output".to_owned(),
-        );
-        let kernel = ToolDrivenReplyKernel::new("preface", true, &result);
-
-        assert_eq!(
-            kernel.raw_reply(),
-            Some("preface\nvisible tool output".to_owned())
         );
     }
 
@@ -2010,48 +1965,5 @@ mod tests {
 
         assert_eq!(reduced.as_ref(), tool_result);
         assert_eq!(reduced.as_ptr(), tool_result.as_ptr());
-    }
-
-    #[test]
-    fn strip_think_tags_removes_think_content() {
-        let input = "<think>Let me think about this...\nThe user wants to know the weather.\nI should check the forecast.</think>The weather today is sunny.";
-        let expected = "The weather today is sunny.";
-        assert_eq!(strip_think_tags(input), expected);
-    }
-
-    #[test]
-    fn strip_think_tags_handles_empty_tags() {
-        let input = "Hello <think></think>world";
-        assert_eq!(strip_think_tags(input), "Hello world");
-    }
-
-    #[test]
-    fn strip_think_tags_handles_multiple_tags() {
-        let input = "<think>First thought</think>Middle<think>Second thought</think>End";
-        assert_eq!(strip_think_tags(input), "MiddleEnd");
-    }
-
-    #[test]
-    fn strip_think_tags_handles_nested_content() {
-        let input = "<think>Think content with <tag> inside</think>Real response";
-        assert_eq!(strip_think_tags(input), "Real response");
-    }
-
-    #[test]
-    fn strip_think_tags_case_insensitive() {
-        let input = "<ThInK>think content</tHiNk>Result";
-        assert_eq!(strip_think_tags(input), "Result");
-    }
-
-    #[test]
-    fn strip_think_tags_drops_unterminated_opening_tag() {
-        let input = "Answer<think>internal reasoning";
-        assert_eq!(strip_think_tags(input), "Answer");
-    }
-
-    #[test]
-    fn strip_think_tags_drops_stray_closing_tag() {
-        let input = "Answer</think>";
-        assert_eq!(strip_think_tags(input), "Answer");
     }
 }

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -38,10 +38,11 @@ pub use orchestrator::{
 #[cfg(test)]
 pub use orchestrator::{MemoryOrchestratorTestFaults, ScopedMemoryOrchestratorTestFaults};
 pub use protocol::{
-    MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_READ_CONTEXT, MEMORY_OP_WINDOW,
-    MemoryContextEntry, MemoryContextKind, WindowTurn, build_append_turn_request,
-    build_read_context_request, build_window_request, decode_memory_context_entries,
-    decode_window_turns,
+    MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_READ_CONTEXT,
+    MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW, MemoryContextEntry, MemoryContextKind, WindowTurn,
+    build_append_turn_request, build_read_context_request, build_replace_turns_request,
+    build_replace_turns_request_with_expectation, build_window_request,
+    decode_memory_context_entries, decode_window_turn_count, decode_window_turns,
 };
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoadDiagnostics};
@@ -74,6 +75,7 @@ pub fn execute_memory_core_with_config(
             MEMORY_OP_WINDOW => load_window(request, config),
             MEMORY_OP_CLEAR_SESSION => clear_session(request, config),
             MEMORY_OP_READ_CONTEXT => context::read_context(request, config),
+            MEMORY_OP_REPLACE_TURNS => replace_turns(request, config),
             _ => Ok(MemoryCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({
@@ -84,21 +86,6 @@ pub fn execute_memory_core_with_config(
             }),
         },
     }
-}
-
-#[cfg(test)]
-fn core_dispatch_count_for_tests() -> usize {
-    test_support::core_dispatch_count()
-}
-
-#[cfg(test)]
-fn begin_core_dispatch_capture_for_tests() {
-    test_support::begin_core_dispatch_capture();
-}
-
-#[cfg(test)]
-fn end_core_dispatch_capture_for_tests() {
-    test_support::end_core_dispatch_capture();
 }
 
 fn append_turn(
@@ -155,6 +142,24 @@ fn clear_session(
     }
 }
 
+fn replace_turns(
+    request: MemoryCoreRequest,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<MemoryCoreOutcome, String> {
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = (request, config);
+        return Err(
+            "sqlite memory is disabled in this build (enable feature `memory-sqlite`)".to_owned(),
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    {
+        sqlite::replace_turns(request, config)
+    }
+}
+
 #[cfg(feature = "memory-sqlite")]
 pub fn append_turn_direct(
     session_id: &str,
@@ -163,6 +168,16 @@ pub fn append_turn_direct(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<(), String> {
     sqlite::append_turn_direct(session_id, role, content, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[cfg(test)]
+pub fn replace_session_turns_direct(
+    session_id: &str,
+    turns: &[WindowTurn],
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<(), String> {
+    sqlite::replace_session_turns_direct(session_id, turns, config)
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -6,8 +6,9 @@ pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
 pub const MEMORY_OP_WINDOW: &str = "window";
 pub const MEMORY_OP_CLEAR_SESSION: &str = "clear_session";
 pub const MEMORY_OP_READ_CONTEXT: &str = "read_context";
+pub const MEMORY_OP_REPLACE_TURNS: &str = "replace_turns";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WindowTurn {
     pub role: String,
     pub content: String,
@@ -59,6 +60,29 @@ pub fn build_read_context_request(session_id: &str) -> MemoryCoreRequest {
     }
 }
 
+pub fn build_replace_turns_request(session_id: &str, turns: &[WindowTurn]) -> MemoryCoreRequest {
+    build_replace_turns_request_with_expectation(session_id, turns, None)
+}
+
+pub fn build_replace_turns_request_with_expectation(
+    session_id: &str,
+    turns: &[WindowTurn],
+    expected_turn_count: Option<usize>,
+) -> MemoryCoreRequest {
+    let mut payload = serde_json::Map::from_iter([
+        ("session_id".to_owned(), json!(session_id)),
+        ("turns".to_owned(), json!(turns)),
+    ]);
+    if let Some(expected_turn_count) = expected_turn_count {
+        payload.insert("expected_turn_count".to_owned(), json!(expected_turn_count));
+    }
+
+    MemoryCoreRequest {
+        operation: MEMORY_OP_REPLACE_TURNS.to_owned(),
+        payload: Value::Object(payload),
+    }
+}
+
 pub fn decode_window_turns(payload: &Value) -> Vec<WindowTurn> {
     payload
         .get("turns")
@@ -79,6 +103,13 @@ pub fn decode_window_turns(payload: &Value) -> Vec<WindowTurn> {
             ts: turn.get("ts").and_then(Value::as_i64),
         })
         .collect()
+}
+
+pub fn decode_window_turn_count(payload: &Value) -> Option<usize> {
+    payload
+        .get("turn_count")
+        .and_then(Value::as_u64)
+        .map(|value| value as usize)
 }
 
 pub fn decode_memory_context_entries(payload: &Value) -> Vec<MemoryContextEntry> {
@@ -121,5 +152,12 @@ mod tests {
         assert!(decode_window_turns(&json!({})).is_empty());
         assert!(decode_window_turns(&json!({"turns": null})).is_empty());
         assert!(decode_window_turns(&json!({"turns": "invalid"})).is_empty());
+    }
+
+    #[test]
+    fn decode_window_turn_count_returns_optional_count() {
+        assert_eq!(decode_window_turn_count(&json!({"turn_count": 7})), Some(7));
+        assert_eq!(decode_window_turn_count(&json!({"turn_count": null})), None);
+        assert_eq!(decode_window_turn_count(&json!({})), None);
     }
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::{
-    MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_WINDOW,
-    runtime_config::MemoryRuntimeConfig,
+    MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW,
+    WindowTurn, runtime_config::MemoryRuntimeConfig,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -115,7 +115,11 @@ const SQL_UPSERT_SESSION_TURN_COUNT: &str =
                  turn_count = memory_session_state.turn_count + 1
              RETURNING turn_count";
 const SQL_DELETE_SESSION_STATE: &str = "DELETE FROM memory_session_state WHERE session_id = ?1";
-const SQL_QUERY_RECENT_TURNS_NO_ID: &str = "SELECT role, content, ts
+const SQL_SET_SESSION_TURN_COUNT: &str = "INSERT INTO memory_session_state(session_id, turn_count)
+             VALUES (?1, ?2)
+             ON CONFLICT(session_id) DO UPDATE SET
+                 turn_count = excluded.turn_count";
+const SQL_QUERY_RECENT_TURNS_NO_ID: &str = "SELECT role, content, ts, session_turn_index
              FROM turns
              WHERE session_id = ?1
              ORDER BY id DESC
@@ -340,6 +344,15 @@ struct WindowLoadResult {
     db_path: PathBuf,
     limit: usize,
     turns: Vec<ConversationTurn>,
+    turn_count: Option<usize>,
+}
+
+enum ReplaceTurnsFailure {
+    Conflict {
+        expected_turn_count: usize,
+        actual_turn_count: usize,
+    },
+    Message(String),
 }
 
 #[derive(Debug)]
@@ -478,6 +491,7 @@ pub(super) fn load_window(
             "limit": window.limit,
             "allow_extended_limit": allow_extended_limit,
             "turns": window.turns,
+            "turn_count": window.turn_count,
             "db_path": window.db_path.display().to_string(),
         }),
     })
@@ -528,6 +542,83 @@ pub(super) fn clear_session(
             "deleted_rows": affected,
         }),
     })
+}
+
+pub(super) fn replace_turns(
+    request: MemoryCoreRequest,
+    config: &MemoryRuntimeConfig,
+) -> Result<MemoryCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "memory.replace_turns payload must be an object".to_owned())?;
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "memory.replace_turns requires payload.session_id".to_owned())
+        .and_then(|value| {
+            normalize_required_str(value, "memory.replace_turns requires payload.session_id")
+        })?;
+    let turns = payload
+        .get("turns")
+        .cloned()
+        .ok_or_else(|| "memory.replace_turns requires payload.turns".to_owned())
+        .and_then(|value| {
+            serde_json::from_value::<Vec<WindowTurn>>(value)
+                .map_err(|error| format!("memory.replace_turns payload.turns invalid: {error}"))
+        })?;
+    let expected_turn_count = match payload.get("expected_turn_count") {
+        None | Some(Value::Null) => None,
+        Some(value) => Some(value.as_u64().ok_or_else(|| {
+            "memory.replace_turns payload.expected_turn_count must be a non-negative integer"
+                .to_owned()
+        })? as usize),
+    };
+
+    match replace_turns_internal(session_id, &turns, expected_turn_count, config) {
+        Ok(replaced) => Ok(MemoryCoreOutcome {
+            status: "ok".to_owned(),
+            payload: json!({
+                "adapter": "sqlite-core",
+                "operation": MEMORY_OP_REPLACE_TURNS,
+                "session_id": session_id,
+                "replaced_turns": replaced,
+            }),
+        }),
+        Err(ReplaceTurnsFailure::Conflict {
+            expected_turn_count,
+            actual_turn_count,
+        }) => Ok(MemoryCoreOutcome {
+            status: "conflict".to_owned(),
+            payload: json!({
+                "adapter": "sqlite-core",
+                "operation": MEMORY_OP_REPLACE_TURNS,
+                "session_id": session_id,
+                "expected_turn_count": expected_turn_count,
+                "actual_turn_count": actual_turn_count,
+            }),
+        }),
+        Err(ReplaceTurnsFailure::Message(error)) => Err(error),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn replace_session_turns_direct(
+    session_id: &str,
+    turns: &[WindowTurn],
+    config: &MemoryRuntimeConfig,
+) -> Result<(), String> {
+    let _ = replace_turns_internal(session_id, turns, None, config)
+        .map_err(|error| match error {
+            ReplaceTurnsFailure::Conflict {
+                expected_turn_count,
+                actual_turn_count,
+            } => format!(
+                "memory.replace_turns conflict: expected turn count {expected_turn_count}, found {actual_turn_count}"
+            ),
+            ReplaceTurnsFailure::Message(message) => message,
+        })?;
+    Ok(())
 }
 
 pub(super) fn append_turn_direct(
@@ -810,6 +901,97 @@ fn append_turn_internal(
     Ok(AppendTurnResult { db_path: path, ts })
 }
 
+fn replace_turns_internal(
+    session_id: &str,
+    turns: &[WindowTurn],
+    expected_turn_count: Option<usize>,
+    config: &MemoryRuntimeConfig,
+) -> Result<usize, ReplaceTurnsFailure> {
+    let session_id = normalize_required_str(
+        session_id,
+        "memory.replace_turns requires payload.session_id",
+    )
+    .map_err(ReplaceTurnsFailure::Message)?;
+    let runtime = acquire_memory_runtime(config).map_err(ReplaceTurnsFailure::Message)?;
+
+    runtime
+        .with_connection_mut("memory.replace_turns", |conn| {
+            let tx = conn
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .map_err(|error| format!("begin memory replace transaction failed: {error}"))?;
+
+            if let Some(expected_turn_count) = expected_turn_count {
+                let actual_turn_count = resolve_actual_turn_count(&tx, session_id)? as usize;
+                if actual_turn_count != expected_turn_count {
+                    return Ok(Err(ReplaceTurnsFailure::Conflict {
+                        expected_turn_count,
+                        actual_turn_count,
+                    }));
+                }
+            }
+
+            {
+                let mut delete_turns = prepare_cached_sqlite_statement(
+                    &tx,
+                    SQL_DELETE_TURNS_FOR_SESSION,
+                    "prepare replace-turns delete statement failed",
+                )?;
+                delete_turns
+                    .execute(rusqlite::params![session_id])
+                    .map_err(|error| format!("delete memory turns failed: {error}"))?;
+            }
+
+            delete_session_state(&tx, session_id)?;
+            delete_summary_checkpoint(&tx, session_id)?;
+
+            if !turns.is_empty() {
+                {
+                    let mut insert_turn = prepare_cached_sqlite_statement(
+                        &tx,
+                        SQL_INSERT_TURN,
+                        "prepare replace-turns insert statement failed",
+                    )?;
+                    for (index, turn) in turns.iter().enumerate() {
+                        let role = normalize_required_str(
+                            &turn.role,
+                            "memory.replace_turns requires turns[*].role",
+                        )?;
+                        let ts = turn.ts.ok_or_else(|| {
+                            "memory.replace_turns requires turns[*].ts".to_owned()
+                        })?;
+                        insert_turn
+                            .execute(rusqlite::params![
+                                session_id,
+                                (index + 1) as i64,
+                                role,
+                                &turn.content,
+                                ts
+                            ])
+                            .map_err(|error| {
+                                format!("insert replaced memory turn failed: {error}")
+                            })?;
+                    }
+                }
+
+                let mut set_turn_count = prepare_cached_sqlite_statement(
+                    &tx,
+                    SQL_SET_SESSION_TURN_COUNT,
+                    "prepare replace-turns session-state statement failed",
+                )?;
+                set_turn_count
+                    .execute(rusqlite::params![session_id, turns.len() as i64])
+                    .map_err(|error| {
+                        format!("upsert replace-turns session state failed: {error}")
+                    })?;
+            }
+
+            tx.commit()
+                .map_err(|error| format!("commit memory replace transaction failed: {error}"))?;
+            Ok(Ok(turns.len()))
+        })
+        .map_err(ReplaceTurnsFailure::Message)?
+}
+
 fn load_window_internal(
     session_id: &str,
     requested_limit: usize,
@@ -827,13 +1009,14 @@ fn load_window_internal(
     };
     let runtime = acquire_memory_runtime(config)?;
     let path = runtime.path().to_path_buf();
-    let turns = runtime.with_connection("memory.window", |conn| {
+    let (turns, turn_count) = runtime.with_connection("memory.window", |conn| {
         query_recent_turns(conn, session_id, effective_limit)
     })?;
     Ok(WindowLoadResult {
         db_path: path,
         limit: effective_limit,
         turns,
+        turn_count,
     })
 }
 
@@ -1529,7 +1712,7 @@ fn query_recent_turns(
     conn: &Connection,
     session_id: &str,
     limit: usize,
-) -> Result<Vec<ConversationTurn>, String> {
+) -> Result<(Vec<ConversationTurn>, Option<usize>), String> {
     let mut stmt = prepare_cached_sqlite_statement(
         conn,
         SQL_QUERY_RECENT_TURNS_NO_ID,
@@ -1539,10 +1722,17 @@ fn query_recent_turns(
         .query(rusqlite::params![session_id, limit as i64])
         .map_err(|error| format!("query memory window failed: {error}"))?;
     let mut turns = Vec::with_capacity(limit);
+    let mut turn_count = None;
     while let Some(row) = rows
         .next()
         .map_err(|error| format!("read memory window row failed: {error}"))?
     {
+        if turn_count.is_none() {
+            turn_count = row
+                .get::<_, Option<i64>>(3)
+                .map_err(|error| format!("decode memory window turn count failed: {error}"))?
+                .map(|value| value.max(0) as usize);
+        }
         turns.push(ConversationTurn {
             role: row
                 .get(0)
@@ -1556,7 +1746,7 @@ fn query_recent_turns(
         });
     }
     turns.reverse();
-    Ok(turns)
+    Ok((turns, turn_count))
 }
 
 #[cfg(test)]
@@ -1749,6 +1939,22 @@ fn query_session_turn_count(conn: &Connection, session_id: &str) -> Result<Optio
             }
         })
         .map_err(|error| format!("query session turn count failed: {error}"))
+}
+
+fn resolve_actual_turn_count(conn: &Connection, session_id: &str) -> Result<i64, String> {
+    if let Some(turn_count) = query_session_turn_count(conn, session_id)? {
+        return Ok(turn_count.max(0));
+    }
+
+    conn.query_row(
+        "SELECT COALESCE(MAX(session_turn_index), 0)
+         FROM turns
+         WHERE session_id = ?1",
+        rusqlite::params![session_id],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|turn_count| turn_count.max(0))
+    .map_err(|error| format!("query fallback session turn count failed: {error}"))
 }
 
 fn query_recent_prompt_turns_with_known_overflow(
@@ -3061,6 +3267,174 @@ mod tests {
             })
             .map_err(|error| format!("read session turn count failed: {error}"))
         })
+    }
+
+    #[test]
+    fn load_window_includes_turn_count_in_payload() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let _guard = sqlite_runtime_test_lock()
+            .lock()
+            .expect("runtime test lock");
+        reset_sqlite_runtime_test_state();
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-window-turn-count-payload-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("window-turn-count.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("window-turn-count-session", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("window-turn-count-session", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("window-turn-count-session", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let outcome = load_window(
+            crate::memory::build_window_request("window-turn-count-session", 2),
+            &config,
+        )
+        .expect("window load should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["turn_count"], 3);
+        assert_eq!(
+            outcome.payload["turns"]
+                .as_array()
+                .expect("window payload turns")
+                .len(),
+            2
+        );
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn replace_turns_requires_object_payload() {
+        let error = replace_turns(
+            MemoryCoreRequest {
+                operation: MEMORY_OP_REPLACE_TURNS.to_owned(),
+                payload: json!("not-an-object"),
+            },
+            &MemoryRuntimeConfig::default(),
+        )
+        .expect_err("replace_turns should reject non-object payloads");
+
+        assert_eq!(error, "memory.replace_turns payload must be an object");
+    }
+
+    #[test]
+    fn replace_turns_rejects_malformed_expected_turn_count() {
+        let error = replace_turns(
+            MemoryCoreRequest {
+                operation: MEMORY_OP_REPLACE_TURNS.to_owned(),
+                payload: json!({
+                    "session_id": "replace-turns-invalid-expected-count",
+                    "turns": [],
+                    "expected_turn_count": "invalid",
+                }),
+            },
+            &MemoryRuntimeConfig::default(),
+        )
+        .expect_err("replace_turns should reject malformed expected_turn_count");
+
+        assert_eq!(
+            error,
+            "memory.replace_turns payload.expected_turn_count must be a non-negative integer"
+        );
+    }
+
+    #[test]
+    fn replace_turns_uses_turn_rows_when_session_state_metadata_is_missing() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let _guard = sqlite_runtime_test_lock()
+            .lock()
+            .expect("runtime test lock");
+        reset_sqlite_runtime_test_state();
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-replace-turns-fallback-count-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("replace-turns-fallback-count.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 4,
+            ..MemoryRuntimeConfig::default()
+        };
+        let session_id = "replace-turns-fallback-count-session";
+
+        append_turn_direct(session_id, "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct(session_id, "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct(session_id, "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let runtime = acquire_memory_runtime(&config).expect("acquire runtime");
+        runtime
+            .with_connection_mut("test.delete_turn_count_before_replace", |conn| {
+                conn.execute(
+                    "DELETE FROM memory_session_state WHERE session_id = ?1",
+                    rusqlite::params![session_id],
+                )
+                .map_err(|error| format!("delete session turn count metadata failed: {error}"))
+            })
+            .expect("delete turn count metadata");
+
+        let outcome = replace_turns(
+            MemoryCoreRequest {
+                operation: MEMORY_OP_REPLACE_TURNS.to_owned(),
+                payload: json!({
+                    "session_id": session_id,
+                    "turns": [
+                        {"role": "user", "content": "replacement 1", "ts": 11},
+                        {"role": "assistant", "content": "replacement 2", "ts": 12},
+                    ],
+                    "expected_turn_count": 3,
+                }),
+            },
+            &config,
+        )
+        .expect("replace_turns should fall back to turn rows when session metadata is missing");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["replaced_turns"], 2);
+        assert_eq!(
+            read_session_turn_count(&config, session_id).expect("read session turn count"),
+            Some(2)
+        );
+        assert_eq!(
+            window_direct(session_id, 4, &config)
+                .expect("load replacement turns")
+                .into_iter()
+                .map(|turn| turn.content)
+                .collect::<Vec<_>>(),
+            vec!["replacement 1".to_owned(), "replacement 2".to_owned()]
+        );
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -221,16 +221,16 @@ fn append_turn_direct_bypasses_core_dispatch() {
         ..runtime_config::MemoryRuntimeConfig::default()
     };
 
-    begin_core_dispatch_capture_for_tests();
+    super::test_support::begin_core_dispatch_capture();
     append_turn_direct("append-fast-path-session", "user", "hello", &config)
         .expect("append_turn_direct should succeed");
 
     assert_eq!(
-        core_dispatch_count_for_tests(),
+        super::test_support::core_dispatch_count(),
         0,
         "append_turn_direct should bypass core dispatch"
     );
-    end_core_dispatch_capture_for_tests();
+    super::test_support::end_core_dispatch_capture();
 
     let _ = fs::remove_file(&db_path);
     let _ = fs::remove_dir(&tmp);
@@ -260,18 +260,104 @@ fn window_direct_bypasses_core_dispatch() {
 
     append_turn_direct("window-fast-path-session", "user", "hello", &config)
         .expect("seed append_turn_direct should succeed");
-    begin_core_dispatch_capture_for_tests();
+    super::test_support::begin_core_dispatch_capture();
 
     let turns = window_direct("window-fast-path-session", 10, &config)
         .expect("window_direct should succeed");
 
     assert_eq!(turns.len(), 1);
     assert_eq!(
-        core_dispatch_count_for_tests(),
+        super::test_support::core_dispatch_count(),
         0,
         "window_direct should bypass core dispatch"
     );
-    end_core_dispatch_capture_for_tests();
+    super::test_support::end_core_dispatch_capture();
+
+    let _ = fs::remove_file(&db_path);
+    let _ = fs::remove_dir(&tmp);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn replace_session_turns_direct_rewrites_window() {
+    use std::fs;
+
+    let tmp = std::env::temp_dir().join(format!(
+        "loongclaw-test-memory-replace-turns-{}",
+        std::process::id()
+    ));
+    let _ = fs::create_dir_all(&tmp);
+    let db_path = tmp.join("replace-turns.sqlite3");
+    let _ = fs::remove_file(&db_path);
+
+    let config = runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+        ..runtime_config::MemoryRuntimeConfig::default()
+    };
+
+    append_turn_direct("replace-turns-session", "user", "turn 1", &config)
+        .expect("seed turn 1 should succeed");
+    append_turn_direct("replace-turns-session", "assistant", "turn 2", &config)
+        .expect("seed turn 2 should succeed");
+
+    replace_session_turns_direct(
+        "replace-turns-session",
+        &[
+            WindowTurn {
+                role: "assistant".into(),
+                content: "summary".into(),
+                ts: Some(2),
+            },
+            WindowTurn {
+                role: "user".into(),
+                content: "recent".into(),
+                ts: Some(3),
+            },
+        ],
+        &config,
+    )
+    .expect("replace_session_turns_direct should succeed");
+
+    let turns = window_direct("replace-turns-session", 10, &config)
+        .expect("window_direct should read rewritten turns");
+    assert_eq!(turns.len(), 2);
+    assert_eq!(turns[0].content, "summary");
+    assert_eq!(turns[1].content, "recent");
+
+    let _ = fs::remove_file(&db_path);
+    let _ = fs::remove_dir(&tmp);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn replace_session_turns_direct_requires_explicit_timestamps() {
+    use std::fs;
+
+    let tmp = std::env::temp_dir().join(format!(
+        "loongclaw-test-memory-replace-turns-ts-{}",
+        std::process::id()
+    ));
+    let _ = fs::create_dir_all(&tmp);
+    let db_path = tmp.join("replace-turns-missing-ts.sqlite3");
+    let _ = fs::remove_file(&db_path);
+
+    let config = runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path.clone()),
+        ..runtime_config::MemoryRuntimeConfig::default()
+    };
+
+    let error = replace_session_turns_direct(
+        "replace-turns-session",
+        &[WindowTurn {
+            role: "assistant".into(),
+            content: "summary".into(),
+            ts: None,
+        }],
+        &config,
+    )
+    .expect_err("replace_session_turns_direct should require explicit timestamps");
+
+    assert!(error.contains("turns[*].ts"), "unexpected error: {error}");
 
     let _ = fs::remove_file(&db_path);
     let _ = fs::remove_dir(&tmp);

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -475,8 +475,13 @@ fn migration_domain_previews_preserve_source_attribution() {
 fn migration_classify_current_setup_distinguishes_basic_states() {
     let home = unique_temp_dir("classify-home");
     std::fs::create_dir_all(&home).expect("create classify home");
-    let _env_guard =
-        MigrationEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+    let _env_guard = MigrationEnvironmentGuard::set(&[
+        ("HOME", Some(home.to_string_lossy().as_ref())),
+        ("OPENAI_API_KEY", None),
+        ("OPENAI_CODEX_OAUTH_TOKEN", None),
+        ("OPENAI_OAUTH_ACCESS_TOKEN", None),
+        ("TELEGRAM_BOT_TOKEN", None),
+    ]);
 
     let missing = unique_temp_dir("missing").join("config.toml");
     assert_eq!(
@@ -582,8 +587,13 @@ fn migration_classify_current_setup_ignores_home_drift_for_default_memory_path()
 
     let path = unique_temp_dir("classify-home-drift").join("config.toml");
     {
-        let _guard =
-            MigrationEnvironmentGuard::set(&[("HOME", Some(home_a.to_string_lossy().as_ref()))]);
+        let _guard = MigrationEnvironmentGuard::set(&[
+            ("HOME", Some(home_a.to_string_lossy().as_ref())),
+            ("OPENAI_API_KEY", None),
+            ("OPENAI_CODEX_OAUTH_TOKEN", None),
+            ("OPENAI_OAUTH_ACCESS_TOKEN", None),
+            ("TELEGRAM_BOT_TOKEN", None),
+        ]);
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Ollama;
@@ -596,8 +606,13 @@ fn migration_classify_current_setup_ignores_home_drift_for_default_memory_path()
             .expect("write legacy-style config under first home");
     }
 
-    let _guard =
-        MigrationEnvironmentGuard::set(&[("HOME", Some(home_b.to_string_lossy().as_ref()))]);
+    let _guard = MigrationEnvironmentGuard::set(&[
+        ("HOME", Some(home_b.to_string_lossy().as_ref())),
+        ("OPENAI_API_KEY", None),
+        ("OPENAI_CODEX_OAUTH_TOKEN", None),
+        ("OPENAI_OAUTH_ACCESS_TOKEN", None),
+        ("TELEGRAM_BOT_TOKEN", None),
+    ]);
 
     assert_eq!(
         crate::migration::discovery::classify_current_setup(&path),
@@ -1720,8 +1735,13 @@ fn migration_compose_recommended_candidate_ignores_home_drift_for_default_memory
     std::fs::create_dir_all(&home_b).expect("create second home");
 
     let (codex, env) = {
-        let _guard =
-            MigrationEnvironmentGuard::set(&[("HOME", Some(home_a.to_string_lossy().as_ref()))]);
+        let _guard = MigrationEnvironmentGuard::set(&[
+            ("HOME", Some(home_a.to_string_lossy().as_ref())),
+            ("OPENAI_API_KEY", None),
+            ("OPENAI_CODEX_OAUTH_TOKEN", None),
+            ("OPENAI_OAUTH_ACCESS_TOKEN", None),
+            ("TELEGRAM_BOT_TOKEN", None),
+        ]);
 
         let mut codex = mvp::config::LoongClawConfig::default();
         codex.provider.model = "openai/gpt-5.1-codex".to_owned();
@@ -1737,8 +1757,13 @@ fn migration_compose_recommended_candidate_ignores_home_drift_for_default_memory
         (codex, env)
     };
 
-    let _guard =
-        MigrationEnvironmentGuard::set(&[("HOME", Some(home_b.to_string_lossy().as_ref()))]);
+    let _guard = MigrationEnvironmentGuard::set(&[
+        ("HOME", Some(home_b.to_string_lossy().as_ref())),
+        ("OPENAI_API_KEY", None),
+        ("OPENAI_CODEX_OAUTH_TOKEN", None),
+        ("OPENAI_OAUTH_ACCESS_TOKEN", None),
+        ("TELEGRAM_BOT_TOKEN", None),
+    ]);
 
     let codex_candidate = crate::migration::discovery::build_import_candidate(
         crate::migration::types::ImportSourceKind::CodexConfig,

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-23T06:07:16Z
+- Generated at: 2026-03-23T06:55:35Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -14,7 +14,7 @@
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 373 | 1000 | 627 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 312 | 650 | 338 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 327 | 650 | 323 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -42,7 +42,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=373 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=312 functions=15 -->
+<!-- arch-hotspot key=memory_mod lines=327 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: safe-lane compaction hooks existed on `dev`, but the default context engine still treated compaction as a no-op and the default config semantics could trigger compaction without any explicit threshold.
- Why it matters: long-running sessions could not actually reduce persisted context size through the built-in safe-lane path, and the default trigger behavior was broader than intended.
- What changed:
  - added a deterministic `compact_window` helper that preserves recent turns and summarizes older history
  - added an atomic memory replace-turns path and used it to make `DefaultContextEngine::compact_context()` rewrite persisted session history durably
  - advertised `ContextCompaction` from the default context engine metadata
  - tightened compaction config semantics so at least one explicit threshold is required before compaction can trigger
  - added regression coverage for helper behavior, config gating, durable memory rewrite, default-engine compaction, and safe-lane completion / fail-open checkpoint handling
- What did not change (scope boundary):
  - no fast-lane compaction
  - no provider overflow retry / recovery
  - no LLM-generated summarization

## Linked Issues

- Closes #424
- Related #307, #291

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test
- passed locally from the repo root after the final compaction and lint fixes

git commit -m "feat: add durable safe-lane context compaction"
- pre-commit hook ran cargo fmt --check and cargo clippy
- both passed before commit a50224b was created

Focused regression coverage exercised during implementation:
- cargo test conversation::tests::compact_window_preserves_recent_turns_and_summarizes_history -- --exact
- cargo test conversation::tests::compact_window_skips_small_histories -- --exact
- cargo test config::tests::conversation_compaction_defaults_require_explicit_thresholds -- --exact
- cargo test memory::tests::replace_session_turns_direct_rewrites_window -- --exact
- cargo test conversation::tests::default_context_engine_metadata_advertises_context_compaction -- --exact
- cargo test conversation::tests::default_context_engine_compact_context_rewrites_persisted_window -- --exact
- cargo test conversation::tests::handle_turn_with_runtime_persists_completed_compaction_checkpoint_when_default_context_engine_compacts_history -- --exact
- cargo test conversation::tests::handle_turn_with_runtime_persists_failed_open_compaction_checkpoint_when_compaction_fails -- --exact
```

Before / after for config semantics:
- Before: enabling compaction without explicit thresholds could still cause trigger evaluation to behave like an always-on path.
- After: compaction only triggers when at least one explicit message-count or token threshold is configured.
- Regression coverage: `config::tests::conversation_compaction_defaults_require_explicit_thresholds`

## User-visible / Operator-visible Changes

- Safe-lane compaction now rewrites persisted session history instead of acting as a no-op.
- Compaction no longer triggers unless an explicit message-count or token threshold is configured.

## Failure Recovery

- Fast rollback or disable path:
  - set `conversation.compaction.enabled = false`, or remove thresholds so compaction no longer triggers under the new semantics
- Observable failure symptoms reviewers should watch for:
  - older session history being condensed unexpectedly
  - compaction checkpoint errors during safe-lane handling
  - missing long-tail context after a compaction checkpoint

## Reviewer Focus

- `crates/app/src/conversation/context_engine.rs`: durable compaction orchestration and capability metadata
- `crates/app/src/conversation/compaction.rs`: preserved-turn boundary and summary content policy
- `crates/app/src/memory/sqlite.rs`: atomic replace-turns transaction behavior
- `crates/app/src/config/conversation.rs`: explicit threshold gating and default semantics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation history compaction with synthetic summaries that preserve recent turns and summarize older history.
  * Context engine can compact persisted windows when using SQLite-backed memory.

* **Configuration**
  * New compact_preserve_recent_turns setting (default 6) to control how many recent turns are kept.
  * Compaction trigger logic refined: token-based triggers now require both a configured threshold and an estimated-token value.

* **Reliability**
  * Compaction persistence includes retry behavior to handle transient conflicts.

* **Tests & Docs**
  * Expanded compaction unit/integration tests and updated architecture notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->