### PR TITLE
feat: stage built-in memory hydration and context assembly

### DIFF
--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -17,6 +17,32 @@ use super::runtime_binding::ConversationRuntimeBinding;
 pub const CONTEXT_ENGINE_API_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ContextArtifactKind {
+    SystemPrompt,
+    Profile,
+    Summary,
+    RetrievedMemory,
+    ConversationTurn,
+    ToolResult,
+    ToolHint,
+    RuntimeContract,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ToolOutputStreamingPolicy {
+    BufferFull,
+    StreamChunks,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextArtifactDescriptor {
+    pub message_index: usize,
+    pub artifact_kind: ContextArtifactKind,
+    pub maskable: bool,
+    pub streaming_policy: ToolOutputStreamingPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ContextEngineCapability {
     KernelMemoryWindowRead,
     LegacyMessageAssembly,
@@ -72,6 +98,7 @@ impl ContextEngineMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct AssembledConversationContext {
     pub messages: Vec<Value>,
+    pub artifacts: Vec<ContextArtifactDescriptor>,
     pub estimated_tokens: Option<usize>,
     pub system_prompt_addition: Option<String>,
 }
@@ -80,6 +107,7 @@ impl AssembledConversationContext {
     pub fn from_messages(messages: Vec<Value>) -> Self {
         Self {
             messages,
+            artifacts: Vec::new(),
             estimated_tokens: None,
             system_prompt_addition: None,
         }
@@ -361,7 +389,6 @@ impl ConversationContextEngine for DefaultContextEngine {
                 }
 
                 let snapshot = load_memory_window_snapshot(config, session_id, kernel_ctx).await?;
-                // Fail closed when compaction cannot see the complete persisted session.
                 if !snapshot.is_complete_session_snapshot() {
                     return Ok(());
                 }
@@ -396,6 +423,53 @@ impl ConversationContextEngine for DefaultContextEngine {
         }
     }
 
+    async fn assemble_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        if !binding.is_kernel_bound() {
+            return crate::provider::build_messages_for_session(
+                config,
+                session_id,
+                include_system_prompt,
+            )
+            .map(AssembledConversationContext::from_messages);
+        }
+
+        #[cfg(feature = "memory-sqlite")]
+        {
+            let kernel_ctx = binding
+                .kernel_context()
+                .ok_or_else(|| "kernel-bound context engine requires kernel context".to_owned())?;
+            let provider_binding = crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx);
+            let envelope = load_stage_envelope(config, session_id, binding).await?;
+            let projected = crate::provider::project_hydrated_memory_context_for_view_with_binding(
+                config,
+                include_system_prompt,
+                &crate::tools::runtime_tool_view(),
+                provider_binding,
+                &envelope.hydrated,
+            )
+            .await;
+            return Ok(AssembledConversationContext {
+                messages: projected.messages,
+                artifacts: projected.artifacts,
+                estimated_tokens: None,
+                system_prompt_addition: None,
+            });
+        }
+
+        #[cfg(not(feature = "memory-sqlite"))]
+        {
+            let _ = binding;
+            crate::provider::build_messages_for_session(config, session_id, include_system_prompt)
+                .map(AssembledConversationContext::from_messages)
+        }
+    }
+
     async fn assemble_messages(
         &self,
         config: &LoongClawConfig,
@@ -403,41 +477,9 @@ impl ConversationContextEngine for DefaultContextEngine {
         include_system_prompt: bool,
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<Vec<Value>> {
-        if !binding.is_kernel_bound() {
-            return crate::provider::build_messages_for_session(
-                config,
-                session_id,
-                include_system_prompt,
-            );
-        }
-
-        let Some(kernel_ctx) = binding.kernel_context() else {
-            return Err("kernel-bound context engine requires kernel context".to_owned());
-        };
-
-        #[cfg_attr(not(feature = "memory-sqlite"), allow(unused_mut))]
-        let mut messages = crate::provider::build_base_messages_with_binding(
-            config,
-            include_system_prompt,
-            crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx),
-        )
-        .await;
-
-        #[cfg(feature = "memory-sqlite")]
-        {
-            let memory_config =
-                memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-            let context_entries =
-                load_memory_context_entries(&memory_config, session_id, kernel_ctx).await?;
-            append_memory_context_messages(&mut messages, context_entries);
-        }
-
-        #[cfg(not(feature = "memory-sqlite"))]
-        {
-            let _ = (session_id, binding);
-        }
-
-        Ok(messages)
+        self.assemble_context(config, session_id, include_system_prompt, binding)
+            .await
+            .map(|assembled| assembled.messages)
     }
 }
 
@@ -535,32 +577,6 @@ async fn load_memory_context_entries(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn append_memory_context_messages(
-    messages: &mut Vec<Value>,
-    entries: Vec<memory::MemoryContextEntry>,
-) {
-    for entry in entries {
-        let role = entry.role;
-        let content = entry.content;
-
-        match entry.kind {
-            memory::MemoryContextKind::Profile
-            | memory::MemoryContextKind::Summary
-            | memory::MemoryContextKind::RetrievedMemory => {
-                let message = json!({
-                    "role": role,
-                    "content": content,
-                });
-                messages.push(message);
-            }
-            memory::MemoryContextKind::Turn => {
-                crate::provider::push_history_message(messages, role.as_str(), content.as_str());
-            }
-        }
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
 async fn persist_memory_window(
     session_id: &str,
     turns: &[memory::WindowTurn],
@@ -593,6 +609,51 @@ async fn persist_memory_window(
             outcome.status
         )),
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn load_stage_envelope(
+    config: &LoongClawConfig,
+    session_id: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) -> CliResult<memory::StageEnvelope> {
+    if let Some(ctx) = binding.kernel_context() {
+        let runtime_config =
+            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let workspace_root = config
+            .tools
+            .file_root
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|_| config.tools.resolved_file_root());
+        let request = memory::build_read_stage_envelope_request_with_workspace_root(
+            session_id,
+            workspace_root.as_deref(),
+            &runtime_config,
+        );
+        let caps = BTreeSet::from([Capability::MemoryRead]);
+        let outcome = ctx
+            .kernel
+            .execute_memory_core(ctx.pack_id(), &ctx.token, &caps, None, request)
+            .await
+            .map_err(|error| format!("load staged memory envelope via kernel failed: {error}"))?;
+
+        if outcome.status != "ok" {
+            return Err(format!(
+                "load staged memory envelope via kernel returned non-ok status: {}",
+                outcome.status
+            ));
+        }
+
+        return memory::decode_stage_envelope(&outcome.payload)
+            .ok_or_else(|| "decode staged memory envelope via kernel failed".to_owned());
+    }
+
+    let runtime_config =
+        memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    memory::hydrate_stage_envelope(session_id, &runtime_config)
+        .map_err(|error| format!("load staged memory envelope failed: {error}"))
 }
 
 #[cfg(test)]
@@ -639,6 +700,12 @@ mod tests {
             ContextEngineCapability::SubagentLifecycle.as_str(),
             "subagent_lifecycle"
         );
+    }
+
+    #[test]
+    fn assembled_context_from_messages_defaults_to_empty_artifacts() {
+        let assembled = AssembledConversationContext::from_messages(vec![Value::Null]);
+        assert!(assembled.artifacts.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -795,6 +862,57 @@ mod tests {
                         .is_some_and(|content| content.contains(profile_note))
             }),
             "expected kernel-bound assembly to keep the profile block"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn default_engine_kernel_bound_messages_match_provider_durable_recall_projection() {
+        let capabilities = std::collections::BTreeSet::from([
+            loongclaw_contracts::Capability::InvokeTool,
+            loongclaw_contracts::Capability::FilesystemRead,
+            loongclaw_contracts::Capability::FilesystemWrite,
+            loongclaw_contracts::Capability::MemoryRead,
+        ]);
+        let harness = TurnTestHarness::with_capabilities(capabilities);
+        let session_id = "kernel-durable-recall-session";
+        let sqlite_path = harness.temp_dir.join("memory.sqlite3");
+        let sqlite_path_text = sqlite_path.display().to_string();
+        let curated_memory_path = harness.temp_dir.join("MEMORY.md");
+
+        std::fs::write(
+            &curated_memory_path,
+            "# Durable Notes\n\nRemember the deploy freeze window.\n",
+        )
+        .expect("write durable recall");
+
+        let mut config = LoongClawConfig::default();
+        config.tools.file_root = Some(harness.temp_dir.display().to_string());
+        config.memory.sqlite_path = sqlite_path_text;
+
+        let binding =
+            ConversationRuntimeBinding::from_optional_kernel_context(Some(&harness.kernel_ctx));
+        let kernel_messages = DefaultContextEngine
+            .assemble_messages(&config, session_id, true, binding)
+            .await
+            .expect("assemble messages");
+        let provider_messages =
+            crate::provider::build_messages_for_session(&config, session_id, true)
+                .expect("build provider messages");
+
+        assert_eq!(
+            kernel_messages, provider_messages,
+            "kernel-bound assembly should preserve durable recall projection parity"
+        );
+        assert!(
+            kernel_messages.iter().any(|message| {
+                message["role"] == "system"
+                    && message["content"].as_str().is_some_and(|content| {
+                        content.contains("## Advisory Durable Recall")
+                            && content.contains("Remember the deploy freeze window.")
+                    })
+            }),
+            "expected kernel-bound assembly to keep the durable recall block"
         );
     }
 }

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -431,12 +431,17 @@ impl ConversationContextEngine for DefaultContextEngine {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         if !binding.is_kernel_bound() {
-            return crate::provider::build_messages_for_session(
+            let projected = crate::provider::build_projected_context_for_session(
                 config,
                 session_id,
                 include_system_prompt,
-            )
-            .map(AssembledConversationContext::from_messages);
+            )?;
+            return Ok(AssembledConversationContext {
+                messages: projected.messages,
+                artifacts: projected.artifacts,
+                estimated_tokens: None,
+                system_prompt_addition: None,
+            });
         }
 
         #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -34,9 +34,10 @@ pub use analytics::{
     summarize_turn_checkpoint_events,
 };
 pub use context_engine::{
-    AssembledConversationContext, CONTEXT_ENGINE_API_VERSION, ContextEngineBootstrapResult,
-    ContextEngineCapability, ContextEngineIngestResult, ContextEngineMetadata,
-    ConversationContextEngine, DefaultContextEngine, LegacyContextEngine,
+    AssembledConversationContext, CONTEXT_ENGINE_API_VERSION, ContextArtifactDescriptor,
+    ContextArtifactKind, ContextEngineBootstrapResult, ContextEngineCapability,
+    ContextEngineIngestResult, ContextEngineMetadata, ConversationContextEngine,
+    DefaultContextEngine, LegacyContextEngine, ToolOutputStreamingPolicy,
 };
 pub use context_engine_registry::{
     CONTEXT_ENGINE_ENV, DEFAULT_CONTEXT_ENGINE_ID, LEGACY_CONTEXT_ENGINE_ID,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -438,6 +438,7 @@ impl ConversationContextEngine for StubSystemPromptAdditionEngine {
                 "role": "system",
                 "content": "base-system-prompt",
             })],
+            artifacts: vec![],
             estimated_tokens: Some(42),
             system_prompt_addition: Some("runtime-policy-addition".to_owned()),
         })
@@ -2900,6 +2901,181 @@ async fn default_runtime_build_context_fail_open_memory_derivation_preserves_rec
             ("assistant".to_owned(), "turn 2".to_owned()),
             ("user".to_owned(), "turn 3".to_owned()),
         ]
