### PR TITLE
Add Android Termux release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  BIN_NAME: loongclaw
+  ANDROID_NDK_VERSION: "27.3.13750724"
+  ANDROID_NDK_REVISION: "r27d"
+  ANDROID_NDK_LINUX_SHA1: "22105e410cf29afcf163760cc95522b9fb981121"
+  ANDROID_API_LEVEL: "24"
+
 jobs:
   governance:
     runs-on: ubuntu-latest
@@ -171,6 +178,56 @@ jobs:
       - name: Test (all features)
         run: cargo test --workspace --all-features --locked
 
+  android-termux-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@a0b273b48ed29de4470960879e8381ff45632f26
+        with:
+          targets: aarch64-linux-android
+
+      - name: Ensure active toolchain target
+        run: rustup target add aarch64-linux-android
+
+      - name: Cache Cargo Artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+
+      - name: Install Android NDK
+        shell: bash
+        run: |
+          set -euo pipefail
+          ndk_zip="android-ndk-${{ env.ANDROID_NDK_REVISION }}-linux.zip"
+          ndk_dir="android-ndk-${{ env.ANDROID_NDK_REVISION }}"
+          curl -fSL "https://dl.google.com/android/repository/${ndk_zip}" -o "${ndk_zip}"
+          echo "${{ env.ANDROID_NDK_LINUX_SHA1 }}  ${ndk_zip}" | sha1sum --check -
+          unzip -q "${ndk_zip}"
+          [ -d "${ndk_dir}" ] || (echo "Missing extracted NDK directory: ${ndk_dir}" && exit 1)
+          rm -f "${ndk_zip}"
+          {
+            echo "ANDROID_NDK_HOME=${PWD}/${ndk_dir}"
+            echo "ANDROID_NDK_ROOT=${PWD}/${ndk_dir}"
+            echo "ANDROID_NDK_LATEST_HOME=${PWD}/${ndk_dir}"
+          } >> "$GITHUB_ENV"
+
+      - name: Build release binary (Android/Termux)
+        shell: bash
+        env:
+          LOONGCLAW_RELEASE_BUILD: "1"
+        run: |
+          set -euo pipefail
+          toolchain="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          export CC_aarch64_linux_android="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
+          export CXX_aarch64_linux_android="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang++"
+          export AR_aarch64_linux_android="${toolchain}/llvm-ar"
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
+          cargo build --release --locked -p loongclaw-daemon --bin "${BIN_NAME}" --target aarch64-linux-android
+
   docs-build:
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -198,6 +255,7 @@ jobs:
       - rust-test-default
       - rust-check-browser-without-webfetch
       - rust-test-all-features
+      - android-termux-build
       - docs-build
     runs-on: ubuntu-latest
     permissions:
@@ -210,6 +268,7 @@ jobs:
           RUST_TEST_DEFAULT_RESULT: ${{ needs.rust-test-default.result }}
           RUST_CHECK_BROWSER_WITHOUT_WEBFETCH_RESULT: ${{ needs.rust-check-browser-without-webfetch.result }}
           RUST_TEST_ALL_FEATURES_RESULT: ${{ needs.rust-test-all-features.result }}
+          ANDROID_TERMUX_BUILD_RESULT: ${{ needs.android-termux-build.result }}
           DOCS_BUILD_RESULT: ${{ needs.docs-build.result }}
         run: |
           set -euo pipefail
@@ -228,4 +287,5 @@ jobs:
           check_result rust-test-default "$RUST_TEST_DEFAULT_RESULT"
           check_result rust-check-browser-without-webfetch "$RUST_CHECK_BROWSER_WITHOUT_WEBFETCH_RESULT"
           check_result rust-test-all-features "$RUST_TEST_ALL_FEATURES_RESULT"
+          check_result android-termux-build "$ANDROID_TERMUX_BUILD_RESULT"
           check_result docs-build "$DOCS_BUILD_RESULT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   BIN_NAME: loongclaw
   ANDROID_NDK_VERSION: "27.3.13750724"
   ANDROID_NDK_REVISION: "r27d"
-  ANDROID_NDK_LINUX_SHA1: "22105e410cf29afcf163760cc95522b9fb981121"
+  ANDROID_NDK_LINUX_SHA256: "601246087a682d1944e1e16dd85bc6e49560fe8b6d61255be2829178c8ed15d9"
   ANDROID_API_LEVEL: "24"
 
 jobs:
