### PR TITLE
fix: persist provider credential env names

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,9 @@ instability from true upstream unavailability.
 outside the config file:
 
 ```toml
-[provider]
+active_provider = "openai"
+
+[providers.openai]
 kind = "openai"
 api_key_env = "PROVIDER_API_KEY"
 ```
@@ -316,7 +318,9 @@ export ARK_API_KEY=your-ark-api-key
 ```
 
 ```toml
-[provider]
+active_provider = "volcengine"
+
+[providers.volcengine]
 kind = "volcengine"
 model = "your-coding-plan-model-id"
 api_key_env = "ARK_API_KEY"

--- a/README.md
+++ b/README.md
@@ -300,13 +300,13 @@ instability from true upstream unavailability.
 
 ## Configuration
 
-`loongclaw onboard` uses `provider.api_key` to reference provider credentials, so secrets stay
+`loongclaw onboard` uses `provider.api_key_env` to reference provider credentials, so secrets stay
 outside the config file:
 
 ```toml
 [provider]
 kind = "openai"
-api_key = "${PROVIDER_API_KEY}"
+api_key_env = "PROVIDER_API_KEY"
 ```
 
 Volcengine / ARK example:
@@ -319,12 +319,12 @@ export ARK_API_KEY=your-ark-api-key
 [provider]
 kind = "volcengine"
 model = "your-coding-plan-model-id"
-api_key = "${ARK_API_KEY}"
+api_key_env = "ARK_API_KEY"
 base_url = "https://ark.cn-beijing.volces.com"
 chat_completions_path = "/api/v3/chat/completions"
 ```
 
-Both `volcengine` and `volcengine_coding` use `api_key = "${ARK_API_KEY}"`. LoongClaw sends that value as `Authorization: Bearer <ARK_API_KEY>` on the OpenAI-compatible Volcengine path; AK/SK request signing is not used there.
+Both `volcengine` and `volcengine_coding` use `api_key_env = "ARK_API_KEY"`. LoongClaw resolves that environment variable and sends it as `Authorization: Bearer <ARK_API_KEY>` on the OpenAI-compatible Volcengine path; AK/SK request signing is not used there.
 
 Feishu channel example (webhook mode):
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -216,7 +216,9 @@ cargo install --path crates/daemon
 `loongclaw onboard` 默认通过 `provider.api_key_env` 引用 provider 凭据，让密钥不直接写进配置文件：
 
 ```toml
-[provider]
+active_provider = "openai"
+
+[providers.openai]
 kind = "openai"
 api_key_env = "PROVIDER_API_KEY"
 ```
@@ -228,7 +230,9 @@ export ARK_API_KEY=your-ark-api-key
 ```
 
 ```toml
-[provider]
+active_provider = "volcengine"
+
+[providers.volcengine]
 kind = "volcengine"
 model = "your-coding-plan-model-id"
 api_key_env = "ARK_API_KEY"

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,12 +213,12 @@ cargo install --path crates/daemon
 
 ## 配置
 
-`loongclaw onboard` 默认通过 `provider.api_key` 引用 provider 凭据，让密钥不直接写进配置文件：
+`loongclaw onboard` 默认通过 `provider.api_key_env` 引用 provider 凭据，让密钥不直接写进配置文件：
 
 ```toml
 [provider]
 kind = "openai"
