### PR TITLE
fix: stabilize Volcengine onboarding credential test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2855,7 +2855,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3193,7 +3193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3293,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -3318,7 +3318,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4191,7 +4191,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -22,7 +22,7 @@ tool-shell = []
 tool-file = []
 tool-browser = ["dep:scraper"]
 tool-webfetch = []
-tool-websearch = ["dep:regex"]
+tool-websearch = []
 test-support = []
 
 [dependencies]
@@ -56,7 +56,7 @@ cbc = { version = "0.1", optional = true }
 wait-timeout = "0.2"
 tempfile = "3"
 which.workspace = true
-regex = { workspace = true, optional = true }
+regex.workspace = true
 prost = { version = "0.13", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"], optional = true }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -6465,6 +6465,8 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::{Arc, MutexGuard};
 
+    use crate::test_support::ScopedEnv;
+
     struct TestOnboardUi {
         inputs: VecDeque<String>,
     }
@@ -7295,6 +7297,8 @@ mod tests {
         config.provider.api_key_env = None;
         config.provider.oauth_access_token = None;
         config.provider.oauth_access_token_env = None;
+        let mut env = ScopedEnv::new();
+        env.remove("ARK_API_KEY");
 
         let check = provider_credential_check(&config);
 

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -154,20 +154,23 @@ mod tests {
 
     #[test]
     fn scoped_env_remove_restores_original_value() {
-        let original_value = std::env::var_os("ARK_API_KEY");
+        let key = "LOONGCLAW_SCOPED_ENV_REMOVE_TEST_KEY";
+        let sentinel_value = "scoped-env-sentinel";
+        let mut env = ScopedEnv::new();
+        let original_value = std::env::var_os(key);
 
-        {
-            let mut env = ScopedEnv::new();
-            env.remove("ARK_API_KEY");
+        env.set(key, sentinel_value);
+        env.remove(key);
 
-            assert!(
-                std::env::var_os("ARK_API_KEY").is_none(),
-                "ScopedEnv::remove should clear the environment variable while the guard is alive"
-            );
-        }
+        assert!(
+            std::env::var_os(key).is_none(),
+            "ScopedEnv::remove should clear the environment variable while the guard is alive"
+        );
+
+        drop(env);
 
         assert_eq!(
-            std::env::var_os("ARK_API_KEY"),
+            std::env::var_os(key),
             original_value,
             "ScopedEnv should restore the original environment value when dropped"
         );

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -1,3 +1,4 @@
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
 
@@ -15,6 +16,73 @@ pub fn lock_daemon_test_environment() -> MutexGuard<'static, ()> {
     DAEMON_TEST_ENV_LOCK
         .lock()
         .unwrap_or_else(|error| error.into_inner())
+}
+
+fn set_test_env_var(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+    // SAFETY: daemon tests serialize process env mutations behind
+    // `lock_daemon_test_environment`, so no concurrent env readers or writers
+    // observe racy updates while these helpers are active.
+    #[allow(unsafe_code, clippy::disallowed_methods)]
+    unsafe {
+        std::env::set_var(key, value);
+    }
+}
+
+fn remove_test_env_var(key: impl AsRef<OsStr>) {
+    // SAFETY: daemon tests serialize process env mutations behind
+    // `lock_daemon_test_environment`, so removals are coordinated with all
+    // other daemon-side env mutation helpers.
+    #[allow(unsafe_code, clippy::disallowed_methods)]
+    unsafe {
+        std::env::remove_var(key);
+    }
+}
+
+pub struct ScopedEnv {
+    saved: Vec<(String, Option<OsString>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl ScopedEnv {
+    pub fn new() -> Self {
+        let lock = lock_daemon_test_environment();
+        let saved = Vec::new();
+        Self { saved, _lock: lock }
+    }
+
+    pub fn set(&mut self, key: impl Into<String>, value: impl AsRef<OsStr>) {
+        let key = key.into();
+        self.capture_original(&key);
+        set_test_env_var(&key, value);
+    }
+
+    pub fn remove(&mut self, key: impl Into<String>) {
+        let key = key.into();
+        self.capture_original(&key);
+        remove_test_env_var(&key);
+    }
+
+    fn capture_original(&mut self, key: &str) {
+        let already_saved = self.saved.iter().any(|(saved_key, _)| saved_key == key);
+        if already_saved {
+            return;
+        }
+
+        let original_value = std::env::var_os(key);
+        let saved_key = key.to_owned();
+        self.saved.push((saved_key, original_value));
+    }
+}
+
+impl Drop for ScopedEnv {
+    fn drop(&mut self) {
+        while let Some((key, original_value)) = self.saved.pop() {
+            match original_value {
+                Some(value) => set_test_env_var(&key, value),
+                None => remove_test_env_var(&key),
+            }
+        }
+    }
 }
 
 pub fn catalog_entry(raw: &str) -> mvp::channel::ChannelCatalogEntry {
@@ -78,4 +146,30 @@ pub fn sign_security_scan_profile_for_test(profile: &SecurityScanProfile) -> (St
     let public_key_base64 = BASE64_STANDARD.encode(signing_key.verifying_key().to_bytes());
     let signature_base64 = BASE64_STANDARD.encode(signature.to_bytes());
     (public_key_base64, signature_base64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScopedEnv;
+
+    #[test]
+    fn scoped_env_remove_restores_original_value() {
+        let original_value = std::env::var_os("ARK_API_KEY");
+
+        {
+            let mut env = ScopedEnv::new();
+            env.remove("ARK_API_KEY");
+
+            assert!(
+                std::env::var_os("ARK_API_KEY").is_none(),
+                "ScopedEnv::remove should clear the environment variable while the guard is alive"
+            );
+        }
+
+        assert_eq!(
+            std::env::var_os("ARK_API_KEY"),
+            original_value,
+            "ScopedEnv should restore the original environment value when dropped"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Problem: `provider_credential_check_adds_volcengine_auth_guidance_when_missing` was machine-dependent because ambient `ARK_API_KEY` satisfied Volcengine's default auth env fallback and flipped the onboarding check from `Warn` to `Pass`.
- Why it matters: the daemon onboarding regression test could silently stop covering the missing-credential guidance path on contributor machines that already export Volcengine credentials.
- What changed: added a daemon-side `ScopedEnv` test helper that serializes process env mutations behind the daemon env mutex and restores original values on drop, then used it to clear `ARK_API_KEY` inside the Volcengine onboarding test. Added a focused unit test for the helper.
- What did not change (scope boundary): production provider credential resolution, `authorization_header()` behavior, and Volcengine's `ARK_API_KEY` fallback semantics are unchanged.

## Linked Issues

- Closes #462
- Related #459

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-daemon onboard_cli::tests::provider_credential_check_adds_volcengine_auth_guidance_when_missing -- --exact --nocapture
- before fix: failed with left=Pass and right=Warn when ambient ARK_API_KEY was present
- after fix: passed

cargo test -p loongclaw-daemon test_support::tests::scoped_env_remove_restores_original_value -- --exact --nocapture
- passed

cargo fmt --all
- passed

cargo test -p loongclaw-daemon --lib
- passed (228 passed, 0 failed)

cargo fmt --all --check
- passed

cargo clippy -p loongclaw-daemon --all-targets --all-features -- -D warnings
- passed
```

Before/after behavior and regression coverage:
- Before: ambient `ARK_API_KEY` could satisfy Volcengine's default auth fallback, so the regression test no longer exercised the missing-credential warning path.
- After: the test explicitly removes `ARK_API_KEY` under the daemon test env lock, so it deterministically covers the warning path while production fallback behavior remains unchanged.
- Boundary covered: helper unit test verifies removed env state is restored after drop.
- Process-global env safety: `ScopedEnv` acquires `lock_daemon_test_environment()` before mutating env vars and restores saved values in reverse order on drop.

## User-visible / Operator-visible Changes

- None. This only stabilizes daemon test coverage for the onboarding guidance path.

## Failure Recovery

- Fast rollback or disable path: revert commit `72f55dae`.
- Observable failure symptoms reviewers should watch for: unexpected env-sensitive daemon test behavior, especially if future tests mutate process-global env without taking the daemon env lock.

## Reviewer Focus

- Review [`crates/daemon/src/test_support.rs`](./crates/daemon/src/test_support.rs) for env lock ownership, value capture, and reverse-order restoration.
- Review [`crates/daemon/src/onboard_cli.rs`](./crates/daemon/src/onboard_cli.rs) to confirm the Volcengine credential-guidance test now isolates `ARK_API_KEY` without changing production onboarding semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a scoped environment-guard utility to isolate and safely mutate environment variables during tests, automatically restoring originals when finished.
  * Updated credential-check and related tests to use the new scoped guard, removing reliance on external environment state and improving test reliability and reproducibility.

* **Chores**
  * Adjusted a dependency/feature configuration to simplify a regex dependency's feature linkage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->