@@ -58,6 +58,7 @@ jobs:
           bash -n scripts/release_artifact_lib.sh
           bash -n scripts/bootstrap_release_local_artifacts.sh
           bash -n scripts/test_release_artifact_lib.sh
+          bash -n scripts/test_release_workflow_hardening.sh
           bash -n scripts/test_bootstrap_release_local_artifacts.sh
           bash -n scripts/test_promotion_guard_workflows.sh
           bash -n scripts/check-docs.sh
@@ -75,6 +76,7 @@ jobs:
           bash scripts/test_check_glibc_floor.sh
           bash scripts/test_install_sh.sh
           bash scripts/test_release_artifact_lib.sh
+          bash scripts/test_release_workflow_hardening.sh
           bash scripts/test_bootstrap_release_local_artifacts.sh
           bash scripts/test_promotion_guard_workflows.sh
           bash scripts/test_sync_github_labels.sh
@@ -205,7 +207,7 @@ jobs:
           ndk_zip="android-ndk-${{ env.ANDROID_NDK_REVISION }}-linux.zip"
           ndk_dir="android-ndk-${{ env.ANDROID_NDK_REVISION }}"
           curl -fSL "https://dl.google.com/android/repository/${ndk_zip}" -o "${ndk_zip}"
-          echo "${{ env.ANDROID_NDK_LINUX_SHA1 }}  ${ndk_zip}" | sha1sum --check -
+          echo "${{ env.ANDROID_NDK_LINUX_SHA256 }}  ${ndk_zip}" | shasum -a 256 --check -
           unzip -q "${ndk_zip}"
           [ -d "${ndk_dir}" ] || (echo "Missing extracted NDK directory: ${ndk_dir}" && exit 1)
           rm -f "${ndk_zip}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   CARGO_ZIGBUILD_VERSION: "0.22.1"
   ANDROID_NDK_VERSION: "27.3.13750724"
   ANDROID_NDK_REVISION: "r27d"
-  ANDROID_NDK_LINUX_SHA1: "22105e410cf29afcf163760cc95522b9fb981121"
+  ANDROID_NDK_LINUX_SHA256: "601246087a682d1944e1e16dd85bc6e49560fe8b6d61255be2829178c8ed15d9"
   ANDROID_API_LEVEL: "24"
 
 jobs:
@@ -148,7 +148,7 @@ jobs:
           ndk_zip="android-ndk-${{ env.ANDROID_NDK_REVISION }}-linux.zip"
           ndk_dir="android-ndk-${{ env.ANDROID_NDK_REVISION }}"
           curl -fSL "https://dl.google.com/android/repository/${ndk_zip}" -o "${ndk_zip}"
-          echo "${{ env.ANDROID_NDK_LINUX_SHA1 }}  ${ndk_zip}" | sha1sum --check -
+          echo "${{ env.ANDROID_NDK_LINUX_SHA256 }}  ${ndk_zip}" | shasum -a 256 --check -
           unzip -q "${ndk_zip}"
           [ -d "${ndk_dir}" ] || (echo "Missing extracted NDK directory: ${ndk_dir}" && exit 1)
           rm -f "${ndk_zip}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ env:
   LINUX_ARM64_ZIG_VERSION: "0.13.0"
   LINUX_ARM64_ZIG_SHA256: "d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea"
   CARGO_ZIGBUILD_VERSION: "0.22.1"
+  ANDROID_NDK_VERSION: "27.3.13750724"
+  ANDROID_NDK_REVISION: "r27d"
+  ANDROID_NDK_LINUX_SHA1: "22105e410cf29afcf163760cc95522b9fb981121"
+  ANDROID_API_LEVEL: "24"
 
 jobs:
   verify-release:
@@ -83,6 +87,11 @@ jobs:
             ext: ""
             archive: tar.gz
             use_zig: true
+          - os: ubuntu-latest
+            target: aarch64-linux-android
+            ext: ""
+            archive: tar.gz
+            use_android_ndk: true
           - os: macos-14
             target: x86_64-apple-darwin
             ext: ""
@@ -116,7 +125,6 @@ jobs:
         if: matrix.install_musl_tools == true
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
-      # 为 aarch64-unknown-linux-gnu 安装 Zig 和 cargo-zigbuild
       - name: Install Zig and cargo-zigbuild
         if: matrix.use_zig == true
         run: |