+    );
+
+    let _ = std::fs::remove_file(sqlite_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_kernel_build_context_matches_builtin_summary_projection() {
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-kernel-context", "summary");
+    let sqlite_path = unique_memory_sqlite_path("kernel-summary");
+    let mut config = test_config();
+    config.memory.system = MemorySystemKind::Builtin;
+    config.memory.profile = MemoryProfile::WindowPlusSummary;
+    config.memory.sliding_window = 2;
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let runtime_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+        .expect("append turn 1 should succeed");
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+        .expect("append turn 2 should succeed");
+    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+        .expect("append turn 3 should succeed");
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 4", &runtime_config)
+        .expect("append turn 4 should succeed");
+
+    let kernel_ctx =
+        test_kernel_context_with_memory("default-runtime-kernel-context-summary", &runtime_config);
+    let assembled = runtime
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("build kernel context from default runtime");
+    let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
+        .expect("build provider messages");
+
+    assert_eq!(
+        assembled.messages, provider_messages,
+        "kernel-bound default runtime should match the builtin staged projection"
+    );
+
+    let _ = std::fs::remove_file(sqlite_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_kernel_build_context_preserves_profile_projection() {
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-kernel-context", "profile");
+    let sqlite_path = unique_memory_sqlite_path("kernel-profile");
+    let mut config = test_config();
+    config.memory.system = MemorySystemKind::Builtin;
+    config.memory.profile = MemoryProfile::ProfilePlusWindow;
+    config.memory.profile_note = Some("Imported ZeroClaw preferences".to_owned());
+    config.memory.sliding_window = 2;
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let runtime_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 1", &runtime_config)
+        .expect("append turn should succeed");
+
+    let kernel_ctx =
+        test_kernel_context_with_memory("default-runtime-kernel-context-profile", &runtime_config);
+    let assembled = runtime
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("build kernel context from default runtime");
+    let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
+        .expect("build provider messages");
+
+    assert_eq!(
+        assembled.messages, provider_messages,
+        "kernel-bound default runtime should preserve builtin profile projection"
+    );
+    assert!(
+        assembled.artifacts.iter().any(|artifact| {
+            artifact.artifact_kind == ContextArtifactKind::Profile
+                && artifact.message_index < assembled.messages.len()
+        }),
+        "expected a profile artifact descriptor for the injected profile block"
+    );
+
+    let _ = std::fs::remove_file(sqlite_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_kernel_build_context_emits_context_artifact_annotations() {
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-kernel-context", "artifacts");
+    let sqlite_path = unique_memory_sqlite_path("kernel-artifacts");
+    let mut config = test_config();
+    config.memory.system = MemorySystemKind::Builtin;
+    config.memory.profile = MemoryProfile::WindowPlusSummary;
+    config.memory.sliding_window = 2;
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let runtime_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+        .expect("append turn 1 should succeed");
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+        .expect("append turn 2 should succeed");
+    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+        .expect("append turn 3 should succeed");
+
+    let kernel_ctx = test_kernel_context_with_memory(
+        "default-runtime-kernel-context-artifacts",
+        &runtime_config,
+    );
+    let assembled = runtime
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("build kernel context from default runtime");
+
+    assert!(
+        assembled
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_kind == ContextArtifactKind::SystemPrompt),
+        "expected a system prompt artifact descriptor"
+    );
+    assert!(
+        assembled
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_kind == ContextArtifactKind::RuntimeContract),
+        "expected a runtime-contract artifact descriptor"
+    );
+    assert!(
+        assembled
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_kind == ContextArtifactKind::Summary),
+        "expected a summary artifact descriptor"
+    );
+    assert!(
+        assembled
+            .artifacts
+            .iter()
+            .filter(|artifact| artifact.artifact_kind == ContextArtifactKind::ConversationTurn)
+            .count()
+            >= 2,
+        "expected conversation-turn artifact descriptors for projected turns"
+    );
+    assert!(
+        assembled
+            .artifacts
+            .iter()
+            .all(|artifact| artifact.message_index < assembled.messages.len()),
+        "artifact indices must point at emitted messages"
+    );
+    assert!(
+        assembled
+            .artifacts
+            .iter()
+            .all(|artifact| artifact.streaming_policy == ToolOutputStreamingPolicy::BufferFull),
+        "slice 1 artifacts should use buffered delivery"
     );
 
     let _ = std::fs::remove_file(sqlite_path);
@@ -13164,6 +13340,7 @@ async fn repair_turn_checkpoint_tail_rebuilds_original_finalization_context_for_
                     json!({"role": "user", "content": "hello"}),
                     json!({"role": "assistant", "content": "assistant-reply"}),
                 ],
+                artifacts: vec![],
                 estimated_tokens: Some(3),
                 system_prompt_addition: None,
             },
@@ -13172,6 +13349,7 @@ async fn repair_turn_checkpoint_tail_rebuilds_original_finalization_context_for_
                     json!({"role": "user", "content": "hello"}),
                     json!({"role": "assistant", "content": "assistant-reply"}),
                 ],
+                artifacts: vec![],
                 estimated_tokens: Some(2),
                 system_prompt_addition: None,
             },
@@ -13285,6 +13463,7 @@ async fn repair_turn_checkpoint_tail_prefers_checkpoint_estimate_for_compaction_
                 json!({"role": "user", "content": "hello"}),
                 json!({"role": "assistant", "content": "assistant-reply"}),
             ],
+            artifacts: vec![],
             estimated_tokens: Some(1),
             system_prompt_addition: None,
         });
@@ -13397,6 +13576,7 @@ async fn probe_turn_checkpoint_tail_runtime_gate_reports_preparation_content_mis
                 json!({"role": "user", "content": "hello"}),
                 json!({"role": "assistant", "content": "assistant-reply"}),
             ],
+            artifacts: vec![],
             estimated_tokens: Some(99),
             system_prompt_addition: None,
         });
@@ -13908,6 +14088,7 @@ async fn load_turn_checkpoint_diagnostics_with_runtime_preserves_summary_assessm
                 json!({"role": "user", "content": "hello"}),
                 json!({"role": "assistant", "content": "assistant-reply"}),
             ],
+            artifacts: vec![],
             estimated_tokens: Some(99),
             system_prompt_addition: None,
         });
@@ -14032,6 +14213,7 @@ async fn load_turn_checkpoint_diagnostics_uses_single_kernel_window_snapshot_for
                 json!({"role": "user", "content": "hello"}),
                 json!({"role": "assistant", "content": "assistant-reply"}),
             ],
+            artifacts: vec![],
             estimated_tokens: Some(99),
             system_prompt_addition: None,
         });
@@ -17177,6 +17359,7 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_preparation_conte
                 json!({"role": "user", "content": "hello"}),
                 json!({"role": "assistant", "content": "assistant-reply"}),
             ],
+            artifacts: vec![],
             estimated_tokens: Some(99),
             system_prompt_addition: None,
         });
@@ -17295,6 +17478,7 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_preparation_conte
                 json!({"role": "user", "content": "hello"}),
                 json!({"role": "assistant", "content": "assistant-reply"}),
             ],
+            artifacts: vec![],
             estimated_tokens: Some(99),
             system_prompt_addition: None,
         });
@@ -17413,6 +17597,7 @@ async fn repair_turn_checkpoint_tail_requires_manual_repair_on_malformed_prepara
                 json!({"role": "user", "content": "hello"}),
                 json!({"role": "assistant", "content": "assistant-reply"}),
             ],
+            artifacts: vec![],
             estimated_tokens: Some(99),
             system_prompt_addition: None,
         });

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -11547,6 +11547,59 @@ fn discovery_first_window_turns(payloads: &[String]) -> Value {
     )
 }
 
