### PR TITLE
feat(app): load workspace self sources into runtime prompt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 futures-util = "0.3"
 sha2 = "0.10"
 flate2 = "1"
-tar = "0.4"
+tar = "0.4.45"
 rand = "0.9"
 regex = "1.12.3"
 wasmparser = "0.245"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -12,6 +12,7 @@ pub mod presentation;
 pub mod prompt;
 pub mod provider;
 pub mod runtime_env;
+mod runtime_self;
 pub mod session;
 pub mod tools;
 

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -2,6 +2,7 @@ use serde_json::{Value, json};
 
 use crate::CliResult;
 use crate::config::LoongClawConfig;
+use crate::runtime_self;
 use crate::tools::{self, ToolView};
 
 #[cfg(feature = "memory-sqlite")]
@@ -36,14 +37,27 @@ fn build_system_message_with_tool_runtime_config(
     if !include_system_prompt {
         return None;
     }
+
     let system_prompt = config.cli.resolved_system_prompt();
     let system = system_prompt.trim();
     let snapshot = tools::capability_snapshot_for_view_with_config(tool_view, tool_runtime_config);
-    let content = if system.is_empty() {
-        snapshot
-    } else {
-        format!("{system}\n\n{snapshot}")
-    };
+
+    let runtime_self_section = tool_runtime_config
+        .file_root
+        .as_deref()
+        .map(runtime_self::load_runtime_self_model)
+        .and_then(|model| runtime_self::render_runtime_self_section(&model));
+
+    let mut sections = Vec::new();
+    if !system.is_empty() {
+        sections.push(system.to_owned());
+    }
+    if let Some(section) = runtime_self_section {
+        sections.push(section);
+    }
+    sections.push(snapshot);
+
+    let content = sections.join("\n\n");
     Some(json!({
         "role": "system",
         "content": content,
@@ -171,6 +185,7 @@ fn should_skip_history_turn(role: &str, content: &str) -> bool {
 mod tests {
     use super::*;
     use crate::config::MemoryProfile;
+    use tempfile::tempdir;
 
     #[test]
     fn build_system_message_returns_none_when_disabled() {
@@ -258,6 +273,54 @@ mod tests {
 
         assert!(system_content.contains("You are a legacy inline prompt."));
         assert!(!system_content.contains("## Personality Overlay: Calm Engineering"));
+    }
+
+    #[test]
+    fn build_system_message_includes_normalized_runtime_self_sections_from_workspace_root() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+
+        let agents_path = workspace_root.join("AGENTS.md");
+        let soul_path = workspace_root.join("SOUL.md");
+        let identity_path = workspace_root.join("IDENTITY.md");
+        let user_path = workspace_root.join("USER.md");
+
+        let agents_text = "Always keep workspace instructions explicit.";
+        let soul_text = "Prefer calm, rigorous, low-drama execution.";
+        let identity_text = "You are the migration-shaped helper identity.";
+        let user_text = "The operator prefers concise technical summaries.";
+
+        std::fs::write(&agents_path, agents_text).expect("write AGENTS");
+        std::fs::write(&soul_path, soul_text).expect("write SOUL");
+        std::fs::write(&identity_path, identity_text).expect("write IDENTITY");
+        std::fs::write(&user_path, user_text).expect("write USER");
+
+        let config = LoongClawConfig::default();
+        let tool_view = tools::runtime_tool_view();
+
+        let tool_runtime_config = tools::runtime_config::ToolRuntimeConfig {
+            file_root: Some(workspace_root.to_path_buf()),
+            ..tools::runtime_config::ToolRuntimeConfig::default()
+        };
+
+        let system_message = build_system_message_with_tool_runtime_config(
+            &config,
+            true,
+            &tool_view,
+            &tool_runtime_config,
+        )
+        .expect("system message");
+        let system_content = system_message["content"].as_str().expect("system content");
+
+        assert!(system_content.contains("## Runtime Self Context"));
+        assert!(system_content.contains("### Standing Instructions"));
+        assert!(system_content.contains(agents_text));
+        assert!(system_content.contains("### Soul Guidance"));
+        assert!(system_content.contains(soul_text));
+        assert!(system_content.contains("### Identity Context"));
+        assert!(system_content.contains(identity_text));
+        assert!(system_content.contains("### User Context"));
+        assert!(system_content.contains(user_text));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -1,0 +1,245 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeSelfLane {
+    StandingInstructions,
+    SoulGuidance,
+    IdentityContext,
+    UserContext,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RuntimeSelfSourceSpec {
+    relative_path: &'static str,
+    lane: RuntimeSelfLane,
+}
+
+const RUNTIME_SELF_SOURCE_SPECS: &[RuntimeSelfSourceSpec] = &[
+    RuntimeSelfSourceSpec {
+        relative_path: "AGENTS.md",
+        lane: RuntimeSelfLane::StandingInstructions,
+    },
+    RuntimeSelfSourceSpec {
+        relative_path: "CLAUDE.md",
+        lane: RuntimeSelfLane::StandingInstructions,
+    },
+    RuntimeSelfSourceSpec {
+        relative_path: "SOUL.md",
+        lane: RuntimeSelfLane::SoulGuidance,
+    },
+    RuntimeSelfSourceSpec {
+        relative_path: "IDENTITY.md",
+        lane: RuntimeSelfLane::IdentityContext,
+    },
+    RuntimeSelfSourceSpec {
+        relative_path: "USER.md",
+        lane: RuntimeSelfLane::UserContext,
+    },
+];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct RuntimeSelfModel {
+    pub standing_instructions: Vec<String>,
+    pub soul_guidance: Vec<String>,
+    pub identity_context: Vec<String>,
+    pub user_context: Vec<String>,
+}
+
+impl RuntimeSelfModel {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.standing_instructions.is_empty()
+            && self.soul_guidance.is_empty()
+            && self.identity_context.is_empty()
+            && self.user_context.is_empty()
+    }
+}
+
+pub(crate) fn load_runtime_self_model(workspace_root: &Path) -> RuntimeSelfModel {
+    let candidate_roots = candidate_roots(workspace_root);
+    let mut loaded_paths = BTreeSet::new();
+    let mut model = RuntimeSelfModel::default();
+
+    for root in candidate_roots {
+        for spec in RUNTIME_SELF_SOURCE_SPECS {
+            let candidate_path = root.join(spec.relative_path);
+            let Some(content) = read_runtime_self_source(&candidate_path) else {
+                continue;
+            };
+
+            let path_key = normalized_path_key(&candidate_path);
+            let inserted = loaded_paths.insert(path_key);
+            if !inserted {
+                continue;
+            }
+
+            append_runtime_self_content(&mut model, spec.lane, content);
+        }
+    }
+
+    model
+}
+
+pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<String> {
+    if model.is_empty() {
+        return None;
+    }
+
+    let mut sections = Vec::new();
+    sections.push("## Runtime Self Context".to_owned());
+
+    push_rendered_lane(
+        &mut sections,
+        "### Standing Instructions",
+        &model.standing_instructions,
+    );
+    push_rendered_lane(&mut sections, "### Soul Guidance", &model.soul_guidance);
+    push_rendered_lane(
+        &mut sections,
+        "### Identity Context",
+        &model.identity_context,
+    );
+    push_rendered_lane(&mut sections, "### User Context", &model.user_context);
+
+    Some(sections.join("\n\n"))
+}
+
+fn candidate_roots(workspace_root: &Path) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    roots.push(workspace_root.to_path_buf());
+
+    let nested_workspace_root = workspace_root.join("workspace");
+    if nested_workspace_root.is_dir() {
+        roots.push(nested_workspace_root);
+    }
+
+    roots
+}
+
+fn read_runtime_self_source(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(trimmed.to_owned())
+}
+
+fn normalized_path_key(path: &Path) -> String {
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    canonical_path.display().to_string()
+}
+
+fn append_runtime_self_content(
+    model: &mut RuntimeSelfModel,
+    lane: RuntimeSelfLane,
+    content: String,
+) {
+    match lane {
+        RuntimeSelfLane::StandingInstructions => {
+            model.standing_instructions.push(content);
+        }
+        RuntimeSelfLane::SoulGuidance => {
+            model.soul_guidance.push(content);
+        }
+        RuntimeSelfLane::IdentityContext => {
+            model.identity_context.push(content);
+        }
+        RuntimeSelfLane::UserContext => {
+            model.user_context.push(content);
+        }
+    }
+}
+
+fn push_rendered_lane(sections: &mut Vec<String>, heading: &str, entries: &[String]) {
+    if entries.is_empty() {
+        return;
+    }
+
+    let mut lane_sections = Vec::new();
+    lane_sections.push(heading.to_owned());
+
+    let joined_entries = entries.join("\n\n");
+    lane_sections.push(joined_entries);
+
+    let rendered_lane = lane_sections.join("\n\n");
+    sections.push(rendered_lane);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_runtime_self_model_reads_root_and_nested_workspace_sources() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let nested_workspace_root = workspace_root.join("workspace");
+
+        std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace root");
+
+        let agents_path = workspace_root.join("AGENTS.md");
+        let soul_path = nested_workspace_root.join("SOUL.md");
+        let identity_path = workspace_root.join("IDENTITY.md");
+        let user_path = nested_workspace_root.join("USER.md");
+
+        std::fs::write(&agents_path, "Keep standing instructions visible.").expect("write AGENTS");
+        std::fs::write(&soul_path, "Prefer rigorous execution.").expect("write SOUL");
+        std::fs::write(&identity_path, "You are the runtime helper.").expect("write IDENTITY");
+        std::fs::write(&user_path, "The operator prefers concise output.").expect("write USER");
+
+        let model = load_runtime_self_model(workspace_root);
+
+        assert_eq!(model.standing_instructions.len(), 1);
+        assert_eq!(model.soul_guidance.len(), 1);
+        assert_eq!(model.identity_context.len(), 1);
+        assert_eq!(model.user_context.len(), 1);
+        assert!(model.standing_instructions[0].contains("standing instructions"));
+        assert!(model.soul_guidance[0].contains("rigorous execution"));
+        assert!(model.identity_context[0].contains("runtime helper"));
+        assert!(model.user_context[0].contains("concise output"));
+    }
+
+    #[test]
+    fn load_runtime_self_model_merges_same_lane_sources_in_stable_order() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let nested_workspace_root = workspace_root.join("workspace");
+
+        std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace root");
+
+        let root_agents_path = workspace_root.join("AGENTS.md");
+        let root_claude_path = workspace_root.join("CLAUDE.md");
+        let nested_agents_path = nested_workspace_root.join("AGENTS.md");
+
+        let root_agents_text = "Root AGENTS standing instructions.";
+        let root_claude_text = "Root CLAUDE standing instructions.";
+        let nested_agents_text = "Nested workspace AGENTS standing instructions.";
+
+        std::fs::write(&root_agents_path, root_agents_text).expect("write root AGENTS");
+        std::fs::write(&root_claude_path, root_claude_text).expect("write root CLAUDE");
+        std::fs::write(&nested_agents_path, nested_agents_text).expect("write nested AGENTS");
+
+        let model = load_runtime_self_model(workspace_root);
+
+        assert_eq!(
+            model.standing_instructions,
+            vec![
+                root_agents_text.to_owned(),
+                root_claude_text.to_owned(),
+                nested_agents_text.to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn render_runtime_self_section_returns_none_for_empty_model() {
+        let model = RuntimeSelfModel::default();
+        let rendered = render_runtime_self_section(&model);
+
+        assert_eq!(rendered, None);
+    }
+}

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -57,6 +57,10 @@ impl RuntimeSelfModel {
 }
 
 pub(crate) fn load_runtime_self_model(workspace_root: &Path) -> RuntimeSelfModel {
+    let Some(canonical_workspace_root) = canonical_workspace_root(workspace_root) else {
+        return RuntimeSelfModel::default();
+    };
+
     let candidate_roots = candidate_roots(workspace_root);
     let mut loaded_paths = BTreeSet::new();
     let mut model = RuntimeSelfModel::default();
@@ -64,7 +68,9 @@ pub(crate) fn load_runtime_self_model(workspace_root: &Path) -> RuntimeSelfModel
     for root in candidate_roots {
         for spec in RUNTIME_SELF_SOURCE_SPECS {
             let candidate_path = root.join(spec.relative_path);
-            let Some(content) = read_runtime_self_source(&candidate_path) else {
+            let Some(content) =
+                read_runtime_self_source(canonical_workspace_root.as_path(), &candidate_path)
+            else {
                 continue;
             };
 
@@ -117,14 +123,24 @@ fn candidate_roots(workspace_root: &Path) -> Vec<PathBuf> {
     roots
 }
 
-fn read_runtime_self_source(path: &Path) -> Option<String> {
-    let content = std::fs::read_to_string(path).ok()?;
+fn read_runtime_self_source(canonical_workspace_root: &Path, path: &Path) -> Option<String> {
+    let canonical_path = path.canonicalize().ok()?;
+    let is_within_workspace = canonical_path.starts_with(canonical_workspace_root);
+    if !is_within_workspace {
+        return None;
+    }
+
+    let content = std::fs::read_to_string(canonical_path).ok()?;
     let trimmed = content.trim();
     if trimmed.is_empty() {
         return None;
     }
 
     Some(trimmed.to_owned())
+}
+
+fn canonical_workspace_root(workspace_root: &Path) -> Option<PathBuf> {
+    workspace_root.canonicalize().ok()
 }
 
 fn normalized_path_key(path: &Path) -> String {
@@ -172,6 +188,11 @@ fn push_rendered_lane(sections: &mut Vec<String>, heading: &str, entries: &[Stri
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[cfg(unix)]
+    fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
 
     #[test]
     fn load_runtime_self_model_reads_root_and_nested_workspace_sources() {
@@ -241,5 +262,53 @@ mod tests {
         let rendered = render_runtime_self_section(&model);
 
         assert_eq!(rendered, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_runtime_self_model_ignores_linked_agents_file_outside_workspace_root() {
+        let temp_dir = tempdir().expect("tempdir");
+        let sandbox_root = temp_dir.path();
+        let workspace_root = sandbox_root.join("workspace");
+        let outside_root = sandbox_root.join("outside");
+        let outside_agents_path = outside_root.join("AGENTS.md");
+        let linked_agents_path = workspace_root.join("AGENTS.md");
+
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::create_dir_all(&outside_root).expect("create outside root");
+        std::fs::write(&outside_agents_path, "outside standing instructions")
+            .expect("write outside agents");
+        create_symlink(&outside_agents_path, &linked_agents_path).expect("create agents symlink");
+
+        let model = load_runtime_self_model(workspace_root.as_path());
+
+        assert!(model.standing_instructions.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_runtime_self_model_ignores_linked_nested_workspace_outside_workspace_root() {
+        let temp_dir = tempdir().expect("tempdir");
+        let sandbox_root = temp_dir.path();
+        let workspace_root = sandbox_root.join("workspace");
+        let linked_nested_workspace_root = workspace_root.join("workspace");
+        let outside_root = sandbox_root.join("outside");
+        let outside_nested_workspace_root = outside_root.join("nested");
+        let outside_agents_path = outside_nested_workspace_root.join("AGENTS.md");
+
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::create_dir_all(&outside_nested_workspace_root)
+            .expect("create outside nested workspace");
+        std::fs::write(&outside_agents_path, "outside nested standing instructions")
+            .expect("write outside nested agents");
+        create_symlink(
+            &outside_nested_workspace_root,
+            &linked_nested_workspace_root,
+        )
+        .expect("create nested workspace symlink");
+
+        let model = load_runtime_self_model(workspace_root.as_path());
+
+        assert!(model.standing_instructions.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Problem: workspace self artifacts such as `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, and `USER.md` were meaningful in migration/nativeization paths, but steady-state runtime prompt assembly still had no normalized workspace-self boundary.
- Why it matters: `#440` needs an additive runtime self-source loader before resolved identity and continuity work can build on a stable contract.
- What changed:
  - added a new `runtime_self` loader that discovers recognized workspace self sources from the workspace root and nested `workspace/` roots
  - normalized those sources into lane-separated runtime data for standing instructions, soul guidance, identity context, and user context
  - rendered that normalized data into a `## Runtime Self Context` section and inserted it into system prompt assembly ahead of the capability snapshot
  - added tests for discovery, stable same-lane merge order, empty-state handling, and prompt assembly wiring
- What did not change (scope boundary):
  - this does not replace the base prompt or prompt-pack system
  - this does not implement durable-memory retrieval; that remains in `#421` and `#429`
  - this does not introduce the later resolved-identity lane from `#443`

## Linked Issues

- Closes #441
- Related #440

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- pass

cargo clippy --workspace --all-targets --all-features -- -D warnings
- pass

cargo test -p loongclaw-app runtime_self::tests -- --test-threads=1
- pass (3 passed)

cargo test -p loongclaw-app --lib -- --test-threads=1
- pass (1792 passed)

cargo test --workspace --locked
- fails outside this PR's touched files at loongclaw-daemon:
  onboard_cli::tests::provider_credential_check_adds_volcengine_auth_guidance_when_missing
  crates/daemon/src/onboard_cli.rs:7299
  assertion failed: left == right
    left: Pass
   right: Warn

cargo test --workspace --all-features --locked
- fails at the same loongclaw-daemon test with the same assertion

cargo test -p loongclaw-daemon onboard_cli::tests::provider_credential_check_adds_volcengine_auth_guidance_when_missing -- --test-threads=1
- reproduces the same failure in isolation
```

## User-visible / Operator-visible Changes

- When the runtime is launched with workspace self-source files present, the system message now includes a normalized `Runtime Self Context` section instead of relying on migration-only handling.

## Failure Recovery

- Fast rollback or disable path: revert this commit or bypass the runtime self section insertion in `build_system_message_with_tool_runtime_config`.
- Observable failure symptoms reviewers should watch for: duplicated or unexpectedly verbose system prompt context when workspace self-source files are present.

## Reviewer Focus

- Review `crates/app/src/runtime_self.rs` for lane mapping, root discovery, and same-lane merge ordering.
- Review `crates/app/src/provider/request_message_runtime.rs` for system prompt section ordering and empty-workspace behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Runtime Self Context" capability to load and inject custom context from configuration when a workspace root is configured, enabling personalized AI behavior.

* **Chores**
  * Updated tar dependency to latest stable version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->