@@ -132,7 +140,24 @@ jobs:
           rm -f "$zig_tarball"
           cargo install "cargo-zigbuild" --version "${{ env.CARGO_ZIGBUILD_VERSION }}" --locked
 
-      # 使用 cargo-zigbuild 构建 aarch64 目标（指定 glibc 2.17）
+      - name: Install Android NDK
+        if: matrix.use_android_ndk == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          ndk_zip="android-ndk-${{ env.ANDROID_NDK_REVISION }}-linux.zip"
+          ndk_dir="android-ndk-${{ env.ANDROID_NDK_REVISION }}"
+          curl -fSL "https://dl.google.com/android/repository/${ndk_zip}" -o "${ndk_zip}"
+          echo "${{ env.ANDROID_NDK_LINUX_SHA1 }}  ${ndk_zip}" | sha1sum --check -
+          unzip -q "${ndk_zip}"
+          [ -d "${ndk_dir}" ] || (echo "Missing extracted NDK directory: ${ndk_dir}" && exit 1)
+          rm -f "${ndk_zip}"
+          {
+            echo "ANDROID_NDK_HOME=${PWD}/${ndk_dir}"
+            echo "ANDROID_NDK_ROOT=${PWD}/${ndk_dir}"
+            echo "ANDROID_NDK_LATEST_HOME=${PWD}/${ndk_dir}"
+          } >> "$GITHUB_ENV"
+
       - name: Build release binary with cargo-zigbuild
         if: matrix.use_zig == true
         env:
@@ -141,9 +166,22 @@ jobs:
           cargo zigbuild --release --locked -p loongclaw-daemon --bin ${{ env.BIN_NAME }} \
             --target "${{ matrix.target }}.${{ env.LINUX_ARM64_GLIBC_FLOOR }}"
 
-      # 其他目标使用普通 cargo build
+      - name: Build release binary (Android/Termux)
+        if: matrix.use_android_ndk == true
+        shell: bash
+        env:
+          LOONGCLAW_RELEASE_BUILD: "1"
+        run: |
+          set -euo pipefail
+          toolchain="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          export CC_aarch64_linux_android="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
+          export CXX_aarch64_linux_android="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang++"
+          export AR_aarch64_linux_android="${toolchain}/llvm-ar"
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
+          cargo build --release --locked -p loongclaw-daemon --bin "${BIN_NAME}" --target "${{ matrix.target }}"
+
       - name: Build release binary (native)
-        if: matrix.use_zig != true
+        if: matrix.use_zig != true && matrix.use_android_ndk != true
         env:
           LOONGCLAW_RELEASE_BUILD: "1"
         run: cargo build --release --locked -p loongclaw-daemon --bin ${{ env.BIN_NAME }} --target ${{ matrix.target }}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -128,6 +128,16 @@ else
       LINUX)
         release_linux_target_for_arch_and_libc "$normalized_arch" "gnu"
         ;;
+      ANDROID)
+        case "$normalized_arch" in
+          x86_64|amd64) printf 'x86_64-linux-android\n' ;;
+          arm64|aarch64) printf 'aarch64-linux-android\n' ;;
+          *)
+            echo "unsupported Android architecture: ${arch}" >&2
+            return 1
+            ;;
+        esac
+        ;;
       DARWIN)
         case "$normalized_arch" in
           x86_64|amd64) printf 'x86_64-apple-darwin\n' ;;
@@ -155,6 +165,37 @@ else
   }
 fi
 
+is_termux_environment() {
+  local uname_operating_system
+
+  if [[ -n "${TERMUX_VERSION:-}" ]]; then
+    return 0
+  fi
+
+  case "${PREFIX:-}" in
+    */com.termux/files/usr) return 0 ;;
+  esac
+
+  if uname_operating_system="$(uname -o 2>/dev/null || true)"; then
+    if [[ "$(printf '%s' "$uname_operating_system" | tr '[:lower:]' '[:upper:]')" == "ANDROID" ]]; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+detect_release_host_platform() {
+  local host_platform
+  host_platform="$(uname -s)"
+
+  if [[ "$(printf '%s' "$host_platform" | tr '[:lower:]' '[:upper:]')" == "LINUX" ]] && is_termux_environment; then
+    printf 'Android\n'
+    return 0
+  fi
+
+  printf '%s\n' "$host_platform"
+}
 prefix="${HOME}/.local/bin"
 run_onboard=0
 install_source=0