+fn staged_memory_envelope_payload_from_window_turns(window_turns: &Value) -> Value {
+    let recent_window: Vec<crate::memory::WindowTurn> = window_turns
+        .as_array()
+        .into_iter()
+        .flatten()
+        .map(|turn| crate::memory::WindowTurn {
+            role: turn
+                .get("role")
+                .and_then(Value::as_str)
+                .unwrap_or("assistant")
+                .to_owned(),
+            content: turn
+                .get("content")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned(),
+            ts: turn.get("ts").and_then(Value::as_i64),
+        })
+        .collect();
+    let entries = recent_window
+        .iter()
+        .map(|turn| crate::memory::MemoryContextEntry {
+            kind: crate::memory::MemoryContextKind::Turn,
+            role: turn.role.clone(),
+            content: turn.content.clone(),
+        })
+        .collect::<Vec<_>>();
+    let envelope = crate::memory::StageEnvelope {
+        hydrated: crate::memory::HydratedMemoryContext {
+            diagnostics: crate::memory::MemoryDiagnostics {
+                system_id: "builtin".to_owned(),
+                fail_open: true,
+                strict_mode_requested: false,
+                strict_mode_active: false,
+                degraded: false,
+                derivation_error: None,
+                retrieval_error: None,
+                recent_window_count: recent_window.len(),
+                entry_count: entries.len(),
+            },
+            entries,
+            recent_window,
+        },
+        retrieval_request: None,
+        diagnostics: vec![
+            crate::memory::StageDiagnostics::succeeded(crate::memory::MemoryStageFamily::Derive),
+            crate::memory::StageDiagnostics::succeeded(crate::memory::MemoryStageFamily::Retrieve),
+            crate::memory::StageDiagnostics::succeeded(crate::memory::MemoryStageFamily::Rank),
+        ],
+    };
+    crate::memory::encode_stage_envelope_payload(&envelope)
+}
+
 struct SharedTestMemoryAdapter {
     invocations: Arc<Mutex<Vec<MemoryCoreRequest>>>,
     window_turns: Value,
@@ -11562,34 +11615,8 @@ impl CoreMemoryAdapter for SharedTestMemoryAdapter {
         &self,
         request: MemoryCoreRequest,
     ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
-        let payload = if request.operation == crate::memory::MEMORY_OP_READ_CONTEXT {
-            let entries = self
-                .window_turns
-                .as_array()
-                .cloned()
-                .unwrap_or_default()
-                .into_iter()
-                .map(|turn| {
-                    let role = turn
-                        .get("role")
-                        .and_then(Value::as_str)
-                        .unwrap_or("assistant");
-                    let content = turn
-                        .get("content")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default();
-
-                    json!({
-                        "kind": "turn",
-                        "role": role,
-                        "content": content,
-                    })
-                })
-                .collect::<Vec<_>>();
-
-            json!({
-                "entries": entries
-            })
+        let payload = if request.operation == crate::memory::MEMORY_OP_READ_STAGE_ENVELOPE {
+            staged_memory_envelope_payload_from_window_turns(&self.window_turns)
         } else if request.operation == crate::memory::MEMORY_OP_WINDOW {
             json!({
                 "turns": self.window_turns.clone()
@@ -11623,7 +11650,13 @@ impl CoreMemoryAdapter for SequencedTestMemoryAdapter {
         &self,
         request: MemoryCoreRequest,
     ) -> Result<MemoryCoreOutcome, MemoryPlaneError> {
-        let payload = if request.operation == crate::memory::MEMORY_OP_WINDOW {
+        let payload = if request.operation == crate::memory::MEMORY_OP_READ_STAGE_ENVELOPE {
+            let turns = {
+                let mut queued_turns = self.window_turns.lock().expect("window turns lock");
+                queued_turns.pop_front().unwrap_or_else(|| json!([]))
+            };
+            staged_memory_envelope_payload_from_window_turns(&turns)
+        } else if request.operation == crate::memory::MEMORY_OP_WINDOW {
             let turns = {
                 let mut queued_turns = self.window_turns.lock().expect("window turns lock");
                 queued_turns.pop_front().unwrap_or_else(|| json!([]))
@@ -11664,7 +11697,9 @@ impl CoreMemoryAdapter for FailingWindowMemoryAdapter {
             .lock()
             .expect("invocations lock")
             .push(request.clone());
-        if request.operation == crate::memory::MEMORY_OP_WINDOW {
+        if request.operation == crate::memory::MEMORY_OP_WINDOW
+            || request.operation == crate::memory::MEMORY_OP_READ_STAGE_ENVELOPE
+        {
             return Err(MemoryPlaneError::Execution(self.error.clone()));
         }
         Ok(MemoryCoreOutcome {
@@ -11693,7 +11728,9 @@ impl CoreMemoryAdapter for RawWindowPayloadMemoryAdapter {
             .lock()
             .expect("invocations lock")
             .push(request.clone());
-        if request.operation == crate::memory::MEMORY_OP_WINDOW {
+        if request.operation == crate::memory::MEMORY_OP_WINDOW
+            || request.operation == crate::memory::MEMORY_OP_READ_STAGE_ENVELOPE
+        {
             return Ok(MemoryCoreOutcome {
                 status: "ok".to_owned(),
                 payload: self.payload.clone(),
@@ -11931,12 +11968,12 @@ async fn build_messages_routes_memory_context_through_kernel_when_context_provid
 
     let captured = invocations.lock().expect("invocations lock");
     assert_eq!(captured.len(), 1);
-    assert_eq!(captured[0].operation, crate::memory::MEMORY_OP_READ_CONTEXT);
-    assert_eq!(captured[0].payload["session_id"], "session-k-window");
     assert_eq!(
-        captured[0].payload["profile"],
-        config.memory.profile.as_str()
+        captured[0].operation,
+        crate::memory::MEMORY_OP_READ_STAGE_ENVELOPE
     );
+    assert_eq!(captured[0].payload["session_id"], "session-k-window");
+    assert_eq!(captured[0].payload["profile"], config.memory.profile.as_str());
     assert_eq!(
         captured[0].payload["sliding_window"],
         json!(config.memory.sliding_window)

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -11973,7 +11973,10 @@ async fn build_messages_routes_memory_context_through_kernel_when_context_provid
         crate::memory::MEMORY_OP_READ_STAGE_ENVELOPE
     );
     assert_eq!(captured[0].payload["session_id"], "session-k-window");
-    assert_eq!(captured[0].payload["profile"], config.memory.profile.as_str());
+    assert_eq!(
+        captured[0].payload["profile"],
+        config.memory.profile.as_str()
+    );
     assert_eq!(
         captured[0].payload["sliding_window"],
         json!(config.memory.sliding_window)

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2260,6 +2260,76 @@ async fn default_runtime_build_context_merges_delegate_runtime_contract_with_sys
     );
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_kernel_stage_hydration_still_applies_system_prompt_addition_and_tool_view()
+{
+    let mut config = test_config();
+    config.memory.system = MemorySystemKind::Builtin;
+    config.memory.profile = MemoryProfile::WindowPlusSummary;
+    config.memory.sliding_window = 2;
+    let child_session_id = seed_delegate_child_session_with_runtime_narrowing(
+        &mut config,
+        "kernel-stage-hydration-tool-view",
+        sample_delegate_runtime_narrowing(),
+    );
+    let runtime_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(&child_session_id, "user", "turn 1", &runtime_config)
+        .expect("append turn 1 should succeed");
+    crate::memory::append_turn_direct(&child_session_id, "assistant", "turn 2", &runtime_config)
+        .expect("append turn 2 should succeed");
+    crate::memory::append_turn_direct(&child_session_id, "user", "turn 3", &runtime_config)
+        .expect("append turn 3 should succeed");
+    crate::memory::append_turn_direct(&child_session_id, "assistant", "turn 4", &runtime_config)
+        .expect("append turn 4 should succeed");
+
+    let runtime = DefaultConversationRuntime::default();
+    let kernel_ctx = test_kernel_context_with_memory(
+        "default-runtime-kernel-stage-hydration-tool-view",
+        &runtime_config,
+    );
+
+    let assembled = runtime
+        .build_context(
+            &config,
+            &child_session_id,
+            true,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("build kernel context with staged hydration and runtime middlewares");
+
+    let system_content = assembled.messages[0]["content"]
+        .as_str()
+        .expect("system prompt should stay string");
+    assert!(
+        system_content.contains("[delegate_child_runtime_contract]"),
+        "expected runtime-owned system prompt addition in kernel-bound staged assembly, got: {system_content}"
+    );
+    assert!(
+        system_content.contains("Plan within these child-session runtime limits:"),
+        "expected delegate runtime contract body, got: {system_content}"
+    );
+    assert!(
+        !system_content.contains("- delegate:"),
+        "expected child tool-view shaping to hide delegate tools in the rewritten system prompt, got: {system_content}"
+    );
+    assert!(
+        !system_content.contains("- shell.exec:"),
+        "expected child tool-view shaping to keep shell hidden by default, got: {system_content}"
+    );
+    assert!(
+        assembled.messages.iter().any(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("## Memory Summary"))
+        }),
+        "expected staged hydration summary block to remain present after runtime middlewares"
+    );
+}
+
 #[tokio::test]
 async fn default_runtime_build_context_does_not_add_delegate_runtime_contract_for_unpersisted_session()
  {

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2464,6 +2464,13 @@ async fn default_runtime_build_context_matches_builtin_summary_projection() {
         }),
         "expected hydrated summary block in default runtime messages"
     );
+    assert!(
+        assembled
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_kind == ContextArtifactKind::Summary),
+        "direct-mode builtin summary projection should preserve summary artifacts"
+    );
 
     let _ = std::fs::remove_file(sqlite_path);
 }
@@ -2748,6 +2755,13 @@ async fn default_runtime_build_context_explicit_builtin_system_preserves_profile
                     .is_some_and(|content| content.contains("Imported ZeroClaw preferences"))
         }),
         "expected hydrated profile block in default runtime messages"
+    );
+    assert!(
+        assembled
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.artifact_kind == ContextArtifactKind::Profile),
+        "direct-mode builtin profile projection should preserve profile artifacts"
     );
 
     let _ = std::fs::remove_file(sqlite_path);

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -7792,6 +7792,7 @@ mod tests {
                     "role": "system",
                     "content": "sys"
                 })],
+                artifacts: vec![],
                 estimated_tokens: Some(42),
                 system_prompt_addition: None,
             },
@@ -7830,6 +7831,7 @@ mod tests {
                     "role": "system",
                     "content": "sys"
                 })],
+                artifacts: vec![],
                 estimated_tokens: Some(42),
                 system_prompt_addition: None,
             },
@@ -8416,6 +8418,7 @@ mod tests {
                     "role": "system",
                     "content": "sys"
                 })],
+                artifacts: vec![],
                 estimated_tokens: Some(42),
                 system_prompt_addition: None,
             },

--- a/crates/app/src/conversation/turn_middleware.rs
+++ b/crates/app/src/conversation/turn_middleware.rs
@@ -7,7 +7,10 @@ use crate::config::LoongClawConfig;
 use crate::tools::ToolView;
 use crate::{CliResult, KernelContext};
 
-use super::context_engine::AssembledConversationContext;
+use super::context_engine::{
+    AssembledConversationContext, ContextArtifactDescriptor, ContextArtifactKind,
+    ToolOutputStreamingPolicy,
+};
 use super::runtime_binding::ConversationRuntimeBinding;
 
 pub const TURN_MIDDLEWARE_API_VERSION: u16 = 1;
@@ -206,6 +209,7 @@ impl ConversationTurnMiddleware for SystemPromptAdditionTurnMiddleware {
     ) -> CliResult<AssembledConversationContext> {
         apply_system_prompt_addition(
             &mut assembled.messages,
+            &mut assembled.artifacts,
             assembled.system_prompt_addition.as_deref(),
         );
         Ok(assembled)
@@ -239,7 +243,11 @@ impl ConversationTurnMiddleware for SystemPromptToolViewTurnMiddleware {
     }
 }
 
-pub(crate) fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: Option<&str>) {
+pub(crate) fn apply_system_prompt_addition(
+    messages: &mut Vec<Value>,
+    artifacts: &mut Vec<ContextArtifactDescriptor>,
+    addition: Option<&str>,
+) {
     let Some(addition) = addition
         .map(str::trim)
         .filter(|content| !content.is_empty())
@@ -247,7 +255,7 @@ pub(crate) fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: 
         return;
     };
 
-    for message in messages.iter_mut() {
+    for (index, message) in messages.iter_mut().enumerate() {
         let is_system = message.get("role").and_then(Value::as_str) == Some("system");
         if !is_system {
             continue;
@@ -261,10 +269,14 @@ pub(crate) fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: 
                 _ => addition.to_owned(),
             };
             object.insert("content".to_owned(), Value::String(merged_content));
+            ensure_runtime_contract_artifact(artifacts, index);
             return;
         }
     }
 
+    for artifact in artifacts.iter_mut() {
+        artifact.message_index += 1;
+    }
     messages.insert(
         0,
         json!({
@@ -272,6 +284,7 @@ pub(crate) fn apply_system_prompt_addition(messages: &mut Vec<Value>, addition: 
             "content": addition,
         }),
     );
+    ensure_runtime_contract_artifact(artifacts, 0);
 }
 
 fn apply_tool_view_to_system_prompt(messages: &mut [Value], tool_view: &ToolView) {
@@ -305,6 +318,25 @@ fn apply_tool_view_to_system_prompt(messages: &mut [Value], tool_view: &ToolView
         }
         return;
     }
+}
+
+fn ensure_runtime_contract_artifact(
+    artifacts: &mut Vec<ContextArtifactDescriptor>,
+    message_index: usize,
+) {
+    if artifacts.iter().any(|artifact| {
+        artifact.message_index == message_index
+            && artifact.artifact_kind == ContextArtifactKind::RuntimeContract
+    }) {
+        return;
+    }
+
+    artifacts.push(ContextArtifactDescriptor {
+        message_index,
+        artifact_kind: ContextArtifactKind::RuntimeContract,
+        maskable: false,
+        streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+    });
 }
 
 #[async_trait]

--- a/crates/app/src/conversation/turn_middleware.rs
+++ b/crates/app/src/conversation/turn_middleware.rs
@@ -448,3 +448,131 @@ where
             .await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn builtin_turn_middlewares_preserve_context_artifact_descriptors() {
+        let assembled = AssembledConversationContext {
+            messages: vec![
+                json!({
+                    "role": "system",
+                    "content": "base system\n\n[available_tools]\n- delegate: spawn a child session"
+                }),
+                json!({
+                    "role": "system",
+                    "content": "## Memory Summary\nOlder context"
+                }),
+                json!({
+                    "role": "user",
+                    "content": "latest user turn"
+                }),
+            ],
+            artifacts: vec![
+                ContextArtifactDescriptor {
+                    message_index: 0,
+                    artifact_kind: ContextArtifactKind::SystemPrompt,
+                    maskable: false,
+                    streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+                },
+                ContextArtifactDescriptor {
+                    message_index: 0,
+                    artifact_kind: ContextArtifactKind::RuntimeContract,
+                    maskable: false,
+                    streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+                },
+                ContextArtifactDescriptor {
+                    message_index: 1,
+                    artifact_kind: ContextArtifactKind::Summary,
+                    maskable: false,
+                    streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+                },
+                ContextArtifactDescriptor {
+                    message_index: 2,
+                    artifact_kind: ContextArtifactKind::ConversationTurn,
+                    maskable: false,
+                    streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+                },
+            ],
+            estimated_tokens: None,
+            system_prompt_addition: Some("runtime-policy-addition".to_owned()),
+        };
+        let runtime_tool_view = crate::tools::runtime_tool_view();
+        let requested_tool_view = crate::tools::ToolView::from_tool_names(["file.read"]);
+
+        let assembled = SystemPromptAdditionTurnMiddleware
+            .transform_context(
+                &crate::config::LoongClawConfig::default(),
+                "session-artifact-preservation",
+                true,
+                assembled,
+                &runtime_tool_view,
+                &requested_tool_view,
+                ConversationRuntimeBinding::direct(),
+            )
+            .await
+            .expect("system prompt addition middleware should succeed");
+        let transformed = SystemPromptToolViewTurnMiddleware
+            .transform_context(
+                &crate::config::LoongClawConfig::default(),
+                "session-artifact-preservation",
+                true,
+                assembled,
+                &runtime_tool_view,
+                &requested_tool_view,
+                ConversationRuntimeBinding::direct(),
+            )
+            .await
+            .expect("tool view middleware should succeed");
+
+        assert_eq!(transformed.artifacts.len(), 4);
+        assert!(
+            transformed
+                .artifacts
+                .iter()
+                .any(
+                    |artifact| artifact.artifact_kind == ContextArtifactKind::SystemPrompt
+                        && artifact.message_index == 0
+                )
+        );
+        assert!(
+            transformed
+                .artifacts
+                .iter()
+                .any(
+                    |artifact| artifact.artifact_kind == ContextArtifactKind::RuntimeContract
+                        && artifact.message_index == 0
+                )
+        );
+        assert!(transformed.artifacts.iter().any(|artifact| {
+            artifact.artifact_kind == ContextArtifactKind::Summary
+                && transformed.messages[artifact.message_index]["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("## Memory Summary"))
+        }));
+        assert!(
+            transformed
+                .artifacts
+                .iter()
+                .any(
+                    |artifact| artifact.artifact_kind == ContextArtifactKind::ConversationTurn
+                        && transformed.messages[artifact.message_index]["content"]
+                            == "latest user turn"
+                )
+        );
+        assert!(
+            transformed
+                .artifacts
+                .iter()
+                .all(|artifact| artifact.message_index < transformed.messages.len())
+        );
+
+        let system_content = transformed.messages[0]["content"]
+            .as_str()
+            .expect("system content");
+        assert!(system_content.contains("runtime-policy-addition"));
+        assert!(system_content.contains("Non-core tools are intentionally hidden"));
+    }
+}

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -9,7 +9,7 @@ use crate::runtime_identity;
 use super::sqlite;
 use super::{
     MEMORY_OP_READ_CONTEXT, MEMORY_OP_READ_STAGE_ENVELOPE, encode_stage_envelope_payload,
-    hydrate_stage_envelope,
+    orchestrator::hydrate_stage_envelope_with_workspace_root,
     protocol::{MemoryContextEntry, MemoryContextKind},
     runtime_config::MemoryRuntimeConfig,
 };
@@ -131,7 +131,31 @@ pub(crate) fn read_stage_envelope(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "memory.read_stage_envelope requires payload.session_id".to_owned())?;
-    let envelope = hydrate_stage_envelope(session_id, config)?;
+    let runtime_config = read_context_runtime_config(payload, config)?;
+    let workspace_root = payload
+        .get("workspace_root")
+        .map(|value| match value {
+            Value::Null => Ok(None),
+            Value::String(raw_path) => {
+                let trimmed_path = raw_path.trim();
+                if trimmed_path.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(std::path::PathBuf::from(trimmed_path)))
+                }
+            }
+            _ => Err(
+                "memory.read_stage_envelope payload.workspace_root must be a string or null"
+                    .to_owned(),
+            ),
+        })
+        .transpose()?
+        .flatten();
+    let envelope = hydrate_stage_envelope_with_workspace_root(
+        session_id,
+        workspace_root.as_deref(),
+        &runtime_config,
+    )?;
     let mut response_payload = encode_stage_envelope_payload(&envelope);
 
     if let Some(map) = response_payload.as_object_mut() {
@@ -201,7 +225,10 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::*;
-    use crate::memory::{build_read_stage_envelope_request, decode_stage_envelope};
+    use crate::memory::{
+        build_read_stage_envelope_request, build_read_stage_envelope_request_with_workspace_root,
+        decode_stage_envelope,
+    };
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
@@ -526,5 +553,46 @@ mod tests {
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn read_stage_envelope_operation_preserves_durable_recall_with_workspace_root() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let curated_memory_path = workspace_root.join("MEMORY.md");
+
+        std::fs::write(
+            &curated_memory_path,
+            "# Durable Notes\n\nRemember the deploy freeze window.\n",
+        )
+        .expect("write durable recall");
+
+        let db_path = workspace_root.join("stage-envelope-durable-recall.sqlite3");
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        let outcome = super::super::execute_memory_core_with_config(
+            build_read_stage_envelope_request_with_workspace_root(
+                "durable-recall-stage-envelope-session",
+                Some(workspace_root),
+                &config,
+            ),
+            &config,
+        )
+        .expect("read_stage_envelope should preserve durable recall");
+
+        let envelope = decode_stage_envelope(&outcome.payload).expect("decode staged envelope");
+        let has_durable_recall = envelope.hydrated.entries.iter().any(|entry| {
+            entry.kind == MemoryContextKind::RetrievedMemory
+                && entry.content.contains("Remember the deploy freeze window.")
+        });
+
+        assert!(
+            has_durable_recall,
+            "expected staged envelope payload to keep workspace durable recall"
+        );
     }
 }

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -8,7 +8,8 @@ use crate::runtime_identity;
 #[cfg(feature = "memory-sqlite")]
 use super::sqlite;
 use super::{
-    MEMORY_OP_READ_CONTEXT,
+    MEMORY_OP_READ_CONTEXT, MEMORY_OP_READ_STAGE_ENVELOPE, encode_stage_envelope_payload,
+    hydrate_stage_envelope,
     protocol::{MemoryContextEntry, MemoryContextKind},
     runtime_config::MemoryRuntimeConfig,
 };
