### PR TITLE
feat(app): load runtime self sources and resolve runtime identity

### DIFF
--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -718,7 +718,8 @@ mod tests {
         memory::append_turn_direct(session_id, "assistant", "turn 4", &memory_config)
             .expect("append turn 4 should succeed");
 
-        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let binding =
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
         let kernel_messages = DefaultContextEngine
             .assemble_messages(&config, session_id, true, binding)
             .await
@@ -770,7 +771,8 @@ mod tests {
         memory::append_turn_direct(session_id, "assistant", "turn 1", &memory_config)
             .expect("append turn should succeed");
 
-        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let binding =
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
         let kernel_messages = DefaultContextEngine
             .assemble_messages(&config, session_id, true, binding)
             .await

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -347,10 +347,13 @@ impl ConversationContextEngine for DefaultContextEngine {
         #[cfg(feature = "memory-sqlite")]
         {
             const MAX_COMPACTION_CONFLICT_RETRIES: usize = 3;
+            let memory_config =
+                memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
 
             for _ in 0..MAX_COMPACTION_CONFLICT_RETRIES {
-                let has_summary_checkpoint = load_memory_context_entries(session_id, kernel_ctx)
-                    .await?
+                let context_entries =
+                    load_memory_context_entries(&memory_config, session_id, kernel_ctx).await?;
+                let has_summary_checkpoint = context_entries
                     .into_iter()
                     .any(|entry| entry.kind == memory::MemoryContextKind::Summary);
                 if has_summary_checkpoint {
@@ -408,19 +411,25 @@ impl ConversationContextEngine for DefaultContextEngine {
             );
         }
 
+        let Some(kernel_ctx) = binding.kernel_context() else {
+            return Err("kernel-bound context engine requires kernel context".to_owned());
+        };
+
         #[cfg_attr(not(feature = "memory-sqlite"), allow(unused_mut))]
-        let mut messages = crate::provider::build_base_messages(config, include_system_prompt);
+        let mut messages = crate::provider::build_base_messages_with_binding(
+            config,
+            include_system_prompt,
+            crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx),
+        )
+        .await;
 
         #[cfg(feature = "memory-sqlite")]
         {
-            let turns = load_memory_window(config, session_id, binding).await?;
-            for turn in turns {
-                crate::provider::push_history_message(
-                    &mut messages,
-                    turn.role.as_str(),
-                    turn.content.as_str(),
-                );
-            }
+            let memory_config =
+                memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+            let context_entries =
+                load_memory_context_entries(&memory_config, session_id, kernel_ctx).await?;
+            append_memory_context_messages(&mut messages, context_entries);
         }
 
         #[cfg(not(feature = "memory-sqlite"))]
@@ -453,48 +462,6 @@ impl ConversationContextEngine for LegacyContextEngine {
     }
 }
 
-#[cfg(feature = "memory-sqlite")]
-async fn load_memory_window(
-    config: &LoongClawConfig,
-    session_id: &str,
-    binding: ConversationRuntimeBinding<'_>,
-) -> CliResult<Vec<memory::WindowTurn>> {
-    use std::collections::BTreeSet;
-
-    if let Some(ctx) = binding.kernel_context() {
-        let request = memory::build_window_request(session_id, config.memory.sliding_window);
-        let caps = BTreeSet::from([Capability::MemoryRead]);
-        let outcome = ctx
-            .kernel
-            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
-            .await
-            .map_err(|error| format!("load memory window via kernel failed: {error}"))?;
-
-        if outcome.status != "ok" {
-            return Err(format!(
-                "load memory window via kernel returned non-ok status: {}",
-                outcome.status
-            ));
-        }
-
-        return Ok(memory::decode_window_turns(&outcome.payload));
-    }
-
-    let runtime_config =
-        memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let turns = memory::window_direct(session_id, config.memory.sliding_window, &runtime_config)
-        .map_err(|error| format!("load memory window failed: {error}"))?;
-    Ok(turns
-        .into_iter()
-        .map(|turn| memory::WindowTurn {
-            role: turn.role,
-            content: turn.content,
-            ts: Some(turn.ts),
-        })
-        .collect())
-}
-
-#[cfg(feature = "memory-sqlite")]
 async fn load_memory_window_snapshot(
     config: &LoongClawConfig,
     session_id: &str,
@@ -539,10 +506,11 @@ async fn load_memory_window_snapshot(
 
 #[cfg(feature = "memory-sqlite")]
 async fn load_memory_context_entries(
+    config: &memory::runtime_config::MemoryRuntimeConfig,
     session_id: &str,
     kernel_ctx: &KernelContext,
 ) -> CliResult<Vec<memory::MemoryContextEntry>> {
-    let request = memory::build_read_context_request(session_id);
+    let request = memory::build_read_context_request(session_id, config);
     let caps = BTreeSet::from([Capability::MemoryRead]);
     let outcome = kernel_ctx
         .kernel
@@ -564,6 +532,30 @@ async fn load_memory_context_entries(
     }
 
     Ok(memory::decode_memory_context_entries(&outcome.payload))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn append_memory_context_messages(
+    messages: &mut Vec<Value>,
+    entries: Vec<memory::MemoryContextEntry>,
+) {
+    for entry in entries {
+        let role = entry.role;
+        let content = entry.content;
+
+        match entry.kind {
+            memory::MemoryContextKind::Profile | memory::MemoryContextKind::Summary => {
+                let message = json!({
+                    "role": role,
+                    "content": content,
+                });
+                messages.push(message);
+            }
+            memory::MemoryContextKind::Turn => {
+                crate::provider::push_history_message(messages, role.as_str(), content.as_str());
+            }
+        }
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -604,6 +596,8 @@ async fn persist_memory_window(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::MemoryProfile;
+    use crate::test_support::TurnTestHarness;
 
     #[test]
     fn default_engine_metadata_has_stable_identity() {
@@ -642,6 +636,161 @@ mod tests {
         assert_eq!(
             ContextEngineCapability::SubagentLifecycle.as_str(),
             "subagent_lifecycle"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn default_engine_assembles_runtime_self_through_kernel_audit_path() {
+        let harness = TurnTestHarness::with_capabilities(std::collections::BTreeSet::from([
+            loongclaw_contracts::Capability::InvokeTool,
+            loongclaw_contracts::Capability::FilesystemRead,
+            loongclaw_contracts::Capability::FilesystemWrite,
+            loongclaw_contracts::Capability::MemoryRead,
+        ]));
+        let agents_path = harness.temp_dir.join("AGENTS.md");
+        let agents_text = "Keep runtime self reads on the audited path.";
+
+        std::fs::write(&agents_path, agents_text).expect("write AGENTS");
+
+        let mut config = LoongClawConfig::default();
+        config.tools.file_root = Some(harness.temp_dir.display().to_string());
+
+        let messages = DefaultContextEngine
+            .assemble_messages(
+                &config,
+                "kernel-runtime-self-session",
+                true,
+                ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx)),
+            )
+            .await
+            .expect("assemble messages");
+
+        let system_content = messages[0]["content"].as_str().expect("system content");
+
+        assert!(system_content.contains(agents_text));
+
+        let audit_events = harness.audit.snapshot();
+        let has_tool_plane_event = audit_events.iter().any(|event| {
+            matches!(
+                &event.kind,
+                loongclaw_kernel::AuditEventKind::PlaneInvoked {
+                    plane: loongclaw_contracts::ExecutionPlane::Tool,
+                    ..
+                }
+            )
+        });
+
+        assert!(
+            has_tool_plane_event,
+            "kernel-bound runtime self loading should emit tool-plane audit"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn default_engine_kernel_bound_messages_match_provider_summary_projection() {
+        let capabilities = std::collections::BTreeSet::from([
+            loongclaw_contracts::Capability::InvokeTool,
+            loongclaw_contracts::Capability::FilesystemRead,
+            loongclaw_contracts::Capability::FilesystemWrite,
+            loongclaw_contracts::Capability::MemoryRead,
+        ]);
+        let harness = TurnTestHarness::with_capabilities(capabilities);
+        let session_id = "kernel-summary-session";
+        let sqlite_path = harness.temp_dir.join("memory.sqlite3");
+        let sqlite_path_text = sqlite_path.display().to_string();
+        let mut config = LoongClawConfig::default();
+
+        config.tools.file_root = Some(harness.temp_dir.display().to_string());
+        config.memory.profile = MemoryProfile::WindowPlusSummary;
+        config.memory.sliding_window = 2;
+        config.memory.sqlite_path = sqlite_path_text.clone();
+
+        let memory_config =
+            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+        memory::append_turn_direct(session_id, "user", "turn 1", &memory_config)
+            .expect("append turn 1 should succeed");
+        memory::append_turn_direct(session_id, "assistant", "turn 2", &memory_config)
+            .expect("append turn 2 should succeed");
+        memory::append_turn_direct(session_id, "user", "turn 3", &memory_config)
+            .expect("append turn 3 should succeed");
+        memory::append_turn_direct(session_id, "assistant", "turn 4", &memory_config)
+            .expect("append turn 4 should succeed");
+
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let kernel_messages = DefaultContextEngine
+            .assemble_messages(&config, session_id, true, binding)
+            .await
+            .expect("assemble messages");
+        let provider_messages =
+            crate::provider::build_messages_for_session(&config, session_id, true)
+                .expect("build provider messages");
+
+        assert_eq!(
+            kernel_messages, provider_messages,
+            "kernel-bound assembly should preserve summary projection parity"
+        );
+        assert!(
+            kernel_messages.iter().any(|message| {
+                message["role"] == "system"
+                    && message["content"]
+                        .as_str()
+                        .is_some_and(|content| content.contains("## Memory Summary"))
+            }),
+            "expected kernel-bound assembly to keep the summary block"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn default_engine_kernel_bound_messages_match_provider_profile_projection() {
+        let capabilities = std::collections::BTreeSet::from([
+            loongclaw_contracts::Capability::InvokeTool,
+            loongclaw_contracts::Capability::FilesystemRead,
+            loongclaw_contracts::Capability::FilesystemWrite,
+            loongclaw_contracts::Capability::MemoryRead,
+        ]);
+        let harness = TurnTestHarness::with_capabilities(capabilities);
+        let session_id = "kernel-profile-session";
+        let sqlite_path = harness.temp_dir.join("memory.sqlite3");
+        let sqlite_path_text = sqlite_path.display().to_string();
+        let profile_note = "Imported ZeroClaw preferences";
+        let mut config = LoongClawConfig::default();
+
+        config.tools.file_root = Some(harness.temp_dir.display().to_string());
+        config.memory.profile = MemoryProfile::ProfilePlusWindow;
+        config.memory.profile_note = Some(profile_note.to_owned());
+        config.memory.sliding_window = 2;
+        config.memory.sqlite_path = sqlite_path_text.clone();
+
+        let memory_config =
+            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+        memory::append_turn_direct(session_id, "assistant", "turn 1", &memory_config)
+            .expect("append turn should succeed");
+
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let kernel_messages = DefaultContextEngine
+            .assemble_messages(&config, session_id, true, binding)
+            .await
+            .expect("assemble messages");
+        let provider_messages =
+            crate::provider::build_messages_for_session(&config, session_id, true)
+                .expect("build provider messages");
+
+        assert_eq!(
+            kernel_messages, provider_messages,
+            "kernel-bound assembly should preserve profile projection parity"
+        );
+        assert!(
+            kernel_messages.iter().any(|message| {
+                message["role"] == "system"
+                    && message["content"]
+                        .as_str()
+                        .is_some_and(|content| content.contains(profile_note))
+            }),
+            "expected kernel-bound assembly to keep the profile block"
         );
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10692,7 +10692,35 @@ impl CoreMemoryAdapter for SharedTestMemoryAdapter {
         &self,
         request: MemoryCoreRequest,
     ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
-        let payload = if request.operation == crate::memory::MEMORY_OP_WINDOW {
+        let payload = if request.operation == crate::memory::MEMORY_OP_READ_CONTEXT {
+            let entries = self
+                .window_turns
+                .as_array()
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|turn| {
+                    let role = turn
+                        .get("role")
+                        .and_then(Value::as_str)
+                        .unwrap_or("assistant");
+                    let content = turn
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+
+                    json!({
+                        "kind": "turn",
+                        "role": role,
+                        "content": content,
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            json!({
+                "entries": entries
+            })
+        } else if request.operation == crate::memory::MEMORY_OP_WINDOW {
             json!({
                 "turns": self.window_turns.clone()
             })
@@ -11005,7 +11033,7 @@ async fn persist_turn_routes_through_kernel_when_context_provided() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn build_messages_routes_memory_window_through_kernel_when_context_provided() {
+async fn build_messages_routes_memory_context_through_kernel_when_context_provided() {
     let audit = Arc::new(InMemoryAuditSink::default());
     let (ctx, invocations) = build_kernel_context(audit.clone());
     let runtime = DefaultConversationRuntime::default();
@@ -11033,11 +11061,19 @@ async fn build_messages_routes_memory_window_through_kernel_when_context_provide
 
     let captured = invocations.lock().expect("invocations lock");
     assert_eq!(captured.len(), 1);
-    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_WINDOW);
+    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_READ_CONTEXT);
     assert_eq!(captured[0].payload["session_id"], "session-k-window");
     assert_eq!(
-        captured[0].payload["limit"],
+        captured[0].payload["profile"],
+        config.memory.profile.as_str()
+    );
+    assert_eq!(
+        captured[0].payload["sliding_window"],
         json!(config.memory.sliding_window)
+    );
+    assert_eq!(
+        captured[0].payload["summary_max_chars"],
+        json!(config.memory.summary_char_budget())
     );
 
     let events = audit.snapshot();

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -12,6 +12,7 @@ pub mod presentation;
 pub mod prompt;
 pub mod provider;
 pub mod runtime_env;
+mod runtime_identity;
 mod runtime_self;
 pub mod session;
 pub mod tools;

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -2,6 +2,7 @@ use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::{Value, json};
 
 use crate::config::MemoryMode;
+use crate::runtime_identity;
 
 #[cfg(feature = "memory-sqlite")]
 use super::sqlite;
@@ -44,19 +45,15 @@ pub fn load_prompt_context(
 ) -> Result<Vec<MemoryContextEntry>, String> {
     let mut entries = Vec::new();
 
+    let profile_section =
+        runtime_identity::render_session_profile_section(config.profile_note.as_deref());
     if matches!(config.mode, MemoryMode::ProfilePlusWindow)
-        && let Some(profile_note) = config
-            .profile_note
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
+        && let Some(profile_section) = profile_section
     {
         entries.push(MemoryContextEntry {
             kind: MemoryContextKind::Profile,
             role: "system".to_owned(),
-            content: format!(
-                "## Session Profile\nDurable preferences or imported identity carried into this session:\n- {profile_note}"
-            ),
+            content: profile_section,
         });
     }
 
@@ -184,6 +181,99 @@ mod tests {
                 .any(|entry| entry.content.contains("Imported ZeroClaw preferences")),
             "expected profile note content"
         );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn profile_plus_window_omits_legacy_identity_blocks_from_profile_projection() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-profile-memory-projection-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("profile-projection.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let profile_note = "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot\n\n## Imported External Skills Artifacts\n- kind=skills_catalog\n- declared=custom/skill-a";
+        let config = MemoryRuntimeConfig {
+            profile: MemoryProfile::ProfilePlusWindow,
+            mode: MemoryMode::ProfilePlusWindow,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            profile_note: Some(profile_note.to_owned()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        super::super::append_turn_direct(
+            "profile-projection-session",
+            "user",
+            "recent turn",
+            &config,
+        )
+        .expect("append turn should succeed");
+
+        let hydrated = load_prompt_context("profile-projection-session", &config)
+            .expect("load prompt context");
+        let profile_entry = hydrated
+            .iter()
+            .find(|entry| entry.kind == MemoryContextKind::Profile)
+            .expect("profile entry");
+
+        assert!(
+            profile_entry
+                .content
+                .contains("Imported External Skills Artifacts")
+        );
+        assert!(!profile_entry.content.contains("Legacy build copilot"));
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn profile_plus_window_drops_profile_entry_when_only_legacy_identity_exists() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-profile-memory-identity-only-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("profile-identity-only.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let profile_note = "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot";
+        let config = MemoryRuntimeConfig {
+            profile: MemoryProfile::ProfilePlusWindow,
+            mode: MemoryMode::ProfilePlusWindow,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            profile_note: Some(profile_note.to_owned()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        super::super::append_turn_direct(
+            "profile-identity-only-session",
+            "user",
+            "recent turn",
+            &config,
+        )
+        .expect("append turn should succeed");
+
+        let hydrated = load_prompt_context("profile-identity-only-session", &config)
+            .expect("load prompt context");
+        let profile_entries = hydrated
+            .iter()
+            .filter(|entry| entry.kind == MemoryContextKind::Profile)
+            .count();
+
+        assert_eq!(profile_entries, 0);
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -1,8 +1,8 @@
 use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::{Value, json};
 
-use crate::config::MemoryProfile;
 use crate::config::MemoryMode;
+use crate::config::MemoryProfile;
 use crate::runtime_identity;
 
 #[cfg(feature = "memory-sqlite")]
@@ -52,9 +52,7 @@ fn read_context_runtime_config(
             .as_str()
             .ok_or_else(|| "memory.read_context payload.profile must be a string".to_owned())?;
         let profile = MemoryProfile::parse_id(profile_text).ok_or_else(|| {
-            format!(
-                "memory.read_context payload.profile `{profile_text}` is unsupported"
-            )
+            format!("memory.read_context payload.profile `{profile_text}` is unsupported")
         })?;
         let mode = profile.mode();
 
@@ -66,13 +64,11 @@ fn read_context_runtime_config(
         let sliding_window = sliding_window_value.as_u64().ok_or_else(|| {
             "memory.read_context payload.sliding_window must be a positive integer".to_owned()
         })?;
-        let sliding_window = usize::try_from(sliding_window).map_err(|_| {
-            "memory.read_context payload.sliding_window exceeds usize".to_owned()
+        let sliding_window = usize::try_from(sliding_window).map_err(|conversion_error| {
+            format!("memory.read_context payload.sliding_window exceeds usize: {conversion_error}")
         })?;
         if sliding_window == 0 {
-            return Err(
-                "memory.read_context payload.sliding_window must be at least 1".to_owned(),
-            );
+            return Err("memory.read_context payload.sliding_window must be at least 1".to_owned());
         }
 
         runtime_config.sliding_window = sliding_window;
@@ -82,8 +78,10 @@ fn read_context_runtime_config(
         let summary_max_chars = summary_max_chars_value.as_u64().ok_or_else(|| {
             "memory.read_context payload.summary_max_chars must be a positive integer".to_owned()
         })?;
-        let summary_max_chars = usize::try_from(summary_max_chars).map_err(|_| {
-            "memory.read_context payload.summary_max_chars exceeds usize".to_owned()
+        let summary_max_chars = usize::try_from(summary_max_chars).map_err(|conversion_error| {
+            format!(
+                "memory.read_context payload.summary_max_chars exceeds usize: {conversion_error}"
+            )
         })?;
         if summary_max_chars == 0 {
             return Err(
@@ -105,7 +103,7 @@ fn read_context_runtime_config(
                     Some(trimmed_value.to_owned())
                 }
             }
-            _ => {
+            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => {
                 return Err(
                     "memory.read_context payload.profile_note must be a string or null".to_owned(),
                 );

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -1,6 +1,7 @@
 use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::{Value, json};
 
+use crate::config::MemoryProfile;
 use crate::config::MemoryMode;
 use crate::runtime_identity;
 
@@ -26,7 +27,8 @@ pub(crate) fn read_context(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "memory.read_context requires payload.session_id".to_owned())?;
-    let entries = load_prompt_context(session_id, config)?;
+    let runtime_config = read_context_runtime_config(payload, config)?;
+    let entries = load_prompt_context(session_id, &runtime_config)?;
 
     Ok(MemoryCoreOutcome {
         status: "ok".to_owned(),
@@ -37,6 +39,83 @@ pub(crate) fn read_context(
             "entries": entries,
         }),
     })
+}
+
+fn read_context_runtime_config(
+    payload: &serde_json::Map<String, Value>,
+    config: &MemoryRuntimeConfig,
+) -> Result<MemoryRuntimeConfig, String> {
+    let mut runtime_config = config.clone();
+
+    if let Some(profile_value) = payload.get("profile") {
+        let profile_text = profile_value
+            .as_str()
+            .ok_or_else(|| "memory.read_context payload.profile must be a string".to_owned())?;
+        let profile = MemoryProfile::parse_id(profile_text).ok_or_else(|| {
+            format!(
+                "memory.read_context payload.profile `{profile_text}` is unsupported"
+            )
+        })?;
+        let mode = profile.mode();
+
+        runtime_config.profile = profile;
+        runtime_config.mode = mode;
+    }
+
+    if let Some(sliding_window_value) = payload.get("sliding_window") {
+        let sliding_window = sliding_window_value.as_u64().ok_or_else(|| {
+            "memory.read_context payload.sliding_window must be a positive integer".to_owned()
+        })?;
+        let sliding_window = usize::try_from(sliding_window).map_err(|_| {
+            "memory.read_context payload.sliding_window exceeds usize".to_owned()
+        })?;
+        if sliding_window == 0 {
+            return Err(
+                "memory.read_context payload.sliding_window must be at least 1".to_owned(),
+            );
+        }
+
+        runtime_config.sliding_window = sliding_window;
+    }
+
+    if let Some(summary_max_chars_value) = payload.get("summary_max_chars") {
+        let summary_max_chars = summary_max_chars_value.as_u64().ok_or_else(|| {
+            "memory.read_context payload.summary_max_chars must be a positive integer".to_owned()
+        })?;
+        let summary_max_chars = usize::try_from(summary_max_chars).map_err(|_| {
+            "memory.read_context payload.summary_max_chars exceeds usize".to_owned()
+        })?;
+        if summary_max_chars == 0 {
+            return Err(
+                "memory.read_context payload.summary_max_chars must be at least 1".to_owned(),
+            );
+        }
+
+        runtime_config.summary_max_chars = summary_max_chars;
+    }
+
+    if let Some(profile_note_value) = payload.get("profile_note") {
+        let profile_note = match profile_note_value {
+            Value::Null => None,
+            Value::String(value) => {
+                let trimmed_value = value.trim();
+                if trimmed_value.is_empty() {
+                    None
+                } else {
+                    Some(trimmed_value.to_owned())
+                }
+            }
+            _ => {
+                return Err(
+                    "memory.read_context payload.profile_note must be a string or null".to_owned(),
+                );
+            }
+        };
+
+        runtime_config.profile_note = profile_note;
+    }
+
+    Ok(runtime_config)
 }
 
 pub fn load_prompt_context(

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -10,6 +10,7 @@ use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::json;
 
 use crate::config::MemoryBackendKind;
+use crate::runtime_identity;
 
 mod canonical;
 mod context;
@@ -224,20 +225,15 @@ pub fn load_prompt_context_with_diagnostics(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<(Vec<MemoryContextEntry>, SqliteContextLoadDiagnostics), String> {
     let mut profile_entry = None;
-
+    let profile_section =
+        runtime_identity::render_session_profile_section(config.profile_note.as_deref());
     if matches!(config.mode, crate::config::MemoryMode::ProfilePlusWindow)
-        && let Some(profile_note) = config
-            .profile_note
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
+        && let Some(profile_section) = profile_section
     {
         profile_entry = Some(MemoryContextEntry {
             kind: MemoryContextKind::Profile,
             role: "system".to_owned(),
-            content: format!(
-                "## Session Profile\nDurable preferences or imported identity carried into this session:\n- {profile_note}"
-            ),
+            content: profile_section,
         });
     }
 

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -2,6 +2,8 @@ use loongclaw_contracts::MemoryCoreRequest;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use crate::memory::runtime_config::MemoryRuntimeConfig;
+
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
 pub const MEMORY_OP_WINDOW: &str = "window";
 pub const MEMORY_OP_CLEAR_SESSION: &str = "clear_session";
@@ -51,11 +53,18 @@ pub fn build_window_request(session_id: &str, limit: usize) -> MemoryCoreRequest
     }
 }
 
-pub fn build_read_context_request(session_id: &str) -> MemoryCoreRequest {
+pub fn build_read_context_request(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> MemoryCoreRequest {
     MemoryCoreRequest {
         operation: MEMORY_OP_READ_CONTEXT.to_owned(),
         payload: json!({
             "session_id": session_id,
+            "profile": config.profile.as_str(),
+            "sliding_window": config.sliding_window,
+            "summary_max_chars": config.summary_max_chars,
+            "profile_note": config.profile_note,
         }),
     }
 }

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -201,6 +201,57 @@ fn memory_window_limit_semantics_cover_explicit_fallback_and_bounds() {
 
 #[cfg(feature = "memory-sqlite")]
 #[test]
+fn load_prompt_context_with_diagnostics_omits_legacy_identity_from_profile_projection() {
+    use crate::config::{MemoryMode, MemoryProfile};
+    use std::fs;
+
+    let tmp = std::env::temp_dir().join(format!(
+        "loongclaw-test-memory-profile-diagnostics-{}",
+        std::process::id()
+    ));
+    let _ = fs::create_dir_all(&tmp);
+    let db_path = tmp.join("profile-diagnostics.sqlite3");
+    let _ = fs::remove_file(&db_path);
+
+    let profile_note = "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot\n\n## Imported External Skills Artifacts\n- kind=skills_catalog\n- declared=custom/skill-a";
+    let config = runtime_config::MemoryRuntimeConfig {
+        profile: MemoryProfile::ProfilePlusWindow,
+        mode: MemoryMode::ProfilePlusWindow,
+        sqlite_path: Some(db_path.clone()),
+        sliding_window: 2,
+        profile_note: Some(profile_note.to_owned()),
+        ..runtime_config::MemoryRuntimeConfig::default()
+    };
+
+    append_turn_direct(
+        "profile-diagnostics-session",
+        "user",
+        "recent turn",
+        &config,
+    )
+    .expect("append_turn_direct should succeed");
+
+    let (entries, _diagnostics) =
+        load_prompt_context_with_diagnostics("profile-diagnostics-session", &config)
+            .expect("load_prompt_context_with_diagnostics should succeed");
+    let profile_entry = entries
+        .iter()
+        .find(|entry| entry.kind == MemoryContextKind::Profile)
+        .expect("profile entry");
+
+    assert!(
+        profile_entry
+            .content
+            .contains("Imported External Skills Artifacts")
+    );
+    assert!(!profile_entry.content.contains("Legacy build copilot"));
+
+    let _ = fs::remove_file(&db_path);
+    let _ = fs::remove_dir(&tmp);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
 fn append_turn_direct_bypasses_core_dispatch() {
     use std::fs;
 

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -156,11 +156,17 @@ pub fn build_system_message(
     request_message_runtime::build_system_message(config, include_system_prompt)
 }
 
-pub(crate) fn build_base_messages(
+pub(crate) async fn build_base_messages_with_binding(
     config: &LoongClawConfig,
     include_system_prompt: bool,
+    binding: ProviderRuntimeBinding<'_>,
 ) -> Vec<Value> {
-    request_message_runtime::build_base_messages(config, include_system_prompt)
+    request_message_runtime::build_base_messages_with_binding(
+        config,
+        include_system_prompt,
+        binding,
+    )
+    .await
 }
 
 pub(crate) fn push_history_message(messages: &mut Vec<Value>, role: &str, content: &str) {

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -2,6 +2,7 @@ use serde_json::{Value, json};
 
 use crate::CliResult;
 use crate::config::LoongClawConfig;
+use crate::runtime_identity;
 use crate::runtime_self;
 use crate::tools::{self, ToolView};
 
@@ -41,18 +42,28 @@ fn build_system_message_with_tool_runtime_config(
     let system_prompt = config.cli.resolved_system_prompt();
     let system = system_prompt.trim();
     let snapshot = tools::capability_snapshot_for_view_with_config(tool_view, tool_runtime_config);
-
-    let runtime_self_section = tool_runtime_config
-        .file_root
-        .as_deref()
-        .map(runtime_self::load_runtime_self_model)
-        .and_then(|model| runtime_self::render_runtime_self_section(&model));
+    let workspace_root = tool_runtime_config.file_root.as_deref();
+    let runtime_self_model = workspace_root.map(runtime_self::load_runtime_self_model);
+    let runtime_self_section = runtime_self_model
+        .as_ref()
+        .and_then(runtime_self::render_runtime_self_section);
+    let trimmed_profile_note = config.memory.trimmed_profile_note();
+    let resolved_runtime_identity = runtime_identity::resolve_runtime_identity(
+        runtime_self_model.as_ref(),
+        trimmed_profile_note.as_deref(),
+    );
+    let runtime_identity_section = resolved_runtime_identity
+        .as_ref()
+        .map(runtime_identity::render_runtime_identity_section);
 
     let mut sections = Vec::new();
     if !system.is_empty() {
         sections.push(system.to_owned());
     }
     if let Some(section) = runtime_self_section {
+        sections.push(section);
+    }
+    if let Some(section) = runtime_identity_section {
         sections.push(section);
     }
     sections.push(snapshot);
@@ -317,10 +328,67 @@ mod tests {
         assert!(system_content.contains(agents_text));
         assert!(system_content.contains("### Soul Guidance"));
         assert!(system_content.contains(soul_text));
-        assert!(system_content.contains("### Identity Context"));
-        assert!(system_content.contains(identity_text));
         assert!(system_content.contains("### User Context"));
         assert!(system_content.contains(user_text));
+        assert!(system_content.contains("## Resolved Runtime Identity"));
+        assert!(system_content.contains(identity_text));
+        assert!(!system_content.contains("### Identity Context"));
+    }
+
+    #[test]
+    fn build_system_message_promotes_legacy_imported_identity_when_workspace_identity_is_absent() {
+        let mut config = LoongClawConfig::default();
+        let legacy_profile_note =
+            "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot";
+        config.memory.profile_note = Some(legacy_profile_note.to_owned());
+
+        let tool_view = tools::runtime_tool_view();
+        let tool_runtime_config = tools::runtime_config::ToolRuntimeConfig::default();
+
+        let system_message = build_system_message_with_tool_runtime_config(
+            &config,
+            true,
+            &tool_view,
+            &tool_runtime_config,
+        )
+        .expect("system message");
+        let system_content = system_message["content"].as_str().expect("system content");
+
+        assert!(system_content.contains("## Resolved Runtime Identity"));
+        assert!(system_content.contains("Legacy build copilot"));
+    }
+
+    #[test]
+    fn build_system_message_prefers_workspace_identity_over_legacy_profile_note_identity() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let identity_path = workspace_root.join("IDENTITY.md");
+        let workspace_identity = "# Identity\n\n- Name: Workspace build copilot";
+        std::fs::write(&identity_path, workspace_identity).expect("write IDENTITY");
+
+        let mut config = LoongClawConfig::default();
+        let legacy_profile_note =
+            "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot";
+        config.memory.profile_note = Some(legacy_profile_note.to_owned());
+
+        let tool_view = tools::runtime_tool_view();
+        let tool_runtime_config = tools::runtime_config::ToolRuntimeConfig {
+            file_root: Some(workspace_root.to_path_buf()),
+            ..tools::runtime_config::ToolRuntimeConfig::default()
+        };
+
+        let system_message = build_system_message_with_tool_runtime_config(
+            &config,
+            true,
+            &tool_view,
+            &tool_runtime_config,
+        )
+        .expect("system message");
+        let system_content = system_message["content"].as_str().expect("system content");
+
+        assert!(system_content.contains("## Resolved Runtime Identity"));
+        assert!(system_content.contains("Workspace build copilot"));
+        assert!(!system_content.contains("Legacy build copilot"));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -371,7 +371,10 @@ mod tests {
         let binding = ProviderRuntimeBinding::kernel(&harness.kernel_ctx);
         let messages = build_base_messages_with_binding(&config, false, binding).await;
 
-        assert!(messages.is_empty(), "disabled system prompts should emit no base messages");
+        assert!(
+            messages.is_empty(),
+            "disabled system prompts should emit no base messages"
+        );
 
         let audit_events = harness.audit.snapshot();
         let has_tool_plane_event = audit_events.iter().any(|event| {

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -1,6 +1,12 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use loongclaw_contracts::ToolCoreRequest;
 use serde_json::{Value, json};
 
+use super::runtime_binding::ProviderRuntimeBinding;
 use crate::CliResult;
+use crate::KernelContext;
 use crate::config::LoongClawConfig;
 use crate::runtime_identity;
 use crate::runtime_self;
@@ -29,6 +35,42 @@ pub(super) fn build_system_message_for_view(
     )
 }
 
+pub(super) async fn build_base_messages_with_binding(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+    binding: ProviderRuntimeBinding<'_>,
+) -> Vec<Value> {
+    if !include_system_prompt {
+        return Vec::new();
+    }
+
+    build_system_message_for_view_with_binding(
+        config,
+        include_system_prompt,
+        &tools::runtime_tool_view(),
+        binding,
+    )
+    .await
+    .into_iter()
+    .collect()
+}
+
+async fn build_system_message_for_view_with_binding(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+    tool_view: &ToolView,
+    binding: ProviderRuntimeBinding<'_>,
+) -> Option<Value> {
+    build_system_message_with_binding_and_tool_runtime_config(
+        config,
+        include_system_prompt,
+        tool_view,
+        &tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None),
+        binding,
+    )
+    .await
+}
+
 fn build_system_message_with_tool_runtime_config(
     config: &LoongClawConfig,
     include_system_prompt: bool,
@@ -39,11 +81,63 @@ fn build_system_message_with_tool_runtime_config(
         return None;
     }
 
+    let workspace_root = tool_runtime_config.file_root.as_deref();
+    let runtime_self_model = workspace_root.map(|workspace_root| {
+        runtime_self::load_runtime_self_model_with_config(workspace_root, tool_runtime_config)
+    });
+
+    build_system_message_from_runtime_self_model(
+        config,
+        include_system_prompt,
+        tool_view,
+        tool_runtime_config,
+        runtime_self_model,
+    )
+}
+
+async fn build_system_message_with_binding_and_tool_runtime_config(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+    tool_view: &ToolView,
+    tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
+    binding: ProviderRuntimeBinding<'_>,
+) -> Option<Value> {
+    if !include_system_prompt {
+        return None;
+    }
+
+    let workspace_root = tool_runtime_config.file_root.as_deref();
+    let runtime_self_model = match workspace_root {
+        Some(workspace_root) => Some(
+            load_runtime_self_model_with_binding(workspace_root, tool_runtime_config, binding)
+                .await,
+        ),
+        None => None,
+    };
+
+    build_system_message_from_runtime_self_model(
+        config,
+        include_system_prompt,
+        tool_view,
+        tool_runtime_config,
+        runtime_self_model,
+    )
+}
+
+fn build_system_message_from_runtime_self_model(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+    tool_view: &ToolView,
+    tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
+    runtime_self_model: Option<runtime_self::RuntimeSelfModel>,
+) -> Option<Value> {
+    if !include_system_prompt {
+        return None;
+    }
+
     let system_prompt = config.cli.resolved_system_prompt();
     let system = system_prompt.trim();
     let snapshot = tools::capability_snapshot_for_view_with_config(tool_view, tool_runtime_config);
-    let workspace_root = tool_runtime_config.file_root.as_deref();
-    let runtime_self_model = workspace_root.map(runtime_self::load_runtime_self_model);
     let runtime_self_section = runtime_self_model
         .as_ref()
         .and_then(runtime_self::render_runtime_self_section);
@@ -75,13 +169,6 @@ fn build_system_message_with_tool_runtime_config(
     }))
 }
 
-pub(super) fn build_base_messages(
-    config: &LoongClawConfig,
-    include_system_prompt: bool,
-) -> Vec<Value> {
-    build_base_messages_for_view(config, include_system_prompt, &tools::runtime_tool_view())
-}
-
 pub(super) fn build_base_messages_for_view(
     config: &LoongClawConfig,
     include_system_prompt: bool,
@@ -90,6 +177,66 @@ pub(super) fn build_base_messages_for_view(
     build_system_message_for_view(config, include_system_prompt, tool_view)
         .into_iter()
         .collect()
+}
+
+async fn load_runtime_self_model_with_binding(
+    workspace_root: &Path,
+    tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
+    binding: ProviderRuntimeBinding<'_>,
+) -> runtime_self::RuntimeSelfModel {
+    let Some(kernel_ctx) = binding.kernel_context() else {
+        return runtime_self::load_runtime_self_model_with_config(
+            workspace_root,
+            tool_runtime_config,
+        );
+    };
+
+    let source_candidates = runtime_self::runtime_self_source_candidates(workspace_root);
+    let mut loaded_paths = BTreeSet::new();
+    let mut model = runtime_self::RuntimeSelfModel::default();
+
+    for (candidate_path, lane) in source_candidates {
+        let Some(content) =
+            read_runtime_self_source_via_kernel(workspace_root, &candidate_path, kernel_ctx).await
+        else {
+            continue;
+        };
+
+        let path_key = runtime_self::normalized_path_key(&candidate_path);
+        let inserted = loaded_paths.insert(path_key);
+        if !inserted {
+            continue;
+        }
+
+        runtime_self::append_runtime_self_content(&mut model, lane, content);
+    }
+
+    model
+}
+
+async fn read_runtime_self_source_via_kernel(
+    workspace_root: &Path,
+    path: &Path,
+    kernel_ctx: &KernelContext,
+) -> Option<String> {
+    let request_path = path.strip_prefix(workspace_root).ok()?;
+    let request_path = request_path.to_string_lossy().to_string();
+    let request = ToolCoreRequest {
+        tool_name: "file.read".to_owned(),
+        payload: json!({
+            "path": request_path,
+        }),
+    };
+
+    let outcome = tools::execute_tool(request, kernel_ctx).await.ok()?;
+    let payload_content = outcome.payload.get("content")?;
+    let content = payload_content.as_str()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(trimmed.to_owned())
 }
 
 pub(super) fn push_history_message(messages: &mut Vec<Value>, role: &str, content: &str) {
@@ -196,12 +343,51 @@ fn should_skip_history_turn(role: &str, content: &str) -> bool {
 mod tests {
     use super::*;
     use crate::config::MemoryProfile;
+    use crate::test_support::TurnTestHarness;
     use tempfile::tempdir;
 
     #[test]
     fn build_system_message_returns_none_when_disabled() {
         let config = LoongClawConfig::default();
         assert_eq!(build_system_message(&config, false), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn build_base_messages_with_binding_skips_runtime_self_reads_when_disabled() {
+        let capabilities = std::collections::BTreeSet::from([
+            loongclaw_contracts::Capability::InvokeTool,
+            loongclaw_contracts::Capability::FilesystemRead,
+            loongclaw_contracts::Capability::FilesystemWrite,
+        ]);
+        let harness = TurnTestHarness::with_capabilities(capabilities);
+        let agents_path = harness.temp_dir.join("AGENTS.md");
+        let agents_text = "Do not read me when system prompts are disabled.";
+        let mut config = LoongClawConfig::default();
+
+        std::fs::write(&agents_path, agents_text).expect("write AGENTS");
+
+        config.tools.file_root = Some(harness.temp_dir.display().to_string());
+
+        let binding = ProviderRuntimeBinding::kernel(&harness.kernel_ctx);
+        let messages = build_base_messages_with_binding(&config, false, binding).await;
+
+        assert!(messages.is_empty(), "disabled system prompts should emit no base messages");
+
+        let audit_events = harness.audit.snapshot();
+        let has_tool_plane_event = audit_events.iter().any(|event| {
+            matches!(
+                &event.kind,
+                loongclaw_kernel::AuditEventKind::PlaneInvoked {
+                    plane: loongclaw_contracts::ExecutionPlane::Tool,
+                    ..
+                }
+            )
+        });
+
+        assert!(
+            !has_tool_plane_event,
+            "disabled system prompts should not trigger runtime-self tool reads"
+        );
     }
 
     #[test]
@@ -332,18 +518,28 @@ mod tests {
         assert!(system_content.contains(user_text));
         assert!(system_content.contains("## Resolved Runtime Identity"));
         assert!(system_content.contains(identity_text));
+        assert_eq!(system_content.matches(identity_text).count(), 1);
         assert!(!system_content.contains("### Identity Context"));
     }
 
     #[test]
     fn build_system_message_promotes_legacy_imported_identity_when_workspace_identity_is_absent() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let agents_text = "Always keep workspace instructions explicit.";
+
+        std::fs::write(workspace_root.join("AGENTS.md"), agents_text).expect("write AGENTS");
+
         let mut config = LoongClawConfig::default();
         let legacy_profile_note =
             "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot";
         config.memory.profile_note = Some(legacy_profile_note.to_owned());
 
         let tool_view = tools::runtime_tool_view();
-        let tool_runtime_config = tools::runtime_config::ToolRuntimeConfig::default();
+        let tool_runtime_config = tools::runtime_config::ToolRuntimeConfig {
+            file_root: Some(workspace_root.to_path_buf()),
+            ..tools::runtime_config::ToolRuntimeConfig::default()
+        };
 
         let system_message = build_system_message_with_tool_runtime_config(
             &config,
@@ -354,8 +550,12 @@ mod tests {
         .expect("system message");
         let system_content = system_message["content"].as_str().expect("system content");
 
+        assert!(system_content.contains("## Runtime Self Context"));
+        assert!(system_content.contains(agents_text));
         assert!(system_content.contains("## Resolved Runtime Identity"));
         assert!(system_content.contains("Legacy build copilot"));
+        assert_eq!(system_content.matches("Legacy build copilot").count(), 1);
+        assert!(!system_content.contains("### Identity Context"));
     }
 
     #[test]
@@ -389,6 +589,8 @@ mod tests {
         assert!(system_content.contains("## Resolved Runtime Identity"));
         assert!(system_content.contains("Workspace build copilot"));
         assert!(!system_content.contains("Legacy build copilot"));
+        assert_eq!(system_content.matches("Workspace build copilot").count(), 1);
+        assert!(!system_content.contains("### Identity Context"));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/runtime_identity.rs
+++ b/crates/app/src/runtime_identity.rs
@@ -307,8 +307,8 @@ mod tests {
     fn legacy_identity_import_keeps_nested_headings_out_of_advisory_profile() {
         let profile_note = "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot\n\n## Traits\n- careful\n- explicit\n\n## Imported External Skills Artifacts\n- kind=skills_catalog";
 
-        let resolved = resolve_runtime_identity(None, Some(profile_note))
-            .expect("resolved runtime identity");
+        let resolved =
+            resolve_runtime_identity(None, Some(profile_note)).expect("resolved runtime identity");
         let rendered =
             render_session_profile_section(Some(profile_note)).expect("session profile section");
 

--- a/crates/app/src/runtime_identity.rs
+++ b/crates/app/src/runtime_identity.rs
@@ -1,0 +1,282 @@
+use crate::runtime_self::RuntimeSelfModel;
+
+const LEGACY_IMPORTED_IDENTITY_HEADINGS: &[&str] =
+    &["## imported identity.md", "## imported identity.json"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeIdentitySource {
+    WorkspaceSelf,
+    LegacyProfileNoteImport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedRuntimeIdentity {
+    pub source: RuntimeIdentitySource,
+    pub content: String,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ProfileNotePartition {
+    identity_blocks: Vec<String>,
+    advisory_blocks: Vec<String>,
+}
+
+pub(crate) fn resolve_runtime_identity(
+    runtime_self_model: Option<&RuntimeSelfModel>,
+    profile_note: Option<&str>,
+) -> Option<ResolvedRuntimeIdentity> {
+    let workspace_identity = runtime_self_model.and_then(resolve_workspace_identity);
+    if let Some(content) = workspace_identity {
+        let identity = ResolvedRuntimeIdentity {
+            source: RuntimeIdentitySource::WorkspaceSelf,
+            content,
+        };
+        return Some(identity);
+    }
+
+    let legacy_identity = resolve_legacy_imported_identity(profile_note);
+    legacy_identity.map(|content| ResolvedRuntimeIdentity {
+        source: RuntimeIdentitySource::LegacyProfileNoteImport,
+        content,
+    })
+}
+
+pub(crate) fn render_runtime_identity_section(identity: &ResolvedRuntimeIdentity) -> String {
+    let intro = runtime_identity_intro(identity.source);
+    let content = identity.content.trim().to_owned();
+
+    let sections = [
+        "## Resolved Runtime Identity".to_owned(),
+        intro.to_owned(),
+        content,
+    ];
+    sections.join("\n\n")
+}
+
+pub(crate) fn render_session_profile_section(profile_note: Option<&str>) -> Option<String> {
+    let advisory_profile_note = resolve_advisory_profile_note(profile_note)?;
+
+    let sections = [
+        "## Session Profile".to_owned(),
+        "Durable preferences and advisory session context carried into this session:".to_owned(),
+        advisory_profile_note,
+    ];
+    Some(sections.join("\n"))
+}
+
+fn runtime_identity_intro(source: RuntimeIdentitySource) -> &'static str {
+    match source {
+        RuntimeIdentitySource::WorkspaceSelf => {
+            "Active workspace identity context loaded from runtime self sources."
+        }
+        RuntimeIdentitySource::LegacyProfileNoteImport => {
+            "Fallback identity context recovered from legacy imported profile state."
+        }
+    }
+}
+
+fn resolve_workspace_identity(model: &RuntimeSelfModel) -> Option<String> {
+    let entries = &model.identity_context;
+    join_trimmed_entries(entries)
+}
+
+fn resolve_legacy_imported_identity(profile_note: Option<&str>) -> Option<String> {
+    let trimmed_profile_note = trim_profile_note(profile_note)?;
+    let partition = partition_profile_note(trimmed_profile_note);
+    let identity_blocks = partition.identity_blocks;
+    join_blocks(identity_blocks)
+}
+
+fn resolve_advisory_profile_note(profile_note: Option<&str>) -> Option<String> {
+    let trimmed_profile_note = trim_profile_note(profile_note)?;
+    let partition = partition_profile_note(trimmed_profile_note);
+    let advisory_blocks = partition.advisory_blocks;
+    join_blocks(advisory_blocks)
+}
+
+fn trim_profile_note(profile_note: Option<&str>) -> Option<&str> {
+    let raw_profile_note = profile_note?;
+    let trimmed_profile_note = raw_profile_note.trim();
+    if trimmed_profile_note.is_empty() {
+        return None;
+    }
+    Some(trimmed_profile_note)
+}
+
+fn partition_profile_note(profile_note: &str) -> ProfileNotePartition {
+    let mut partition = ProfileNotePartition::default();
+    let blocks = split_profile_note_blocks(profile_note);
+
+    for block in blocks {
+        let is_identity_block = is_legacy_imported_identity_block(&block);
+        if is_identity_block {
+            partition.identity_blocks.push(block);
+            continue;
+        }
+        partition.advisory_blocks.push(block);
+    }
+
+    partition
+}
+
+fn split_profile_note_blocks(profile_note: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current_lines = Vec::new();
+
+    for line in profile_note.lines() {
+        let trimmed_line = line.trim();
+        let starts_heading = trimmed_line.starts_with("## ");
+        let has_current_block = !current_lines.is_empty();
+
+        if starts_heading && has_current_block {
+            let block = finalize_profile_note_block(&current_lines);
+            if let Some(block) = block {
+                blocks.push(block);
+            }
+            current_lines.clear();
+        }
+
+        current_lines.push(line.to_owned());
+    }
+
+    let final_block = finalize_profile_note_block(&current_lines);
+    if let Some(final_block) = final_block {
+        blocks.push(final_block);
+    }
+
+    blocks
+}
+
+fn finalize_profile_note_block(lines: &[String]) -> Option<String> {
+    if lines.is_empty() {
+        return None;
+    }
+
+    let joined_lines = lines.join("\n");
+    let trimmed_block = joined_lines.trim();
+    if trimmed_block.is_empty() {
+        return None;
+    }
+
+    Some(trimmed_block.to_owned())
+}
+
+fn is_legacy_imported_identity_block(block: &str) -> bool {
+    let heading = first_non_empty_line(block);
+    let Some(heading) = heading else {
+        return false;
+    };
+
+    let normalized_heading = heading.trim().to_ascii_lowercase();
+    LEGACY_IMPORTED_IDENTITY_HEADINGS.contains(&normalized_heading.as_str())
+}
+
+fn first_non_empty_line(block: &str) -> Option<&str> {
+    for line in block.lines() {
+        let trimmed_line = line.trim();
+        if trimmed_line.is_empty() {
+            continue;
+        }
+        return Some(trimmed_line);
+    }
+
+    None
+}
+
+fn join_trimmed_entries(entries: &[String]) -> Option<String> {
+    let mut normalized_entries = Vec::new();
+
+    for entry in entries {
+        let trimmed_entry = entry.trim();
+        if trimmed_entry.is_empty() {
+            continue;
+        }
+        normalized_entries.push(trimmed_entry.to_owned());
+    }
+
+    join_blocks(normalized_entries)
+}
+
+fn join_blocks(blocks: Vec<String>) -> Option<String> {
+    let mut normalized_blocks = Vec::new();
+
+    for block in blocks {
+        let trimmed_block = block.trim();
+        if trimmed_block.is_empty() {
+            continue;
+        }
+        normalized_blocks.push(trimmed_block.to_owned());
+    }
+
+    if normalized_blocks.is_empty() {
+        return None;
+    }
+
+    Some(normalized_blocks.join("\n\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_runtime_identity_prefers_workspace_identity_over_legacy_profile_note_identity() {
+        let runtime_self_model = RuntimeSelfModel {
+            identity_context: vec!["# Identity\n\n- Name: Workspace build copilot".to_owned()],
+            ..RuntimeSelfModel::default()
+        };
+        let legacy_profile_note =
+            "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot";
+
+        let resolved =
+            resolve_runtime_identity(Some(&runtime_self_model), Some(legacy_profile_note))
+                .expect("resolved runtime identity");
+
+        assert_eq!(resolved.source, RuntimeIdentitySource::WorkspaceSelf);
+        assert!(resolved.content.contains("Workspace build copilot"));
+        assert!(!resolved.content.contains("Legacy build copilot"));
+    }
+
+    #[test]
+    fn resolve_runtime_identity_falls_back_to_legacy_profile_note_identity() {
+        let legacy_profile_note =
+            "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot";
+
+        let resolved = resolve_runtime_identity(None, Some(legacy_profile_note))
+            .expect("resolved runtime identity");
+
+        assert_eq!(
+            resolved.source,
+            RuntimeIdentitySource::LegacyProfileNoteImport
+        );
+        assert!(resolved.content.contains("Legacy build copilot"));
+    }
+
+    #[test]
+    fn resolve_runtime_identity_ignores_non_identity_profile_notes() {
+        let profile_note = "Operator prefers concise shell output.";
+        let resolved = resolve_runtime_identity(None, Some(profile_note));
+
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn render_session_profile_section_strips_legacy_identity_blocks() {
+        let profile_note = "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot\n\n## Imported External Skills Artifacts\n- kind=skills_catalog";
+
+        let rendered =
+            render_session_profile_section(Some(profile_note)).expect("session profile section");
+
+        assert!(rendered.contains("Imported External Skills Artifacts"));
+        assert!(!rendered.contains("Legacy build copilot"));
+    }
+
+    #[test]
+    fn render_session_profile_section_keeps_plain_profile_note_text() {
+        let profile_note = "Operator prefers concise shell output.";
+        let rendered =
+            render_session_profile_section(Some(profile_note)).expect("session profile section");
+
+        assert!(rendered.contains("Operator prefers concise shell output."));
+    }
+}

--- a/crates/app/src/runtime_identity.rs
+++ b/crates/app/src/runtime_identity.rs
@@ -128,7 +128,11 @@ fn split_profile_note_blocks(profile_note: &str) -> Vec<String> {
         let starts_heading = trimmed_line.starts_with("## ");
         let has_current_block = !current_lines.is_empty();
 
-        if starts_heading && has_current_block {
+        let should_split = starts_heading
+            && has_current_block
+            && should_split_profile_note_block(&current_lines, trimmed_line);
+
+        if should_split {
             let block = finalize_profile_note_block(&current_lines);
             if let Some(block) = block {
                 blocks.push(block);
@@ -145,6 +149,20 @@ fn split_profile_note_blocks(profile_note: &str) -> Vec<String> {
     }
 
     blocks
+}
+
+fn should_split_profile_note_block(current_lines: &[String], next_heading: &str) -> bool {
+    let current_block = finalize_profile_note_block(current_lines);
+    let Some(current_block) = current_block else {
+        return false;
+    };
+
+    let current_is_identity_import = is_legacy_imported_identity_block(&current_block);
+    if !current_is_identity_import {
+        return true;
+    }
+
+    is_imported_profile_block_heading(next_heading)
 }
 
 fn finalize_profile_note_block(lines: &[String]) -> Option<String> {
@@ -169,6 +187,11 @@ fn is_legacy_imported_identity_block(block: &str) -> bool {
 
     let normalized_heading = heading.trim().to_ascii_lowercase();
     LEGACY_IMPORTED_IDENTITY_HEADINGS.contains(&normalized_heading.as_str())
+}
+
+fn is_imported_profile_block_heading(heading: &str) -> bool {
+    let normalized_heading = heading.trim().to_ascii_lowercase();
+    normalized_heading.starts_with("## imported ")
 }
 
 fn first_non_empty_line(block: &str) -> Option<&str> {
@@ -278,5 +301,21 @@ mod tests {
             render_session_profile_section(Some(profile_note)).expect("session profile section");
 
         assert!(rendered.contains("Operator prefers concise shell output."));
+    }
+
+    #[test]
+    fn legacy_identity_import_keeps_nested_headings_out_of_advisory_profile() {
+        let profile_note = "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot\n\n## Traits\n- careful\n- explicit\n\n## Imported External Skills Artifacts\n- kind=skills_catalog";
+
+        let resolved = resolve_runtime_identity(None, Some(profile_note))
+            .expect("resolved runtime identity");
+        let rendered =
+            render_session_profile_section(Some(profile_note)).expect("session profile section");
+
+        assert!(resolved.content.contains("## Traits"));
+        assert!(resolved.content.contains("- careful"));
+        assert!(!rendered.contains("## Traits"));
+        assert!(!rendered.contains("- careful"));
+        assert!(rendered.contains("Imported External Skills Artifacts"));
     }
 }

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -101,11 +101,6 @@ pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<St
         &model.standing_instructions,
     );
     push_rendered_lane(&mut sections, "### Soul Guidance", &model.soul_guidance);
-    push_rendered_lane(
-        &mut sections,
-        "### Identity Context",
-        &model.identity_context,
-    );
     push_rendered_lane(&mut sections, "### User Context", &model.user_context);
 
     Some(sections.join("\n\n"))

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -1,8 +1,13 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use loongclaw_contracts::ToolCoreRequest;
+use serde_json::json;
+
+use crate::tools;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RuntimeSelfLane {
+pub(crate) enum RuntimeSelfLane {
     StandingInstructions,
     SoulGuidance,
     IdentityContext,
@@ -46,49 +51,49 @@ pub(crate) struct RuntimeSelfModel {
     pub user_context: Vec<String>,
 }
 
-impl RuntimeSelfModel {
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.standing_instructions.is_empty()
-            && self.soul_guidance.is_empty()
-            && self.identity_context.is_empty()
-            && self.user_context.is_empty()
-    }
-}
-
+#[cfg(test)]
 pub(crate) fn load_runtime_self_model(workspace_root: &Path) -> RuntimeSelfModel {
-    let Some(canonical_workspace_root) = canonical_workspace_root(workspace_root) else {
-        return RuntimeSelfModel::default();
+    let tool_runtime_config = crate::tools::runtime_config::ToolRuntimeConfig {
+        file_root: Some(workspace_root.to_path_buf()),
+        ..crate::tools::runtime_config::ToolRuntimeConfig::default()
     };
 
-    let candidate_roots = candidate_roots(workspace_root);
+    load_runtime_self_model_with_config(workspace_root, &tool_runtime_config)
+}
+
+pub(crate) fn load_runtime_self_model_with_config(
+    workspace_root: &Path,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+) -> RuntimeSelfModel {
+    let source_candidates = runtime_self_source_candidates(workspace_root);
     let mut loaded_paths = BTreeSet::new();
     let mut model = RuntimeSelfModel::default();
 
-    for root in candidate_roots {
-        for spec in RUNTIME_SELF_SOURCE_SPECS {
-            let candidate_path = root.join(spec.relative_path);
-            let Some(content) =
-                read_runtime_self_source(canonical_workspace_root.as_path(), &candidate_path)
-            else {
-                continue;
-            };
+    for (candidate_path, lane) in source_candidates {
+        let Some(content) =
+            read_runtime_self_source(workspace_root, &candidate_path, tool_runtime_config)
+        else {
+            continue;
+        };
 
-            let path_key = normalized_path_key(&candidate_path);
-            let inserted = loaded_paths.insert(path_key);
-            if !inserted {
-                continue;
-            }
-
-            append_runtime_self_content(&mut model, spec.lane, content);
+        let path_key = normalized_path_key(&candidate_path);
+        let inserted = loaded_paths.insert(path_key);
+        if !inserted {
+            continue;
         }
+
+        append_runtime_self_content(&mut model, lane, content);
     }
 
     model
 }
 
 pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<String> {
-    if model.is_empty() {
+    let has_renderable_content = !model.standing_instructions.is_empty()
+        || !model.soul_guidance.is_empty()
+        || !model.user_context.is_empty();
+
+    if !has_renderable_content {
         return None;
     }
 
@@ -106,26 +111,41 @@ pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<St
     Some(sections.join("\n\n"))
 }
 
-fn candidate_roots(workspace_root: &Path) -> Vec<PathBuf> {
-    let mut roots = Vec::new();
-    roots.push(workspace_root.to_path_buf());
+pub(crate) fn runtime_self_source_candidates(
+    workspace_root: &Path,
+) -> Vec<(PathBuf, RuntimeSelfLane)> {
+    let candidate_roots = [
+        workspace_root.to_path_buf(),
+        workspace_root.join("workspace"),
+    ];
+    let mut source_candidates = Vec::new();
 
-    let nested_workspace_root = workspace_root.join("workspace");
-    if nested_workspace_root.is_dir() {
-        roots.push(nested_workspace_root);
+    for root in candidate_roots {
+        for spec in RUNTIME_SELF_SOURCE_SPECS {
+            let candidate_path = root.join(spec.relative_path);
+            source_candidates.push((candidate_path, spec.lane));
+        }
     }
 
-    roots
+    source_candidates
 }
 
-fn read_runtime_self_source(canonical_workspace_root: &Path, path: &Path) -> Option<String> {
-    let canonical_path = path.canonicalize().ok()?;
-    let is_within_workspace = canonical_path.starts_with(canonical_workspace_root);
-    if !is_within_workspace {
-        return None;
-    }
+fn read_runtime_self_source(
+    workspace_root: &Path,
+    path: &Path,
+    tool_runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+) -> Option<String> {
+    let request_path = request_path_from_workspace_root(workspace_root, path)?;
+    let request = ToolCoreRequest {
+        tool_name: "file.read".to_owned(),
+        payload: json!({
+            "path": request_path,
+        }),
+    };
 
-    let content = std::fs::read_to_string(canonical_path).ok()?;
+    let outcome = tools::execute_tool_core_with_config(request, tool_runtime_config).ok()?;
+    let payload_content = outcome.payload.get("content")?;
+    let content = payload_content.as_str()?;
     let trimmed = content.trim();
     if trimmed.is_empty() {
         return None;
@@ -134,16 +154,18 @@ fn read_runtime_self_source(canonical_workspace_root: &Path, path: &Path) -> Opt
     Some(trimmed.to_owned())
 }
 
-fn canonical_workspace_root(workspace_root: &Path) -> Option<PathBuf> {
-    workspace_root.canonicalize().ok()
+fn request_path_from_workspace_root(workspace_root: &Path, path: &Path) -> Option<String> {
+    let relative_path = path.strip_prefix(workspace_root).ok()?;
+    let request_path = relative_path.to_string_lossy().to_string();
+    Some(request_path)
 }
 
-fn normalized_path_key(path: &Path) -> String {
+pub(crate) fn normalized_path_key(path: &Path) -> String {
     let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     canonical_path.display().to_string()
 }
 
-fn append_runtime_self_content(
+pub(crate) fn append_runtime_self_content(
     model: &mut RuntimeSelfModel,
     lane: RuntimeSelfLane,
     content: String,
@@ -259,39 +281,49 @@ mod tests {
         assert_eq!(rendered, None);
     }
 
+    #[test]
+    fn render_runtime_self_section_returns_none_for_identity_only_model() {
+        let model = RuntimeSelfModel {
+            identity_context: vec!["# Identity\n\n- Name: Workspace helper".to_owned()],
+            ..RuntimeSelfModel::default()
+        };
+
+        let rendered = render_runtime_self_section(&model);
+
+        assert_eq!(rendered, None);
+    }
+
     #[cfg(unix)]
     #[test]
     fn load_runtime_self_model_ignores_linked_agents_file_outside_workspace_root() {
-        let temp_dir = tempdir().expect("tempdir");
-        let sandbox_root = temp_dir.path();
-        let workspace_root = sandbox_root.join("workspace");
-        let outside_root = sandbox_root.join("outside");
-        let outside_agents_path = outside_root.join("AGENTS.md");
+        let workspace_dir = tempdir().expect("workspace tempdir");
+        let outside_dir = tempdir().expect("outside tempdir");
+        let workspace_root = workspace_dir.path();
+        let outside_agents_path = outside_dir.path().join("AGENTS.md");
         let linked_agents_path = workspace_root.join("AGENTS.md");
 
-        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
-        std::fs::create_dir_all(&outside_root).expect("create outside root");
         std::fs::write(&outside_agents_path, "outside standing instructions")
             .expect("write outside agents");
         create_symlink(&outside_agents_path, &linked_agents_path).expect("create agents symlink");
 
-        let model = load_runtime_self_model(workspace_root.as_path());
+        let model = load_runtime_self_model(workspace_root);
 
-        assert!(model.standing_instructions.is_empty());
+        assert!(
+            model.standing_instructions.is_empty(),
+            "linked file outside workspace root should be rejected"
+        );
     }
 
     #[cfg(unix)]
     #[test]
     fn load_runtime_self_model_ignores_linked_nested_workspace_outside_workspace_root() {
-        let temp_dir = tempdir().expect("tempdir");
-        let sandbox_root = temp_dir.path();
-        let workspace_root = sandbox_root.join("workspace");
+        let workspace_dir = tempdir().expect("workspace tempdir");
+        let outside_dir = tempdir().expect("outside tempdir");
+        let workspace_root = workspace_dir.path();
         let linked_nested_workspace_root = workspace_root.join("workspace");
-        let outside_root = sandbox_root.join("outside");
-        let outside_nested_workspace_root = outside_root.join("nested");
+        let outside_nested_workspace_root = outside_dir.path().join("nested");
         let outside_agents_path = outside_nested_workspace_root.join("AGENTS.md");
 
-        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
         std::fs::create_dir_all(&outside_nested_workspace_root)
             .expect("create outside nested workspace");
         std::fs::write(&outside_agents_path, "outside nested standing instructions")
@@ -302,8 +334,11 @@ mod tests {
         )
         .expect("create nested workspace symlink");
 
-        let model = load_runtime_self_model(workspace_root.as_path());
+        let model = load_runtime_self_model(workspace_root);
 
-        assert!(model.standing_instructions.is_empty());
+        assert!(
+            model.standing_instructions.is_empty(),
+            "linked nested workspace outside workspace root should be rejected"
+        );
     }
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -7291,6 +7291,9 @@ mod tests {
 
     #[test]
     fn provider_credential_check_adds_volcengine_auth_guidance_when_missing() {
+        let mut env = mvp::test_support::ScopedEnv::new();
+        env.remove("ARK_API_KEY");
+
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::VolcengineCoding;
         config.provider.api_key = None;

--- a/docs/product-specs/memory-profiles.md
+++ b/docs/product-specs/memory-profiles.md
@@ -15,7 +15,10 @@ how continuity is preserved without manually wiring different memory systems.
 - [ ] `window_plus_summary` injects condensed earlier session context before the
       recent sliding window.
 - [ ] `profile_plus_window` can inject a durable `profile_note` block for
-      imported identity, preferences, or tuning.
+      preferences, tuning, or advisory imported context.
+- [ ] Legacy imported identity can still be recovered from `profile_note`, but
+      it is resolved into a separate runtime identity lane rather than being
+      projected back into the session profile block.
 - [ ] Non-interactive onboarding supports selecting a memory profile.
 
 ## Out of Scope

--- a/docs/product-specs/prompt-and-personality.md
+++ b/docs/product-specs/prompt-and-personality.md
@@ -15,6 +15,9 @@ system prompt.
 - [ ] All personalities share the same safety-first operating boundaries.
 - [ ] Personality selection can affect tone and action style without weakening
       security requirements.
+- [ ] Runtime identity overlays are resolved separately from the native base
+      prompt so workspace `IDENTITY.md` context can take precedence over legacy
+      imported identity without replacing LoongClaw's product-owned baseline.
 - [ ] Non-interactive onboarding supports personality selection with a stable
       CLI flag.
 - [ ] Advanced users can still provide a full inline system prompt override.

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-24T04:21:38Z
+- Generated at: 2026-03-24T06:04:30Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -14,7 +14,7 @@
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 379 | 1000 | 621 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 308 | 650 | 342 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 323 | 650 | 327 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -42,7 +42,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=379 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=308 functions=15 -->
+<!-- arch-hotspot key=memory_mod lines=323 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-23T06:55:35Z
+- Generated at: 2026-03-24T04:21:38Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -13,8 +13,8 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
-| provider_mod | `crates/app/src/provider/mod.rs` | 373 | 1000 | 627 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 327 | 650 | 323 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| provider_mod | `crates/app/src/provider/mod.rs` | 379 | 1000 | 621 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 308 | 650 | 342 | 15 | 16 | 1 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -41,8 +41,8 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
-<!-- arch-hotspot key=provider_mod lines=373 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=327 functions=14 -->
+<!-- arch-hotspot key=provider_mod lines=379 functions=10 -->
+<!-- arch-hotspot key=memory_mod lines=308 functions=15 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: LoongClaw still treated imported or workspace identity as prompt-adjacent memory-shaped text, so downstream runtime surfaces had to depend on `profile_note` or raw files instead of one resolved identity surface.
- Why it matters: that kept soul / identity / memory concerns structurally mixed, made migrated `IDENTITY.md` content look like legacy baggage, and blocked a cleaner runtime self model for future continuity work.
- What changed: loaded workspace self sources (`AGENTS.md`, `CLAUDE.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`) into explicit self-model lanes, resolved runtime identity through one precedence path, rendered identity separately from session-profile memory, and updated prompt/memory projections plus docs/tests to match the new boundary.
- What did not change (scope boundary): this does not implement durable recall, semantic retrieval, or a new editable persona UI; it only establishes runtime self loading and resolved identity separation.

## Linked Issues

- Closes #441
- Closes #444
- Related #440

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this changes prompt/context assembly precedence by letting workspace self sources and resolved runtime identity participate directly in system-message construction and memory profile projection.
- Rollout / guardrails: the change is additive and covered by precedence tests, profile-projection tests, and full `loongclaw-app` library tests.
- Rollback path: revert commits `04e39ddf` and `e3c3b91e` to restore the previous `profile_note`-centric behavior.

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-app runtime_identity -- --nocapture
- passed

cargo test -p loongclaw-app runtime_self -- --nocapture
- passed

cargo test -p loongclaw-app provider::request_message_runtime::tests::build_system_message_includes_normalized_runtime_self_sections_from_workspace_root -- --exact --nocapture
- passed

cargo test -p loongclaw-app memory::tests::load_prompt_context_with_diagnostics_omits_legacy_identity_from_profile_projection -- --exact --nocapture
- passed

cargo fmt --all --check
- passed

cargo test -p loongclaw-app --lib
- passed (1805 passed, 0 failed)

cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
- passed
```

Before/after behavior and regression coverage:
- Before: workspace `IDENTITY.md` and imported identity mostly survived through `profile_note` or raw prompt-adjacent text, so runtime identity and memory-shaped context stayed mixed.
- After: workspace self files are loaded into explicit runtime-self lanes, resolved identity is rendered separately, and the session profile block keeps advisory memory-shaped context without re-projecting legacy imported identity.
- Precedence covered: workspace identity wins over legacy imported identity from `profile_note`.
- Boundary covered: plain advisory `profile_note` content still appears in the session profile block, while legacy identity-only profile notes no longer pollute profile projection.

## User-visible / Operator-visible Changes

- Workspace self files now influence runtime prompt assembly directly through explicit sections.
- `IDENTITY.md` is treated as resolved runtime identity instead of being routed primarily through `profile_note`.
- `profile_plus_window` memory projection keeps advisory session profile material without echoing legacy imported identity back into the profile block.

## Failure Recovery

- Fast rollback or disable path: revert commits `04e39ddf` and `e3c3b91e`.
- Observable failure symptoms reviewers should watch for: duplicated identity text in system prompts, missing advisory profile-note projection, or incorrect precedence where legacy imported identity overrides workspace identity.

## Reviewer Focus

- Review `crates/app/src/runtime_self.rs` for source discovery, lane normalization, and render boundaries.
- Review `crates/app/src/runtime_identity.rs` for precedence rules and `profile_note` partitioning.
- Review `crates/app/src/provider/request_message_runtime.rs` and `crates/app/src/memory/context.rs` for prompt/profile projection behavior after the new runtime identity lane was introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace identity files now take precedence over legacy imported identity information
  * Memory profiles now independently render session advisory content separate from identity context
  * Enhanced runtime context configuration for personalization and profile management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->