@@ -521,7 +562,7 @@ install_from_release() {
   require_command "curl" "Install curl first or use --source inside a repository checkout."
   require_command "install" "Install coreutils or use --source inside a repository checkout."
 
-  host_platform="$(uname -s)"
+  host_platform="$(detect_release_host_platform)"
   host_arch="$(uname -m)"
   target="$(release_target_for_install "${host_platform}" "${host_arch}" "${target_libc}")"
   target_tag="$(normalize_release_tag "${release_version}")"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -167,6 +167,14 @@ fi
 is_termux_environment() {
   local uname_operating_system
 
+  uname_operating_system="$(uname -o 2>/dev/null || true)"
+  if [[ -n "$uname_operating_system" ]]; then
+    if [[ "$(printf '%s' "$uname_operating_system" | tr '[:lower:]' '[:upper:]')" == "ANDROID" ]]; then
+      return 0
+    fi
+    return 1
+  fi
+
   if [[ -n "${TERMUX_VERSION:-}" ]]; then
     return 0
   fi
@@ -174,12 +182,6 @@ is_termux_environment() {
   case "${PREFIX:-}" in
     */com.termux/files/usr) return 0 ;;
   esac
-
-  if uname_operating_system="$(uname -o 2>/dev/null || true)"; then
-    if [[ "$(printf '%s' "$uname_operating_system" | tr '[:lower:]' '[:upper:]')" == "ANDROID" ]]; then
-      return 0
-    fi
-  fi
 
   return 1
 }
@@ -195,6 +197,7 @@ detect_release_host_platform() {
 
   printf '%s\n' "$host_platform"
 }
+
 prefix="${HOME}/.local/bin"
 run_onboard=0
 install_source=0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,7 +130,6 @@ else
         ;;
       ANDROID)
         case "$normalized_arch" in
-          x86_64|amd64) printf 'x86_64-linux-android\n' ;;
           arm64|aarch64) printf 'aarch64-linux-android\n' ;;
           *)
             echo "unsupported Android architecture: ${arch}" >&2

--- a/scripts/release_artifact_lib.sh
+++ b/scripts/release_artifact_lib.sh
@@ -116,7 +116,6 @@ release_target_for_platform() {
       ;;
     ANDROID)
       case "$normalized_arch" in
-        x86_64|amd64) printf 'x86_64-linux-android\n' ;;
         arm64|aarch64) printf 'aarch64-linux-android\n' ;;
         *)
           echo "unsupported Android architecture: ${arch}" >&2

--- a/scripts/release_artifact_lib.sh
+++ b/scripts/release_artifact_lib.sh
@@ -114,6 +114,16 @@ release_target_for_platform() {
     LINUX)
       release_linux_target_for_arch_and_libc "$normalized_arch" "gnu"
       ;;
+    ANDROID)
+      case "$normalized_arch" in
+        x86_64|amd64) printf 'x86_64-linux-android\n' ;;
+        arm64|aarch64) printf 'aarch64-linux-android\n' ;;
+        *)
+          echo "unsupported Android architecture: ${arch}" >&2
+          return 1
+          ;;
+      esac
+      ;;
     DARWIN)
       case "$normalized_arch" in
         x86_64|amd64) printf 'x86_64-apple-darwin\n' ;;

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -256,6 +256,30 @@ run_termux_arm64_installs_android_release_test() {
     exit 1
   fi
 }