@@ -116,6 +117,35 @@ fn read_context_runtime_config(
     Ok(runtime_config)
 }
 
+pub(crate) fn read_stage_envelope(
+    request: MemoryCoreRequest,
+    config: &MemoryRuntimeConfig,
+) -> Result<MemoryCoreOutcome, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "memory.read_stage_envelope payload must be an object".to_owned())?;
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "memory.read_stage_envelope requires payload.session_id".to_owned())?;
+    let envelope = hydrate_stage_envelope(session_id, config)?;
+    let mut response_payload = encode_stage_envelope_payload(&envelope);
+
+    if let Some(map) = response_payload.as_object_mut() {
+        map.insert("adapter".to_owned(), json!("sqlite-core"));
+        map.insert("operation".to_owned(), json!(MEMORY_OP_READ_STAGE_ENVELOPE));
+        map.insert("session_id".to_owned(), json!(session_id));
+    }
+
+    Ok(MemoryCoreOutcome {
+        status: "ok".to_owned(),
+        payload: response_payload,
+    })
+}
+
 pub fn load_prompt_context(
     session_id: &str,
     config: &MemoryRuntimeConfig,
@@ -171,6 +201,7 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::*;
+    use crate::memory::{build_read_stage_envelope_request, decode_stage_envelope};
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
@@ -411,6 +442,87 @@ mod tests {
                 .any(|entry| entry.get("kind") == Some(&json!("summary"))),
             "expected read_context payload to include a summary entry"
         );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn read_stage_envelope_operation_serializes_hydrated_entries_and_diagnostics() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-read-stage-envelope-memory-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("read-stage-envelope.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..MemoryRuntimeConfig::default()
+        };
+
+        super::super::append_turn_direct("read-stage-envelope-session", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        super::super::append_turn_direct(
+            "read-stage-envelope-session",
+            "assistant",
+            "turn 2",
+            &config,
+        )
+        .expect("append turn 2 should succeed");
+        super::super::append_turn_direct("read-stage-envelope-session", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let outcome = super::super::execute_memory_core_with_config(
+            build_read_stage_envelope_request("read-stage-envelope-session"),
+            &config,
+        )
+        .expect("read_stage_envelope should succeed");
+
+        let envelope = decode_stage_envelope(&outcome.payload).expect("decode staged envelope");
+        assert!(!envelope.hydrated.entries.is_empty());
+        assert!(!envelope.diagnostics.is_empty());
+        assert_eq!(envelope.hydrated.diagnostics.system_id, "builtin");
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn execute_memory_core_dispatches_read_stage_envelope_operation() {
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-dispatch-stage-envelope-memory-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("dispatch-stage-envelope.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        let outcome = super::super::execute_memory_core_with_config(
+            build_read_stage_envelope_request("dispatch-session"),
+            &config,
+        )
+        .expect("dispatch read_stage_envelope");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(
+            outcome.payload["operation"],
+            json!(MEMORY_OP_READ_STAGE_ENVELOPE)
+        );
+        assert!(decode_stage_envelope(&outcome.payload).is_some());
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);

--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -144,7 +144,7 @@ pub(crate) fn read_stage_envelope(
                     Ok(Some(std::path::PathBuf::from(trimmed_path)))
                 }
             }
-            _ => Err(
+            Value::Bool(_) | Value::Number(_) | Value::Array(_) | Value::Object(_) => Err(
                 "memory.read_stage_envelope payload.workspace_root must be a string or null"
                     .to_owned(),
             ),

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -44,17 +44,18 @@ pub use kernel_adapter::MvpMemoryAdapter;
 pub use orchestrator::{
     BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,
     hydrate_memory_context_with_workspace_root,
+    hydrate_stage_envelope,
 };
 #[cfg(test)]
 pub use orchestrator::{MemoryOrchestratorTestFaults, ScopedMemoryOrchestratorTestFaults};
 pub use protocol::{
     MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_READ_CONTEXT,
-    MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW, MemoryContextEntry, MemoryContextKind, WindowTurn,
-    build_append_turn_request, build_read_context_request, build_replace_turns_request,
-    build_replace_turns_request_with_expectation, build_window_request,
-    decode_memory_context_entries, decode_window_turn_count, decode_window_turns,
-    decode_stage_envelope, decode_window_turns, encode_stage_envelope_payload,
-    encode_stage_envelope_payload,
+    MEMORY_OP_READ_STAGE_ENVELOPE, MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW,
+    MemoryContextEntry, MemoryContextKind, WindowTurn, build_append_turn_request,
+    build_read_context_request, build_read_stage_envelope_request,
+    build_replace_turns_request, build_replace_turns_request_with_expectation,
+    build_window_request, decode_memory_context_entries, decode_stage_envelope,
+    decode_window_turn_count, decode_window_turns, encode_stage_envelope_payload,
 };
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoadDiagnostics};
@@ -95,6 +96,8 @@ pub fn execute_memory_core_with_config(
             MEMORY_OP_WINDOW => load_window(request, config),
             MEMORY_OP_CLEAR_SESSION => clear_session(request, config),
             MEMORY_OP_READ_CONTEXT => context::read_context(request, config),
+            MEMORY_OP_REPLACE_TURNS => replace_turns(request, config),
+            MEMORY_OP_READ_STAGE_ENVELOPE => context::read_stage_envelope(request, config),
             MEMORY_OP_REPLACE_TURNS => replace_turns(request, config),
             _ => Ok(MemoryCoreOutcome {
                 status: "ok".to_owned(),

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -43,16 +43,15 @@ pub(crate) use durable_recall::load_durable_recall_entries;
 pub use kernel_adapter::MvpMemoryAdapter;
 pub use orchestrator::{
     BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,
-    hydrate_memory_context_with_workspace_root,
-    hydrate_stage_envelope,
+    hydrate_memory_context_with_workspace_root, hydrate_stage_envelope,
 };
 #[cfg(test)]
 pub use orchestrator::{MemoryOrchestratorTestFaults, ScopedMemoryOrchestratorTestFaults};
 pub use protocol::{
     MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_READ_CONTEXT,
-    MEMORY_OP_READ_STAGE_ENVELOPE, MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW,
-    MemoryContextEntry, MemoryContextKind, WindowTurn, build_append_turn_request,
-    build_read_context_request, build_read_stage_envelope_request,
+    MEMORY_OP_READ_STAGE_ENVELOPE, MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW, MemoryContextEntry,
+    MemoryContextKind, WindowTurn, build_append_turn_request, build_read_context_request,
+    build_read_stage_envelope_request, build_read_stage_envelope_request_with_workspace_root,
     build_replace_turns_request, build_replace_turns_request_with_expectation,
     build_window_request, decode_memory_context_entries, decode_stage_envelope,
     decode_window_turn_count, decode_window_turns, encode_stage_envelope_payload,
@@ -98,7 +97,6 @@ pub fn execute_memory_core_with_config(
             MEMORY_OP_READ_CONTEXT => context::read_context(request, config),
             MEMORY_OP_REPLACE_TURNS => replace_turns(request, config),
             MEMORY_OP_READ_STAGE_ENVELOPE => context::read_stage_envelope(request, config),
-            MEMORY_OP_REPLACE_TURNS => replace_turns(request, config),
             _ => Ok(MemoryCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -23,6 +23,7 @@ mod protocol;
 pub mod runtime_config;
 #[cfg(feature = "memory-sqlite")]
 mod sqlite;
+mod stage;
 mod system;
 mod system_registry;
 #[cfg(test)]
@@ -52,9 +53,15 @@ pub use protocol::{
     build_append_turn_request, build_read_context_request, build_replace_turns_request,
     build_replace_turns_request_with_expectation, build_window_request,
     decode_memory_context_entries, decode_window_turn_count, decode_window_turns,
+    decode_stage_envelope, decode_window_turns, encode_stage_envelope_payload,
+    encode_stage_envelope_payload,
 };
 #[cfg(feature = "memory-sqlite")]
 pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoadDiagnostics};
+pub use stage::{
+    DerivedMemoryKind, MemoryRetrievalRequest, MemoryStageFamily, StageDiagnostics, StageEnvelope,
+    StageOutcome, builtin_post_turn_stage_families, builtin_pre_assembly_stage_families,
+};
 pub use system::{
     BuiltinMemorySystem, DEFAULT_MEMORY_SYSTEM_ID, MEMORY_SYSTEM_API_VERSION, MemorySystem,
     MemorySystemCapability, MemorySystemMetadata,

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -78,6 +78,15 @@ pub(crate) use workspace_files::{
     collect_workspace_memory_document_locations,
 };
 
+pub(crate) fn normalize_system_id(raw: &str) -> Option<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
 pub fn execute_memory_core(request: MemoryCoreRequest) -> Result<MemoryCoreOutcome, String> {
     execute_memory_core_with_config(request, runtime_config::get_memory_runtime_config())
 }

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -643,6 +643,89 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn hydrate_stage_envelope_window_plus_summary_keeps_summary_retrieval_request() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-window-plus-summary");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("window-plus-summary.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 4,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        let envelope = hydrate_stage_envelope("stage-window-plus-summary", &config)
+            .expect("hydrate staged envelope");
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("window-plus-summary should advertise retrieval request");
+        assert_eq!(retrieval_request.budget_items, config.sliding_window);
+        assert_eq!(
+            retrieval_request.allowed_kinds,
+            vec![DerivedMemoryKind::Summary]
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_window_only_omits_summary_retrieval_request() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-window-only");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("window-only.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 4,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        let envelope =
+            hydrate_stage_envelope("stage-window-only", &config).expect("hydrate staged envelope");
+
+        assert_eq!(envelope.retrieval_request, None);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_profile_plus_window_omits_summary_retrieval_request() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-profile-plus-window");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("profile-plus-window.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::ProfilePlusWindow,
+            mode: MemoryMode::ProfilePlusWindow,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 4,
+            profile_note: Some("Imported ZeroClaw preferences".to_owned()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        let envelope = hydrate_stage_envelope("stage-profile-plus-window", &config)
+            .expect("hydrate staged envelope");
+
+        assert_eq!(envelope.retrieval_request, None);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn fail_open_memory_derivation_failure_keeps_recent_window_behavior() {
         let session_id = "fail-open-derivation";
         let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -2,10 +2,12 @@ use std::path::Path;
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
-use crate::config::MemorySystemKind;
+use crate::config::{MemoryMode, MemorySystemKind};
 
 use super::{
-    MemoryContextEntry, WindowTurn, load_prompt_context, runtime_config::MemoryRuntimeConfig,
+    DerivedMemoryKind, MemoryContextEntry, MemoryRetrievalRequest, MemoryScope, MemoryStageFamily,
+    StageDiagnostics, StageEnvelope, StageOutcome, WindowTurn, load_prompt_context,
+    runtime_config::MemoryRuntimeConfig,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,35 +116,95 @@ impl Drop for ScopedMemoryOrchestratorTestFaults {
 }
 
 impl BuiltinMemoryOrchestrator {
+    pub fn hydrate_stage_envelope(
+        &self,
+        session_id: &str,
+        workspace_root: Option<&Path>,
+        config: &MemoryRuntimeConfig,
+    ) -> Result<StageEnvelope, String> {
+        let recent_window = recent_window_records(session_id, config)?;
+        let mut entries = load_prompt_context(session_id, config)?;
+        let retrieval_request = build_builtin_retrieval_request(session_id, config);
+
+        let derive = run_pre_assembly_stage(MemoryStageFamily::Derive, config, || {
+            run_derivation_stage(session_id, config, &recent_window)
+        })?;
+        entries.extend(derive.records);
+
+        let retrieve = run_pre_assembly_stage(MemoryStageFamily::Retrieve, config, || {
+            run_retrieval_stage(session_id, workspace_root, config, &recent_window)
+        })?;
+        entries.extend(retrieve.records);
+
+        let rank = run_rank_stage(entries);
+        let diagnostics = vec![derive.diagnostics, retrieve.diagnostics, rank.diagnostics];
+
+        Ok(StageEnvelope {
+            hydrated: HydratedMemoryContext::from_stage_parts(
+                rank.records,
+                recent_window,
+                diagnostics.as_slice(),
+                config,
+            ),
+            retrieval_request,
+            diagnostics,
+        })
+    }
+
     pub fn hydrate(
         &self,
         session_id: &str,
         workspace_root: Option<&Path>,
         config: &MemoryRuntimeConfig,
     ) -> Result<HydratedMemoryContext, String> {
-        let recent_window = recent_window_records(session_id, config)?;
-        let mut entries = load_prompt_context(session_id, config)?;
-        let mut derivation_error = None;
-        let mut retrieval_error = None;
-        let fail_open = config.effective_fail_open();
+        Ok(self
+            .hydrate_stage_envelope(session_id, workspace_root, config)?
+            .hydrated)
+    }
+}
 
-        match run_derivation_stage(session_id, config, &recent_window) {
-            Ok(extra_entries) => entries.extend(extra_entries),
-            Err(error) if fail_open => derivation_error = Some(error),
-            Err(error) => return Err(format!("memory derivation stage failed: {error}")),
+impl HydratedMemoryContext {
+    fn from_stage_parts(
+        entries: Vec<MemoryContextEntry>,
+        recent_window: Vec<WindowTurn>,
+        stage_diagnostics: &[StageDiagnostics],
+        config: &MemoryRuntimeConfig,
+    ) -> Self {
+        let diagnostics = MemoryDiagnostics::from_stage_diagnostics(
+            config,
+            &recent_window,
+            &entries,
+            stage_diagnostics,
+        );
+
+        Self {
+            entries,
+            recent_window,
+            diagnostics,
         }
+    }
+}
 
-        match run_retrieval_stage(session_id, workspace_root, config, &recent_window) {
-            Ok(extra_entries) => entries.extend(extra_entries),
-            Err(error) if fail_open => retrieval_error = Some(error),
-            Err(error) => return Err(format!("memory retrieval stage failed: {error}")),
-        }
+impl MemoryDiagnostics {
+    fn from_stage_diagnostics(
+        config: &MemoryRuntimeConfig,
+        recent_window: &[WindowTurn],
+        entries: &[MemoryContextEntry],
+        stage_diagnostics: &[StageDiagnostics],
+    ) -> Self {
+        let derivation_error = stage_error_message(stage_diagnostics, MemoryStageFamily::Derive);
+        let retrieval_error = stage_error_message(stage_diagnostics, MemoryStageFamily::Retrieve);
+        let degraded = stage_diagnostics.iter().any(|diagnostic| {
+            matches!(
+                diagnostic.outcome,
+                StageOutcome::Fallback | StageOutcome::Failed
+            )
+        });
 
-        let degraded = derivation_error.is_some() || retrieval_error.is_some();
-        let diagnostics = MemoryDiagnostics {
+        Self {
             system_id: MemoryDiagnostics::normalize_system_id(config.system.as_str())
                 .unwrap_or_else(|| config.system.as_str().to_owned()),
-            fail_open,
+            fail_open: config.effective_fail_open(),
             strict_mode_requested: config.strict_mode_requested(),
             strict_mode_active: config.strict_mode_active(),
             degraded,
@@ -150,14 +212,78 @@ impl BuiltinMemoryOrchestrator {
             retrieval_error,
             recent_window_count: recent_window.len(),
             entry_count: entries.len(),
-        };
-
-        Ok(HydratedMemoryContext {
-            entries,
-            recent_window,
-            diagnostics,
-        })
+        }
     }
+}
+
+struct StageRunResult {
+    records: Vec<MemoryContextEntry>,
+    diagnostics: StageDiagnostics,
+}
+
+fn run_pre_assembly_stage<F>(
+    family: MemoryStageFamily,
+    config: &MemoryRuntimeConfig,
+    runner: F,
+) -> Result<StageRunResult, String>
+where
+    F: FnOnce() -> Result<Vec<MemoryContextEntry>, String>,
+{
+    match runner() {
+        Ok(records) => Ok(StageRunResult {
+            records,
+            diagnostics: StageDiagnostics::succeeded(family),
+        }),
+        Err(error) if config.effective_fail_open() => Ok(StageRunResult {
+            records: Vec::new(),
+            diagnostics: StageDiagnostics {
+                family,
+                outcome: StageOutcome::Fallback,
+                budget_ms: None,
+                elapsed_ms: None,
+                fallback_activated: true,
+                message: Some(error),
+            },
+        }),
+        Err(error) => Err(format!("memory {} stage failed: {error}", family.as_str())),
+    }
+}
+
+fn run_rank_stage(entries: Vec<MemoryContextEntry>) -> StageRunResult {
+    StageRunResult {
+        records: entries,
+        diagnostics: StageDiagnostics::succeeded(MemoryStageFamily::Rank),
+    }
+}
+
+fn build_builtin_retrieval_request(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Option<MemoryRetrievalRequest> {
+    if !matches!(config.mode, MemoryMode::WindowPlusSummary) {
+        return None;
+    }
+
+    Some(MemoryRetrievalRequest {
+        session_id: session_id.to_owned(),
+        query: None,
+        scopes: vec![MemoryScope::Session],
+        budget_items: config.sliding_window,
+        allowed_kinds: vec![DerivedMemoryKind::Summary],
+    })
+}
+
+fn stage_error_message(
+    stage_diagnostics: &[StageDiagnostics],
+    family: MemoryStageFamily,
+) -> Option<String> {
+    stage_diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.family == family)
+        .and_then(|diagnostic| match diagnostic.outcome {
+            StageOutcome::Fallback | StageOutcome::Failed => diagnostic.message.clone(),
+            StageOutcome::Succeeded | StageOutcome::Skipped => None,
+        })
 }
 
 fn run_derivation_stage(
@@ -203,9 +329,26 @@ pub fn hydrate_memory_context_with_workspace_root(
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
 ) -> Result<HydratedMemoryContext, String> {
+    Ok(
+        hydrate_stage_envelope_with_workspace_root(session_id, workspace_root, config)?.hydrated,
+    )
+}
+
+pub fn hydrate_stage_envelope(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+) -> Result<StageEnvelope, String> {
+    hydrate_stage_envelope_with_workspace_root(session_id, None, config)
+}
+
+fn hydrate_stage_envelope_with_workspace_root(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+) -> Result<StageEnvelope, String> {
     match config.system {
         MemorySystemKind::Builtin => {
-            BuiltinMemoryOrchestrator.hydrate(session_id, workspace_root, config)
+            BuiltinMemoryOrchestrator.hydrate_stage_envelope(session_id, workspace_root, config)
         }
     }
 }
@@ -239,7 +382,7 @@ fn recent_window_records(
 mod tests {
     use super::*;
     use crate::config::{MemoryMode, MemoryProfile};
-    use crate::memory::{MemoryContextKind, append_turn_direct};
+    use crate::memory::{MemoryContextKind, MemoryStageFamily, StageOutcome, append_turn_direct};
 
     fn hydrated_memory_temp_dir(prefix: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()))
@@ -390,6 +533,109 @@ mod tests {
                 .any(|entry| entry.content.contains("Imported ZeroClaw preferences")),
             "expected profile note content"
         );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_emits_builtin_stage_diagnostics_in_order() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-order");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("stage-order.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("stage-order", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("stage-order", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("stage-order", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let envelope =
+            hydrate_stage_envelope("stage-order", &config).expect("hydrate staged envelope");
+
+        assert_eq!(
+            envelope
+                .diagnostics
+                .iter()
+                .map(|diag| diag.family)
+                .collect::<Vec<_>>(),
+            vec![
+                MemoryStageFamily::Derive,
+                MemoryStageFamily::Retrieve,
+                MemoryStageFamily::Rank,
+            ]
+        );
+        assert!(
+            envelope
+                .diagnostics
+                .iter()
+                .all(|diag| diag.outcome == StageOutcome::Succeeded)
+        );
+        assert_eq!(
+            envelope
+                .retrieval_request
+                .as_ref()
+                .map(|req| req.budget_items),
+            Some(config.sliding_window)
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_fail_open_marks_fallback_without_losing_recent_window() {
+        let session_id = "stage-fail-open-derivation";
+        let _faults = ScopedMemoryOrchestratorTestFaults::set(MemoryOrchestratorTestFaults {
+            session_id: Some(session_id.to_owned()),
+            derivation_error: Some("synthetic derivation failure".to_owned()),
+            ..MemoryOrchestratorTestFaults::default()
+        });
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-fallback");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("stage-fallback.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct(session_id, "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct(session_id, "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct(session_id, "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let envelope = hydrate_stage_envelope(session_id, &config)
+            .expect("fail-open staged hydration should succeed");
+
+        assert_eq!(envelope.diagnostics[0].family, MemoryStageFamily::Derive);
+        assert_eq!(envelope.diagnostics[0].outcome, StageOutcome::Fallback);
+        assert!(envelope.diagnostics[0].fallback_activated);
+        assert_eq!(
+            envelope.diagnostics[0].message.as_deref(),
+            Some("synthetic derivation failure")
+        );
+        assert_eq!(envelope.hydrated.recent_window.len(), 2);
+        assert_eq!(envelope.hydrated.recent_window[0].content, "turn 2");
+        assert_eq!(envelope.hydrated.recent_window[1].content, "turn 3");
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -329,9 +329,7 @@ pub fn hydrate_memory_context_with_workspace_root(
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
 ) -> Result<HydratedMemoryContext, String> {
-    Ok(
-        hydrate_stage_envelope_with_workspace_root(session_id, workspace_root, config)?.hydrated,
-    )
+    Ok(hydrate_stage_envelope_with_workspace_root(session_id, workspace_root, config)?.hydrated)
 }
 
 pub fn hydrate_stage_envelope(
@@ -341,7 +339,7 @@ pub fn hydrate_stage_envelope(
     hydrate_stage_envelope_with_workspace_root(session_id, None, config)
 }
 
-fn hydrate_stage_envelope_with_workspace_root(
+pub(crate) fn hydrate_stage_envelope_with_workspace_root(
     session_id: &str,
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -17,7 +17,7 @@ pub struct HydratedMemoryContext {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryDiagnostics {
-    pub system_id: &'static str,
+    pub system_id: String,
     pub fail_open: bool,
     pub strict_mode_requested: bool,
     pub strict_mode_active: bool,
@@ -26,6 +26,17 @@ pub struct MemoryDiagnostics {
     pub retrieval_error: Option<String>,
     pub recent_window_count: usize,
     pub entry_count: usize,
+}
+
+impl MemoryDiagnostics {
+    pub fn normalize_system_id(raw: &str) -> Option<String> {
+        let normalized = raw.trim().to_ascii_lowercase();
+        if normalized.is_empty() {
+            None
+        } else {
+            Some(normalized)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -129,7 +140,8 @@ impl BuiltinMemoryOrchestrator {
 
         let degraded = derivation_error.is_some() || retrieval_error.is_some();
         let diagnostics = MemoryDiagnostics {
-            system_id: config.system.as_str(),
+            system_id: MemoryDiagnostics::normalize_system_id(config.system.as_str())
+                .unwrap_or_else(|| config.system.as_str().to_owned()),
             fail_open,
             strict_mode_requested: config.strict_mode_requested(),
             strict_mode_active: config.strict_mode_active(),

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -32,12 +32,7 @@ pub struct MemoryDiagnostics {
 
 impl MemoryDiagnostics {
     pub fn normalize_system_id(raw: &str) -> Option<String> {
-        let normalized = raw.trim().to_ascii_lowercase();
-        if normalized.is_empty() {
-            None
-        } else {
-            Some(normalized)
-        }
+        super::normalize_system_id(raw)
     }
 }
 
@@ -250,6 +245,8 @@ where
 }
 
 fn run_rank_stage(entries: Vec<MemoryContextEntry>) -> StageRunResult {
+    // Slice 1 keeps ranking as an identity stage until compaction and external
+    // ranking hooks graduate beyond the built-in pipeline contract.
     StageRunResult {
         records: entries,
         diagnostics: StageDiagnostics::succeeded(MemoryStageFamily::Rank),

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -14,6 +14,7 @@ pub const MEMORY_OP_WINDOW: &str = "window";
 pub const MEMORY_OP_CLEAR_SESSION: &str = "clear_session";
 pub const MEMORY_OP_READ_CONTEXT: &str = "read_context";
 pub const MEMORY_OP_REPLACE_TURNS: &str = "replace_turns";
+pub const MEMORY_OP_READ_STAGE_ENVELOPE: &str = "read_stage_envelope";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WindowTurn {
@@ -169,6 +170,15 @@ pub fn build_replace_turns_request_with_expectation(
     MemoryCoreRequest {
         operation: MEMORY_OP_REPLACE_TURNS.to_owned(),
         payload: Value::Object(payload),
+    }
+}
+
+pub fn build_read_stage_envelope_request(session_id: &str) -> MemoryCoreRequest {
+    MemoryCoreRequest {
+        operation: MEMORY_OP_READ_STAGE_ENVELOPE.to_owned(),
+        payload: json!({
+            "session_id": session_id,
+        }),
     }
 }
 

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use loongclaw_contracts::MemoryCoreRequest;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -179,6 +181,34 @@ pub fn build_read_stage_envelope_request(session_id: &str) -> MemoryCoreRequest 
         payload: json!({
             "session_id": session_id,
         }),
+    }
+}
+
+pub fn build_read_stage_envelope_request_with_workspace_root(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+) -> MemoryCoreRequest {
+    let mut payload = serde_json::Map::from_iter([("session_id".to_owned(), json!(session_id))]);
+
+    if let Some(workspace_root) = workspace_root {
+        payload.insert(
+            "workspace_root".to_owned(),
+            json!(workspace_root.to_string_lossy().to_string()),
+        );
+    }
+
+    payload.insert("profile".to_owned(), json!(config.profile.as_str()));
+    payload.insert("sliding_window".to_owned(), json!(config.sliding_window));
+    payload.insert(
+        "summary_max_chars".to_owned(),
+        json!(config.summary_max_chars),
+    );
+    payload.insert("profile_note".to_owned(), json!(config.profile_note));
+
+    MemoryCoreRequest {
+        operation: MEMORY_OP_READ_STAGE_ENVELOPE.to_owned(),
+        payload: Value::Object(payload),
     }
 }
 

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -5,9 +5,8 @@ use serde_json::{Value, json};
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::{
-    DEFAULT_MEMORY_SYSTEM_ID, DerivedMemoryKind, HydratedMemoryContext, MemoryDiagnostics,
-    MemoryRetrievalRequest, MemoryScope, MemoryStageFamily, StageDiagnostics, StageEnvelope,
-    StageOutcome,
+    DerivedMemoryKind, HydratedMemoryContext, MemoryDiagnostics, MemoryRetrievalRequest,
+    MemoryScope, MemoryStageFamily, StageDiagnostics, StageEnvelope, StageOutcome,
 };
 
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
@@ -350,7 +349,7 @@ fn decode_memory_diagnostics_payload(
     payload: MemoryDiagnosticsPayload,
 ) -> Option<MemoryDiagnostics> {
     Some(MemoryDiagnostics {
-        system_id: decode_memory_system_id(payload.system_id.as_str())?,
+        system_id: MemoryDiagnostics::normalize_system_id(payload.system_id.as_str())?,
         fail_open: payload.fail_open,
         strict_mode_requested: payload.strict_mode_requested,
         strict_mode_active: payload.strict_mode_active,
@@ -397,16 +396,10 @@ fn decode_stage_diagnostics_payload(payload: StageDiagnosticsPayload) -> Option<
     })
 }
 
-fn decode_memory_system_id(raw: &str) -> Option<&'static str> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        DEFAULT_MEMORY_SYSTEM_ID => Some(DEFAULT_MEMORY_SYSTEM_ID),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::{MemoryStageFamily, StageOutcome};
 
     #[test]
     fn decode_window_turns_tolerates_partial_payload_shape() {
@@ -443,5 +436,61 @@ mod tests {
         assert_eq!(decode_window_turn_count(&json!({"turn_count": 7})), Some(7));
         assert_eq!(decode_window_turn_count(&json!({"turn_count": null})), None);
         assert_eq!(decode_window_turn_count(&json!({})), None);
+    }
+
+    #[test]
+    fn decode_stage_envelope_tolerates_omitted_optional_fields() {
+        let payload = json!({
+            "hydrated": {
+                "diagnostics": {
+                    "system_id": " builtin "
+                }
+            },
+            "retrieval_request": {
+                "session_id": "session-123"
+            },
+            "diagnostics": [
+                {
+                    "family": "derive",
+                    "outcome": "succeeded"
+                },
+                {
+                    "family": "rank",
+                    "outcome": "skipped"
+                }
+            ]
+        });
+
+        let envelope = decode_stage_envelope(&payload).expect("decode stage envelope");
+        assert!(envelope.hydrated.entries.is_empty());
+        assert!(envelope.hydrated.recent_window.is_empty());
+        assert_eq!(envelope.hydrated.diagnostics.system_id, "builtin");
+        assert!(!envelope.hydrated.diagnostics.fail_open);
+        assert!(!envelope.hydrated.diagnostics.strict_mode_requested);
+        assert!(!envelope.hydrated.diagnostics.strict_mode_active);
+        assert!(!envelope.hydrated.diagnostics.degraded);
+        assert_eq!(envelope.hydrated.diagnostics.derivation_error, None);
+        assert_eq!(envelope.hydrated.diagnostics.retrieval_error, None);
+        assert_eq!(envelope.hydrated.diagnostics.recent_window_count, 0);
+        assert_eq!(envelope.hydrated.diagnostics.entry_count, 0);
+
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("retrieval request should decode");
+        assert_eq!(retrieval_request.session_id, "session-123");
+        assert_eq!(retrieval_request.query, None);
+        assert!(retrieval_request.scopes.is_empty());
+        assert_eq!(retrieval_request.budget_items, 0);
+        assert!(retrieval_request.allowed_kinds.is_empty());
+
+        assert_eq!(envelope.diagnostics.len(), 2);
+        assert_eq!(envelope.diagnostics[0].family, MemoryStageFamily::Derive);
+        assert_eq!(envelope.diagnostics[0].outcome, StageOutcome::Succeeded);
+        assert_eq!(envelope.diagnostics[0].budget_ms, None);
+        assert_eq!(envelope.diagnostics[0].elapsed_ms, None);
+        assert!(!envelope.diagnostics[0].fallback_activated);
+        assert_eq!(envelope.diagnostics[0].message, None);
+        assert_eq!(envelope.diagnostics[1].family, MemoryStageFamily::Rank);
+        assert_eq!(envelope.diagnostics[1].outcome, StageOutcome::Skipped);
     }
 }

--- a/crates/app/src/memory/protocol.rs
+++ b/crates/app/src/memory/protocol.rs
@@ -4,6 +4,12 @@ use serde_json::{Value, json};
 
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
+use super::{
+    DEFAULT_MEMORY_SYSTEM_ID, DerivedMemoryKind, HydratedMemoryContext, MemoryDiagnostics,
+    MemoryRetrievalRequest, MemoryScope, MemoryStageFamily, StageDiagnostics, StageEnvelope,
+    StageOutcome,
+};
+
 pub const MEMORY_OP_APPEND_TURN: &str = "append_turn";
 pub const MEMORY_OP_WINDOW: &str = "window";
 pub const MEMORY_OP_CLEAR_SESSION: &str = "clear_session";
@@ -31,6 +37,80 @@ pub struct MemoryContextEntry {
     pub kind: MemoryContextKind,
     pub role: String,
     pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct WindowTurnPayload {
+    role: String,
+    content: String,
+    #[serde(default)]
+    ts: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MemoryDiagnosticsPayload {
+    system_id: String,
+    #[serde(default)]
+    fail_open: bool,
+    #[serde(default)]
+    strict_mode_requested: bool,
+    #[serde(default)]
+    strict_mode_active: bool,
+    #[serde(default)]
+    degraded: bool,
+    #[serde(default)]
+    derivation_error: Option<String>,
+    #[serde(default)]
+    retrieval_error: Option<String>,
+    #[serde(default)]
+    recent_window_count: usize,
+    #[serde(default)]
+    entry_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct HydratedMemoryContextPayload {
+    #[serde(default)]
+    entries: Vec<MemoryContextEntry>,
+    #[serde(default)]
+    recent_window: Vec<WindowTurnPayload>,
+    diagnostics: Option<MemoryDiagnosticsPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MemoryRetrievalRequestPayload {
+    session_id: String,
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    scopes: Vec<String>,
+    #[serde(default)]
+    budget_items: Option<usize>,
+    #[serde(default)]
+    allowed_kinds: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct StageDiagnosticsPayload {
+    family: String,
+    outcome: String,
+    #[serde(default)]
+    budget_ms: Option<u64>,
+    #[serde(default)]
+    elapsed_ms: Option<u64>,
+    #[serde(default)]
+    fallback_activated: bool,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct StageEnvelopePayload {
+    hydrated: Option<HydratedMemoryContextPayload>,
+    #[serde(default)]
+    retrieval_request: Option<MemoryRetrievalRequestPayload>,
+    #[serde(default)]
+    diagnostics: Vec<StageDiagnosticsPayload>,
 }
 
 pub fn build_append_turn_request(session_id: &str, role: &str, content: &str) -> MemoryCoreRequest {
@@ -128,6 +208,200 @@ pub fn decode_memory_context_entries(payload: &Value) -> Vec<MemoryContextEntry>
         .cloned()
         .and_then(|entries| serde_json::from_value(entries).ok())
         .unwrap_or_default()
+}
+
+pub fn encode_stage_envelope_payload(envelope: &StageEnvelope) -> Value {
+    serde_json::to_value(StageEnvelopePayload::from(envelope)).unwrap_or(Value::Null)
+}
+
+pub fn decode_stage_envelope(payload: &Value) -> Option<StageEnvelope> {
+    let payload = serde_json::from_value::<StageEnvelopePayload>(payload.clone()).ok()?;
+
+    Some(StageEnvelope {
+        hydrated: decode_hydrated_memory_context_payload(payload.hydrated?)?,
+        retrieval_request: payload
+            .retrieval_request
+            .and_then(decode_memory_retrieval_request_payload),
+        diagnostics: payload
+            .diagnostics
+            .into_iter()
+            .filter_map(decode_stage_diagnostics_payload)
+            .collect(),
+    })
+}
+
+impl From<&WindowTurn> for WindowTurnPayload {
+    fn from(value: &WindowTurn) -> Self {
+        Self {
+            role: value.role.clone(),
+            content: value.content.clone(),
+            ts: value.ts,
+        }
+    }
+}
+
+impl From<&MemoryDiagnostics> for MemoryDiagnosticsPayload {
+    fn from(value: &MemoryDiagnostics) -> Self {
+        Self {
+            system_id: value.system_id.to_owned(),
+            fail_open: value.fail_open,
+            strict_mode_requested: value.strict_mode_requested,
+            strict_mode_active: value.strict_mode_active,
+            degraded: value.degraded,
+            derivation_error: value.derivation_error.clone(),
+            retrieval_error: value.retrieval_error.clone(),
+            recent_window_count: value.recent_window_count,
+            entry_count: value.entry_count,
+        }
+    }
+}
+
+impl From<&HydratedMemoryContext> for HydratedMemoryContextPayload {
+    fn from(value: &HydratedMemoryContext) -> Self {
+        Self {
+            entries: value.entries.clone(),
+            recent_window: value
+                .recent_window
+                .iter()
+                .map(WindowTurnPayload::from)
+                .collect(),
+            diagnostics: Some(MemoryDiagnosticsPayload::from(&value.diagnostics)),
+        }
+    }
+}
+
+impl From<&MemoryRetrievalRequest> for MemoryRetrievalRequestPayload {
+    fn from(value: &MemoryRetrievalRequest) -> Self {
+        Self {
+            session_id: value.session_id.clone(),
+            query: value.query.clone(),
+            scopes: value
+                .scopes
+                .iter()
+                .copied()
+                .map(MemoryScope::as_str)
+                .map(str::to_owned)
+                .collect(),
+            budget_items: Some(value.budget_items),
+            allowed_kinds: value
+                .allowed_kinds
+                .iter()
+                .copied()
+                .map(DerivedMemoryKind::as_str)
+                .map(str::to_owned)
+                .collect(),
+        }
+    }
+}
+
+impl From<&StageDiagnostics> for StageDiagnosticsPayload {
+    fn from(value: &StageDiagnostics) -> Self {
+        Self {
+            family: value.family.as_str().to_owned(),
+            outcome: value.outcome.as_str().to_owned(),
+            budget_ms: value.budget_ms,
+            elapsed_ms: value.elapsed_ms,
+            fallback_activated: value.fallback_activated,
+            message: value.message.clone(),
+        }
+    }
+}
+
+impl From<&StageEnvelope> for StageEnvelopePayload {
+    fn from(value: &StageEnvelope) -> Self {
+        Self {
+            hydrated: Some(HydratedMemoryContextPayload::from(&value.hydrated)),
+            retrieval_request: value
+                .retrieval_request
+                .as_ref()
+                .map(MemoryRetrievalRequestPayload::from),
+            diagnostics: value
+                .diagnostics
+                .iter()
+                .map(StageDiagnosticsPayload::from)
+                .collect(),
+        }
+    }
+}
+
+fn decode_hydrated_memory_context_payload(
+    payload: HydratedMemoryContextPayload,
+) -> Option<HydratedMemoryContext> {
+    Some(HydratedMemoryContext {
+        entries: payload.entries,
+        recent_window: payload
+            .recent_window
+            .into_iter()
+            .map(decode_window_turn_payload)
+            .collect(),
+        diagnostics: decode_memory_diagnostics_payload(payload.diagnostics?)?,
+    })
+}
+
+fn decode_window_turn_payload(payload: WindowTurnPayload) -> WindowTurn {
+    WindowTurn {
+        role: payload.role,
+        content: payload.content,
+        ts: payload.ts,
+    }
+}
+
+fn decode_memory_diagnostics_payload(
+    payload: MemoryDiagnosticsPayload,
+) -> Option<MemoryDiagnostics> {
+    Some(MemoryDiagnostics {
+        system_id: decode_memory_system_id(payload.system_id.as_str())?,
+        fail_open: payload.fail_open,
+        strict_mode_requested: payload.strict_mode_requested,
+        strict_mode_active: payload.strict_mode_active,
+        degraded: payload.degraded,
+        derivation_error: payload.derivation_error,
+        retrieval_error: payload.retrieval_error,
+        recent_window_count: payload.recent_window_count,
+        entry_count: payload.entry_count,
+    })
+}
+
+fn decode_memory_retrieval_request_payload(
+    payload: MemoryRetrievalRequestPayload,
+) -> Option<MemoryRetrievalRequest> {
+    if payload.session_id.trim().is_empty() {
+        return None;
+    }
+
+    Some(MemoryRetrievalRequest {
+        session_id: payload.session_id,
+        query: payload.query,
+        scopes: payload
+            .scopes
+            .into_iter()
+            .filter_map(|scope| MemoryScope::parse_id(scope.as_str()))
+            .collect(),
+        budget_items: payload.budget_items.unwrap_or_default(),
+        allowed_kinds: payload
+            .allowed_kinds
+            .into_iter()
+            .filter_map(|kind| DerivedMemoryKind::parse_id(kind.as_str()))
+            .collect(),
+    })
+}
+
+fn decode_stage_diagnostics_payload(payload: StageDiagnosticsPayload) -> Option<StageDiagnostics> {
+    Some(StageDiagnostics {
+        family: MemoryStageFamily::parse_id(payload.family.as_str())?,
+        outcome: StageOutcome::parse_id(payload.outcome.as_str())?,
+        budget_ms: payload.budget_ms,
+        elapsed_ms: payload.elapsed_ms,
+        fallback_activated: payload.fallback_activated,
+        message: payload.message,
+    })
+}
+
+fn decode_memory_system_id(raw: &str) -> Option<&'static str> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        DEFAULT_MEMORY_SYSTEM_ID => Some(DEFAULT_MEMORY_SYSTEM_ID),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/app/src/memory/stage.rs
+++ b/crates/app/src/memory/stage.rs
@@ -1,0 +1,208 @@
+use super::{HydratedMemoryContext, MemoryScope};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryStageFamily {
+    Derive,
+    Retrieve,
+    Rank,
+    AfterTurn,
+    Compact,
+}
+
+impl MemoryStageFamily {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Derive => "derive",
+            Self::Retrieve => "retrieve",
+            Self::Rank => "rank",
+            Self::AfterTurn => "after_turn",
+            Self::Compact => "compact",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "derive" => Some(Self::Derive),
+            "retrieve" => Some(Self::Retrieve),
+            "rank" => Some(Self::Rank),
+            "after_turn" => Some(Self::AfterTurn),
+            "compact" => Some(Self::Compact),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StageOutcome {
+    Succeeded,
+    Fallback,
+    Failed,
+    Skipped,
+}
+
+impl StageOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::Fallback => "fallback",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "succeeded" => Some(Self::Succeeded),
+            "fallback" => Some(Self::Fallback),
+            "failed" => Some(Self::Failed),
+            "skipped" => Some(Self::Skipped),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DerivedMemoryKind {
+    Summary,
+    Profile,
+    Fact,
+    Entity,
+    Episode,
+    Procedure,
+    Overview,
+}
+
+impl DerivedMemoryKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Summary => "summary",
+            Self::Profile => "profile",
+            Self::Fact => "fact",
+            Self::Entity => "entity",
+            Self::Episode => "episode",
+            Self::Procedure => "procedure",
+            Self::Overview => "overview",
+        }
+    }
+
+    pub fn parse_id(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "summary" => Some(Self::Summary),
+            "profile" => Some(Self::Profile),
+            "fact" => Some(Self::Fact),
+            "entity" => Some(Self::Entity),
+            "episode" => Some(Self::Episode),
+            "procedure" => Some(Self::Procedure),
+            "overview" => Some(Self::Overview),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryRetrievalRequest {
+    pub session_id: String,
+    pub query: Option<String>,
+    pub scopes: Vec<MemoryScope>,
+    pub budget_items: usize,
+    pub allowed_kinds: Vec<DerivedMemoryKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StageDiagnostics {
+    pub family: MemoryStageFamily,
+    pub outcome: StageOutcome,
+    pub budget_ms: Option<u64>,
+    pub elapsed_ms: Option<u64>,
+    pub fallback_activated: bool,
+    pub message: Option<String>,
+}
+
+impl StageDiagnostics {
+    pub fn succeeded(family: MemoryStageFamily) -> Self {
+        Self {
+            family,
+            outcome: StageOutcome::Succeeded,
+            budget_ms: None,
+            elapsed_ms: None,
+            fallback_activated: false,
+            message: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StageEnvelope {
+    pub hydrated: HydratedMemoryContext,
+    pub retrieval_request: Option<MemoryRetrievalRequest>,
+    pub diagnostics: Vec<StageDiagnostics>,
+}
+
+pub fn builtin_pre_assembly_stage_families() -> Vec<MemoryStageFamily> {
+    vec![
+        MemoryStageFamily::Derive,
+        MemoryStageFamily::Retrieve,
+        MemoryStageFamily::Rank,
+    ]
+}
+
+pub fn builtin_post_turn_stage_families() -> Vec<MemoryStageFamily> {
+    vec![MemoryStageFamily::AfterTurn]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::{
+        HydratedMemoryContext, MemoryDiagnostics, MemoryScope, decode_stage_envelope,
+        encode_stage_envelope_payload,
+    };
+
+    #[test]
+    fn stage_families_have_stable_builtin_order() {
+        assert_eq!(
+            builtin_pre_assembly_stage_families(),
+            vec![
+                MemoryStageFamily::Derive,
+                MemoryStageFamily::Retrieve,
+                MemoryStageFamily::Rank,
+            ]
+        );
+        assert_eq!(
+            builtin_post_turn_stage_families(),
+            vec![MemoryStageFamily::AfterTurn]
+        );
+    }
+
+    #[test]
+    fn stage_envelope_round_trips_through_protocol_payload() {
+        let envelope = StageEnvelope {
+            hydrated: HydratedMemoryContext {
+                entries: vec![],
+                recent_window: vec![],
+                diagnostics: MemoryDiagnostics {
+                    system_id: "builtin",
+                    fail_open: true,
+                    strict_mode_requested: false,
+                    strict_mode_active: false,
+                    degraded: false,
+                    derivation_error: None,
+                    retrieval_error: None,
+                    recent_window_count: 0,
+                    entry_count: 0,
+                },
+            },
+            retrieval_request: Some(MemoryRetrievalRequest {
+                session_id: "session-123".to_owned(),
+                query: None,
+                scopes: vec![MemoryScope::Session],
+                budget_items: 8,
+                allowed_kinds: vec![DerivedMemoryKind::Summary],
+            }),
+            diagnostics: vec![StageDiagnostics::succeeded(MemoryStageFamily::Derive)],
+        };
+
+        let payload = encode_stage_envelope_payload(&envelope);
+        assert_eq!(decode_stage_envelope(&payload), Some(envelope));
+    }
+}

--- a/crates/app/src/memory/stage.rs
+++ b/crates/app/src/memory/stage.rs
@@ -139,6 +139,7 @@ pub struct StageEnvelope {
 }
 
 pub fn builtin_pre_assembly_stage_families() -> Vec<MemoryStageFamily> {
+    // `Compact` stays part of the declared vocabulary but is intentionally inactive in slice 1.
     vec![
         MemoryStageFamily::Derive,
         MemoryStageFamily::Retrieve,
@@ -181,7 +182,7 @@ mod tests {
                 entries: vec![],
                 recent_window: vec![],
                 diagnostics: MemoryDiagnostics {
-                    system_id: "builtin",
+                    system_id: "builtin".to_owned(),
                     fail_open: true,
                     strict_mode_requested: false,
                     strict_mode_active: false,
@@ -204,5 +205,42 @@ mod tests {
 
         let payload = encode_stage_envelope_payload(&envelope);
         assert_eq!(decode_stage_envelope(&payload), Some(envelope));
+    }
+
+    #[test]
+    fn stage_envelope_round_trips_non_builtin_system_id_through_protocol_payload() {
+        let envelope = StageEnvelope {
+            hydrated: HydratedMemoryContext {
+                entries: vec![],
+                recent_window: vec![],
+                diagnostics: MemoryDiagnostics {
+                    system_id: "Lucid".to_owned(),
+                    fail_open: false,
+                    strict_mode_requested: false,
+                    strict_mode_active: false,
+                    degraded: false,
+                    derivation_error: None,
+                    retrieval_error: None,
+                    recent_window_count: 0,
+                    entry_count: 0,
+                },
+            },
+            retrieval_request: None,
+            diagnostics: vec![],
+        };
+
+        let payload = encode_stage_envelope_payload(&envelope);
+        let decoded = decode_stage_envelope(&payload).expect("decode stage envelope");
+        assert_eq!(decoded.hydrated.diagnostics.system_id, "lucid");
+    }
+
+    #[test]
+    fn compact_stage_family_is_reserved_but_not_in_builtin_slice_one_ordering() {
+        assert_eq!(
+            MemoryStageFamily::parse_id("compact"),
+            Some(MemoryStageFamily::Compact)
+        );
+        assert!(!builtin_pre_assembly_stage_families().contains(&MemoryStageFamily::Compact));
+        assert!(!builtin_post_turn_stage_families().contains(&MemoryStageFamily::Compact));
     }
 }

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -92,10 +92,6 @@ fn registry() -> &'static RwLock<BTreeMap<String, MemorySystemFactory>> {
     })
 }
 
-fn normalize_system_id(raw: &str) -> String {
-    raw.trim().to_ascii_lowercase()
-}
-
 #[cfg(test)]
 fn env_override() -> &'static Mutex<Option<Option<String>>> {
     MEMORY_SYSTEM_ENV_OVERRIDE.get_or_init(|| Mutex::new(None))
@@ -105,10 +101,8 @@ pub fn register_memory_system<F>(id: &str, factory: F) -> CliResult<()>
 where
     F: Fn() -> Box<dyn MemorySystem> + Send + Sync + 'static,
 {
-    let normalized = normalize_system_id(id);
-    if normalized.is_empty() {
-        return Err("memory system id must not be empty".to_owned());
-    }
+    let normalized = super::normalize_system_id(id)
+        .ok_or_else(|| "memory system id must not be empty".to_owned())?;
     if normalized == DEFAULT_MEMORY_SYSTEM_ID {
         return Err(format!(
             "memory system `{DEFAULT_MEMORY_SYSTEM_ID}` is reserved and cannot be overridden"
@@ -116,9 +110,11 @@ where
     }
 
     let system = factory();
-    let runtime_id = normalize_system_id(system.id());
+    let runtime_id = super::normalize_system_id(system.id())
+        .ok_or_else(|| "memory system runtime id must not be empty".to_owned())?;
     let metadata = system.metadata();
-    let metadata_id = normalize_system_id(metadata.id);
+    let metadata_id = super::normalize_system_id(metadata.id)
+        .ok_or_else(|| "memory system metadata id must not be empty".to_owned())?;
     if runtime_id != normalized || metadata_id != normalized {
         return Err(format!(
             "registered memory system id `{normalized}` must match system.id `{}` and metadata.id `{}`",
@@ -155,8 +151,7 @@ pub fn list_memory_system_metadata() -> CliResult<Vec<MemorySystemMetadata>> {
 
 pub fn resolve_memory_system(id: Option<&str>) -> CliResult<Box<dyn MemorySystem>> {
     let normalized = id
-        .map(normalize_system_id)
-        .filter(|value| !value.is_empty())
+        .and_then(super::normalize_system_id)
         .unwrap_or_else(|| DEFAULT_MEMORY_SYSTEM_ID.to_owned());
 
     let guard = registry()
@@ -185,8 +180,7 @@ pub fn memory_system_id_from_env() -> Option<String> {
 
     std::env::var(MEMORY_SYSTEM_ENV)
         .ok()
-        .map(|value| normalize_system_id(value.as_str()))
-        .filter(|value| !value.is_empty())
+        .and_then(|value| super::normalize_system_id(value.as_str()))
 }
 
 pub fn supported_memory_system_kind_from_env() -> Option<MemorySystemKind> {
@@ -235,9 +229,7 @@ pub fn collect_memory_system_runtime_snapshot(
 
 #[cfg(test)]
 pub(crate) fn set_memory_system_env_override(value: Option<&str>) {
-    let normalized = value
-        .map(normalize_system_id)
-        .filter(|entry| !entry.is_empty());
+    let normalized = value.and_then(super::normalize_system_id);
     if let Ok(mut guard) = env_override().lock() {
         *guard = Some(normalized);
     }

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -156,22 +156,7 @@ pub fn build_system_message(
     request_message_runtime::build_system_message(config, include_system_prompt)
 }
 
-pub(crate) async fn build_base_messages_with_binding(
-    config: &LoongClawConfig,
-    include_system_prompt: bool,
-    binding: ProviderRuntimeBinding<'_>,
-) -> Vec<Value> {
-    request_message_runtime::build_base_messages_with_binding(
-        config,
-        include_system_prompt,
-        binding,
-    )
-    .await
-}
-
-pub(crate) fn push_history_message(messages: &mut Vec<Value>, role: &str, content: &str) {
-    request_message_runtime::push_history_message(messages, role, content);
-}
+pub(crate) use request_message_runtime::project_hydrated_memory_context_for_view_with_binding;
 
 pub fn build_messages_for_session(
     config: &LoongClawConfig,

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -156,6 +156,7 @@ pub fn build_system_message(
     request_message_runtime::build_system_message(config, include_system_prompt)
 }
 
+pub(crate) use request_message_runtime::build_projected_context_for_session;
 pub(crate) use request_message_runtime::project_hydrated_memory_context_for_view_with_binding;
 
 pub fn build_messages_for_session(

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -8,12 +8,21 @@ use super::runtime_binding::ProviderRuntimeBinding;
 use crate::CliResult;
 use crate::KernelContext;
 use crate::config::LoongClawConfig;
+use crate::conversation::{
+    ContextArtifactDescriptor, ContextArtifactKind, ToolOutputStreamingPolicy,
+};
 use crate::runtime_identity;
 use crate::runtime_self;
 use crate::tools::{self, ToolView};
 
 #[cfg(feature = "memory-sqlite")]
 use crate::memory;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectedMessageContext {
+    pub messages: Vec<Value>,
+    pub artifacts: Vec<ContextArtifactDescriptor>,
+}
 
 pub(super) fn build_system_message(
     config: &LoongClawConfig,
@@ -35,6 +44,7 @@ pub(super) fn build_system_message_for_view(
     )
 }
 
+#[cfg(test)]
 pub(super) async fn build_base_messages_with_binding(
     config: &LoongClawConfig,
     include_system_prompt: bool,
@@ -179,6 +189,27 @@ pub(super) fn build_base_messages_for_view(
         .collect()
 }
 
+fn build_base_artifacts(messages: &[Value]) -> Vec<ContextArtifactDescriptor> {
+    if messages.is_empty() {
+        return Vec::new();
+    }
+
+    vec![
+        ContextArtifactDescriptor {
+            message_index: 0,
+            artifact_kind: ContextArtifactKind::SystemPrompt,
+            maskable: false,
+            streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+        },
+        ContextArtifactDescriptor {
+            message_index: 0,
+            artifact_kind: ContextArtifactKind::RuntimeContract,
+            maskable: false,
+            streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+        },
+    ]
+}
+
 async fn load_runtime_self_model_with_binding(
     workspace_root: &Path,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
@@ -271,46 +302,96 @@ pub(super) fn build_messages_for_session_in_view(
     include_system_prompt: bool,
     tool_view: &ToolView,
 ) -> CliResult<Vec<Value>> {
-    let mut messages = build_base_messages_for_view(config, include_system_prompt, tool_view);
-    messages.extend(load_memory_window_messages(config, session_id)?);
-    Ok(messages)
-}
-
-pub(super) fn load_memory_window_messages(
-    config: &LoongClawConfig,
-    session_id: &str,
-) -> CliResult<Vec<Value>> {
     #[cfg(feature = "memory-sqlite")]
     {
         let mem_config =
             memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-        let workspace_root = config
-            .tools
-            .file_root
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(|_| config.tools.resolved_file_root());
+        let workspace_root = resolved_workspace_root(config);
         let hydrated = memory::hydrate_memory_context_with_workspace_root(
             session_id,
             workspace_root.as_deref(),
             &mem_config,
         )
         .map_err(|error| format!("hydrate prompt memory context failed: {error}"))?;
-        let mut messages = Vec::with_capacity(hydrated.entries.len());
-        append_hydrated_memory_messages(&mut messages, &hydrated);
-        Ok(messages)
+        Ok(project_hydrated_memory_context_for_view(
+            config,
+            include_system_prompt,
+            tool_view,
+            &hydrated,
+        )
+        .messages)
     }
+
     #[cfg(not(feature = "memory-sqlite"))]
     {
-        let _ = (config, session_id);
-        Ok(Vec::new())
+        let _ = session_id;
+        Ok(build_base_messages_for_view(
+            config,
+            include_system_prompt,
+            tool_view,
+        ))
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolved_workspace_root(config: &LoongClawConfig) -> Option<std::path::PathBuf> {
+    config
+        .tools
+        .file_root
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|_| config.tools.resolved_file_root())
+}
+
+pub(crate) async fn project_hydrated_memory_context_for_view_with_binding(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+    tool_view: &ToolView,
+    binding: ProviderRuntimeBinding<'_>,
+    #[cfg(feature = "memory-sqlite")] hydrated: &memory::HydratedMemoryContext,
+) -> ProjectedMessageContext {
+    let system_message = build_system_message_for_view_with_binding(
+        config,
+        include_system_prompt,
+        tool_view,
+        binding,
+    )
+    .await;
+    let mut messages = system_message.into_iter().collect::<Vec<_>>();
+    let mut artifacts = build_base_artifacts(messages.as_slice());
+
+    #[cfg(feature = "memory-sqlite")]
+    append_hydrated_memory_messages(&mut messages, &mut artifacts, hydrated);
+
+    ProjectedMessageContext {
+        messages,
+        artifacts,
+    }
+}
+
+pub(crate) fn project_hydrated_memory_context_for_view(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+    tool_view: &ToolView,
+    #[cfg(feature = "memory-sqlite")] hydrated: &memory::HydratedMemoryContext,
+) -> ProjectedMessageContext {
+    let mut messages = build_base_messages_for_view(config, include_system_prompt, tool_view);
+    let mut artifacts = build_base_artifacts(messages.as_slice());
+
+    #[cfg(feature = "memory-sqlite")]
+    append_hydrated_memory_messages(&mut messages, &mut artifacts, hydrated);
+
+    ProjectedMessageContext {
+        messages,
+        artifacts,
     }
 }
 
 #[cfg(feature = "memory-sqlite")]
 fn append_hydrated_memory_messages(
     messages: &mut Vec<Value>,
+    artifacts: &mut Vec<ContextArtifactDescriptor>,
     hydrated: &memory::HydratedMemoryContext,
 ) {
     for entry in &hydrated.entries {
@@ -318,13 +399,36 @@ fn append_hydrated_memory_messages(
             memory::MemoryContextKind::Profile
             | memory::MemoryContextKind::Summary
             | memory::MemoryContextKind::RetrievedMemory => {
+                let message_index = messages.len();
                 messages.push(json!({
                     "role": entry.role,
                     "content": entry.content,
                 }));
+                artifacts.push(ContextArtifactDescriptor {
+                    message_index,
+                    artifact_kind: match entry.kind {
+                        memory::MemoryContextKind::Profile => ContextArtifactKind::Profile,
+                        memory::MemoryContextKind::Summary => ContextArtifactKind::Summary,
+                        memory::MemoryContextKind::RetrievedMemory => {
+                            ContextArtifactKind::RetrievedMemory
+                        }
+                        memory::MemoryContextKind::Turn => ContextArtifactKind::ConversationTurn,
+                    },
+                    maskable: false,
+                    streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+                });
             }
             memory::MemoryContextKind::Turn => {
+                let original_len = messages.len();
                 push_history_message(messages, entry.role.as_str(), entry.content.as_str());
+                if messages.len() != original_len {
+                    artifacts.push(ContextArtifactDescriptor {
+                        message_index: original_len,
+                        artifact_kind: ContextArtifactKind::ConversationTurn,
+                        maskable: false,
+                        streaming_policy: ToolOutputStreamingPolicy::BufferFull,
+                    });
+                }
             }
         }
     }

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -288,7 +288,21 @@ pub(super) fn build_messages_for_session(
     session_id: &str,
     include_system_prompt: bool,
 ) -> CliResult<Vec<Value>> {
-    build_messages_for_session_in_view(
+    build_projected_context_for_session_in_view(
+        config,
+        session_id,
+        include_system_prompt,
+        &tools::runtime_tool_view(),
+    )
+    .map(|projected| projected.messages)
+}
+
+pub(crate) fn build_projected_context_for_session(
+    config: &LoongClawConfig,
+    session_id: &str,
+    include_system_prompt: bool,
+) -> CliResult<ProjectedMessageContext> {
+    build_projected_context_for_session_in_view(
         config,
         session_id,
         include_system_prompt,
@@ -296,12 +310,12 @@ pub(super) fn build_messages_for_session(
     )
 }
 
-pub(super) fn build_messages_for_session_in_view(
+pub(crate) fn build_projected_context_for_session_in_view(
     config: &LoongClawConfig,
     session_id: &str,
     include_system_prompt: bool,
     tool_view: &ToolView,
-) -> CliResult<Vec<Value>> {
+) -> CliResult<ProjectedMessageContext> {
     #[cfg(feature = "memory-sqlite")]
     {
         let mem_config =
@@ -318,18 +332,16 @@ pub(super) fn build_messages_for_session_in_view(
             include_system_prompt,
             tool_view,
             &hydrated,
-        )
-        .messages)
+        ))
     }
 
     #[cfg(not(feature = "memory-sqlite"))]
     {
         let _ = session_id;
-        Ok(build_base_messages_for_view(
-            config,
-            include_system_prompt,
-            tool_view,
-        ))
+        Ok(ProjectedMessageContext {
+            messages: build_base_messages_for_view(config, include_system_prompt, tool_view),
+            artifacts: Vec::new(),
+        })
     }
 }
 

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-24T09:15:02Z
+- Generated at: 2026-03-24T09:17:14Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -14,7 +14,7 @@
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 365 | 1000 | 635 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 343 | 650 | 307 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 352 | 650 | 298 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -42,7 +42,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=365 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=343 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=352 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-24T06:44:41Z
+- Generated at: 2026-03-24T09:15:02Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -13,8 +13,8 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
-| provider_mod | `crates/app/src/provider/mod.rs` | 379 | 1000 | 621 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 335 | 650 | 315 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| provider_mod | `crates/app/src/provider/mod.rs` | 365 | 1000 | 635 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 343 | 650 | 307 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -41,8 +41,8 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
-<!-- arch-hotspot key=provider_mod lines=379 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=335 functions=14 -->
+<!-- arch-hotspot key=provider_mod lines=365 functions=10 -->
+<!-- arch-hotspot key=memory_mod lines=343 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: built-in memory hydration and default context assembly had partial typed seams, but kernel reads still exposed only raw window context and there was no explicit staged envelope or artifact-preserving assembled-context contract.
- Why it matters: this blocked the first safe slice of `#455` because direct and kernel paths could not share one typed staged-hydration contract while preserving runtime-owned middleware, ACP, and delegate boundaries.
- What changed: added the typed stage-contract and `StageEnvelope` transport, emitted staged built-in hydration through memory-core, routed default context assembly through staged hydration with direct/kernel artifact parity, and locked runtime-boundary regressions around middleware, ACP bypass, and delegate lifecycle behavior.
- What did not change (scope boundary): runtime-owned compaction remains deferred, external/custom stage registration and config/env surfaces are not added here, and governed candidate-pipeline evaluation/promotion remains follow-up work.

## Linked Issues

- Partial for #455
- Related #455

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this changes the internal contract between memory hydration, default context assembly, and middleware artifact preservation. Prompt bytes are intended to stay stable, but regressions would show up as context ordering, ACP bypass, or delegate lifecycle drift.
- Rollout / guardrails: the slice keeps runtime-owned compaction and lifecycle authority unchanged, uses staged hydration only for the built-in path, and is covered by direct/kernel parity plus ACP/delegate regression tests.
- Rollback path: revert the branch or disable the staged slice by backing out the memory/context-engine commits; canonical conversation history does not depend on the new envelope surface.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-$(date -u +%Y-%m).md
cargo test -p loongclaw-app stage_envelope -- --nocapture
cargo test -p loongclaw-app hydrated_memory_builtin_orchestrator -- --nocapture
cargo test -p loongclaw-app default_runtime_build_context -- --nocapture
cargo test -p loongclaw-app default_runtime_kernel_build_context -- --nocapture
cargo test -p loongclaw-app builtin_turn_middlewares_preserve_context_artifact_descriptors -- --nocapture
cargo test -p loongclaw-app handle_turn_with_runtime_automatic_acp_routing_bypasses_context_engine_lifecycle_hooks -- --nocapture
cargo test -p loongclaw-app handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks -- --nocapture
cargo test -p loongclaw-app handle_turn_with_runtime_delegate_rejects_spawn_when_prepare_subagent_spawn_fails -- --nocapture
cargo test -p loongclaw-app handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_completion -- --nocapture
```

Full workspace validation and governance freshness passed locally after follow-up commit `b115cf8`.
Process-global env tests remain serialized behind existing test-local scoped env helpers/locks in the touched suites.

## User-visible / Operator-visible Changes

- No intentional user-visible prompt change. This slice formalizes the built-in staged memory/context contract and preserves direct/kernel prompt parity while adding typed internal artifact descriptors.

## Failure Recovery

- Fast rollback or disable path: revert this PR or temporarily back out the staged-hydration routing commits (`9133a67`, `e34df85`, `72c44d7`, `78d3096`, `b115cf8`) to restore the previous built-in assembly path.
- Observable failure symptoms reviewers should watch for: missing summary/profile blocks, kernel/direct prompt mismatch, middleware-added system prompt drift, ACP routing unexpectedly invoking context-engine lifecycle hooks, or delegate hook regressions.

## Reviewer Focus

- `crates/app/src/memory/orchestrator.rs`, `crates/app/src/memory/context.rs`, and `crates/app/src/memory/protocol.rs` for the staged envelope and mode-aware retrieval contract
- `crates/app/src/conversation/context_engine.rs` and `crates/app/src/provider/request_message_runtime.rs` for direct/kernel projection parity and artifact preservation
- `crates/app/src/conversation/turn_middleware.rs` plus the new conversation regressions for message-index stability, ACP bypass, and delegate lifecycle boundaries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stage-envelope memory support and explicit context artifact descriptors attached to assembled conversation context.

* **Refactor**
  * Reworked context assembly, provider projection, and system-prompt handling to produce and maintain artifact annotations with correct message indexing.
  * Redesigned memory orchestration to hydrate staged envelopes with per-stage diagnostics and new stage-envelope protocol operations.

* **Tests**
  * Expanded unit and integration tests for artifact tracking, stage hydration, kernel-bound projections, middleware adjustments, and memory routing.

* **Documentation**
  * Updated architecture report timestamp and hotspot metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
