### PR TITLE
feat(app): preserve runtime self continuity across compaction and delegation

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -661,6 +661,10 @@ fn format_prompt_context_history_lines(entries: &[memory::MemoryContextEntry]) -
                 lines.push("[summary]".to_owned());
                 lines.push(entry.content.clone());
             }
+            memory::MemoryContextKind::RetrievedMemory => {
+                lines.push("[retrieved_memory]".to_owned());
+                lines.push(entry.content.clone());
+            }
             memory::MemoryContextKind::Turn => {
                 lines.push(format!("{}: {}", entry.role, entry.content));
             }

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -544,7 +544,9 @@ fn append_memory_context_messages(
         let content = entry.content;
 
         match entry.kind {
-            memory::MemoryContextKind::Profile | memory::MemoryContextKind::Summary => {
+            memory::MemoryContextKind::Profile
+            | memory::MemoryContextKind::Summary
+            | memory::MemoryContextKind::RetrievedMemory => {
                 let message = json!({
                     "role": role,
                     "content": content,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 
 use crate::CliResult;
 use crate::KernelContext;
+use crate::runtime_self_continuity::{self, RuntimeSelfContinuity};
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
 use crate::tools::{
     ToolView, delegate_child_tool_view_for_config,
@@ -47,6 +48,7 @@ pub struct SessionContext {
     pub parent_session_id: Option<String>,
     pub tool_view: ToolView,
     pub runtime_narrowing: Option<ToolRuntimeNarrowing>,
+    pub(crate) runtime_self_continuity: Option<RuntimeSelfContinuity>,
 }
 
 impl SessionContext {
@@ -56,6 +58,7 @@ impl SessionContext {
             parent_session_id: None,
             tool_view,
             runtime_narrowing: None,
+            runtime_self_continuity: None,
         }
     }
 
@@ -69,6 +72,7 @@ impl SessionContext {
             parent_session_id: Some(normalize_session_id(parent_session_id.into())),
             tool_view,
             runtime_narrowing: None,
+            runtime_self_continuity: None,
         }
     }
 
@@ -76,6 +80,17 @@ impl SessionContext {
     pub fn with_runtime_narrowing(mut self, runtime_narrowing: ToolRuntimeNarrowing) -> Self {
         if !runtime_narrowing.is_empty() {
             self.runtime_narrowing = Some(runtime_narrowing);
+        }
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_runtime_self_continuity(
+        mut self,
+        runtime_self_continuity: RuntimeSelfContinuity,
+    ) -> Self {
+        if !runtime_self_continuity.is_empty() {
+            self.runtime_self_continuity = Some(runtime_self_continuity);
         }
         self
     }
@@ -111,6 +126,39 @@ fn load_delegate_runtime_narrowing(
     }))
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn load_delegate_runtime_self_continuity(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<RuntimeSelfContinuity>, String> {
+    let events = repo.list_delegate_lifecycle_events(session_id)?;
+    let continuity = events.into_iter().rev().find_map(|event| {
+        runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
+    });
+    Ok(continuity)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_session_runtime_self_continuity(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<RuntimeSelfContinuity>, String> {
+    let recent_events = repo.list_recent_events(session_id, 64)?;
+    let continuity = recent_events.into_iter().rev().find_map(|event| {
+        let is_continuity_event =
+            event.event_kind == runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND;
+        if !is_continuity_event {
+            return None;
+        }
+        runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
+    });
+    if continuity.is_some() {
+        return Ok(continuity);
+    }
+
+    load_delegate_runtime_self_continuity(repo, session_id)
+}
+
 #[derive(Clone)]
 pub struct AsyncDelegateSpawnRequest {
     pub child_session_id: String,
@@ -118,6 +166,7 @@ pub struct AsyncDelegateSpawnRequest {
     pub task: String,
     pub label: Option<String>,
     pub execution: ConstrainedSubagentExecution,
+    pub(crate) runtime_self_continuity: Option<RuntimeSelfContinuity>,
     pub timeout_seconds: u64,
     pub kernel_context: Option<KernelContext>,
 }
@@ -176,7 +225,11 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
                         actor_session_id: Some(request.parent_session_id.clone()),
                         event_payload_json: request
                             .execution
-                            .spawn_payload(&request.task, request.label.as_deref()),
+                            .spawn_payload_with_runtime_self_continuity(
+                                &request.task,
+                                request.label.as_deref(),
+                                request.runtime_self_continuity.as_ref(),
+                            ),
                     },
                 )?;
                 if started.is_none() {
@@ -420,9 +473,16 @@ where
                 binding,
             )
             .await?;
+        let runtime_self_continuity = include_system_prompt
+            .then(|| runtime_self_continuity_prompt_summary(config, session_context))
+            .flatten();
         let delegate_runtime_contract = include_system_prompt
             .then(|| delegate_child_runtime_contract_prompt_summary(config, session_context))
             .flatten();
+        assembled.system_prompt_addition = merge_system_prompt_additions(
+            assembled.system_prompt_addition.as_deref(),
+            runtime_self_continuity.as_deref(),
+        );
         assembled.system_prompt_addition = merge_system_prompt_additions(
             assembled.system_prompt_addition.as_deref(),
             delegate_runtime_contract.as_deref(),
@@ -762,25 +822,63 @@ where
                 {
                     if let Some(parent_session_id) = session.parent_session_id {
                         let runtime_narrowing = load_delegate_runtime_narrowing(&repo, session_id)?;
-                        return Ok(SessionContext::child(
-                            session.session_id,
-                            parent_session_id,
-                            tool_view,
-                        )
-                        .with_runtime_narrowing(runtime_narrowing.unwrap_or_default()));
+                        let runtime_self_continuity =
+                            load_session_runtime_self_continuity(&repo, session_id)?;
+                        let session_context =
+                            SessionContext::child(session.session_id, parent_session_id, tool_view)
+                                .with_runtime_narrowing(runtime_narrowing.unwrap_or_default());
+                        let session_context = match runtime_self_continuity {
+                            Some(runtime_self_continuity) => session_context
+                                .with_runtime_self_continuity(runtime_self_continuity),
+                            None => session_context,
+                        };
+                        return Ok(session_context);
                     }
+
+                    let runtime_self_continuity =
+                        load_session_runtime_self_continuity(&repo, session_id)?;
+                    let session_context =
+                        SessionContext::root_with_tool_view(session.session_id, tool_view);
+                    let session_context = match runtime_self_continuity {
+                        Some(runtime_self_continuity) => {
+                            session_context.with_runtime_self_continuity(runtime_self_continuity)
+                        }
+                        None => session_context,
+                    };
+                    return Ok(session_context);
                 } else if let Some(summary) = repo
                     .load_session_summary_with_legacy_fallback(session_id)
                     .map_err(|error| format!("load legacy session context failed: {error}"))?
                     && let Some(parent_session_id) = summary.parent_session_id
                 {
                     let runtime_narrowing = load_delegate_runtime_narrowing(&repo, session_id)?;
-                    return Ok(SessionContext::child(
-                        summary.session_id,
-                        parent_session_id,
-                        tool_view,
-                    )
-                    .with_runtime_narrowing(runtime_narrowing.unwrap_or_default()));
+                    let runtime_self_continuity =
+                        load_session_runtime_self_continuity(&repo, session_id)?;
+                    let session_context =
+                        SessionContext::child(summary.session_id, parent_session_id, tool_view)
+                            .with_runtime_narrowing(runtime_narrowing.unwrap_or_default());
+                    let session_context = match runtime_self_continuity {
+                        Some(runtime_self_continuity) => {
+                            session_context.with_runtime_self_continuity(runtime_self_continuity)
+                        }
+                        None => session_context,
+                    };
+                    return Ok(session_context);
+                } else if let Some(summary) = repo
+                    .load_session_summary_with_legacy_fallback(session_id)
+                    .map_err(|error| format!("load legacy session context failed: {error}"))?
+                {
+                    let runtime_self_continuity =
+                        load_session_runtime_self_continuity(&repo, session_id)?;
+                    let session_context =
+                        SessionContext::root_with_tool_view(summary.session_id, tool_view);
+                    let session_context = match runtime_self_continuity {
+                        Some(runtime_self_continuity) => {
+                            session_context.with_runtime_self_continuity(runtime_self_continuity)
+                        }
+                        None => session_context,
+                    };
+                    return Ok(session_context);
                 }
             }
         }
@@ -1093,6 +1191,21 @@ fn delegate_child_runtime_contract_prompt_summary(
     let runtime_narrowing = session_context.runtime_narrowing.as_ref()?;
     crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None)
         .delegate_child_prompt_summary(runtime_narrowing)
+}
+
+fn runtime_self_continuity_prompt_summary(
+    config: &LoongClawConfig,
+    session_context: &SessionContext,
+) -> Option<String> {
+    let stored_continuity = session_context.runtime_self_continuity.as_ref()?;
+    let live_continuity =
+        runtime_self_continuity::resolve_runtime_self_continuity_for_config(config);
+    let missing_continuity = runtime_self_continuity::missing_runtime_self_continuity(
+        stored_continuity,
+        live_continuity.as_ref(),
+    )?;
+    let inherited = session_context.parent_session_id.is_some();
+    runtime_self_continuity::render_runtime_self_continuity_section(&missing_continuity, inherited)
 }
 
 fn merge_system_prompt_additions(existing: Option<&str>, extra: Option<&str>) -> Option<String> {

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -127,36 +127,11 @@ fn load_delegate_runtime_narrowing(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn load_delegate_runtime_self_continuity(
-    repo: &SessionRepository,
-    session_id: &str,
-) -> Result<Option<RuntimeSelfContinuity>, String> {
-    let events = repo.list_delegate_lifecycle_events(session_id)?;
-    let continuity = events.into_iter().rev().find_map(|event| {
-        runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
-    });
-    Ok(continuity)
-}
-
-#[cfg(feature = "memory-sqlite")]
 fn load_session_runtime_self_continuity(
     repo: &SessionRepository,
     session_id: &str,
 ) -> Result<Option<RuntimeSelfContinuity>, String> {
-    let recent_events = repo.list_recent_events(session_id, 64)?;
-    let continuity = recent_events.into_iter().rev().find_map(|event| {
-        let is_continuity_event =
-            event.event_kind == runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND;
-        if !is_continuity_event {
-            return None;
-        }
-        runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
-    });
-    if continuity.is_some() {
-        return Ok(continuity);
-    }
-
-    load_delegate_runtime_self_continuity(repo, session_id)
+    runtime_self_continuity::load_persisted_runtime_self_continuity(repo, session_id)
 }
 
 #[derive(Clone)]

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use crate::runtime_self_continuity::RuntimeSelfContinuity;
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -40,6 +41,8 @@ pub struct ConstrainedSubagentSpawnEventPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub execution: ConstrainedSubagentExecution,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_self_continuity: Option<RuntimeSelfContinuity>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -55,10 +58,20 @@ pub struct ConstrainedSubagentTerminalEventPayload {
 
 impl ConstrainedSubagentExecution {
     pub fn spawn_payload(&self, task: &str, label: Option<&str>) -> Value {
+        self.spawn_payload_with_runtime_self_continuity(task, label, None)
+    }
+
+    pub(crate) fn spawn_payload_with_runtime_self_continuity(
+        &self,
+        task: &str,
+        label: Option<&str>,
+        runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    ) -> Value {
         json!(ConstrainedSubagentSpawnEventPayload {
             task: task.to_owned(),
             label: label.map(ToOwned::to_owned),
             execution: self.clone(),
+            runtime_self_continuity: runtime_self_continuity.cloned(),
         })
     }
 
@@ -87,6 +100,9 @@ impl ConstrainedSubagentExecution {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime_identity::{ResolvedRuntimeIdentity, RuntimeIdentitySource};
+    use crate::runtime_self::RuntimeSelfModel;
+    use crate::runtime_self_continuity::RuntimeSelfContinuity;
 
     #[test]
     fn constrained_subagent_execution_round_trips_event_payload() {
@@ -111,6 +127,52 @@ mod tests {
         assert_eq!(
             ConstrainedSubagentExecution::from_event_payload(&payload),
             Some(execution)
+        );
+    }
+
+    #[test]
+    fn constrained_subagent_execution_preserves_runtime_self_continuity_in_spawn_payload() {
+        let execution = ConstrainedSubagentExecution {
+            mode: ConstrainedSubagentMode::Inline,
+            depth: 1,
+            max_depth: 2,
+            active_children: 0,
+            max_active_children: 2,
+            timeout_seconds: 30,
+            allow_shell_in_child: false,
+            child_tool_allowlist: vec!["web.fetch".to_owned()],
+            runtime_narrowing: ToolRuntimeNarrowing::default(),
+            kernel_bound: false,
+        };
+        let continuity = RuntimeSelfContinuity {
+            runtime_self: RuntimeSelfModel {
+                standing_instructions: vec!["Keep continuity explicit.".to_owned()],
+                soul_guidance: vec!["Prefer rigorous execution.".to_owned()],
+                identity_context: vec!["# Identity\n- Name: Child".to_owned()],
+                user_context: vec!["User prefers concise output.".to_owned()],
+            },
+            resolved_identity: Some(ResolvedRuntimeIdentity {
+                source: RuntimeIdentitySource::WorkspaceSelf,
+                content: "# Identity\n- Name: Child".to_owned(),
+            }),
+            session_profile_projection: Some(
+                "## Session Profile\nDurable preferences and advisory session context carried into this session:\nUser prefers concise output.".to_owned(),
+            ),
+        };
+
+        let payload = execution.spawn_payload_with_runtime_self_continuity(
+            "research",
+            Some("child"),
+            Some(&continuity),
+        );
+
+        assert_eq!(
+            payload["runtime_self_continuity"]["resolved_identity"]["content"],
+            continuity
+                .resolved_identity
+                .as_ref()
+                .expect("resolved identity")
+                .content
         );
     }
 }

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -147,6 +147,7 @@ mod tests {
         let continuity = RuntimeSelfContinuity {
             runtime_self: RuntimeSelfModel {
                 standing_instructions: vec!["Keep continuity explicit.".to_owned()],
+                tool_usage_policy: vec!["Search memory before guessing workspace facts.".to_owned()],
                 soul_guidance: vec!["Prefer rigorous execution.".to_owned()],
                 identity_context: vec!["# Identity\n- Name: Child".to_owned()],
                 user_context: vec!["User prefers concise output.".to_owned()],
@@ -173,6 +174,10 @@ mod tests {
                 .as_ref()
                 .expect("resolved identity")
                 .content
+        );
+        assert_eq!(
+            payload["runtime_self_continuity"]["runtime_self"]["tool_usage_policy"][0],
+            "Search memory before guessing workspace facts."
         );
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1410,6 +1410,30 @@ fn test_kernel_context(agent_id: &str) -> KernelContext {
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn collect_markdown_file_paths(root: &std::path::Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if !root.exists() {
+        return paths;
+    }
+
+    let read_dir = std::fs::read_dir(root).expect("read markdown directory");
+    for entry_result in read_dir {
+        let entry = entry_result.expect("read markdown entry");
+        let path = entry.path();
+        let extension = path.extension().and_then(|value| value.to_str());
+        let is_markdown = extension.is_some_and(|value| value.eq_ignore_ascii_case("md"));
+        if !is_markdown {
+            continue;
+        }
+        paths.push(path);
+    }
+
+    paths.sort();
+    paths
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn test_kernel_context_with_memory(
     agent_id: &str,
     memory_config: &MemoryRuntimeConfig,
@@ -4558,6 +4582,105 @@ async fn handle_turn_with_runtime_compacts_when_token_threshold_reached() {
     let compact = runtime.compact_calls.lock().expect("compact lock").clone();
     assert_eq!(compact.len(), 1);
     assert_eq!(compact[0].0, "session-compact-token-threshold");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_flushes_durable_memory_before_compaction() {
+    let workspace_root = crate::test_support::unique_temp_dir("pre-compaction-durable-flush");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+
+    let db_path = workspace_root.join("memory.sqlite3");
+    let mut config = test_config();
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 1;
+    config.conversation.compact_min_messages = Some(999);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("assistant-reply".to_owned()),
+    )
+    .with_durable_memory_config(memory_config.clone());
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context_with_memory("test-pre-compaction-flush", &memory_config);
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-pre-compaction-flush",
+            "hello before compaction",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+
+    let compact = runtime.compact_calls.lock().expect("compact lock").clone();
+    assert_eq!(compact.len(), 1);
+
+    let memory_dir = workspace_root.join("memory");
+    let exported_paths = collect_markdown_file_paths(&memory_dir);
+    assert_eq!(
+        exported_paths.len(),
+        1,
+        "expected one durable memory export"
+    );
+
+    let exported = std::fs::read_to_string(&exported_paths[0]).expect("read durable memory export");
+    assert!(exported.contains("Advisory durable recall"));
+    assert!(exported.contains("Resolved Runtime Identity"));
+    assert!(exported.contains("hello before compaction"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_does_not_flush_durable_memory_when_compaction_is_skipped() {
+    let workspace_root = crate::test_support::unique_temp_dir("pre-compaction-durable-skip");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+
+    let db_path = workspace_root.join("memory.sqlite3");
+    let mut config = test_config();
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.memory.sliding_window = 1;
+    config.conversation.compact_enabled = false;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("assistant-reply".to_owned()),
+    )
+    .with_durable_memory_config(memory_config.clone());
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx =
+        test_kernel_context_with_memory("test-pre-compaction-flush-skipped", &memory_config);
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-pre-compaction-flush-skipped",
+            "hello without compaction",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "assistant-reply");
+
+    let memory_dir = workspace_root.join("memory");
+    let exported_paths = collect_markdown_file_paths(&memory_dir);
+    assert!(
+        exported_paths.is_empty(),
+        "compaction skip should not create durable exports"
+    );
 }
 
 #[tokio::test]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2474,10 +2474,14 @@ async fn default_runtime_build_context_rehydrates_runtime_self_continuity_when_l
     let runtime = DefaultConversationRuntime::default();
     let session_id = unique_acp_test_id("default-runtime-context", "stored-self-fallback");
     let sqlite_path = unique_memory_sqlite_path("stored-self-fallback");
+    let empty_workspace_root =
+        crate::test_support::unique_temp_dir("stored-self-fallback-empty-workspace");
     let mut config = test_config();
     let identity_text = "# Identity\n\n- Name: Stored continuity identity";
 
+    std::fs::create_dir_all(&empty_workspace_root).expect("create empty workspace root");
     config.memory.sqlite_path = sqlite_path.clone();
+    config.tools.file_root = Some(empty_workspace_root.display().to_string());
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
@@ -2535,10 +2539,14 @@ async fn default_runtime_build_context_rehydrates_delegate_child_runtime_self_co
     let root_session_id = unique_acp_test_id("default-runtime-context", "delegate-parent");
     let child_session_id = unique_acp_test_id("default-runtime-context", "delegate-child");
     let sqlite_path = unique_memory_sqlite_path("delegate-self-fallback");
+    let empty_workspace_root =
+        crate::test_support::unique_temp_dir("delegate-self-fallback-empty-workspace");
     let mut config = test_config();
     let identity_text = "# Identity\n\n- Name: Inherited child identity";
 
+    std::fs::create_dir_all(&empty_workspace_root).expect("create empty workspace root");
     config.memory.sqlite_path = sqlite_path.clone();
+    config.tools.file_root = Some(empty_workspace_root.display().to_string());
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
@@ -2766,11 +2774,8 @@ async fn handle_turn_with_runtime_records_runtime_self_continuity_before_compact
     let session_id_for_hook = session_id.clone();
     let memory_config_for_hook = memory_config.clone();
     let compact_hook: CompactHook = Arc::new(move |hook_session_id, _messages| {
-        let hook_repo =
-            SessionRepository::new(&memory_config_for_hook).map_err(|error| error.to_string())?;
-        let events = hook_repo
-            .list_recent_events(&session_id_for_hook, 20)
-            .map_err(|error| error.to_string())?;
+        let hook_repo = SessionRepository::new(&memory_config_for_hook)?;
+        let events = hook_repo.list_recent_events(&session_id_for_hook, 20)?;
         let continuity_event = events
             .iter()
             .find(|event| event.event_kind == "runtime_self_continuity_refreshed");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1555,6 +1555,9 @@ fn runtime_self_continuity_fixture(identity_text: &str) -> Value {
             "standing_instructions": [
                 "Keep continuity explicit."
             ],
+            "tool_usage_policy": [
+                "Search durable workspace memory before guessing project facts."
+            ],
             "soul_guidance": [
                 "Prefer rigorous execution."
             ],
@@ -1582,15 +1585,18 @@ fn create_runtime_self_workspace(suffix: &str, identity_text: &str) -> PathBuf {
     std::fs::create_dir_all(&workspace_root).expect("create runtime self workspace");
 
     let agents_path = workspace_root.join("AGENTS.md");
+    let tools_path = workspace_root.join("TOOLS.md");
     let soul_path = workspace_root.join("SOUL.md");
     let identity_path = workspace_root.join("IDENTITY.md");
     let user_path = workspace_root.join("USER.md");
 
     let agents_text = "Keep continuity explicit.";
+    let tools_text = "Search durable workspace memory before guessing project facts.";
     let soul_text = "Prefer rigorous execution.";
     let user_text = "The operator prefers concise technical summaries.";
 
     std::fs::write(&agents_path, agents_text).expect("write AGENTS");
+    std::fs::write(&tools_path, tools_text).expect("write TOOLS");
     std::fs::write(&soul_path, soul_text).expect("write SOUL");
     std::fs::write(&identity_path, identity_text).expect("write IDENTITY");
     std::fs::write(&user_path, user_text).expect("write USER");
@@ -2495,6 +2501,10 @@ async fn default_runtime_build_context_rehydrates_runtime_self_continuity_when_l
         system_content.contains("Keep continuity explicit."),
         "expected stored standing instructions in system prompt, got: {system_content}"
     );
+    assert!(
+        system_content.contains("Search durable workspace memory before guessing project facts."),
+        "expected stored tool usage policy in system prompt, got: {system_content}"
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -2547,6 +2557,10 @@ async fn default_runtime_build_context_rehydrates_delegate_child_runtime_self_co
     assert!(
         system_content.contains("Inherited child identity"),
         "expected inherited identity in child system prompt, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("Search durable workspace memory before guessing project facts."),
+        "expected inherited tool usage policy in child system prompt, got: {system_content}"
     );
 }
 
@@ -2704,6 +2718,10 @@ async fn handle_turn_with_runtime_records_runtime_self_continuity_before_compact
     assert!(
         payload_text.contains("Workspace continuity identity"),
         "expected workspace identity in continuity payload, got: {payload_text}"
+    );
+    assert!(
+        payload_text.contains("Search durable workspace memory before guessing project facts."),
+        "expected tool usage policy in continuity payload, got: {payload_text}"
     );
     assert!(
         !payload_text.contains("Temporary Bob"),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -32,7 +32,9 @@ use crate::memory::MEMORY_OP_WINDOW;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::session::repository::{NewSessionRecord, SessionKind, SessionRepository, SessionState};
+use crate::session::repository::{
+    NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+};
 
 struct FakeRuntime {
     seed_messages: Vec<Value>,
@@ -1522,6 +1524,120 @@ fn seed_delegate_child_session_with_runtime_narrowing(
     child_session_id
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn runtime_self_continuity_fixture(identity_text: &str) -> Value {
+    let continuity = json!({
+        "runtime_self": {
+            "standing_instructions": [
+                "Keep continuity explicit."
+            ],
+            "soul_guidance": [
+                "Prefer rigorous execution."
+            ],
+            "identity_context": [
+                identity_text
+            ],
+            "user_context": [
+                "The operator prefers concise technical summaries."
+            ]
+        },
+        "resolved_identity": {
+            "source": "workspace_self",
+            "content": identity_text
+        },
+        "session_profile_projection": "## Session Profile\nDurable preferences and advisory session context carried into this session:\nOperator prefers concise technical summaries."
+    });
+    continuity
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn create_runtime_self_workspace(suffix: &str, identity_text: &str) -> PathBuf {
+    let directory_name = unique_acp_test_id("conversation-runtime-self-workspace", suffix);
+    let workspace_root = std::env::temp_dir().join(directory_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create runtime self workspace");
+
+    let agents_path = workspace_root.join("AGENTS.md");
+    let soul_path = workspace_root.join("SOUL.md");
+    let identity_path = workspace_root.join("IDENTITY.md");
+    let user_path = workspace_root.join("USER.md");
+
+    let agents_text = "Keep continuity explicit.";
+    let soul_text = "Prefer rigorous execution.";
+    let user_text = "The operator prefers concise technical summaries.";
+
+    std::fs::write(&agents_path, agents_text).expect("write AGENTS");
+    std::fs::write(&soul_path, soul_text).expect("write SOUL");
+    std::fs::write(&identity_path, identity_text).expect("write IDENTITY");
+    std::fs::write(&user_path, user_text).expect("write USER");
+
+    workspace_root
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn create_root_session_record(session_id: &str) -> NewSessionRecord {
+    NewSessionRecord {
+        session_id: session_id.to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: SessionState::Ready,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn create_child_session_record(session_id: &str, parent_session_id: &str) -> NewSessionRecord {
+    NewSessionRecord {
+        session_id: session_id.to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some(parent_session_id.to_owned()),
+        label: Some("Child".to_owned()),
+        state: SessionState::Running,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn append_runtime_self_continuity_refresh_event(
+    repo: &SessionRepository,
+    session_id: &str,
+    identity_text: &str,
+) {
+    let payload = json!({
+        "source": "compaction",
+        "runtime_self_continuity": runtime_self_continuity_fixture(identity_text),
+    });
+    let event = NewSessionEvent {
+        session_id: session_id.to_owned(),
+        event_kind: "runtime_self_continuity_refreshed".to_owned(),
+        actor_session_id: Some(session_id.to_owned()),
+        payload_json: payload,
+    };
+    repo.append_event(event)
+        .expect("append runtime self continuity refresh event");
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn append_delegate_started_event_with_runtime_self_continuity(
+    repo: &SessionRepository,
+    child_session_id: &str,
+    parent_session_id: &str,
+    identity_text: &str,
+) {
+    let payload = json!({
+        "task": "research continuity",
+        "label": "Child",
+        "runtime_self_continuity": runtime_self_continuity_fixture(identity_text),
+    });
+    let event = NewSessionEvent {
+        session_id: child_session_id.to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        payload_json: payload,
+    };
+    repo.append_event(event)
+        .expect("append delegate_started event");
+}
+
 fn provider_tool_intent(
     tool_name: &str,
     args_json: Value,
@@ -2311,6 +2427,159 @@ async fn default_runtime_build_context_matches_builtin_summary_projection() {
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn default_runtime_build_context_rehydrates_runtime_self_continuity_when_live_sources_are_missing()
+ {
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-context", "stored-self-fallback");
+    let sqlite_path = unique_memory_sqlite_path("stored-self-fallback");
+    let mut config = test_config();
+    let identity_text = "# Identity\n\n- Name: Stored continuity identity";
+
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let root_session = create_root_session_record(&session_id);
+
+    repo.create_session(root_session)
+        .expect("create root session");
+    append_runtime_self_continuity_refresh_event(&repo, &session_id, identity_text);
+
+    let assembled = runtime
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("build context from stored continuity");
+
+    let system_content = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should be text");
+
+    assert!(
+        system_content.contains("[runtime_self_continuity]"),
+        "expected stored continuity marker in system prompt, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("Stored continuity identity"),
+        "expected stored identity in system prompt, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("Keep continuity explicit."),
+        "expected stored standing instructions in system prompt, got: {system_content}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_rehydrates_delegate_child_runtime_self_continuity_when_live_sources_are_missing()
+ {
+    let runtime = DefaultConversationRuntime::default();
+    let root_session_id = unique_acp_test_id("default-runtime-context", "delegate-parent");
+    let child_session_id = unique_acp_test_id("default-runtime-context", "delegate-child");
+    let sqlite_path = unique_memory_sqlite_path("delegate-self-fallback");
+    let mut config = test_config();
+    let identity_text = "# Identity\n\n- Name: Inherited child identity";
+
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let root_session = create_root_session_record(&root_session_id);
+    let child_session = create_child_session_record(&child_session_id, &root_session_id);
+
+    repo.create_session(root_session)
+        .expect("create root session");
+    repo.create_session(child_session)
+        .expect("create child session");
+    append_delegate_started_event_with_runtime_self_continuity(
+        &repo,
+        &child_session_id,
+        &root_session_id,
+        identity_text,
+    );
+
+    let assembled = runtime
+        .build_context(
+            &config,
+            &child_session_id,
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("build child context from inherited continuity");
+
+    let system_content = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should be text");
+
+    assert!(
+        system_content.contains("[runtime_self_continuity]"),
+        "expected inherited continuity marker in child system prompt, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("Inherited child identity"),
+        "expected inherited identity in child system prompt, got: {system_content}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_prefers_live_identity_over_stored_runtime_self_continuity() {
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-context", "live-over-stored");
+    let sqlite_path = unique_memory_sqlite_path("live-over-stored");
+    let workspace_root = create_runtime_self_workspace(
+        "live-over-stored",
+        "# Identity\n\n- Name: Live workspace identity",
+    );
+    let mut config = test_config();
+
+    config.memory.sqlite_path = sqlite_path.clone();
+    config.tools.file_root = Some(workspace_root.display().to_string());
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let root_session = create_root_session_record(&session_id);
+    let stored_identity_text = "# Identity\n\n- Name: Stored continuity identity";
+
+    repo.create_session(root_session)
+        .expect("create root session");
+    append_runtime_self_continuity_refresh_event(&repo, &session_id, stored_identity_text);
+
+    let assembled = runtime
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("build context with live identity");
+
+    let system_content = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should be text");
+
+    assert!(
+        system_content.contains("Live workspace identity"),
+        "expected live identity in system prompt, got: {system_content}"
+    );
+    assert!(
+        !system_content.contains("[runtime_self_continuity]"),
+        "stored continuity should not override or duplicate live identity, got: {system_content}"
+    );
+    assert!(
+        !system_content.contains("Stored continuity identity"),
+        "stored continuity should not override live identity, got: {system_content}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn default_runtime_build_context_explicit_builtin_system_preserves_profile_projection() {
     let runtime = DefaultConversationRuntime::default();
     let session_id = unique_acp_test_id("default-runtime-context", "profile");
@@ -2354,6 +2623,68 @@ async fn default_runtime_build_context_explicit_builtin_system_preserves_profile
     );
 
     let _ = std::fs::remove_file(sqlite_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_records_runtime_self_continuity_before_compaction() {
+    let session_id = unique_acp_test_id("conversation-runtime-self", "compaction");
+    let sqlite_path = unique_memory_sqlite_path("runtime-self-compaction");
+    let workspace_root = create_runtime_self_workspace(
+        "runtime-self-compaction",
+        "# Identity\n\n- Name: Workspace continuity identity",
+    );
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("I am Temporary Bob".to_owned()),
+    );
+    let mut config = test_config();
+
+    config.memory.sqlite_path = sqlite_path.clone();
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.conversation.compact_min_messages = Some(999);
+    config.conversation.compact_trigger_estimated_tokens = Some(1);
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let root_session = create_root_session_record(&session_id);
+
+    repo.create_session(root_session)
+        .expect("create root session");
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("test-runtime-self-compaction");
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            &session_id,
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("handle turn success");
+
+    assert_eq!(reply, "I am Temporary Bob");
+
+    let events = repo
+        .list_recent_events(&session_id, 20)
+        .expect("list recent events");
+    let continuity_event = events
+        .iter()
+        .find(|event| event.event_kind == "runtime_self_continuity_refreshed")
+        .expect("runtime self continuity event");
+    let payload_text = continuity_event.payload_json.to_string();
+
+    assert!(
+        payload_text.contains("Workspace continuity identity"),
+        "expected workspace identity in continuity payload, got: {payload_text}"
+    );
+    assert!(
+        !payload_text.contains("Temporary Bob"),
+        "session-local assistant reply must not be promoted into continuity payload: {payload_text}"
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -5772,72 +6103,64 @@ async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_
     assert_eq!(payload["total_intents"], 5);
     assert_eq!(payload["parallel_execution_enabled"], true);
     assert_eq!(payload["parallel_execution_max_in_flight"], 2);
-    assert!(
-        payload["observed_peak_in_flight"]
-            .as_u64()
-            .expect("observed peak should exist")
-            >= 1
-    );
-    assert!(
-        payload["observed_wall_time_ms"]
-            .as_u64()
-            .expect("observed wall time should exist")
-            >= 1
-    );
+    let observed_peak_in_flight = payload["observed_peak_in_flight"]
+        .as_u64()
+        .expect("observed peak should exist");
+    let observed_wall_time_ms = payload["observed_wall_time_ms"]
+        .as_u64()
+        .expect("observed wall time should exist");
+    assert!(observed_peak_in_flight >= 1);
     assert_eq!(payload["parallel_safe_intents"], 4);
     assert_eq!(payload["serial_only_intents"], 1);
     assert_eq!(payload["parallel_segments"], 2);
     assert_eq!(payload["sequential_segments"], 1);
 
     let segments = payload["segments"].as_array().expect("segments array");
+    let first_segment = &segments[0];
+    let second_segment = &segments[1];
+    let third_segment = &segments[2];
     assert_eq!(
         segments.len(),
         3,
         "expected contiguous mixed-batch segments"
     );
-    assert_eq!(segments[0]["segment_index"], 0);
-    assert_eq!(segments[0]["scheduling_class"], "parallel_safe");
-    assert_eq!(segments[0]["execution_mode"], "parallel");
-    assert_eq!(segments[0]["intent_count"], 2);
+    let first_segment_observed_wall_time_ms = first_segment["observed_wall_time_ms"]
+        .as_u64()
+        .expect("parallel segment wall time should exist");
+    assert_eq!(first_segment["segment_index"], 0);
+    assert_eq!(first_segment["scheduling_class"], "parallel_safe");
+    assert_eq!(first_segment["execution_mode"], "parallel");
+    assert_eq!(first_segment["intent_count"], 2);
     assert!(
-        segments[0]["observed_peak_in_flight"]
+        first_segment["observed_peak_in_flight"]
             .as_u64()
             .expect("parallel segment observed peak should exist")
             >= 1
     );
+    let second_segment_observed_wall_time_ms = second_segment["observed_wall_time_ms"]
+        .as_u64()
+        .expect("sequential segment wall time should exist");
+    assert_eq!(second_segment["segment_index"], 1);
+    assert_eq!(second_segment["scheduling_class"], "serial_only");
+    assert_eq!(second_segment["execution_mode"], "sequential");
+    assert_eq!(second_segment["intent_count"], 1);
+    assert_eq!(second_segment["observed_peak_in_flight"], 1);
+    let third_segment_observed_wall_time_ms = third_segment["observed_wall_time_ms"]
+        .as_u64()
+        .expect("parallel segment wall time should exist");
+    assert_eq!(third_segment["segment_index"], 2);
+    assert_eq!(third_segment["scheduling_class"], "parallel_safe");
+    assert_eq!(third_segment["execution_mode"], "parallel");
+    assert_eq!(third_segment["intent_count"], 2);
     assert!(
-        segments[0]["observed_wall_time_ms"]
-            .as_u64()
-            .expect("parallel segment wall time should exist")
-            >= 1
-    );
-    assert_eq!(segments[1]["segment_index"], 1);
-    assert_eq!(segments[1]["scheduling_class"], "serial_only");
-    assert_eq!(segments[1]["execution_mode"], "sequential");
-    assert_eq!(segments[1]["intent_count"], 1);
-    assert_eq!(segments[1]["observed_peak_in_flight"], 1);
-    assert!(
-        segments[1]["observed_wall_time_ms"]
-            .as_u64()
-            .expect("sequential segment wall time should exist")
-            >= 1
-    );
-    assert_eq!(segments[2]["segment_index"], 2);
-    assert_eq!(segments[2]["scheduling_class"], "parallel_safe");
-    assert_eq!(segments[2]["execution_mode"], "parallel");
-    assert_eq!(segments[2]["intent_count"], 2);
-    assert!(
-        segments[2]["observed_peak_in_flight"]
+        third_segment["observed_peak_in_flight"]
             .as_u64()
             .expect("parallel segment observed peak should exist")
             >= 1
     );
-    assert!(
-        segments[2]["observed_wall_time_ms"]
-            .as_u64()
-            .expect("parallel segment wall time should exist")
-            >= 1
-    );
+    assert!(observed_wall_time_ms >= first_segment_observed_wall_time_ms);
+    assert!(observed_wall_time_ms >= second_segment_observed_wall_time_ms);
+    assert!(observed_wall_time_ms >= third_segment_observed_wall_time_ms);
 
     let _ = std::fs::remove_file(sqlite_path);
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2775,7 +2775,12 @@ async fn handle_turn_with_runtime_records_runtime_self_continuity_before_compact
     let memory_config_for_hook = memory_config.clone();
     let compact_hook: CompactHook = Arc::new(move |hook_session_id, _messages| {
         let hook_repo = SessionRepository::new(&memory_config_for_hook)?;
-        let events = hook_repo.list_recent_events(&session_id_for_hook, 20)?;
+        if hook_session_id != session_id_for_hook {
+            return Err(format!(
+                "compact hook invoked for unexpected session: expected {session_id_for_hook}, got {hook_session_id}"
+            ));
+        }
+        let events = hook_repo.list_recent_events(hook_session_id, 20)?;
         let continuity_event = events
             .iter()
             .find(|event| event.event_kind == "runtime_self_continuity_refreshed");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -64,6 +64,7 @@ struct FakeRuntime {
     turn_calls: Mutex<usize>,
     after_turn_calls: Mutex<Vec<(String, String, String, usize)>>,
     compact_calls: Mutex<Vec<(String, usize)>>,
+    compact_hook: Option<CompactHook>,
     persist_failure: Option<(String, String)>,
     prepare_subagent_spawn_result: Result<(), String>,
     on_subagent_ended_result: Result<(), String>,
@@ -74,6 +75,8 @@ enum FakeTurnResponse {
     Parsed(ProviderTurn),
     RawBody(Value),
 }
+
+type CompactHook = Arc<dyn Fn(&str, &[Value]) -> Result<(), String> + Send + Sync>;
 
 struct TraitDefaultToolViewRuntime;
 struct NoopTurnMiddleware {
@@ -739,6 +742,7 @@ impl FakeRuntime {
             turn_calls: Mutex::new(0),
             after_turn_calls: Mutex::new(Vec::new()),
             compact_calls: Mutex::new(Vec::new()),
+            compact_hook: None,
             persist_failure: None,
             prepare_subagent_spawn_result: Ok(()),
             on_subagent_ended_result: Ok(()),
@@ -774,6 +778,11 @@ impl FakeRuntime {
 
     fn with_compact_result(mut self, result: Result<(), String>) -> Self {
         self.compact_result = result;
+        self
+    }
+
+    fn with_compact_hook(mut self, compact_hook: CompactHook) -> Self {
+        self.compact_hook = Some(compact_hook);
         self
     }
 
@@ -1359,6 +1368,9 @@ impl ConversationRuntime for FakeRuntime {
         messages: &[Value],
         _kernel_ctx: &KernelContext,
     ) -> CliResult<()> {
+        if let Some(compact_hook) = self.compact_hook.as_ref() {
+            compact_hook(session_id, messages)?;
+        }
         self.compact_calls
             .lock()
             .expect("compact lock")
@@ -2505,6 +2517,14 @@ async fn default_runtime_build_context_rehydrates_runtime_self_continuity_when_l
         system_content.contains("Search durable workspace memory before guessing project facts."),
         "expected stored tool usage policy in system prompt, got: {system_content}"
     );
+    assert!(
+        system_content.contains("## Session Profile"),
+        "expected stored session profile in system prompt, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("Operator prefers concise technical summaries."),
+        "expected stored session profile text in system prompt, got: {system_content}"
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -2607,12 +2627,73 @@ async fn default_runtime_build_context_prefers_live_identity_over_stored_runtime
         "expected live identity in system prompt, got: {system_content}"
     );
     assert!(
-        !system_content.contains("[runtime_self_continuity]"),
-        "stored continuity should not override or duplicate live identity, got: {system_content}"
+        system_content.contains("## Session Profile"),
+        "stored session profile should still rehydrate when the live profile lane is missing, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("Operator prefers concise technical summaries."),
+        "stored session profile text should still rehydrate when the live profile lane is missing, got: {system_content}"
     );
     assert!(
         !system_content.contains("Stored continuity identity"),
         "stored continuity should not override live identity, got: {system_content}"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_rehydrates_missing_session_profile_from_stored_runtime_self_continuity()
+ {
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-context", "live-identity-stored-profile");
+    let sqlite_path = unique_memory_sqlite_path("live-identity-stored-profile");
+    let workspace_root = create_runtime_self_workspace(
+        "live-identity-stored-profile",
+        "# Identity\n\n- Name: Live workspace identity",
+    );
+    let mut config = test_config();
+
+    config.memory.sqlite_path = sqlite_path.clone();
+    config.tools.file_root = Some(workspace_root.display().to_string());
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let root_session = create_root_session_record(&session_id);
+    let stored_identity_text = "# Identity\n\n- Name: Stored continuity identity";
+
+    repo.create_session(root_session)
+        .expect("create root session");
+    append_runtime_self_continuity_refresh_event(&repo, &session_id, stored_identity_text);
+
+    let assembled = runtime
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("build context with live identity and stored profile");
+
+    let system_content = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should be text");
+
+    assert!(
+        system_content.contains("Live workspace identity"),
+        "expected live identity in system prompt, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("## Session Profile"),
+        "expected stored session profile to rehydrate, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("Operator prefers concise technical summaries."),
+        "expected stored session profile text to rehydrate, got: {system_content}"
+    );
+    assert!(
+        !system_content.contains("Stored continuity identity"),
+        "stored identity should stay shadowed by live identity, got: {system_content}"
     );
 }
 
@@ -2672,10 +2753,6 @@ async fn handle_turn_with_runtime_records_runtime_self_continuity_before_compact
         "runtime-self-compaction",
         "# Identity\n\n- Name: Workspace continuity identity",
     );
-    let runtime = FakeRuntime::new(
-        vec![json!({"role": "system", "content": "sys"})],
-        Ok("I am Temporary Bob".to_owned()),
-    );
     let mut config = test_config();
 
     config.memory.sqlite_path = sqlite_path.clone();
@@ -2686,6 +2763,36 @@ async fn handle_turn_with_runtime_records_runtime_self_continuity_before_compact
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
     let root_session = create_root_session_record(&session_id);
+    let session_id_for_hook = session_id.clone();
+    let memory_config_for_hook = memory_config.clone();
+    let compact_hook: CompactHook = Arc::new(move |hook_session_id, _messages| {
+        let hook_repo =
+            SessionRepository::new(&memory_config_for_hook).map_err(|error| error.to_string())?;
+        let events = hook_repo
+            .list_recent_events(&session_id_for_hook, 20)
+            .map_err(|error| error.to_string())?;
+        let continuity_event = events
+            .iter()
+            .find(|event| event.event_kind == "runtime_self_continuity_refreshed");
+        let continuity_event = continuity_event.ok_or_else(|| {
+            format!(
+                "runtime self continuity event must exist before compaction for session {hook_session_id}"
+            )
+        })?;
+        let payload_text = continuity_event.payload_json.to_string();
+        let contains_identity = payload_text.contains("Workspace continuity identity");
+        if !contains_identity {
+            return Err(format!(
+                "runtime self continuity payload must be persisted before compaction for session {hook_session_id}"
+            ));
+        }
+        Ok(())
+    });
+    let runtime = FakeRuntime::new(
+        vec![json!({"role": "system", "content": "sys"})],
+        Ok("I am Temporary Bob".to_owned()),
+    )
+    .with_compact_hook(compact_hook);
 
     repo.create_session(root_session)
         .expect("create root session");
@@ -4617,11 +4724,40 @@ async fn handle_turn_with_runtime_flushes_durable_memory_before_compaction() {
     config.conversation.compact_trigger_estimated_tokens = Some(1);
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let workspace_root_for_hook = workspace_root.clone();
+    let compact_hook: CompactHook = Arc::new(move |session_id, _messages| {
+        let memory_dir = workspace_root_for_hook.join("memory");
+        let exported_paths = collect_markdown_file_paths(memory_dir.as_path());
+        let exported_path = exported_paths.first().ok_or_else(|| {
+            format!("expected durable memory export before compaction for session {session_id}")
+        })?;
+        let exported = std::fs::read_to_string(exported_path).map_err(|error| error.to_string())?;
+        let contains_intro = exported.contains("Advisory durable recall");
+        if !contains_intro {
+            return Err(format!(
+                "durable export must include advisory durable recall label before compaction for session {session_id}"
+            ));
+        }
+        let contains_identity = exported.contains("Resolved Runtime Identity");
+        if !contains_identity {
+            return Err(format!(
+                "durable export must include resolved identity before compaction for session {session_id}"
+            ));
+        }
+        let contains_turn_text = exported.contains("hello before compaction");
+        if !contains_turn_text {
+            return Err(format!(
+                "durable export must include the pre-compaction summary before compaction for session {session_id}"
+            ));
+        }
+        Ok(())
+    });
     let runtime = FakeRuntime::new(
         vec![json!({"role": "system", "content": "sys"})],
         Ok("assistant-reply".to_owned()),
     )
-    .with_durable_memory_config(memory_config.clone());
+    .with_durable_memory_config(memory_config.clone())
+    .with_compact_hook(compact_hook);
 
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context_with_memory("test-pre-compaction-flush", &memory_config);
@@ -6257,14 +6393,14 @@ async fn handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_
     assert_eq!(payload["sequential_segments"], 1);
 
     let segments = payload["segments"].as_array().expect("segments array");
-    let first_segment = &segments[0];
-    let second_segment = &segments[1];
-    let third_segment = &segments[2];
     assert_eq!(
         segments.len(),
         3,
         "expected contiguous mixed-batch segments"
     );
+    let first_segment = &segments[0];
+    let second_segment = &segments[1];
+    let third_segment = &segments[2];
     let first_segment_observed_wall_time_ms = first_segment["observed_wall_time_ms"]
         .as_u64()
         .expect("parallel segment wall time should exist");

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -29,6 +29,7 @@ use crate::acp::{
     execute_acp_conversation_turn_for_address,
 };
 use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::runtime_self_continuity;
 
 use super::super::config::LoongClawConfig;
 use super::ConversationSessionAddress;
@@ -99,8 +100,8 @@ use crate::session::recovery::{
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, CreateSessionWithEventRequest,
-    FinalizeSessionTerminalRequest, NewApprovalGrantRecord, NewSessionRecord, SessionKind,
-    SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
+    FinalizeSessionTerminalRequest, NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord,
+    SessionKind, SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
     TransitionSessionWithEventIfCurrentRequest,
 };
 
@@ -2315,6 +2316,11 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
         return Ok(ContextCompactionOutcome::Skipped);
     };
 
+    #[cfg(feature = "memory-sqlite")]
+    {
+        persist_runtime_self_continuity_for_compaction(config, session_id)?;
+    }
+
     match runtime
         .compact_context(config, session_id, messages, kernel_ctx)
         .await
@@ -2325,6 +2331,80 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
         }
         Err(error) => Err(error),
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn persist_runtime_self_continuity_for_compaction(
+    config: &LoongClawConfig,
+    session_id: &str,
+) -> Result<(), String> {
+    let continuity = runtime_self_continuity::resolve_runtime_self_continuity_for_config(config);
+    let Some(continuity) = continuity else {
+        return Ok(());
+    };
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config)?;
+
+    ensure_root_session_exists_for_runtime_self_continuity(&repo, session_id)?;
+
+    let recent_events = repo.list_recent_events(session_id, 8)?;
+    let latest_continuity = recent_events.into_iter().rev().find_map(|event| {
+        let is_continuity_event =
+            event.event_kind == runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND;
+        if !is_continuity_event {
+            return None;
+        }
+        runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
+    });
+    if latest_continuity.as_ref() == Some(&continuity) {
+        return Ok(());
+    }
+
+    let payload = json!({
+        "source": "compaction",
+        "runtime_self_continuity": continuity,
+    });
+    let event = NewSessionEvent {
+        session_id: session_id.to_owned(),
+        event_kind: runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND.to_owned(),
+        actor_session_id: Some(session_id.to_owned()),
+        payload_json: payload,
+    };
+    repo.append_event(event)?;
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_root_session_exists_for_runtime_self_continuity(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<(), String> {
+    let existing_session = repo.load_session(session_id)?;
+    if existing_session.is_some() {
+        return Ok(());
+    }
+
+    let record = NewSessionRecord {
+        session_id: session_id.to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: SessionState::Ready,
+    };
+    let _ = repo.ensure_session(record)?;
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn effective_runtime_self_continuity_for_session(
+    config: &LoongClawConfig,
+    session_context: &SessionContext,
+) -> Option<runtime_self_continuity::RuntimeSelfContinuity> {
+    let live_continuity =
+        runtime_self_continuity::resolve_runtime_self_continuity_for_config(config);
+    let stored_continuity = session_context.runtime_self_continuity.as_ref();
+    runtime_self_continuity::merge_runtime_self_continuity(live_continuity, stored_continuity)
 }
 
 fn estimate_tokens(messages: &[Value]) -> Option<usize> {
@@ -4055,6 +4135,8 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
     let child_label = delegate_request.label.clone();
     let repo = SessionRepository::new(&MemoryRuntimeConfig::from_memory_config(&config.memory))?;
     let next_child_depth = next_delegate_child_depth_for_delegate(config, &repo, session_context)?;
+    let runtime_self_continuity =
+        effective_runtime_self_continuity_for_session(config, session_context);
     with_prepared_subagent_spawn_cleanup_if_kernel_bound(
         runtime,
         &session_context.session_id,
@@ -4085,7 +4167,11 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
                             event_kind: "delegate_started".to_owned(),
                             actor_session_id: Some(session_context.session_id.clone()),
                             event_payload_json: execution
-                                .spawn_payload(&delegate_request.task, child_label.as_deref()),
+                                .spawn_payload_with_runtime_self_continuity(
+                                    &delegate_request.task,
+                                    child_label.as_deref(),
+                                    runtime_self_continuity.as_ref(),
+                                ),
                         },
                         execution,
                     ))
@@ -4135,6 +4221,8 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
     let next_child_depth = next_delegate_child_depth_for_delegate(config, &repo, session_context)?;
+    let runtime_self_continuity =
+        effective_runtime_self_continuity_for_session(config, session_context);
     let (_, execution) = repo.create_delegate_child_session_with_event_if_within_limit(
         &session_context.session_id,
         config.tools.delegate.max_active_children,
@@ -4158,8 +4246,11 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
                     },
                     event_kind: "delegate_queued".to_owned(),
                     actor_session_id: Some(session_context.session_id.clone()),
-                    event_payload_json: execution
-                        .spawn_payload(&delegate_request.task, child_label.as_deref()),
+                    event_payload_json: execution.spawn_payload_with_runtime_self_continuity(
+                        &delegate_request.task,
+                        child_label.as_deref(),
+                        runtime_self_continuity.as_ref(),
+                    ),
                 },
                 execution,
             ))
@@ -4176,6 +4267,7 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
             task: delegate_request.task,
             label: child_label,
             execution,
+            runtime_self_continuity,
             timeout_seconds: delegate_request.timeout_seconds,
             kernel_context: binding.kernel_context().cloned(),
         },

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2318,7 +2318,15 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
 
     #[cfg(feature = "memory-sqlite")]
     {
-        persist_runtime_self_continuity_for_compaction(config, session_id)?;
+        if let Err(error) = persist_runtime_self_continuity_for_compaction(config, session_id) {
+            if config.conversation.compaction_fail_open() {
+                return Ok(ContextCompactionOutcome::FailedOpen);
+            }
+
+            return Err(format!(
+                "pre-compaction runtime self continuity persist failed: {error}"
+            ));
+        }
 
         let workspace_root = config
             .tools
@@ -2362,26 +2370,23 @@ fn persist_runtime_self_continuity_for_compaction(
     config: &LoongClawConfig,
     session_id: &str,
 ) -> Result<(), String> {
-    let continuity = runtime_self_continuity::resolve_runtime_self_continuity_for_config(config);
-    let Some(continuity) = continuity else {
-        return Ok(());
-    };
-
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
 
-    ensure_root_session_exists_for_runtime_self_continuity(&repo, session_id)?;
+    ensure_session_exists_for_runtime_self_continuity(&repo, session_id)?;
 
-    let recent_events = repo.list_recent_events(session_id, 8)?;
-    let latest_continuity = recent_events.into_iter().rev().find_map(|event| {
-        let is_continuity_event =
-            event.event_kind == runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND;
-        if !is_continuity_event {
-            return None;
-        }
-        runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
-    });
-    if latest_continuity.as_ref() == Some(&continuity) {
+    let live_continuity =
+        runtime_self_continuity::resolve_runtime_self_continuity_for_config(config);
+    let stored_continuity =
+        runtime_self_continuity::load_persisted_runtime_self_continuity(&repo, session_id)?;
+    let continuity = runtime_self_continuity::merge_runtime_self_continuity(
+        live_continuity,
+        stored_continuity.as_ref(),
+    );
+    let Some(continuity) = continuity else {
+        return Ok(());
+    };
+    if stored_continuity.as_ref() == Some(&continuity) {
         return Ok(());
     }
 
@@ -2400,7 +2405,7 @@ fn persist_runtime_self_continuity_for_compaction(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn ensure_root_session_exists_for_runtime_self_continuity(
+fn ensure_session_exists_for_runtime_self_continuity(
     repo: &SessionRepository,
     session_id: &str,
 ) -> Result<(), String> {
@@ -2409,12 +2414,46 @@ fn ensure_root_session_exists_for_runtime_self_continuity(
         return Ok(());
     }
 
+    let summary = repo.load_session_summary_with_legacy_fallback(session_id)?;
+    let delegate_parent_session_id = repo
+        .list_delegate_lifecycle_events(session_id)?
+        .into_iter()
+        .rev()
+        .find_map(|event| event.actor_session_id);
+    let kind = summary.as_ref().map(|value| value.kind).unwrap_or_else(|| {
+        if session_id.starts_with("delegate:") || delegate_parent_session_id.is_some() {
+            SessionKind::DelegateChild
+        } else {
+            SessionKind::Root
+        }
+    });
+    let parent_session_id = match kind {
+        SessionKind::Root => None,
+        SessionKind::DelegateChild => {
+            let stored_parent_session_id = summary
+                .as_ref()
+                .and_then(|value| value.parent_session_id.clone());
+            let reconstructed_parent_session_id =
+                delegate_parent_session_id.or(stored_parent_session_id);
+            let Some(reconstructed_parent_session_id) = reconstructed_parent_session_id else {
+                return Err(format!(
+                    "delegate session `{session_id}` is missing lineage required for runtime self continuity persistence"
+                ));
+            };
+            Some(reconstructed_parent_session_id)
+        }
+    };
+    let label = summary.as_ref().and_then(|value| value.label.clone());
+    let state = summary
+        .as_ref()
+        .map(|value| value.state)
+        .unwrap_or(SessionState::Ready);
     let record = NewSessionRecord {
         session_id: session_id.to_owned(),
-        kind: SessionKind::Root,
-        parent_session_id: None,
-        label: None,
-        state: SessionState::Ready,
+        kind,
+        parent_session_id,
+        label,
+        state,
     };
     let _ = repo.ensure_session(record)?;
     Ok(())
@@ -6711,8 +6750,10 @@ async fn execute_single_tool_intent(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::bootstrap_test_kernel_context;
     use crate::session::repository::FinalizeSessionTerminalResult;
     use std::path::PathBuf;
+    use std::sync::Mutex as StdMutex;
 
     fn unique_sqlite_path(label: &str) -> PathBuf {
         std::env::temp_dir().join(format!(
@@ -6731,6 +6772,94 @@ mod tests {
         let mut config = LoongClawConfig::default();
         config.memory.sqlite_path = path.display().to_string();
         MemoryRuntimeConfig::from_memory_config(&config.memory)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn unique_workspace_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "loongclaw-turn-coordinator-workspace-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ))
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[derive(Default)]
+    struct RecordingCompactRuntime {
+        compact_calls: StdMutex<usize>,
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[async_trait]
+    impl ConversationRuntime for RecordingCompactRuntime {
+        async fn build_messages(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _include_system_prompt: bool,
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<Vec<Value>> {
+            Ok(Vec::new())
+        }
+
+        async fn request_completion(
+            &self,
+            _config: &LoongClawConfig,
+            _messages: &[Value],
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<String> {
+            Ok(String::new())
+        }
+
+        async fn request_turn(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<ProviderTurn> {
+            panic!("request_turn should not be called in compaction tests")
+        }
+
+        async fn request_turn_streaming(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+            _on_token: crate::provider::StreamingTokenCallback,
+        ) -> CliResult<ProviderTurn> {
+            panic!("request_turn_streaming should not be called in compaction tests")
+        }
+
+        async fn persist_turn(
+            &self,
+            _session_id: &str,
+            _role: &str,
+            _content: &str,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<()> {
+            Ok(())
+        }
+
+        async fn compact_context(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _messages: &[Value],
+            _kernel_ctx: &KernelContext,
+        ) -> CliResult<()> {
+            let mut compact_calls = self.compact_calls.lock().expect("compact lock");
+            *compact_calls += 1;
+            Ok(())
+        }
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -7118,6 +7247,228 @@ mod tests {
                 .any(|content| content.contains("[tool_result]\n[ok]")),
             "truncated invoke payload should stay as ordinary assistant tool_result content: {messages:?}"
         );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn persist_runtime_self_continuity_for_compaction_merges_live_and_stored_delegate_continuity() {
+        let workspace_root = unique_workspace_root("merged-runtime-self-continuity");
+        let memory_config = sqlite_memory_config("merged-runtime-self-continuity");
+        let repo = SessionRepository::new(&memory_config).expect("session repository");
+        let root_session_id = "root-session";
+        let child_session_id = "delegate:child-session";
+        let live_agents_text = "Keep standing instructions visible.";
+        let stored_identity_text = "# Identity\n\n- Name: Stored continuity identity";
+        let mut config = LoongClawConfig::default();
+
+        let sqlite_path = memory_config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path")
+            .display()
+            .to_string();
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::write(workspace_root.join("AGENTS.md"), live_agents_text).expect("write AGENTS");
+        config.memory.sqlite_path = sqlite_path;
+        config.tools.file_root = Some(workspace_root.display().to_string());
+
+        repo.create_session(NewSessionRecord {
+            session_id: root_session_id.to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+        repo.create_session(NewSessionRecord {
+            session_id: child_session_id.to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some(root_session_id.to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child session");
+
+        let stored_continuity = runtime_self_continuity::RuntimeSelfContinuity {
+            runtime_self: crate::runtime_self::RuntimeSelfModel {
+                identity_context: vec![stored_identity_text.to_owned()],
+                ..Default::default()
+            },
+            resolved_identity: Some(crate::runtime_identity::ResolvedRuntimeIdentity {
+                source: crate::runtime_identity::RuntimeIdentitySource::LegacyProfileNoteImport,
+                content: stored_identity_text.to_owned(),
+            }),
+            session_profile_projection: None,
+        };
+        repo.append_event(NewSessionEvent {
+            session_id: child_session_id.to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some(root_session_id.to_owned()),
+            payload_json: json!({
+                "runtime_self_continuity": stored_continuity,
+            }),
+        })
+        .expect("append delegate event");
+
+        persist_runtime_self_continuity_for_compaction(&config, child_session_id)
+            .expect("persist merged runtime self continuity");
+
+        let recent_events = repo
+            .list_recent_events(child_session_id, 10)
+            .expect("list recent events");
+        let persisted_event = recent_events
+            .iter()
+            .rev()
+            .find(|event| {
+                event.event_kind == runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND
+            })
+            .expect("persisted continuity event");
+        let persisted_continuity =
+            runtime_self_continuity::runtime_self_continuity_from_event_payload(
+                &persisted_event.payload_json,
+            )
+            .expect("decode persisted continuity payload");
+
+        assert_eq!(
+            persisted_continuity.runtime_self.standing_instructions,
+            vec![live_agents_text.to_owned()]
+        );
+        assert_eq!(
+            persisted_continuity.runtime_self.identity_context,
+            vec![stored_identity_text.to_owned()]
+        );
+        assert_eq!(
+            persisted_continuity
+                .resolved_identity
+                .as_ref()
+                .map(|value| value.content.as_str()),
+            Some(stored_identity_text)
+        );
+
+        let _ = std::fs::remove_dir_all(&workspace_root);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn persist_runtime_self_continuity_for_compaction_reconstructs_legacy_delegate_session_row() {
+        let workspace_root = unique_workspace_root("legacy-delegate-session-row");
+        let memory_config = sqlite_memory_config("legacy-delegate-session-row");
+        let repo = SessionRepository::new(&memory_config).expect("session repository");
+        let root_session_id = "root-session";
+        let child_session_id = "delegate:legacy-child";
+        let mut config = LoongClawConfig::default();
+
+        let sqlite_path = memory_config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path")
+            .clone();
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::write(
+            workspace_root.join("AGENTS.md"),
+            "Keep continuity explicit.",
+        )
+        .expect("write AGENTS");
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        config.tools.file_root = Some(workspace_root.display().to_string());
+
+        repo.create_session(NewSessionRecord {
+            session_id: root_session_id.to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+
+        let conn = rusqlite::Connection::open(&sqlite_path).expect("open sqlite connection");
+        conn.execute(
+            "INSERT INTO turns(session_id, session_turn_index, role, content, ts)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![child_session_id, 1_i64, "assistant", "legacy turn", 1_i64],
+        )
+        .expect("insert legacy turn");
+        conn.execute(
+            "INSERT INTO session_events(session_id, event_kind, actor_session_id, payload_json, ts)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![
+                child_session_id,
+                "delegate_started",
+                root_session_id,
+                json!({}).to_string(),
+                2_i64
+            ],
+        )
+        .expect("insert legacy delegate event");
+        drop(conn);
+
+        persist_runtime_self_continuity_for_compaction(&config, child_session_id)
+            .expect("persist runtime self continuity");
+
+        let reconstructed_session = repo
+            .load_session(child_session_id)
+            .expect("load reconstructed session")
+            .expect("reconstructed session row");
+
+        assert_eq!(reconstructed_session.kind, SessionKind::DelegateChild);
+        assert_eq!(
+            reconstructed_session.parent_session_id.as_deref(),
+            Some(root_session_id)
+        );
+
+        let _ = std::fs::remove_dir_all(&workspace_root);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn maybe_compact_context_fails_open_when_runtime_self_continuity_persist_cannot_reconstruct_delegate_lineage()
+     {
+        let workspace_root = unique_workspace_root("compaction-fail-open");
+        let sqlite_path = unique_sqlite_path("compaction-fail-open");
+        let runtime = RecordingCompactRuntime::default();
+        let mut config = LoongClawConfig::default();
+
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::write(
+            workspace_root.join("AGENTS.md"),
+            "Keep continuity explicit.",
+        )
+        .expect("write AGENTS");
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        config.tools.file_root = Some(workspace_root.display().to_string());
+        config.conversation.compact_min_messages = Some(1);
+        config.conversation.compact_trigger_estimated_tokens = Some(1);
+        config.conversation.compact_fail_open = true;
+
+        let kernel_ctx = bootstrap_test_kernel_context("turn-coordinator-compaction", 3600)
+            .expect("bootstrap kernel context");
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&kernel_ctx));
+        let runtime_handle = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "trigger compaction"}),
+        ];
+        let outcome = runtime_handle.block_on(maybe_compact_context(
+            &config,
+            &runtime,
+            "delegate:missing-lineage",
+            &messages,
+            Some(16),
+            binding,
+        ));
+
+        assert_eq!(
+            outcome.expect("compaction should fail open"),
+            ContextCompactionOutcome::FailedOpen
+        );
+        let compact_calls = runtime.compact_calls.lock().expect("compact lock");
+        assert_eq!(*compact_calls, 0);
+
+        let _ = std::fs::remove_dir_all(&workspace_root);
+        let _ = std::fs::remove_file(&sqlite_path);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2341,7 +2341,8 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
             session_id,
             workspace_root.as_deref(),
             &memory_config,
-        );
+        )
+        .await;
         match durable_flush_result {
             Ok(_) => {}
             Err(_error) if config.conversation.compaction_fail_open() => {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2319,6 +2319,30 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
     #[cfg(feature = "memory-sqlite")]
     {
         persist_runtime_self_continuity_for_compaction(config, session_id)?;
+
+        let workspace_root = config
+            .tools
+            .file_root
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|_| config.tools.resolved_file_root());
+
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let durable_flush_result = crate::memory::flush_pre_compaction_durable_memory(
+            session_id,
+            workspace_root.as_deref(),
+            &memory_config,
+        );
+        match durable_flush_result {
+            Ok(_) => {}
+            Err(_error) if config.conversation.compaction_fail_open() => {}
+            Err(error) => {
+                return Err(format!(
+                    "pre-compaction durable memory flush failed: {error}"
+                ));
+            }
+        }
     }
 
     match runtime

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2344,7 +2344,9 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
         );
         match durable_flush_result {
             Ok(_) => {}
-            Err(_error) if config.conversation.compaction_fail_open() => {}
+            Err(_error) if config.conversation.compaction_fail_open() => {
+                return Ok(ContextCompactionOutcome::FailedOpen);
+            }
             Err(error) => {
                 return Err(format!(
                     "pre-compaction durable memory flush failed: {error}"
@@ -7468,6 +7470,77 @@ mod tests {
         assert_eq!(*compact_calls, 0);
 
         let _ = std::fs::remove_dir_all(&workspace_root);
+        let _ = std::fs::remove_file(&sqlite_path);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn maybe_compact_context_fails_open_when_durable_flush_cannot_write_workspace_export() {
+        let workspace_root_parent = unique_workspace_root("compaction-durable-flush-fail-open");
+        let workspace_root_file = workspace_root_parent.join("workspace-root-file");
+        let sqlite_path = unique_sqlite_path("compaction-durable-flush-fail-open");
+        let runtime = RecordingCompactRuntime::default();
+        let mut config = LoongClawConfig::default();
+
+        std::fs::create_dir_all(&workspace_root_parent).expect("create workspace root parent");
+        std::fs::write(
+            workspace_root_parent.join("AGENTS.md"),
+            "Keep continuity explicit.",
+        )
+        .expect("write AGENTS");
+        std::fs::write(&workspace_root_file, "not a workspace directory")
+            .expect("write workspace root file");
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        config.tools.file_root = Some(workspace_root_file.display().to_string());
+        config.memory.sliding_window = 1;
+        config.conversation.compact_min_messages = Some(1);
+        config.conversation.compact_trigger_estimated_tokens = Some(1);
+        config.conversation.compact_fail_open = true;
+
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        crate::memory::append_turn_direct(
+            "session-durable-flush-fail-open",
+            "user",
+            "remember the deployment cutoff",
+            &memory_config,
+        )
+        .expect("append user turn");
+        crate::memory::append_turn_direct(
+            "session-durable-flush-fail-open",
+            "assistant",
+            "deployment cutoff is tonight",
+            &memory_config,
+        )
+        .expect("append assistant turn");
+
+        let kernel_ctx = bootstrap_test_kernel_context("turn-coordinator-compaction", 3600)
+            .expect("bootstrap kernel context");
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(Some(&kernel_ctx));
+        let runtime_handle = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+        let messages = vec![
+            json!({"role": "system", "content": "sys"}),
+            json!({"role": "user", "content": "trigger compaction"}),
+        ];
+        let outcome = runtime_handle.block_on(maybe_compact_context(
+            &config,
+            &runtime,
+            "session-durable-flush-fail-open",
+            &messages,
+            Some(16),
+            binding,
+        ));
+
+        assert_eq!(
+            outcome.expect("compaction should fail open"),
+            ContextCompactionOutcome::FailedOpen
+        );
+        let compact_calls = runtime.compact_calls.lock().expect("compact lock");
+        assert_eq!(*compact_calls, 0);
+
+        let _ = std::fs::remove_dir_all(&workspace_root_parent);
         let _ = std::fs::remove_file(&sqlite_path);
     }
 

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -29,14 +29,14 @@ const THINK_CLOSE_TAG: &str = "</think>";
 fn strip_think_tags(text: &str) -> String {
     let mut cleaned_text = String::with_capacity(text.len());
     let mut cursor = 0;
-    let mut inside_think_block = false;
+    let mut think_depth = 0usize;
 
     while cursor < text.len() {
         let remaining_text = &text[cursor..];
         let open_tag_length = think_tag_prefix_len(remaining_text, THINK_OPEN_TAG);
 
         if let Some(tag_length) = open_tag_length {
-            inside_think_block = true;
+            think_depth = think_depth.saturating_add(1);
             cursor += tag_length;
             continue;
         }
@@ -44,7 +44,7 @@ fn strip_think_tags(text: &str) -> String {
         let close_tag_length = think_tag_prefix_len(remaining_text, THINK_CLOSE_TAG);
 
         if let Some(tag_length) = close_tag_length {
-            inside_think_block = false;
+            think_depth = think_depth.saturating_sub(1);
             cursor += tag_length;
             continue;
         }
@@ -55,7 +55,7 @@ fn strip_think_tags(text: &str) -> String {
         };
         let current_char_length = current_char.len_utf8();
 
-        if !inside_think_block {
+        if think_depth == 0 {
             cleaned_text.push(current_char);
         }
 
@@ -2100,7 +2100,7 @@ mod tests {
     #[test]
     fn strip_think_tags_handles_nested_think_tags() {
         let input = "<think>outer<think>inner</think>visible</think>done";
-        assert_eq!(strip_think_tags(input), "visibledone");
+        assert_eq!(strip_think_tags(input), "done");
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -76,6 +76,12 @@ fn think_tag_prefix_len(input: &str, tag: &str) -> Option<usize> {
 
     Some(tag_length)
 }
+
+fn sanitize_reply_text(text: &str) -> String {
+    let stripped_text = strip_think_tags(text);
+    let trimmed_text = stripped_text.trim();
+    trimmed_text.to_owned()
+}
 pub fn next_conversation_turn_id() -> String {
     static NEXT_CONVERSATION_TURN_SEQ: AtomicU64 = AtomicU64::new(1);
     let seq = NEXT_CONVERSATION_TURN_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -139,7 +145,10 @@ pub fn tool_driven_followup_payload(
         TurnResult::FinalText(text)
         | TurnResult::StreamingText(text)
         | TurnResult::StreamingDone(text) => {
-            Some(ToolDrivenFollowupPayload::ToolResult { text: text.clone() })
+            let sanitized_text = sanitize_reply_text(text);
+            Some(ToolDrivenFollowupPayload::ToolResult {
+                text: sanitized_text,
+            })
         }
         TurnResult::NeedsApproval(_) => None,
         TurnResult::ToolDenied(failure) | TurnResult::ToolError(failure) => {
@@ -299,10 +308,12 @@ impl<'a> ToolDrivenReplyKernel<'a> {
         match self.turn_result {
             TurnResult::FinalText(text)
             | TurnResult::StreamingText(text)
-            | TurnResult::StreamingDone(text) => Some(join_non_empty_lines(&[
-                self.assistant_preface,
-                text.as_str(),
-            ])),
+            | TurnResult::StreamingDone(text) => {
+                let sanitized_text = sanitize_reply_text(text);
+                let reply =
+                    join_non_empty_lines(&[self.assistant_preface, sanitized_text.as_str()]);
+                Some(reply)
+            }
             TurnResult::NeedsApproval(requirement) => Some(format_approval_required_reply(
                 self.assistant_preface,
                 requirement,
@@ -362,10 +373,11 @@ pub fn compose_assistant_reply(
         TurnResult::FinalText(text)
         | TurnResult::StreamingText(text)
         | TurnResult::StreamingDone(text) => {
+            let sanitized_text = sanitize_reply_text(text.as_str());
             if had_tool_intents {
-                join_non_empty_lines(&[assistant_preface, text.as_str()])
+                join_non_empty_lines(&[assistant_preface, sanitized_text.as_str()])
             } else {
-                text
+                sanitized_text
             }
         }
         TurnResult::NeedsApproval(requirement) => {
@@ -918,14 +930,14 @@ pub async fn request_completion_with_raw_fallback<R: ConversationRuntime + ?Size
 ) -> String {
     match runtime.request_completion(config, messages, binding).await {
         Ok(final_reply) => {
-            let trimmed = final_reply.trim();
-            if trimmed.is_empty() {
-                raw_reply.to_owned()
+            let sanitized_reply = sanitize_reply_text(final_reply.as_str());
+            if sanitized_reply.is_empty() {
+                sanitize_reply_text(raw_reply)
             } else {
-                trimmed.to_owned()
+                sanitized_reply
             }
         }
-        Err(_) => raw_reply.to_owned(),
+        Err(_) => sanitize_reply_text(raw_reply),
     }
 }
 
@@ -1103,6 +1115,17 @@ mod tests {
     }
 
     #[test]
+    fn compose_assistant_reply_strips_think_tags_from_final_text() {
+        let reply = compose_assistant_reply(
+            "preface",
+            false,
+            TurnResult::FinalText("<think>internal reasoning</think>visible reply".to_owned()),
+        );
+
+        assert_eq!(reply, "visible reply");
+    }
+
+    #[test]
     fn tool_driven_reply_kernel_extracts_raw_reply_and_result_followup() {
         let result = TurnResult::FinalText("tool output".to_owned());
         let kernel = ToolDrivenReplyKernel::new("preface", true, &result);
@@ -1114,6 +1137,19 @@ mod tests {
             Some(ToolDrivenFollowupPayload::ToolResult {
                 text: "tool output".to_owned(),
             })
+        );
+    }
+
+    #[test]
+    fn tool_driven_reply_kernel_strips_think_tags_from_raw_reply() {
+        let result = TurnResult::FinalText(
+            "<think>internal reasoning</think>visible tool output".to_owned(),
+        );
+        let kernel = ToolDrivenReplyKernel::new("preface", true, &result);
+
+        assert_eq!(
+            kernel.raw_reply(),
+            Some("preface\nvisible tool output".to_owned())
         );
     }
 
@@ -1161,6 +1197,20 @@ mod tests {
 
         assert_eq!(payload.kind(), ToolDrivenFollowupKind::ToolResult);
         assert_eq!(payload.message_context(), ("tool_result", "tool output"));
+    }
+
+    #[test]
+    fn tool_driven_followup_payload_strips_think_tags_from_tool_result_text() {
+        let turn_result = TurnResult::FinalText(
+            "<think>internal reasoning</think>visible tool output".to_owned(),
+        );
+
+        assert_eq!(
+            tool_driven_followup_payload(true, &turn_result),
+            Some(ToolDrivenFollowupPayload::ToolResult {
+                text: "visible tool output".to_owned(),
+            })
+        );
     }
 
     #[test]
@@ -2021,8 +2071,6 @@ mod tests {
         assert_eq!(reduced.as_ref(), tool_result);
         assert_eq!(reduced.as_ptr(), tool_result.as_ptr());
     }
-<<<<<<< HEAD
-=======
 
     #[test]
     fn strip_think_tags_removes_think_content() {
@@ -2072,5 +2120,4 @@ mod tests {
         let input = "Answer</think>";
         assert_eq!(strip_think_tags(input), "Answer");
     }
->>>>>>> e36c634f (fix(ci): unblock self continuity checks)
 }

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -20,7 +20,62 @@ pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rou
 const FILE_READ_FOLLOWUP_CONTENT_PREVIEW_CHARS: usize = 384;
 const SHELL_FOLLOWUP_STDIO_PREVIEW_CHARS: usize = 384;
 const SHELL_FOLLOWUP_STDIO_OMISSION_MARKER: &str = "\n[... omitted ...]\n";
+const THINK_OPEN_TAG: &str = "<think>";
+const THINK_CLOSE_TAG: &str = "</think>";
 
+/// Strips <think>...</think> tags from model response text to prevent
+/// internal reasoning chains from leaking to user-facing output.
+/// This handles both standard think tags and case-insensitive variants.
+fn strip_think_tags(text: &str) -> String {
+    let mut cleaned_text = String::with_capacity(text.len());
+    let mut cursor = 0;
+    let mut inside_think_block = false;
+
+    while cursor < text.len() {
+        let remaining_text = &text[cursor..];
+        let open_tag_length = think_tag_prefix_len(remaining_text, THINK_OPEN_TAG);
+
+        if let Some(tag_length) = open_tag_length {
+            inside_think_block = true;
+            cursor += tag_length;
+            continue;
+        }
+
+        let close_tag_length = think_tag_prefix_len(remaining_text, THINK_CLOSE_TAG);
+
+        if let Some(tag_length) = close_tag_length {
+            inside_think_block = false;
+            cursor += tag_length;
+            continue;
+        }
+
+        let mut remaining_chars = remaining_text.chars();
+        let Some(current_char) = remaining_chars.next() else {
+            break;
+        };
+        let current_char_length = current_char.len_utf8();
+
+        if !inside_think_block {
+            cleaned_text.push(current_char);
+        }
+
+        cursor += current_char_length;
+    }
+
+    cleaned_text
+}
+
+fn think_tag_prefix_len(input: &str, tag: &str) -> Option<usize> {
+    let tag_length = tag.len();
+    let input_prefix = input.get(..tag_length)?;
+    let matches_tag = input_prefix.eq_ignore_ascii_case(tag);
+
+    if !matches_tag {
+        return None;
+    }
+
+    Some(tag_length)
+}
 pub fn next_conversation_turn_id() -> String {
     static NEXT_CONVERSATION_TURN_SEQ: AtomicU64 = AtomicU64::new(1);
     let seq = NEXT_CONVERSATION_TURN_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -1966,4 +2021,56 @@ mod tests {
         assert_eq!(reduced.as_ref(), tool_result);
         assert_eq!(reduced.as_ptr(), tool_result.as_ptr());
     }
+<<<<<<< HEAD
+=======
+
+    #[test]
+    fn strip_think_tags_removes_think_content() {
+        let input = "<think>Let me think about this...\nThe user wants to know the weather.\nI should check the forecast.</think>The weather today is sunny.";
+        let expected = "The weather today is sunny.";
+        assert_eq!(strip_think_tags(input), expected);
+    }
+
+    #[test]
+    fn strip_think_tags_handles_empty_tags() {
+        let input = "Hello <think></think>world";
+        assert_eq!(strip_think_tags(input), "Hello world");
+    }
+
+    #[test]
+    fn strip_think_tags_handles_multiple_tags() {
+        let input = "<think>First thought</think>Middle<think>Second thought</think>End";
+        assert_eq!(strip_think_tags(input), "MiddleEnd");
+    }
+
+    #[test]
+    fn strip_think_tags_handles_nested_content() {
+        let input = "<think>Think content with <tag> inside</think>Real response";
+        assert_eq!(strip_think_tags(input), "Real response");
+    }
+
+    #[test]
+    fn strip_think_tags_handles_nested_think_tags() {
+        let input = "<think>outer<think>inner</think>visible</think>done";
+        assert_eq!(strip_think_tags(input), "visibledone");
+    }
+
+    #[test]
+    fn strip_think_tags_case_insensitive() {
+        let input = "<ThInK>think content</tHiNk>Result";
+        assert_eq!(strip_think_tags(input), "Result");
+    }
+
+    #[test]
+    fn strip_think_tags_drops_unterminated_opening_tag() {
+        let input = "Answer<think>internal reasoning";
+        assert_eq!(strip_think_tags(input), "Answer");
+    }
+
+    #[test]
+    fn strip_think_tags_drops_stray_closing_tag() {
+        let input = "Answer</think>";
+        assert_eq!(strip_think_tags(input), "Answer");
+    }
+>>>>>>> e36c634f (fix(ci): unblock self continuity checks)
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -14,6 +14,7 @@ pub mod provider;
 pub mod runtime_env;
 mod runtime_identity;
 mod runtime_self;
+mod runtime_self_continuity;
 pub mod session;
 pub mod tools;
 

--- a/crates/app/src/memory/durable_flush.rs
+++ b/crates/app/src/memory/durable_flush.rs
@@ -1,0 +1,177 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use chrono::Local;
+use sha2::{Digest, Sha256};
+
+use crate::runtime_self_continuity;
+
+use super::runtime_config::MemoryRuntimeConfig;
+
+const DURABLE_MEMORY_DIR: &str = "memory";
+const DURABLE_MEMORY_SOURCE: &str = "pre_compaction_memory_flush";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PreCompactionDurableFlushOutcome {
+    SkippedMissingWorkspaceRoot,
+    SkippedNoSummary,
+    SkippedDuplicate,
+    Flushed {
+        path: PathBuf,
+        content_sha256: String,
+    },
+}
+
+pub(crate) fn flush_pre_compaction_durable_memory(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    memory_config: &MemoryRuntimeConfig,
+) -> Result<PreCompactionDurableFlushOutcome, String> {
+    let Some(workspace_root) = workspace_root else {
+        return Ok(PreCompactionDurableFlushOutcome::SkippedMissingWorkspaceRoot);
+    };
+
+    let summary_body =
+        super::sqlite::load_summary_body_for_durable_flush(session_id, memory_config)?;
+    let Some(summary_body) = summary_body else {
+        return Ok(PreCompactionDurableFlushOutcome::SkippedNoSummary);
+    };
+
+    let exported_on = Local::now().format("%Y-%m-%d").to_string();
+    let content_sha256 = durable_flush_content_sha256(session_id, summary_body.as_str());
+    let target_path = durable_memory_log_path(workspace_root, exported_on.as_str());
+
+    let is_duplicate =
+        durable_flush_already_recorded(target_path.as_path(), content_sha256.as_str())?;
+    if is_duplicate {
+        return Ok(PreCompactionDurableFlushOutcome::SkippedDuplicate);
+    }
+
+    let rendered_entry = render_durable_flush_entry(
+        session_id,
+        summary_body.as_str(),
+        exported_on.as_str(),
+        content_sha256.as_str(),
+    );
+    append_durable_flush_entry(target_path.as_path(), rendered_entry.as_str())?;
+
+    Ok(PreCompactionDurableFlushOutcome::Flushed {
+        path: target_path,
+        content_sha256,
+    })
+}
+
+fn durable_flush_content_sha256(session_id: &str, summary_body: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(session_id.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(summary_body.as_bytes());
+
+    let digest = hasher.finalize();
+    format!("{digest:x}")
+}
+
+fn durable_memory_log_path(workspace_root: &Path, exported_on: &str) -> PathBuf {
+    let file_name = format!("{exported_on}.md");
+    let memory_dir = workspace_root.join(DURABLE_MEMORY_DIR);
+    memory_dir.join(file_name)
+}
+
+fn durable_flush_already_recorded(path: &Path, content_sha256: &str) -> Result<bool, String> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let existing = std::fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read durable memory file {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let marker = durable_flush_hash_marker(content_sha256);
+
+    Ok(existing.contains(marker.as_str()))
+}
+
+fn durable_flush_hash_marker(content_sha256: &str) -> String {
+    format!("- content_sha256: {content_sha256}")
+}
+
+fn render_durable_flush_entry(
+    session_id: &str,
+    summary_body: &str,
+    exported_on: &str,
+    content_sha256: &str,
+) -> String {
+    let intro = runtime_self_continuity::durable_recall_intro();
+    let hash_marker = durable_flush_hash_marker(content_sha256);
+
+    let sections = [
+        "## Durable Recall".to_owned(),
+        intro.to_owned(),
+        format!("- source: {DURABLE_MEMORY_SOURCE}"),
+        format!("- session_id: {session_id}"),
+        format!("- exported_on: {exported_on}"),
+        hash_marker,
+        summary_body.trim().to_owned(),
+    ];
+    sections.join("\n\n")
+}
+
+fn append_durable_flush_entry(path: &Path, rendered_entry: &str) -> Result<(), String> {
+    let Some(parent) = path.parent() else {
+        return Err(format!(
+            "durable memory path {} has no parent directory",
+            path.display()
+        ));
+    };
+
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "create durable memory directory {} failed: {error}",
+            parent.display()
+        )
+    })?;
+
+    let existing_len = std::fs::metadata(path)
+        .ok()
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| {
+            format!(
+                "open durable memory file {} failed: {error}",
+                path.display()
+            )
+        })?;
+
+    if existing_len > 0 {
+        file.write_all(b"\n\n").map_err(|error| {
+            format!(
+                "append durable memory separator to {} failed: {error}",
+                path.display()
+            )
+        })?;
+    }
+
+    file.write_all(rendered_entry.as_bytes()).map_err(|error| {
+        format!(
+            "append durable memory entry to {} failed: {error}",
+            path.display()
+        )
+    })?;
+
+    file.write_all(b"\n").map_err(|error| {
+        format!(
+            "finalize durable memory entry in {} failed: {error}",
+            path.display()
+        )
+    })?;
+
+    Ok(())
+}

--- a/crates/app/src/memory/durable_flush.rs
+++ b/crates/app/src/memory/durable_flush.rs
@@ -1,9 +1,12 @@
-use std::fs::OpenOptions;
-use std::io::{ErrorKind, Write};
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use chrono::Local;
 use sha2::{Digest, Sha256};
+use tokio::fs;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
 
 use crate::runtime_self_continuity;
 
@@ -12,6 +15,8 @@ use super::runtime_config::MemoryRuntimeConfig;
 const DURABLE_MEMORY_DIR: &str = "memory";
 const DURABLE_MEMORY_SOURCE: &str = "pre_compaction_memory_flush";
 const DURABLE_FLUSH_CLAIM_EXTENSION: &str = "claim";
+const DURABLE_FLUSH_CLAIM_RETRY_DELAY: Duration = Duration::from_millis(5);
+const DURABLE_FLUSH_CLAIM_RETRY_ATTEMPTS: usize = 60;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PreCompactionDurableFlushOutcome {
@@ -24,6 +29,7 @@ pub(crate) enum PreCompactionDurableFlushOutcome {
     },
 }
 
+#[derive(Debug)]
 struct DurableFlushClaimGuard {
     path: PathBuf,
 }
@@ -34,7 +40,7 @@ impl Drop for DurableFlushClaimGuard {
     }
 }
 
-pub(crate) fn flush_pre_compaction_durable_memory(
+pub(crate) async fn flush_pre_compaction_durable_memory(
     session_id: &str,
     workspace_root: Option<&Path>,
     memory_config: &MemoryRuntimeConfig,
@@ -52,13 +58,14 @@ pub(crate) fn flush_pre_compaction_durable_memory(
     let exported_on = Local::now().format("%Y-%m-%d").to_string();
     let content_sha256 = durable_flush_content_sha256(session_id, summary_body.as_str());
     let target_path = durable_memory_log_path(workspace_root, exported_on.as_str());
-    let claim_guard = try_claim_durable_flush(target_path.as_path(), content_sha256.as_str())?;
+    let claim_guard =
+        try_claim_durable_flush(target_path.as_path(), content_sha256.as_str()).await?;
     let Some(_claim_guard) = claim_guard else {
         return Ok(PreCompactionDurableFlushOutcome::SkippedDuplicate);
     };
 
     let is_duplicate =
-        durable_flush_already_recorded(target_path.as_path(), content_sha256.as_str())?;
+        durable_flush_already_recorded(target_path.as_path(), content_sha256.as_str()).await?;
     if is_duplicate {
         return Ok(PreCompactionDurableFlushOutcome::SkippedDuplicate);
     }
@@ -69,7 +76,7 @@ pub(crate) fn flush_pre_compaction_durable_memory(
         exported_on.as_str(),
         content_sha256.as_str(),
     );
-    append_durable_flush_entry(target_path.as_path(), rendered_entry.as_str())?;
+    append_durable_flush_entry(target_path.as_path(), rendered_entry.as_str()).await?;
 
     Ok(PreCompactionDurableFlushOutcome::Flushed {
         path: target_path,
@@ -93,17 +100,17 @@ fn durable_memory_log_path(workspace_root: &Path, exported_on: &str) -> PathBuf 
     memory_dir.join(file_name)
 }
 
-fn durable_flush_already_recorded(path: &Path, content_sha256: &str) -> Result<bool, String> {
-    if !path.exists() {
-        return Ok(false);
-    }
-
-    let existing = std::fs::read_to_string(path).map_err(|error| {
-        format!(
-            "read durable memory file {} failed: {error}",
-            path.display()
-        )
-    })?;
+async fn durable_flush_already_recorded(path: &Path, content_sha256: &str) -> Result<bool, String> {
+    let existing = match fs::read_to_string(path).await {
+        Ok(existing) => existing,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "read durable memory file {} failed: {error}",
+                path.display()
+            ));
+        }
+    };
     let marker = durable_flush_hash_marker(content_sha256);
 
     Ok(existing.contains(marker.as_str()))
@@ -113,7 +120,7 @@ fn durable_flush_hash_marker(content_sha256: &str) -> String {
     format!("- content_sha256: {content_sha256}")
 }
 
-fn durable_flush_claim_path(path: &Path, content_sha256: &str) -> Result<PathBuf, String> {
+fn durable_flush_claim_path(path: &Path, _content_sha256: &str) -> Result<PathBuf, String> {
     let Some(parent) = path.parent() else {
         return Err(format!(
             "durable memory path {} has no parent directory",
@@ -124,12 +131,12 @@ fn durable_flush_claim_path(path: &Path, content_sha256: &str) -> Result<PathBuf
         .file_name()
         .and_then(|value| value.to_str())
         .unwrap_or("durable-memory");
-    let claim_file_name = format!(".{file_name}.{content_sha256}.{DURABLE_FLUSH_CLAIM_EXTENSION}");
+    let claim_file_name = format!(".{file_name}.{DURABLE_FLUSH_CLAIM_EXTENSION}");
     let claim_path = parent.join(claim_file_name);
     Ok(claim_path)
 }
 
-fn try_claim_durable_flush(
+async fn try_claim_durable_flush(
     path: &Path,
     content_sha256: &str,
 ) -> Result<Option<DurableFlushClaimGuard>, String> {
@@ -140,7 +147,7 @@ fn try_claim_durable_flush(
         ));
     };
 
-    std::fs::create_dir_all(parent).map_err(|error| {
+    fs::create_dir_all(parent).await.map_err(|error| {
         format!(
             "create durable memory directory {} failed: {error}",
             parent.display()
@@ -148,18 +155,34 @@ fn try_claim_durable_flush(
     })?;
 
     let claim_path = durable_flush_claim_path(path, content_sha256)?;
-    let claim_file = OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .open(claim_path.as_path());
+    let mut attempts_remaining = DURABLE_FLUSH_CLAIM_RETRY_ATTEMPTS;
 
-    match claim_file {
-        Ok(_) => Ok(Some(DurableFlushClaimGuard { path: claim_path })),
-        Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(None),
-        Err(error) => Err(format!(
-            "create durable flush claim {} failed: {error}",
-            claim_path.display()
-        )),
+    loop {
+        let claim_file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(claim_path.as_path())
+            .await;
+
+        match claim_file {
+            Ok(_) => return Ok(Some(DurableFlushClaimGuard { path: claim_path })),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists && attempts_remaining > 0 => {
+                attempts_remaining = attempts_remaining.saturating_sub(1);
+                tokio::time::sleep(DURABLE_FLUSH_CLAIM_RETRY_DELAY).await;
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                return Err(format!(
+                    "timed out waiting for durable flush claim {} to clear",
+                    claim_path.display()
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "create durable flush claim {} failed: {error}",
+                    claim_path.display()
+                ));
+            }
+        }
     }
 }
 
@@ -184,7 +207,7 @@ fn render_durable_flush_entry(
     sections.join("\n\n")
 }
 
-fn append_durable_flush_entry(path: &Path, rendered_entry: &str) -> Result<(), String> {
+async fn append_durable_flush_entry(path: &Path, rendered_entry: &str) -> Result<(), String> {
     let Some(parent) = path.parent() else {
         return Err(format!(
             "durable memory path {} has no parent directory",
@@ -192,22 +215,29 @@ fn append_durable_flush_entry(path: &Path, rendered_entry: &str) -> Result<(), S
         ));
     };
 
-    std::fs::create_dir_all(parent).map_err(|error| {
+    fs::create_dir_all(parent).await.map_err(|error| {
         format!(
             "create durable memory directory {} failed: {error}",
             parent.display()
         )
     })?;
 
-    let existing_len = std::fs::metadata(path)
-        .ok()
-        .map(|metadata| metadata.len())
-        .unwrap_or(0);
+    let existing_len = match fs::metadata(path).await {
+        Ok(metadata) => metadata.len(),
+        Err(error) if error.kind() == ErrorKind::NotFound => 0,
+        Err(error) => {
+            return Err(format!(
+                "read durable memory metadata {} failed: {error}",
+                path.display()
+            ));
+        }
+    };
 
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
+        .await
         .map_err(|error| {
             format!(
                 "open durable memory file {} failed: {error}",
@@ -216,7 +246,7 @@ fn append_durable_flush_entry(path: &Path, rendered_entry: &str) -> Result<(), S
         })?;
 
     if existing_len > 0 {
-        file.write_all(b"\n\n").map_err(|error| {
+        file.write_all(b"\n\n").await.map_err(|error| {
             format!(
                 "append durable memory separator to {} failed: {error}",
                 path.display()
@@ -224,21 +254,23 @@ fn append_durable_flush_entry(path: &Path, rendered_entry: &str) -> Result<(), S
         })?;
     }
 
-    file.write_all(rendered_entry.as_bytes()).map_err(|error| {
-        format!(
-            "append durable memory entry to {} failed: {error}",
-            path.display()
-        )
-    })?;
+    file.write_all(rendered_entry.as_bytes())
+        .await
+        .map_err(|error| {
+            format!(
+                "append durable memory entry to {} failed: {error}",
+                path.display()
+            )
+        })?;
 
-    file.write_all(b"\n").map_err(|error| {
+    file.write_all(b"\n").await.map_err(|error| {
         format!(
             "finalize durable memory entry in {} failed: {error}",
             path.display()
         )
     })?;
 
-    file.sync_data().map_err(|error| {
+    file.sync_data().await.map_err(|error| {
         format!(
             "sync durable memory file {} failed: {error}",
             path.display()
@@ -251,9 +283,23 @@ fn append_durable_flush_entry(path: &Path, rendered_entry: &str) -> Result<(), S
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
-    fn try_claim_durable_flush_skips_when_claim_already_exists() {
+    fn durable_flush_claim_path_is_scoped_to_target_path() {
+        let workspace_root = crate::test_support::unique_temp_dir("durable-flush-claim-scope");
+        let target_path = workspace_root.join("memory").join("2026-03-24.md");
+        let first_claim_path =
+            durable_flush_claim_path(target_path.as_path(), "hash-a").expect("first claim path");
+        let second_claim_path =
+            durable_flush_claim_path(target_path.as_path(), "hash-b").expect("second claim path");
+
+        assert_eq!(first_claim_path, second_claim_path);
+    }
+
+    #[tokio::test]
+    async fn try_claim_durable_flush_times_out_when_claim_never_clears() {
         let workspace_root = crate::test_support::unique_temp_dir("durable-flush-claim-exists");
         let target_path = workspace_root.join("memory").join("2026-03-24.md");
         let content_sha256 = "abc123";
@@ -264,12 +310,52 @@ mod tests {
         std::fs::create_dir_all(parent).expect("create claim parent");
         std::fs::write(claim_path.as_path(), "claimed").expect("write existing claim");
 
-        let claim = try_claim_durable_flush(target_path.as_path(), content_sha256)
-            .expect("claim lookup should succeed");
+        let error = try_claim_durable_flush(target_path.as_path(), content_sha256)
+            .await
+            .expect_err("stale claim should time out");
 
         assert!(
-            claim.is_none(),
-            "existing claim should skip duplicate flush"
+            error.contains("timed out waiting for durable flush claim"),
+            "stale claim should surface a timeout error"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_claim_durable_flush_blocks_parallel_claims_for_same_target() {
+        let workspace_root =
+            crate::test_support::unique_temp_dir("durable-flush-claim-parallel-target");
+        let target_path = workspace_root.join("memory").join("2026-03-24.md");
+        let first_claim = try_claim_durable_flush(target_path.as_path(), "hash-a")
+            .await
+            .expect("first claim should succeed")
+            .expect("first claim guard");
+        let acquired = Arc::new(AtomicBool::new(false));
+        let acquired_for_thread = Arc::clone(&acquired);
+        let thread_target_path = target_path.clone();
+
+        let handle = tokio::spawn(async move {
+            let second_claim = try_claim_durable_flush(thread_target_path.as_path(), "hash-b")
+                .await
+                .expect("second claim should eventually succeed")
+                .expect("second claim guard");
+
+            acquired_for_thread.store(true, Ordering::SeqCst);
+            drop(second_claim);
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(
+            !acquired.load(Ordering::SeqCst),
+            "second claim should wait until the first target lock is released"
+        );
+
+        drop(first_claim);
+        handle.await.expect("claim waiter should complete");
+
+        assert!(
+            acquired.load(Ordering::SeqCst),
+            "second claim should acquire after the first target lock is released"
         );
     }
 }

--- a/crates/app/src/memory/durable_flush.rs
+++ b/crates/app/src/memory/durable_flush.rs
@@ -1,5 +1,5 @@
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use chrono::Local;
@@ -11,6 +11,7 @@ use super::runtime_config::MemoryRuntimeConfig;
 
 const DURABLE_MEMORY_DIR: &str = "memory";
 const DURABLE_MEMORY_SOURCE: &str = "pre_compaction_memory_flush";
+const DURABLE_FLUSH_CLAIM_EXTENSION: &str = "claim";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PreCompactionDurableFlushOutcome {
@@ -21,6 +22,16 @@ pub(crate) enum PreCompactionDurableFlushOutcome {
         path: PathBuf,
         content_sha256: String,
     },
+}
+
+struct DurableFlushClaimGuard {
+    path: PathBuf,
+}
+
+impl Drop for DurableFlushClaimGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(self.path.as_path());
+    }
 }
 
 pub(crate) fn flush_pre_compaction_durable_memory(
@@ -41,6 +52,10 @@ pub(crate) fn flush_pre_compaction_durable_memory(
     let exported_on = Local::now().format("%Y-%m-%d").to_string();
     let content_sha256 = durable_flush_content_sha256(session_id, summary_body.as_str());
     let target_path = durable_memory_log_path(workspace_root, exported_on.as_str());
+    let claim_guard = try_claim_durable_flush(target_path.as_path(), content_sha256.as_str())?;
+    let Some(_claim_guard) = claim_guard else {
+        return Ok(PreCompactionDurableFlushOutcome::SkippedDuplicate);
+    };
 
     let is_duplicate =
         durable_flush_already_recorded(target_path.as_path(), content_sha256.as_str())?;
@@ -96,6 +111,56 @@ fn durable_flush_already_recorded(path: &Path, content_sha256: &str) -> Result<b
 
 fn durable_flush_hash_marker(content_sha256: &str) -> String {
     format!("- content_sha256: {content_sha256}")
+}
+
+fn durable_flush_claim_path(path: &Path, content_sha256: &str) -> Result<PathBuf, String> {
+    let Some(parent) = path.parent() else {
+        return Err(format!(
+            "durable memory path {} has no parent directory",
+            path.display()
+        ));
+    };
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("durable-memory");
+    let claim_file_name = format!(".{file_name}.{content_sha256}.{DURABLE_FLUSH_CLAIM_EXTENSION}");
+    let claim_path = parent.join(claim_file_name);
+    Ok(claim_path)
+}
+
+fn try_claim_durable_flush(
+    path: &Path,
+    content_sha256: &str,
+) -> Result<Option<DurableFlushClaimGuard>, String> {
+    let Some(parent) = path.parent() else {
+        return Err(format!(
+            "durable memory path {} has no parent directory",
+            path.display()
+        ));
+    };
+
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "create durable memory directory {} failed: {error}",
+            parent.display()
+        )
+    })?;
+
+    let claim_path = durable_flush_claim_path(path, content_sha256)?;
+    let claim_file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(claim_path.as_path());
+
+    match claim_file {
+        Ok(_) => Ok(Some(DurableFlushClaimGuard { path: claim_path })),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(None),
+        Err(error) => Err(format!(
+            "create durable flush claim {} failed: {error}",
+            claim_path.display()
+        )),
+    }
 }
 
 fn render_durable_flush_entry(
@@ -173,5 +238,38 @@ fn append_durable_flush_entry(path: &Path, rendered_entry: &str) -> Result<(), S
         )
     })?;
 
+    file.sync_data().map_err(|error| {
+        format!(
+            "sync durable memory file {} failed: {error}",
+            path.display()
+        )
+    })?;
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_claim_durable_flush_skips_when_claim_already_exists() {
+        let workspace_root = crate::test_support::unique_temp_dir("durable-flush-claim-exists");
+        let target_path = workspace_root.join("memory").join("2026-03-24.md");
+        let content_sha256 = "abc123";
+
+        let claim_path =
+            durable_flush_claim_path(target_path.as_path(), content_sha256).expect("claim path");
+        let parent = claim_path.parent().expect("claim parent");
+        std::fs::create_dir_all(parent).expect("create claim parent");
+        std::fs::write(claim_path.as_path(), "claimed").expect("write existing claim");
+
+        let claim = try_claim_durable_flush(target_path.as_path(), content_sha256)
+            .expect("claim lookup should succeed");
+
+        assert!(
+            claim.is_none(),
+            "existing claim should skip duplicate flush"
+        );
+    }
 }

--- a/crates/app/src/memory/durable_recall.rs
+++ b/crates/app/src/memory/durable_recall.rs
@@ -32,16 +32,19 @@ pub(crate) fn load_durable_recall_entries(
         return Ok(Vec::new());
     };
 
+    let canonical_workspace_root = canonical_workspace_memory_root(workspace_root)?;
     let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
     let per_file_char_budget = config.summary_max_chars.max(256);
 
     let curated_documents = collect_curated_memory_documents(
         workspace_root,
+        canonical_workspace_root.as_path(),
         candidate_roots.as_slice(),
         per_file_char_budget,
     )?;
     let daily_documents = collect_recent_daily_log_documents(
         workspace_root,
+        canonical_workspace_root.as_path(),
         candidate_roots.as_slice(),
         per_file_char_budget,
     )?;
@@ -66,6 +69,7 @@ pub(crate) fn load_durable_recall_entries(
 
 fn collect_curated_memory_documents(
     workspace_root: &Path,
+    canonical_workspace_root: &Path,
     candidate_roots: &[PathBuf],
     per_file_char_budget: usize,
 ) -> Result<Vec<DurableRecallDocument>, String> {
@@ -78,6 +82,7 @@ fn collect_curated_memory_documents(
             let candidate_path = root.join(relative_path);
             let maybe_document = load_document_if_present(
                 workspace_root,
+                canonical_workspace_root,
                 candidate_path.as_path(),
                 per_file_char_budget,
                 &mut seen_paths,
@@ -94,6 +99,7 @@ fn collect_curated_memory_documents(
 
 fn collect_recent_daily_log_documents(
     workspace_root: &Path,
+    canonical_workspace_root: &Path,
     candidate_roots: &[PathBuf],
     per_file_char_budget: usize,
 ) -> Result<Vec<DurableRecallDocument>, String> {
@@ -105,6 +111,12 @@ fn collect_recent_daily_log_documents(
         if !memory_dir.is_dir() {
             continue;
         }
+
+        let Some(_canonical_memory_dir) =
+            resolve_workspace_memory_path(canonical_workspace_root, memory_dir.as_path())?
+        else {
+            continue;
+        };
 
         let read_dir = std::fs::read_dir(&memory_dir).map_err(|error| {
             format!(
@@ -124,7 +136,13 @@ fn collect_recent_daily_log_documents(
                 continue;
             };
 
-            let path_key = normalized_path_key(path.as_path());
+            let Some(canonical_path) =
+                resolve_workspace_memory_path(canonical_workspace_root, path.as_path())?
+            else {
+                continue;
+            };
+
+            let path_key = canonical_path_key(canonical_path.as_path());
             let inserted = seen_paths.insert(path_key);
             if !inserted {
                 continue;
@@ -163,6 +181,7 @@ fn collect_recent_daily_log_documents(
 
 fn load_document_if_present(
     workspace_root: &Path,
+    canonical_workspace_root: &Path,
     path: &Path,
     per_file_char_budget: usize,
     seen_paths: &mut BTreeSet<String>,
@@ -171,13 +190,19 @@ fn load_document_if_present(
         return Ok(None);
     }
 
-    let path_key = normalized_path_key(path);
+    let Some(canonical_path) = resolve_workspace_memory_path(canonical_workspace_root, path)?
+    else {
+        return Ok(None);
+    };
+
+    let path_key = canonical_path_key(canonical_path.as_path());
     let inserted = seen_paths.insert(path_key);
     if !inserted {
         return Ok(None);
     }
 
-    let maybe_content = load_trimmed_document_content(path, per_file_char_budget)?;
+    let maybe_content =
+        load_trimmed_document_content(canonical_path.as_path(), per_file_char_budget)?;
     let Some(content) = maybe_content else {
         return Ok(None);
     };
@@ -223,9 +248,35 @@ fn durable_recall_label(workspace_root: &Path, path: &Path) -> String {
     display_path.display().to_string()
 }
 
-fn normalized_path_key(path: &Path) -> String {
-    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    canonical_path.display().to_string()
+fn canonical_workspace_memory_root(workspace_root: &Path) -> Result<PathBuf, String> {
+    workspace_root.canonicalize().map_err(|error| {
+        format!(
+            "canonicalize durable recall workspace root {} failed: {error}",
+            workspace_root.display()
+        )
+    })
+}
+
+fn resolve_workspace_memory_path(
+    canonical_workspace_root: &Path,
+    path: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let canonical_path = path.canonicalize().map_err(|error| {
+        format!(
+            "canonicalize durable recall path {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let is_within_workspace = canonical_path.starts_with(canonical_workspace_root);
+    if !is_within_workspace {
+        return Ok(None);
+    }
+
+    Ok(Some(canonical_path))
+}
+
+fn canonical_path_key(path: &Path) -> String {
+    path.display().to_string()
 }
 
 fn truncate_chars(input: &str, max_chars: usize) -> String {
@@ -264,6 +315,11 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    #[cfg(unix)]
+    fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
     #[test]
     fn collect_recent_daily_log_documents_prefers_newest_dated_logs() {
         let temp_dir = tempdir().expect("tempdir");
@@ -276,9 +332,15 @@ mod tests {
         std::fs::write(memory_dir.join("2026-03-22.md"), "new").expect("write new log");
 
         let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
-        let documents =
-            collect_recent_daily_log_documents(workspace_root, candidate_roots.as_slice(), 256)
-                .expect("collect daily log documents");
+        let canonical_workspace_root =
+            canonical_workspace_memory_root(workspace_root).expect("canonical workspace root");
+        let documents = collect_recent_daily_log_documents(
+            workspace_root,
+            canonical_workspace_root.as_path(),
+            candidate_roots.as_slice(),
+            256,
+        )
+        .expect("collect daily log documents");
 
         assert_eq!(documents.len(), 2);
         assert_eq!(documents[0].label, "memory/2026-03-22.md");
@@ -293,10 +355,63 @@ mod tests {
         std::fs::write(workspace_root.join("MEMORY.md"), "   ").expect("write empty memory file");
 
         let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
-        let documents =
-            collect_curated_memory_documents(workspace_root, candidate_roots.as_slice(), 256)
-                .expect("collect curated memory documents");
+        let canonical_workspace_root =
+            canonical_workspace_memory_root(workspace_root).expect("canonical workspace root");
+        let documents = collect_curated_memory_documents(
+            workspace_root,
+            canonical_workspace_root.as_path(),
+            candidate_roots.as_slice(),
+            256,
+        )
+        .expect("collect curated memory documents");
 
         assert!(documents.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_durable_recall_entries_ignores_symlinked_memory_file_outside_workspace_root() {
+        let temp_dir = tempdir().expect("tempdir");
+        let sandbox_root = temp_dir.path();
+        let workspace_root = sandbox_root.join("workspace");
+        let outside_root = sandbox_root.join("outside");
+        let outside_memory_path = outside_root.join("secret.md");
+        let linked_memory_path = workspace_root.join("MEMORY.md");
+
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::create_dir_all(&outside_root).expect("create outside root");
+        std::fs::write(&outside_memory_path, "outside durable recall secret")
+            .expect("write outside memory");
+        create_symlink(&outside_memory_path, &linked_memory_path).expect("create symlink");
+
+        let config = MemoryRuntimeConfig::default();
+        let entries = load_durable_recall_entries(Some(workspace_root.as_path()), &config)
+            .expect("load durable recall entries");
+
+        assert!(entries.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_durable_recall_entries_ignores_symlinked_memory_directory_outside_workspace_root() {
+        let temp_dir = tempdir().expect("tempdir");
+        let sandbox_root = temp_dir.path();
+        let workspace_root = sandbox_root.join("workspace");
+        let outside_root = sandbox_root.join("outside");
+        let outside_memory_dir = outside_root.join("logs");
+        let outside_daily_log_path = outside_memory_dir.join("2026-03-24.md");
+        let linked_memory_dir = workspace_root.join("memory");
+
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::create_dir_all(&outside_memory_dir).expect("create outside memory dir");
+        std::fs::write(&outside_daily_log_path, "outside durable recall daily log")
+            .expect("write outside daily log");
+        create_symlink(&outside_memory_dir, &linked_memory_dir).expect("create dir symlink");
+
+        let config = MemoryRuntimeConfig::default();
+        let entries = load_durable_recall_entries(Some(workspace_root.as_path()), &config)
+            .expect("load durable recall entries");
+
+        assert!(entries.is_empty());
     }
 }

--- a/crates/app/src/memory/durable_recall.rs
+++ b/crates/app/src/memory/durable_recall.rs
@@ -1,27 +1,19 @@
-use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use chrono::NaiveDate;
+use crate::runtime_self_continuity;
 
-use crate::{runtime_self, runtime_self_continuity};
+use super::{
+    MemoryContextEntry, MemoryContextKind, WorkspaceMemoryDocumentKind,
+    WorkspaceMemoryDocumentLocation, collect_workspace_memory_document_locations,
+    runtime_config::MemoryRuntimeConfig,
+};
 
-use super::{MemoryContextEntry, MemoryContextKind, runtime_config::MemoryRuntimeConfig};
-
-const ROOT_MEMORY_FILE: &str = "MEMORY.md";
-const NESTED_MEMORY_FILE: &str = "memory/MEMORY.md";
 const RECENT_DAILY_LOG_LIMIT: usize = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DurableRecallDocument {
     label: String,
     content: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct DailyLogCandidate {
-    label: String,
-    path: PathBuf,
-    date: NaiveDate,
 }
 
 pub(crate) fn load_durable_recall_entries(
@@ -32,26 +24,8 @@ pub(crate) fn load_durable_recall_entries(
         return Ok(Vec::new());
     };
 
-    let canonical_workspace_root = canonical_workspace_memory_root(workspace_root)?;
-    let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
     let per_file_char_budget = config.summary_max_chars.max(256);
-
-    let curated_documents = collect_curated_memory_documents(
-        workspace_root,
-        canonical_workspace_root.as_path(),
-        candidate_roots.as_slice(),
-        per_file_char_budget,
-    )?;
-    let daily_documents = collect_recent_daily_log_documents(
-        workspace_root,
-        canonical_workspace_root.as_path(),
-        candidate_roots.as_slice(),
-        per_file_char_budget,
-    )?;
-
-    let mut documents = Vec::new();
-    documents.extend(curated_documents);
-    documents.extend(daily_documents);
+    let documents = collect_durable_recall_documents(workspace_root, per_file_char_budget)?;
 
     if documents.is_empty() {
         return Ok(Vec::new());
@@ -67,111 +41,32 @@ pub(crate) fn load_durable_recall_entries(
     Ok(vec![entry])
 }
 
-fn collect_curated_memory_documents(
+fn collect_durable_recall_documents(
     workspace_root: &Path,
-    canonical_workspace_root: &Path,
-    candidate_roots: &[PathBuf],
     per_file_char_budget: usize,
 ) -> Result<Vec<DurableRecallDocument>, String> {
+    let document_locations = collect_workspace_memory_document_locations(workspace_root)?;
     let mut documents = Vec::new();
-    let mut seen_paths = BTreeSet::new();
-    let relative_paths = [ROOT_MEMORY_FILE, NESTED_MEMORY_FILE];
 
-    for root in candidate_roots {
-        for relative_path in relative_paths {
-            let candidate_path = root.join(relative_path);
-            let maybe_document = load_document_if_present(
-                workspace_root,
-                canonical_workspace_root,
-                candidate_path.as_path(),
-                per_file_char_budget,
-                &mut seen_paths,
-            )?;
-            let Some(document) = maybe_document else {
-                continue;
-            };
-            documents.push(document);
-        }
-    }
-
-    Ok(documents)
-}
-
-fn collect_recent_daily_log_documents(
-    workspace_root: &Path,
-    canonical_workspace_root: &Path,
-    candidate_roots: &[PathBuf],
-    per_file_char_budget: usize,
-) -> Result<Vec<DurableRecallDocument>, String> {
-    let mut candidates = Vec::new();
-    let mut seen_paths = BTreeSet::new();
-
-    for root in candidate_roots {
-        let memory_dir = root.join("memory");
-        if !memory_dir.is_dir() {
-            continue;
-        }
-
-        let Some(_canonical_memory_dir) =
-            resolve_workspace_memory_path(canonical_workspace_root, memory_dir.as_path())?
-        else {
+    let curated_locations = document_locations
+        .iter()
+        .filter(|location| location.kind == WorkspaceMemoryDocumentKind::Curated);
+    for location in curated_locations {
+        let maybe_document = load_document_from_location(location, per_file_char_budget)?;
+        let Some(document) = maybe_document else {
             continue;
         };
-
-        let read_dir = std::fs::read_dir(&memory_dir).map_err(|error| {
-            format!(
-                "read durable recall directory {} failed: {error}",
-                memory_dir.display()
-            )
-        })?;
-        for entry_result in read_dir {
-            let entry = entry_result.map_err(|error| {
-                format!(
-                    "read durable recall directory entry in {} failed: {error}",
-                    memory_dir.display()
-                )
-            })?;
-            let path = entry.path();
-            let Some(date) = parse_daily_log_date(path.as_path()) else {
-                continue;
-            };
-
-            let Some(canonical_path) =
-                resolve_workspace_memory_path(canonical_workspace_root, path.as_path())?
-            else {
-                continue;
-            };
-
-            let path_key = canonical_path_key(canonical_path.as_path());
-            let inserted = seen_paths.insert(path_key);
-            if !inserted {
-                continue;
-            }
-
-            let label = durable_recall_label(workspace_root, path.as_path());
-            let candidate = DailyLogCandidate { label, path, date };
-            candidates.push(candidate);
-        }
+        documents.push(document);
     }
 
-    candidates.sort_by(|left, right| {
-        right
-            .date
-            .cmp(&left.date)
-            .then(left.label.cmp(&right.label))
-    });
-
-    let mut documents = Vec::new();
-    let selected_candidates = candidates.into_iter().take(RECENT_DAILY_LOG_LIMIT);
-    for candidate in selected_candidates {
-        let maybe_content =
-            load_trimmed_document_content(candidate.path.as_path(), per_file_char_budget)?;
-        let Some(content) = maybe_content else {
+    let daily_locations = document_locations
+        .iter()
+        .filter(|location| location.kind == WorkspaceMemoryDocumentKind::DailyLog)
+        .take(RECENT_DAILY_LOG_LIMIT);
+    for location in daily_locations {
+        let maybe_document = load_document_from_location(location, per_file_char_budget)?;
+        let Some(document) = maybe_document else {
             continue;
-        };
-        let document = DurableRecallDocument {
-            label: candidate.label,
-            content,
         };
         documents.push(document);
     }
@@ -179,36 +74,20 @@ fn collect_recent_daily_log_documents(
     Ok(documents)
 }
 
-fn load_document_if_present(
-    workspace_root: &Path,
-    canonical_workspace_root: &Path,
-    path: &Path,
+fn load_document_from_location(
+    location: &WorkspaceMemoryDocumentLocation,
     per_file_char_budget: usize,
-    seen_paths: &mut BTreeSet<String>,
 ) -> Result<Option<DurableRecallDocument>, String> {
-    if !path.is_file() {
-        return Ok(None);
-    }
-
-    let Some(canonical_path) = resolve_workspace_memory_path(canonical_workspace_root, path)?
-    else {
-        return Ok(None);
-    };
-
-    let path_key = canonical_path_key(canonical_path.as_path());
-    let inserted = seen_paths.insert(path_key);
-    if !inserted {
-        return Ok(None);
-    }
-
-    let maybe_content =
-        load_trimmed_document_content(canonical_path.as_path(), per_file_char_budget)?;
+    let path = location.path.as_path();
+    let maybe_content = load_trimmed_document_content(path, per_file_char_budget)?;
     let Some(content) = maybe_content else {
         return Ok(None);
     };
 
-    let label = durable_recall_label(workspace_root, path);
-    let document = DurableRecallDocument { label, content };
+    let document = DurableRecallDocument {
+        label: location.label.clone(),
+        content,
+    };
     Ok(Some(document))
 }
 
@@ -229,54 +108,6 @@ fn load_trimmed_document_content(
 
     let bounded_content = truncate_chars(trimmed_content, per_file_char_budget);
     Ok(Some(bounded_content))
-}
-
-fn parse_daily_log_date(path: &Path) -> Option<NaiveDate> {
-    let extension = path.extension().and_then(|value| value.to_str());
-    let is_markdown = extension.is_some_and(|value| value.eq_ignore_ascii_case("md"));
-    if !is_markdown {
-        return None;
-    }
-
-    let stem = path.file_stem().and_then(|value| value.to_str())?;
-    NaiveDate::parse_from_str(stem, "%Y-%m-%d").ok()
-}
-
-fn durable_recall_label(workspace_root: &Path, path: &Path) -> String {
-    let relative_path = path.strip_prefix(workspace_root).ok();
-    let display_path = relative_path.unwrap_or(path);
-    display_path.display().to_string()
-}
-
-fn canonical_workspace_memory_root(workspace_root: &Path) -> Result<PathBuf, String> {
-    workspace_root.canonicalize().map_err(|error| {
-        format!(
-            "canonicalize durable recall workspace root {} failed: {error}",
-            workspace_root.display()
-        )
-    })
-}
-
-fn resolve_workspace_memory_path(
-    canonical_workspace_root: &Path,
-    path: &Path,
-) -> Result<Option<PathBuf>, String> {
-    let canonical_path = path.canonicalize().map_err(|error| {
-        format!(
-            "canonicalize durable recall path {} failed: {error}",
-            path.display()
-        )
-    })?;
-    let is_within_workspace = canonical_path.starts_with(canonical_workspace_root);
-    if !is_within_workspace {
-        return Ok(None);
-    }
-
-    Ok(Some(canonical_path))
-}
-
-fn canonical_path_key(path: &Path) -> String {
-    path.display().to_string()
 }
 
 fn truncate_chars(input: &str, max_chars: usize) -> String {
@@ -315,103 +146,42 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    #[cfg(unix)]
-    fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
-        std::os::unix::fs::symlink(target, link)
-    }
-
     #[test]
     fn collect_recent_daily_log_documents_prefers_newest_dated_logs() {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
         let memory_dir = workspace_root.join("memory");
+
         std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(workspace_root.join("MEMORY.md"), "curated").expect("write curated memory");
 
         std::fs::write(memory_dir.join("2026-03-20.md"), "old").expect("write old log");
         std::fs::write(memory_dir.join("2026-03-21.md"), "middle").expect("write middle log");
         std::fs::write(memory_dir.join("2026-03-22.md"), "new").expect("write new log");
 
-        let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
-        let canonical_workspace_root =
-            canonical_workspace_memory_root(workspace_root).expect("canonical workspace root");
-        let documents = collect_recent_daily_log_documents(
-            workspace_root,
-            canonical_workspace_root.as_path(),
-            candidate_roots.as_slice(),
-            256,
-        )
-        .expect("collect daily log documents");
+        let documents = collect_durable_recall_documents(workspace_root, 256)
+            .expect("collect durable recall documents");
 
-        assert_eq!(documents.len(), 2);
-        assert_eq!(documents[0].label, "memory/2026-03-22.md");
-        assert_eq!(documents[1].label, "memory/2026-03-21.md");
+        assert_eq!(documents.len(), 3);
+        assert_eq!(documents[0].label, "MEMORY.md");
+        assert_eq!(documents[1].label, "memory/2026-03-22.md");
+        assert_eq!(documents[2].label, "memory/2026-03-21.md");
     }
 
     #[test]
     fn collect_curated_memory_documents_skips_empty_files() {
         let temp_dir = tempdir().expect("tempdir");
         let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
 
         std::fs::write(workspace_root.join("MEMORY.md"), "   ").expect("write empty memory file");
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(memory_dir.join("2026-03-22.md"), "daily log").expect("write daily log");
 
-        let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
-        let canonical_workspace_root =
-            canonical_workspace_memory_root(workspace_root).expect("canonical workspace root");
-        let documents = collect_curated_memory_documents(
-            workspace_root,
-            canonical_workspace_root.as_path(),
-            candidate_roots.as_slice(),
-            256,
-        )
-        .expect("collect curated memory documents");
+        let documents = collect_durable_recall_documents(workspace_root, 256)
+            .expect("collect durable recall documents");
 
-        assert!(documents.is_empty());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn load_durable_recall_entries_ignores_symlinked_memory_file_outside_workspace_root() {
-        let temp_dir = tempdir().expect("tempdir");
-        let sandbox_root = temp_dir.path();
-        let workspace_root = sandbox_root.join("workspace");
-        let outside_root = sandbox_root.join("outside");
-        let outside_memory_path = outside_root.join("secret.md");
-        let linked_memory_path = workspace_root.join("MEMORY.md");
-
-        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
-        std::fs::create_dir_all(&outside_root).expect("create outside root");
-        std::fs::write(&outside_memory_path, "outside durable recall secret")
-            .expect("write outside memory");
-        create_symlink(&outside_memory_path, &linked_memory_path).expect("create symlink");
-
-        let config = MemoryRuntimeConfig::default();
-        let entries = load_durable_recall_entries(Some(workspace_root.as_path()), &config)
-            .expect("load durable recall entries");
-
-        assert!(entries.is_empty());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn load_durable_recall_entries_ignores_symlinked_memory_directory_outside_workspace_root() {
-        let temp_dir = tempdir().expect("tempdir");
-        let sandbox_root = temp_dir.path();
-        let workspace_root = sandbox_root.join("workspace");
-        let outside_root = sandbox_root.join("outside");
-        let outside_memory_dir = outside_root.join("logs");
-        let outside_daily_log_path = outside_memory_dir.join("2026-03-24.md");
-        let linked_memory_dir = workspace_root.join("memory");
-
-        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
-        std::fs::create_dir_all(&outside_memory_dir).expect("create outside memory dir");
-        std::fs::write(&outside_daily_log_path, "outside durable recall daily log")
-            .expect("write outside daily log");
-        create_symlink(&outside_memory_dir, &linked_memory_dir).expect("create dir symlink");
-
-        let config = MemoryRuntimeConfig::default();
-        let entries = load_durable_recall_entries(Some(workspace_root.as_path()), &config)
-            .expect("load durable recall entries");
-
-        assert!(entries.is_empty());
+        assert_eq!(documents.len(), 1);
+        assert_eq!(documents[0].label, "memory/2026-03-22.md");
     }
 }

--- a/crates/app/src/memory/durable_recall.rs
+++ b/crates/app/src/memory/durable_recall.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+use std::io::{BufReader, Read};
 use std::path::Path;
 
 use crate::runtime_self_continuity;
@@ -9,6 +11,7 @@ use super::{
 };
 
 const RECENT_DAILY_LOG_LIMIT: usize = 2;
+const DURABLE_RECALL_READ_SLACK_BYTES: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DurableRecallDocument {
@@ -95,12 +98,33 @@ fn load_trimmed_document_content(
     path: &Path,
     per_file_char_budget: usize,
 ) -> Result<Option<String>, String> {
-    let raw_content = std::fs::read_to_string(path).map_err(|error| {
+    let read_limit = per_file_char_budget.saturating_add(DURABLE_RECALL_READ_SLACK_BYTES);
+    let file = File::open(path).map_err(|error| {
         format!(
             "read durable recall file {} failed: {error}",
             path.display()
         )
     })?;
+    let reader = BufReader::new(file);
+    let mut limited_reader = reader.take(read_limit as u64);
+    let mut raw_bytes = Vec::new();
+
+    limited_reader
+        .read_to_end(&mut raw_bytes)
+        .map_err(|error| {
+            format!(
+                "read durable recall file {} failed: {error}",
+                path.display()
+            )
+        })?;
+
+    let raw_content = String::from_utf8(raw_bytes).map_err(|error| {
+        format!(
+            "read durable recall file {} failed: {error}",
+            path.display()
+        )
+    })?;
+
     let trimmed_content = raw_content.trim();
     if trimmed_content.is_empty() {
         return Ok(None);
@@ -194,6 +218,25 @@ mod tests {
 
         assert_eq!(documents.len(), 1);
         assert_eq!(documents[0].label, "memory/2026-03-22.md");
+    }
+
+    #[test]
+    fn load_trimmed_document_content_ignores_invalid_tail_beyond_budget() {
+        let temp_dir = tempdir().expect("tempdir");
+        let document_path = temp_dir.path().join("MEMORY.md");
+        let mut bytes = vec![b'a'; 1600];
+
+        bytes.push(0xff);
+        bytes.push(0xfe);
+
+        std::fs::write(&document_path, bytes).expect("write memory fixture");
+
+        let content = load_trimmed_document_content(&document_path, 64)
+            .expect("bounded durable recall read should succeed")
+            .expect("content should be present");
+
+        assert!(content.starts_with("aaaaaaaa"));
+        assert!(content.contains("(truncated "));
     }
 
     #[test]

--- a/crates/app/src/memory/durable_recall.rs
+++ b/crates/app/src/memory/durable_recall.rs
@@ -115,16 +115,27 @@ fn truncate_chars(input: &str, max_chars: usize) -> String {
     if char_count <= max_chars {
         return input.to_owned();
     }
-
-    let mut truncated = String::new();
-    let kept_chars = max_chars.saturating_sub(1);
-    for ch in input.chars().take(kept_chars) {
-        truncated.push(ch);
+    if max_chars == 0 {
+        return String::new();
     }
 
-    let removed_chars = char_count.saturating_sub(kept_chars);
-    truncated.push_str(&format!("...(truncated {removed_chars} chars)"));
-    truncated
+    let mut removed_chars = char_count.saturating_sub(max_chars);
+    loop {
+        let suffix = format!("...(truncated {removed_chars} chars)");
+        let suffix_char_count = suffix.chars().count();
+        if suffix_char_count >= max_chars {
+            return suffix.chars().take(max_chars).collect();
+        }
+
+        let kept_chars = max_chars.saturating_sub(suffix_char_count);
+        let next_removed_chars = char_count.saturating_sub(kept_chars);
+        if next_removed_chars == removed_chars {
+            let prefix = input.chars().take(kept_chars).collect::<String>();
+            return format!("{prefix}{suffix}");
+        }
+
+        removed_chars = next_removed_chars;
+    }
 }
 
 fn render_durable_recall_block(documents: &[DurableRecallDocument]) -> String {
@@ -183,5 +194,27 @@ mod tests {
 
         assert_eq!(documents.len(), 1);
         assert_eq!(documents[0].label, "memory/2026-03-22.md");
+    }
+
+    #[test]
+    fn truncate_chars_respects_budget_when_suffix_fits() {
+        let input = "a".repeat(80);
+
+        let truncated = truncate_chars(input.as_str(), 32);
+        let truncated_char_count = truncated.chars().count();
+
+        assert_eq!(truncated_char_count, 32);
+        assert!(truncated.contains("(truncated "));
+    }
+
+    #[test]
+    fn truncate_chars_respects_budget_when_suffix_exceeds_budget() {
+        let input = "a".repeat(80);
+
+        let truncated = truncate_chars(input.as_str(), 8);
+        let truncated_char_count = truncated.chars().count();
+
+        assert_eq!(truncated_char_count, 8);
+        assert!(!truncated.is_empty());
     }
 }

--- a/crates/app/src/memory/durable_recall.rs
+++ b/crates/app/src/memory/durable_recall.rs
@@ -1,0 +1,302 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDate;
+
+use crate::{runtime_self, runtime_self_continuity};
+
+use super::{MemoryContextEntry, MemoryContextKind, runtime_config::MemoryRuntimeConfig};
+
+const ROOT_MEMORY_FILE: &str = "MEMORY.md";
+const NESTED_MEMORY_FILE: &str = "memory/MEMORY.md";
+const RECENT_DAILY_LOG_LIMIT: usize = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DurableRecallDocument {
+    label: String,
+    content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct DailyLogCandidate {
+    label: String,
+    path: PathBuf,
+    date: NaiveDate,
+}
+
+pub(crate) fn load_durable_recall_entries(
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<MemoryContextEntry>, String> {
+    let Some(workspace_root) = workspace_root else {
+        return Ok(Vec::new());
+    };
+
+    let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
+    let per_file_char_budget = config.summary_max_chars.max(256);
+
+    let curated_documents = collect_curated_memory_documents(
+        workspace_root,
+        candidate_roots.as_slice(),
+        per_file_char_budget,
+    )?;
+    let daily_documents = collect_recent_daily_log_documents(
+        workspace_root,
+        candidate_roots.as_slice(),
+        per_file_char_budget,
+    )?;
+
+    let mut documents = Vec::new();
+    documents.extend(curated_documents);
+    documents.extend(daily_documents);
+
+    if documents.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let content = render_durable_recall_block(documents.as_slice());
+    let entry = MemoryContextEntry {
+        kind: MemoryContextKind::RetrievedMemory,
+        role: "system".to_owned(),
+        content,
+    };
+
+    Ok(vec![entry])
+}
+
+fn collect_curated_memory_documents(
+    workspace_root: &Path,
+    candidate_roots: &[PathBuf],
+    per_file_char_budget: usize,
+) -> Result<Vec<DurableRecallDocument>, String> {
+    let mut documents = Vec::new();
+    let mut seen_paths = BTreeSet::new();
+    let relative_paths = [ROOT_MEMORY_FILE, NESTED_MEMORY_FILE];
+
+    for root in candidate_roots {
+        for relative_path in relative_paths {
+            let candidate_path = root.join(relative_path);
+            let maybe_document = load_document_if_present(
+                workspace_root,
+                candidate_path.as_path(),
+                per_file_char_budget,
+                &mut seen_paths,
+            )?;
+            let Some(document) = maybe_document else {
+                continue;
+            };
+            documents.push(document);
+        }
+    }
+
+    Ok(documents)
+}
+
+fn collect_recent_daily_log_documents(
+    workspace_root: &Path,
+    candidate_roots: &[PathBuf],
+    per_file_char_budget: usize,
+) -> Result<Vec<DurableRecallDocument>, String> {
+    let mut candidates = Vec::new();
+    let mut seen_paths = BTreeSet::new();
+
+    for root in candidate_roots {
+        let memory_dir = root.join("memory");
+        if !memory_dir.is_dir() {
+            continue;
+        }
+
+        let read_dir = std::fs::read_dir(&memory_dir).map_err(|error| {
+            format!(
+                "read durable recall directory {} failed: {error}",
+                memory_dir.display()
+            )
+        })?;
+        for entry_result in read_dir {
+            let entry = entry_result.map_err(|error| {
+                format!(
+                    "read durable recall directory entry in {} failed: {error}",
+                    memory_dir.display()
+                )
+            })?;
+            let path = entry.path();
+            let Some(date) = parse_daily_log_date(path.as_path()) else {
+                continue;
+            };
+
+            let path_key = normalized_path_key(path.as_path());
+            let inserted = seen_paths.insert(path_key);
+            if !inserted {
+                continue;
+            }
+
+            let label = durable_recall_label(workspace_root, path.as_path());
+            let candidate = DailyLogCandidate { label, path, date };
+            candidates.push(candidate);
+        }
+    }
+
+    candidates.sort_by(|left, right| {
+        right
+            .date
+            .cmp(&left.date)
+            .then(left.label.cmp(&right.label))
+    });
+
+    let mut documents = Vec::new();
+    let selected_candidates = candidates.into_iter().take(RECENT_DAILY_LOG_LIMIT);
+    for candidate in selected_candidates {
+        let maybe_content =
+            load_trimmed_document_content(candidate.path.as_path(), per_file_char_budget)?;
+        let Some(content) = maybe_content else {
+            continue;
+        };
+        let document = DurableRecallDocument {
+            label: candidate.label,
+            content,
+        };
+        documents.push(document);
+    }
+
+    Ok(documents)
+}
+
+fn load_document_if_present(
+    workspace_root: &Path,
+    path: &Path,
+    per_file_char_budget: usize,
+    seen_paths: &mut BTreeSet<String>,
+) -> Result<Option<DurableRecallDocument>, String> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    let path_key = normalized_path_key(path);
+    let inserted = seen_paths.insert(path_key);
+    if !inserted {
+        return Ok(None);
+    }
+
+    let maybe_content = load_trimmed_document_content(path, per_file_char_budget)?;
+    let Some(content) = maybe_content else {
+        return Ok(None);
+    };
+
+    let label = durable_recall_label(workspace_root, path);
+    let document = DurableRecallDocument { label, content };
+    Ok(Some(document))
+}
+
+fn load_trimmed_document_content(
+    path: &Path,
+    per_file_char_budget: usize,
+) -> Result<Option<String>, String> {
+    let raw_content = std::fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read durable recall file {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let trimmed_content = raw_content.trim();
+    if trimmed_content.is_empty() {
+        return Ok(None);
+    }
+
+    let bounded_content = truncate_chars(trimmed_content, per_file_char_budget);
+    Ok(Some(bounded_content))
+}
+
+fn parse_daily_log_date(path: &Path) -> Option<NaiveDate> {
+    let extension = path.extension().and_then(|value| value.to_str());
+    let is_markdown = extension.is_some_and(|value| value.eq_ignore_ascii_case("md"));
+    if !is_markdown {
+        return None;
+    }
+
+    let stem = path.file_stem().and_then(|value| value.to_str())?;
+    NaiveDate::parse_from_str(stem, "%Y-%m-%d").ok()
+}
+
+fn durable_recall_label(workspace_root: &Path, path: &Path) -> String {
+    let relative_path = path.strip_prefix(workspace_root).ok();
+    let display_path = relative_path.unwrap_or(path);
+    display_path.display().to_string()
+}
+
+fn normalized_path_key(path: &Path) -> String {
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    canonical_path.display().to_string()
+}
+
+fn truncate_chars(input: &str, max_chars: usize) -> String {
+    let char_count = input.chars().count();
+    if char_count <= max_chars {
+        return input.to_owned();
+    }
+
+    let mut truncated = String::new();
+    let kept_chars = max_chars.saturating_sub(1);
+    for ch in input.chars().take(kept_chars) {
+        truncated.push(ch);
+    }
+
+    let removed_chars = char_count.saturating_sub(kept_chars);
+    truncated.push_str(&format!("...(truncated {removed_chars} chars)"));
+    truncated
+}
+
+fn render_durable_recall_block(documents: &[DurableRecallDocument]) -> String {
+    let mut sections = Vec::new();
+    sections.push("## Advisory Durable Recall".to_owned());
+    sections.push(runtime_self_continuity::runtime_durable_recall_intro().to_owned());
+
+    for document in documents {
+        let heading = format!("### {}", document.label);
+        sections.push(heading);
+        sections.push(document.content.clone());
+    }
+
+    sections.join("\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn collect_recent_daily_log_documents_prefers_newest_dated_logs() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+
+        std::fs::write(memory_dir.join("2026-03-20.md"), "old").expect("write old log");
+        std::fs::write(memory_dir.join("2026-03-21.md"), "middle").expect("write middle log");
+        std::fs::write(memory_dir.join("2026-03-22.md"), "new").expect("write new log");
+
+        let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
+        let documents =
+            collect_recent_daily_log_documents(workspace_root, candidate_roots.as_slice(), 256)
+                .expect("collect daily log documents");
+
+        assert_eq!(documents.len(), 2);
+        assert_eq!(documents[0].label, "memory/2026-03-22.md");
+        assert_eq!(documents[1].label, "memory/2026-03-21.md");
+    }
+
+    #[test]
+    fn collect_curated_memory_documents_skips_empty_files() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+
+        std::fs::write(workspace_root.join("MEMORY.md"), "   ").expect("write empty memory file");
+
+        let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
+        let documents =
+            collect_curated_memory_documents(workspace_root, candidate_roots.as_slice(), 256)
+                .expect("collect curated memory documents");
+
+        assert!(documents.is_empty());
+    }
+}

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -14,6 +14,8 @@ use crate::runtime_identity;
 
 mod canonical;
 mod context;
+#[cfg(feature = "memory-sqlite")]
+mod durable_flush;
 mod kernel_adapter;
 mod orchestrator;
 mod protocol;
@@ -32,6 +34,8 @@ pub use canonical::{
     canonical_memory_record_from_persisted_turn,
 };
 pub use context::load_prompt_context;
+#[cfg(feature = "memory-sqlite")]
+pub(crate) use durable_flush::flush_pre_compaction_durable_memory;
 pub use kernel_adapter::MvpMemoryAdapter;
 pub use orchestrator::{
     BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -27,6 +27,7 @@ mod system;
 mod system_registry;
 #[cfg(test)]
 mod tests;
+mod workspace_files;
 
 pub use canonical::{
     CANONICAL_MEMORY_RECORD_TYPE, CanonicalMemoryKind, CanonicalMemoryRecord,
@@ -64,6 +65,10 @@ pub use system_registry::{
     describe_memory_system, list_memory_system_ids, list_memory_system_metadata,
     memory_system_id_from_env, register_memory_system, resolve_memory_system,
     resolve_memory_system_selection, supported_memory_system_kind_from_env,
+};
+pub(crate) use workspace_files::{
+    WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
+    collect_workspace_memory_document_locations,
 };
 
 pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -16,6 +16,7 @@ mod canonical;
 mod context;
 #[cfg(feature = "memory-sqlite")]
 mod durable_flush;
+mod durable_recall;
 mod kernel_adapter;
 mod orchestrator;
 mod protocol;
@@ -36,9 +37,11 @@ pub use canonical::{
 pub use context::load_prompt_context;
 #[cfg(feature = "memory-sqlite")]
 pub(crate) use durable_flush::flush_pre_compaction_durable_memory;
+pub(crate) use durable_recall::load_durable_recall_entries;
 pub use kernel_adapter::MvpMemoryAdapter;
 pub use orchestrator::{
     BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,
+    hydrate_memory_context_with_workspace_root,
 };
 #[cfg(test)]
 pub use orchestrator::{MemoryOrchestratorTestFaults, ScopedMemoryOrchestratorTestFaults};

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
@@ -105,6 +106,7 @@ impl BuiltinMemoryOrchestrator {
     pub fn hydrate(
         &self,
         session_id: &str,
+        workspace_root: Option<&Path>,
         config: &MemoryRuntimeConfig,
     ) -> Result<HydratedMemoryContext, String> {
         let recent_window = recent_window_records(session_id, config)?;
@@ -119,7 +121,7 @@ impl BuiltinMemoryOrchestrator {
             Err(error) => return Err(format!("memory derivation stage failed: {error}")),
         }
 
-        match run_retrieval_stage(session_id, config, &recent_window) {
+        match run_retrieval_stage(session_id, workspace_root, config, &recent_window) {
             Ok(extra_entries) => entries.extend(extra_entries),
             Err(error) if fail_open => retrieval_error = Some(error),
             Err(error) => return Err(format!("memory retrieval stage failed: {error}")),
@@ -163,6 +165,7 @@ fn run_derivation_stage(
 
 fn run_retrieval_stage(
     _session_id: &str,
+    workspace_root: Option<&Path>,
     _config: &MemoryRuntimeConfig,
     _recent_window: &[WindowTurn],
 ) -> Result<Vec<MemoryContextEntry>, String> {
@@ -173,15 +176,25 @@ fn run_retrieval_stage(
         return Err(error);
     }
 
-    Ok(Vec::new())
+    super::load_durable_recall_entries(workspace_root, _config)
 }
 
 pub fn hydrate_memory_context(
     session_id: &str,
     config: &MemoryRuntimeConfig,
 ) -> Result<HydratedMemoryContext, String> {
+    hydrate_memory_context_with_workspace_root(session_id, None, config)
+}
+
+pub fn hydrate_memory_context_with_workspace_root(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+) -> Result<HydratedMemoryContext, String> {
     match config.system {
-        MemorySystemKind::Builtin => BuiltinMemoryOrchestrator.hydrate(session_id, config),
+        MemorySystemKind::Builtin => {
+            BuiltinMemoryOrchestrator.hydrate(session_id, workspace_root, config)
+        }
     }
 }
 

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -22,6 +22,7 @@ pub struct WindowTurn {
 pub enum MemoryContextKind {
     Profile,
     Summary,
+    RetrievedMemory,
     Turn,
 }
 

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -711,6 +711,36 @@ pub(super) fn load_context_snapshot_with_diagnostics(
     })
 }
 
+pub(super) fn load_summary_body_for_durable_flush(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<Option<String>, String> {
+    let window_limit = default_window_size(config);
+    let runtime = acquire_memory_runtime(config)?;
+
+    runtime.with_connection("memory.durable_flush_summary", |conn| {
+        let recent_window =
+            query_recent_prompt_turns_with_overflow_probe(conn, session_id, window_limit, None)?;
+        if recent_window.window_starts_at_session_origin {
+            return Ok(None);
+        }
+
+        let checkpoint_meta = match recent_window.checkpoint_meta_lookup {
+            SummaryCheckpointMetaLookup::Known(checkpoint_meta) => checkpoint_meta,
+            SummaryCheckpointMetaLookup::Unknown => load_summary_checkpoint_meta(conn, session_id)?,
+        };
+        let checkpoint = materialize_summary_checkpoint(
+            conn,
+            session_id,
+            recent_window.summary_before_turn_id,
+            checkpoint_meta,
+            config,
+        )?;
+
+        Ok(checkpoint.map(|value| value.summary_body))
+    })
+}
+
 pub(super) fn ensure_memory_db_ready(
     path: Option<PathBuf>,
     config: &MemoryRuntimeConfig,

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -272,6 +272,10 @@ fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
     let _guard = core_dispatch_test_lock()
         .lock()
         .expect("core dispatch test lock");
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread runtime");
 
     let (workspace_root, config) =
         isolated_memory_workspace("loongclaw-pre-compaction-durable-flush");
@@ -295,8 +299,8 @@ fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
         "durable-flush-session",
         Some(workspace_root.as_path()),
         &config,
-    )
-    .expect("first durable flush");
+    );
+    let first = runtime.block_on(first).expect("first durable flush");
     let first_path = match first {
         super::durable_flush::PreCompactionDurableFlushOutcome::Flushed { path, .. } => path,
         other @ super::durable_flush::PreCompactionDurableFlushOutcome::SkippedMissingWorkspaceRoot
@@ -310,8 +314,8 @@ fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
         "durable-flush-session",
         Some(workspace_root.as_path()),
         &config,
-    )
-    .expect("second durable flush");
+    );
+    let second = runtime.block_on(second).expect("second durable flush");
     assert_eq!(
         second,
         super::durable_flush::PreCompactionDurableFlushOutcome::SkippedDuplicate
@@ -334,6 +338,10 @@ fn pre_compaction_durable_flush_skips_when_no_summary_checkpoint_exists() {
     let _guard = core_dispatch_test_lock()
         .lock()
         .expect("core dispatch test lock");
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread runtime");
 
     let (workspace_root, config) =
         isolated_memory_workspace("loongclaw-pre-compaction-durable-flush-empty");
@@ -350,8 +358,10 @@ fn pre_compaction_durable_flush_skips_when_no_summary_checkpoint_exists() {
         "durable-flush-empty-session",
         Some(workspace_root.as_path()),
         &config,
-    )
-    .expect("durable flush without summary should succeed");
+    );
+    let outcome = runtime
+        .block_on(outcome)
+        .expect("durable flush without summary should succeed");
 
     assert_eq!(
         outcome,

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -1,5 +1,6 @@
 use loongclaw_contracts::MemoryCoreRequest;
 use serde_json::json;
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 use super::*;
@@ -7,6 +8,21 @@ use super::*;
 fn core_dispatch_test_lock() -> &'static Mutex<()> {
     static CORE_DISPATCH_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     CORE_DISPATCH_TEST_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn isolated_memory_workspace(prefix: &str) -> (PathBuf, runtime_config::MemoryRuntimeConfig) {
+    let root = crate::test_support::unique_temp_dir(prefix);
+    std::fs::create_dir_all(&root).expect("create isolated memory workspace");
+
+    let db_path = root.join("memory.sqlite3");
+    let config = runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(db_path),
+        sliding_window: 1,
+        ..runtime_config::MemoryRuntimeConfig::default()
+    };
+
+    (root, config)
 }
 
 #[test]
@@ -248,6 +264,99 @@ fn load_prompt_context_with_diagnostics_omits_legacy_identity_from_profile_proje
 
     let _ = fs::remove_file(&db_path);
     let _ = fs::remove_dir(&tmp);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
+    let _guard = core_dispatch_test_lock()
+        .lock()
+        .expect("core dispatch test lock");
+
+    let (workspace_root, config) =
+        isolated_memory_workspace("loongclaw-pre-compaction-durable-flush");
+
+    append_turn_direct(
+        "durable-flush-session",
+        "user",
+        "remember the deployment cutoff",
+        &config,
+    )
+    .expect("append user turn");
+    append_turn_direct(
+        "durable-flush-session",
+        "assistant",
+        "deployment cutoff is tonight",
+        &config,
+    )
+    .expect("append assistant turn");
+
+    let first = super::durable_flush::flush_pre_compaction_durable_memory(
+        "durable-flush-session",
+        Some(workspace_root.as_path()),
+        &config,
+    )
+    .expect("first durable flush");
+    let first_path = match first {
+        super::durable_flush::PreCompactionDurableFlushOutcome::Flushed { path, .. } => path,
+        other @ super::durable_flush::PreCompactionDurableFlushOutcome::SkippedMissingWorkspaceRoot
+        | other @ super::durable_flush::PreCompactionDurableFlushOutcome::SkippedNoSummary
+        | other @ super::durable_flush::PreCompactionDurableFlushOutcome::SkippedDuplicate => {
+            panic!("expected flushed outcome, got {other:?}")
+        }
+    };
+
+    let second = super::durable_flush::flush_pre_compaction_durable_memory(
+        "durable-flush-session",
+        Some(workspace_root.as_path()),
+        &config,
+    )
+    .expect("second durable flush");
+    assert_eq!(
+        second,
+        super::durable_flush::PreCompactionDurableFlushOutcome::SkippedDuplicate
+    );
+
+    let exported = std::fs::read_to_string(&first_path).expect("read durable memory log");
+    let marker_count = exported.matches("- content_sha256: ").count();
+    assert_eq!(
+        marker_count, 1,
+        "duplicate flush should not append another entry"
+    );
+    assert!(exported.contains("Advisory durable recall"));
+    assert!(exported.contains("remember the deployment cutoff"));
+    assert!(!exported.contains("## Resolved Runtime Identity"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn pre_compaction_durable_flush_skips_when_no_summary_checkpoint_exists() {
+    let _guard = core_dispatch_test_lock()
+        .lock()
+        .expect("core dispatch test lock");
+
+    let (workspace_root, config) =
+        isolated_memory_workspace("loongclaw-pre-compaction-durable-flush-empty");
+
+    append_turn_direct(
+        "durable-flush-empty-session",
+        "user",
+        "only one turn",
+        &config,
+    )
+    .expect("append user turn");
+
+    let outcome = super::durable_flush::flush_pre_compaction_durable_memory(
+        "durable-flush-empty-session",
+        Some(workspace_root.as_path()),
+        &config,
+    )
+    .expect("durable flush without summary should succeed");
+
+    assert_eq!(
+        outcome,
+        super::durable_flush::PreCompactionDurableFlushOutcome::SkippedNoSummary
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/workspace_files.rs
+++ b/crates/app/src/memory/workspace_files.rs
@@ -1,0 +1,231 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDate;
+
+use crate::runtime_self;
+
+pub(crate) const ROOT_MEMORY_FILE: &str = "MEMORY.md";
+pub(crate) const NESTED_MEMORY_FILE: &str = "memory/MEMORY.md";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkspaceMemoryDocumentKind {
+    Curated,
+    DailyLog,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceMemoryDocumentLocation {
+    pub label: String,
+    pub path: PathBuf,
+    pub kind: WorkspaceMemoryDocumentKind,
+    pub date: Option<NaiveDate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct DailyLogCandidate {
+    label: String,
+    path: PathBuf,
+    date: NaiveDate,
+}
+
+pub(crate) fn collect_workspace_memory_document_locations(
+    workspace_root: &Path,
+) -> Result<Vec<WorkspaceMemoryDocumentLocation>, String> {
+    let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
+    let curated_documents =
+        collect_curated_memory_document_locations(workspace_root, candidate_roots.as_slice())?;
+    let daily_documents =
+        collect_daily_log_document_locations(workspace_root, candidate_roots.as_slice())?;
+
+    let mut documents = Vec::new();
+    documents.extend(curated_documents);
+    documents.extend(daily_documents);
+
+    Ok(documents)
+}
+
+fn collect_curated_memory_document_locations(
+    workspace_root: &Path,
+    candidate_roots: &[PathBuf],
+) -> Result<Vec<WorkspaceMemoryDocumentLocation>, String> {
+    let mut documents = Vec::new();
+    let mut seen_paths = BTreeSet::new();
+    let relative_paths = [ROOT_MEMORY_FILE, NESTED_MEMORY_FILE];
+
+    for root in candidate_roots {
+        for relative_path in relative_paths {
+            let candidate_path = root.join(relative_path);
+            let maybe_document = collect_document_if_present(
+                workspace_root,
+                candidate_path.as_path(),
+                WorkspaceMemoryDocumentKind::Curated,
+                None,
+                &mut seen_paths,
+            )?;
+            let Some(document) = maybe_document else {
+                continue;
+            };
+            documents.push(document);
+        }
+    }
+
+    Ok(documents)
+}
+
+fn collect_daily_log_document_locations(
+    workspace_root: &Path,
+    candidate_roots: &[PathBuf],
+) -> Result<Vec<WorkspaceMemoryDocumentLocation>, String> {
+    let mut candidates = Vec::new();
+    let mut seen_paths = BTreeSet::new();
+
+    for root in candidate_roots {
+        let memory_dir = root.join("memory");
+        if !memory_dir.is_dir() {
+            continue;
+        }
+
+        let read_dir = std::fs::read_dir(&memory_dir).map_err(|error| {
+            format!(
+                "read workspace memory directory {} failed: {error}",
+                memory_dir.display()
+            )
+        })?;
+        for entry_result in read_dir {
+            let entry = entry_result.map_err(|error| {
+                format!(
+                    "read workspace memory directory entry in {} failed: {error}",
+                    memory_dir.display()
+                )
+            })?;
+            let path = entry.path();
+            let Some(date) = parse_daily_log_date(path.as_path()) else {
+                continue;
+            };
+
+            let path_key = normalized_path_key(path.as_path());
+            let inserted = seen_paths.insert(path_key);
+            if !inserted {
+                continue;
+            }
+
+            let label = workspace_memory_label(workspace_root, path.as_path());
+            let candidate = DailyLogCandidate { label, path, date };
+            candidates.push(candidate);
+        }
+    }
+
+    candidates.sort_by(|left, right| {
+        right
+            .date
+            .cmp(&left.date)
+            .then(left.label.cmp(&right.label))
+    });
+
+    let mut documents = Vec::new();
+    for candidate in candidates {
+        let document = WorkspaceMemoryDocumentLocation {
+            label: candidate.label,
+            path: candidate.path,
+            kind: WorkspaceMemoryDocumentKind::DailyLog,
+            date: Some(candidate.date),
+        };
+        documents.push(document);
+    }
+
+    Ok(documents)
+}
+
+fn collect_document_if_present(
+    workspace_root: &Path,
+    path: &Path,
+    kind: WorkspaceMemoryDocumentKind,
+    date: Option<NaiveDate>,
+    seen_paths: &mut BTreeSet<String>,
+) -> Result<Option<WorkspaceMemoryDocumentLocation>, String> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    let path_key = normalized_path_key(path);
+    let inserted = seen_paths.insert(path_key);
+    if !inserted {
+        return Ok(None);
+    }
+
+    let label = workspace_memory_label(workspace_root, path);
+    let document = WorkspaceMemoryDocumentLocation {
+        label,
+        path: path.to_path_buf(),
+        kind,
+        date,
+    };
+
+    Ok(Some(document))
+}
+
+pub(crate) fn workspace_memory_label(workspace_root: &Path, path: &Path) -> String {
+    let relative_path = path.strip_prefix(workspace_root).ok();
+    let display_path = relative_path.unwrap_or(path);
+    display_path.display().to_string()
+}
+
+fn parse_daily_log_date(path: &Path) -> Option<NaiveDate> {
+    let extension = path.extension().and_then(|value| value.to_str());
+    let is_markdown = extension.is_some_and(|value| value.eq_ignore_ascii_case("md"));
+    if !is_markdown {
+        return None;
+    }
+
+    let stem = path.file_stem().and_then(|value| value.to_str())?;
+    NaiveDate::parse_from_str(stem, "%Y-%m-%d").ok()
+}
+
+fn normalized_path_key(path: &Path) -> String {
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    canonical_path.display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn collect_workspace_memory_document_locations_prefers_newest_daily_logs_first() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(workspace_root.join("MEMORY.md"), "root").expect("write root memory");
+        std::fs::write(memory_dir.join("2026-03-20.md"), "old").expect("write old log");
+        std::fs::write(memory_dir.join("2026-03-22.md"), "new").expect("write new log");
+
+        let documents = collect_workspace_memory_document_locations(workspace_root)
+            .expect("collect workspace memory documents");
+
+        assert_eq!(documents.len(), 3);
+        assert_eq!(documents[0].label, "MEMORY.md");
+        assert_eq!(documents[1].label, "memory/2026-03-22.md");
+        assert_eq!(documents[2].label, "memory/2026-03-20.md");
+    }
+
+    #[test]
+    fn collect_workspace_memory_document_locations_includes_nested_workspace_memory() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let nested_workspace_root = workspace_root.join("workspace");
+
+        std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace");
+        std::fs::write(nested_workspace_root.join("MEMORY.md"), "nested memory")
+            .expect("write nested memory");
+
+        let documents = collect_workspace_memory_document_locations(workspace_root)
+            .expect("collect workspace memory documents");
+
+        assert_eq!(documents.len(), 1);
+        assert_eq!(documents[0].label, "workspace/MEMORY.md");
+    }
+}

--- a/crates/app/src/memory/workspace_files.rs
+++ b/crates/app/src/memory/workspace_files.rs
@@ -32,11 +32,18 @@ struct DailyLogCandidate {
 pub(crate) fn collect_workspace_memory_document_locations(
     workspace_root: &Path,
 ) -> Result<Vec<WorkspaceMemoryDocumentLocation>, String> {
+    let canonical_workspace_root = canonical_workspace_memory_root(workspace_root)?;
     let candidate_roots = runtime_self::candidate_workspace_roots(workspace_root);
-    let curated_documents =
-        collect_curated_memory_document_locations(workspace_root, candidate_roots.as_slice())?;
-    let daily_documents =
-        collect_daily_log_document_locations(workspace_root, candidate_roots.as_slice())?;
+    let curated_documents = collect_curated_memory_document_locations(
+        workspace_root,
+        canonical_workspace_root.as_path(),
+        candidate_roots.as_slice(),
+    )?;
+    let daily_documents = collect_daily_log_document_locations(
+        workspace_root,
+        canonical_workspace_root.as_path(),
+        candidate_roots.as_slice(),
+    )?;
 
     let mut documents = Vec::new();
     documents.extend(curated_documents);
@@ -47,6 +54,7 @@ pub(crate) fn collect_workspace_memory_document_locations(
 
 fn collect_curated_memory_document_locations(
     workspace_root: &Path,
+    canonical_workspace_root: &Path,
     candidate_roots: &[PathBuf],
 ) -> Result<Vec<WorkspaceMemoryDocumentLocation>, String> {
     let mut documents = Vec::new();
@@ -58,6 +66,7 @@ fn collect_curated_memory_document_locations(
             let candidate_path = root.join(relative_path);
             let maybe_document = collect_document_if_present(
                 workspace_root,
+                canonical_workspace_root,
                 candidate_path.as_path(),
                 WorkspaceMemoryDocumentKind::Curated,
                 None,
@@ -75,6 +84,7 @@ fn collect_curated_memory_document_locations(
 
 fn collect_daily_log_document_locations(
     workspace_root: &Path,
+    canonical_workspace_root: &Path,
     candidate_roots: &[PathBuf],
 ) -> Result<Vec<WorkspaceMemoryDocumentLocation>, String> {
     let mut candidates = Vec::new();
@@ -85,6 +95,12 @@ fn collect_daily_log_document_locations(
         if !memory_dir.is_dir() {
             continue;
         }
+
+        let Some(_canonical_memory_dir) =
+            resolve_workspace_memory_path(canonical_workspace_root, memory_dir.as_path())?
+        else {
+            continue;
+        };
 
         let read_dir = std::fs::read_dir(&memory_dir).map_err(|error| {
             format!(
@@ -104,14 +120,24 @@ fn collect_daily_log_document_locations(
                 continue;
             };
 
-            let path_key = normalized_path_key(path.as_path());
+            let Some(canonical_path) =
+                resolve_workspace_memory_path(canonical_workspace_root, path.as_path())?
+            else {
+                continue;
+            };
+
+            let path_key = canonical_path_key(canonical_path.as_path());
             let inserted = seen_paths.insert(path_key);
             if !inserted {
                 continue;
             }
 
             let label = workspace_memory_label(workspace_root, path.as_path());
-            let candidate = DailyLogCandidate { label, path, date };
+            let candidate = DailyLogCandidate {
+                label,
+                path: canonical_path,
+                date,
+            };
             candidates.push(candidate);
         }
     }
@@ -139,6 +165,7 @@ fn collect_daily_log_document_locations(
 
 fn collect_document_if_present(
     workspace_root: &Path,
+    canonical_workspace_root: &Path,
     path: &Path,
     kind: WorkspaceMemoryDocumentKind,
     date: Option<NaiveDate>,
@@ -148,7 +175,12 @@ fn collect_document_if_present(
         return Ok(None);
     }
 
-    let path_key = normalized_path_key(path);
+    let Some(canonical_path) = resolve_workspace_memory_path(canonical_workspace_root, path)?
+    else {
+        return Ok(None);
+    };
+
+    let path_key = canonical_path_key(canonical_path.as_path());
     let inserted = seen_paths.insert(path_key);
     if !inserted {
         return Ok(None);
@@ -157,7 +189,7 @@ fn collect_document_if_present(
     let label = workspace_memory_label(workspace_root, path);
     let document = WorkspaceMemoryDocumentLocation {
         label,
-        path: path.to_path_buf(),
+        path: canonical_path,
         kind,
         date,
     };
@@ -182,15 +214,46 @@ fn parse_daily_log_date(path: &Path) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(stem, "%Y-%m-%d").ok()
 }
 
-fn normalized_path_key(path: &Path) -> String {
-    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    canonical_path.display().to_string()
+fn canonical_workspace_memory_root(workspace_root: &Path) -> Result<PathBuf, String> {
+    workspace_root.canonicalize().map_err(|error| {
+        format!(
+            "canonicalize workspace memory root {} failed: {error}",
+            workspace_root.display()
+        )
+    })
+}
+
+fn resolve_workspace_memory_path(
+    canonical_workspace_root: &Path,
+    path: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let canonical_path = path.canonicalize().map_err(|error| {
+        format!(
+            "canonicalize workspace memory path {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let is_within_workspace = canonical_path.starts_with(canonical_workspace_root);
+    if !is_within_workspace {
+        return Ok(None);
+    }
+
+    Ok(Some(canonical_path))
+}
+
+fn canonical_path_key(path: &Path) -> String {
+    path.display().to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[cfg(unix)]
+    fn create_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
 
     #[test]
     fn collect_workspace_memory_document_locations_prefers_newest_daily_logs_first() {
@@ -227,5 +290,52 @@ mod tests {
 
         assert_eq!(documents.len(), 1);
         assert_eq!(documents[0].label, "workspace/MEMORY.md");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_workspace_memory_document_locations_ignores_symlinked_memory_file_outside_workspace_root()
+     {
+        let temp_dir = tempdir().expect("tempdir");
+        let sandbox_root = temp_dir.path();
+        let workspace_root = sandbox_root.join("workspace");
+        let outside_root = sandbox_root.join("outside");
+        let outside_memory_path = outside_root.join("secret.md");
+        let linked_memory_path = workspace_root.join("MEMORY.md");
+
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::create_dir_all(&outside_root).expect("create outside root");
+        std::fs::write(&outside_memory_path, "outside durable recall secret")
+            .expect("write outside memory");
+        create_symlink(&outside_memory_path, &linked_memory_path).expect("create symlink");
+
+        let documents = collect_workspace_memory_document_locations(workspace_root.as_path())
+            .expect("collect workspace memory documents");
+
+        assert!(documents.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_workspace_memory_document_locations_ignores_symlinked_memory_directory_outside_workspace_root()
+     {
+        let temp_dir = tempdir().expect("tempdir");
+        let sandbox_root = temp_dir.path();
+        let workspace_root = sandbox_root.join("workspace");
+        let outside_root = sandbox_root.join("outside");
+        let outside_memory_dir = outside_root.join("logs");
+        let outside_daily_log_path = outside_memory_dir.join("2026-03-24.md");
+        let linked_memory_dir = workspace_root.join("memory");
+
+        std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+        std::fs::create_dir_all(&outside_memory_dir).expect("create outside memory dir");
+        std::fs::write(&outside_daily_log_path, "outside durable recall daily log")
+            .expect("write outside daily log");
+        create_symlink(&outside_memory_dir, &linked_memory_dir).expect("create dir symlink");
+
+        let documents = collect_workspace_memory_document_locations(workspace_root.as_path())
+            .expect("collect workspace memory documents");
+
+        assert!(documents.is_empty());
     }
 }

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -494,16 +494,19 @@ mod tests {
         let workspace_root = temp_dir.path();
 
         let agents_path = workspace_root.join("AGENTS.md");
+        let tools_path = workspace_root.join("TOOLS.md");
         let soul_path = workspace_root.join("SOUL.md");
         let identity_path = workspace_root.join("IDENTITY.md");
         let user_path = workspace_root.join("USER.md");
 
         let agents_text = "Always keep workspace instructions explicit.";
+        let tools_text = "Search durable workspace memory before guessing project facts.";
         let soul_text = "Prefer calm, rigorous, low-drama execution.";
         let identity_text = "You are the migration-shaped helper identity.";
         let user_text = "The operator prefers concise technical summaries.";
 
         std::fs::write(&agents_path, agents_text).expect("write AGENTS");
+        std::fs::write(&tools_path, tools_text).expect("write TOOLS");
         std::fs::write(&soul_path, soul_text).expect("write SOUL");
         std::fs::write(&identity_path, identity_text).expect("write IDENTITY");
         std::fs::write(&user_path, user_text).expect("write USER");
@@ -528,6 +531,8 @@ mod tests {
         assert!(system_content.contains("## Runtime Self Context"));
         assert!(system_content.contains("### Standing Instructions"));
         assert!(system_content.contains(agents_text));
+        assert!(system_content.contains("### Tool Usage Policy"));
+        assert!(system_content.contains(tools_text));
         assert!(system_content.contains("### Soul Guidance"));
         assert!(system_content.contains(soul_text));
         assert!(system_content.contains("### User Context"));

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -284,8 +284,19 @@ pub(super) fn load_memory_window_messages(
     {
         let mem_config =
             memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-        let hydrated = memory::hydrate_memory_context(session_id, &mem_config)
-            .map_err(|error| format!("hydrate prompt memory context failed: {error}"))?;
+        let workspace_root = config
+            .tools
+            .file_root
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|_| config.tools.resolved_file_root());
+        let hydrated = memory::hydrate_memory_context_with_workspace_root(
+            session_id,
+            workspace_root.as_deref(),
+            &mem_config,
+        )
+        .map_err(|error| format!("hydrate prompt memory context failed: {error}"))?;
         let mut messages = Vec::with_capacity(hydrated.entries.len());
         append_hydrated_memory_messages(&mut messages, &hydrated);
         Ok(messages)
@@ -304,7 +315,9 @@ fn append_hydrated_memory_messages(
 ) {
     for entry in &hydrated.entries {
         match entry.kind {
-            memory::MemoryContextKind::Profile | memory::MemoryContextKind::Summary => {
+            memory::MemoryContextKind::Profile
+            | memory::MemoryContextKind::Summary
+            | memory::MemoryContextKind::RetrievedMemory => {
                 messages.push(json!({
                     "role": entry.role,
                     "content": entry.content,
@@ -636,5 +649,143 @@ mod tests {
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn message_builder_bootstraps_advisory_durable_recall_from_workspace_memory_files() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+
+        let curated_memory_path = workspace_root.join("MEMORY.md");
+        let recent_daily_path = memory_dir.join("2026-03-23.md");
+
+        std::fs::write(
+            &curated_memory_path,
+            "# Durable Notes\n\nRemember the deploy freeze window.\n",
+        )
+        .expect("write curated memory");
+        std::fs::write(
+            &recent_daily_path,
+            "## Durable Recall\n\nCustomer migration starts tomorrow.\n",
+        )
+        .expect("write daily durable memory");
+
+        let db_path = workspace_root.join("provider-durable-recall.sqlite3");
+        let mut config = LoongClawConfig::default();
+        config.tools.file_root = Some(workspace_root.display().to_string());
+        config.memory.sqlite_path = db_path.display().to_string();
+
+        let messages = build_messages_for_session(&config, "durable-recall-session", true)
+            .expect("build messages");
+
+        let durable_recall_message = messages
+            .iter()
+            .find(|message| {
+                message["role"] == "system"
+                    && message["content"]
+                        .as_str()
+                        .is_some_and(|content| content.contains("## Advisory Durable Recall"))
+            })
+            .expect("durable recall system message");
+        let durable_recall_content = durable_recall_message["content"]
+            .as_str()
+            .expect("durable recall content");
+
+        assert!(durable_recall_content.contains("Remember the deploy freeze window."));
+        assert!(durable_recall_content.contains("Customer migration starts tomorrow."));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn message_builder_keeps_durable_recall_advisory_when_memory_files_look_like_identity() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+
+        let identity_path = workspace_root.join("IDENTITY.md");
+        let curated_memory_path = workspace_root.join("MEMORY.md");
+
+        std::fs::write(
+            &identity_path,
+            "# Identity\n\n- Name: Workspace build copilot\n",
+        )
+        .expect("write workspace identity");
+        std::fs::write(
+            &curated_memory_path,
+            "## Imported IDENTITY.md\n# Identity\n\n- Name: Legacy build copilot\n",
+        )
+        .expect("write identity-like durable memory");
+
+        let db_path = workspace_root.join("provider-durable-recall-identity.sqlite3");
+        let mut config = LoongClawConfig::default();
+        config.tools.file_root = Some(workspace_root.display().to_string());
+        config.memory.sqlite_path = db_path.display().to_string();
+
+        let messages = build_messages_for_session(&config, "durable-recall-identity", true)
+            .expect("build messages");
+
+        let resolved_identity_message = messages
+            .iter()
+            .find(|message| {
+                message["role"] == "system"
+                    && message["content"]
+                        .as_str()
+                        .is_some_and(|content| content.contains("## Resolved Runtime Identity"))
+            })
+            .expect("resolved runtime identity message");
+        let resolved_identity_content = resolved_identity_message["content"]
+            .as_str()
+            .expect("resolved runtime identity content");
+        assert!(resolved_identity_content.contains("Workspace build copilot"));
+        assert!(!resolved_identity_content.contains("Legacy build copilot"));
+
+        let durable_recall_message = messages
+            .iter()
+            .find(|message| {
+                message["role"] == "system"
+                    && message["content"]
+                        .as_str()
+                        .is_some_and(|content| content.contains("## Advisory Durable Recall"))
+            })
+            .expect("durable recall system message");
+        let durable_recall_content = durable_recall_message["content"]
+            .as_str()
+            .expect("durable recall content");
+
+        assert!(durable_recall_content.contains("Legacy build copilot"));
+        assert!(!durable_recall_content.contains("## Resolved Runtime Identity"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn message_builder_skips_durable_recall_without_explicit_safe_file_root() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let curated_memory_path = workspace_root.join("MEMORY.md");
+
+        std::fs::write(
+            &curated_memory_path,
+            "# Durable Notes\n\nThis should stay unread without an explicit file root.\n",
+        )
+        .expect("write curated memory");
+
+        let db_path = workspace_root.join("provider-durable-recall-missing-root.sqlite3");
+        let mut config = LoongClawConfig::default();
+        config.memory.sqlite_path = db_path.display().to_string();
+
+        let messages = build_messages_for_session(&config, "durable-recall-without-root", true)
+            .expect("build messages");
+
+        let durable_recall_message = messages.iter().find(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("## Advisory Durable Recall"))
+        });
+        assert!(durable_recall_message.is_none());
     }
 }

--- a/crates/app/src/runtime_identity.rs
+++ b/crates/app/src/runtime_identity.rs
@@ -1,15 +1,17 @@
 use crate::runtime_self::RuntimeSelfModel;
+use serde::{Deserialize, Serialize};
 
 const LEGACY_IMPORTED_IDENTITY_HEADINGS: &[&str] =
     &["## imported identity.md", "## imported identity.json"];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum RuntimeIdentitySource {
     WorkspaceSelf,
     LegacyProfileNoteImport,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ResolvedRuntimeIdentity {
     pub source: RuntimeIdentitySource,
     pub content: String,

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -59,7 +59,17 @@ pub(crate) struct RuntimeSelfModel {
     pub user_context: Vec<String>,
 }
 
-#[cfg(test)]
+impl RuntimeSelfModel {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.standing_instructions.is_empty()
+            && self.tool_usage_policy.is_empty()
+            && self.soul_guidance.is_empty()
+            && self.identity_context.is_empty()
+            && self.user_context.is_empty()
+    }
+}
+
 pub(crate) fn load_runtime_self_model(workspace_root: &Path) -> RuntimeSelfModel {
     let tool_runtime_config = crate::tools::runtime_config::ToolRuntimeConfig {
         file_root: Some(workspace_root.to_path_buf()),
@@ -128,10 +138,7 @@ pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<St
 pub(crate) fn runtime_self_source_candidates(
     workspace_root: &Path,
 ) -> Vec<(PathBuf, RuntimeSelfLane)> {
-    let candidate_roots = [
-        workspace_root.to_path_buf(),
-        workspace_root.join("workspace"),
-    ];
+    let candidate_roots = candidate_workspace_roots(workspace_root);
     let mut source_candidates = Vec::new();
 
     for root in candidate_roots {
@@ -142,6 +149,19 @@ pub(crate) fn runtime_self_source_candidates(
     }
 
     source_candidates
+}
+
+pub(crate) fn candidate_workspace_roots(workspace_root: &Path) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let nested_workspace_root = workspace_root.join("workspace");
+
+    roots.push(workspace_root.to_path_buf());
+
+    if nested_workspace_root.is_dir() {
+        roots.push(nested_workspace_root);
+    }
+
+    roots
 }
 
 fn read_runtime_self_source(
@@ -349,6 +369,20 @@ mod tests {
         let rendered = render_runtime_self_section(&model);
 
         assert_eq!(rendered, None);
+    }
+
+    #[test]
+    fn render_runtime_self_section_keeps_tool_usage_policy_only_models() {
+        let model = RuntimeSelfModel {
+            tool_usage_policy: vec!["Prefer audited tool paths.".to_owned()],
+            ..RuntimeSelfModel::default()
+        };
+
+        let rendered = render_runtime_self_section(&model).expect("rendered runtime self");
+
+        assert!(rendered.contains("## Runtime Self Context"));
+        assert!(rendered.contains("### Tool Usage Policy"));
+        assert!(rendered.contains("Prefer audited tool paths."));
     }
 
     #[test]

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use loongclaw_contracts::ToolCoreRequest;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::tools;
@@ -43,7 +44,7 @@ const RUNTIME_SELF_SOURCE_SPECS: &[RuntimeSelfSourceSpec] = &[
     },
 ];
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct RuntimeSelfModel {
     pub standing_instructions: Vec<String>,
     pub soul_guidance: Vec<String>,

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -50,6 +50,7 @@ const RUNTIME_SELF_SOURCE_SPECS: &[RuntimeSelfSourceSpec] = &[
 ];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub(crate) struct RuntimeSelfModel {
     pub standing_instructions: Vec<String>,
     pub tool_usage_policy: Vec<String>,

--- a/crates/app/src/runtime_self.rs
+++ b/crates/app/src/runtime_self.rs
@@ -10,6 +10,7 @@ use crate::tools;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RuntimeSelfLane {
     StandingInstructions,
+    ToolUsagePolicy,
     SoulGuidance,
     IdentityContext,
     UserContext,
@@ -31,6 +32,10 @@ const RUNTIME_SELF_SOURCE_SPECS: &[RuntimeSelfSourceSpec] = &[
         lane: RuntimeSelfLane::StandingInstructions,
     },
     RuntimeSelfSourceSpec {
+        relative_path: "TOOLS.md",
+        lane: RuntimeSelfLane::ToolUsagePolicy,
+    },
+    RuntimeSelfSourceSpec {
         relative_path: "SOUL.md",
         lane: RuntimeSelfLane::SoulGuidance,
     },
@@ -47,6 +52,7 @@ const RUNTIME_SELF_SOURCE_SPECS: &[RuntimeSelfSourceSpec] = &[
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct RuntimeSelfModel {
     pub standing_instructions: Vec<String>,
+    pub tool_usage_policy: Vec<String>,
     pub soul_guidance: Vec<String>,
     pub identity_context: Vec<String>,
     pub user_context: Vec<String>,
@@ -91,6 +97,7 @@ pub(crate) fn load_runtime_self_model_with_config(
 
 pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<String> {
     let has_renderable_content = !model.standing_instructions.is_empty()
+        || !model.tool_usage_policy.is_empty()
         || !model.soul_guidance.is_empty()
         || !model.user_context.is_empty();
 
@@ -105,6 +112,11 @@ pub(crate) fn render_runtime_self_section(model: &RuntimeSelfModel) -> Option<St
         &mut sections,
         "### Standing Instructions",
         &model.standing_instructions,
+    );
+    push_rendered_lane(
+        &mut sections,
+        "### Tool Usage Policy",
+        &model.tool_usage_policy,
     );
     push_rendered_lane(&mut sections, "### Soul Guidance", &model.soul_guidance);
     push_rendered_lane(&mut sections, "### User Context", &model.user_context);
@@ -174,6 +186,9 @@ pub(crate) fn append_runtime_self_content(
     match lane {
         RuntimeSelfLane::StandingInstructions => {
             model.standing_instructions.push(content);
+        }
+        RuntimeSelfLane::ToolUsagePolicy => {
+            model.tool_usage_policy.push(content);
         }
         RuntimeSelfLane::SoulGuidance => {
             model.soul_guidance.push(content);
@@ -272,6 +287,59 @@ mod tests {
                 nested_agents_text.to_owned(),
             ]
         );
+    }
+
+    #[test]
+    fn render_runtime_self_section_includes_dedicated_tool_usage_policy_lane() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+
+        let agents_path = workspace_root.join("AGENTS.md");
+        let tools_path = workspace_root.join("TOOLS.md");
+
+        let agents_text = "Keep standing instructions visible.";
+        let tools_text = "When durable workspace facts may matter, search memory before answering.";
+
+        std::fs::write(&agents_path, agents_text).expect("write AGENTS");
+        std::fs::write(&tools_path, tools_text).expect("write TOOLS");
+
+        let model = load_runtime_self_model(workspace_root);
+        let rendered = render_runtime_self_section(&model).expect("render runtime self");
+
+        assert!(rendered.contains("### Standing Instructions"));
+        assert!(rendered.contains(agents_text));
+        assert!(rendered.contains("### Tool Usage Policy"));
+        assert!(rendered.contains(tools_text));
+    }
+
+    #[test]
+    fn render_runtime_self_section_keeps_root_and_nested_tool_policy_order_stable() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let nested_workspace_root = workspace_root.join("workspace");
+
+        std::fs::create_dir_all(&nested_workspace_root).expect("create nested workspace root");
+
+        let root_tools_path = workspace_root.join("TOOLS.md");
+        let nested_tools_path = nested_workspace_root.join("TOOLS.md");
+
+        let root_tools_text = "Root tool policy guidance.";
+        let nested_tools_text = "Nested workspace tool policy guidance.";
+
+        std::fs::write(&root_tools_path, root_tools_text).expect("write root TOOLS");
+        std::fs::write(&nested_tools_path, nested_tools_text).expect("write nested TOOLS");
+
+        let model = load_runtime_self_model(workspace_root);
+        let rendered = render_runtime_self_section(&model).expect("render runtime self");
+
+        let root_index = rendered
+            .find(root_tools_text)
+            .expect("root tool policy should be rendered");
+        let nested_index = rendered
+            .find(nested_tools_text)
+            .expect("nested tool policy should be rendered");
+
+        assert!(root_index < nested_index);
     }
 
     #[test]

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -107,6 +107,9 @@ pub(crate) fn merge_runtime_self_continuity(
         merged.runtime_self.standing_instructions =
             fallback.runtime_self.standing_instructions.clone();
     }
+    if merged.runtime_self.tool_usage_policy.is_empty() {
+        merged.runtime_self.tool_usage_policy = fallback.runtime_self.tool_usage_policy.clone();
+    }
     if merged.runtime_self.soul_guidance.is_empty() {
         merged.runtime_self.soul_guidance = fallback.runtime_self.soul_guidance.clone();
     }
@@ -141,6 +144,9 @@ pub(crate) fn missing_runtime_self_continuity(
     if live.runtime_self.standing_instructions.is_empty() {
         missing.runtime_self.standing_instructions =
             stored.runtime_self.standing_instructions.clone();
+    }
+    if live.runtime_self.tool_usage_policy.is_empty() {
+        missing.runtime_self.tool_usage_policy = stored.runtime_self.tool_usage_policy.clone();
     }
     if live.runtime_self.soul_guidance.is_empty() {
         missing.runtime_self.soul_guidance = stored.runtime_self.soul_guidance.clone();
@@ -214,4 +220,81 @@ pub(crate) const fn durable_recall_intro() -> &'static str {
 
 pub(crate) const fn runtime_durable_recall_intro() -> &'static str {
     RUNTIME_DURABLE_RECALL_INTRO
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn runtime_self_continuity_from_event_payload_defaults_missing_tool_usage_policy_lane() {
+        let payload = json!({
+            "runtime_self_continuity": {
+                "runtime_self": {
+                    "standing_instructions": ["Keep continuity explicit."],
+                    "soul_guidance": ["Prefer rigorous execution."],
+                    "identity_context": ["# Identity\n\n- Name: Stored continuity identity"],
+                    "user_context": ["The operator prefers concise technical summaries."]
+                },
+                "resolved_identity": {
+                    "source": "workspace_self",
+                    "content": "# Identity\n\n- Name: Stored continuity identity"
+                }
+            }
+        });
+
+        let continuity =
+            runtime_self_continuity_from_event_payload(&payload).expect("deserialize continuity");
+
+        assert!(continuity.runtime_self.tool_usage_policy.is_empty());
+        assert_eq!(
+            continuity.runtime_self.standing_instructions,
+            vec!["Keep continuity explicit.".to_owned()]
+        );
+    }
+
+    #[test]
+    fn missing_runtime_self_continuity_rehydrates_missing_tool_usage_policy_lane() {
+        let stored = RuntimeSelfContinuity {
+            runtime_self: RuntimeSelfModel {
+                tool_usage_policy: vec![
+                    "Search memory before guessing workspace facts.".to_owned(),
+                ],
+                ..RuntimeSelfModel::default()
+            },
+            ..RuntimeSelfContinuity::default()
+        };
+        let live = RuntimeSelfContinuity::default();
+
+        let missing = missing_runtime_self_continuity(&stored, Some(&live))
+            .expect("missing continuity should preserve tool usage policy");
+
+        assert_eq!(
+            missing.runtime_self.tool_usage_policy,
+            vec!["Search memory before guessing workspace facts.".to_owned()]
+        );
+    }
+
+    #[test]
+    fn merge_runtime_self_continuity_rehydrates_missing_tool_usage_policy_lane() {
+        let fallback = RuntimeSelfContinuity {
+            runtime_self: RuntimeSelfModel {
+                tool_usage_policy: vec![
+                    "Search memory before guessing workspace facts.".to_owned(),
+                ],
+                ..RuntimeSelfModel::default()
+            },
+            ..RuntimeSelfContinuity::default()
+        };
+        let primary = Some(RuntimeSelfContinuity::default());
+
+        let merged = merge_runtime_self_continuity(primary, Some(&fallback))
+            .expect("merged continuity should preserve tool usage policy");
+
+        assert_eq!(
+            merged.runtime_self.tool_usage_policy,
+            vec!["Search memory before guessing workspace facts.".to_owned()]
+        );
+    }
 }

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -6,6 +6,8 @@ use serde_json::Value;
 use crate::config::LoongClawConfig;
 use crate::runtime_identity::{self, ResolvedRuntimeIdentity};
 use crate::runtime_self::{self, RuntimeSelfModel};
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::SessionRepository;
 use crate::tools::runtime_config::ToolRuntimeConfig;
 
 const DURABLE_RECALL_INTRO: &str = concat!(
@@ -92,6 +94,32 @@ pub(crate) fn runtime_self_continuity_from_event_payload(
 ) -> Option<RuntimeSelfContinuity> {
     let continuity = payload.get("runtime_self_continuity")?.clone();
     serde_json::from_value(continuity).ok()
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn load_persisted_runtime_self_continuity(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<RuntimeSelfContinuity>, String> {
+    let recent_events = repo.list_recent_events(session_id, 64)?;
+    let recent_continuity = recent_events.into_iter().rev().find_map(|event| {
+        let is_continuity_event = event.event_kind == RUNTIME_SELF_CONTINUITY_EVENT_KIND;
+        if !is_continuity_event {
+            return None;
+        }
+
+        runtime_self_continuity_from_event_payload(&event.payload_json)
+    });
+    if recent_continuity.is_some() {
+        return Ok(recent_continuity);
+    }
+
+    let delegate_events = repo.list_delegate_lifecycle_events(session_id)?;
+    let delegate_continuity = delegate_events
+        .into_iter()
+        .rev()
+        .find_map(|event| runtime_self_continuity_from_event_payload(&event.payload_json));
+    Ok(delegate_continuity)
 }
 
 pub(crate) fn merge_runtime_self_continuity(

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -8,6 +8,26 @@ use crate::runtime_identity::{self, ResolvedRuntimeIdentity};
 use crate::runtime_self::{self, RuntimeSelfModel};
 use crate::tools::runtime_config::ToolRuntimeConfig;
 
+const DURABLE_RECALL_INTRO: &str = concat!(
+    "Advisory durable recall exported immediately before context compaction. ",
+    "It may enrich future recall. ",
+    "It does not replace Runtime Self Context. ",
+    "It does not override Resolved Runtime Identity or Session Profile.",
+);
+
+const DELEGATE_CHILD_CONTINUITY_LINES: &[&str] = &[
+    "- Runtime Self Context continues to supply standing instructions and soul guidance.",
+    "- Resolved Runtime Identity remains the identity authority for this session chain.",
+    concat!(
+        "- Session Profile may carry durable advisory context, and future durable ",
+        "recall can enrich it without overriding Resolved Runtime Identity."
+    ),
+    concat!(
+        "- Memory Summary and child-task findings stay session-local unless a ",
+        "separate durable-memory path promotes them."
+    ),
+];
+
 // Lane-separated continuity carrier for runtime self state.
 // Live workspace/config state remains authoritative.
 // Stored continuity only fills missing lanes across compaction and delegation boundaries.
@@ -162,7 +182,8 @@ pub(crate) fn render_runtime_self_continuity_section(
     } else {
         "Rehydrate the preserved runtime self state below when a live lane is missing."
     };
-    let continuity_note = "Session-local conversation content must not be promoted into durable self state automatically.";
+    let continuity_note =
+        "Session-local conversation content must not be promoted into durable self state automatically.";
     let runtime_self_section = runtime_self::render_runtime_self_section(&continuity.runtime_self);
     let resolved_identity_section = continuity
         .resolved_identity
@@ -192,4 +213,12 @@ fn normalize_projection(value: Option<&str>) -> Option<String> {
     }
 
     Some(trimmed_projection.to_owned())
+}
+
+pub(crate) const fn durable_recall_intro() -> &'static str {
+    DURABLE_RECALL_INTRO
+}
+
+pub(crate) const fn delegate_child_continuity_lines() -> &'static [&'static str] {
+    DELEGATE_CHILD_CONTINUITY_LINES
 }

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -15,19 +15,6 @@ const DURABLE_RECALL_INTRO: &str = concat!(
     "It does not override Resolved Runtime Identity or Session Profile.",
 );
 
-const DELEGATE_CHILD_CONTINUITY_LINES: &[&str] = &[
-    "- Runtime Self Context continues to supply standing instructions and soul guidance.",
-    "- Resolved Runtime Identity remains the identity authority for this session chain.",
-    concat!(
-        "- Session Profile may carry durable advisory context, and future durable ",
-        "recall can enrich it without overriding Resolved Runtime Identity."
-    ),
-    concat!(
-        "- Memory Summary and child-task findings stay session-local unless a ",
-        "separate durable-memory path promotes them."
-    ),
-];
-
 // Lane-separated continuity carrier for runtime self state.
 // Live workspace/config state remains authoritative.
 // Stored continuity only fills missing lanes across compaction and delegation boundaries.
@@ -182,8 +169,7 @@ pub(crate) fn render_runtime_self_continuity_section(
     } else {
         "Rehydrate the preserved runtime self state below when a live lane is missing."
     };
-    let continuity_note =
-        "Session-local conversation content must not be promoted into durable self state automatically.";
+    let continuity_note = "Session-local conversation content must not be promoted into durable self state automatically.";
     let runtime_self_section = runtime_self::render_runtime_self_section(&continuity.runtime_self);
     let resolved_identity_section = continuity
         .resolved_identity
@@ -217,8 +203,4 @@ fn normalize_projection(value: Option<&str>) -> Option<String> {
 
 pub(crate) const fn durable_recall_intro() -> &'static str {
     DURABLE_RECALL_INTRO
-}
-
-pub(crate) const fn delegate_child_continuity_lines() -> &'static [&'static str] {
-    DELEGATE_CHILD_CONTINUITY_LINES
 }

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -1,0 +1,195 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::config::LoongClawConfig;
+use crate::runtime_identity::{self, ResolvedRuntimeIdentity};
+use crate::runtime_self::{self, RuntimeSelfModel};
+use crate::tools::runtime_config::ToolRuntimeConfig;
+
+// Lane-separated continuity carrier for runtime self state.
+// Live workspace/config state remains authoritative.
+// Stored continuity only fills missing lanes across compaction and delegation boundaries.
+// Session-local conversation content must never be promoted automatically.
+// Profile projections are preserved for future durable-recall consumers without becoming
+// an identity override path.
+pub(crate) const RUNTIME_SELF_CONTINUITY_EVENT_KIND: &str = "runtime_self_continuity_refreshed";
+pub(crate) const RUNTIME_SELF_CONTINUITY_MARKER: &str = "[runtime_self_continuity]";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeSelfContinuity {
+    pub runtime_self: RuntimeSelfModel,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_identity: Option<ResolvedRuntimeIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_profile_projection: Option<String>,
+}
+
+impl RuntimeSelfContinuity {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        let profile_projection = normalize_projection(self.session_profile_projection.as_deref());
+        self.runtime_self.is_empty()
+            && self.resolved_identity.is_none()
+            && profile_projection.is_none()
+    }
+
+    #[must_use]
+    pub fn has_prompt_projection(&self) -> bool {
+        !self.runtime_self.is_empty() || self.resolved_identity.is_some()
+    }
+}
+
+pub(crate) fn resolve_runtime_self_continuity(
+    workspace_root: Option<&Path>,
+    profile_note: Option<&str>,
+) -> Option<RuntimeSelfContinuity> {
+    let runtime_self = match workspace_root {
+        Some(workspace_root) => runtime_self::load_runtime_self_model(workspace_root),
+        None => RuntimeSelfModel::default(),
+    };
+    let resolved_identity =
+        runtime_identity::resolve_runtime_identity(Some(&runtime_self), profile_note);
+    let session_profile_projection = runtime_identity::render_session_profile_section(profile_note);
+    let continuity = RuntimeSelfContinuity {
+        runtime_self,
+        resolved_identity,
+        session_profile_projection,
+    };
+
+    (!continuity.is_empty()).then_some(continuity)
+}
+
+pub(crate) fn resolve_runtime_self_continuity_for_config(
+    config: &LoongClawConfig,
+) -> Option<RuntimeSelfContinuity> {
+    let tool_runtime_config = ToolRuntimeConfig::from_loongclaw_config(config, None);
+    let workspace_root = tool_runtime_config.file_root.as_deref();
+    let profile_note = config.memory.trimmed_profile_note();
+    resolve_runtime_self_continuity(workspace_root, profile_note.as_deref())
+}
+
+pub(crate) fn runtime_self_continuity_from_event_payload(
+    payload: &Value,
+) -> Option<RuntimeSelfContinuity> {
+    let continuity = payload.get("runtime_self_continuity")?.clone();
+    serde_json::from_value(continuity).ok()
+}
+
+pub(crate) fn merge_runtime_self_continuity(
+    primary: Option<RuntimeSelfContinuity>,
+    fallback: Option<&RuntimeSelfContinuity>,
+) -> Option<RuntimeSelfContinuity> {
+    let Some(fallback) = fallback else {
+        return primary;
+    };
+
+    let Some(mut merged) = primary else {
+        return Some(fallback.clone());
+    };
+
+    if merged.runtime_self.standing_instructions.is_empty() {
+        merged.runtime_self.standing_instructions =
+            fallback.runtime_self.standing_instructions.clone();
+    }
+    if merged.runtime_self.soul_guidance.is_empty() {
+        merged.runtime_self.soul_guidance = fallback.runtime_self.soul_guidance.clone();
+    }
+    if merged.runtime_self.identity_context.is_empty() {
+        merged.runtime_self.identity_context = fallback.runtime_self.identity_context.clone();
+    }
+    if merged.runtime_self.user_context.is_empty() {
+        merged.runtime_self.user_context = fallback.runtime_self.user_context.clone();
+    }
+    if merged.resolved_identity.is_none() {
+        merged.resolved_identity = fallback.resolved_identity.clone();
+    }
+
+    let merged_projection = normalize_projection(merged.session_profile_projection.as_deref());
+    if merged_projection.is_none() {
+        merged.session_profile_projection = fallback.session_profile_projection.clone();
+    }
+
+    Some(merged)
+}
+
+pub(crate) fn missing_runtime_self_continuity(
+    stored: &RuntimeSelfContinuity,
+    live: Option<&RuntimeSelfContinuity>,
+) -> Option<RuntimeSelfContinuity> {
+    let Some(live) = live else {
+        return stored.has_prompt_projection().then_some(stored.clone());
+    };
+
+    let mut missing = RuntimeSelfContinuity::default();
+
+    if live.runtime_self.standing_instructions.is_empty() {
+        missing.runtime_self.standing_instructions =
+            stored.runtime_self.standing_instructions.clone();
+    }
+    if live.runtime_self.soul_guidance.is_empty() {
+        missing.runtime_self.soul_guidance = stored.runtime_self.soul_guidance.clone();
+    }
+    if live.runtime_self.identity_context.is_empty() {
+        missing.runtime_self.identity_context = stored.runtime_self.identity_context.clone();
+    }
+    if live.runtime_self.user_context.is_empty() {
+        missing.runtime_self.user_context = stored.runtime_self.user_context.clone();
+    }
+    if live.resolved_identity.is_none() {
+        missing.resolved_identity = stored.resolved_identity.clone();
+    }
+
+    let live_projection = normalize_projection(live.session_profile_projection.as_deref());
+    if live_projection.is_none() {
+        missing.session_profile_projection = stored.session_profile_projection.clone();
+    }
+
+    missing.has_prompt_projection().then_some(missing)
+}
+
+pub(crate) fn render_runtime_self_continuity_section(
+    continuity: &RuntimeSelfContinuity,
+    inherited: bool,
+) -> Option<String> {
+    if !continuity.has_prompt_projection() {
+        return None;
+    }
+
+    let continuity_scope = if inherited {
+        "Rehydrate the inherited runtime self state below when a live lane is missing."
+    } else {
+        "Rehydrate the preserved runtime self state below when a live lane is missing."
+    };
+    let continuity_note = "Session-local conversation content must not be promoted into durable self state automatically.";
+    let runtime_self_section = runtime_self::render_runtime_self_section(&continuity.runtime_self);
+    let resolved_identity_section = continuity
+        .resolved_identity
+        .as_ref()
+        .map(runtime_identity::render_runtime_identity_section);
+
+    let mut sections = Vec::new();
+    sections.push(RUNTIME_SELF_CONTINUITY_MARKER.to_owned());
+    sections.push(continuity_scope.to_owned());
+    sections.push(continuity_note.to_owned());
+
+    if let Some(runtime_self_section) = runtime_self_section {
+        sections.push(runtime_self_section);
+    }
+    if let Some(resolved_identity_section) = resolved_identity_section {
+        sections.push(resolved_identity_section);
+    }
+
+    Some(sections.join("\n\n"))
+}
+
+fn normalize_projection(value: Option<&str>) -> Option<String> {
+    let projection = value?;
+    let trimmed_projection = projection.trim();
+    if trimmed_projection.is_empty() {
+        return None;
+    }
+
+    Some(trimmed_projection.to_owned())
+}

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -51,7 +51,10 @@ impl RuntimeSelfContinuity {
 
     #[must_use]
     pub fn has_prompt_projection(&self) -> bool {
-        !self.runtime_self.is_empty() || self.resolved_identity.is_some()
+        let profile_projection = normalize_projection(self.session_profile_projection.as_deref());
+        !self.runtime_self.is_empty()
+            || self.resolved_identity.is_some()
+            || profile_projection.is_some()
     }
 }
 
@@ -200,6 +203,11 @@ pub(crate) fn render_runtime_self_continuity_section(
     if let Some(resolved_identity_section) = resolved_identity_section {
         sections.push(resolved_identity_section);
     }
+    let session_profile_projection =
+        normalize_projection(continuity.session_profile_projection.as_deref());
+    if let Some(session_profile_projection) = session_profile_projection {
+        sections.push(session_profile_projection);
+    }
 
     Some(sections.join("\n\n"))
 }
@@ -295,6 +303,28 @@ mod tests {
         assert_eq!(
             merged.runtime_self.tool_usage_policy,
             vec!["Search memory before guessing workspace facts.".to_owned()]
+        );
+    }
+
+    #[test]
+    fn render_runtime_self_continuity_section_renders_projection_only_continuity() {
+        let continuity = RuntimeSelfContinuity {
+            session_profile_projection: Some(
+                "## Session Profile\nDurable preferences and advisory session context carried into this session:\nOperator prefers concise technical summaries.".to_owned(),
+            ),
+            ..RuntimeSelfContinuity::default()
+        };
+
+        let rendered = render_runtime_self_continuity_section(&continuity, false)
+            .expect("projection-only continuity should render");
+
+        assert!(
+            rendered.contains("## Session Profile"),
+            "expected session profile section, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("Operator prefers concise technical summaries."),
+            "expected projected profile text, got: {rendered}"
         );
     }
 }

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -24,6 +24,13 @@ const DURABLE_RECALL_INTRO: &str = concat!(
 pub(crate) const RUNTIME_SELF_CONTINUITY_EVENT_KIND: &str = "runtime_self_continuity_refreshed";
 pub(crate) const RUNTIME_SELF_CONTINUITY_MARKER: &str = "[runtime_self_continuity]";
 
+const RUNTIME_DURABLE_RECALL_INTRO: &str = concat!(
+    "Advisory durable recall loaded from workspace memory files. ",
+    "It may enrich the current session. ",
+    "It does not replace Runtime Self Context. ",
+    "It does not override Resolved Runtime Identity or Session Profile.",
+);
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeSelfContinuity {
     pub runtime_self: RuntimeSelfModel,
@@ -203,4 +210,8 @@ fn normalize_projection(value: Option<&str>) -> Option<String> {
 
 pub(crate) const fn durable_recall_intro() -> &'static str {
     DURABLE_RECALL_INTRO
+}
+
+pub(crate) const fn runtime_durable_recall_intro() -> &'static str {
+    RUNTIME_DURABLE_RECALL_INTRO
 }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1031,10 +1031,27 @@ fn tool_visibility_gate_enabled_for_runtime_policy(
         ToolVisibilityGate::Browser => config.browser.enabled,
         ToolVisibilityGate::BrowserCompanion => config.browser_companion.is_runtime_ready(),
         ToolVisibilityGate::ExternalSkills => config.external_skills.enabled,
-        ToolVisibilityGate::MemoryFileRoot => config
-            .file_root
-            .as_ref()
-            .is_some_and(|value| !value.as_os_str().is_empty()),
+        ToolVisibilityGate::MemoryFileRoot => {
+            let has_file_root = config
+                .file_root
+                .as_ref()
+                .is_some_and(|value| !value.as_os_str().is_empty());
+
+            if !has_file_root {
+                return false;
+            }
+
+            #[cfg(feature = "tool-file")]
+            {
+                let memory_corpus_available = super::memory_tools::memory_corpus_available(config);
+                memory_corpus_available
+            }
+
+            #[cfg(not(feature = "tool-file"))]
+            {
+                has_file_root
+            }
+        }
         ToolVisibilityGate::WebFetch => config.web_fetch.enabled,
         ToolVisibilityGate::WebSearch => config.web_search.enabled,
     }
@@ -2578,6 +2595,7 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[cfg(feature = "tool-browser")]
     #[test]
@@ -2682,8 +2700,26 @@ mod tests {
             &hidden_runtime
         ));
 
+        let empty_runtime_dir = tempdir().expect("tempdir");
+        let empty_runtime = ToolRuntimeConfig {
+            file_root: Some(empty_runtime_dir.path().to_path_buf()),
+            ..ToolRuntimeConfig::default()
+        };
+        assert!(!tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::MemoryFileRoot,
+            &empty_runtime
+        ));
+
+        let visible_runtime_dir = tempdir().expect("tempdir");
+        let visible_memory_path = visible_runtime_dir.path().join("MEMORY.md");
+        std::fs::write(
+            &visible_memory_path,
+            "# Durable Notes\nDeploy freeze window is Friday.\n",
+        )
+        .expect("write root memory");
+
         let visible_runtime = ToolRuntimeConfig {
-            file_root: Some(std::path::PathBuf::from("/tmp/workspace")),
+            file_root: Some(visible_runtime_dir.path().to_path_buf()),
             ..ToolRuntimeConfig::default()
         };
         assert!(tool_visibility_gate_enabled_for_runtime_policy(

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1043,8 +1043,7 @@ fn tool_visibility_gate_enabled_for_runtime_policy(
 
             #[cfg(feature = "tool-file")]
             {
-                let memory_corpus_available = super::memory_tools::memory_corpus_available(config);
-                memory_corpus_available
+                super::memory_tools::memory_corpus_available(config)
             }
 
             #[cfg(not(feature = "tool-file"))]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -120,9 +120,8 @@ pub fn governance_profile_for_descriptor(descriptor: &ToolDescriptor) -> ToolGov
 
 pub fn scheduling_class_for_tool_name(tool_name: &str) -> ToolSchedulingClass {
     match tool_name {
-        "tool.search" | "file.read" | "web.fetch" | "web.search" | "sessions_list" => {
-            ToolSchedulingClass::ParallelSafe
-        }
+        "tool.search" | "file.read" | "memory_search" | "memory_get" | "web.fetch"
+        | "web.search" | "sessions_list" => ToolSchedulingClass::ParallelSafe,
         _ => ToolSchedulingClass::SerialOnly,
     }
 }
@@ -142,6 +141,7 @@ pub enum ToolVisibilityGate {
     Browser,
     BrowserCompanion,
     ExternalSkills,
+    MemoryFileRoot,
     WebFetch,
     WebSearch,
 }
@@ -621,6 +621,28 @@ pub fn tool_catalog() -> ToolCatalog {
             provider_definition_builder: file_read_definition,
         });
         descriptors.push(ToolDescriptor {
+            name: "memory_search",
+            provider_name: "memory_search",
+            aliases: &[],
+            description: "Search durable workspace memory files with bounded citation-bearing snippets",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::MemoryFileRoot,
+            provider_definition_builder: memory_search_definition,
+        });
+        descriptors.push(ToolDescriptor {
+            name: "memory_get",
+            provider_name: "memory_get",
+            aliases: &[],
+            description: "Read a bounded line window from one durable workspace memory file",
+            execution_kind: ToolExecutionKind::Core,
+            availability: ToolAvailability::Runtime,
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::MemoryFileRoot,
+            provider_definition_builder: memory_get_definition,
+        });
+        descriptors.push(ToolDescriptor {
             name: "file.write",
             provider_name: "file_write",
             aliases: &[],
@@ -988,6 +1010,10 @@ fn tool_visibility_gate_enabled_for_runtime_view(
         ToolVisibilityGate::Browser => config.browser.enabled,
         ToolVisibilityGate::BrowserCompanion => false,
         ToolVisibilityGate::ExternalSkills => external_skills_enabled,
+        ToolVisibilityGate::MemoryFileRoot => config
+            .file_root
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
         ToolVisibilityGate::WebFetch => config.web.enabled,
         ToolVisibilityGate::WebSearch => config.web_search.enabled,
     }
@@ -1005,6 +1031,10 @@ fn tool_visibility_gate_enabled_for_runtime_policy(
         ToolVisibilityGate::Browser => config.browser.enabled,
         ToolVisibilityGate::BrowserCompanion => config.browser_companion.is_runtime_ready(),
         ToolVisibilityGate::ExternalSkills => config.external_skills.enabled,
+        ToolVisibilityGate::MemoryFileRoot => config
+            .file_root
+            .as_ref()
+            .is_some_and(|value| !value.as_os_str().is_empty()),
         ToolVisibilityGate::WebFetch => config.web_fetch.enabled,
         ToolVisibilityGate::WebSearch => config.web_search.enabled,
     }
@@ -1678,6 +1708,65 @@ fn file_write_definition(descriptor: &ToolDescriptor) -> Value {
     })
 }
 
+fn memory_search_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural-language lookup query for durable workspace memory."
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 8,
+                        "description": "Optional maximum number of memory hits to return. Defaults to 5."
+                    }
+                },
+                "required": ["query"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn memory_get_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative or absolute durable memory file path within the configured safe file root."
+                    },
+                    "from": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional 1-based starting line number. Defaults to 1."
+                    },
+                    "lines": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 200,
+                        "description": "Optional number of lines to read. Defaults to 40."
+                    }
+                },
+                "required": ["path"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
 fn file_edit_definition(descriptor: &ToolDescriptor) -> Value {
     json!({
         "type": "function",
@@ -2296,6 +2385,8 @@ fn tool_argument_hint(name: &str) -> &'static str {
         "browser.companion.click" => "session_id:string,selector:string",
         "browser.companion.type" => "session_id:string,selector:string,text:string",
         "file.read" => "path:string,max_bytes?:integer",
+        "memory_search" => "query:string,max_results?:integer",
+        "memory_get" => "path:string,from?:integer,lines?:integer",
         "file.write" => "path:string,content:string,create_dirs?:boolean",
         "file.edit" => "path:string,old_string:string,new_string:string,replace_all?:boolean",
         "shell.exec" => "command:string,args?:string[],timeout_ms?:integer,cwd?:string",
@@ -2361,6 +2452,12 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
             ("blocked_domains", "array"),
         ],
         "file.read" => &[("path", "string"), ("max_bytes", "integer")],
+        "memory_search" => &[("query", "string"), ("max_results", "integer")],
+        "memory_get" => &[
+            ("path", "string"),
+            ("from", "integer"),
+            ("lines", "integer"),
+        ],
         "file.write" => &[
             ("path", "string"),
             ("content", "string"),
@@ -2419,6 +2516,8 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "browser.companion.click" => &["session_id", "selector"],
         "browser.companion.type" => &["session_id", "selector", "text"],
         "file.read" => &["path"],
+        "memory_search" => &["query"],
+        "memory_get" => &["path"],
         "file.write" => &["path", "content"],
         "file.edit" => &["path", "old_string", "new_string"],
         "shell.exec" => &["command"],
@@ -2459,6 +2558,8 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
             &["browser", "companion", "write", "approval"]
         }
         "file.read" => &["file", "read", "filesystem", "repo"],
+        "memory_search" => &["memory", "search", "recall", "durable", "workspace"],
+        "memory_get" => &["memory", "read", "recall", "durable", "workspace"],
         "file.write" => &["file", "write", "filesystem"],
         "file.edit" => &["file", "edit", "filesystem"],
         "shell.exec" => &["shell", "command", "process", "exec"],
@@ -2557,6 +2658,41 @@ mod tests {
     }
 
     #[test]
+    fn memory_file_root_visibility_gate_requires_safe_root_configuration() {
+        let hidden_config = ToolConfig::default();
+        assert!(!tool_visibility_gate_enabled_for_runtime_view(
+            ToolVisibilityGate::MemoryFileRoot,
+            &hidden_config,
+            false
+        ));
+
+        let visible_config = ToolConfig {
+            file_root: Some("/tmp/workspace".to_owned()),
+            ..ToolConfig::default()
+        };
+        assert!(tool_visibility_gate_enabled_for_runtime_view(
+            ToolVisibilityGate::MemoryFileRoot,
+            &visible_config,
+            false
+        ));
+
+        let hidden_runtime = ToolRuntimeConfig::default();
+        assert!(!tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::MemoryFileRoot,
+            &hidden_runtime
+        ));
+
+        let visible_runtime = ToolRuntimeConfig {
+            file_root: Some(std::path::PathBuf::from("/tmp/workspace")),
+            ..ToolRuntimeConfig::default()
+        };
+        assert!(tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::MemoryFileRoot,
+            &visible_runtime
+        ));
+    }
+
+    #[test]
     fn browser_visibility_gate_is_independent_from_companion_settings() {
         let mut config = ToolRuntimeConfig::default();
         config.browser.enabled = true;
@@ -2595,6 +2731,22 @@ mod tests {
             catalog
                 .descriptor("file.read")
                 .expect("file.read descriptor")
+                .scheduling_class(),
+            ToolSchedulingClass::ParallelSafe
+        );
+        #[cfg(feature = "tool-file")]
+        assert_eq!(
+            catalog
+                .descriptor("memory_search")
+                .expect("memory_search descriptor")
+                .scheduling_class(),
+            ToolSchedulingClass::ParallelSafe
+        );
+        #[cfg(feature = "tool-file")]
+        assert_eq!(
+            catalog
+                .descriptor("memory_get")
+                .expect("memory_get descriptor")
                 .scheduling_class(),
             ToolSchedulingClass::ParallelSafe
         );

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -346,6 +346,44 @@ mod tests {
     }
 
     #[test]
+    fn memory_search_requires_filesystem_read() {
+        assert_eq!(
+            FilePolicyExtension::required_capability("memory_search"),
+            Some(Capability::FilesystemRead)
+        );
+
+        let ext = FilePolicyExtension::new(None);
+        let pack = test_pack();
+        let token = token_with_caps(BTreeSet::from([Capability::InvokeTool]));
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({"tool_name": "memory_search", "payload": {"path": "MEMORY.md", "query": "deploy"}});
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        assert!(matches!(
+            ext.authorize_extension(&ctx).unwrap_err(),
+            PolicyError::ExtensionDenied { .. }
+        ));
+    }
+
+    #[test]
+    fn memory_get_allowed_with_filesystem_read() {
+        assert_eq!(
+            FilePolicyExtension::required_capability("memory_get"),
+            Some(Capability::FilesystemRead)
+        );
+
+        let ext = FilePolicyExtension::new(None);
+        let pack = test_pack();
+        let token = token_with_caps(BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+        ]));
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({"tool_name": "memory_get", "payload": {"path": "MEMORY.md"}});
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        assert!(ext.authorize_extension(&ctx).is_ok());
+    }
+
+    #[test]
     fn normalizes_file_read_underscore_alias() {
         let ext = FilePolicyExtension::new(None);
         let pack = test_pack();

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -356,7 +356,35 @@ mod tests {
         let pack = test_pack();
         let token = token_with_caps(BTreeSet::from([Capability::InvokeTool]));
         let caps = BTreeSet::from([Capability::InvokeTool]);
-        let params = json!({"tool_name": "memory_search", "payload": {"path": "MEMORY.md", "query": "deploy"}});
+        let params = json!({"tool_name": "memory_search", "payload": {"query": "deploy"}});
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        assert!(matches!(
+            ext.authorize_extension(&ctx).unwrap_err(),
+            PolicyError::ExtensionDenied { .. }
+        ));
+    }
+
+    #[test]
+    fn memory_search_allowed_with_filesystem_read() {
+        let ext = FilePolicyExtension::new(None);
+        let pack = test_pack();
+        let token = token_with_caps(BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+        ]));
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({"tool_name": "memory_search", "payload": {"query": "deploy"}});
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        assert!(ext.authorize_extension(&ctx).is_ok());
+    }
+
+    #[test]
+    fn memory_get_requires_filesystem_read() {
+        let ext = FilePolicyExtension::new(None);
+        let pack = test_pack();
+        let token = token_with_caps(BTreeSet::from([Capability::InvokeTool]));
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({"tool_name": "memory_get", "payload": {"path": "MEMORY.md"}});
         let ctx = make_context(&pack, &token, &caps, Some(&params));
         assert!(matches!(
             ext.authorize_extension(&ctx).unwrap_err(),

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -30,7 +30,9 @@ impl FilePolicyExtension {
 
     fn required_capability(tool_name: &str) -> Option<Capability> {
         match tool_name {
-            "file.read" | "claw.migrate" => Some(Capability::FilesystemRead),
+            "file.read" | "memory_search" | "memory_get" | "claw.migrate" => {
+                Some(Capability::FilesystemRead)
+            }
             "file.write" | "file.edit" => Some(Capability::FilesystemWrite),
             _ => None,
         }

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
@@ -25,6 +26,12 @@ struct MemorySearchResult {
 struct BestLineMatch {
     line_number: usize,
     score: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MemoryFileWindow {
+    total_lines: usize,
+    selected_lines: Vec<String>,
 }
 
 pub(super) fn execute_memory_search_tool_with_config(
@@ -134,34 +141,29 @@ pub(super) fn execute_memory_get_tool_with_config(
             )
         })?;
 
-    let content = fs::read_to_string(matched_location.path.as_path()).map_err(|error| {
-        format!(
-            "failed to read memory file {}: {error}",
-            matched_location.path.display()
-        )
-    })?;
-    let lines = content.lines().collect::<Vec<_>>();
-    if lines.is_empty() {
+    let file_window = read_memory_file_window(
+        matched_location.path.as_path(),
+        requested_start_line,
+        requested_line_count,
+    )?;
+    let total_lines = file_window.total_lines;
+    let selected_lines = file_window.selected_lines;
+
+    if total_lines == 0 {
         return Err(format!("memory file `{}` is empty", matched_location.label));
     }
-    if requested_start_line > lines.len() {
+    if requested_start_line > total_lines {
         return Err(format!(
             "memory_get start line {} exceeds file length {} for `{}`",
-            requested_start_line,
-            lines.len(),
-            matched_location.label
+            requested_start_line, total_lines, matched_location.label
         ));
     }
 
-    let start_index = requested_start_line.saturating_sub(1);
-    let end_index = start_index
-        .saturating_add(requested_line_count)
-        .min(lines.len());
-    let start_line = start_index.saturating_add(1);
-    let end_line = end_index;
-    let selected_lines = lines
-        .get(start_index..end_index)
-        .ok_or_else(|| "memory_get selected line window is out of bounds".to_owned())?;
+    let start_line = requested_start_line;
+    let selected_line_count = selected_lines.len();
+    let end_line = start_line
+        .saturating_add(selected_line_count)
+        .saturating_sub(1);
     let text = selected_lines.join("\n");
 
     Ok(ToolCoreOutcome {
@@ -188,6 +190,55 @@ pub(super) fn memory_corpus_available(config: &super::runtime_config::ToolRuntim
     };
 
     !locations.is_empty()
+}
+
+fn read_memory_file_window(
+    path: &Path,
+    requested_start_line: usize,
+    requested_line_count: usize,
+) -> Result<MemoryFileWindow, String> {
+    let file = File::open(path)
+        .map_err(|error| format!("failed to read memory file {}: {error}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let mut total_lines = 0usize;
+    let mut selected_lines = Vec::new();
+    let mut buffer = String::new();
+
+    loop {
+        buffer.clear();
+
+        let bytes_read = reader
+            .read_line(&mut buffer)
+            .map_err(|error| format!("failed to read memory file {}: {error}", path.display()))?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        total_lines = total_lines.saturating_add(1);
+
+        if total_lines < requested_start_line {
+            continue;
+        }
+        if selected_lines.len() >= requested_line_count {
+            break;
+        }
+
+        let line = trim_trailing_line_endings(&buffer);
+        let owned_line = line.to_owned();
+
+        selected_lines.push(owned_line);
+
+        if selected_lines.len() >= requested_line_count {
+            break;
+        }
+    }
+
+    let file_window = MemoryFileWindow {
+        total_lines,
+        selected_lines,
+    };
+
+    Ok(file_window)
 }
 
 fn workspace_root_from_config(
@@ -413,4 +464,10 @@ fn memory_search_result_payload(result: &MemorySearchResult) -> Value {
         "snippet": result.snippet,
         "score": result.score,
     })
+}
+
+fn trim_trailing_line_endings(line: &str) -> &str {
+    let without_newline = line.strip_suffix('\n').unwrap_or(line);
+    let without_carriage_return = without_newline.strip_suffix('\r');
+    without_carriage_return.unwrap_or(without_newline)
 }

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use crate::memory::{WorkspaceMemoryDocumentLocation, collect_workspace_memory_document_locations};
 
@@ -31,6 +31,7 @@ pub(super) fn execute_memory_search_tool_with_config(
     request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let tool_name = request.tool_name.as_str();
     let payload = request
         .payload
         .as_object()
@@ -43,11 +44,14 @@ pub(super) fn execute_memory_search_tool_with_config(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "memory_search requires payload.query".to_owned())?;
 
-    let max_results = payload
-        .get("max_results")
-        .and_then(Value::as_u64)
-        .map(|value| value.clamp(1, MAX_MEMORY_SEARCH_RESULTS as u64) as usize)
-        .unwrap_or(DEFAULT_MEMORY_SEARCH_MAX_RESULTS);
+    let max_results = parse_optional_usize_field(
+        payload,
+        tool_name,
+        "max_results",
+        DEFAULT_MEMORY_SEARCH_MAX_RESULTS,
+        1,
+        Some(MAX_MEMORY_SEARCH_RESULTS),
+    )?;
 
     let workspace_root = workspace_root_from_config(config)?;
     let locations = collect_workspace_memory_document_locations(workspace_root)?;
@@ -97,6 +101,7 @@ pub(super) fn execute_memory_get_tool_with_config(
     request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let tool_name = request.tool_name.as_str();
     let payload = request
         .payload
         .as_object()
@@ -109,27 +114,19 @@ pub(super) fn execute_memory_get_tool_with_config(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "memory_get requires payload.path".to_owned())?;
 
-    let requested_start_line = payload
-        .get("from")
-        .and_then(Value::as_u64)
-        .map(|value| value.max(1) as usize)
-        .unwrap_or(1);
-
-    let requested_line_count = payload
-        .get("lines")
-        .and_then(Value::as_u64)
-        .map(|value| value.clamp(1, MAX_MEMORY_GET_LINES as u64) as usize)
-        .unwrap_or(DEFAULT_MEMORY_GET_LINES);
+    let requested_start_line = parse_optional_usize_field(payload, tool_name, "from", 1, 1, None)?;
+    let requested_line_count = parse_optional_usize_field(
+        payload,
+        tool_name,
+        "lines",
+        DEFAULT_MEMORY_GET_LINES,
+        1,
+        Some(MAX_MEMORY_GET_LINES),
+    )?;
 
     let workspace_root = workspace_root_from_config(config)?;
     let locations = collect_workspace_memory_document_locations(workspace_root)?;
     let resolved_path = super::file::resolve_safe_file_path_with_config(raw_path, config)?;
-    if !resolved_path.is_file() {
-        return Err(format!(
-            "memory_get target `{raw_path}` is not an existing file under the configured memory corpus"
-        ));
-    }
-
     let matched_location = find_memory_location_for_path(&locations, resolved_path.as_path())?
         .ok_or_else(|| {
             format!(
@@ -200,6 +197,70 @@ fn workspace_root_from_config(
         "memory tools require a configured safe file root before they can access workspace durable memory"
             .to_owned()
     })
+}
+
+fn parse_optional_usize_field(
+    payload: &Map<String, Value>,
+    tool_name: &str,
+    field_name: &str,
+    default_value: usize,
+    min_value: usize,
+    max_value: Option<usize>,
+) -> Result<usize, String> {
+    let Some(raw_value) = payload.get(field_name) else {
+        return Ok(default_value);
+    };
+
+    let maybe_integer = raw_value.as_u64();
+    let Some(integer_value) = maybe_integer else {
+        return Err(invalid_numeric_field_message(
+            tool_name, field_name, min_value, max_value,
+        ));
+    };
+    let parsed_value = usize::try_from(integer_value).map_err(|conversion_error| {
+        format!(
+            "{}: {conversion_error}",
+            invalid_numeric_field_message(tool_name, field_name, min_value, max_value)
+        )
+    })?;
+    if parsed_value < min_value {
+        return Err(invalid_numeric_field_message(
+            tool_name, field_name, min_value, max_value,
+        ));
+    }
+
+    if let Some(max_value) = max_value
+        && parsed_value > max_value
+    {
+        return Err(invalid_numeric_field_message(
+            tool_name,
+            field_name,
+            min_value,
+            Some(max_value),
+        ));
+    }
+
+    Ok(parsed_value)
+}
+
+fn invalid_numeric_field_message(
+    tool_name: &str,
+    field_name: &str,
+    min_value: usize,
+    max_value: Option<usize>,
+) -> String {
+    match max_value {
+        Some(max_value) => {
+            format!(
+                "{tool_name} payload.{field_name} must be an integer between {min_value} and {max_value}"
+            )
+        }
+        None => {
+            format!(
+                "{tool_name} payload.{field_name} must be an integer greater than or equal to {min_value}"
+            )
+        }
+    }
 }
 
 fn search_memory_location(
@@ -317,7 +378,7 @@ fn find_memory_location_for_path<'a>(
     locations: &'a [WorkspaceMemoryDocumentLocation],
     resolved_path: &Path,
 ) -> Result<Option<&'a WorkspaceMemoryDocumentLocation>, String> {
-    let resolved_key = normalized_existing_path_key(resolved_path)?;
+    let resolved_key = normalized_requested_path_key(resolved_path);
 
     for location in locations {
         let location_key = normalized_existing_path_key(location.path.as_path())?;
@@ -327,6 +388,11 @@ fn find_memory_location_for_path<'a>(
     }
 
     Ok(None)
+}
+
+fn normalized_requested_path_key(path: &Path) -> String {
+    let normalized_path = super::normalize_without_fs(path);
+    normalized_path.display().to_string()
 }
 
 fn normalized_existing_path_key(path: &Path) -> Result<String, String> {

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -1,0 +1,350 @@
+use std::fs;
+use std::path::Path;
+
+use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+use serde_json::{Value, json};
+
+use crate::memory::{WorkspaceMemoryDocumentLocation, collect_workspace_memory_document_locations};
+
+const DEFAULT_MEMORY_SEARCH_MAX_RESULTS: usize = 5;
+const MAX_MEMORY_SEARCH_RESULTS: usize = 8;
+const MEMORY_SEARCH_CONTEXT_RADIUS_LINES: usize = 1;
+const DEFAULT_MEMORY_GET_LINES: usize = 40;
+const MAX_MEMORY_GET_LINES: usize = 200;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MemorySearchResult {
+    path: String,
+    start_line: usize,
+    end_line: usize,
+    snippet: String,
+    score: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BestLineMatch {
+    line_number: usize,
+    score: u32,
+}
+
+pub(super) fn execute_memory_search_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "memory_search payload must be an object".to_owned())?;
+
+    let query = payload
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory_search requires payload.query".to_owned())?;
+
+    let max_results = payload
+        .get("max_results")
+        .and_then(Value::as_u64)
+        .map(|value| value.clamp(1, MAX_MEMORY_SEARCH_RESULTS as u64) as usize)
+        .unwrap_or(DEFAULT_MEMORY_SEARCH_MAX_RESULTS);
+
+    let workspace_root = workspace_root_from_config(config)?;
+    let locations = collect_workspace_memory_document_locations(workspace_root)?;
+    let query_normalized = query.to_ascii_lowercase();
+    let query_tokens = tokenize_memory_query(query_normalized.as_str());
+
+    let mut results = Vec::new();
+    for location in locations {
+        let maybe_result = search_memory_location(
+            query_normalized.as_str(),
+            query_tokens.as_slice(),
+            &location,
+        )?;
+        let Some(result) = maybe_result else {
+            continue;
+        };
+        results.push(result);
+    }
+
+    results.sort_by(|left, right| {
+        right
+            .score
+            .cmp(&left.score)
+            .then(left.path.cmp(&right.path))
+            .then(left.start_line.cmp(&right.start_line))
+    });
+
+    let bounded_results = results.into_iter().take(max_results).collect::<Vec<_>>();
+    let result_payload = bounded_results
+        .iter()
+        .map(memory_search_result_payload)
+        .collect::<Vec<_>>();
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "query": query,
+            "returned": result_payload.len(),
+            "results": result_payload,
+        }),
+    })
+}
+
+pub(super) fn execute_memory_get_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "memory_get payload must be an object".to_owned())?;
+
+    let raw_path = payload
+        .get("path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory_get requires payload.path".to_owned())?;
+
+    let requested_start_line = payload
+        .get("from")
+        .and_then(Value::as_u64)
+        .map(|value| value.max(1) as usize)
+        .unwrap_or(1);
+
+    let requested_line_count = payload
+        .get("lines")
+        .and_then(Value::as_u64)
+        .map(|value| value.clamp(1, MAX_MEMORY_GET_LINES as u64) as usize)
+        .unwrap_or(DEFAULT_MEMORY_GET_LINES);
+
+    let workspace_root = workspace_root_from_config(config)?;
+    let locations = collect_workspace_memory_document_locations(workspace_root)?;
+    let resolved_path = super::file::resolve_safe_file_path_with_config(raw_path, config)?;
+    if !resolved_path.is_file() {
+        return Err(format!(
+            "memory_get target `{raw_path}` is not an existing file under the configured memory corpus"
+        ));
+    }
+
+    let matched_location = find_memory_location_for_path(&locations, resolved_path.as_path())?
+        .ok_or_else(|| {
+            format!(
+                "memory_get path `{raw_path}` is not part of the workspace durable memory corpus"
+            )
+        })?;
+
+    let content = fs::read_to_string(matched_location.path.as_path()).map_err(|error| {
+        format!(
+            "failed to read memory file {}: {error}",
+            matched_location.path.display()
+        )
+    })?;
+    let lines = content.lines().collect::<Vec<_>>();
+    if lines.is_empty() {
+        return Err(format!("memory file `{}` is empty", matched_location.label));
+    }
+    if requested_start_line > lines.len() {
+        return Err(format!(
+            "memory_get start line {} exceeds file length {} for `{}`",
+            requested_start_line,
+            lines.len(),
+            matched_location.label
+        ));
+    }
+
+    let start_index = requested_start_line.saturating_sub(1);
+    let end_index = start_index
+        .saturating_add(requested_line_count)
+        .min(lines.len());
+    let start_line = start_index.saturating_add(1);
+    let end_line = end_index;
+    let selected_lines = lines
+        .get(start_index..end_index)
+        .ok_or_else(|| "memory_get selected line window is out of bounds".to_owned())?;
+    let text = selected_lines.join("\n");
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": request.tool_name,
+            "path": matched_location.label,
+            "start_line": start_line,
+            "end_line": end_line,
+            "text": text,
+        }),
+    })
+}
+
+pub(super) fn memory_corpus_available(config: &super::runtime_config::ToolRuntimeConfig) -> bool {
+    let Some(workspace_root) = config.file_root.as_deref() else {
+        return false;
+    };
+
+    let result = collect_workspace_memory_document_locations(workspace_root);
+    let Ok(locations) = result else {
+        return false;
+    };
+
+    !locations.is_empty()
+}
+
+fn workspace_root_from_config(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<&Path, String> {
+    config.file_root.as_deref().ok_or_else(|| {
+        "memory tools require a configured safe file root before they can access workspace durable memory"
+            .to_owned()
+    })
+}
+
+fn search_memory_location(
+    query: &str,
+    query_tokens: &[String],
+    location: &WorkspaceMemoryDocumentLocation,
+) -> Result<Option<MemorySearchResult>, String> {
+    let content = fs::read_to_string(location.path.as_path()).map_err(|error| {
+        format!(
+            "failed to read memory file {}: {error}",
+            location.path.display()
+        )
+    })?;
+    let lines = content.lines().collect::<Vec<_>>();
+    if lines.is_empty() {
+        return Ok(None);
+    }
+
+    let maybe_match = best_line_match(query, query_tokens, lines.as_slice());
+    let Some(best_match) = maybe_match else {
+        return Ok(None);
+    };
+
+    let total_lines = lines.len();
+    let context_radius = MEMORY_SEARCH_CONTEXT_RADIUS_LINES;
+    let (start_line, end_line) =
+        snippet_window(total_lines, best_match.line_number, context_radius);
+    let start_index = start_line.saturating_sub(1);
+    let end_index = end_line;
+    let snippet_lines = lines
+        .get(start_index..end_index)
+        .ok_or_else(|| "memory_search selected snippet window is out of bounds".to_owned())?;
+    let snippet = snippet_lines.join("\n");
+
+    let result = MemorySearchResult {
+        path: location.label.clone(),
+        start_line,
+        end_line,
+        snippet,
+        score: best_match.score,
+    };
+
+    Ok(Some(result))
+}
+
+fn best_line_match(query: &str, query_tokens: &[String], lines: &[&str]) -> Option<BestLineMatch> {
+    let mut best_match: Option<BestLineMatch> = None;
+
+    for (index, line) in lines.iter().enumerate() {
+        let score = line_match_score(query, query_tokens, line);
+        if score == 0 {
+            continue;
+        }
+
+        let line_number = index.saturating_add(1);
+        let candidate = BestLineMatch { line_number, score };
+        let should_replace = match best_match {
+            None => true,
+            Some(current) => {
+                candidate.score > current.score
+                    || (candidate.score == current.score
+                        && candidate.line_number < current.line_number)
+            }
+        };
+        if should_replace {
+            best_match = Some(candidate);
+        }
+    }
+
+    best_match
+}
+
+fn line_match_score(query: &str, query_tokens: &[String], line: &str) -> u32 {
+    let normalized_line = line.to_ascii_lowercase();
+    let mut score = 0u32;
+
+    if normalized_line.contains(query) {
+        score = score.saturating_add(100);
+    }
+
+    let mut matched_token_count = 0u32;
+    for token in query_tokens {
+        if normalized_line.contains(token) {
+            matched_token_count = matched_token_count.saturating_add(1);
+            score = score.saturating_add(20);
+        }
+    }
+
+    if matched_token_count > 1 && matched_token_count as usize == query_tokens.len() {
+        score = score.saturating_add(20);
+    }
+
+    score
+}
+
+fn tokenize_memory_query(query: &str) -> Vec<String> {
+    query
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-')
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn snippet_window(total_lines: usize, focus_line: usize, context_radius: usize) -> (usize, usize) {
+    let start_line = focus_line.saturating_sub(context_radius).max(1);
+    let end_line = focus_line
+        .saturating_add(context_radius)
+        .min(total_lines)
+        .max(start_line);
+    (start_line, end_line)
+}
+
+fn find_memory_location_for_path<'a>(
+    locations: &'a [WorkspaceMemoryDocumentLocation],
+    resolved_path: &Path,
+) -> Result<Option<&'a WorkspaceMemoryDocumentLocation>, String> {
+    let resolved_key = normalized_existing_path_key(resolved_path)?;
+
+    for location in locations {
+        let location_key = normalized_existing_path_key(location.path.as_path())?;
+        if location_key == resolved_key {
+            return Ok(Some(location));
+        }
+    }
+
+    Ok(None)
+}
+
+fn normalized_existing_path_key(path: &Path) -> Result<String, String> {
+    let canonical_path = path.canonicalize().map_err(|error| {
+        format!(
+            "failed to canonicalize workspace memory path {}: {error}",
+            path.display()
+        )
+    })?;
+    Ok(canonical_path.display().to_string())
+}
+
+fn memory_search_result_payload(result: &MemorySearchResult) -> Value {
+    json!({
+        "path": result.path,
+        "start_line": result.start_line,
+        "end_line": result.end_line,
+        "snippet": result.snippet,
+        "score": result.score,
+    })
+}

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2643,6 +2643,39 @@ mod tests {
 
     #[cfg(feature = "tool-file")]
     #[test]
+    fn memory_get_tool_reads_requested_window_without_loading_invalid_tail() {
+        let root = unique_tool_temp_dir("loongclaw-memory-get-invalid-tail");
+        let memory_path = root.join("MEMORY.md");
+        let mut bytes = b"line one\nline two\n".to_vec();
+
+        bytes.push(0xff);
+        bytes.push(0xfe);
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(&memory_path, bytes).expect("write root memory");
+
+        let config = test_tool_runtime_config(root);
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_get".to_owned(),
+                payload: json!({
+                    "path": "MEMORY.md",
+                    "from": 1,
+                    "lines": 2
+                }),
+            },
+            &config,
+        )
+        .expect("memory get should ignore invalid bytes beyond requested window");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["start_line"], 1);
+        assert_eq!(outcome.payload["end_line"], 2);
+        assert_eq!(outcome.payload["text"], "line one\nline two");
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
     fn memory_search_tool_rejects_invalid_max_results_values() {
         let root = unique_tool_temp_dir("loongclaw-memory-search-invalid-max-results");
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -34,6 +34,8 @@ mod feishu;
 mod file;
 pub mod file_policy_ext;
 mod kernel_adapter;
+#[cfg(feature = "tool-file")]
+mod memory_tools;
 pub(crate) mod messaging;
 mod provider_switch;
 pub mod runtime_config;
@@ -474,6 +476,9 @@ fn required_capabilities_for_tool_name_and_payload(
         "file.read" => {
             caps.insert(Capability::FilesystemRead);
         }
+        "memory_search" | "memory_get" => {
+            caps.insert(Capability::FilesystemRead);
+        }
         "file.write" | "file.edit" => {
             caps.insert(Capability::FilesystemWrite);
         }
@@ -729,6 +734,10 @@ fn execute_discoverable_tool_core_with_config(
         }
         "shell.exec" => shell::execute_shell_tool_with_config(request, config),
         "file.read" => file::execute_file_read_tool_with_config(request, config),
+        #[cfg(feature = "tool-file")]
+        "memory_search" => memory_tools::execute_memory_search_tool_with_config(request, config),
+        #[cfg(feature = "tool-file")]
+        "memory_get" => memory_tools::execute_memory_get_tool_with_config(request, config),
         "file.write" => file::execute_file_write_tool_with_config(request, config),
         "file.edit" => file::execute_file_edit_tool_with_config(request, config),
         "provider.switch" => {
@@ -1175,6 +1184,8 @@ fn tool_search_entry_is_runtime_usable(
         | "external_skills.invoke"
         | "external_skills.list"
         | "external_skills.remove" => config.external_skills.enabled,
+        #[cfg(feature = "tool-file")]
+        "memory_search" | "memory_get" => memory_tools::memory_corpus_available(config),
         _ => true,
     }
 }
@@ -1533,6 +1544,21 @@ fn _shape_examples() -> BTreeMap<&'static str, Value> {
             json!({
                 "path": "README.md",
                 "max_bytes": 4096
+            }),
+        ),
+        (
+            "memory_search",
+            json!({
+                "query": "deploy freeze window",
+                "max_results": 3
+            }),
+        ),
+        (
+            "memory_get",
+            json!({
+                "path": "MEMORY.md",
+                "from": 1,
+                "lines": 20
             }),
         ),
         (
@@ -2291,6 +2317,24 @@ mod tests {
             BTreeSet::from([Capability::InvokeTool, Capability::FilesystemWrite])
         );
 
+        let direct_memory_search = ToolCoreRequest {
+            tool_name: "memory_search".to_owned(),
+            payload: json!({"query": "deploy freeze"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_memory_search),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let direct_memory_get = ToolCoreRequest {
+            tool_name: "memory_get".to_owned(),
+            payload: json!({"path": "MEMORY.md"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_memory_get),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
         let invoked_file_read = ToolCoreRequest {
             tool_name: "tool.invoke".to_owned(),
             payload: json!({
@@ -2301,6 +2345,19 @@ mod tests {
         };
         assert_eq!(
             required_capabilities_for_request(&invoked_file_read),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let invoked_memory_search = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "memory_search",
+                "lease": "unused",
+                "arguments": {"query": "deploy freeze"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_memory_search),
             BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
         );
 
@@ -2348,6 +2405,17 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn runtime_tool_view_includes_memory_tools_when_safe_file_root_is_configured() {
+        let root = unique_tool_temp_dir("loongclaw-memory-tool-view");
+        let config = test_tool_runtime_config(root);
+        let tool_view = runtime_tool_view_for_runtime_config(&config);
+
+        assert!(tool_view.contains("memory_search"));
+        assert!(tool_view.contains("memory_get"));
+    }
+
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_search_returns_discoverable_tools_with_leases() {
@@ -2390,6 +2458,134 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[test]
+    fn tool_search_surfaces_memory_tools_when_memory_corpus_is_available() {
+        let root = unique_tool_temp_dir("loongclaw-memory-tool-search");
+        let memory_dir = root.join("memory");
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(root.join("MEMORY.md"), "Deploy freeze window: Friday.\n")
+            .expect("write root memory");
+        std::fs::write(
+            memory_dir.join("2026-03-23.md"),
+            "Migration starts tomorrow.\n",
+        )
+        .expect("write daily log");
+
+        let config = test_tool_runtime_config(root);
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "search memory recall durable notes",
+                    "limit": 6
+                }),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+
+        assert!(
+            results
+                .iter()
+                .any(|entry| entry["tool_id"] == "memory_search")
+        );
+        assert!(results.iter().any(|entry| entry["tool_id"] == "memory_get"));
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_search_tool_returns_structured_hits_from_workspace_memory_files() {
+        let root = unique_tool_temp_dir("loongclaw-memory-search");
+        let memory_dir = root.join("memory");
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(
+            root.join("MEMORY.md"),
+            "# Durable Notes\nDeploy freeze window is Friday.\n",
+        )
+        .expect("write root memory");
+        std::fs::write(
+            memory_dir.join("2026-03-23.md"),
+            "Customer migration starts tomorrow.\n",
+        )
+        .expect("write daily log");
+
+        let config = test_tool_runtime_config(root);
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "deploy freeze window",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("memory search should succeed");
+
+        assert_eq!(outcome.status, "ok");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|entry| entry["path"] == "MEMORY.md"));
+        assert!(
+            results
+                .iter()
+                .all(|entry| entry["start_line"].as_u64().is_some()),
+            "expected structured line spans: {results:?}"
+        );
+        assert!(
+            results
+                .iter()
+                .all(|entry| entry["end_line"].as_u64().is_some()),
+            "expected structured line spans: {results:?}"
+        );
+        assert!(
+            results.iter().all(|entry| entry["snippet"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty())),
+            "expected non-empty snippets: {results:?}"
+        );
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_get_tool_returns_bounded_line_window_from_memory_file() {
+        let root = unique_tool_temp_dir("loongclaw-memory-get");
+        let memory_path = root.join("MEMORY.md");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(
+            &memory_path,
+            "line one\nline two\nline three\nline four\nline five\n",
+        )
+        .expect("write root memory");
+
+        let config = test_tool_runtime_config(root);
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_get".to_owned(),
+                payload: json!({
+                    "path": "MEMORY.md",
+                    "from": 2,
+                    "lines": 2
+                }),
+            },
+            &config,
+        )
+        .expect("memory get should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["path"], "MEMORY.md");
+        assert_eq!(outcome.payload["start_line"], 2);
+        assert_eq!(outcome.payload["end_line"], 3);
+        assert_eq!(outcome.payload["text"], "line two\nline three");
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2407,8 +2407,31 @@ mod tests {
 
     #[cfg(feature = "tool-file")]
     #[test]
-    fn runtime_tool_view_includes_memory_tools_when_safe_file_root_is_configured() {
-        let root = unique_tool_temp_dir("loongclaw-memory-tool-view");
+    fn runtime_tool_view_hides_memory_tools_when_memory_corpus_is_empty() {
+        let root = unique_tool_temp_dir("loongclaw-memory-tool-view-empty");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+
+        let config = test_tool_runtime_config(root);
+        let tool_view = runtime_tool_view_for_runtime_config(&config);
+
+        assert!(!tool_view.contains("memory_search"));
+        assert!(!tool_view.contains("memory_get"));
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn runtime_tool_view_includes_memory_tools_when_memory_corpus_exists() {
+        let root = unique_tool_temp_dir("loongclaw-memory-tool-view-visible");
+        let memory_path = root.join("MEMORY.md");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(
+            &memory_path,
+            "# Durable Notes\nDeploy freeze window is Friday.\n",
+        )
+        .expect("write root memory");
+
         let config = test_tool_runtime_config(root);
         let tool_view = runtime_tool_view_for_runtime_config(&config);
 
@@ -2496,6 +2519,36 @@ mod tests {
                 .any(|entry| entry["tool_id"] == "memory_search")
         );
         assert!(results.iter().any(|entry| entry["tool_id"] == "memory_get"));
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[test]
+    fn tool_search_hides_memory_tools_when_memory_corpus_is_empty() {
+        let root = unique_tool_temp_dir("loongclaw-memory-tool-search-empty");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+
+        let config = test_tool_runtime_config(root);
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "search memory recall durable notes",
+                    "limit": 6
+                }),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+
+        assert!(
+            results
+                .iter()
+                .all(|entry| entry["tool_id"] != "memory_search")
+        );
+        assert!(results.iter().all(|entry| entry["tool_id"] != "memory_get"));
     }
 
     #[cfg(feature = "tool-file")]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2483,7 +2483,7 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
-    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[cfg(feature = "tool-file")]
     #[test]
     fn tool_search_surfaces_memory_tools_when_memory_corpus_is_available() {
         let root = unique_tool_temp_dir("loongclaw-memory-tool-search");
@@ -2521,7 +2521,7 @@ mod tests {
         assert!(results.iter().any(|entry| entry["tool_id"] == "memory_get"));
     }
 
-    #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
+    #[cfg(feature = "tool-file")]
     #[test]
     fn tool_search_hides_memory_tools_when_memory_corpus_is_empty() {
         let root = unique_tool_temp_dir("loongclaw-memory-tool-search-empty");
@@ -2639,6 +2639,119 @@ mod tests {
         assert_eq!(outcome.payload["start_line"], 2);
         assert_eq!(outcome.payload["end_line"], 3);
         assert_eq!(outcome.payload["text"], "line two\nline three");
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_search_tool_rejects_invalid_max_results_values() {
+        let root = unique_tool_temp_dir("loongclaw-memory-search-invalid-max-results");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(root.join("MEMORY.md"), "deploy freeze window\n").expect("write memory");
+
+        let config = test_tool_runtime_config(root);
+        let non_numeric_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "deploy",
+                    "max_results": "3"
+                }),
+            },
+            &config,
+        )
+        .expect_err("non-numeric max_results should fail");
+        let out_of_range_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "deploy",
+                    "max_results": 0
+                }),
+            },
+            &config,
+        )
+        .expect_err("out-of-range max_results should fail");
+
+        assert!(non_numeric_error.contains("payload.max_results"));
+        assert!(out_of_range_error.contains("payload.max_results"));
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_get_tool_rejects_invalid_window_arguments() {
+        let root = unique_tool_temp_dir("loongclaw-memory-get-invalid-window");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(root.join("MEMORY.md"), "line one\nline two\n").expect("write memory");
+
+        let config = test_tool_runtime_config(root);
+        let invalid_from_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_get".to_owned(),
+                payload: json!({
+                    "path": "MEMORY.md",
+                    "from": "2"
+                }),
+            },
+            &config,
+        )
+        .expect_err("non-numeric from should fail");
+        let invalid_lines_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_get".to_owned(),
+                payload: json!({
+                    "path": "MEMORY.md",
+                    "lines": 0
+                }),
+            },
+            &config,
+        )
+        .expect_err("out-of-range lines should fail");
+
+        assert!(invalid_from_error.contains("payload.from"));
+        assert!(invalid_lines_error.contains("payload.lines"));
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn memory_get_tool_hides_non_corpus_file_existence() {
+        let root = unique_tool_temp_dir("loongclaw-memory-get-corpus-boundary");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        std::fs::write(root.join("MEMORY.md"), "line one\nline two\n").expect("write memory");
+        std::fs::write(root.join("README.md"), "not in corpus\n").expect("write readme");
+
+        let config = test_tool_runtime_config(root);
+        let existing_non_corpus_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_get".to_owned(),
+                payload: json!({
+                    "path": "README.md"
+                }),
+            },
+            &config,
+        )
+        .expect_err("existing non-corpus file should fail");
+        let missing_non_corpus_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_get".to_owned(),
+                payload: json!({
+                    "path": "missing.md"
+                }),
+            },
+            &config,
+        )
+        .expect_err("missing non-corpus file should fail");
+
+        assert!(
+            existing_non_corpus_error.contains("not part of the workspace durable memory corpus")
+        );
+        assert!(
+            missing_non_corpus_error.contains("not part of the workspace durable memory corpus")
+        );
+        assert!(!existing_non_corpus_error.contains("not an existing file"));
+        assert!(!missing_non_corpus_error.contains("not an existing file"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1849,6 +1849,7 @@ mod tests {
     static FEISHU_TEST_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     use super::*;
+    use crate::test_support::ScopedEnv;
     use mvp::channel::{
         ChannelOperationHealth, ChannelOperationRuntime, ChannelOperationStatus,
         ChannelStatusSnapshot,
@@ -3085,6 +3086,11 @@ mod tests {
         config.provider.api_key_env = None;
         config.provider.oauth_access_token = None;
         config.provider.oauth_access_token_env = None;
+        let auth_env_names = config.provider.auth_hint_env_names();
+        let mut env = ScopedEnv::new();
+        for env_name in auth_env_names {
+            env.remove(env_name);
+        }
 
         let check = provider_credentials_doctor_check(&config, false);
 

--- a/crates/daemon/src/memory_context_benchmark.rs
+++ b/crates/daemon/src/memory_context_benchmark.rs
@@ -1333,6 +1333,7 @@ fn memory_context_shape(entries: &[MemoryContextEntry]) -> MemoryContextShape {
                 summary_chars = summary_chars.saturating_add(entry.content.len());
             }
             MemoryContextKind::Profile => {}
+            MemoryContextKind::RetrievedMemory => {}
         }
     }
 
@@ -1477,4 +1478,41 @@ fn benchmark_temp_root(prefix: &str, parent: Option<&Path>) -> PathBuf {
         std::process::id(),
         next_benchmark_temp_suffix()
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_context_shape_excludes_retrieved_memory_from_summary_counts() {
+        let retrieved_entry = MemoryContextEntry {
+            kind: MemoryContextKind::RetrievedMemory,
+            role: "system".to_owned(),
+            content: "durable recall".to_owned(),
+        };
+        let summary_entry = MemoryContextEntry {
+            kind: MemoryContextKind::Summary,
+            role: "system".to_owned(),
+            content: "summary block".to_owned(),
+        };
+        let turn_entry = MemoryContextEntry {
+            kind: MemoryContextKind::Turn,
+            role: "user".to_owned(),
+            content: "hello".to_owned(),
+        };
+        let entries = vec![retrieved_entry, summary_entry, turn_entry];
+        let retrieved_payload_chars = "system".len() + "durable recall".len();
+        let summary_payload_chars = "system".len() + "summary block".len();
+        let turn_payload_chars = "user".len() + "hello".len();
+        let expected_payload_chars =
+            retrieved_payload_chars + summary_payload_chars + turn_payload_chars;
+
+        let shape = memory_context_shape(entries.as_slice());
+
+        assert_eq!(shape.entry_count, 3);
+        assert_eq!(shape.turn_entries, 1);
+        assert_eq!(shape.summary_chars, "summary block".len());
+        assert_eq!(shape.payload_chars, expected_payload_chars);
+    }
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -7291,9 +7291,6 @@ mod tests {
 
     #[test]
     fn provider_credential_check_adds_volcengine_auth_guidance_when_missing() {
-        let mut env = ScopedEnv::new();
-        env.remove("ARK_API_KEY");
-
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::VolcengineCoding;
         config.provider.api_key = None;

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -7297,6 +7297,11 @@ mod tests {
         config.provider.api_key_env = None;
         config.provider.oauth_access_token = None;
         config.provider.oauth_access_token_env = None;
+        let auth_env_names = config.provider.auth_hint_env_names();
+        let mut env = ScopedEnv::new();
+        for env_name in auth_env_names {
+            env.remove(env_name);
+        }
 
         let check = provider_credential_check(&config);
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -7291,7 +7291,7 @@ mod tests {
 
     #[test]
     fn provider_credential_check_adds_volcengine_auth_guidance_when_missing() {
-        let mut env = mvp::test_support::ScopedEnv::new();
+        let mut env = ScopedEnv::new();
         env.remove("ARK_API_KEY");
 
         let mut config = mvp::config::LoongClawConfig::default();
@@ -7300,8 +7300,6 @@ mod tests {
         config.provider.api_key_env = None;
         config.provider.oauth_access_token = None;
         config.provider.oauth_access_token_env = None;
-        let mut env = ScopedEnv::new();
-        env.remove("ARK_API_KEY");
 
         let check = provider_credential_check(&config);
 

--- a/docs/plans/2026-03-23-durable-recall-bootstrap-implementation-plan.md
+++ b/docs/plans/2026-03-23-durable-recall-bootstrap-implementation-plan.md
@@ -1,0 +1,107 @@
+# Durable Recall Bootstrap Implementation Plan
+
+Date: 2026-03-23
+Issue: #469
+Depends on: #468
+Stack base: `8a5b631b feat(app): flush durable memory before compaction`
+
+## Goal
+
+Add the smallest correct durable-memory read path after `#468` so LoongClaw can
+bootstrap advisory durable recall from workspace memory files into runtime
+context without jumping into semantic search or new tool surfaces.
+
+## Scope
+
+In scope:
+
+- load advisory durable recall from workspace files under the configured safe
+  file root
+- support:
+  - `MEMORY.md`
+  - `memory/MEMORY.md`
+  - recent `memory/YYYY-MM-DD.md` daily logs
+- inject the resulting material into hydrated runtime memory as advisory durable
+  recall
+- keep runtime self and resolved runtime identity authoritative
+- add deterministic tests and docs
+
+Out of scope:
+
+- embeddings
+- sqlite-vec
+- FTS5
+- query extraction
+- `memory_search` / `memory_get`
+- identity promotion from durable memory files
+
+## Design Choice
+
+Use the memory hydration path, not the runtime-self system-prompt bootstrap.
+
+Reasoning:
+
+- durable recall is memory context, not runtime self
+- this keeps memory, runtime self, and runtime identity in distinct lanes
+- provider message assembly already treats hydrated memory entries as explicit
+  system or history messages
+
+## Implementation Shape
+
+1. Add a dedicated durable-recall loader in the memory subsystem.
+   - collect candidate workspace roots in the same root + nested-workspace style
+     as runtime self
+   - discover and read:
+     - root `MEMORY.md`
+     - `memory/MEMORY.md`
+     - the newest dated daily logs under `memory/`
+   - deduplicate by canonical path
+   - bound loaded content deterministically
+
+2. Thread safe workspace-root awareness into memory hydration.
+   - hydration should only read durable recall when the caller explicitly passes
+     a safe workspace root
+   - callers without an explicit safe file root should continue to get no
+     durable recall
+
+3. Represent injected durable recall as an explicit memory context entry.
+   - prefer a new typed memory entry kind rather than overloading summary or
+     profile
+   - provider message assembly should render it as a system message
+
+4. Keep the rendered content advisory by construction.
+   - add a dedicated durable-recall runtime intro
+   - label the block clearly
+   - avoid wording that could imply identity authority
+
+## TDD Plan
+
+Write tests before implementation for:
+
+1. Hydration includes durable recall when workspace memory files exist.
+2. Hydration skips durable recall when no safe workspace root is provided.
+3. Provider message assembly includes the durable recall system block.
+4. Identity-looking durable recall content remains advisory and does not replace
+   runtime identity.
+5. Duplicate or empty files do not produce duplicate prompt entries.
+
+## Files Expected To Change
+
+- `crates/app/src/memory/mod.rs`
+- `crates/app/src/memory/orchestrator.rs`
+- `crates/app/src/memory/protocol.rs`
+- `crates/app/src/memory/` new durable recall helper module
+- `crates/app/src/provider/request_message_runtime.rs`
+- `crates/app/src/runtime_self.rs` only if shared workspace-root helper reuse is
+  cleaner than duplication
+- relevant memory/provider tests
+- product spec docs if behavior becomes user-visible enough to document
+
+## Validation Plan
+
+- `cargo fmt --all --check`
+- `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+- focused failing tests first, then passing targeted tests
+- `cargo test -p loongclaw-app --lib`
+- if unchanged external blocker remains, note workspace-level validation status
+  separately from app-level verification

--- a/docs/plans/2026-03-23-pre-compaction-memory-flush-implementation-plan.md
+++ b/docs/plans/2026-03-23-pre-compaction-memory-flush-implementation-plan.md
@@ -35,7 +35,7 @@ cargo test -p loongclaw-app pre_compaction
 Expected:
 - at least one new test fails because no durable flush exists yet
 
-**Step 3: Reproduce the red state locally without committing it**
+**Step 3: Keep the red state local after confirming failure**
 
 Run the failing case locally, capture the command and failure signal, and keep
 that state local while you debug. If you need scratch work, use a private WIP
@@ -43,7 +43,7 @@ branch or an unpushed local commit. Do not commit or push a broken tree. Before
 any shared commit, rerun `cargo test --workspace --all-features` and bring the
 tree back to green.
 
-### Task 2: Add helper plumbing for pre-compaction export
+## Task 2: Add helper plumbing for pre-compaction export
 
 **Files:**
 - Modify: `crates/app/src/memory/mod.rs`
@@ -75,7 +75,7 @@ cargo test -p loongclaw-app durable_flush
 Expected:
 - helper-level tests pass
 
-### Task 3: Wire the helper into the compaction gate
+## Task 3: Wire the helper into the compaction gate
 
 **Files:**
 - Modify: `crates/app/src/conversation/turn_coordinator.rs`
@@ -103,7 +103,7 @@ cargo test -p loongclaw-app pre_compaction
 Expected:
 - new compaction-path tests pass
 
-### Task 4: Document the new behavior
+## Task 4: Document the new behavior
 
 **Files:**
 - Modify: `docs/product-specs/runtime-self-continuity.md`
@@ -120,7 +120,7 @@ Describe:
 
 Do not over-promise retrieval or search behavior.
 
-### Task 5: Verify the full touched surface
+## Task 5: Verify the full touched surface
 
 **Files:**
 - Verify only

--- a/docs/plans/2026-03-23-pre-compaction-memory-flush-implementation-plan.md
+++ b/docs/plans/2026-03-23-pre-compaction-memory-flush-implementation-plan.md
@@ -1,0 +1,185 @@
+# Pre-Compaction Memory Flush Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a deterministic pre-compaction durable memory flush that exports advisory session continuity into a workspace memory file right before LoongClaw compacts context.
+
+**Architecture:** Reuse the existing SQLite summary checkpoint machinery instead of adding a second summarization path or a hidden LLM turn. Wire a small flush helper into the existing compaction gate, keep the flushed record explicitly advisory, and deduplicate repeated exports with a stable content hash.
+
+**Tech Stack:** Rust, existing `conversation` runtime hooks, existing SQLite summary checkpoint/context snapshot logic, filesystem writes under the configured safe file root, focused unit/integration tests.
+
+---
+
+### Task 1: Add the failing tests for deterministic durable flush behavior
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/memory/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that cover:
+- flush runs when compaction is triggered
+- flush does not run when compaction is skipped
+- repeated compaction attempts with unchanged content do not duplicate the durable note
+- flushed content is labeled as advisory and does not look like runtime identity
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app pre_compaction
+```
+
+Expected:
+- at least one new test fails because no durable flush exists yet
+
+**Step 3: Commit the red state only after confirming failure locally**
+
+Do not commit implementation code in this task.
+
+### Task 2: Add helper plumbing for pre-compaction export
+
+**Files:**
+- Modify: `crates/app/src/memory/mod.rs`
+- Create: `crates/app/src/memory/durable_flush.rs`
+
+**Step 1: Reuse the existing safe workspace root gate**
+
+Use the existing configured `tools.file_root` as the opt-in safe workspace root
+for durable export. Do not add a second toggle unless implementation pressure
+proves it necessary.
+
+**Step 2: Add deterministic helper**
+
+Create a helper that:
+- resolves the safe workspace root
+- materializes the durable export content from existing summary/checkpoint data
+- writes to `memory/YYYY-MM-DD.md`
+- stamps metadata needed for dedupe
+- treats the flushed note as advisory only
+
+**Step 3: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app durable_flush
+```
+
+Expected:
+- helper-level tests pass
+
+### Task 3: Wire the helper into the compaction gate
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+
+**Step 1: Hook immediately before runtime compaction**
+
+In `maybe_compact_context(...)`:
+- keep the existing compaction eligibility logic
+- if compaction will run, invoke the pre-compaction durable flush helper first
+- preserve existing fail-open / fail-closed behavior intentionally
+
+**Step 2: Keep scope tight**
+
+Do not alter unrelated turn finalization paths.
+Do not add retrieval or read-path logic in this task.
+
+**Step 3: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app pre_compaction
+```
+
+Expected:
+- new compaction-path tests pass
+
+### Task 4: Document the new behavior
+
+**Files:**
+- Modify: `docs/product-specs/runtime-self-continuity.md`
+- Modify: `docs/product-specs/memory-profiles.md`
+
+**Step 1: Document the new runtime seam**
+
+Describe:
+- when the pre-compaction flush runs
+- that it writes advisory durable recall only
+- that it does not override runtime identity
+
+**Step 2: Keep docs aligned with `#421`, `#440`, and `#468`**
+
+Do not over-promise retrieval or search behavior.
+
+### Task 5: Verify the full touched surface
+
+**Files:**
+- Verify only
+
+**Step 1: Run formatting**
+
+```bash
+cargo fmt --all
+cargo fmt --all --check
+```
+
+**Step 2: Run targeted tests**
+
+```bash
+cargo test -p loongclaw-app pre_compaction
+cargo test -p loongclaw-app durable_flush
+```
+
+**Step 3: Run broader app verification**
+
+```bash
+cargo test -p loongclaw-app --lib
+cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
+```
+
+**Step 4: Run workspace verification if the stacked base is still valid**
+
+Preferred:
+
+```bash
+cargo test --workspace --locked
+cargo test --workspace --all-features --locked
+```
+
+If plain `dev` remains blocked by unrelated open stacked prerequisites, rerun the same verification on the known-good stacked verification worktree and record that evidence explicitly.
+
+### Task 6: Commit the implementation cleanly
+
+**Files:**
+- Modify only the files touched by this plan
+
+**Step 1: Inspect staged scope**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-03-23-pre-compaction-memory-flush-implementation-plan.md
+git add crates/app/src/config/conversation.rs
+git add crates/app/src/config/mod.rs
+git add crates/app/src/memory/mod.rs
+git add crates/app/src/memory/durable_flush.rs
+git add crates/app/src/conversation/turn_coordinator.rs
+git add crates/app/src/conversation/tests.rs
+git add crates/app/src/memory/tests.rs
+git add docs/product-specs/runtime-self-continuity.md
+git add docs/product-specs/memory-profiles.md
+git commit -m "feat(app): flush durable memory before compaction"
+```

--- a/docs/plans/2026-03-23-pre-compaction-memory-flush-implementation-plan.md
+++ b/docs/plans/2026-03-23-pre-compaction-memory-flush-implementation-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add the failing tests for deterministic durable flush behavior
+## Task 1: Add the failing tests for deterministic durable flush behavior
 
 **Files:**
 - Modify: `crates/app/src/conversation/tests.rs`
@@ -35,9 +35,13 @@ cargo test -p loongclaw-app pre_compaction
 Expected:
 - at least one new test fails because no durable flush exists yet
 
-**Step 3: Commit the red state only after confirming failure locally**
+**Step 3: Reproduce the red state locally without committing it**
 
-Do not commit implementation code in this task.
+Run the failing case locally, capture the command and failure signal, and keep
+that state local while you debug. If you need scratch work, use a private WIP
+branch or an unpushed local commit. Do not commit or push a broken tree. Before
+any shared commit, rerun `cargo test --workspace --all-features` and bring the
+tree back to green.
 
 ### Task 2: Add helper plumbing for pre-compaction export
 
@@ -142,16 +146,18 @@ cargo test -p loongclaw-app --lib
 cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
 ```
 
-**Step 4: Run workspace verification if the stacked base is still valid**
-
-Preferred:
+**Step 4: Run workspace verification**
 
 ```bash
 cargo test --workspace --locked
 cargo test --workspace --all-features --locked
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-If plain `dev` remains blocked by unrelated open stacked prerequisites, rerun the same verification on the known-good stacked verification worktree and record that evidence explicitly.
+Expected:
+- workspace-level tests and lint pass on the final branch state
+- if an unrelated blocker appears, stop, investigate, and record the blocker
+  explicitly before claiming completion
 
 ### Task 6: Commit the implementation cleanly
 

--- a/docs/product-specs/memory-profiles.md
+++ b/docs/product-specs/memory-profiles.md
@@ -16,6 +16,11 @@ how continuity is preserved without manually wiring different memory systems.
       recent sliding window.
 - [ ] `profile_plus_window` can inject a durable `profile_note` block for
       preferences, tuning, or advisory imported context.
+- [ ] `profile_plus_window` remains the durable advisory lane that future recall
+      may enrich without becoming a second identity authority.
+- [ ] When compaction runs with a configured safe workspace root, LoongClaw can
+      export advisory durable recall into `memory/YYYY-MM-DD.md` before
+      compacting context.
 - [ ] Legacy imported identity can still be recovered from `profile_note`, but
       it is resolved into a separate runtime identity lane rather than being
       projected back into the session profile block.

--- a/docs/product-specs/memory-profiles.md
+++ b/docs/product-specs/memory-profiles.md
@@ -21,6 +21,10 @@ how continuity is preserved without manually wiring different memory systems.
 - [ ] When compaction runs with a configured safe workspace root, LoongClaw can
       export advisory durable recall into `memory/YYYY-MM-DD.md` before
       compacting context.
+- [ ] When a configured safe workspace root exposes durable memory files,
+      LoongClaw can bootstrap advisory durable recall from `MEMORY.md`,
+      `memory/MEMORY.md`, and recent daily logs without overriding runtime
+      identity.
 - [ ] Legacy imported identity can still be recovered from `profile_note`, but
       it is resolved into a separate runtime identity lane rather than being
       projected back into the session profile block.

--- a/docs/product-specs/runtime-self-continuity.md
+++ b/docs/product-specs/runtime-self-continuity.md
@@ -1,0 +1,57 @@
+# Runtime Self Continuity
+
+## User Story
+
+As a LoongClaw operator, I want runtime self continuity to survive compaction,
+delegation, and future durable recall so that the agent stays coherent without
+mixing identity authority with transient task context.
+
+## Continuity Lanes
+
+- `Runtime Self Context`
+  Standing instructions and soul guidance loaded from runtime self sources such
+  as `AGENTS.md`, `CLAUDE.md`, and `SOUL.md`. This lane remains runtime
+  guidance. It is reloaded through the normal runtime path instead of being
+  copied into durable memory.
+
+- `Resolved Runtime Identity`
+  The identity authority for the active session chain. It is resolved from
+  runtime self sources first and can fall back to legacy imported identity from
+  `profile_note`. Compaction, session profile projection, and future retrieval
+  must not override this lane.
+
+- `Session Profile`
+  Durable advisory context such as preferences, tuning, and imported
+  non-identity profile material. Future durable recall from `#421` and `#429`
+  may enrich this lane, but that enrichment remains advisory and cannot become a
+  second identity authority.
+
+- `Session-Local Recall`
+  Memory summaries, sliding-window turns, and delegate child task findings.
+  These artifacts preserve useful session context, but they stay local to the
+  session chain unless a separate durable-memory flow explicitly promotes them.
+
+## Boundary Rules
+
+- Compaction and summarization preserve continuity by treating summary blocks as
+  session-local recall only.
+- Delegate child sessions inherit continuity through one explicit runtime
+  contract, even when the child has no extra tool narrowing.
+- Durable recall augments advisory context; it does not replace runtime self
+  guidance or resolved runtime identity.
+- When a safe workspace file root is configured and compaction is about to run,
+  LoongClaw may export advisory durable recall into `memory/YYYY-MM-DD.md`
+  before compaction proceeds.
+- Session-local content is never promoted into durable self state implicitly.
+
+## Acceptance Criteria
+
+- Summary blocks clearly state that they do not replace runtime self guidance,
+  resolved runtime identity, or durable advisory profile context.
+- Session profile projection clearly states that durable recall is advisory and
+  does not override resolved runtime identity.
+- Delegate child sessions always receive an explicit self continuity contract.
+- Pre-compaction durable exports, when enabled by workspace configuration, stay
+  advisory and do not become an identity override path.
+- The relationship to `#421` and `#429` is explicit: retrieval may enrich
+  durable context, but it must not become an identity override path.

--- a/docs/product-specs/runtime-self-continuity.md
+++ b/docs/product-specs/runtime-self-continuity.md
@@ -1,22 +1,22 @@
-# Runtime Self Continuity
+# Runtime-Self Continuity
 
 ## User Story
 
-As a LoongClaw operator, I want runtime self continuity to survive compaction,
+As a LoongClaw operator, I want runtime-self continuity to survive compaction,
 delegation, and future durable recall so that the agent stays coherent without
 mixing identity authority with transient task context.
 
 ## Continuity Lanes
 
 - `Runtime Self Context`
-  Standing instructions and soul guidance loaded from runtime self sources such
+  Standing instructions and soul guidance loaded from runtime-self sources such
   as `AGENTS.md`, `CLAUDE.md`, and `SOUL.md`. This lane remains runtime
   guidance. It is reloaded through the normal runtime path instead of being
   copied into durable memory.
 
 - `Resolved Runtime Identity`
   The identity authority for the active session chain. It is resolved from
-  runtime self sources first and can fall back to legacy imported identity from
+  runtime-self sources first and can fall back to legacy imported identity from
   `profile_note`. Compaction, session profile projection, and future retrieval
   must not override this lane.
 
@@ -37,7 +37,7 @@ mixing identity authority with transient task context.
   session-local recall only.
 - Delegate child sessions inherit continuity through one explicit runtime
   contract, even when the child has no extra tool narrowing.
-- Durable recall augments advisory context; it does not replace runtime self
+- Durable recall augments advisory context; it does not replace runtime-self
   guidance or resolved runtime identity.
 - When a safe workspace file root is configured and compaction is about to run,
   LoongClaw may export advisory durable recall into `memory/YYYY-MM-DD.md`
@@ -46,15 +46,15 @@ mixing identity authority with transient task context.
   present, LoongClaw may bootstrap advisory durable recall from `MEMORY.md`,
   `memory/MEMORY.md`, and recent `memory/YYYY-MM-DD.md` logs into runtime
   context.
-- Session-local content is never promoted into durable self state implicitly.
+- Session-local content is never promoted into durable self-state implicitly.
 
 ## Acceptance Criteria
 
-- Summary blocks clearly state that they do not replace runtime self guidance,
+- Summary blocks clearly state that they do not replace runtime-self guidance,
   resolved runtime identity, or durable advisory profile context.
 - Session profile projection clearly states that durable recall is advisory and
   does not override resolved runtime identity.
-- Delegate child sessions always receive an explicit self continuity contract.
+- Delegate child sessions always receive an explicit self-continuity contract.
 - Pre-compaction durable exports, when enabled by workspace configuration, stay
   advisory and do not become an identity override path.
 - Runtime durable-recall bootstrap, when enabled by workspace configuration,

--- a/docs/product-specs/runtime-self-continuity.md
+++ b/docs/product-specs/runtime-self-continuity.md
@@ -42,6 +42,10 @@ mixing identity authority with transient task context.
 - When a safe workspace file root is configured and compaction is about to run,
   LoongClaw may export advisory durable recall into `memory/YYYY-MM-DD.md`
   before compaction proceeds.
+- When a safe workspace file root is configured and durable memory files are
+  present, LoongClaw may bootstrap advisory durable recall from `MEMORY.md`,
+  `memory/MEMORY.md`, and recent `memory/YYYY-MM-DD.md` logs into runtime
+  context.
 - Session-local content is never promoted into durable self state implicitly.
 
 ## Acceptance Criteria
@@ -53,5 +57,7 @@ mixing identity authority with transient task context.
 - Delegate child sessions always receive an explicit self continuity contract.
 - Pre-compaction durable exports, when enabled by workspace configuration, stay
   advisory and do not become an identity override path.
+- Runtime durable-recall bootstrap, when enabled by workspace configuration,
+  stays advisory and does not become an identity override path.
 - The relationship to `#421` and `#429` is explicit: retrieval may enrich
   durable context, but it must not become an identity override path.

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-24T06:04:30Z
+- Generated at: 2026-03-24T06:44:41Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -14,7 +14,7 @@
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 379 | 1000 | 621 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 323 | 650 | 327 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 335 | 650 | 315 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -42,7 +42,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=379 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=323 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=335 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw did not yet have one complete runtime self continuity path across live workspace self sources, resolved runtime identity, compaction, delegated child sessions, durable recall bootstrap, and durable memory discovery tools. The partial state made soul / identity / memory continuity brittle and left the branch exposed to CI breakage in non-default feature combinations.
- Why it matters:
  Without one explicit continuity contract, identity can disappear after compaction, delegated children inherit state inconsistently, durable recall has no stable boundary relative to live workspace lanes, and operators cannot safely inspect workspace durable memory through deterministic tool surfaces.
- What changed:
  Added live runtime self lane loading and resolved runtime identity, persisted runtime self continuity before compaction, rehydrated only missing live lanes during rebuild, propagated continuity through delegate spawn payloads, bootstrapped advisory durable recall from workspace memory files, added deterministic `memory_search` / `memory_get` tools over the durable corpus, and loaded `TOOLS.md` into runtime self policy context. This update also removes the unconditional `regex` dependency from think-tag stripping so no-default feature builds stay green, refreshes the tracked architecture drift report, hardens the Volcengine onboarding test against host environment leakage, and updates `tar` to `0.4.45` to clear current RustSec advisories.
- What did not change (scope boundary):
  This PR does not add semantic retrieval, vector storage, schema migration, or a new durable-memory backend. Stored continuity remains fallback-only and does not override live workspace/config identity.

## Linked Issues

- Closes #441
- Closes #443
- Closes #444
- Closes #468
- Closes #469
- Closes #470
- Closes #471
- Supersedes #446
- Supersedes #452

## Change Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes how runtime self state is preserved and rehydrated across compaction and delegation, and it exposes new durable-memory read tools. The main behavioral risk is stale or duplicate identity/context if stored continuity ever overrides live lanes or if memory corpus boundaries leak outside the durable workspace set.
- Rollout / guardrails:
  Live workspace/config state stays authoritative. Stored continuity is lane-separated, fallback-only, and only injected for missing live lanes. Durable memory tools fail closed on malformed numeric inputs and hide non-corpus file existence. The Volcengine onboarding regression test now clears ambient credentials before asserting the missing-credential path.
- Rollback path:
  Revert this PR to return compaction and delegation behavior to the prior runtime-only path, remove the new memory tools, and restore the previous dependency lock state.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all --check
  -> passed

cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
  -> passed

cargo audit
  -> passed after updating tar to 0.4.45

cargo check -p loongclaw-app --no-default-features --features channel-cli,channel-telegram,channel-feishu,channel-matrix,config-toml,memory-sqlite,feishu-integration,tool-shell,tool-file,tool-browser,provider-openai,provider-anthropic,provider-bedrock,provider-volcengine --locked
  -> passed

cargo test -p loongclaw-app strip_think_tags --lib --locked
  -> passed (8 passed; 0 failed)

cargo test -p loongclaw-app install_from_tar_gz_archive_extracts_wrapped_skill_root --lib --locked
  -> passed

cargo test -p loongclaw-app install_from_archive_rejects_symlink_entries --lib --locked
  -> passed

cargo test -p loongclaw-daemon provider_credential_check_adds_volcengine_auth_guidance_when_missing --lib --locked
  -> passed

bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
  -> passed after regenerating the tracked monthly report

cargo test -p loongclaw-app --lib --locked
  -> passed (1891 passed; 0 failed)

cargo test --workspace --locked
  -> passed

cargo test --workspace --all-features --locked
  -> passed
```

## User-visible / Operator-visible Changes

- Live workspace self sources, resolved runtime identity, and fallback continuity now share one explicit runtime contract instead of drifting across separate partial paths.
- Long-running sessions persist runtime self continuity before compaction and delegated child sessions inherit that continuity through one explicit spawn payload.
- Advisory durable recall is bootstrapped from workspace memory files and remains fallback-only relative to live runtime lanes.
- Runtime memory discovery now exposes deterministic `memory_search` and `memory_get` tools over the workspace durable memory corpus.
- `TOOLS.md` is loaded into runtime self as tool-usage policy guidance.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR. The new continuity persistence path, durable recall bootstrap, and memory tools are additive at the branch level and do not require a storage migration rollback.
- Observable failure symptoms reviewers should watch for:
  Duplicate self-context sections in prompts, child sessions missing inherited identity, stored continuity appearing when live identity is already present, or durable memory tools surfacing files outside the corpus.

## Reviewer Focus

- `crates/app/src/runtime_self.rs`, `crates/app/src/runtime_identity.rs`, and `crates/app/src/runtime_self_continuity.rs` for the lane model, live identity precedence, and fallback-only semantics.
- `crates/app/src/conversation/runtime.rs` and `crates/app/src/conversation/turn_coordinator.rs` for compaction persistence timing, delegate inheritance wiring, and context rebuild behavior.
- `crates/app/src/memory/durable_flush.rs`, `crates/app/src/memory/durable_recall.rs`, and `crates/app/src/memory/workspace_files.rs` for durable export and advisory recall bootstrap behavior.
- `crates/app/src/tools/memory_tools.rs`, `crates/app/src/tools/file_policy_ext.rs`, and `crates/app/src/tools/mod.rs` for durable memory discovery boundaries and validation.
- `crates/app/src/conversation/turn_shared.rs` for the feature-safe think-tag stripping path used by non-default builds.
- `crates/daemon/src/onboard_cli.rs` for the hermetic Volcengine credential regression coverage.
- `docs/releases/architecture-drift-2026-03.md` for the refreshed governance snapshot that now matches the merged code state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added workspace memory support with durable recall bootstrapping from memory documents.
  * Introduced `memory_search` and `memory_get` tools for querying workspace memory.
  * Added runtime identity and continuity persistence across session compaction.
  * Implemented pre-compaction advisory durable memory exports.

* **Improvements**
  * Enhanced session profile handling to separate advisory content from identity.
  * Added automatic response sanitization to remove internal reasoning tags.
  * Extended tool usage policy framework integration.

* **Documentation**
  * Added specifications for runtime identity, continuity, and memory profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->