+
+run_termux_x86_64_rejects_android_release_test() {
+  local fixture output_file
+  fixture="$(mktemp -d)"
+  trap 'rm -rf "$fixture"' RETURN
+  output_file="$fixture/termux-android-x86_64.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64" "Android"
+
+  if (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      TERMUX_VERSION="0.119.0" \
+      PREFIX="/data/data/com.termux/files/usr" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$fixture/install" >"$output_file" 2>&1
+  ); then
+    echo "expected install.sh to reject unsupported Android x86_64 hosts" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "unsupported Android architecture"
+}
+
 run_linux_x86_64_falls_back_to_musl_when_glibc_is_too_old_test() {
   local fixture install_dir output_file installed_output
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
@@ -579,6 +603,7 @@ run_checksum_mismatch_fails_test
 run_missing_release_guidance_test
 run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test
 run_termux_arm64_installs_android_release_test
+run_termux_x86_64_rejects_android_release_test
 run_version_at_least_falls_back_when_sort_version_is_unavailable_test
 run_version_at_least_rejects_older_version_with_sort_version_test
 run_detect_host_glibc_version_rejects_musl_ldd_output_test

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -257,6 +257,55 @@ run_termux_arm64_installs_android_release_test() {
   fi
 }
 
+run_linux_guest_with_termux_env_is_not_termux_test() {
+  if (
+    source_install_functions
+    TERMUX_VERSION="0.119.0"
+    PREFIX="/data/data/com.termux/files/usr"
+    uname() {
+      case "${1:-}" in
+        -s) printf 'Linux\n' ;;
+        -m) printf 'x86_64\n' ;;
+        -o) printf 'GNU/Linux\n' ;;
+        *)
+          echo "unexpected uname invocation: $*" >&2
+          return 1
+          ;;
+      esac
+    }
+    is_termux_environment
+  ); then
+    echo "expected GNU/Linux shells with inherited Termux env to stay on Linux artifacts" >&2
+    exit 1
+  fi
+}
+
+run_linux_guest_with_termux_env_prefers_linux_release_test() {
+  local fixture install_dir output_file installed_output
+  fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/linux-termux-env.out"
+  make_uname_stub_bin "$fixture" "Linux" "x86_64" "GNU/Linux"
+  make_getconf_stub_bin "$fixture" "glibc 2.39"
+
+  (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      TERMUX_VERSION="0.119.0" \
+      PREFIX="/data/data/com.termux/files/usr" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_contains "$output_file" "x86_64-unknown-linux-gnu"
+  installed_output="$("$install_dir/loongclaw")"
+  if [[ "$installed_output" != "gnu-binary" ]]; then
+    echo "expected Linux artifact to be installed when uname -o reports GNU/Linux but got '$installed_output'" >&2
+    exit 1
+  fi
+}
+
 run_termux_x86_64_rejects_android_release_test() {
   local fixture output_file
   fixture="$(mktemp -d)"
@@ -603,6 +652,8 @@ run_checksum_mismatch_fails_test
 run_missing_release_guidance_test
 run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test
 run_termux_arm64_installs_android_release_test
+run_linux_guest_with_termux_env_is_not_termux_test
+run_linux_guest_with_termux_env_prefers_linux_release_test
 run_termux_x86_64_rejects_android_release_test
 run_version_at_least_falls_back_when_sort_version_is_unavailable_test
 run_version_at_least_rejects_older_version_with_sort_version_test

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -113,20 +113,22 @@ make_uname_stub_bin() {
   local fixture="$1"
   local stub_platform="$2"
   local stub_arch="$3"
+  local stub_operating_system="${4:-GNU/Linux}"
   mkdir -p "$fixture/fake-bin"
-  cat >"$fixture/fake-bin/uname" <<EOF
+  cat >"$fixture/fake-bin/uname" <<EOF2
 #!/usr/bin/env bash
 set -euo pipefail
 
 case "\${1:-}" in
   -s) printf '%s\n' "$stub_platform" ;;
   -m) printf '%s\n' "$stub_arch" ;;
+  -o) printf '%s\n' "$stub_operating_system" ;;
   *)
     echo "unexpected uname invocation: \$*" >&2
     exit 1
     ;;
 esac
-EOF
+EOF2
   chmod +x "$fixture/fake-bin/uname"
 }
 
@@ -134,7 +136,7 @@ make_getconf_stub_bin() {
   local fixture="$1"
   local response="$2"
   mkdir -p "$fixture/fake-bin"
-  cat >"$fixture/fake-bin/getconf" <<EOF
+  cat >"$fixture/fake-bin/getconf" <<EOF2
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -148,7 +150,7 @@ if [[ "$response" == "__FAIL__" ]]; then
 fi
 
 printf '%s\n' "$response"
-EOF
+EOF2
   chmod +x "$fixture/fake-bin/getconf"
 }
 
@@ -156,7 +158,7 @@ make_ldd_stub_bin() {
   local fixture="$1"
   local response="$2"
   mkdir -p "$fixture/fake-bin"
-  cat >"$fixture/fake-bin/ldd" <<EOF
+  cat >"$fixture/fake-bin/ldd" <<EOF2
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -164,11 +166,10 @@ if [[ "$response" == "__FAIL__" ]]; then
   exit 1
 fi
 
-  printf '%s\n' "$response"
-EOF
+printf '%s\n' "$response"
+EOF2
   chmod +x "$fixture/fake-bin/ldd"
 }
