### PR TITLE
ci: restore effective dev-to-main enforcement on main

### DIFF
--- a/.github/workflows/enforce-dev-to-main.yml
+++ b/.github/workflows/enforce-dev-to-main.yml
@@ -1,0 +1,47 @@
+name: enforce-dev-to-main
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  block-non-dev-source:
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.head.ref != 'dev' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Close PR when source branch is not dev
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = [
+              "Only the same-repository `dev` branch can merge into `main` in this repository.",
+              "",
+              `Current source branch: \`${pr.head.repo.full_name}:${pr.head.ref}\``,
+              "Please land your changes on `dev` first, then open the promotion PR from `dev` to `main`."
+            ].join("\\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: "closed"
+            });
+            core.setFailed("Blocked: only dev can merge into main.");


### PR DESCRIPTION
## Summary

- Problem: `main` is missing the workflow that enforces same-repository `dev -> main` promotion pull requests, so the intended source-branch gate does not run.
- Why it matters: repository rules and classic branch protection do not express "head branch must equal dev" by themselves, so the policy is currently unenforced.
- What changed: this PR adds `.github/workflows/enforce-dev-to-main.yml` to the `main` track so pull requests targeting `main` will actually execute the guard.
- What did not change (scope boundary): no review-count changes, no merge-method changes, no extra release logic, and no changes to `dev` or `web` protections.

## Linked Issues

- Closes #453
- Related #345

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
gh api 'repos/loongclaw-ai/loongclaw/contents/.github/workflows/enforce-dev-to-main.yml?ref=main'
# -> 404 Not Found before this PR

gh api 'repos/loongclaw-ai/loongclaw/branches/main/protection' --jq '{required_approving_review_count: .required_pull_request_reviews.required_approving_review_count, restrict_push_users: [.restrictions.users[].login], require_last_push_approval: .required_pull_request_reviews.require_last_push_approval, conversation_resolution: .required_conversation_resolution.enabled, linear_history: .required_linear_history.enabled, enforce_admins: .enforce_admins.enabled}'
# -> main is PR-only and cannot be fixed by direct write

gh api 'repos/loongclaw-ai/loongclaw/compare/main...chumyin:fix/restore-main-dev-promotion-guard-20260323' --jq '{status: .status, ahead_by: .ahead_by, files: [.files[].filename]}'
# -> {"status":"ahead","ahead_by":1,"files":[".github/workflows/enforce-dev-to-main.yml"]}
```

## User-visible / Operator-visible Changes

- Promotion pull requests into `main` will again be limited to the same-repository `dev` branch once this lands.

## Failure Recovery

- Fast rollback or disable path: revert `.github/workflows/enforce-dev-to-main.yml` from `main` in a follow-up PR.
- Observable failure symptoms reviewers should watch for: legitimate `dev -> main` promotion PRs must remain allowed; only non-`dev` sources should be commented on and closed.

## Reviewer Focus

- Confirm the workflow is intentionally restored on `main` rather than changed on `dev`.
- Confirm the blocking condition remains exactly `same repository + head ref == dev`.