-api_key = "${PROVIDER_API_KEY}"
+api_key_env = "PROVIDER_API_KEY"
 ```
 
 Volcengine Coding Plan / ARK 示例：
@@ -231,7 +231,7 @@ export ARK_API_KEY=your-ark-api-key
 [provider]
 kind = "volcengine"
 model = "your-coding-plan-model-id"
-api_key = "${ARK_API_KEY}"
+api_key_env = "ARK_API_KEY"
 base_url = "https://ark.cn-beijing.volces.com"
 chat_completions_path = "/api/v3/chat/completions"
 ```

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -750,16 +750,8 @@ impl<'de> Deserialize<'de> for ProviderConfig {
         let chat_completions_path = raw
             .chat_completions_path
             .unwrap_or_else(default_openai_chat_path);
-        let api_key_env_explicit = raw
-            .api_key_env
-            .as_deref()
-            .map(|value| is_explicit_api_key_env_name(raw.kind, value))
-            .unwrap_or(false);
-        let oauth_access_token_env_explicit = raw
-            .oauth_access_token_env
-            .as_deref()
-            .map(|value| is_explicit_oauth_access_token_env_name(raw.kind, value))
-            .unwrap_or(false);
+        let api_key_env_explicit = raw.api_key_env.is_some();
+        let oauth_access_token_env_explicit = raw.oauth_access_token_env.is_some();
 
         let mut config = Self {
             kind: raw.kind,
@@ -819,16 +811,8 @@ impl ProviderConfig {
         self.base_url_explicit = is_explicit_base_url(self.kind, self.base_url.as_str());
         self.chat_completions_path_explicit =
             is_explicit_chat_completions_path(self.kind, self.chat_completions_path.as_str());
-        self.api_key_env_explicit = self
-            .api_key_env
-            .as_deref()
-            .map(|value| is_explicit_api_key_env_name(self.kind, value))
-            .unwrap_or(false);
-        self.oauth_access_token_env_explicit = self
-            .oauth_access_token_env
-            .as_deref()
-            .map(|value| is_explicit_oauth_access_token_env_name(self.kind, value))
-            .unwrap_or(false);
+        self.api_key_env_explicit = self.api_key_env.is_some();
+        self.oauth_access_token_env_explicit = self.oauth_access_token_env.is_some();
         self.refresh_endpoint_override_flags();
     }
 
@@ -856,18 +840,12 @@ impl ProviderConfig {
     }
 
     pub fn set_api_key_env(&mut self, api_key_env: Option<String>) {
-        self.api_key_env_explicit = api_key_env
-            .as_deref()
-            .map(|value| is_explicit_api_key_env_name(self.kind, value))
-            .unwrap_or(false);
+        self.api_key_env_explicit = api_key_env.is_some();
         self.api_key_env = api_key_env;
     }
 
     pub fn set_oauth_access_token_env(&mut self, oauth_access_token_env: Option<String>) {
-        self.oauth_access_token_env_explicit = oauth_access_token_env
-            .as_deref()
-            .map(|value| is_explicit_oauth_access_token_env_name(self.kind, value))
-            .unwrap_or(false);
+        self.oauth_access_token_env_explicit = oauth_access_token_env.is_some();
         self.oauth_access_token_env = oauth_access_token_env;
     }
 
@@ -1857,13 +1835,6 @@ fn contains_template_placeholder(value: &str) -> bool {
     value.contains('<') && value.contains('>')
 }
 
-fn is_explicit_api_key_env_name(kind: ProviderKind, env_name: &str) -> bool {
-    let Some(env_name) = non_empty(Some(env_name)) else {
-        return false;
-    };
-    !is_current_provider_api_key_env_name(kind, env_name)
-}
-
 fn is_explicit_base_url(kind: ProviderKind, base_url: &str) -> bool {
     let Some(base_url) = non_empty(Some(base_url)) else {
         return false;
@@ -1892,28 +1863,12 @@ fn is_explicit_models_endpoint(provider: &ProviderConfig, endpoint: &str) -> boo
     !is_same_base_url(endpoint, provider.derived_models_endpoint().as_str())
 }
 
-fn is_explicit_oauth_access_token_env_name(kind: ProviderKind, env_name: &str) -> bool {
-    let Some(env_name) = non_empty(Some(env_name)) else {
-        return false;
-    };
-    !is_current_provider_oauth_access_token_env_name(kind, env_name)
-}
-
 fn is_current_provider_base_url(kind: ProviderKind, base_url: &str) -> bool {
     is_same_base_url(base_url, kind.profile().base_url)
 }
 
 fn is_current_provider_chat_completions_path(kind: ProviderKind, path: &str) -> bool {
     is_same_chat_path(path, kind.profile().chat_completions_path)
-}
-
-fn is_current_provider_api_key_env_name(kind: ProviderKind, env_name: &str) -> bool {
-    kind.default_api_key_env() == Some(env_name) || kind.api_key_env_aliases().contains(&env_name)
-}
-
-fn is_current_provider_oauth_access_token_env_name(kind: ProviderKind, env_name: &str) -> bool {
-    kind.default_oauth_access_token_env() == Some(env_name)
-        || kind.oauth_access_token_env_aliases().contains(&env_name)
 }
 
 fn is_provider_managed_api_key_env_name(env_name: &str) -> bool {
@@ -3474,6 +3429,32 @@ mod tests {
             api_key: Some("${OPENAI_API_KEY}".to_owned()),
             ..ProviderConfig::default()
         };
+
+        assert_eq!(config.oauth_access_token(), None);
+        assert_eq!(config.api_key().as_deref(), Some("api-key-wins"));
+        assert_eq!(
+            config.resolved_auth_secret().as_deref(),
+            Some("api-key-wins")
+        );
+        assert_eq!(
+            config.authorization_header().as_deref(),
+            Some("Bearer api-key-wins")
+        );
+    }
+
+    #[test]
+    fn explicit_api_key_env_field_beats_default_oauth_fallback() {
+        let mut env = ScopedEnv::new();
+        env.set("OPENAI_API_KEY", "api-key-wins");
+        env.set("OPENAI_CODEX_OAUTH_TOKEN", "oauth-fallback-should-not-win");
+
+        let config: ProviderConfig = toml::from_str(
+            r#"
+kind = "openai"
+api_key_env = "OPENAI_API_KEY"
+"#,
+        )
+        .expect("deserialize provider config");
 
         assert_eq!(config.oauth_access_token(), None);
         assert_eq!(config.api_key().as_deref(), Some("api-key-wins"));

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -992,16 +992,16 @@ fn canonicalize_provider_secret_env_reference(
     else {
         return;
     };
-    match env_name
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
+    let configured_env_name = env_name.as_deref();
+    let configured_env_name = configured_env_name.map(str::trim);
+    let configured_env_name = configured_env_name.filter(|value| !value.is_empty());
+    match configured_env_name {
         None => {
             *env_name = Some(explicit_env_name);
             *inline_secret = None;
         }
         Some(configured) if configured == explicit_env_name => {
+            *env_name = Some(explicit_env_name);
             *inline_secret = None;
         }
         Some(_) => {}
@@ -2504,12 +2504,46 @@ model = "gpt-5"
         let path = unique_config_path("loongclaw-config-runtime-inline-provider-env");
         let path_string = path.display().to_string();
         let mut config = LoongClawConfig::default();
+        let inline_references = [
+            "${TEAM_OPENAI_KEY}",
+            "$TEAM_OPENAI_KEY",
+            "env:TEAM_OPENAI_KEY",
+            "%TEAM_OPENAI_KEY%",
+        ];
+
+        for inline_reference in inline_references {
+            config.provider.api_key = Some(inline_reference.to_owned());
+
+            write(Some(&path_string), &config, true).expect("config write should pass");
+
+            let raw = fs::read_to_string(&path).expect("read written config");
+            assert!(
+                raw.contains("api_key_env = \"TEAM_OPENAI_KEY\""),
+                "expected api_key_env writeback for {inline_reference}"
+            );
+            assert!(
+                !raw.contains(inline_reference),
+                "expected inline env reference removal for {inline_reference}"
+            );
+        }
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_canonicalizes_matching_provider_env_name_fields() {
+        let path = unique_config_path("loongclaw-config-runtime-trimmed-provider-env");
+        let path_string = path.display().to_string();
+        let mut config = LoongClawConfig::default();
         config.provider.api_key = Some("${TEAM_OPENAI_KEY}".to_owned());
+        config.provider.api_key_env = Some(" TEAM_OPENAI_KEY ".to_owned());
 
         write(Some(&path_string), &config, true).expect("config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read written config");
         assert!(raw.contains("api_key_env = \"TEAM_OPENAI_KEY\""));
+        assert!(!raw.contains("api_key_env = \" TEAM_OPENAI_KEY \""));
         assert!(!raw.contains("api_key = \"${TEAM_OPENAI_KEY}\""));
 
         let _ = fs::remove_file(path);

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -19,7 +19,7 @@ use super::{
     shared::{
         ConfigValidationIssue, ConfigValidationLocale, ConfigValidationSeverity,
         DEFAULT_CONFIG_FILE, default_loongclaw_home as shared_default_loongclaw_home, expand_path,
-        format_config_validation_issues,
+        format_config_validation_issues, parse_explicit_env_reference,
     },
     tools::{
         DEFAULT_WEB_SEARCH_PROVIDER, ExternalSkillsConfig, ToolConfig,
@@ -970,27 +970,42 @@ impl<'a> ProviderSelectorIndex<'a> {
     }
 }
 
-fn canonical_env_reference(env_name: &str) -> Option<String> {
-    let trimmed = env_name.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    Some(format!("${{{trimmed}}}"))
+fn canonicalize_provider_profile_for_encoding(profile: &mut ProviderProfileConfig) {
+    canonicalize_provider_secret_env_reference(
+        &mut profile.provider.api_key,
+        &mut profile.provider.api_key_env,
+    );
+    canonicalize_provider_secret_env_reference(
+        &mut profile.provider.oauth_access_token,
+        &mut profile.provider.oauth_access_token_env,
+    );
 }
 
-fn canonicalize_provider_profile_for_encoding(profile: &mut ProviderProfileConfig) {
-    if profile.provider.api_key.is_none()
-        && let Some(api_key_env) = profile.provider.api_key_env.as_deref()
+fn canonicalize_provider_secret_env_reference(
+    inline_secret: &mut Option<String>,
+    env_name: &mut Option<String>,
+) {
+    let Some(explicit_env_name) = inline_secret
+        .as_deref()
+        .and_then(parse_explicit_env_reference)
+        .map(str::to_owned)
+    else {
+        return;
+    };
+    match env_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
     {
-        profile.provider.api_key = canonical_env_reference(api_key_env);
+        None => {
+            *env_name = Some(explicit_env_name);
+            *inline_secret = None;
+        }
+        Some(configured) if configured == explicit_env_name => {
+            *inline_secret = None;
+        }
+        Some(_) => {}
     }
-    if profile.provider.oauth_access_token.is_none()
-        && let Some(oauth_env) = profile.provider.oauth_access_token_env.as_deref()
-    {
-        profile.provider.oauth_access_token = canonical_env_reference(oauth_env);
-    }
-    profile.provider.api_key_env = None;
-    profile.provider.oauth_access_token_env = None;
 }
 
 fn normalize_acp_agent_id(raw: &str) -> Option<String> {
@@ -1689,9 +1704,9 @@ fn encode_toml_config(_config: &LoongClawConfig) -> CliResult<String> {
 
 fn template_secret_usage_comment() -> &'static str {
     "# Secret configuration notes:\n\
-# - Preferred provider credential form: `providers.<profile_id>.api_key = \"${PROVIDER_API_KEY}\"`.\n\
-# - `providers.<profile_id>.api_key` also accepts direct literals and explicit env refs like `$VAR`, `env:VAR`, and `%VAR%`.\n\
-# - Legacy `*_env` fields stay supported for compatibility, but new configs should prefer the non-`_env` fields.\n\
+# - Preferred provider credential form: `providers.<profile_id>.api_key_env = \"PROVIDER_API_KEY\"`.\n\
+# - Inline fields like `providers.<profile_id>.api_key` still accept direct literals and explicit env refs like `$VAR`, `env:VAR`, and `%VAR%`.\n\
+# - When LoongClaw writes config back to disk, explicit env refs are persisted as `*_env` fields.\n\
 \n"
 }
 
@@ -1772,7 +1787,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_template_prefers_generic_provider_api_key_reference_example() {
+    fn write_template_prefers_generic_provider_api_key_env_example() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
@@ -1785,8 +1800,8 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .expect("write template should succeed");
 
         let raw = std::fs::read_to_string(&config_path).expect("read template");
-        assert!(raw.contains("providers.<profile_id>.api_key = \"${PROVIDER_API_KEY}\""));
-        assert!(!raw.contains("provider.api_key_env = \"PROVIDER_API_KEY\""));
+        assert!(raw.contains("providers.<profile_id>.api_key_env = \"PROVIDER_API_KEY\""));
+        assert!(!raw.contains("providers.<profile_id>.api_key = \"${PROVIDER_API_KEY}\""));
 
         std::fs::remove_file(&config_path).ok();
         std::fs::remove_dir_all(&temp_dir).ok();
@@ -2414,7 +2429,7 @@ model = "gpt-5"
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_default_config_omits_legacy_provider_api_key_env_field() {
+    fn write_default_config_does_not_eagerly_persist_provider_api_key_env_field() {
         let path = unique_config_path("loongclaw-config-runtime-default");
         let path_string = path.display().to_string();
 
@@ -2423,6 +2438,7 @@ model = "gpt-5"
 
         let raw = fs::read_to_string(&path).expect("read written config");
         assert!(!raw.contains("api_key_env = \"OPENAI_API_KEY\""));
+        assert!(!raw.contains("api_key = \"${OPENAI_API_KEY}\""));
 
         let _ = fs::remove_file(path);
     }
@@ -2467,7 +2483,7 @@ model = "gpt-5"
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_canonicalizes_provider_env_pointers_to_inline_env_references() {
+    fn write_persists_provider_env_pointers_as_env_name_fields() {
         let path = unique_config_path("loongclaw-config-runtime-canonical-provider-env");
         let path_string = path.display().to_string();
         let mut config = LoongClawConfig::default();
@@ -2476,8 +2492,25 @@ model = "gpt-5"
         write(Some(&path_string), &config, true).expect("config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read written config");
-        assert!(raw.contains("api_key = \"${OPENAI_API_KEY}\""));
-        assert!(!raw.contains("api_key_env = "));
+        assert!(raw.contains("api_key_env = \"OPENAI_API_KEY\""));
+        assert!(!raw.contains("api_key = \"${OPENAI_API_KEY}\""));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_migrates_inline_provider_env_references_to_env_name_fields() {
+        let path = unique_config_path("loongclaw-config-runtime-inline-provider-env");
+        let path_string = path.display().to_string();
+        let mut config = LoongClawConfig::default();
+        config.provider.api_key = Some("${TEAM_OPENAI_KEY}".to_owned());
+
+        write(Some(&path_string), &config, true).expect("config write should pass");
+
+        let raw = fs::read_to_string(&path).expect("read written config");
+        assert!(raw.contains("api_key_env = \"TEAM_OPENAI_KEY\""));
+        assert!(!raw.contains("api_key = \"${TEAM_OPENAI_KEY}\""));
 
         let _ = fs::remove_file(path);
     }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1698,20 +1698,13 @@ fn runtime_snapshot_migrate_provider_env_reference(
     else {
         return;
     };
-    match env_name
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        None => {
-            *env_name = Some(explicit_env_name);
-            *inline_secret = None;
-        }
-        Some(configured) if configured == explicit_env_name => {
-            *inline_secret = None;
-        }
-        Some(_) => {}
+    let configured_env_name = env_name.as_deref();
+    let configured_env_name = configured_env_name.map(str::trim);
+    let configured_env_name = configured_env_name.filter(|value| !value.is_empty());
+    if configured_env_name.is_none() {
+        *env_name = Some(explicit_env_name);
     }
+    *inline_secret = None;
 }
 
 fn runtime_snapshot_is_env_reference_literal(raw: &str) -> bool {
@@ -1926,6 +1919,41 @@ mod runtime_snapshot_restore_spec_tests {
         assert_eq!(
             profile.provider.oauth_access_token_env.as_deref(),
             Some("OPENAI_CODEX_OAUTH_TOKEN")
+        );
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn runtime_snapshot_restore_normalization_prefers_existing_env_name_fields() {
+        let mut warnings = Vec::new();
+        let mut profile = mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "openai/gpt-5.1-codex".to_owned(),
+                api_key: Some("${INLINE_OPENAI_API_KEY}".to_owned()),
+                api_key_env: Some("CONFIGURED_OPENAI_API_KEY".to_owned()),
+                oauth_access_token: Some("$INLINE_OPENAI_OAUTH_TOKEN".to_owned()),
+                oauth_access_token_env: Some("CONFIGURED_OPENAI_OAUTH_TOKEN".to_owned()),
+                ..Default::default()
+            },
+        };
+
+        normalize_runtime_snapshot_restore_provider_profile(
+            "openai-main",
+            &mut profile,
+            &mut warnings,
+        );
+
+        assert_eq!(profile.provider.api_key, None);
+        assert_eq!(
+            profile.provider.api_key_env.as_deref(),
+            Some("CONFIGURED_OPENAI_API_KEY")
+        );
+        assert_eq!(profile.provider.oauth_access_token, None);
+        assert_eq!(
+            profile.provider.oauth_access_token_env.as_deref(),
+            Some("CONFIGURED_OPENAI_OAUTH_TOKEN")
         );
         assert!(warnings.is_empty());
     }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1592,18 +1592,14 @@ fn normalize_runtime_snapshot_restore_provider_profile(
     profile: &mut mvp::config::ProviderProfileConfig,
     warnings: &mut Vec<String>,
 ) {
-    if profile.provider.api_key.is_none() {
-        profile.provider.api_key =
-            runtime_snapshot_canonical_env_reference(profile.provider.api_key_env.as_deref());
-    }
-    if profile.provider.oauth_access_token.is_none() {
-        profile.provider.oauth_access_token = runtime_snapshot_canonical_env_reference(
-            profile.provider.oauth_access_token_env.as_deref(),
-        );
-    }
-
-    profile.provider.api_key_env = None;
-    profile.provider.oauth_access_token_env = None;
+    runtime_snapshot_migrate_provider_env_reference(
+        &mut profile.provider.api_key,
+        &mut profile.provider.api_key_env,
+    );
+    runtime_snapshot_migrate_provider_env_reference(
+        &mut profile.provider.oauth_access_token,
+        &mut profile.provider.oauth_access_token_env,
+    );
 
     if runtime_snapshot_redact_provider_secret_field(
         profile.provider.api_key.as_mut(),
@@ -1691,40 +1687,66 @@ fn runtime_snapshot_provider_header_is_safe_to_persist(
         .any(|(default_name, _)| default_name.eq_ignore_ascii_case(&normalized))
 }
 
-fn runtime_snapshot_canonical_env_reference(env_name: Option<&str>) -> Option<String> {
-    let env_name = env_name.map(str::trim).filter(|value| !value.is_empty())?;
-    Some(format!("${{{env_name}}}"))
+fn runtime_snapshot_migrate_provider_env_reference(
+    inline_secret: &mut Option<String>,
+    env_name: &mut Option<String>,
+) {
+    let Some(explicit_env_name) = inline_secret
+        .as_deref()
+        .and_then(runtime_snapshot_parse_env_reference)
+        .map(str::to_owned)
+    else {
+        return;
+    };
+    match env_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        None => {
+            *env_name = Some(explicit_env_name);
+            *inline_secret = None;
+        }
+        Some(configured) if configured == explicit_env_name => {
+            *inline_secret = None;
+        }
+        Some(_) => {}
+    }
 }
 
 fn runtime_snapshot_is_env_reference_literal(raw: &str) -> bool {
+    runtime_snapshot_parse_env_reference(raw).is_some()
+}
+
+fn runtime_snapshot_parse_env_reference(raw: &str) -> Option<&str> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        return false;
+        return None;
     }
 
     if let Some(inner) = trimmed
         .strip_prefix("${")
         .and_then(|value| value.strip_suffix('}'))
     {
-        return runtime_snapshot_is_valid_env_name(inner);
+        return runtime_snapshot_is_valid_env_name(inner).then_some(inner);
     }
 
     if let Some(inner) = trimmed.strip_prefix('$') {
-        return runtime_snapshot_is_valid_env_name(inner);
+        return runtime_snapshot_is_valid_env_name(inner).then_some(inner);
     }
 
     if let Some(inner) = trimmed.strip_prefix("env:") {
-        return runtime_snapshot_is_valid_env_name(inner);
+        return runtime_snapshot_is_valid_env_name(inner).then_some(inner);
     }
 
     if let Some(inner) = trimmed
         .strip_prefix('%')
         .and_then(|value| value.strip_suffix('%'))
     {
-        return runtime_snapshot_is_valid_env_name(inner);
+        return runtime_snapshot_is_valid_env_name(inner).then_some(inner);
     }
 
-    false
+    None
 }
 
 fn runtime_snapshot_is_valid_env_name(raw: &str) -> bool {
@@ -1873,6 +1895,39 @@ mod runtime_snapshot_restore_spec_tests {
             "x-secret-version",
             "literal-secret",
         ));
+    }
+
+    #[test]
+    fn runtime_snapshot_restore_normalization_keeps_provider_env_name_fields() {
+        let mut warnings = Vec::new();
+        let mut profile = mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "openai/gpt-5.1-codex".to_owned(),
+                api_key_env: Some("OPENAI_API_KEY".to_owned()),
+                oauth_access_token_env: Some("OPENAI_CODEX_OAUTH_TOKEN".to_owned()),
+                ..Default::default()
+            },
+        };
+
+        normalize_runtime_snapshot_restore_provider_profile(
+            "openai-main",
+            &mut profile,
+            &mut warnings,
+        );
+
+        assert_eq!(profile.provider.api_key, None);
+        assert_eq!(
+            profile.provider.api_key_env.as_deref(),
+            Some("OPENAI_API_KEY")
+        );
+        assert_eq!(profile.provider.oauth_access_token, None);
+        assert_eq!(
+            profile.provider.oauth_access_token_env.as_deref(),
+            Some("OPENAI_CODEX_OAUTH_TOKEN")
+        );
+        assert!(warnings.is_empty());
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2784,7 +2784,6 @@ fn render_provider_credential_source_value(raw: Option<&str>) -> Option<String> 
         return None;
     }
     normalize_provider_credential_env_name(trimmed)
-        .map(|env_name| env_name.to_owned())
         .or_else(|| Some("environment variable".to_owned()))
 }
 
@@ -7511,6 +7510,7 @@ mod tests {
 
         let mut api_key_env_update = current.clone();
         apply_selected_api_key_env(&mut api_key_env_update, "OPENAI_API_KEY".to_owned());
+        assert!(api_key_env_update.api_key_env_explicit);
         assert!(
             provider_matches_for_review(&current, &api_key_env_update),
             "review matching should ignore explicit api_key_env metadata when the provider identity is otherwise unchanged"
@@ -7518,6 +7518,7 @@ mod tests {
 
         let mut oauth_env_update = current.clone();
         apply_selected_api_key_env(&mut oauth_env_update, "OPENAI_CODEX_OAUTH_TOKEN".to_owned());
+        assert!(oauth_env_update.oauth_access_token_env_explicit);
         assert!(
             provider_matches_for_review(&current, &oauth_env_update),
             "review matching should ignore explicit oauth_access_token_env metadata when the provider identity is otherwise unchanged"

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2784,7 +2784,7 @@ fn render_provider_credential_source_value(raw: Option<&str>) -> Option<String> 
         return None;
     }
     normalize_provider_credential_env_name(trimmed)
-        .map(|env_name| format!("${{{env_name}}}"))
+        .map(|env_name| env_name.to_owned())
         .or_else(|| Some("environment variable".to_owned()))
 }
 
@@ -3870,13 +3870,17 @@ fn provider_matches_for_review(
 
     left.api_key = None;
     left.api_key_env = None;
+    left.api_key_env_explicit = false;
     left.oauth_access_token = None;
     left.oauth_access_token_env = None;
+    left.oauth_access_token_env_explicit = false;
 
     right.api_key = None;
     right.api_key_env = None;
+    right.api_key_env_explicit = false;
     right.oauth_access_token = None;
     right.oauth_access_token_env = None;
+    right.oauth_access_token_env_explicit = false;
 
     left == right
 }
@@ -7493,6 +7497,30 @@ mod tests {
         assert_eq!(
             provider.oauth_access_token_env, None,
             "switching to a custom env name should clear the stale oauth binding"
+        );
+    }
+
+    #[test]
+    fn provider_matches_for_review_ignores_credential_field_explicitness() {
+        let current = mvp::config::ProviderConfig {
+            kind: mvp::config::ProviderKind::Openai,
+            model: "gpt-4.1".to_owned(),
+            api_key: Some("inline-secret".to_owned()),
+            ..mvp::config::ProviderConfig::default()
+        };
+
+        let mut api_key_env_update = current.clone();
+        apply_selected_api_key_env(&mut api_key_env_update, "OPENAI_API_KEY".to_owned());
+        assert!(
+            provider_matches_for_review(&current, &api_key_env_update),
+            "review matching should ignore explicit api_key_env metadata when the provider identity is otherwise unchanged"
+        );
+
+        let mut oauth_env_update = current.clone();
+        apply_selected_api_key_env(&mut oauth_env_update, "OPENAI_CODEX_OAUTH_TOKEN".to_owned());
+        assert!(
+            provider_matches_for_review(&current, &oauth_env_update),
+            "review matching should ignore explicit oauth_access_token_env metadata when the provider identity is otherwise unchanged"
         );
     }
 

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -1308,9 +1308,13 @@ model = "deepseek-chat"
     );
     assert_eq!(imported.provider.model, "deepseek-chat");
     assert_eq!(
-        imported.provider.api_key.as_deref(),
-        Some("${DEEPSEEK_API_KEY}"),
-        "source-path-selected provider should retain its provider-specific credential binding in canonical inline-env form"
+        imported.provider.api_key, None,
+        "source-path-selected provider should not keep the legacy inline api_key field once the env name field is persisted"
+    );
+    assert_eq!(
+        imported.provider.api_key_env.as_deref(),
+        Some("DEEPSEEK_API_KEY"),
+        "source-path-selected provider should retain its provider-specific credential binding as an env name field"
     );
     assert_eq!(
         imported.provider.authorization_header().as_deref(),
@@ -1418,13 +1422,13 @@ requires_openai_auth = true
         mvp::config::ProviderWireApi::Responses
     );
     assert_eq!(
-        imported.provider.api_key.as_deref(),
-        Some("${OPENAI_API_KEY}"),
-        "codex import should persist OpenAI auth in canonical inline-env form"
+        imported.provider.api_key, None,
+        "codex import should not keep the legacy inline api_key field once the env name field is persisted"
     );
-    assert!(
-        imported.provider.api_key_env.is_none(),
-        "codex import should not keep the legacy api_key_env pointer once the canonical inline-env reference is written"
+    assert_eq!(
+        imported.provider.api_key_env.as_deref(),
+        Some("OPENAI_API_KEY"),
+        "codex import should persist OpenAI auth as an env name field"
     );
 
     let models = mvp::provider::fetch_available_models(&imported)

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -833,29 +833,29 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     assert!(
-        raw.contains("oauth_access_token = \"${OPENAI_CODEX_OAUTH_TOKEN}\""),
-        "onboarding should persist the openai oauth binding as the canonical env reference after provider-aligned credential routing: {raw}"
+        raw.contains("oauth_access_token_env = \"OPENAI_CODEX_OAUTH_TOKEN\""),
+        "onboarding should persist the openai oauth env name after provider-aligned credential routing: {raw}"
+    );
+    assert!(
+        !raw.contains("oauth_access_token = "),
+        "provider-aligned onboarding should not fall back to the legacy oauth_access_token field for the openai oauth route: {raw}"
     );
     assert!(
         !raw.contains("api_key = "),
         "provider-aligned onboarding should not fall back to the legacy api_key field for the openai oauth route: {raw}"
-    );
-    assert!(
-        !raw.contains("api_key_env"),
-        "canonical onboarding config should not persist the legacy api_key_env field: {raw}"
     );
 
     let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
         .expect("load written onboarding config");
     assert_eq!(config.provider.model, "openai/gpt-5.1-codex");
     assert_eq!(
-        config.provider.oauth_access_token.as_deref(),
-        Some("${OPENAI_CODEX_OAUTH_TOKEN}"),
-        "reloaded config should keep the canonical oauth credential source after provider-aligned routing"
+        config.provider.oauth_access_token, None,
+        "reloaded config should not repopulate the legacy oauth_access_token field for the oauth-backed openai route"
     );
     assert_eq!(
-        config.provider.api_key, None,
-        "reloaded config should not repopulate the legacy api_key field for the oauth-backed openai route"
+        config.provider.oauth_access_token_env.as_deref(),
+        Some("OPENAI_CODEX_OAUTH_TOKEN"),
+        "reloaded config should keep the routed oauth env name after provider-aligned onboarding"
     );
     assert_eq!(
         config.provider.authorization_header(),
@@ -1026,7 +1026,7 @@ async fn non_interactive_api_key_env_override_clears_existing_oauth_credentials(
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     assert!(
-        raw.contains("api_key = \"${OPENAI_API_KEY}\""),
+        raw.contains("api_key_env = \"OPENAI_API_KEY\""),
         "api key env override should persist the selected api key source: {raw}"
     );
     assert!(
@@ -1037,9 +1037,14 @@ async fn non_interactive_api_key_env_override_clears_existing_oauth_credentials(
     let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
         .expect("load written onboarding config");
     assert_eq!(config.provider.oauth_access_token, None);
+    assert_eq!(config.provider.oauth_access_token_env, None);
     assert_eq!(
-        config.provider.api_key.as_deref(),
-        Some("${OPENAI_API_KEY}"),
+        config.provider.api_key, None,
+        "reloaded config should not keep the legacy inline api_key field once the env name field is persisted"
+    );
+    assert_eq!(
+        config.provider.api_key_env.as_deref(),
+        Some("OPENAI_API_KEY"),
         "reloaded config should keep only the selected api key credential source"
     );
 }
@@ -1075,7 +1080,7 @@ async fn non_interactive_api_key_env_override_clears_existing_inline_api_key() {
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     assert!(
-        raw.contains("api_key = \"${OPENAI_API_KEY}\""),
+        raw.contains("api_key_env = \"OPENAI_API_KEY\""),
         "api key env override should persist the selected api key source: {raw}"
     );
     assert!(
@@ -1086,8 +1091,12 @@ async fn non_interactive_api_key_env_override_clears_existing_inline_api_key() {
     let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
         .expect("load written onboarding config");
     assert_eq!(
-        config.provider.api_key.as_deref(),
-        Some("${OPENAI_API_KEY}"),
+        config.provider.api_key, None,
+        "reloaded config should not keep the legacy inline api_key field once the env name field is persisted"
+    );
+    assert_eq!(
+        config.provider.api_key_env.as_deref(),
+        Some("OPENAI_API_KEY"),
         "reloaded config should keep only the selected api key env reference"
     );
 }
@@ -4279,19 +4288,19 @@ fn onboard_api_key_env_screen_explains_suggested_env_and_blank_behavior() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("- current source: ${OPENAI_CODEX_OAUTH_TOKEN}")),
+            .any(|line| line.contains("- current source: OPENAI_CODEX_OAUTH_TOKEN")),
         "credential-env screen should show the active oauth credential source instead of hiding it behind api-key-only rendering: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("- suggested source: ${OPENAI_API_KEY}")),
+            .any(|line| line.contains("- suggested source: OPENAI_API_KEY")),
         "credential-env screen should surface the suggested env var name: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .any(|line| line == "- press Enter to use suggested source: ${OPENAI_API_KEY}"),
+            .any(|line| line == "- press Enter to use suggested source: OPENAI_API_KEY"),
         "credential-env screen should state that Enter uses the suggested env when no current env is set: {lines:#?}"
     );
     assert!(
@@ -4326,7 +4335,7 @@ fn onboard_api_key_env_screen_shows_prefilled_env_when_enter_default_is_overridd
     assert!(
         lines
             .iter()
-            .any(|line| line == "- press Enter to use prefilled source: ${TEAM_OPENAI_KEY}"),
+            .any(|line| line == "- press Enter to use prefilled source: TEAM_OPENAI_KEY"),
         "credential-env screen should surface the actual prefilled env when it differs from both the current and suggested env: {lines:#?}"
     );
     assert!(
@@ -5851,7 +5860,7 @@ fn onboard_review_lines_include_core_setup_summary_for_fresh_setup() {
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("- credential source: ${OPENAI_CODEX_OAUTH_TOKEN}")),
+            .any(|line| line.contains("- credential source: OPENAI_CODEX_OAUTH_TOKEN")),
         "review should keep the provider-preferred credential env visible for fresh setup flows: {lines:#?}"
     );
     assert!(
@@ -5889,13 +5898,13 @@ fn onboard_review_lines_prefer_oauth_env_over_api_key_env_when_both_are_configur
     assert!(
         lines
             .iter()
-            .any(|line| line.contains("- credential source: ${OPENAI_CODEX_OAUTH_TOKEN}")),
+            .any(|line| line.contains("- credential source: OPENAI_CODEX_OAUTH_TOKEN")),
         "review should reflect the higher-priority oauth credential path when both bindings exist: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .all(|line| !line.contains("- credential source: ${OPENAI_API_KEY}")),
+            .all(|line| !line.contains("- credential source: OPENAI_API_KEY")),
         "review should not keep advertising the api key env as primary once oauth is configured: {lines:#?}"
     );
 }
@@ -6254,13 +6263,13 @@ fn onboarding_success_summary_prefers_oauth_env_over_api_key_env_when_both_are_c
     assert!(
         lines
             .iter()
-            .any(|line| line == "- credential source: ${OPENAI_CODEX_OAUTH_TOKEN}"),
+            .any(|line| line == "- credential source: OPENAI_CODEX_OAUTH_TOKEN"),
         "success summary should surface the primary oauth binding when oauth and api key envs both exist: {lines:#?}"
     );
     assert!(
         lines
             .iter()
-            .all(|line| line != "- credential source: ${OPENAI_API_KEY}"),
+            .all(|line| line != "- credential source: OPENAI_API_KEY"),
         "success summary should not keep the api key env as the primary credential line once oauth is configured: {lines:#?}"
     );
 }
@@ -6278,7 +6287,7 @@ fn onboarding_success_summary_reports_existing_config_kept() {
         provider_endpoint: None,
         credential: Some(loongclaw_daemon::onboard_cli::OnboardingCredentialSummary {
             label: "credential source",
-            value: "${OPENAI_API_KEY}".to_owned(),
+            value: "OPENAI_API_KEY".to_owned(),
         }),
         prompt_mode: "native prompt pack".to_owned(),
         personality: Some("calm_engineering".to_owned()),
@@ -6356,7 +6365,7 @@ fn onboarding_success_summary_groups_domain_outcomes_by_decision() {
         provider_endpoint: None,
         credential: Some(loongclaw_daemon::onboard_cli::OnboardingCredentialSummary {
             label: "credential source",
-            value: "${OPENAI_API_KEY}".to_owned(),
+            value: "OPENAI_API_KEY".to_owned(),
         }),
         prompt_mode: "native prompt pack".to_owned(),
         personality: Some("friendly_collab".to_owned()),
@@ -6421,7 +6430,7 @@ fn onboarding_success_summary_wraps_domain_outcomes_for_narrow_width() {
         provider_endpoint: None,
         credential: Some(loongclaw_daemon::onboard_cli::OnboardingCredentialSummary {
             label: "credential source",
-            value: "${OPENAI_API_KEY}".to_owned(),
+            value: "OPENAI_API_KEY".to_owned(),
         }),
         prompt_mode: "native prompt pack".to_owned(),
         personality: Some("friendly_collab".to_owned()),


### PR DESCRIPTION
## Summary

- Problem:
  Env-backed provider credentials were being rewritten into inline `${ENV}` strings during config persistence and runtime snapshot restore, while explicit `api_key_env` / `oauth_access_token_env` fields that matched provider defaults could lose explicitness and fall behind default auth fallback logic.
- Why it matters:
  This breaks stable auth precedence, produces misleading onboarding/import displays, and can surface provider 401s on `dev` even when the operator explicitly selected the correct env binding.
- What changed:
  LoongClaw now preserves env-backed provider credentials in canonical `*_env` fields, migrates accepted inline env refs into those fields on write/restore, preserves explicit env-field intent based on field presence, and renders raw env names in onboarding/review output. Added regression coverage for writeback, import, onboarding, snapshot restore, auth precedence, and review matching.
- What did not change (scope boundary):
  This does not change literal-secret auth behavior, and it does not hardcode provider-specific region or model-availability workarounds.

## Linked Issues

- Closes #437
- Related #427

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all --check
env -i HOME="$HOME" PATH="$PATH" SHELL="$SHELL" TERM="${TERM:-xterm-256color}" LANG="${LANG:-en_US.UTF-8}" LC_ALL="${LC_ALL:-en_US.UTF-8}" RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" TMPDIR="${TMPDIR:-/tmp}" cargo test -p loongclaw-app --locked --quiet
env -i HOME="$HOME" PATH="$PATH" SHELL="$SHELL" TERM="${TERM:-xterm-256color}" LANG="${LANG:-en_US.UTF-8}" LC_ALL="${LC_ALL:-en_US.UTF-8}" RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" TMPDIR="${TMPDIR:-/tmp}" cargo test -p loongclaw-daemon --locked --quiet
env -i HOME="$HOME" PATH="$PATH" SHELL="$SHELL" TERM="${TERM:-xterm-256color}" LANG="${LANG:-en_US.UTF-8}" LC_ALL="${LC_ALL:-en_US.UTF-8}" RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" TMPDIR="${TMPDIR:-/tmp}" cargo test --workspace --locked --quiet

Manual/provider validation:
- `validate-config --config <openrouter-config> --json` => valid, 0 diagnostics
- `validate-config --config <volcengine-config> --json` => valid, 0 diagnostics
- `list-models --config <openrouter-config> --json` => non-empty model list returned from OpenRouter
- `list-models --config <volcengine-config> --json` => non-empty model list returned from Volcengine
- `ask` no longer failed with 401 on the verified auth paths:
  - OpenRouter request reached the provider and returned a region-availability 403 for the chosen model
  - Volcengine request reached the provider and returned a model-activation 404 for the chosen model
```

## User-visible / Operator-visible Changes

- Env-backed provider credentials now persist as `api_key_env = "ENV_NAME"` / `oauth_access_token_env = "ENV_NAME"` instead of being rewritten to inline `${ENV}` form.
- Onboarding/review/import displays show raw env names instead of `${ENV}` wrappers.
- Explicit env fields keep their intended auth precedence even when they match provider-default env names.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `b551e36e`.
- Observable failure symptoms reviewers should watch for:
  Any path that rewrites explicit env-name fields back into inline `${ENV}` form, any OpenAI auth flow where explicit `api_key_env` loses to OAuth fallback, or any onboarding review path that marks unchanged provider config as adjusted due only to credential explicitness metadata.

## Reviewer Focus

- `crates/app/src/config/provider.rs` explicitness semantics for `api_key_env` / `oauth_access_token_env`
- `crates/app/src/config/runtime.rs` writeback migration from inline env refs to `*_env`
- `crates/daemon/src/lib.rs` snapshot restore normalization
- `crates/daemon/src/onboard_cli.rs` review matching and credential-source rendering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README (EN and CN) examples to show environment-variable-based provider credentials and provider-specific TOML sections with active_provider + api_key_env/oauth_access_token_env.

* **Refactor**
  * Credential persistence now prefers dedicated env-name fields (api_key_env / oauth_access_token_env); inline secret literals are migrated into those fields and cleared.
  * Display of credential sources now shows raw env names (no ${...} interpolation).

* **Tests**
  * Integration and unit tests updated to assert env-name persistence, migration, and display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->