-
 make_sort_stub_bin() {
   local fixture="$1"
   local mode="$2"
@@ -230,6 +231,31 @@ run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test() {
   fi
 }
 
+
+run_termux_arm64_installs_android_release_test() {
+  local fixture install_dir output_file installed_output
+  fixture="$(make_release_fixture "v0.1.2" "aarch64-linux-android" "termux-binary")"
+  trap 'rm -rf "$fixture"' RETURN
+  install_dir="$fixture/install"
+  output_file="$fixture/termux-android.out"
+  make_uname_stub_bin "$fixture" "Linux" "aarch64" "Android"
+
+  (
+    cd "$REPO_ROOT"
+    PATH="$fixture/fake-bin:$PATH" \
+      TERMUX_VERSION="0.119.0" \
+      PREFIX="/data/data/com.termux/files/usr" \
+      LOONGCLAW_INSTALL_RELEASE_BASE_URL="file://$fixture/releases" \
+      bash "$SCRIPT_UNDER_TEST" --version v0.1.2 --prefix "$install_dir" >"$output_file" 2>&1
+  )
+
+  assert_contains "$output_file" "aarch64-linux-android"
+  installed_output="$("$install_dir/loongclaw")"
+  if [[ "$installed_output" != "termux-binary" ]]; then
+    echo "expected Android artifact to be installed on Termux but got '$installed_output'" >&2
+    exit 1
+  fi
+}
 run_linux_x86_64_falls_back_to_musl_when_glibc_is_too_old_test() {
   local fixture install_dir output_file installed_output
   fixture="$(make_linux_dual_libc_fixture "v0.1.2")"
@@ -552,6 +578,7 @@ run_release_override_install_and_onboard_test
 run_checksum_mismatch_fails_test
 run_missing_release_guidance_test
 run_linux_x86_64_prefers_gnu_when_glibc_is_supported_test
+run_termux_arm64_installs_android_release_test
 run_version_at_least_falls_back_when_sort_version_is_unavailable_test
 run_version_at_least_rejects_older_version_with_sort_version_test
 run_detect_host_glibc_version_rejects_musl_ldd_output_test

--- a/scripts/test_release_artifact_lib.sh
+++ b/scripts/test_release_artifact_lib.sh
@@ -57,6 +57,9 @@ EOF
     "loongclaw-v0.1.2-aarch64-unknown-linux-gnu.tar.gz" \
     "$(release_archive_name "loongclaw" "v0.1.2" "aarch64-unknown-linux-gnu")"
   assert_equals \
+    "loongclaw-v0.1.2-aarch64-linux-android.tar.gz" \
+    "$(release_archive_name "loongclaw" "v0.1.2" "aarch64-linux-android")"
+  assert_equals \
     "loongclaw-v0.1.2-x86_64-unknown-linux-musl.tar.gz" \
     "$(release_archive_name "loongclaw" "v0.1.2" "x86_64-unknown-linux-musl")"
   assert_equals \
@@ -74,6 +77,9 @@ EOF
   assert_equals \
     "aarch64-unknown-linux-gnu" \
     "$(release_target_for_platform "Linux" "arm64")"
+  assert_equals \
+    "aarch64-linux-android" \
+    "$(release_target_for_platform "Android" "arm64")"
   assert_equals \
     $'gnu\nmusl' \
     "$(release_supported_linux_libcs_for_arch "x86_64")"

--- a/scripts/test_release_artifact_lib.sh
+++ b/scripts/test_release_artifact_lib.sh
@@ -80,6 +80,10 @@ EOF
   assert_equals \
     "aarch64-linux-android" \
     "$(release_target_for_platform "Android" "arm64")"
+  if release_target_for_platform "Android" "x86_64" >/dev/null 2>&1; then
+    echo "expected release_target_for_platform to reject unsupported Android x86_64 hosts" >&2
+    exit 1
+  fi
   assert_equals \
     $'gnu\nmusl' \
     "$(release_supported_linux_libcs_for_arch "x86_64")"

--- a/scripts/test_release_workflow_hardening.sh
+++ b/scripts/test_release_workflow_hardening.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANDROID_NDK_LINUX_SHA256="601246087a682d1944e1e16dd85bc6e49560fe8b6d61255be2829178c8ed15d9"
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "expected to find '$needle' in $file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq "$needle" "$file"; then
+    echo "expected not to find '$needle' in $file" >&2
+    exit 1
+  fi
+}
+
+assert_android_ndk_sha256_hardening() {
+  local workflow_path="$1"
+
+  assert_contains "$workflow_path" "ANDROID_NDK_LINUX_SHA256: \"$ANDROID_NDK_LINUX_SHA256\""
+  assert_not_contains "$workflow_path" "ANDROID_NDK_LINUX_SHA1:"
+  assert_contains "$workflow_path" 'shasum -a 256 --check -'
+  assert_not_contains "$workflow_path" 'sha1sum --check -'
+}
+
+cd "$REPO_ROOT"
+
+assert_android_ndk_sha256_hardening ".github/workflows/ci.yml"
+assert_android_ndk_sha256_hardening ".github/workflows/release.yml"
+
+echo "release workflow hardening checks passed"

--- a/scripts/test_release_workflow_hardening.sh
+++ b/scripts/test_release_workflow_hardening.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ANDROID_NDK_LINUX_SHA256="601246087a682d1944e1e16dd85bc6e49560fe8b6d61255be2829178c8ed15d9"
 
+. "$REPO_ROOT/scripts/release_artifact_lib.sh"
+
 assert_contains() {
   local file="$1"
   local needle="$2"
-  if ! grep -Fq "$needle" "$file"; then
+  if ! grep -Fq -- "$needle" "$file"; then
     echo "expected to find '$needle' in $file" >&2
     cat "$file" >&2
     exit 1
@@ -17,7 +19,7 @@ assert_contains() {
 assert_not_contains() {
   local file="$1"
   local needle="$2"
-  if grep -Fq "$needle" "$file"; then
+  if grep -Fq -- "$needle" "$file"; then
     echo "expected not to find '$needle' in $file" >&2
     exit 1
   fi
@@ -32,9 +34,22 @@ assert_android_ndk_sha256_hardening() {
   assert_not_contains "$workflow_path" 'sha1sum --check -'
 }
 
+assert_android_release_target_parity() {
+  local expected_target
+
+  expected_target="$(release_target_for_platform "Android" "aarch64")"
+
+  assert_contains ".github/workflows/ci.yml" "targets: ${expected_target}"
+  assert_contains ".github/workflows/ci.yml" "--target ${expected_target}"
+  assert_not_contains ".github/workflows/ci.yml" "x86_64-linux-android"
+  assert_contains ".github/workflows/release.yml" "target: ${expected_target}"
+  assert_not_contains ".github/workflows/release.yml" "target: x86_64-linux-android"
+}
+
 cd "$REPO_ROOT"
 
 assert_android_ndk_sha256_hardening ".github/workflows/ci.yml"
 assert_android_ndk_sha256_hardening ".github/workflows/release.yml"
+assert_android_release_target_parity
 
 echo "release workflow hardening checks passed"

--- a/scripts/test_release_workflow_hardening.sh
+++ b/scripts/test_release_workflow_hardening.sh
@@ -9,6 +9,7 @@ assert_contains() {
   local needle="$2"
   if ! grep -Fq "$needle" "$file"; then
     echo "expected to find '$needle' in $file" >&2
+    cat "$file" >&2
     exit 1
   fi
 }


### PR DESCRIPTION
## Summary
- add Android Termux cross-build validation to CI
- publish aarch64-linux-android release artifacts
- teach the installer and release helpers to resolve Android Termux targets

## Testing
- bash -n scripts/install.sh
- bash -n scripts/release_artifact_lib.sh
- bash -n scripts/test_install_sh.sh
- bash -n scripts/test_release_artifact_lib.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml")'\n- bash scripts/test_release_artifact_lib.sh\n- bash scripts/test_install_sh.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android/Termux release build support in CI and release pipelines, producing aarch64 Android binaries and integrating the Android build into the overall release flow.
* **Tests**
  * Added automated tests for Android/Termux install and release-target selection, including negative cases for unsupported architectures and new workflow hardening checks.
* **Chores**
  * Hardened release workflows with NDK checksum verification, workflow-level Android configuration, CI checks, and propagation of the Android build result into the main build flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->