### PR TITLE
feat: add multi-session concurrent channel dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,20 @@ loongclaw matrix-serve --config ~/.loongclaw/config.toml --once
 
 By default, LoongClaw reads `MATRIX_ACCESS_TOKEN`. Matrix room and user IDs often contain `:`, so the runtime preserves structured Matrix route/session IDs without relying on Matrix-specific path hacks.
 
+### Multi-Channel Serve
+
+Use `multi-channel-serve` when you want one process to keep an interactive CLI session in the foreground while supervising Telegram and Feishu surfaces in the same runtime.
+
+```bash
+loongclaw multi-channel-serve \
+  --session cli-supervisor \
+  --telegram-account bot_123456 \
+  --feishu-account alerts \
+  --config ~/.loongclaw/config.toml
+```
+
+`--session` is required. `--telegram-account` and `--feishu-account` are optional selectors for the channel accounts this runtime should supervise.
+
 Tool policy stays explicit:
 
 ```toml

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -281,6 +281,20 @@ loongclaw feishu-serve --config ~/.loongclaw/config.toml
 
 websocket 模式不需要 webhook secret。如果你接的是 Lark，可以再加上 `domain = "lark"`。
 
+### 多通道运行
+
+当你希望一个进程把交互式 CLI 会话放在前台，同时在同一运行时里监督 Telegram 和飞书通道时，使用 `multi-channel-serve`。
+
+```bash
+loongclaw multi-channel-serve \
+  --session cli-supervisor \
+  --telegram-account bot_123456 \
+  --feishu-account alerts \
+  --config ~/.loongclaw/config.toml
+```
+
+`--session` 是必填项。`--telegram-account` 和 `--feishu-account` 是可选的通道账号选择参数，用来指定这个运行时要监督的账号。
+
 工具策略需要明确配置：
 
 ```toml

--- a/crates/app/src/channel/feishu/mod.rs
+++ b/crates/app/src/channel/feishu/mod.rs
@@ -6,7 +6,7 @@ use axum::{Router, routing::post};
 use crate::CliResult;
 use crate::KernelContext;
 use crate::channel::{
-    ChannelAdapter, ChannelOutboundTarget, FeishuChannelSendRequest,
+    ChannelAdapter, ChannelOutboundTarget, ChannelServeStopHandle, FeishuChannelSendRequest,
     runtime_state::ChannelOperationRuntimeTracker,
 };
 use crate::config::{
@@ -74,6 +74,7 @@ pub(super) async fn run_feishu_channel(
     path_override: Option<&str>,
     kernel_ctx: KernelContext,
     runtime: Arc<ChannelOperationRuntimeTracker>,
+    stop: ChannelServeStopHandle,
 ) -> CliResult<()> {
     if resolved.mode == crate::config::FeishuChannelServeMode::Websocket {
         return websocket::run_feishu_websocket_channel(
@@ -84,6 +85,7 @@ pub(super) async fn run_feishu_channel(
             default_account_source,
             kernel_ctx,
             runtime,
+            stop,
         )
         .await;
     }
@@ -135,6 +137,9 @@ pub(super) async fn run_feishu_channel(
     );
 
     axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            stop.wait().await;
+        })
         .await
         .map_err(|error| format!("feishu webhook server stopped: {error}"))
 }

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -273,9 +273,12 @@ async fn run_feishu_websocket_session(
     // Install the same process default once so websocket TLS does not panic when other crates
     // also link rustls with aws-lc-rs enabled.
     ensure_feishu_websocket_rustls_provider();
-    let (mut stream, _) = connect_async(parsed_url.as_str())
-        .await
-        .map_err(|error| format!("connect Feishu websocket failed: {error}"))?;
+    let connect_result = tokio::select! {
+        _ = stop.wait() => return Ok(()),
+        result = connect_async(parsed_url.as_str()) => result,
+    };
+    let (mut stream, _) =
+        connect_result.map_err(|error| format!("connect Feishu websocket failed: {error}"))?;
     let mut ping_interval = tokio::time::interval(Duration::from_secs(ping_interval_s));
     ping_interval.tick().await;
     let mut fragments = FeishuWsFragments::default();
@@ -450,7 +453,7 @@ mod tests {
     use futures_util::{SinkExt, StreamExt};
     use serde_json::{Value, json};
     use tokio::net::TcpListener;
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, Notify};
     use tokio_tungstenite::accept_async;
 
     use super::*;
@@ -845,6 +848,94 @@ mod tests {
 
         accept_task.abort();
         let _ = accept_task.await;
+        provider_server.abort();
+        feishu_server.abort();
+    }
+
+    #[tokio::test]
+    async fn feishu_websocket_session_stop_interrupts_stalled_initial_connect() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let (provider_base_url, provider_server) =
+            spawn_mock_provider_server(provider_requests.clone()).await;
+        let (feishu_base_url, feishu_server) =
+            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_ws_stop_1").await;
+
+        let config = test_websocket_config(&provider_base_url, &feishu_base_url);
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve websocket feishu account");
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before websocket stop test");
+        let kernel_ctx =
+            bootstrap_test_kernel_context("feishu-websocket-stop-test", DEFAULT_TOKEN_TTL_S)
+                .expect("bootstrap kernel context");
+        let runtime = Arc::new(
+            ChannelOperationRuntimeTracker::start(
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+            )
+            .await
+            .expect("start runtime tracker"),
+        );
+        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stalled websocket listener");
+        let address = listener
+            .local_addr()
+            .expect("stalled websocket listener addr");
+        let accepted = Arc::new(Notify::new());
+        let release_socket = Arc::new(Notify::new());
+        let accepted_for_server = accepted.clone();
+        let release_for_server = release_socket.clone();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener
+                .accept()
+                .await
+                .expect("accept stalled websocket socket");
+            accepted_for_server.notify_waiters();
+            release_for_server.notified().await;
+            drop(socket);
+        });
+
+        let stop = ChannelServeStopHandle::new();
+        let stop_for_session = stop.clone();
+        let session_url = format!("ws://{address}/events?service_id=42");
+        let mut session = tokio::spawn(async move {
+            run_feishu_websocket_session(
+                &state,
+                session_url.as_str(),
+                &FeishuWsEndpointClientConfig::default(),
+                stop_for_session,
+            )
+            .await
+        });
+
+        accepted.notified().await;
+        stop.request_stop();
+
+        let session_result = tokio::select! {
+            result = &mut session => result,
+            _ = tokio::time::sleep(Duration::from_secs(2)) => {
+                session.abort();
+                panic!("stop should interrupt the stalled websocket connect");
+            }
+        };
+        let session_result = session_result
+            .expect("join stalled websocket session")
+            .expect("stop should end stalled websocket connect cleanly");
+        assert_eq!(session_result, ());
+
+        release_socket.notify_waiters();
+        let _ = server.await;
         provider_server.abort();
         feishu_server.abort();
     }

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -14,7 +14,7 @@ use tokio_tungstenite::tungstenite::Message;
 
 use crate::CliResult;
 use crate::KernelContext;
-use crate::channel::runtime_state::ChannelOperationRuntimeTracker;
+use crate::channel::{ChannelServeStopHandle, runtime_state::ChannelOperationRuntimeTracker};
 use crate::config::{
     ChannelDefaultAccountSelectionSource, LoongClawConfig, ResolvedFeishuChannelConfig,
 };
@@ -182,6 +182,7 @@ pub(super) async fn run_feishu_websocket_channel(
     default_account_source: ChannelDefaultAccountSelectionSource,
     kernel_ctx: KernelContext,
     runtime: Arc<ChannelOperationRuntimeTracker>,
+    stop: ChannelServeStopHandle,
 ) -> CliResult<()> {
     let mut adapter = FeishuAdapter::new(resolved)?;
     adapter.refresh_tenant_token().await?;
@@ -208,14 +209,20 @@ pub(super) async fn run_feishu_websocket_channel(
     }
 
     loop {
-        let endpoint = match client.get_websocket_endpoint().await {
+        let endpoint = match tokio::select! {
+            _ = stop.wait() => return Ok(()),
+            endpoint = client.get_websocket_endpoint() => endpoint,
+        } {
             Ok(endpoint) => endpoint,
             Err(error) => {
                 #[allow(clippy::print_stderr)]
                 {
                     eprintln!("warning: feishu websocket endpoint discovery failed: {error}");
                 }
-                tokio::time::sleep(Duration::from_secs(DEFAULT_WS_RECONNECT_INTERVAL_S)).await;
+                tokio::select! {
+                    _ = stop.wait() => return Ok(()),
+                    _ = tokio::time::sleep(Duration::from_secs(DEFAULT_WS_RECONNECT_INTERVAL_S)) => {}
+                }
                 continue;
             }
         };
@@ -227,14 +234,19 @@ pub(super) async fn run_feishu_websocket_channel(
                 .max(1),
         );
 
-        if let Err(error) = run_feishu_websocket_session(&state, &endpoint.url, &ws_config).await {
+        if let Err(error) =
+            run_feishu_websocket_session(&state, &endpoint.url, &ws_config, stop.clone()).await
+        {
             #[allow(clippy::print_stderr)]
             {
                 eprintln!("warning: feishu websocket session ended: {error}");
             }
         }
 
-        tokio::time::sleep(reconnect_interval).await;
+        tokio::select! {
+            _ = stop.wait() => return Ok(()),
+            _ = tokio::time::sleep(reconnect_interval) => {}
+        }
     }
 }
 
@@ -242,6 +254,7 @@ async fn run_feishu_websocket_session(
     state: &FeishuWebhookState,
     url: &str,
     ws_config: &FeishuWsEndpointClientConfig,
+    stop: ChannelServeStopHandle,
 ) -> CliResult<()> {
     let parsed_url = reqwest::Url::parse(url)
         .map_err(|error| format!("parse Feishu websocket URL failed: {error}"))?;
@@ -269,6 +282,7 @@ async fn run_feishu_websocket_session(
 
     loop {
         tokio::select! {
+            _ = stop.wait() => return Ok(()),
             _ = ping_interval.tick() => {
                 let ping_frame = FeishuWsFrame {
                     seq_id: 0,
@@ -809,6 +823,7 @@ mod tests {
                     &state,
                     session_url.as_str(),
                     &FeishuWsEndpointClientConfig::default(),
+                    ChannelServeStopHandle::new(),
                 )
                 .await
             }),
@@ -899,6 +914,7 @@ mod tests {
                 ping_interval_s: Some(30),
                 ..FeishuWsEndpointClientConfig::default()
             },
+            ChannelServeStopHandle::new(),
         )
         .await
         .expect_err("session should end after the mock server closes");

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -929,10 +929,9 @@ mod tests {
                 panic!("stop should interrupt the stalled websocket connect");
             }
         };
-        let session_result = session_result
+        session_result
             .expect("join stalled websocket session")
             .expect("stop should end stalled websocket connect cleanly");
-        assert_eq!(session_result, ());
 
         release_socket.notify_waiters();
         let _ = server.await;

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -28,6 +28,12 @@ use serde::Serialize;
     feature = "channel-matrix"
 ))]
 use serde_json::Value;
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix"
+))]
+use tokio::sync::Notify;
 #[cfg(feature = "channel-telegram")]
 use tokio::time::sleep;
 
@@ -1135,6 +1141,37 @@ struct ChannelServeCommandSpec {
     feature = "channel-feishu",
     feature = "channel-matrix"
 ))]
+#[derive(Debug, Clone)]
+pub struct ChannelServeStopHandle {
+    stop: Arc<Notify>,
+}
+
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix"
+))]
+impl ChannelServeStopHandle {
+    pub fn new() -> Self {
+        Self {
+            stop: Arc::new(Notify::new()),
+        }
+    }
+
+    pub fn request_stop(&self) {
+        self.stop.notify_one();
+    }
+
+    async fn wait(&self) {
+        self.stop.notified().await;
+    }
+}
+
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix"
+))]
 fn channel_runtime_now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1228,10 +1265,79 @@ where
     feature = "channel-feishu",
     feature = "channel-matrix"
 ))]
+async fn with_channel_serve_runtime_with_stop<F, Fut>(
+    spec: ChannelServeRuntimeSpec<'_>,
+    stop: ChannelServeStopHandle,
+    run: F,
+) -> CliResult<()>
+where
+    F: FnOnce(Arc<ChannelOperationRuntimeTracker>) -> Fut,
+    Fut: Future<Output = CliResult<()>>,
+{
+    with_channel_serve_runtime(spec, move |runtime| async move {
+        tokio::select! {
+            result = run(runtime) => result,
+            _ = stop.wait() => Ok(()),
+        }
+    })
+    .await
+}
+
+#[cfg(test)]
+async fn with_channel_serve_runtime_with_stop_in_dir<F, Fut>(
+    runtime_dir: &std::path::Path,
+    process_id: u32,
+    spec: ChannelServeRuntimeSpec<'_>,
+    stop: ChannelServeStopHandle,
+    run: F,
+) -> CliResult<()>
+where
+    F: FnOnce(Arc<ChannelOperationRuntimeTracker>) -> Fut,
+    Fut: Future<Output = CliResult<()>>,
+{
+    with_channel_serve_runtime_in_dir(runtime_dir, process_id, spec, move |runtime| async move {
+        tokio::select! {
+            result = run(runtime) => result,
+            _ = stop.wait() => Ok(()),
+        }
+    })
+    .await
+}
+
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix"
+))]
 async fn run_channel_serve_command<R, V, F>(
     context: ChannelCommandContext<R>,
     spec: ChannelServeCommandSpec,
     validate: V,
+    run: F,
+) -> CliResult<()>
+where
+    R: ChannelResolvedRuntimeAccount,
+    V: FnOnce(&R) -> CliResult<()>,
+    F: for<'a> FnOnce(
+        &'a ChannelCommandContext<R>,
+        KernelContext,
+        Arc<ChannelOperationRuntimeTracker>,
+    ) -> ChannelCommandFuture<'a>,
+{
+    run_channel_serve_command_with_stop(context, spec, validate, ChannelServeStopHandle::new(), run)
+        .await
+}
+
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix"
+))]
+async fn run_channel_serve_command_with_stop<R, V, F>(
+    context: ChannelCommandContext<R>,
+    spec: ChannelServeCommandSpec,
+    validate: V,
+    stop: ChannelServeStopHandle,
     run: F,
 ) -> CliResult<()>
 where
@@ -1256,13 +1362,14 @@ where
     let runtime_account_id = context.resolved.runtime_account_id().to_owned();
     let runtime_account_label = context.resolved.runtime_account_label().to_owned();
 
-    with_channel_serve_runtime(
+    with_channel_serve_runtime_with_stop(
         ChannelServeRuntimeSpec {
             platform: spec.family.runtime.platform,
             operation_id: spec.family.serve().id,
             account_id: runtime_account_id.as_str(),
             account_label: runtime_account_label.as_str(),
         },
+        stop,
         move |runtime| async move {
             context.emit_route_notice(spec.family.runtime.platform);
             run(&context, kernel_ctx, runtime).await
@@ -1270,6 +1377,112 @@ where
     )
     .await
 }
+
+#[cfg(feature = "channel-telegram")]
+#[allow(clippy::print_stdout)] // CLI startup banner
+async fn run_telegram_channel_with_context(
+    context: ChannelCommandContext<ResolvedTelegramChannelConfig>,
+    once: bool,
+    stop: ChannelServeStopHandle,
+) -> CliResult<()> {
+    validate_telegram_security_config(&context.resolved)?;
+    crate::runtime_env::initialize_runtime_environment(
+        &context.config,
+        Some(context.resolved_path.as_path()),
+    );
+    let kernel_ctx = bootstrap_kernel_context_with_config(
+        "channel-telegram",
+        DEFAULT_TOKEN_TTL_S,
+        &context.config,
+    )?;
+    let token = context
+        .resolved
+        .bot_token()
+        .ok_or_else(|| "telegram bot token missing (set telegram.bot_token or env)".to_owned())?;
+    let route = context.route.clone();
+    let resolved_path = context.resolved_path.clone();
+    let resolved = context.resolved.clone();
+    let batch_config = context.config.clone();
+    let batch_kernel_ctx = Arc::new(crate::KernelContext {
+        kernel: kernel_ctx.kernel.clone(),
+        token: kernel_ctx.token.clone(),
+    });
+    let runtime_account_id = resolved.account.id.clone();
+    let runtime_account_label = resolved.account.label.clone();
+
+    with_channel_serve_runtime_with_stop(
+        ChannelServeRuntimeSpec {
+            platform: ChannelPlatform::Telegram,
+            operation_id: CHANNEL_OPERATION_SERVE_ID,
+            account_id: runtime_account_id.as_str(),
+            account_label: runtime_account_label.as_str(),
+        },
+        stop,
+        move |runtime| async move {
+            let mut adapter = telegram::TelegramAdapter::new(&resolved, token);
+            context.emit_route_notice(ChannelPlatform::Telegram);
+
+            println!(
+                "{} channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, timeout={}s)",
+                adapter.name(),
+                resolved_path.display(),
+                resolved.configured_account_id,
+                resolved.account.label,
+                route.selected_by_default(),
+                route.default_account_source.as_str(),
+                resolved.polling_timeout_s
+            );
+
+            loop {
+                let batch = adapter.receive_batch().await?;
+                let config = batch_config.clone();
+                let kernel_ctx = batch_kernel_ctx.clone();
+                let had_messages = process_channel_batch(
+                    &mut adapter,
+                    batch,
+                    Some(runtime.as_ref()),
+                    |message| {
+                        let config = config.clone();
+                        let kernel_ctx = kernel_ctx.clone();
+                        let resolved_path = resolved_path.clone();
+                        Box::pin(async move {
+                            process_inbound_with_provider(
+                                &config,
+                                Some(resolved_path.as_path()),
+                                &message,
+                                Some(kernel_ctx.as_ref()),
+                            )
+                            .await
+                        })
+                    },
+                )
+                .await?;
+                if !had_messages && once {
+                    break;
+                }
+                if once {
+                    break;
+                }
+                sleep(Duration::from_millis(250)).await;
+            }
+            Ok(())
+        },
+    )
+    .await
+}
+
+#[cfg(feature = "channel-telegram")]
+pub async fn run_telegram_channel_with_stop(
+    resolved_path: PathBuf,
+    config: LoongClawConfig,
+    once: bool,
+    account_id: Option<&str>,
+    stop: ChannelServeStopHandle,
+) -> CliResult<()> {
+    let context = build_telegram_command_context(resolved_path, config, account_id)?;
+    run_telegram_channel_with_context(context, once, stop).await
+}
+
 #[cfg(test)]
 async fn with_channel_serve_runtime_in_dir<T, F, Fut>(
     runtime_dir: &std::path::Path,
@@ -1323,84 +1536,7 @@ pub async fn run_telegram_channel(
     #[cfg(feature = "channel-telegram")]
     {
         let context = load_telegram_command_context(config_path, account_id)?;
-        validate_telegram_security_config(&context.resolved)?;
-        crate::runtime_env::initialize_runtime_environment(
-            &context.config,
-            Some(context.resolved_path.as_path()),
-        );
-        let kernel_ctx = bootstrap_kernel_context_with_config(
-            "channel-telegram",
-            DEFAULT_TOKEN_TTL_S,
-            &context.config,
-        )?;
-        let token = context.resolved.bot_token().ok_or_else(|| {
-            "telegram bot token missing (set telegram.bot_token or env)".to_owned()
-        })?;
-        let route = context.route.clone();
-        let resolved_path = context.resolved_path.clone();
-        let resolved = context.resolved.clone();
-        let batch_config = context.config.clone();
-        let batch_kernel_ctx = Arc::new(crate::KernelContext {
-            kernel: kernel_ctx.kernel.clone(),
-            token: kernel_ctx.token.clone(),
-        });
-        let runtime_account_id = resolved.account.id.clone();
-        let runtime_account_label = resolved.account.label.clone();
-
-        with_channel_serve_runtime(
-            ChannelServeRuntimeSpec {
-                platform: ChannelPlatform::Telegram,
-                operation_id: CHANNEL_OPERATION_SERVE_ID,
-                account_id: runtime_account_id.as_str(),
-                account_label: runtime_account_label.as_str(),
-            },
-            move |runtime| async move {
-                let mut adapter = telegram::TelegramAdapter::new(&resolved, token);
-                context.emit_route_notice(ChannelPlatform::Telegram);
-
-                println!(
-                    "{} channel started (config={}, configured_account={}, account={}, selected_by_default={}, default_source={}, timeout={}s)",
-                    adapter.name(),
-                    resolved_path.display(),
-                    resolved.configured_account_id,
-                    resolved.account.label,
-                    route.selected_by_default(),
-                    route.default_account_source.as_str(),
-                    resolved.polling_timeout_s
-                );
-
-                loop {
-                    let batch = adapter.receive_batch().await?;
-                    let config = batch_config.clone();
-                    let kernel_ctx = batch_kernel_ctx.clone();
-                    let had_messages =
-                        process_channel_batch(&mut adapter, batch, Some(runtime.as_ref()), |message| {
-                            let config = config.clone();
-                            let kernel_ctx = kernel_ctx.clone();
-                            let resolved_path = resolved_path.clone();
-                            Box::pin(async move {
-                                process_inbound_with_provider(
-                                    &config,
-                                    Some(resolved_path.as_path()),
-                                    &message,
-                                    Some(kernel_ctx.as_ref()),
-                                )
-                                .await
-                            })
-                        })
-                        .await?;
-                    if !had_messages && once {
-                        break;
-                    }
-                    if once {
-                        break;
-                    }
-                    sleep(Duration::from_millis(250)).await;
-                }
-                Ok(())
-            }
-        )
-        .await
+        run_telegram_channel_with_context(context, once, ChannelServeStopHandle::new()).await
     }
 }
 
@@ -1536,37 +1672,67 @@ pub async fn run_feishu_channel(
     #[cfg(feature = "channel-feishu")]
     {
         let context = load_feishu_command_context(config_path, account_id)?;
-        let bind_override = bind_override.map(str::to_owned);
-        let path_override = path_override.map(str::to_owned);
-        run_channel_serve_command(
+        run_feishu_channel_with_context(
             context,
-            ChannelServeCommandSpec {
-                family: FEISHU_COMMAND_FAMILY_DESCRIPTOR,
-            },
-            validate_feishu_security_config,
-            move |context, kernel_ctx, runtime| {
-                Box::pin(async move {
-                    let route = context.route.clone();
-                    let resolved_path = context.resolved_path.clone();
-                    let resolved = context.resolved.clone();
-                    let config = context.config.clone();
-                    feishu::run_feishu_channel(
-                        &config,
-                        &resolved,
-                        &resolved_path,
-                        route.selected_by_default(),
-                        route.default_account_source,
-                        bind_override.as_deref(),
-                        path_override.as_deref(),
-                        kernel_ctx,
-                        runtime,
-                    )
-                    .await
-                })
-            },
+            bind_override,
+            path_override,
+            ChannelServeStopHandle::new(),
         )
         .await
     }
+}
+
+#[cfg(feature = "channel-feishu")]
+async fn run_feishu_channel_with_context(
+    context: ChannelCommandContext<ResolvedFeishuChannelConfig>,
+    bind_override: Option<&str>,
+    path_override: Option<&str>,
+    stop: ChannelServeStopHandle,
+) -> CliResult<()> {
+    let bind_override = bind_override.map(str::to_owned);
+    let path_override = path_override.map(str::to_owned);
+    run_channel_serve_command_with_stop(
+        context,
+        ChannelServeCommandSpec {
+            family: FEISHU_COMMAND_FAMILY_DESCRIPTOR,
+        },
+        validate_feishu_security_config,
+        stop,
+        move |context, kernel_ctx, runtime| {
+            Box::pin(async move {
+                let route = context.route.clone();
+                let resolved_path = context.resolved_path.clone();
+                let resolved = context.resolved.clone();
+                let config = context.config.clone();
+                feishu::run_feishu_channel(
+                    &config,
+                    &resolved,
+                    &resolved_path,
+                    route.selected_by_default(),
+                    route.default_account_source,
+                    bind_override.as_deref(),
+                    path_override.as_deref(),
+                    kernel_ctx,
+                    runtime,
+                )
+                .await
+            })
+        },
+    )
+    .await
+}
+
+#[cfg(feature = "channel-feishu")]
+pub async fn run_feishu_channel_with_stop(
+    resolved_path: PathBuf,
+    config: LoongClawConfig,
+    account_id: Option<&str>,
+    bind_override: Option<&str>,
+    path_override: Option<&str>,
+    stop: ChannelServeStopHandle,
+) -> CliResult<()> {
+    let context = build_feishu_command_context(resolved_path, config, account_id)?;
+    run_feishu_channel_with_context(context, bind_override, path_override, stop).await
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -2981,6 +3147,76 @@ mod tests {
         .expect("serve runtime wrapper should succeed");
 
         assert_eq!(result, "ok");
+
+        let finished = runtime_state::load_channel_operation_runtime_for_account_from_dir(
+            runtime_dir.as_path(),
+            ChannelPlatform::Telegram,
+            "serve",
+            "bot_123456",
+            0,
+        )
+        .expect("runtime should remain readable after shutdown");
+        assert!(!finished.running);
+        assert_eq!(finished.pid, Some(9191));
+    }
+
+    #[cfg(any(
+        feature = "channel-telegram",
+        feature = "channel-feishu",
+        feature = "channel-matrix"
+    ))]
+    #[tokio::test]
+    async fn with_channel_serve_runtime_shuts_down_cleanly_after_cooperative_stop() {
+        let runtime_dir = temp_runtime_dir("serve-runtime-cooperative-stop");
+        let runtime_dir_for_wrapper = runtime_dir.clone();
+        let runtime_dir_for_body = runtime_dir.clone();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let entered_for_body = entered.clone();
+        let stop = ChannelServeStopHandle::new();
+        let stop_for_body = stop.clone();
+        let operation = ChannelServeRuntimeSpec {
+            platform: ChannelPlatform::Telegram,
+            operation_id: CHANNEL_OPERATION_SERVE_ID,
+            account_id: "bot_123456",
+            account_label: "bot:123456",
+        };
+
+        let wrapper = tokio::spawn(async move {
+            with_channel_serve_runtime_with_stop_in_dir(
+                runtime_dir_for_wrapper.as_path(),
+                9191,
+                operation,
+                stop_for_body,
+                move |_runtime| {
+                    let runtime_dir_for_body = runtime_dir_for_body.clone();
+                    async move {
+                        let live =
+                            runtime_state::load_channel_operation_runtime_for_account_from_dir(
+                                runtime_dir_for_body.as_path(),
+                                ChannelPlatform::Telegram,
+                                "serve",
+                                "bot_123456",
+                                0,
+                            )
+                            .expect("runtime should exist while serve body is running");
+                        assert!(live.running);
+                        assert_eq!(live.pid, Some(9191));
+                        entered_for_body.notify_one();
+                        let _: CliResult<()> = std::future::pending().await;
+                        Ok::<_, String>(())
+                    }
+                },
+            )
+            .await
+        });
+
+        entered.notified().await;
+        stop.request_stop();
+
+        wrapper
+            .await
+            .expect("cooperative stop wrapper join should succeed")
+            .expect("cooperative stop wrapper should succeed");
 
         let finished = runtime_state::load_channel_operation_runtime_for_account_from_dir(
             runtime_dir.as_path(),

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -1338,6 +1338,7 @@ where
         spec,
         validate,
         ChannelServeStopHandle::new(),
+        true,
         move |context, kernel_ctx, runtime, _stop| run(context, kernel_ctx, runtime),
     )
     .await
@@ -1353,6 +1354,7 @@ async fn run_channel_serve_command_with_stop<R, V, F>(
     spec: ChannelServeCommandSpec,
     validate: V,
     stop: ChannelServeStopHandle,
+    initialize_runtime_environment: bool,
     run: F,
 ) -> CliResult<()>
 where
@@ -1366,10 +1368,12 @@ where
     ) -> ChannelCommandFuture<'a>,
 {
     validate(&context.resolved)?;
-    crate::runtime_env::initialize_runtime_environment(
-        &context.config,
-        Some(context.resolved_path.as_path()),
-    );
+    if initialize_runtime_environment {
+        crate::runtime_env::initialize_runtime_environment(
+            &context.config,
+            Some(context.resolved_path.as_path()),
+        );
+    }
     let kernel_ctx = bootstrap_kernel_context_with_config(
         spec.family.runtime.serve_bootstrap_agent_id,
         DEFAULT_TOKEN_TTL_S,
@@ -1400,12 +1404,15 @@ async fn run_telegram_channel_with_context(
     context: ChannelCommandContext<ResolvedTelegramChannelConfig>,
     once: bool,
     stop: ChannelServeStopHandle,
+    initialize_runtime_environment: bool,
 ) -> CliResult<()> {
     validate_telegram_security_config(&context.resolved)?;
-    crate::runtime_env::initialize_runtime_environment(
-        &context.config,
-        Some(context.resolved_path.as_path()),
-    );
+    if initialize_runtime_environment {
+        crate::runtime_env::initialize_runtime_environment(
+            &context.config,
+            Some(context.resolved_path.as_path()),
+        );
+    }
     let kernel_ctx = bootstrap_kernel_context_with_config(
         "channel-telegram",
         DEFAULT_TOKEN_TTL_S,
@@ -1500,9 +1507,10 @@ pub async fn run_telegram_channel_with_stop(
     once: bool,
     account_id: Option<&str>,
     stop: ChannelServeStopHandle,
+    initialize_runtime_environment: bool,
 ) -> CliResult<()> {
     let context = build_telegram_command_context(resolved_path, config, account_id)?;
-    run_telegram_channel_with_context(context, once, stop).await
+    run_telegram_channel_with_context(context, once, stop, initialize_runtime_environment).await
 }
 
 #[cfg(test)]
@@ -1558,7 +1566,7 @@ pub async fn run_telegram_channel(
     #[cfg(feature = "channel-telegram")]
     {
         let context = load_telegram_command_context(config_path, account_id)?;
-        run_telegram_channel_with_context(context, once, ChannelServeStopHandle::new()).await
+        run_telegram_channel_with_context(context, once, ChannelServeStopHandle::new(), true).await
     }
 }
 
@@ -1699,6 +1707,7 @@ pub async fn run_feishu_channel(
             bind_override,
             path_override,
             ChannelServeStopHandle::new(),
+            true,
         )
         .await
     }
@@ -1710,6 +1719,7 @@ async fn run_feishu_channel_with_context(
     bind_override: Option<&str>,
     path_override: Option<&str>,
     stop: ChannelServeStopHandle,
+    initialize_runtime_environment: bool,
 ) -> CliResult<()> {
     let bind_override = bind_override.map(str::to_owned);
     let path_override = path_override.map(str::to_owned);
@@ -1720,6 +1730,7 @@ async fn run_feishu_channel_with_context(
         },
         validate_feishu_security_config,
         stop,
+        initialize_runtime_environment,
         move |context, kernel_ctx, runtime, stop| {
             Box::pin(async move {
                 let route = context.route.clone();
@@ -1753,9 +1764,17 @@ pub async fn run_feishu_channel_with_stop(
     bind_override: Option<&str>,
     path_override: Option<&str>,
     stop: ChannelServeStopHandle,
+    initialize_runtime_environment: bool,
 ) -> CliResult<()> {
     let context = build_feishu_command_context(resolved_path, config, account_id)?;
-    run_feishu_channel_with_context(context, bind_override, path_override, stop).await
+    run_feishu_channel_with_context(
+        context,
+        bind_override,
+        path_override,
+        stop,
+        initialize_runtime_environment,
+    )
+    .await
 }
 
 #[doc(hidden)]

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -10,7 +10,10 @@ use std::{
     future::Future,
     path::PathBuf,
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
 use std::{fmt, str::FromStr};
@@ -1143,6 +1146,7 @@ struct ChannelServeCommandSpec {
 ))]
 #[derive(Debug, Clone)]
 pub struct ChannelServeStopHandle {
+    requested: Arc<AtomicBool>,
     stop: Arc<Notify>,
 }
 
@@ -1154,16 +1158,30 @@ pub struct ChannelServeStopHandle {
 impl ChannelServeStopHandle {
     pub fn new() -> Self {
         Self {
+            requested: Arc::new(AtomicBool::new(false)),
             stop: Arc::new(Notify::new()),
         }
     }
 
     pub fn request_stop(&self) {
-        self.stop.notify_one();
+        self.requested.store(true, Ordering::SeqCst);
+        self.stop.notify_waiters();
+    }
+
+    pub fn is_requested(&self) -> bool {
+        self.requested.load(Ordering::SeqCst)
     }
 
     async fn wait(&self) {
-        self.stop.notified().await;
+        if self.is_requested() {
+            return;
+        }
+        let notified = self.stop.notified();
+        tokio::pin!(notified);
+        if self.is_requested() {
+            return;
+        }
+        notified.await;
     }
 }
 
@@ -1271,16 +1289,10 @@ async fn with_channel_serve_runtime_with_stop<F, Fut>(
     run: F,
 ) -> CliResult<()>
 where
-    F: FnOnce(Arc<ChannelOperationRuntimeTracker>) -> Fut,
+    F: FnOnce(Arc<ChannelOperationRuntimeTracker>, ChannelServeStopHandle) -> Fut,
     Fut: Future<Output = CliResult<()>>,
 {
-    with_channel_serve_runtime(spec, move |runtime| async move {
-        tokio::select! {
-            result = run(runtime) => result,
-            _ = stop.wait() => Ok(()),
-        }
-    })
-    .await
+    with_channel_serve_runtime(spec, move |runtime| run(runtime, stop)).await
 }
 
 #[cfg(test)]
@@ -1292,14 +1304,11 @@ async fn with_channel_serve_runtime_with_stop_in_dir<F, Fut>(
     run: F,
 ) -> CliResult<()>
 where
-    F: FnOnce(Arc<ChannelOperationRuntimeTracker>) -> Fut,
+    F: FnOnce(Arc<ChannelOperationRuntimeTracker>, ChannelServeStopHandle) -> Fut,
     Fut: Future<Output = CliResult<()>>,
 {
-    with_channel_serve_runtime_in_dir(runtime_dir, process_id, spec, move |runtime| async move {
-        tokio::select! {
-            result = run(runtime) => result,
-            _ = stop.wait() => Ok(()),
-        }
+    with_channel_serve_runtime_in_dir(runtime_dir, process_id, spec, move |runtime| {
+        run(runtime, stop)
     })
     .await
 }
@@ -1324,8 +1333,14 @@ where
         Arc<ChannelOperationRuntimeTracker>,
     ) -> ChannelCommandFuture<'a>,
 {
-    run_channel_serve_command_with_stop(context, spec, validate, ChannelServeStopHandle::new(), run)
-        .await
+    run_channel_serve_command_with_stop(
+        context,
+        spec,
+        validate,
+        ChannelServeStopHandle::new(),
+        move |context, kernel_ctx, runtime, _stop| run(context, kernel_ctx, runtime),
+    )
+    .await
 }
 
 #[cfg(any(
@@ -1347,6 +1362,7 @@ where
         &'a ChannelCommandContext<R>,
         KernelContext,
         Arc<ChannelOperationRuntimeTracker>,
+        ChannelServeStopHandle,
     ) -> ChannelCommandFuture<'a>,
 {
     validate(&context.resolved)?;
@@ -1370,9 +1386,9 @@ where
             account_label: runtime_account_label.as_str(),
         },
         stop,
-        move |runtime| async move {
+        move |runtime, stop| async move {
             context.emit_route_notice(spec.family.runtime.platform);
-            run(&context, kernel_ctx, runtime).await
+            run(&context, kernel_ctx, runtime, stop).await
         },
     )
     .await
@@ -1418,7 +1434,7 @@ async fn run_telegram_channel_with_context(
             account_label: runtime_account_label.as_str(),
         },
         stop,
-        move |runtime| async move {
+        move |runtime, stop| async move {
             let mut adapter = telegram::TelegramAdapter::new(&resolved, token);
             context.emit_route_notice(ChannelPlatform::Telegram);
 
@@ -1434,7 +1450,10 @@ async fn run_telegram_channel_with_context(
             );
 
             loop {
-                let batch = adapter.receive_batch().await?;
+                let batch = tokio::select! {
+                    _ = stop.wait() => break,
+                    batch = adapter.receive_batch() => batch?,
+                };
                 let config = batch_config.clone();
                 let kernel_ctx = batch_kernel_ctx.clone();
                 let had_messages = process_channel_batch(
@@ -1463,7 +1482,10 @@ async fn run_telegram_channel_with_context(
                 if once {
                     break;
                 }
-                sleep(Duration::from_millis(250)).await;
+                tokio::select! {
+                    _ = stop.wait() => break,
+                    _ = sleep(Duration::from_millis(250)) => {}
+                }
             }
             Ok(())
         },
@@ -1698,7 +1720,7 @@ async fn run_feishu_channel_with_context(
         },
         validate_feishu_security_config,
         stop,
-        move |context, kernel_ctx, runtime| {
+        move |context, kernel_ctx, runtime, stop| {
             Box::pin(async move {
                 let route = context.route.clone();
                 let resolved_path = context.resolved_path.clone();
@@ -1714,6 +1736,7 @@ async fn run_feishu_channel_with_context(
                     path_override.as_deref(),
                     kernel_ctx,
                     runtime,
+                    stop,
                 )
                 .await
             })
@@ -3187,7 +3210,7 @@ mod tests {
                 9191,
                 operation,
                 stop_for_body,
-                move |_runtime| {
+                move |_runtime, stop| {
                     let runtime_dir_for_body = runtime_dir_for_body.clone();
                     async move {
                         let live =
@@ -3202,8 +3225,8 @@ mod tests {
                         assert!(live.running);
                         assert_eq!(live.pid, Some(9191));
                         entered_for_body.notify_one();
-                        let _: CliResult<()> = std::future::pending().await;
-                        Ok::<_, String>(())
+                        stop.wait().await;
+                        Ok(())
                     }
                 },
             )

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -1758,6 +1758,53 @@ pub async fn run_feishu_channel_with_stop(
     run_feishu_channel_with_context(context, bind_override, path_override, stop).await
 }
 
+#[doc(hidden)]
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix"
+))]
+pub async fn run_channel_serve_runtime_probe_for_test(
+    platform: ChannelPlatform,
+    account_id: &str,
+    account_label: &str,
+    stop: ChannelServeStopHandle,
+    entered: Arc<Notify>,
+) -> CliResult<()> {
+    with_channel_serve_runtime_with_stop(
+        ChannelServeRuntimeSpec {
+            platform,
+            operation_id: CHANNEL_OPERATION_SERVE_ID,
+            account_id,
+            account_label,
+        },
+        stop,
+        move |_runtime, stop| async move {
+            entered.notify_one();
+            stop.wait().await;
+            Ok(())
+        },
+    )
+    .await
+}
+
+#[doc(hidden)]
+pub fn load_channel_operation_runtime_for_account_from_dir_for_test(
+    runtime_dir: &std::path::Path,
+    platform: ChannelPlatform,
+    operation_id: &str,
+    account_id: &str,
+    now_ms: u64,
+) -> Option<ChannelOperationRuntime> {
+    runtime_state::load_channel_operation_runtime_for_account_from_dir(
+        runtime_dir,
+        platform,
+        operation_id,
+        account_id,
+        now_ms,
+    )
+}
+
 #[allow(clippy::print_stdout)] // CLI output
 pub async fn run_matrix_send(
     config_path: Option<&str>,

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -2,7 +2,10 @@
 use std::collections::BTreeSet;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 #[cfg(feature = "memory-sqlite")]
 use loongclaw_contracts::Capability;
@@ -56,7 +59,54 @@ pub struct ConcurrentCliHostOptions {
     pub resolved_path: PathBuf,
     pub config: LoongClawConfig,
     pub session_id: String,
-    pub shutdown: Arc<Notify>,
+    pub shutdown: ConcurrentCliShutdown,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConcurrentCliShutdown {
+    requested: Arc<AtomicBool>,
+    notify: Arc<Notify>,
+}
+
+impl Default for ConcurrentCliShutdown {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConcurrentCliShutdown {
+    pub fn new() -> Self {
+        Self {
+            requested: Arc::new(AtomicBool::new(false)),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    pub fn request_shutdown(&self) {
+        self.requested.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
+    }
+
+    pub fn is_requested(&self) -> bool {
+        self.requested.load(Ordering::SeqCst)
+    }
+
+    pub async fn wait(&self) {
+        if self.is_requested() {
+            return;
+        }
+
+        loop {
+            if self.is_requested() {
+                return;
+            }
+            let notified = self.notify.notified();
+            if self.is_requested() {
+                return;
+            }
+            notified.await;
+        }
+    }
 }
 
 impl CliChatOptions {
@@ -304,7 +354,7 @@ pub fn run_concurrent_cli_host(options: &ConcurrentCliHostOptions) -> CliResult<
 
     host_runtime.block_on(async {
         print_turn_checkpoint_startup_health(&runtime).await;
-        run_concurrent_cli_host_loop(&runtime, &chat_options, options.shutdown.as_ref()).await
+        run_concurrent_cli_host_loop(&runtime, &chat_options, &options.shutdown).await
     })
 }
 
@@ -440,7 +490,7 @@ async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntime) {
 async fn run_concurrent_cli_host_loop(
     runtime: &CliTurnRuntime,
     options: &CliChatOptions,
-    shutdown: &Notify,
+    shutdown: &ConcurrentCliShutdown,
 ) -> CliResult<()> {
     let mut stdin_lines = BufReader::new(tokio_io::stdin()).lines();
 
@@ -451,7 +501,7 @@ async fn run_concurrent_cli_host_loop(
             .map_err(|error| format!("flush stdout failed: {error}"))?;
 
         let next_line = tokio::select! {
-            _ = shutdown.notified() => None,
+            _ = shutdown.wait() => None,
             line = stdin_lines.next_line() => Some(
                 line.map_err(|error| format!("read stdin failed: {error}"))?
             ),
@@ -1840,8 +1890,6 @@ mod tests {
     };
     #[cfg(feature = "memory-sqlite")]
     use serde_json::{Value, json};
-    use tokio::sync::Notify;
-
     #[test]
     fn cli_chat_options_detect_explicit_acp_requests() {
         assert!(
@@ -2247,7 +2295,7 @@ mod tests {
 
     #[test]
     fn concurrent_cli_host_requires_explicit_session_id() {
-        let shutdown = Arc::new(Notify::new());
+        let shutdown = ConcurrentCliShutdown::new();
         let error = run_concurrent_cli_host(&ConcurrentCliHostOptions {
             resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
             config: LoongClawConfig::default(),
@@ -2278,10 +2326,10 @@ mod tests {
             false,
         )
         .expect("concurrent host runtime");
-        let shutdown = Arc::new(Notify::new());
-        shutdown.notify_one();
+        let shutdown = ConcurrentCliShutdown::new();
+        shutdown.request_shutdown();
 
-        run_concurrent_cli_host_loop(&runtime, &options, shutdown.as_ref())
+        run_concurrent_cli_host_loop(&runtime, &options, &shutdown)
             .await
             .expect("concurrent host should stop cleanly when shutdown is requested");
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -60,6 +60,7 @@ pub struct ConcurrentCliHostOptions {
     pub config: LoongClawConfig,
     pub session_id: String,
     pub shutdown: ConcurrentCliShutdown,
+    pub initialize_runtime_environment: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -343,7 +344,7 @@ pub fn run_concurrent_cli_host(options: &ConcurrentCliHostOptions) -> CliResult<
         &chat_options,
         "cli-chat-concurrent",
         CliSessionRequirement::RequireExplicit,
-        true,
+        options.initialize_runtime_environment,
     )?;
     print_cli_chat_startup(&runtime, &chat_options)?;
 
@@ -2301,6 +2302,7 @@ mod tests {
             config: LoongClawConfig::default(),
             session_id: "   ".to_owned(),
             shutdown,
+            initialize_runtime_environment: false,
         })
         .expect_err("concurrent host should reject an implicit session id");
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -2,9 +2,12 @@
 use std::collections::BTreeSet;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 #[cfg(feature = "memory-sqlite")]
 use loongclaw_contracts::Capability;
+use tokio::io::{self as tokio_io, AsyncBufReadExt, BufReader};
+use tokio::sync::Notify;
 
 use crate::CliResult;
 use crate::acp::{
@@ -46,6 +49,14 @@ pub struct CliChatOptions {
     pub acp_event_stream: bool,
     pub acp_bootstrap_mcp_servers: Vec<String>,
     pub acp_working_directory: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConcurrentCliHostOptions {
+    pub resolved_path: PathBuf,
+    pub config: LoongClawConfig,
+    pub session_id: String,
+    pub shutdown: Arc<Notify>,
 }
 
 impl CliChatOptions {
@@ -125,6 +136,18 @@ struct CliTurnRuntime {
     memory_config: MemoryRuntimeConfig,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliSessionRequirement {
+    AllowImplicitDefault,
+    RequireExplicit,
+}
+
+enum CliChatLoopControl {
+    Continue,
+    Exit,
+    AssistantText(String),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CliChatStartupSummary {
     config_path: String,
@@ -190,10 +213,192 @@ pub async fn run_cli_chat(
         return Ok(());
     }
 
-    let runtime =
-        initialize_cli_turn_runtime(config_path, session_hint, options, "cli-chat").await?;
+    let runtime = initialize_cli_turn_runtime(config_path, session_hint, options, "cli-chat")?;
     print_cli_chat_startup(&runtime, options)?;
+    print_turn_checkpoint_startup_health(&runtime).await;
+    let acp_event_printer = options
+        .acp_event_stream
+        .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
 
+    loop {
+        print!("you> ");
+        io::stdout()
+            .flush()
+            .map_err(|error| format!("flush stdout failed: {error}"))?;
+        let mut line = String::new();
+        let read = io::stdin()
+            .read_line(&mut line)
+            .map_err(|error| format!("read stdin failed: {error}"))?;
+        if read == 0 {
+            println!();
+            break;
+        }
+        match process_cli_chat_input(
+            &runtime,
+            line.trim(),
+            options,
+            acp_event_printer
+                .as_ref()
+                .map(|printer| printer as &dyn AcpTurnEventSink),
+        )
+        .await?
+        {
+            CliChatLoopControl::Continue => continue,
+            CliChatLoopControl::Exit => break,
+            CliChatLoopControl::AssistantText(assistant_text) => {
+                println!("loongclaw> {assistant_text}");
+            }
+        }
+    }
+
+    println!("bye.");
+    Ok(())
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+pub async fn run_cli_ask(
+    config_path: Option<&str>,
+    session_hint: Option<&str>,
+    message: &str,
+    options: &CliChatOptions,
+) -> CliResult<()> {
+    let input = message.trim();
+    if input.is_empty() {
+        return Err("ask message must not be empty".to_owned());
+    }
+
+    let runtime = initialize_cli_turn_runtime(config_path, session_hint, options, "cli-ask")?;
+    let acp_event_printer = options
+        .acp_event_stream
+        .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
+    let assistant_text = run_cli_turn(
+        &runtime,
+        input,
+        options,
+        acp_event_printer
+            .as_ref()
+            .map(|printer| printer as &dyn AcpTurnEventSink),
+    )
+    .await?;
+    println!("{assistant_text}");
+    Ok(())
+}
+
+pub fn run_concurrent_cli_host(options: &ConcurrentCliHostOptions) -> CliResult<()> {
+    let chat_options = CliChatOptions::default();
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        options.resolved_path.clone(),
+        options.config.clone(),
+        Some(options.session_id.as_str()),
+        &chat_options,
+        "cli-chat-concurrent",
+        CliSessionRequirement::RequireExplicit,
+    )?;
+    print_cli_chat_startup(&runtime, &chat_options)?;
+
+    let host_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("failed to initialize concurrent CLI host runtime: {error}"))?;
+
+    host_runtime.block_on(async {
+        print_turn_checkpoint_startup_health(&runtime).await;
+        run_concurrent_cli_host_loop(&runtime, &chat_options, options.shutdown.as_ref()).await
+    })
+}
+
+fn initialize_cli_turn_runtime(
+    config_path: Option<&str>,
+    session_hint: Option<&str>,
+    options: &CliChatOptions,
+    kernel_scope: &'static str,
+) -> CliResult<CliTurnRuntime> {
+    let (resolved_path, config) = config::load(config_path)?;
+    initialize_cli_turn_runtime_with_loaded_config(
+        resolved_path,
+        config,
+        session_hint,
+        options,
+        kernel_scope,
+        CliSessionRequirement::AllowImplicitDefault,
+    )
+}
+
+fn initialize_cli_turn_runtime_with_loaded_config(
+    resolved_path: PathBuf,
+    config: LoongClawConfig,
+    session_hint: Option<&str>,
+    options: &CliChatOptions,
+    kernel_scope: &'static str,
+    session_requirement: CliSessionRequirement,
+) -> CliResult<CliTurnRuntime> {
+    if !config.cli.enabled {
+        return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
+    }
+
+    crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+    let kernel_ctx =
+        bootstrap_kernel_context_with_config(kernel_scope, DEFAULT_TOKEN_TTL_S, &config)?;
+    let explicit_acp_request = options.requests_explicit_acp();
+    let effective_bootstrap_mcp_servers = config
+        .acp
+        .dispatch
+        .bootstrap_mcp_server_names_with_additions(&options.acp_bootstrap_mcp_servers)?;
+    let effective_working_directory = options
+        .acp_working_directory
+        .clone()
+        .or_else(|| config.acp.dispatch.resolved_working_directory());
+    let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
+    let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
+
+    #[cfg(feature = "memory-sqlite")]
+    let (memory_config, memory_label) = {
+        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let sqlite_path = config.memory.resolved_sqlite_path();
+        let initialized = memory::ensure_memory_db_ready(Some(sqlite_path), &memory_config)
+            .map_err(|error| format!("failed to initialize sqlite memory: {error}"))?;
+        (memory_config, initialized.display().to_string())
+    };
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    let memory_label = "disabled".to_owned();
+
+    Ok(CliTurnRuntime {
+        resolved_path,
+        config,
+        session_id,
+        session_address,
+        turn_coordinator: ConversationTurnCoordinator::new(),
+        kernel_ctx,
+        explicit_acp_request,
+        effective_bootstrap_mcp_servers,
+        effective_working_directory,
+        memory_label,
+        #[cfg(feature = "memory-sqlite")]
+        memory_config,
+    })
+}
+
+fn resolve_cli_session_id(
+    session_hint: Option<&str>,
+    session_requirement: CliSessionRequirement,
+) -> CliResult<String> {
+    match session_hint
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(session_id) => Ok(session_id.to_owned()),
+        None => match session_requirement {
+            CliSessionRequirement::AllowImplicitDefault => Ok("default".to_owned()),
+            CliSessionRequirement::RequireExplicit => {
+                Err("concurrent CLI host requires an explicit session id".to_owned())
+            }
+        },
+    }
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+async fn print_turn_checkpoint_startup_health(runtime: &CliTurnRuntime) {
     #[cfg(feature = "memory-sqlite")]
     match runtime
         .turn_coordinator
@@ -224,232 +429,162 @@ pub async fn run_cli_chat(
             );
         }
     }
-    let acp_event_printer = options
-        .acp_event_stream
-        .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
+}
+
+#[allow(clippy::print_stdout)] // CLI output
+async fn run_concurrent_cli_host_loop(
+    runtime: &CliTurnRuntime,
+    options: &CliChatOptions,
+    shutdown: &Notify,
+) -> CliResult<()> {
+    let mut stdin_lines = BufReader::new(tokio_io::stdin()).lines();
 
     loop {
         print!("you> ");
         io::stdout()
             .flush()
             .map_err(|error| format!("flush stdout failed: {error}"))?;
-        let mut line = String::new();
-        let read = io::stdin()
-            .read_line(&mut line)
-            .map_err(|error| format!("read stdin failed: {error}"))?;
-        if read == 0 {
+
+        let next_line = tokio::select! {
+            _ = shutdown.notified() => None,
+            line = stdin_lines.next_line() => Some(
+                line.map_err(|error| format!("read stdin failed: {error}"))?
+            ),
+        };
+
+        let Some(line) = next_line else {
+            break;
+        };
+        let Some(line) = line else {
             println!();
             break;
-        }
-        let input = line.trim();
-        if input.is_empty() {
-            continue;
-        }
-        if is_exit_command(&runtime.config, input) {
-            break;
-        }
-        if input == "/help" {
-            print_help();
-            continue;
-        }
-        if input == "/history" {
-            #[cfg(feature = "memory-sqlite")]
-            print_history(
-                &runtime.session_id,
-                runtime.config.memory.sliding_window,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-                &runtime.memory_config,
-            )
-            .await?;
-            #[cfg(not(feature = "memory-sqlite"))]
-            print_history(
-                &runtime.session_id,
-                runtime.config.memory.sliding_window,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            )
-            .await?;
-            continue;
-        }
-        if let Some(limit) =
-            parse_fast_lane_summary_limit(input, runtime.config.memory.sliding_window)?
-        {
-            #[cfg(feature = "memory-sqlite")]
-            print_fast_lane_summary(
-                &runtime.session_id,
-                limit,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-                &runtime.memory_config,
-            )
-            .await?;
-            #[cfg(not(feature = "memory-sqlite"))]
-            print_fast_lane_summary(
-                &runtime.session_id,
-                limit,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            )
-            .await?;
-            continue;
-        }
-        if let Some(limit) =
-            parse_safe_lane_summary_limit(input, runtime.config.memory.sliding_window)?
-        {
-            #[cfg(feature = "memory-sqlite")]
-            print_safe_lane_summary(
-                &runtime.session_id,
-                limit,
-                &runtime.config.conversation,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-                &runtime.memory_config,
-            )
-            .await?;
-            #[cfg(not(feature = "memory-sqlite"))]
-            print_safe_lane_summary(
-                &runtime.session_id,
-                limit,
-                &runtime.config.conversation,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            )
-            .await?;
-            continue;
-        }
-        if let Some(limit) =
-            parse_turn_checkpoint_summary_limit(input, runtime.config.memory.sliding_window)?
-        {
-            #[cfg(feature = "memory-sqlite")]
-            print_turn_checkpoint_summary(
-                &runtime.turn_coordinator,
-                &runtime.config,
-                &runtime.session_id,
-                limit,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-                &runtime.memory_config,
-            )
-            .await?;
-            #[cfg(not(feature = "memory-sqlite"))]
-            print_turn_checkpoint_summary(
-                &runtime.turn_coordinator,
-                &runtime.config,
-                &runtime.session_id,
-                limit,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            )
-            .await?;
-            continue;
-        }
-        if is_turn_checkpoint_repair_command(input)? {
-            print_turn_checkpoint_repair(
-                &runtime.turn_coordinator,
-                &runtime.config,
-                &runtime.session_id,
-                ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
-            )
-            .await?;
-            continue;
-        }
+        };
 
-        let assistant_text = run_cli_turn(
-            &runtime,
-            input,
-            options,
-            acp_event_printer
-                .as_ref()
-                .map(|printer| printer as &dyn AcpTurnEventSink),
-        )
-        .await?;
-
-        println!("loongclaw> {assistant_text}");
+        match process_cli_chat_input(runtime, line.trim(), options, None).await? {
+            CliChatLoopControl::Continue => continue,
+            CliChatLoopControl::Exit => break,
+            CliChatLoopControl::AssistantText(assistant_text) => {
+                println!("loongclaw> {assistant_text}");
+            }
+        }
     }
 
     println!("bye.");
     Ok(())
 }
 
-#[allow(clippy::print_stdout)] // CLI output
-pub async fn run_cli_ask(
-    config_path: Option<&str>,
-    session_hint: Option<&str>,
-    message: &str,
+async fn process_cli_chat_input(
+    runtime: &CliTurnRuntime,
+    input: &str,
     options: &CliChatOptions,
-) -> CliResult<()> {
-    let input = message.trim();
+    event_sink: Option<&dyn AcpTurnEventSink>,
+) -> CliResult<CliChatLoopControl> {
     if input.is_empty() {
-        return Err("ask message must not be empty".to_owned());
+        return Ok(CliChatLoopControl::Continue);
     }
-
-    let runtime =
-        initialize_cli_turn_runtime(config_path, session_hint, options, "cli-ask").await?;
-    let acp_event_printer = options
-        .acp_event_stream
-        .then(|| JsonlAcpTurnEventSink::stderr_with_prefix("acp-event> "));
-    let assistant_text = run_cli_turn(
-        &runtime,
-        input,
-        options,
-        acp_event_printer
-            .as_ref()
-            .map(|printer| printer as &dyn AcpTurnEventSink),
-    )
-    .await?;
-    println!("{assistant_text}");
-    Ok(())
-}
-
-async fn initialize_cli_turn_runtime(
-    config_path: Option<&str>,
-    session_hint: Option<&str>,
-    options: &CliChatOptions,
-    kernel_scope: &'static str,
-) -> CliResult<CliTurnRuntime> {
-    let (resolved_path, config) = config::load(config_path)?;
-    if !config.cli.enabled {
-        return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
+    if is_exit_command(&runtime.config, input) {
+        return Ok(CliChatLoopControl::Exit);
     }
-
-    crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
-    let kernel_ctx =
-        bootstrap_kernel_context_with_config(kernel_scope, DEFAULT_TOKEN_TTL_S, &config)?;
-    let explicit_acp_request = options.requests_explicit_acp();
-    let effective_bootstrap_mcp_servers = config
-        .acp
-        .dispatch
-        .bootstrap_mcp_server_names_with_additions(&options.acp_bootstrap_mcp_servers)?;
-    let effective_working_directory = options
-        .acp_working_directory
-        .clone()
-        .or_else(|| config.acp.dispatch.resolved_working_directory());
-    let session_id = session_hint
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("default")
-        .to_owned();
-    let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
-
-    #[cfg(feature = "memory-sqlite")]
-    let (memory_config, memory_label) = {
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        let sqlite_path = config.memory.resolved_sqlite_path();
-        let initialized = memory::ensure_memory_db_ready(Some(sqlite_path), &memory_config)
-            .map_err(|error| format!("failed to initialize sqlite memory: {error}"))?;
-        (memory_config, initialized.display().to_string())
-    };
-
-    #[cfg(not(feature = "memory-sqlite"))]
-    let memory_label = "disabled".to_owned();
-
-    Ok(CliTurnRuntime {
-        resolved_path,
-        config,
-        session_id,
-        session_address,
-        turn_coordinator: ConversationTurnCoordinator::new(),
-        kernel_ctx,
-        explicit_acp_request,
-        effective_bootstrap_mcp_servers,
-        effective_working_directory,
-        memory_label,
+    if input == "/help" {
+        print_help();
+        return Ok(CliChatLoopControl::Continue);
+    }
+    if input == "/history" {
         #[cfg(feature = "memory-sqlite")]
-        memory_config,
-    })
+        print_history(
+            &runtime.session_id,
+            runtime.config.memory.sliding_window,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            &runtime.memory_config,
+        )
+        .await?;
+        #[cfg(not(feature = "memory-sqlite"))]
+        print_history(
+            &runtime.session_id,
+            runtime.config.memory.sliding_window,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+        )
+        .await?;
+        return Ok(CliChatLoopControl::Continue);
+    }
+    if let Some(limit) = parse_fast_lane_summary_limit(input, runtime.config.memory.sliding_window)?
+    {
+        #[cfg(feature = "memory-sqlite")]
+        print_fast_lane_summary(
+            &runtime.session_id,
+            limit,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            &runtime.memory_config,
+        )
+        .await?;
+        #[cfg(not(feature = "memory-sqlite"))]
+        print_fast_lane_summary(
+            &runtime.session_id,
+            limit,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+        )
+        .await?;
+        return Ok(CliChatLoopControl::Continue);
+    }
+    if let Some(limit) = parse_safe_lane_summary_limit(input, runtime.config.memory.sliding_window)?
+    {
+        #[cfg(feature = "memory-sqlite")]
+        print_safe_lane_summary(
+            &runtime.session_id,
+            limit,
+            &runtime.config.conversation,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            &runtime.memory_config,
+        )
+        .await?;
+        #[cfg(not(feature = "memory-sqlite"))]
+        print_safe_lane_summary(
+            &runtime.session_id,
+            limit,
+            &runtime.config.conversation,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+        )
+        .await?;
+        return Ok(CliChatLoopControl::Continue);
+    }
+    if let Some(limit) =
+        parse_turn_checkpoint_summary_limit(input, runtime.config.memory.sliding_window)?
+    {
+        #[cfg(feature = "memory-sqlite")]
+        print_turn_checkpoint_summary(
+            &runtime.turn_coordinator,
+            &runtime.config,
+            &runtime.session_id,
+            limit,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            &runtime.memory_config,
+        )
+        .await?;
+        #[cfg(not(feature = "memory-sqlite"))]
+        print_turn_checkpoint_summary(
+            &runtime.turn_coordinator,
+            &runtime.config,
+            &runtime.session_id,
+            limit,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+        )
+        .await?;
+        return Ok(CliChatLoopControl::Continue);
+    }
+    if is_turn_checkpoint_repair_command(input)? {
+        print_turn_checkpoint_repair(
+            &runtime.turn_coordinator,
+            &runtime.config,
+            &runtime.session_id,
+            ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+        )
+        .await?;
+        return Ok(CliChatLoopControl::Continue);
+    }
+
+    Ok(CliChatLoopControl::AssistantText(
+        run_cli_turn(runtime, input, options, event_sink).await?,
+    ))
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -1682,10 +1817,11 @@ mod tests {
     use crate::conversation::ConversationRuntimeBinding;
     use std::ffi::OsStr;
     use std::path::PathBuf;
+    use std::sync::Arc;
     #[cfg(feature = "memory-sqlite")]
     use std::{
         collections::{BTreeMap, BTreeSet},
-        sync::{Arc, Mutex},
+        sync::Mutex,
     };
 
     #[cfg(feature = "memory-sqlite")]
@@ -1699,6 +1835,7 @@ mod tests {
     };
     #[cfg(feature = "memory-sqlite")]
     use serde_json::{Value, json};
+    use tokio::sync::Notify;
 
     #[test]
     fn cli_chat_options_detect_explicit_acp_requests() {
@@ -2101,6 +2238,43 @@ mod tests {
             .expect_err("empty one-shot message should fail");
 
         assert!(error.contains("ask message must not be empty"));
+    }
+
+    #[test]
+    fn concurrent_cli_host_requires_explicit_session_id() {
+        let shutdown = Arc::new(Notify::new());
+        let error = run_concurrent_cli_host(&ConcurrentCliHostOptions {
+            resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+            config: LoongClawConfig::default(),
+            session_id: "   ".to_owned(),
+            shutdown,
+        })
+        .expect_err("concurrent host should reject an implicit session id");
+
+        assert!(
+            error.contains("explicit session"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "memory-sqlite")]
+    fn concurrent_cli_host_exits_when_shutdown_is_requested() {
+        let (mut config, _memory_config, sqlite_path) = init_chat_test_memory("concurrent-host");
+        config.audit.mode = crate::config::AuditMode::InMemory;
+
+        let shutdown = Arc::new(Notify::new());
+        shutdown.notify_one();
+
+        run_concurrent_cli_host(&ConcurrentCliHostOptions {
+            resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            session_id: "cli-supervisor".to_owned(),
+            shutdown,
+        })
+        .expect("concurrent host should stop cleanly when shutdown is requested");
+
+        cleanup_chat_test_memory(&sqlite_path);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -293,6 +293,7 @@ pub fn run_concurrent_cli_host(options: &ConcurrentCliHostOptions) -> CliResult<
         &chat_options,
         "cli-chat-concurrent",
         CliSessionRequirement::RequireExplicit,
+        true,
     )?;
     print_cli_chat_startup(&runtime, &chat_options)?;
 
@@ -321,6 +322,7 @@ fn initialize_cli_turn_runtime(
         options,
         kernel_scope,
         CliSessionRequirement::AllowImplicitDefault,
+        true,
     )
 }
 
@@ -331,12 +333,16 @@ fn initialize_cli_turn_runtime_with_loaded_config(
     options: &CliChatOptions,
     kernel_scope: &'static str,
     session_requirement: CliSessionRequirement,
+    initialize_runtime_environment: bool,
 ) -> CliResult<CliTurnRuntime> {
     if !config.cli.enabled {
         return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
     }
 
-    crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+    let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
+    if initialize_runtime_environment {
+        crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+    }
     let kernel_ctx =
         bootstrap_kernel_context_with_config(kernel_scope, DEFAULT_TOKEN_TTL_S, &config)?;
     let explicit_acp_request = options.requests_explicit_acp();
@@ -348,7 +354,6 @@ fn initialize_cli_turn_runtime_with_loaded_config(
         .acp_working_directory
         .clone()
         .or_else(|| config.acp.dispatch.resolved_working_directory());
-    let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
     let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
 
     #[cfg(feature = "memory-sqlite")]
@@ -2257,22 +2262,28 @@ mod tests {
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(feature = "memory-sqlite")]
-    fn concurrent_cli_host_exits_when_shutdown_is_requested() {
+    async fn concurrent_cli_host_exits_when_shutdown_is_requested() {
         let (mut config, _memory_config, sqlite_path) = init_chat_test_memory("concurrent-host");
         config.audit.mode = crate::config::AuditMode::InMemory;
-
+        let options = CliChatOptions::default();
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("cli-supervisor"),
+            &options,
+            "cli-chat-concurrent-test",
+            CliSessionRequirement::RequireExplicit,
+            false,
+        )
+        .expect("concurrent host runtime");
         let shutdown = Arc::new(Notify::new());
         shutdown.notify_one();
 
-        run_concurrent_cli_host(&ConcurrentCliHostOptions {
-            resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            session_id: "cli-supervisor".to_owned(),
-            shutdown,
-        })
-        .expect("concurrent host should stop cleanly when shutdown is requested");
+        run_concurrent_cli_host_loop(&runtime, &options, shutdown.as_ref())
+            .await
+            .expect("concurrent host should stop cleanly when shutdown is requested");
 
         cleanup_chat_test_memory(&sqlite_path);
     }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -3309,6 +3309,7 @@ mod tests {
             "expected normalized bootstrap count to be recorded under the canonical path"
         );
 
+        drop(_cwd_guard);
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);
     }
@@ -3362,6 +3363,7 @@ mod tests {
             "expected normalized bootstrap count to land on the canonical db path"
         );
 
+        drop(_cwd_guard);
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);
     }
@@ -3461,6 +3463,7 @@ mod tests {
             "expected repeated same-path runtime lookups to reuse the existing cached sqlite runtime"
         );
 
+        drop(_cwd_guard);
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -1143,6 +1143,7 @@ mod tests {
     #[cfg(feature = "tool-shell")]
     #[test]
     fn injected_config_overrides_global() {
+        let _env = ScopedEnv::new();
         let config = ToolRuntimeConfig {
             file_root: Some(PathBuf::from("/tmp/injected-root")),
             shell_allow: BTreeSet::from(["echo".to_owned()]),

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -93,7 +93,7 @@ pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;
 pub mod skills_cli;
 pub mod source_presentation;
-mod supervisor;
+pub mod supervisor;
 
 pub use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -93,6 +93,7 @@ pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;
 pub mod skills_cli;
 pub mod source_presentation;
+mod supervisor;
 
 pub use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,
@@ -696,6 +697,17 @@ pub enum Commands {
         once: bool,
         #[arg(long)]
         account: Option<String>,
+    },
+    /// Run the multi-channel supervisor for coordinated Telegram and Feishu serving
+    MultiChannelServe {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long)]
+        session: String,
+        #[arg(long)]
+        telegram_account: Option<String>,
+        #[arg(long)]
+        feishu_account: Option<String>,
     },
     /// Run the Feishu integration namespace
     Feishu {
@@ -3602,6 +3614,16 @@ pub fn run_matrix_serve_cli_impl(args: ChannelServeCliArgs<'_>) -> ChannelCliCom
         ))
         .await
     })
+}
+
+pub async fn run_multi_channel_serve_cli(
+    config_path: Option<&str>,
+    session: &str,
+    telegram_account: Option<&str>,
+    feishu_account: Option<&str>,
+) -> CliResult<()> {
+    supervisor::run_multi_channel_serve(config_path, session, telegram_account, feishu_account)
+        .await
 }
 
 pub fn parse_json_payload(raw: &str, context: &str) -> CliResult<Value> {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -493,6 +493,20 @@ async fn main() {
             )
             .await
         }
+        Commands::MultiChannelServe {
+            config,
+            session,
+            telegram_account,
+            feishu_account,
+        } => {
+            run_multi_channel_serve_cli(
+                config.as_deref(),
+                &session,
+                telegram_account.as_deref(),
+                feishu_account.as_deref(),
+            )
+            .await
+        }
         Commands::Feishu { command } => feishu_cli::run_feishu_command(command).await,
         Commands::Completions { shell } => {
             completions_cli::run_completions_cli(completions_cli::CompletionsCommandOptions {

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -528,12 +528,15 @@ pub struct BackgroundChannelRunnerRequest {
     pub config: mvp::config::LoongClawConfig,
     pub account_id: Option<String>,
     pub stop: mvp::channel::ChannelServeStopHandle,
+    pub initialize_runtime_environment: bool,
 }
 
 #[derive(Clone)]
 pub struct SupervisorRuntimeHooks {
     pub load_config:
         Arc<dyn Fn(Option<&str>) -> CliResult<LoadedSupervisorConfig> + Send + Sync + 'static>,
+    pub initialize_runtime_environment:
+        Arc<dyn Fn(&LoadedSupervisorConfig) + Send + Sync + 'static>,
     pub run_cli_host: Arc<
         dyn Fn(mvp::chat::ConcurrentCliHostOptions) -> BoxedSupervisorFuture
             + Send
@@ -559,6 +562,12 @@ impl SupervisorRuntimeHooks {
                     config,
                 })
             }),
+            initialize_runtime_environment: Arc::new(|loaded_config| {
+                mvp::runtime_env::initialize_runtime_environment(
+                    &loaded_config.config,
+                    Some(loaded_config.resolved_path.as_path()),
+                );
+            }),
             run_cli_host: Arc::new(|options| {
                 Box::pin(async move {
                     tokio::task::spawn_blocking(move || {
@@ -576,6 +585,7 @@ impl SupervisorRuntimeHooks {
                         false,
                         request.account_id.as_deref(),
                         request.stop,
+                        request.initialize_runtime_environment,
                     )
                     .await
                 })
@@ -589,6 +599,7 @@ impl SupervisorRuntimeHooks {
                         None,
                         None,
                         request.stop,
+                        request.initialize_runtime_environment,
                     )
                     .await
                 })
@@ -666,10 +677,12 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
     feishu_account: Option<&str>,
     hooks: SupervisorRuntimeHooks,
 ) -> CliResult<SupervisorState> {
+    let loaded_config = (hooks.load_config)(config_path)?;
+    (hooks.initialize_runtime_environment)(&loaded_config);
     let LoadedSupervisorConfig {
         resolved_path,
         config,
-    } = (hooks.load_config)(config_path)?;
+    } = loaded_config;
     let spec = SupervisorSpec::from_loaded_multi_channel_serve(
         session,
         &config,
@@ -695,6 +708,7 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                     config: config.clone(),
                     account_id: account_id.clone(),
                     stop: telegram_stop.clone(),
+                    initialize_runtime_environment: false,
                 };
                 let run_telegram = hooks.run_telegram.clone();
                 let tracked_surface = surface.clone();
@@ -715,6 +729,7 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                     config: config.clone(),
                     account_id: account_id.clone(),
                     stop: feishu_stop.clone(),
+                    initialize_runtime_environment: false,
                 };
                 let run_feishu = hooks.run_feishu.clone();
                 let tracked_surface = surface.clone();
@@ -737,6 +752,7 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
         config: config.clone(),
         session_id: session.to_owned(),
         shutdown: cli_shutdown.clone(),
+        initialize_runtime_environment: false,
     }));
     let mut cli_active = true;
 

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use loongclaw_spec::CliResult;
-use tokio::task::JoinSet;
+use tokio::task::{Id, JoinSet};
 
 use crate::{mvp, wait_for_shutdown_signal};
 
@@ -182,6 +182,34 @@ impl SupervisorSpec {
                 cli_session: session.to_owned(),
             },
             BackgroundChannelSurface::all_from_accounts(telegram_account, feishu_account),
+        )
+    }
+
+    pub fn from_loaded_multi_channel_serve(
+        session: &str,
+        config: &mvp::config::LoongClawConfig,
+        telegram_account: Option<&str>,
+        feishu_account: Option<&str>,
+    ) -> Result<Self, String> {
+        let mut surfaces = Vec::new();
+
+        if telegram_surface_is_enabled(config, telegram_account)? {
+            surfaces.push(BackgroundChannelSurface::Telegram {
+                account_id: telegram_account.map(str::to_owned),
+            });
+        }
+
+        if feishu_surface_is_enabled(config, feishu_account)? {
+            surfaces.push(BackgroundChannelSurface::Feishu {
+                account_id: feishu_account.map(str::to_owned),
+            });
+        }
+
+        Self::new(
+            RuntimeOwnerMode::MultiChannelServe {
+                cli_session: session.to_owned(),
+            },
+            surfaces,
         )
     }
 }
@@ -578,6 +606,31 @@ enum BackgroundTaskExit {
     },
 }
 
+fn telegram_surface_is_enabled(
+    config: &mvp::config::LoongClawConfig,
+    account_id: Option<&str>,
+) -> CliResult<bool> {
+    if !config.telegram.enabled {
+        return Ok(false);
+    }
+    Ok(config.telegram.resolve_account(account_id)?.enabled)
+}
+
+fn feishu_surface_is_enabled(
+    config: &mvp::config::LoongClawConfig,
+    account_id: Option<&str>,
+) -> CliResult<bool> {
+    if !config.feishu.enabled {
+        return Ok(false);
+    }
+    Ok(mvp::feishu::resolve_requested_feishu_account(
+        &config.feishu,
+        account_id,
+        "rerun with `--account <configured_account_id>` using one of those configured accounts",
+    )?
+    .enabled)
+}
+
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -613,11 +666,16 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
     feishu_account: Option<&str>,
     hooks: SupervisorRuntimeHooks,
 ) -> CliResult<SupervisorState> {
-    let spec = SupervisorSpec::from_multi_channel_serve(session, telegram_account, feishu_account)?;
     let LoadedSupervisorConfig {
         resolved_path,
         config,
     } = (hooks.load_config)(config_path)?;
+    let spec = SupervisorSpec::from_loaded_multi_channel_serve(
+        session,
+        &config,
+        telegram_account,
+        feishu_account,
+    )?;
     let mut supervisor = SupervisorState::new(spec.clone());
 
     let cli_shutdown = mvp::chat::ConcurrentCliShutdown::new();
@@ -626,6 +684,7 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
     let stop_handles = vec![telegram_stop.clone(), feishu_stop.clone()];
 
     let mut background_tasks = JoinSet::new();
+    let mut background_task_surfaces = BTreeMap::<Id, BackgroundChannelSurface>::new();
 
     for surface in &spec.surfaces {
         supervisor.mark_surface_running(surface, now_ms())?;
@@ -638,13 +697,17 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                     stop: telegram_stop.clone(),
                 };
                 let run_telegram = hooks.run_telegram.clone();
-                let surface = surface.clone();
-                background_tasks.spawn(async move {
-                    BackgroundTaskExit::Surface {
-                        surface,
-                        result: run_telegram(request).await,
-                    }
-                });
+                let tracked_surface = surface.clone();
+                let task_surface = tracked_surface.clone();
+                let task_id = background_tasks
+                    .spawn(async move {
+                        BackgroundTaskExit::Surface {
+                            surface: task_surface,
+                            result: run_telegram(request).await,
+                        }
+                    })
+                    .id();
+                background_task_surfaces.insert(task_id, tracked_surface);
             }
             BackgroundChannelSurface::Feishu { account_id } => {
                 let request = BackgroundChannelRunnerRequest {
@@ -654,13 +717,17 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                     stop: feishu_stop.clone(),
                 };
                 let run_feishu = hooks.run_feishu.clone();
-                let surface = surface.clone();
-                background_tasks.spawn(async move {
-                    BackgroundTaskExit::Surface {
-                        surface,
-                        result: run_feishu(request).await,
-                    }
-                });
+                let tracked_surface = surface.clone();
+                let task_surface = tracked_surface.clone();
+                let task_id = background_tasks
+                    .spawn(async move {
+                        BackgroundTaskExit::Surface {
+                            surface: task_surface,
+                            result: run_feishu(request).await,
+                        }
+                    })
+                    .id();
+                background_task_surfaces.insert(task_id, tracked_surface);
             }
         }
     }
@@ -706,10 +773,10 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                 }
                 forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
             }
-            Some(joined) = background_tasks.join_next(), if !background_tasks.is_empty() => {
-                let exit = joined.map_err(|error| format!("background channel task failed to join: {error}"))?;
-                match exit {
-                    BackgroundTaskExit::Surface { surface, result } => {
+            Some(joined) = background_tasks.join_next_with_id(), if !background_tasks.is_empty() => {
+                match joined {
+                    Ok((task_id, BackgroundTaskExit::Surface { surface, result })) => {
+                        background_task_surfaces.remove(&task_id);
                         match result {
                             Ok(()) => {
                                 supervisor.mark_surface_stopped(&surface, now_ms())?;
@@ -718,6 +785,18 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                                 supervisor.record_surface_failure(&surface, now_ms(), error)?;
                             }
                         }
+                    }
+                    Err(error) => {
+                        let Some(surface) = background_task_surfaces.remove(&error.id()) else {
+                            return Err(format!(
+                                "background channel task failed to join and could not be attributed to a tracked surface: {error}"
+                            ));
+                        };
+                        supervisor.record_surface_failure(
+                            &surface,
+                            now_ms(),
+                            format!("background channel task failed to join: {error}"),
+                        )?;
                     }
                 }
 

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use loongclaw_spec::CliResult;
-use tokio::{sync::Notify, task::JoinSet};
+use tokio::task::JoinSet;
 
 use crate::{mvp, wait_for_shutdown_signal};
 
@@ -587,11 +587,11 @@ fn now_ms() -> u64 {
 
 fn forward_root_shutdown(
     supervisor: &mut SupervisorState,
-    cli_shutdown: &Arc<Notify>,
+    cli_shutdown: &mvp::chat::ConcurrentCliShutdown,
     stop_handles: &[mvp::channel::ChannelServeStopHandle],
     signal_active: &mut bool,
 ) {
-    cli_shutdown.notify_waiters();
+    cli_shutdown.request_shutdown();
     for stop in stop_handles {
         stop.request_stop();
     }
@@ -620,7 +620,7 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
     } = (hooks.load_config)(config_path)?;
     let mut supervisor = SupervisorState::new(spec.clone());
 
-    let cli_shutdown = Arc::new(Notify::new());
+    let cli_shutdown = mvp::chat::ConcurrentCliShutdown::new();
     let telegram_stop = mvp::channel::ChannelServeStopHandle::new();
     let feishu_stop = mvp::channel::ChannelServeStopHandle::new();
     let stop_handles = vec![telegram_stop.clone(), feishu_stop.clone()];

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -334,6 +334,24 @@ impl SupervisorState {
         surface: &BackgroundChannelSurface,
         stopped_at_ms: u64,
     ) -> Result<(), String> {
+        let current_phase = self
+            .surface_state(surface)
+            .ok_or_else(|| format!("unknown background surface: {surface}"))?
+            .phase;
+        if current_phase == SurfacePhase::Failed {
+            let state = self.surface_state_mut(surface)?;
+            state.stopped_at_ms = Some(stopped_at_ms);
+            return Ok(());
+        }
+
+        if self.shutdown_reason.is_none() {
+            return self.record_surface_failure(
+                surface,
+                stopped_at_ms,
+                "surface stopped unexpectedly without a shutdown request",
+            );
+        }
+
         let exit_reason = self.shutdown_reason.as_ref().map(|reason| match reason {
             SupervisorShutdownReason::Requested { reason } => {
                 format!("shutdown requested: {reason}")
@@ -386,6 +404,19 @@ impl SupervisorState {
             return summary;
         }
 
+        if self.all_surfaces_terminal() && self.shutdown_reason().is_none() {
+            let surfaces = self
+                .spec
+                .surfaces
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            return format!(
+                "multi-channel supervisor failed because surfaces stopped without a shutdown request: {surfaces}"
+            );
+        }
+
         let surfaces = self
             .spec
             .surfaces
@@ -407,7 +438,10 @@ impl SupervisorState {
         }
 
         if self.all_surfaces_terminal() {
-            return Ok(());
+            return match self.shutdown_reason() {
+                Some(SupervisorShutdownReason::Requested { .. }) => Ok(()),
+                _ => Err(self.final_exit_summary()),
+            };
         }
 
         Err(self.final_exit_summary())
@@ -617,6 +651,84 @@ mod tests {
         assert_eq!(
             state.exit_reason.as_deref(),
             Some("surface failed: lost upstream connection")
+        );
+    }
+
+    #[tokio::test]
+    async fn child_stop_without_shutdown_request_returns_failure_result() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let mut supervisor =
+            SupervisorState::new(sample_spec(vec![telegram.clone()]).expect("build spec"));
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .mark_surface_stopped(&telegram, 1_710_000_000_500)
+            .expect("record unexpected stop");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Failed);
+        let state = supervisor
+            .surface_state(&telegram)
+            .expect("telegram surface should be tracked");
+        assert_eq!(state.phase, SurfacePhase::Failed);
+        assert_eq!(
+            state.last_error.as_deref(),
+            Some("surface stopped unexpectedly without a shutdown request")
+        );
+        assert_eq!(
+            state.exit_reason.as_deref(),
+            Some("surface failed: surface stopped unexpectedly without a shutdown request")
+        );
+
+        let result = supervisor.final_exit_result();
+        let error = result.expect_err("unexpected child exit must fail closed");
+        assert!(
+            error.contains("telegram"),
+            "failure result should name the stopped surface: {error}"
+        );
+        assert!(
+            error.contains("surface stopped unexpectedly without a shutdown request"),
+            "failure result should explain the unexpected clean exit: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_child_later_reporting_stopped_preserves_failure_phase_and_result() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let mut supervisor =
+            SupervisorState::new(sample_spec(vec![telegram.clone()]).expect("build spec"));
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .record_surface_failure(&telegram, 1_710_000_000_500, "lost upstream connection")
+            .expect("record telegram failure");
+        supervisor
+            .mark_surface_stopped(&telegram, 1_710_000_000_800)
+            .expect("record stop bookkeeping after failure");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Failed);
+        let state = supervisor
+            .surface_state(&telegram)
+            .expect("telegram surface should be tracked");
+        assert_eq!(state.phase, SurfacePhase::Failed);
+        assert_eq!(state.stopped_at_ms, Some(1_710_000_000_800));
+        assert_eq!(
+            state.last_error.as_deref(),
+            Some("lost upstream connection")
+        );
+        assert_eq!(
+            state.exit_reason.as_deref(),
+            Some("surface failed: lost upstream connection")
+        );
+
+        let result = supervisor.final_exit_result();
+        let error = result.expect_err("failure result must be preserved");
+        assert!(
+            error.contains("lost upstream connection"),
+            "failure result should keep the original failure reason: {error}"
         );
     }
 

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -1,9 +1,19 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use loongclaw_spec::CliResult;
+use tokio::{sync::Notify, task::JoinSet};
+
+use crate::{mvp, wait_for_shutdown_signal};
+
+type BoxedSupervisorFuture = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'static>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BackgroundChannelSurface {
@@ -478,15 +488,270 @@ impl SupervisorState {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct LoadedSupervisorConfig {
+    pub resolved_path: PathBuf,
+    pub config: mvp::config::LoongClawConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct BackgroundChannelRunnerRequest {
+    pub resolved_path: PathBuf,
+    pub config: mvp::config::LoongClawConfig,
+    pub account_id: Option<String>,
+    pub stop: mvp::channel::ChannelServeStopHandle,
+}
+
+#[derive(Clone)]
+pub struct SupervisorRuntimeHooks {
+    pub load_config:
+        Arc<dyn Fn(Option<&str>) -> CliResult<LoadedSupervisorConfig> + Send + Sync + 'static>,
+    pub run_cli_host: Arc<
+        dyn Fn(mvp::chat::ConcurrentCliHostOptions) -> BoxedSupervisorFuture
+            + Send
+            + Sync
+            + 'static,
+    >,
+    pub run_telegram: Arc<
+        dyn Fn(BackgroundChannelRunnerRequest) -> BoxedSupervisorFuture + Send + Sync + 'static,
+    >,
+    pub run_feishu: Arc<
+        dyn Fn(BackgroundChannelRunnerRequest) -> BoxedSupervisorFuture + Send + Sync + 'static,
+    >,
+    pub wait_for_shutdown: Arc<dyn Fn() -> BoxedSupervisorFuture + Send + Sync + 'static>,
+}
+
+impl SupervisorRuntimeHooks {
+    fn production() -> Self {
+        Self {
+            load_config: Arc::new(|config_path| {
+                let (resolved_path, config) = mvp::config::load(config_path)?;
+                Ok(LoadedSupervisorConfig {
+                    resolved_path,
+                    config,
+                })
+            }),
+            run_cli_host: Arc::new(|options| {
+                Box::pin(async move {
+                    tokio::task::spawn_blocking(move || {
+                        mvp::chat::run_concurrent_cli_host(&options)
+                    })
+                    .await
+                    .map_err(|error| format!("concurrent CLI host task failed to join: {error}"))?
+                })
+            }),
+            run_telegram: Arc::new(|request| {
+                Box::pin(async move {
+                    mvp::channel::run_telegram_channel_with_stop(
+                        request.resolved_path,
+                        request.config,
+                        false,
+                        request.account_id.as_deref(),
+                        request.stop,
+                    )
+                    .await
+                })
+            }),
+            run_feishu: Arc::new(|request| {
+                Box::pin(async move {
+                    mvp::channel::run_feishu_channel_with_stop(
+                        request.resolved_path,
+                        request.config,
+                        request.account_id.as_deref(),
+                        None,
+                        None,
+                        request.stop,
+                    )
+                    .await
+                })
+            }),
+            wait_for_shutdown: Arc::new(|| Box::pin(async { wait_for_shutdown_signal().await })),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum BackgroundTaskExit {
+    Surface {
+        surface: BackgroundChannelSurface,
+        result: CliResult<()>,
+    },
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn forward_root_shutdown(
+    supervisor: &mut SupervisorState,
+    cli_shutdown: &Arc<Notify>,
+    stop_handles: &[mvp::channel::ChannelServeStopHandle],
+    signal_active: &mut bool,
+) {
+    cli_shutdown.notify_waiters();
+    for stop in stop_handles {
+        stop.request_stop();
+    }
+    *signal_active = false;
+    if matches!(
+        supervisor.phase(),
+        RuntimeOwnerPhase::Stopping | RuntimeOwnerPhase::Failed | RuntimeOwnerPhase::Stopped
+    ) {
+        return;
+    }
+    supervisor.phase = RuntimeOwnerPhase::Stopping;
+}
+
+#[doc(hidden)]
+pub async fn run_multi_channel_serve_with_hooks_for_test(
+    config_path: Option<&str>,
+    session: &str,
+    telegram_account: Option<&str>,
+    feishu_account: Option<&str>,
+    hooks: SupervisorRuntimeHooks,
+) -> CliResult<SupervisorState> {
+    let spec = SupervisorSpec::from_multi_channel_serve(session, telegram_account, feishu_account)?;
+    let LoadedSupervisorConfig {
+        resolved_path,
+        config,
+    } = (hooks.load_config)(config_path)?;
+    let mut supervisor = SupervisorState::new(spec.clone());
+
+    let cli_shutdown = Arc::new(Notify::new());
+    let telegram_stop = mvp::channel::ChannelServeStopHandle::new();
+    let feishu_stop = mvp::channel::ChannelServeStopHandle::new();
+    let stop_handles = vec![telegram_stop.clone(), feishu_stop.clone()];
+
+    let mut background_tasks = JoinSet::new();
+
+    for surface in &spec.surfaces {
+        supervisor.mark_surface_running(surface, now_ms())?;
+        match surface {
+            BackgroundChannelSurface::Telegram { account_id } => {
+                let request = BackgroundChannelRunnerRequest {
+                    resolved_path: resolved_path.clone(),
+                    config: config.clone(),
+                    account_id: account_id.clone(),
+                    stop: telegram_stop.clone(),
+                };
+                let run_telegram = hooks.run_telegram.clone();
+                let surface = surface.clone();
+                background_tasks.spawn(async move {
+                    BackgroundTaskExit::Surface {
+                        surface,
+                        result: run_telegram(request).await,
+                    }
+                });
+            }
+            BackgroundChannelSurface::Feishu { account_id } => {
+                let request = BackgroundChannelRunnerRequest {
+                    resolved_path: resolved_path.clone(),
+                    config: config.clone(),
+                    account_id: account_id.clone(),
+                    stop: feishu_stop.clone(),
+                };
+                let run_feishu = hooks.run_feishu.clone();
+                let surface = surface.clone();
+                background_tasks.spawn(async move {
+                    BackgroundTaskExit::Surface {
+                        surface,
+                        result: run_feishu(request).await,
+                    }
+                });
+            }
+        }
+    }
+
+    let mut cli_host = Box::pin((hooks.run_cli_host)(mvp::chat::ConcurrentCliHostOptions {
+        resolved_path: resolved_path.clone(),
+        config: config.clone(),
+        session_id: session.to_owned(),
+        shutdown: cli_shutdown.clone(),
+    }));
+    let mut cli_active = true;
+
+    let mut shutdown_signal = Box::pin((hooks.wait_for_shutdown)());
+    let mut signal_active = true;
+
+    let mut foreground_failure: Option<String> = None;
+
+    while cli_active || !background_tasks.is_empty() {
+        tokio::select! {
+            cli_result = &mut cli_host, if cli_active => {
+                cli_active = false;
+                match cli_result {
+                    Ok(()) => {
+                        if !supervisor.shutdown_requested() {
+                            supervisor.request_shutdown("foreground CLI host exited".to_owned())?;
+                        }
+                        forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
+                    }
+                    Err(error) => {
+                        foreground_failure = Some(error.clone());
+                        if !supervisor.shutdown_requested() {
+                            supervisor.request_shutdown(format!("foreground CLI host failed: {error}"))?;
+                        }
+                        forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
+                    }
+                }
+            }
+            signal_result = &mut shutdown_signal, if signal_active => {
+                signal_active = false;
+                signal_result?;
+                if !supervisor.shutdown_requested() {
+                    supervisor.request_shutdown("ctrl-c received".to_owned())?;
+                }
+                forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
+            }
+            Some(joined) = background_tasks.join_next(), if !background_tasks.is_empty() => {
+                let exit = joined.map_err(|error| format!("background channel task failed to join: {error}"))?;
+                match exit {
+                    BackgroundTaskExit::Surface { surface, result } => {
+                        match result {
+                            Ok(()) => {
+                                supervisor.mark_surface_stopped(&surface, now_ms())?;
+                            }
+                            Err(error) => {
+                                supervisor.record_surface_failure(&surface, now_ms(), error)?;
+                            }
+                        }
+                    }
+                }
+
+                if supervisor.shutdown_requested() {
+                    forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
+                }
+            }
+        }
+    }
+
+    if let Some(error) = foreground_failure {
+        return Err(format!(
+            "multi-channel supervisor failed because foreground CLI host exited unexpectedly: {error}"
+        ));
+    }
+
+    Ok(supervisor)
+}
+
 pub async fn run_multi_channel_serve(
     config_path: Option<&str>,
     session: &str,
     telegram_account: Option<&str>,
     feishu_account: Option<&str>,
 ) -> CliResult<()> {
-    let spec = SupervisorSpec::from_multi_channel_serve(session, telegram_account, feishu_account)?;
-    let _ = (config_path, spec);
-    Err("multi-channel-serve is not implemented yet".to_owned())
+    let supervisor = run_multi_channel_serve_with_hooks_for_test(
+        config_path,
+        session,
+        telegram_account,
+        feishu_account,
+        SupervisorRuntimeHooks::production(),
+    )
+    .await?;
+    supervisor.final_exit_result()
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -229,6 +229,30 @@ impl SupervisorState {
         surface: &BackgroundChannelSurface,
         started_at_ms: u64,
     ) -> Result<(), String> {
+        let owner_in_shutdown_path = self.shutdown_requested()
+            || matches!(
+                self.phase,
+                RuntimeOwnerPhase::Stopping
+                    | RuntimeOwnerPhase::Stopped
+                    | RuntimeOwnerPhase::Failed
+            );
+        let surface_phase = self
+            .surface_state(surface)
+            .ok_or_else(|| format!("unknown background surface: {surface}"))?
+            .phase;
+        if owner_in_shutdown_path
+            || matches!(
+                surface_phase,
+                SurfacePhase::Stopping | SurfacePhase::Stopped | SurfacePhase::Failed
+            )
+        {
+            return Err(format!(
+                "cannot mark background surface as running after shutdown/failure has begun: \
+                 surface={surface}, owner_phase={:?}, surface_phase={surface_phase:?}",
+                self.phase
+            ));
+        }
+
         let state = self.surface_state_mut(surface)?;
         state.phase = SurfacePhase::Running;
         state.started_at_ms = Some(started_at_ms);
@@ -292,7 +316,12 @@ impl SupervisorState {
         });
 
         for (tracked_surface, tracked_state) in &mut self.surfaces {
-            if tracked_surface != surface && matches!(tracked_state.phase, SurfacePhase::Running) {
+            if tracked_surface != surface
+                && matches!(
+                    tracked_state.phase,
+                    SurfacePhase::Starting | SurfacePhase::Running
+                )
+            {
                 tracked_state.phase = SurfacePhase::Stopping;
             }
         }
@@ -589,5 +618,84 @@ mod tests {
             state.exit_reason.as_deref(),
             Some("surface failed: lost upstream connection")
         );
+    }
+
+    #[tokio::test]
+    async fn shutdown_while_surface_is_starting_does_not_allow_late_running_transition() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let feishu = feishu_surface(Some("alerts"));
+        let mut supervisor = SupervisorState::new(
+            sample_spec(vec![telegram.clone(), feishu.clone()]).expect("build spec"),
+        );
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .request_shutdown("ctrl-c received".to_owned())
+            .expect("request shutdown");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Stopping);
+        assert_eq!(
+            supervisor
+                .surface_state(&feishu)
+                .expect("feishu surface")
+                .phase,
+            SurfacePhase::Stopping
+        );
+
+        let error = supervisor
+            .mark_surface_running(&feishu, 1_710_000_000_100)
+            .expect_err("late startup completion should be rejected");
+        assert!(
+            error.contains("cannot mark background surface as running"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Stopping);
+        let feishu_state = supervisor
+            .surface_state(&feishu)
+            .expect("feishu surface should still be tracked");
+        assert_eq!(feishu_state.phase, SurfacePhase::Stopping);
+        assert_eq!(feishu_state.started_at_ms, None);
+    }
+
+    #[tokio::test]
+    async fn sibling_failure_stops_starting_surface_and_rejects_late_running_transition() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let feishu = feishu_surface(Some("alerts"));
+        let mut supervisor = SupervisorState::new(
+            sample_spec(vec![telegram.clone(), feishu.clone()]).expect("build spec"),
+        );
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .record_surface_failure(
+                &telegram,
+                1_710_000_000_500,
+                "telegram task exited unexpectedly",
+            )
+            .expect("record telegram failure");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Failed);
+        let feishu_state = supervisor
+            .surface_state(&feishu)
+            .expect("feishu surface should still be tracked");
+        assert_eq!(feishu_state.phase, SurfacePhase::Stopping);
+
+        let error = supervisor
+            .mark_surface_running(&feishu, 1_710_000_000_900)
+            .expect_err("late startup completion should be rejected");
+        assert!(
+            error.contains("cannot mark background surface as running"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Failed);
+        let feishu_state = supervisor
+            .surface_state(&feishu)
+            .expect("feishu surface should still be tracked");
+        assert_eq!(feishu_state.phase, SurfacePhase::Stopping);
+        assert_eq!(feishu_state.started_at_ms, None);
     }
 }

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -273,15 +273,12 @@ impl SupervisorState {
     }
 
     pub fn request_shutdown(&mut self, reason: String) -> Result<(), String> {
-        if reason.trim().is_empty() {
-            return Err("shutdown reason cannot be empty".to_owned());
+        if self.shutdown_reason.is_some() {
+            return Ok(());
         }
 
-        if matches!(
-            self.shutdown_reason,
-            Some(SupervisorShutdownReason::SurfaceFailed { .. })
-        ) {
-            return Ok(());
+        if reason.trim().is_empty() {
+            return Err("shutdown reason cannot be empty".to_owned());
         }
 
         self.shutdown_reason = Some(SupervisorShutdownReason::Requested { reason });
@@ -302,7 +299,19 @@ impl SupervisorState {
         stopped_at_ms: u64,
         error: impl Into<String>,
     ) -> Result<(), String> {
+        let current_phase = self
+            .surface_state(surface)
+            .ok_or_else(|| format!("unknown background surface: {surface}"))?
+            .phase;
+        if matches!(current_phase, SurfacePhase::Stopped | SurfacePhase::Failed) {
+            return Ok(());
+        }
+
         let error = error.into();
+        let preserve_shutdown_reason = matches!(
+            self.shutdown_reason,
+            Some(SupervisorShutdownReason::SurfaceFailed { .. })
+        );
         let state = self.surface_state_mut(surface)?;
         state.phase = SurfacePhase::Failed;
         state.stopped_at_ms = Some(stopped_at_ms);
@@ -310,10 +319,12 @@ impl SupervisorState {
         state.exit_reason = Some(format!("surface failed: {error}"));
 
         self.phase = RuntimeOwnerPhase::Failed;
-        self.shutdown_reason = Some(SupervisorShutdownReason::SurfaceFailed {
-            surface: surface.clone(),
-            error,
-        });
+        if !preserve_shutdown_reason {
+            self.shutdown_reason = Some(SupervisorShutdownReason::SurfaceFailed {
+                surface: surface.clone(),
+                error,
+            });
+        }
 
         for (tracked_surface, tracked_state) in &mut self.surfaces {
             if tracked_surface != surface
@@ -729,6 +740,163 @@ mod tests {
         assert!(
             error.contains("lost upstream connection"),
             "failure result should keep the original failure reason: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_shutdown_request_preserves_original_reason_and_terminal_phase() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let mut supervisor =
+            SupervisorState::new(sample_spec(vec![telegram.clone()]).expect("build spec"));
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .request_shutdown("ctrl-c received".to_owned())
+            .expect("request shutdown");
+        supervisor
+            .mark_surface_stopped(&telegram, 1_710_000_000_500)
+            .expect("stop telegram");
+        supervisor
+            .request_shutdown("   ".to_owned())
+            .expect("duplicate shutdown should be ignored");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Stopped);
+        assert_eq!(
+            supervisor.shutdown_reason(),
+            Some(&SupervisorShutdownReason::Requested {
+                reason: "ctrl-c received".to_owned(),
+            })
+        );
+        assert!(supervisor.final_exit_result().is_ok());
+        assert_eq!(
+            supervisor
+                .surface_state(&telegram)
+                .expect("telegram surface")
+                .exit_reason
+                .as_deref(),
+            Some("shutdown requested: ctrl-c received")
+        );
+    }
+
+    #[tokio::test]
+    async fn first_surface_failure_remains_root_cause_when_sibling_fails_during_unwind() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let feishu = feishu_surface(Some("alerts"));
+        let mut supervisor = SupervisorState::new(
+            sample_spec(vec![telegram.clone(), feishu.clone()]).expect("build spec"),
+        );
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .mark_surface_running(&feishu, 1_710_000_000_100)
+            .expect("start feishu");
+
+        supervisor
+            .record_surface_failure(&telegram, 1_710_000_000_500, "telegram failed first")
+            .expect("record telegram failure");
+        supervisor
+            .record_surface_failure(&feishu, 1_710_000_000_700, "feishu failed second")
+            .expect("record feishu failure");
+
+        assert_eq!(
+            supervisor.shutdown_reason(),
+            Some(&SupervisorShutdownReason::SurfaceFailed {
+                surface: telegram.clone(),
+                error: "telegram failed first".to_owned(),
+            })
+        );
+        let error = supervisor
+            .final_exit_result()
+            .expect_err("first failure should keep the supervisor in failed state");
+        assert!(
+            error.contains("telegram failed first"),
+            "root-cause summary should preserve the first failure: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn late_failure_after_requested_shutdown_does_not_rewrite_clean_stop() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let mut supervisor =
+            SupervisorState::new(sample_spec(vec![telegram.clone()]).expect("build spec"));
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .request_shutdown("ctrl-c received".to_owned())
+            .expect("request shutdown");
+        supervisor
+            .mark_surface_stopped(&telegram, 1_710_000_000_500)
+            .expect("stop telegram");
+        supervisor
+            .record_surface_failure(
+                &telegram,
+                1_710_000_000_700,
+                "late failure should not rewrite a clean shutdown",
+            )
+            .expect("late failure after clean shutdown should be ignored");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Stopped);
+        assert_eq!(
+            supervisor.shutdown_reason(),
+            Some(&SupervisorShutdownReason::Requested {
+                reason: "ctrl-c received".to_owned(),
+            })
+        );
+        let state = supervisor
+            .surface_state(&telegram)
+            .expect("telegram surface");
+        assert_eq!(state.phase, SurfacePhase::Stopped);
+        assert_eq!(state.last_error, None);
+        assert_eq!(
+            state.exit_reason.as_deref(),
+            Some("shutdown requested: ctrl-c received")
+        );
+        assert!(supervisor.final_exit_result().is_ok());
+    }
+
+    #[tokio::test]
+    async fn late_failure_after_failure_unwind_stop_does_not_rewrite_surface_state() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let feishu = feishu_surface(Some("alerts"));
+        let mut supervisor = SupervisorState::new(
+            sample_spec(vec![telegram.clone(), feishu.clone()]).expect("build spec"),
+        );
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .mark_surface_running(&feishu, 1_710_000_000_100)
+            .expect("start feishu");
+        supervisor
+            .record_surface_failure(&telegram, 1_710_000_000_500, "telegram failed first")
+            .expect("record telegram failure");
+        supervisor
+            .mark_surface_stopped(&feishu, 1_710_000_000_600)
+            .expect("stop feishu during unwind");
+        supervisor
+            .record_surface_failure(&feishu, 1_710_000_000_700, "late feishu failure")
+            .expect("late failure after stop should be ignored");
+
+        assert_eq!(
+            supervisor.shutdown_reason(),
+            Some(&SupervisorShutdownReason::SurfaceFailed {
+                surface: telegram.clone(),
+                error: "telegram failed first".to_owned(),
+            })
+        );
+        let state = supervisor.surface_state(&feishu).expect("feishu surface");
+        assert_eq!(state.phase, SurfacePhase::Stopped);
+        assert_eq!(state.last_error, None);
+        assert_eq!(
+            state.exit_reason.as_deref(),
+            Some("shutdown after telegram(account=bot_123456) failed: telegram failed first")
         );
     }
 

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -1,4 +1,408 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
+
 use loongclaw_spec::CliResult;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BackgroundChannelSurface {
+    Telegram { account_id: Option<String> },
+    Feishu { account_id: Option<String> },
+}
+
+impl BackgroundChannelSurface {
+    pub fn all_from_accounts(
+        telegram_account: Option<&str>,
+        feishu_account: Option<&str>,
+    ) -> Vec<Self> {
+        vec![
+            Self::Telegram {
+                account_id: telegram_account.map(str::to_owned),
+            },
+            Self::Feishu {
+                account_id: feishu_account.map(str::to_owned),
+            },
+        ]
+    }
+}
+
+impl fmt::Display for BackgroundChannelSurface {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Telegram {
+                account_id: Some(account_id),
+            } => write!(f, "telegram(account={account_id})"),
+            Self::Telegram { account_id: None } => write!(f, "telegram"),
+            Self::Feishu {
+                account_id: Some(account_id),
+            } => write!(f, "feishu(account={account_id})"),
+            Self::Feishu { account_id: None } => write!(f, "feishu"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfacePhase {
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SurfaceState {
+    pub surface: BackgroundChannelSurface,
+    pub phase: SurfacePhase,
+    pub started_at_ms: Option<u64>,
+    pub stopped_at_ms: Option<u64>,
+    pub last_error: Option<String>,
+    pub exit_reason: Option<String>,
+}
+
+impl SurfaceState {
+    fn new(surface: BackgroundChannelSurface) -> Self {
+        Self {
+            surface,
+            phase: SurfacePhase::Starting,
+            started_at_ms: None,
+            stopped_at_ms: None,
+            last_error: None,
+            exit_reason: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeOwnerPhase {
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SupervisorShutdownReason {
+    Requested {
+        reason: String,
+    },
+    SurfaceFailed {
+        surface: BackgroundChannelSurface,
+        error: String,
+    },
+}
+
+impl SupervisorShutdownReason {
+    fn surface_exit_reason(&self) -> String {
+        match self {
+            Self::Requested { reason } => format!("shutdown requested: {reason}"),
+            Self::SurfaceFailed { surface, error } => {
+                format!("shutdown after {surface} failed: {error}")
+            }
+        }
+    }
+}
+
+impl fmt::Display for SupervisorShutdownReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Requested { reason } => write!(f, "shutdown requested: {reason}"),
+            Self::SurfaceFailed { surface, error } => {
+                write!(f, "{surface} exited unexpectedly: {error}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeOwnerMode {
+    MultiChannelServe { cli_session: String },
+}
+
+impl RuntimeOwnerMode {
+    fn validate(&self) -> Result<(), String> {
+        match self {
+            Self::MultiChannelServe { cli_session } => {
+                if cli_session.trim().is_empty() {
+                    return Err("multi-channel supervisor requires a non-empty CLI session".into());
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupervisorSpec {
+    pub mode: RuntimeOwnerMode,
+    pub surfaces: Vec<BackgroundChannelSurface>,
+}
+
+impl SupervisorSpec {
+    pub fn new(
+        mode: RuntimeOwnerMode,
+        surfaces: Vec<BackgroundChannelSurface>,
+    ) -> Result<Self, String> {
+        mode.validate()?;
+        if surfaces.is_empty() {
+            return Err("supervisor requires at least one background surface".to_owned());
+        }
+
+        let mut seen = BTreeSet::new();
+        for surface in &surfaces {
+            if !seen.insert(surface.clone()) {
+                return Err(format!(
+                    "duplicate background surface configured: {surface}"
+                ));
+            }
+        }
+
+        Ok(Self { mode, surfaces })
+    }
+
+    pub fn from_multi_channel_serve(
+        session: &str,
+        telegram_account: Option<&str>,
+        feishu_account: Option<&str>,
+    ) -> Result<Self, String> {
+        Self::new(
+            RuntimeOwnerMode::MultiChannelServe {
+                cli_session: session.to_owned(),
+            },
+            BackgroundChannelSurface::all_from_accounts(telegram_account, feishu_account),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SupervisorState {
+    spec: SupervisorSpec,
+    phase: RuntimeOwnerPhase,
+    surfaces: BTreeMap<BackgroundChannelSurface, SurfaceState>,
+    shutdown_reason: Option<SupervisorShutdownReason>,
+}
+
+impl SupervisorState {
+    pub fn new(spec: SupervisorSpec) -> Self {
+        let surfaces = spec
+            .surfaces
+            .iter()
+            .cloned()
+            .map(|surface| {
+                let state = SurfaceState::new(surface.clone());
+                (surface, state)
+            })
+            .collect();
+
+        Self {
+            spec,
+            phase: RuntimeOwnerPhase::Starting,
+            surfaces,
+            shutdown_reason: None,
+        }
+    }
+
+    pub fn spec(&self) -> &SupervisorSpec {
+        &self.spec
+    }
+
+    pub fn phase(&self) -> RuntimeOwnerPhase {
+        self.phase
+    }
+
+    pub fn shutdown_requested(&self) -> bool {
+        self.shutdown_reason.is_some()
+    }
+
+    pub fn shutdown_reason(&self) -> Option<&SupervisorShutdownReason> {
+        self.shutdown_reason.as_ref()
+    }
+
+    pub fn surface_state(&self, surface: &BackgroundChannelSurface) -> Option<&SurfaceState> {
+        self.surfaces.get(surface)
+    }
+
+    pub fn mark_surface_running(
+        &mut self,
+        surface: &BackgroundChannelSurface,
+        started_at_ms: u64,
+    ) -> Result<(), String> {
+        let state = self.surface_state_mut(surface)?;
+        state.phase = SurfacePhase::Running;
+        state.started_at_ms = Some(started_at_ms);
+        state.stopped_at_ms = None;
+        state.last_error = None;
+        state.exit_reason = None;
+
+        if self.all_surfaces_in_phase(SurfacePhase::Running) {
+            self.phase = RuntimeOwnerPhase::Running;
+        } else if !matches!(
+            self.phase,
+            RuntimeOwnerPhase::Stopping | RuntimeOwnerPhase::Stopped | RuntimeOwnerPhase::Failed
+        ) {
+            self.phase = RuntimeOwnerPhase::Starting;
+        }
+
+        Ok(())
+    }
+
+    pub fn request_shutdown(&mut self, reason: String) -> Result<(), String> {
+        if reason.trim().is_empty() {
+            return Err("shutdown reason cannot be empty".to_owned());
+        }
+
+        if matches!(
+            self.shutdown_reason,
+            Some(SupervisorShutdownReason::SurfaceFailed { .. })
+        ) {
+            return Ok(());
+        }
+
+        self.shutdown_reason = Some(SupervisorShutdownReason::Requested { reason });
+        self.phase = RuntimeOwnerPhase::Stopping;
+
+        for state in self.surfaces.values_mut() {
+            if matches!(state.phase, SurfacePhase::Running | SurfacePhase::Starting) {
+                state.phase = SurfacePhase::Stopping;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn record_surface_failure(
+        &mut self,
+        surface: &BackgroundChannelSurface,
+        stopped_at_ms: u64,
+        error: impl Into<String>,
+    ) -> Result<(), String> {
+        let error = error.into();
+        let state = self.surface_state_mut(surface)?;
+        state.phase = SurfacePhase::Failed;
+        state.stopped_at_ms = Some(stopped_at_ms);
+        state.last_error = Some(error.clone());
+        state.exit_reason = Some(format!("surface failed: {error}"));
+
+        self.phase = RuntimeOwnerPhase::Failed;
+        self.shutdown_reason = Some(SupervisorShutdownReason::SurfaceFailed {
+            surface: surface.clone(),
+            error,
+        });
+
+        for (tracked_surface, tracked_state) in &mut self.surfaces {
+            if tracked_surface != surface && matches!(tracked_state.phase, SurfacePhase::Running) {
+                tracked_state.phase = SurfacePhase::Stopping;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn mark_surface_stopped(
+        &mut self,
+        surface: &BackgroundChannelSurface,
+        stopped_at_ms: u64,
+    ) -> Result<(), String> {
+        let exit_reason = self.shutdown_reason.as_ref().map(|reason| match reason {
+            SupervisorShutdownReason::Requested { reason } => {
+                format!("shutdown requested: {reason}")
+            }
+            SupervisorShutdownReason::SurfaceFailed {
+                surface: failed_surface,
+                error,
+            } if failed_surface == surface => format!("surface failed: {error}"),
+            reason => reason.surface_exit_reason(),
+        });
+
+        let state = self.surface_state_mut(surface)?;
+        state.phase = SurfacePhase::Stopped;
+        state.stopped_at_ms = Some(stopped_at_ms);
+        if state.exit_reason.is_none() {
+            state.exit_reason = exit_reason;
+        }
+
+        if self.all_surfaces_terminal() && !matches!(self.phase, RuntimeOwnerPhase::Failed) {
+            self.phase = RuntimeOwnerPhase::Stopped;
+        }
+
+        Ok(())
+    }
+
+    pub fn failure_summary(&self) -> Option<String> {
+        match self.shutdown_reason() {
+            Some(SupervisorShutdownReason::SurfaceFailed { surface, error }) => Some(format!(
+                "multi-channel supervisor failed because {surface} exited unexpectedly: {error}"
+            )),
+            _ => self
+                .surfaces
+                .values()
+                .find(|state| state.phase == SurfacePhase::Failed)
+                .map(|state| {
+                    let error = state
+                        .last_error
+                        .as_deref()
+                        .unwrap_or("unknown background surface failure");
+                    format!(
+                        "multi-channel supervisor failed because {} exited unexpectedly: {error}",
+                        state.surface
+                    )
+                }),
+        }
+    }
+
+    pub fn final_exit_summary(&self) -> String {
+        if let Some(summary) = self.failure_summary() {
+            return summary;
+        }
+
+        let surfaces = self
+            .spec
+            .surfaces
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        match self.shutdown_reason() {
+            Some(reason) => format!(
+                "multi-channel supervisor exited cleanly after {reason}; surfaces: {surfaces}"
+            ),
+            None => format!("multi-channel supervisor is still active for surfaces: {surfaces}"),
+        }
+    }
+
+    pub fn final_exit_result(&self) -> CliResult<()> {
+        if let Some(summary) = self.failure_summary() {
+            return Err(summary);
+        }
+
+        if self.all_surfaces_terminal() {
+            return Ok(());
+        }
+
+        Err(self.final_exit_summary())
+    }
+
+    fn surface_state_mut(
+        &mut self,
+        surface: &BackgroundChannelSurface,
+    ) -> Result<&mut SurfaceState, String> {
+        self.surfaces
+            .get_mut(surface)
+            .ok_or_else(|| format!("unknown background surface: {surface}"))
+    }
+
+    fn all_surfaces_in_phase(&self, phase: SurfacePhase) -> bool {
+        self.surfaces.values().all(|state| state.phase == phase)
+    }
+
+    fn all_surfaces_terminal(&self) -> bool {
+        self.surfaces
+            .values()
+            .all(|state| matches!(state.phase, SurfacePhase::Stopped | SurfacePhase::Failed))
+    }
+}
 
 pub async fn run_multi_channel_serve(
     config_path: Option<&str>,
@@ -6,6 +410,184 @@ pub async fn run_multi_channel_serve(
     telegram_account: Option<&str>,
     feishu_account: Option<&str>,
 ) -> CliResult<()> {
-    let _ = (config_path, session, telegram_account, feishu_account);
+    let spec = SupervisorSpec::from_multi_channel_serve(session, telegram_account, feishu_account)?;
+    let _ = (config_path, spec);
     Err("multi-channel-serve is not implemented yet".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BackgroundChannelSurface, RuntimeOwnerMode, RuntimeOwnerPhase, SupervisorShutdownReason,
+        SupervisorSpec, SupervisorState, SurfacePhase,
+    };
+
+    fn telegram_surface(account_id: Option<&str>) -> BackgroundChannelSurface {
+        BackgroundChannelSurface::Telegram {
+            account_id: account_id.map(str::to_owned),
+        }
+    }
+
+    fn feishu_surface(account_id: Option<&str>) -> BackgroundChannelSurface {
+        BackgroundChannelSurface::Feishu {
+            account_id: account_id.map(str::to_owned),
+        }
+    }
+
+    fn sample_spec(surfaces: Vec<BackgroundChannelSurface>) -> Result<SupervisorSpec, String> {
+        SupervisorSpec::new(
+            RuntimeOwnerMode::MultiChannelServe {
+                cli_session: "cli-supervisor".to_owned(),
+            },
+            surfaces,
+        )
+    }
+
+    #[tokio::test]
+    async fn background_surface_startup_records_start_timestamp_and_running_phase() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let mut supervisor =
+            SupervisorState::new(sample_spec(vec![telegram.clone()]).expect("build spec"));
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("mark telegram running");
+
+        let state = supervisor
+            .surface_state(&telegram)
+            .expect("telegram surface should be tracked");
+        assert_eq!(state.phase, SurfacePhase::Running);
+        assert_eq!(state.started_at_ms, Some(1_710_000_000_000));
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Running);
+    }
+
+    #[tokio::test]
+    async fn background_surface_failure_marks_runtime_owner_failed() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let feishu = feishu_surface(Some("alerts"));
+        let mut supervisor = SupervisorState::new(
+            sample_spec(vec![telegram.clone(), feishu.clone()]).expect("build spec"),
+        );
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .mark_surface_running(&feishu, 1_710_000_000_100)
+            .expect("start feishu");
+
+        supervisor
+            .record_surface_failure(
+                &telegram,
+                1_710_000_000_500,
+                "telegram task exited unexpectedly",
+            )
+            .expect("record telegram failure");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Failed);
+        assert!(supervisor.shutdown_requested());
+        assert_eq!(
+            supervisor.shutdown_reason(),
+            Some(&SupervisorShutdownReason::SurfaceFailed {
+                surface: telegram.clone(),
+                error: "telegram task exited unexpectedly".to_owned(),
+            })
+        );
+        let summary = supervisor
+            .failure_summary()
+            .expect("failure summary should exist");
+        assert!(
+            summary.contains("telegram"),
+            "summary should name the failed surface: {summary}"
+        );
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_marks_running_children_stopping_then_stopped() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let feishu = feishu_surface(Some("alerts"));
+        let mut supervisor = SupervisorState::new(
+            sample_spec(vec![telegram.clone(), feishu.clone()]).expect("build spec"),
+        );
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .mark_surface_running(&feishu, 1_710_000_000_100)
+            .expect("start feishu");
+
+        supervisor
+            .request_shutdown("ctrl-c received".to_owned())
+            .expect("request shutdown");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Stopping);
+        assert_eq!(
+            supervisor
+                .surface_state(&telegram)
+                .expect("telegram surface")
+                .phase,
+            SurfacePhase::Stopping
+        );
+        assert_eq!(
+            supervisor
+                .surface_state(&feishu)
+                .expect("feishu surface")
+                .phase,
+            SurfacePhase::Stopping
+        );
+
+        supervisor
+            .mark_surface_stopped(&telegram, 1_710_000_000_800)
+            .expect("stop telegram");
+        supervisor
+            .mark_surface_stopped(&feishu, 1_710_000_000_900)
+            .expect("stop feishu");
+
+        assert_eq!(supervisor.phase(), RuntimeOwnerPhase::Stopped);
+        assert_eq!(
+            supervisor
+                .surface_state(&telegram)
+                .expect("telegram surface")
+                .phase,
+            SurfacePhase::Stopped
+        );
+        assert_eq!(
+            supervisor
+                .surface_state(&telegram)
+                .expect("telegram surface")
+                .exit_reason
+                .as_deref(),
+            Some("shutdown requested: ctrl-c received")
+        );
+        assert!(supervisor.final_exit_result().is_ok());
+    }
+
+    #[tokio::test]
+    async fn final_exit_reason_is_recorded_for_failed_child() {
+        let telegram = telegram_surface(Some("bot_123456"));
+        let mut supervisor =
+            SupervisorState::new(sample_spec(vec![telegram.clone()]).expect("build spec"));
+
+        supervisor
+            .mark_surface_running(&telegram, 1_710_000_000_000)
+            .expect("start telegram");
+        supervisor
+            .record_surface_failure(&telegram, 1_710_000_000_500, "lost upstream connection")
+            .expect("record telegram failure");
+
+        let state = supervisor
+            .surface_state(&telegram)
+            .expect("telegram surface should be tracked");
+        assert_eq!(state.phase, SurfacePhase::Failed);
+        assert_eq!(state.stopped_at_ms, Some(1_710_000_000_500));
+        assert_eq!(
+            state.last_error.as_deref(),
+            Some("lost upstream connection")
+        );
+        assert_eq!(
+            state.exit_reason.as_deref(),
+            Some("surface failed: lost upstream connection")
+        );
+    }
 }

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -7,5 +7,5 @@ pub async fn run_multi_channel_serve(
     feishu_account: Option<&str>,
 ) -> CliResult<()> {
     let _ = (config_path, session, telegram_account, feishu_account);
-    Ok(())
+    Err("multi-channel-serve is not implemented yet".to_owned())
 }

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -1,0 +1,11 @@
+use loongclaw_spec::CliResult;
+
+pub async fn run_multi_channel_serve(
+    config_path: Option<&str>,
+    session: &str,
+    telegram_account: Option<&str>,
+    feishu_account: Option<&str>,
+) -> CliResult<()> {
+    let _ = (config_path, session, telegram_account, feishu_account);
+    Ok(())
+}

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -1320,24 +1320,6 @@ fn multi_channel_serve_cli_help_mentions_session_and_account_flags() {
 }
 
 #[test]
-fn multi_channel_serve_cli_fails_closed_until_implemented() {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("build test runtime");
-    let error = runtime
-        .block_on(run_multi_channel_serve_cli(
-            None,
-            "cli-supervisor",
-            None,
-            None,
-        ))
-        .expect_err("multi-channel-serve should fail closed for now");
-
-    assert!(error.contains("not implemented yet"));
-}
-
-#[test]
 fn default_channel_send_target_kind_uses_command_family_send_metadata() {
     assert_eq!(
         default_channel_send_target_kind(ChannelSendCliSpec {

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -1297,6 +1297,47 @@ fn multi_channel_serve_cli_parses_account_selection_flags() {
 }
 
 #[test]
+fn multi_channel_serve_cli_help_mentions_session_and_account_flags() {
+    let mut command = Cli::command();
+    let multi_channel_serve = command
+        .find_subcommand_mut("multi-channel-serve")
+        .expect("multi-channel-serve subcommand should exist");
+    let mut rendered = Vec::new();
+    multi_channel_serve
+        .write_long_help(&mut rendered)
+        .expect("render multi-channel-serve help");
+    let help = String::from_utf8(rendered).expect("help should be utf-8");
+
+    assert!(help.contains("--session <SESSION>"), "help: {help}");
+    assert!(
+        help.contains("--telegram-account <TELEGRAM_ACCOUNT>"),
+        "help: {help}"
+    );
+    assert!(
+        help.contains("--feishu-account <FEISHU_ACCOUNT>"),
+        "help: {help}"
+    );
+}
+
+#[test]
+fn multi_channel_serve_cli_fails_closed_until_implemented() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build test runtime");
+    let error = runtime
+        .block_on(run_multi_channel_serve_cli(
+            None,
+            "cli-supervisor",
+            None,
+            None,
+        ))
+        .expect_err("multi-channel-serve should fail closed for now");
+
+    assert!(error.contains("not implemented yet"));
+}
+
+#[test]
 fn default_channel_send_target_kind_uses_command_family_send_metadata() {
     assert_eq!(
         default_channel_send_target_kind(ChannelSendCliSpec {

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -1261,6 +1261,42 @@ fn run_channel_serve_cli_forwards_optional_arguments_to_runner() {
 }
 
 #[test]
+fn multi_channel_serve_cli_requires_explicit_cli_session() {
+    let error = Cli::try_parse_from(["loongclaw", "multi-channel-serve"])
+        .expect_err("missing --session should fail");
+    assert!(error.to_string().contains("--session <SESSION>"));
+}
+
+#[test]
+fn multi_channel_serve_cli_parses_account_selection_flags() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "multi-channel-serve",
+        "--session",
+        "cli-supervisor",
+        "--telegram-account",
+        "bot_123456",
+        "--feishu-account",
+        "alerts",
+    ])
+    .expect("multi-channel-serve should parse");
+
+    match cli.command {
+        Some(Commands::MultiChannelServe {
+            session,
+            telegram_account,
+            feishu_account,
+            ..
+        }) => {
+            assert_eq!(session, "cli-supervisor");
+            assert_eq!(telegram_account.as_deref(), Some("bot_123456"));
+            assert_eq!(feishu_account.as_deref(), Some("alerts"));
+        }
+        other => panic!("unexpected parse result: {other:?}"),
+    }
+}
+
+#[test]
 fn default_channel_send_target_kind_uses_command_family_send_metadata() {
     assert_eq!(
         default_channel_send_target_kind(ChannelSendCliSpec {

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -32,6 +32,7 @@ mod import_cli;
 mod memory_context_benchmark_cli;
 mod migrate_cli;
 mod migration;
+mod multi_channel_serve_cli;
 mod onboard_cli;
 mod programmatic;
 mod runtime_capability_cli;

--- a/crates/daemon/tests/integration/multi_channel_serve_cli.rs
+++ b/crates/daemon/tests/integration/multi_channel_serve_cli.rs
@@ -50,9 +50,32 @@ fn pending_shutdown_future() -> BoxedCliFuture {
 }
 
 fn loaded_config_fixture() -> LoadedSupervisorConfig {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.telegram.enabled = true;
+    config.feishu.enabled = true;
     LoadedSupervisorConfig {
         resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
-        config: mvp::config::LoongClawConfig::default(),
+        config,
+    }
+}
+
+fn telegram_only_loaded_config_fixture() -> LoadedSupervisorConfig {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.telegram.enabled = true;
+    config.feishu.enabled = false;
+    LoadedSupervisorConfig {
+        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+    }
+}
+
+fn feishu_only_loaded_config_fixture() -> LoadedSupervisorConfig {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.telegram.enabled = false;
+    config.feishu.enabled = true;
+    LoadedSupervisorConfig {
+        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+        config,
     }
 }
 
@@ -198,6 +221,156 @@ async fn multi_channel_serve_starts_telegram_and_feishu_background_tasks() {
         events
             .iter()
             .any(|event| event == "feishu-start account=alerts"),
+        "events: {events:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_skips_feishu_when_only_telegram_is_enabled() {
+    let log = EventLog::default();
+    let state = run_multi_channel_serve_with_hooks_for_test(
+        None,
+        "cli-supervisor",
+        Some("bot_123456"),
+        Some("stale-feishu"),
+        hooks(
+            |_| Ok(telegram_only_loaded_config_fixture()),
+            {
+                let log = log.clone();
+                move |options| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!("cli-start session={}", options.session_id));
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let log = log.clone();
+                move |request| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!(
+                            "telegram-start account={}",
+                            request.account_id.as_deref().unwrap_or("-")
+                        ));
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        log.push("telegram-stop");
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let log = log.clone();
+                move |_| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push("feishu-start");
+                        Err("feishu should not start when disabled".to_owned())
+                    })
+                }
+            },
+            pending_shutdown_future,
+        ),
+    )
+    .await
+    .expect("run helper");
+
+    assert!(state.final_exit_result().is_ok());
+    assert_eq!(state.spec().surfaces.len(), 1);
+    assert_eq!(
+        state.spec().surfaces[0],
+        loongclaw_daemon::supervisor::BackgroundChannelSurface::Telegram {
+            account_id: Some("bot_123456".to_owned()),
+        }
+    );
+
+    let events = log.snapshot();
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "telegram-start account=bot_123456"),
+        "events: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| event == "feishu-start"),
+        "events: {events:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_skips_telegram_when_only_feishu_is_enabled() {
+    let log = EventLog::default();
+    let state = run_multi_channel_serve_with_hooks_for_test(
+        None,
+        "cli-supervisor",
+        Some("stale-telegram"),
+        Some("alerts"),
+        hooks(
+            |_| Ok(feishu_only_loaded_config_fixture()),
+            {
+                let log = log.clone();
+                move |options| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!("cli-start session={}", options.session_id));
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let log = log.clone();
+                move |_| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push("telegram-start");
+                        Err("telegram should not start when disabled".to_owned())
+                    })
+                }
+            },
+            {
+                let log = log.clone();
+                move |request| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!(
+                            "feishu-start account={}",
+                            request.account_id.as_deref().unwrap_or("-")
+                        ));
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        log.push("feishu-stop");
+                        Ok(())
+                    })
+                }
+            },
+            pending_shutdown_future,
+        ),
+    )
+    .await
+    .expect("run helper");
+
+    assert!(state.final_exit_result().is_ok());
+    assert_eq!(state.spec().surfaces.len(), 1);
+    assert_eq!(
+        state.spec().surfaces[0],
+        loongclaw_daemon::supervisor::BackgroundChannelSurface::Feishu {
+            account_id: Some("alerts".to_owned()),
+        }
+    );
+
+    let events = log.snapshot();
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "feishu-start account=alerts"),
+        "events: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| event == "telegram-start"),
         "events: {events:?}"
     );
 }
@@ -373,6 +546,88 @@ async fn multi_channel_serve_background_failure_before_cli_wait_still_stops_fore
     assert!(
         events.iter().any(|event| event == "cli-stop"),
         "cli host should still stop after shutdown was requested early: {events:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_background_join_error_still_shuts_down_cli_and_other_surfaces() {
+    let log = EventLog::default();
+    let run_log = log.clone();
+    let run: tokio::task::JoinHandle<CliResult<loongclaw_daemon::supervisor::SupervisorState>> =
+        tokio::spawn(async move {
+            run_multi_channel_serve_with_hooks_for_test(
+                None,
+                "cli-supervisor",
+                Some("bot_123456"),
+                Some("alerts"),
+                hooks(
+                    |_| Ok(loaded_config_fixture()),
+                    {
+                        let log = run_log.clone();
+                        move |options| {
+                            let log = log.clone();
+                            boxed_cli_result(async move {
+                                log.push("cli-start");
+                                options.shutdown.wait().await;
+                                log.push("cli-stop");
+                                Ok(())
+                            })
+                        }
+                    },
+                    {
+                        let log = run_log.clone();
+                        move |_| {
+                            let log = log.clone();
+                            boxed_cli_result(async move {
+                                log.push("telegram-panic");
+                                panic!("telegram runner panicked");
+                            })
+                        }
+                    },
+                    {
+                        let log = run_log.clone();
+                        move |request| {
+                            let log = log.clone();
+                            boxed_cli_result(async move {
+                                log.push("feishu-start");
+                                while !request.stop.is_requested() {
+                                    tokio::task::yield_now().await;
+                                }
+                                log.push("feishu-stop");
+                                Ok(())
+                            })
+                        }
+                    },
+                    pending_shutdown_future,
+                ),
+            )
+            .await
+        });
+
+    let state = tokio::time::timeout(Duration::from_millis(250), run)
+        .await
+        .expect("supervisor should not hang after a background join error")
+        .expect("supervisor join")
+        .expect("run helper");
+
+    let error = state
+        .final_exit_result()
+        .expect_err("background join error should fail the supervisor");
+    assert!(
+        error.contains("telegram(account=bot_123456) exited unexpectedly"),
+        "error: {error}"
+    );
+    assert!(error.contains("failed to join"), "error: {error}");
+
+    let events = log.snapshot();
+    assert!(events.iter().any(|event| event == "telegram-panic"));
+    assert!(
+        events.iter().any(|event| event == "cli-stop"),
+        "events: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| event == "feishu-stop"),
+        "events: {events:?}"
     );
 }
 

--- a/crates/daemon/tests/integration/multi_channel_serve_cli.rs
+++ b/crates/daemon/tests/integration/multi_channel_serve_cli.rs
@@ -19,6 +19,7 @@ use loongclaw_daemon::supervisor::{
 use tokio::{sync::Notify, time::sleep};
 
 type BoxedCliFuture = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'static>>;
+const MULTI_CHANNEL_TEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Default)]
 struct EventLog {
@@ -59,6 +60,12 @@ fn loaded_config_fixture() -> LoadedSupervisorConfig {
     }
 }
 
+fn loaded_config_fixture_with_path(path: &str) -> LoadedSupervisorConfig {
+    let mut fixture = loaded_config_fixture();
+    fixture.resolved_path = PathBuf::from(path);
+    fixture
+}
+
 fn telegram_only_loaded_config_fixture() -> LoadedSupervisorConfig {
     let mut config = mvp::config::LoongClawConfig::default();
     config.telegram.enabled = true;
@@ -88,6 +95,7 @@ fn hooks(
 ) -> SupervisorRuntimeHooks {
     SupervisorRuntimeHooks {
         load_config: Arc::new(load_config),
+        initialize_runtime_environment: Arc::new(|_| {}),
         run_cli_host: Arc::new(run_cli_host),
         run_telegram: Arc::new(run_telegram),
         run_feishu: Arc::new(run_feishu),
@@ -471,7 +479,7 @@ async fn multi_channel_serve_background_failure_exits_foreground_cli_host_with_s
 async fn multi_channel_serve_background_failure_before_cli_wait_still_stops_foreground_cli_host() {
     let log = EventLog::default();
     let state = tokio::time::timeout(
-        Duration::from_millis(250),
+        MULTI_CHANNEL_TEST_TIMEOUT,
         run_multi_channel_serve_with_hooks_for_test(
             None,
             "cli-supervisor",
@@ -604,7 +612,7 @@ async fn multi_channel_serve_background_join_error_still_shuts_down_cli_and_othe
             .await
         });
 
-    let state = tokio::time::timeout(Duration::from_millis(250), run)
+    let state = tokio::time::timeout(MULTI_CHANNEL_TEST_TIMEOUT, run)
         .await
         .expect("supervisor should not hang after a background join error")
         .expect("supervisor join")
@@ -787,6 +795,118 @@ async fn multi_channel_serve_loads_config_once_before_spawning_children() {
         log.snapshot().first().map(String::as_str),
         Some("load-config path=/tmp/loongclaw.toml")
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_initializes_runtime_environment_before_spawning_children() {
+    let expected_path = "/tmp/loongclaw-supervisor-runtime-env.toml";
+    let expected_path_string = expected_path.to_owned();
+    let initialized_config_path = Arc::new(Mutex::new(None::<String>));
+    let started = Arc::new(AtomicUsize::new(0));
+
+    let state = run_multi_channel_serve_with_hooks_for_test(
+        None,
+        "cli-supervisor",
+        Some("bot_123456"),
+        Some("alerts"),
+        SupervisorRuntimeHooks {
+            load_config: Arc::new(move |_| Ok(loaded_config_fixture_with_path(expected_path))),
+            initialize_runtime_environment: Arc::new({
+                let initialized_config_path = initialized_config_path.clone();
+                move |loaded_config| {
+                    // The runtime env module has its own coverage; this test only needs to prove
+                    // the supervisor runs the hook before spawning children.
+                    let mut guard = initialized_config_path
+                        .lock()
+                        .expect("initialized config path lock");
+                    *guard = Some(loaded_config.resolved_path.display().to_string());
+                }
+            }),
+            run_cli_host: Arc::new({
+                let initialized_config_path = initialized_config_path.clone();
+                let started = started.clone();
+                let expected_path_string = expected_path_string.clone();
+                move |options| {
+                    let initialized_config_path = initialized_config_path.clone();
+                    let started = started.clone();
+                    let expected_path_string = expected_path_string.clone();
+                    boxed_cli_result(async move {
+                        while started.load(Ordering::SeqCst) < 2 {
+                            tokio::task::yield_now().await;
+                        }
+
+                        let observed_path = initialized_config_path
+                            .lock()
+                            .expect("initialized config path lock")
+                            .clone();
+                        assert_eq!(
+                            observed_path.as_deref(),
+                            Some(expected_path_string.as_str())
+                        );
+                        assert!(!options.initialize_runtime_environment);
+                        Ok(())
+                    })
+                }
+            }),
+            run_telegram: Arc::new({
+                let initialized_config_path = initialized_config_path.clone();
+                let started = started.clone();
+                let expected_path_string = expected_path_string.clone();
+                move |request| {
+                    let initialized_config_path = initialized_config_path.clone();
+                    let started = started.clone();
+                    let expected_path_string = expected_path_string.clone();
+                    boxed_cli_result(async move {
+                        let observed_path = initialized_config_path
+                            .lock()
+                            .expect("initialized config path lock")
+                            .clone();
+                        assert_eq!(
+                            observed_path.as_deref(),
+                            Some(expected_path_string.as_str())
+                        );
+                        assert!(!request.initialize_runtime_environment);
+                        started.fetch_add(1, Ordering::SeqCst);
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        Ok(())
+                    })
+                }
+            }),
+            run_feishu: Arc::new({
+                let initialized_config_path = initialized_config_path.clone();
+                let started = started.clone();
+                let expected_path_string = expected_path_string.clone();
+                move |request| {
+                    let initialized_config_path = initialized_config_path.clone();
+                    let started = started.clone();
+                    let expected_path_string = expected_path_string.clone();
+                    boxed_cli_result(async move {
+                        let observed_path = initialized_config_path
+                            .lock()
+                            .expect("initialized config path lock")
+                            .clone();
+                        assert_eq!(
+                            observed_path.as_deref(),
+                            Some(expected_path_string.as_str())
+                        );
+                        assert!(!request.initialize_runtime_environment);
+                        started.fetch_add(1, Ordering::SeqCst);
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        Ok(())
+                    })
+                }
+            }),
+            wait_for_shutdown: Arc::new(pending_shutdown_future),
+        },
+    )
+    .await
+    .expect("run helper");
+
+    assert!(state.final_exit_result().is_ok());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/daemon/tests/integration/multi_channel_serve_cli.rs
+++ b/crates/daemon/tests/integration/multi_channel_serve_cli.rs
@@ -224,7 +224,7 @@ async fn multi_channel_serve_background_failure_exits_foreground_cli_host_with_s
                             let log = log.clone();
                             boxed_cli_result(async move {
                                 log.push(format!("cli-start session={}", options.session_id));
-                                options.shutdown.notified().await;
+                                options.shutdown.wait().await;
                                 log.push("cli-stop");
                                 Ok(())
                             })
@@ -291,6 +291,88 @@ async fn multi_channel_serve_background_failure_exits_foreground_cli_host_with_s
     assert!(
         log.snapshot().iter().any(|event| event == "cli-stop"),
         "cli host should stop after the background failure"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_background_failure_before_cli_wait_still_stops_foreground_cli_host() {
+    let log = EventLog::default();
+    let state = tokio::time::timeout(
+        Duration::from_millis(250),
+        run_multi_channel_serve_with_hooks_for_test(
+            None,
+            "cli-supervisor",
+            Some("bot_123456"),
+            Some("alerts"),
+            hooks(
+                |_| Ok(loaded_config_fixture()),
+                {
+                    let log = log.clone();
+                    move |options| {
+                        let log = log.clone();
+                        boxed_cli_result(async move {
+                            log.push("cli-start");
+                            sleep(Duration::from_millis(50)).await;
+                            log.push("cli-await-shutdown");
+                            options.shutdown.wait().await;
+                            log.push("cli-stop");
+                            Ok(())
+                        })
+                    }
+                },
+                {
+                    let log = log.clone();
+                    move |request| {
+                        let log = log.clone();
+                        boxed_cli_result(async move {
+                            log.push("telegram-fail");
+                            let _ = request;
+                            Err("telegram task exited unexpectedly".to_owned())
+                        })
+                    }
+                },
+                move |request| {
+                    boxed_cli_result(async move {
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        Ok(())
+                    })
+                },
+                pending_shutdown_future,
+            ),
+        ),
+    )
+    .await
+    .expect("supervisor should not hang after an early background failure")
+    .expect("run helper");
+
+    let error = state
+        .final_exit_result()
+        .expect_err("surface failure should fail the supervisor");
+    assert!(
+        error.contains(
+            "telegram(account=bot_123456) exited unexpectedly: telegram task exited unexpectedly"
+        ),
+        "error: {error}"
+    );
+
+    let events = log.snapshot();
+    let telegram_fail = events
+        .iter()
+        .position(|event| event == "telegram-fail")
+        .expect("telegram failure logged");
+    let cli_wait = events
+        .iter()
+        .position(|event| event == "cli-await-shutdown")
+        .expect("cli wait logged");
+    assert!(
+        telegram_fail < cli_wait,
+        "expected shutdown to be requested before CLI started waiting: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| event == "cli-stop"),
+        "cli host should still stop after shutdown was requested early: {events:?}"
     );
 }
 
@@ -476,7 +558,7 @@ async fn multi_channel_serve_ctrl_c_waits_for_background_joins_and_reports_shutd
                                 let log = log.clone();
                                 boxed_cli_result(async move {
                                     log.push("cli-start");
-                                    options.shutdown.notified().await;
+                                    options.shutdown.wait().await;
                                     log.push("cli-stop");
                                     Ok(())
                                 })
@@ -585,7 +667,7 @@ async fn multi_channel_serve_cooperative_stop_clears_channel_runtime_running_sta
                     |_| Ok(loaded_config_fixture()),
                     move |options| {
                         boxed_cli_result(async move {
-                            options.shutdown.notified().await;
+                            options.shutdown.wait().await;
                             Ok(())
                         })
                     },

--- a/crates/daemon/tests/integration/multi_channel_serve_cli.rs
+++ b/crates/daemon/tests/integration/multi_channel_serve_cli.rs
@@ -1,0 +1,644 @@
+use super::*;
+
+use std::{
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use loongclaw_daemon::supervisor::{
+    BackgroundChannelRunnerRequest, LoadedSupervisorConfig, RuntimeOwnerPhase,
+    SupervisorRuntimeHooks, SupervisorShutdownReason, SurfacePhase,
+    run_multi_channel_serve_with_hooks_for_test,
+};
+use tokio::{sync::Notify, time::sleep};
+
+type BoxedCliFuture = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'static>>;
+
+#[derive(Clone, Default)]
+struct EventLog {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl EventLog {
+    fn push(&self, event: impl Into<String>) {
+        self.events
+            .lock()
+            .expect("event log lock")
+            .push(event.into());
+    }
+
+    fn snapshot(&self) -> Vec<String> {
+        self.events.lock().expect("event log lock").clone()
+    }
+}
+
+fn boxed_cli_result(f: impl Future<Output = CliResult<()>> + Send + 'static) -> BoxedCliFuture {
+    Box::pin(f)
+}
+
+fn pending_shutdown_future() -> BoxedCliFuture {
+    Box::pin(async move {
+        std::future::pending::<()>().await;
+        Ok(())
+    })
+}
+
+fn loaded_config_fixture() -> LoadedSupervisorConfig {
+    LoadedSupervisorConfig {
+        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+        config: mvp::config::LoongClawConfig::default(),
+    }
+}
+
+fn hooks(
+    load_config: impl Fn(Option<&str>) -> CliResult<LoadedSupervisorConfig> + Send + Sync + 'static,
+    run_cli_host: impl Fn(mvp::chat::ConcurrentCliHostOptions) -> BoxedCliFuture + Send + Sync + 'static,
+    run_telegram: impl Fn(BackgroundChannelRunnerRequest) -> BoxedCliFuture + Send + Sync + 'static,
+    run_feishu: impl Fn(BackgroundChannelRunnerRequest) -> BoxedCliFuture + Send + Sync + 'static,
+    wait_for_shutdown: impl Fn() -> BoxedCliFuture + Send + Sync + 'static,
+) -> SupervisorRuntimeHooks {
+    SupervisorRuntimeHooks {
+        load_config: Arc::new(load_config),
+        run_cli_host: Arc::new(run_cli_host),
+        run_telegram: Arc::new(run_telegram),
+        run_feishu: Arc::new(run_feishu),
+        wait_for_shutdown: Arc::new(wait_for_shutdown),
+    }
+}
+
+async fn wait_until(description: &str, predicate: impl Fn() -> bool) {
+    for _ in 0..200 {
+        if predicate() {
+            return;
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+
+    panic!("timed out waiting for {description}");
+}
+
+fn unique_runtime_dir(label: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "loongclaw-daemon-multi-channel-serve-{label}-{suffix}"
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+    runtime_dir
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_starts_telegram_and_feishu_background_tasks() {
+    let log = EventLog::default();
+    let state = run_multi_channel_serve_with_hooks_for_test(
+        None,
+        "cli-supervisor",
+        Some("bot_123456"),
+        Some("alerts"),
+        hooks(
+            {
+                let log = log.clone();
+                move |_| {
+                    log.push("load-config");
+                    Ok(loaded_config_fixture())
+                }
+            },
+            {
+                let log = log.clone();
+                move |options| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!("cli-start session={}", options.session_id));
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let log = log.clone();
+                move |request| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!(
+                            "telegram-start account={}",
+                            request.account_id.as_deref().unwrap_or("-")
+                        ));
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        log.push("telegram-stop");
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let log = log.clone();
+                move |request| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!(
+                            "feishu-start account={}",
+                            request.account_id.as_deref().unwrap_or("-")
+                        ));
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        log.push("feishu-stop");
+                        Ok(())
+                    })
+                }
+            },
+            pending_shutdown_future,
+        ),
+    )
+    .await
+    .expect("run helper");
+
+    assert_eq!(state.phase(), RuntimeOwnerPhase::Stopped);
+    assert!(state.final_exit_result().is_ok());
+    assert_eq!(
+        state
+            .surface_state(
+                &loongclaw_daemon::supervisor::BackgroundChannelSurface::Telegram {
+                    account_id: Some("bot_123456".to_owned()),
+                }
+            )
+            .expect("telegram tracked")
+            .phase,
+        SurfacePhase::Stopped
+    );
+    assert_eq!(
+        state
+            .surface_state(
+                &loongclaw_daemon::supervisor::BackgroundChannelSurface::Feishu {
+                    account_id: Some("alerts".to_owned()),
+                }
+            )
+            .expect("feishu tracked")
+            .phase,
+        SurfacePhase::Stopped
+    );
+
+    let events = log.snapshot();
+    assert_eq!(events.first().map(String::as_str), Some("load-config"));
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "telegram-start account=bot_123456"),
+        "events: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "feishu-start account=alerts"),
+        "events: {events:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_background_failure_exits_foreground_cli_host_with_summarized_shutdown_reason()
+ {
+    let log = EventLog::default();
+    let fail_telegram = Arc::new(Notify::new());
+    let run_log = log.clone();
+    let run: tokio::task::JoinHandle<CliResult<loongclaw_daemon::supervisor::SupervisorState>> = {
+        let fail_telegram_for_run = fail_telegram.clone();
+        tokio::spawn(async move {
+            run_multi_channel_serve_with_hooks_for_test(
+                None,
+                "cli-supervisor",
+                Some("bot_123456"),
+                Some("alerts"),
+                hooks(
+                    |_| Ok(loaded_config_fixture()),
+                    {
+                        let log = run_log.clone();
+                        move |options| {
+                            let log = log.clone();
+                            boxed_cli_result(async move {
+                                log.push(format!("cli-start session={}", options.session_id));
+                                options.shutdown.notified().await;
+                                log.push("cli-stop");
+                                Ok(())
+                            })
+                        }
+                    },
+                    {
+                        let log = run_log.clone();
+                        move |request| {
+                            let log = log.clone();
+                            let fail_telegram_for_run = fail_telegram_for_run.clone();
+                            boxed_cli_result(async move {
+                                log.push("telegram-start");
+                                fail_telegram_for_run.notified().await;
+                                let _ = request;
+                                Err("telegram task exited unexpectedly".to_owned())
+                            })
+                        }
+                    },
+                    {
+                        let log = run_log.clone();
+                        move |request| {
+                            let log = log.clone();
+                            boxed_cli_result(async move {
+                                log.push("feishu-start");
+                                while !request.stop.is_requested() {
+                                    tokio::task::yield_now().await;
+                                }
+                                log.push("feishu-stop");
+                                Ok(())
+                            })
+                        }
+                    },
+                    pending_shutdown_future,
+                ),
+            )
+            .await
+        })
+    };
+    wait_until("telegram background start", || {
+        log.snapshot().iter().any(|event| event == "telegram-start")
+    })
+    .await;
+    fail_telegram.notify_waiters();
+    let state = run.await.expect("supervisor join").expect("run helper");
+
+    let error = state
+        .final_exit_result()
+        .expect_err("surface failure should fail the supervisor");
+    assert!(
+        error.contains(
+            "telegram(account=bot_123456) exited unexpectedly: telegram task exited unexpectedly"
+        ),
+        "error: {error}"
+    );
+    assert_eq!(
+        state.shutdown_reason(),
+        Some(&SupervisorShutdownReason::SurfaceFailed {
+            surface: loongclaw_daemon::supervisor::BackgroundChannelSurface::Telegram {
+                account_id: Some("bot_123456".to_owned()),
+            },
+            error: "telegram task exited unexpectedly".to_owned(),
+        })
+    );
+    assert!(
+        log.snapshot().iter().any(|event| event == "cli-stop"),
+        "cli host should stop after the background failure"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_keeps_cli_session_distinct_from_channel_sessions() {
+    let log = EventLog::default();
+    let state = run_multi_channel_serve_with_hooks_for_test(
+        None,
+        "cli-supervisor",
+        Some("bot_123456"),
+        Some("alerts"),
+        hooks(
+            |_| Ok(loaded_config_fixture()),
+            {
+                let log = log.clone();
+                move |options| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!("cli-session={}", options.session_id));
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let log = log.clone();
+                move |request| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!(
+                            "telegram-account={}",
+                            request.account_id.as_deref().unwrap_or("-")
+                        ));
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let log = log.clone();
+                move |request| {
+                    let log = log.clone();
+                    boxed_cli_result(async move {
+                        log.push(format!(
+                            "feishu-account={}",
+                            request.account_id.as_deref().unwrap_or("-")
+                        ));
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        Ok(())
+                    })
+                }
+            },
+            pending_shutdown_future,
+        ),
+    )
+    .await
+    .expect("run helper");
+
+    assert!(state.final_exit_result().is_ok());
+    let events = log.snapshot();
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "cli-session=cli-supervisor")
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "telegram-account=bot_123456")
+    );
+    assert!(events.iter().any(|event| event == "feishu-account=alerts"));
+    assert!(
+        !events
+            .iter()
+            .any(|event| event == "telegram-account=cli-supervisor"
+                || event == "feishu-account=cli-supervisor"),
+        "background channel runners must not reuse the CLI session id: {events:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_loads_config_once_before_spawning_children() {
+    let load_count = Arc::new(AtomicUsize::new(0));
+    let log = EventLog::default();
+    let state = run_multi_channel_serve_with_hooks_for_test(
+        Some("/tmp/loongclaw.toml"),
+        "cli-supervisor",
+        Some("bot_123456"),
+        Some("alerts"),
+        hooks(
+            {
+                let load_count = load_count.clone();
+                let log = log.clone();
+                move |config_path| {
+                    log.push(format!("load-config path={}", config_path.unwrap_or("-")));
+                    load_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(loaded_config_fixture())
+                }
+            },
+            {
+                let load_count = load_count.clone();
+                let log = log.clone();
+                move |_options| {
+                    let log = log.clone();
+                    let load_count = load_count.clone();
+                    boxed_cli_result(async move {
+                        assert_eq!(load_count.load(Ordering::SeqCst), 1);
+                        log.push("cli-start");
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let load_count = load_count.clone();
+                let log = log.clone();
+                move |request| {
+                    let log = log.clone();
+                    let load_count = load_count.clone();
+                    boxed_cli_result(async move {
+                        assert_eq!(load_count.load(Ordering::SeqCst), 1);
+                        log.push(format!("telegram-path={}", request.resolved_path.display()));
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        Ok(())
+                    })
+                }
+            },
+            {
+                let load_count = load_count.clone();
+                let log = log.clone();
+                move |request| {
+                    let log = log.clone();
+                    let load_count = load_count.clone();
+                    boxed_cli_result(async move {
+                        assert_eq!(load_count.load(Ordering::SeqCst), 1);
+                        log.push(format!("feishu-path={}", request.resolved_path.display()));
+                        while !request.stop.is_requested() {
+                            tokio::task::yield_now().await;
+                        }
+                        Ok(())
+                    })
+                }
+            },
+            pending_shutdown_future,
+        ),
+    )
+    .await
+    .expect("run helper");
+
+    assert!(state.final_exit_result().is_ok());
+    assert_eq!(load_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        log.snapshot().first().map(String::as_str),
+        Some("load-config path=/tmp/loongclaw.toml")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_ctrl_c_waits_for_background_joins_and_reports_shutdown_reason() {
+    let ctrl_c = Arc::new(Notify::new());
+    let release_telegram = Arc::new(Notify::new());
+    let log = EventLog::default();
+    let run: tokio::task::JoinHandle<CliResult<loongclaw_daemon::supervisor::SupervisorState>> =
+        tokio::spawn({
+            let ctrl_c = ctrl_c.clone();
+            let release_telegram = release_telegram.clone();
+            let log = log.clone();
+            async move {
+                run_multi_channel_serve_with_hooks_for_test(
+                    None,
+                    "cli-supervisor",
+                    Some("bot_123456"),
+                    Some("alerts"),
+                    hooks(
+                        |_| Ok(loaded_config_fixture()),
+                        {
+                            let log = log.clone();
+                            move |options| {
+                                let log = log.clone();
+                                boxed_cli_result(async move {
+                                    log.push("cli-start");
+                                    options.shutdown.notified().await;
+                                    log.push("cli-stop");
+                                    Ok(())
+                                })
+                            }
+                        },
+                        {
+                            let log = log.clone();
+                            let release_telegram = release_telegram.clone();
+                            move |request| {
+                                let log = log.clone();
+                                let release_telegram = release_telegram.clone();
+                                boxed_cli_result(async move {
+                                    log.push("telegram-start");
+                                    while !request.stop.is_requested() {
+                                        tokio::task::yield_now().await;
+                                    }
+                                    log.push("telegram-stop-requested");
+                                    release_telegram.notified().await;
+                                    log.push("telegram-joined");
+                                    Ok(())
+                                })
+                            }
+                        },
+                        {
+                            let log = log.clone();
+                            move |request| {
+                                let log = log.clone();
+                                boxed_cli_result(async move {
+                                    log.push("feishu-start");
+                                    while !request.stop.is_requested() {
+                                        tokio::task::yield_now().await;
+                                    }
+                                    log.push("feishu-joined");
+                                    Ok(())
+                                })
+                            }
+                        },
+                        move || {
+                            let ctrl_c = ctrl_c.clone();
+                            let log = log.clone();
+                            boxed_cli_result(async move {
+                                ctrl_c.notified().await;
+                                log.push("ctrl-c");
+                                Ok(())
+                            })
+                        },
+                    ),
+                )
+                .await
+            }
+        });
+
+    wait_until("background and cli startup", || {
+        let events = log.snapshot();
+        events.iter().any(|event| event == "cli-start")
+            && events.iter().any(|event| event == "telegram-start")
+            && events.iter().any(|event| event == "feishu-start")
+    })
+    .await;
+
+    ctrl_c.notify_waiters();
+    wait_until("cooperative stop request", || {
+        log.snapshot()
+            .iter()
+            .any(|event| event == "telegram-stop-requested")
+    })
+    .await;
+    assert!(
+        !run.is_finished(),
+        "supervisor should wait for background joins after Ctrl-C"
+    );
+
+    release_telegram.notify_waiters();
+    let state = run.await.expect("supervisor join").expect("run helper");
+
+    assert_eq!(state.phase(), RuntimeOwnerPhase::Stopped);
+    assert!(state.final_exit_result().is_ok());
+    assert!(
+        state
+            .final_exit_summary()
+            .contains("shutdown requested: ctrl-c received"),
+        "summary: {}",
+        state.final_exit_summary()
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_channel_serve_cooperative_stop_clears_channel_runtime_running_state() {
+    let temp_home = unique_runtime_dir("cooperative-stop-home");
+    let runtime_dir = temp_home.join(".loongclaw").join("channel-runtime");
+    let _env =
+        MigrationEnvironmentGuard::set(&[("HOME", Some(temp_home.to_string_lossy().as_ref()))]);
+    let runtime_entered = Arc::new(Notify::new());
+    let ctrl_c = Arc::new(Notify::new());
+
+    let run: tokio::task::JoinHandle<CliResult<loongclaw_daemon::supervisor::SupervisorState>> = {
+        let runtime_entered = runtime_entered.clone();
+        let ctrl_c = ctrl_c.clone();
+        tokio::spawn(async move {
+            run_multi_channel_serve_with_hooks_for_test(
+                None,
+                "cli-supervisor",
+                Some("bot_123456"),
+                Some("alerts"),
+                hooks(
+                    |_| Ok(loaded_config_fixture()),
+                    move |options| {
+                        boxed_cli_result(async move {
+                            options.shutdown.notified().await;
+                            Ok(())
+                        })
+                    },
+                    move |request| {
+                        let runtime_entered = runtime_entered.clone();
+                        boxed_cli_result(async move {
+                            mvp::channel::run_channel_serve_runtime_probe_for_test(
+                                mvp::channel::ChannelPlatform::Telegram,
+                                request.account_id.as_deref().unwrap_or("bot_123456"),
+                                "bot:123456",
+                                request.stop,
+                                runtime_entered,
+                            )
+                            .await
+                        })
+                    },
+                    move |request| {
+                        boxed_cli_result(async move {
+                            while !request.stop.is_requested() {
+                                tokio::task::yield_now().await;
+                            }
+                            Ok(())
+                        })
+                    },
+                    move || {
+                        let ctrl_c = ctrl_c.clone();
+                        boxed_cli_result(async move {
+                            ctrl_c.notified().await;
+                            Ok(())
+                        })
+                    },
+                ),
+            )
+            .await
+        })
+    };
+
+    runtime_entered.notified().await;
+    ctrl_c.notify_waiters();
+    let state = run.await.expect("supervisor join").expect("run helper");
+
+    assert!(state.final_exit_result().is_ok());
+
+    let runtime = mvp::channel::load_channel_operation_runtime_for_account_from_dir_for_test(
+        runtime_dir.as_path(),
+        mvp::channel::ChannelPlatform::Telegram,
+        "serve",
+        "bot_123456",
+        0,
+    )
+    .expect("runtime snapshot should exist after cooperative shutdown");
+    assert!(
+        !runtime.running,
+        "cooperative stop should clear the runtime running flag"
+    );
+}

--- a/docs/PRODUCT_SENSE.md
+++ b/docs/PRODUCT_SENSE.md
@@ -65,7 +65,7 @@ The primary daemon surfaces are:
 | `chat` | Interactive CLI conversation |
 | `doctor` | Health diagnostics with optional safe repair |
 | `migrate` | Power-user migration path |
-| `telegram-serve` / `feishu-serve` | Service channels once the base setup is healthy |
+| `telegram-serve` / `feishu-serve` / `multi-channel-serve` | Service channels once the base setup is healthy |
 
 ## See Also
 

--- a/docs/plans/2026-03-22-multi-session-concurrent-channel-dispatch-design.md
+++ b/docs/plans/2026-03-22-multi-session-concurrent-channel-dispatch-design.md
@@ -1,0 +1,390 @@
+# Multi-Session Concurrent Channel Dispatch Design
+
+**Issue:** `#301`  
+**Branch target:** `upstream/dev`  
+**Related:** `#293`, `#217`, `#218`
+
+## Scope
+
+Issue `#301` should add one in-process runtime owner that can run the MVP
+surfaces concurrently in a single LoongClaw process:
+
+- CLI
+- Telegram
+- Feishu / Lark
+
+This slice includes:
+
+- concurrent task ownership in one process
+- per-surface task lifecycle tracking
+- coordinated graceful shutdown
+- health data usable by logs and tests
+
+This slice does **not** include:
+
+- a new top-level operator-facing `status` command
+- restart / backoff / self-healing policy
+- broader daemon / service / gateway ownership work from `#217`
+
+## Problem Statement
+
+LoongClaw already has real channel runtime entrypoints and per-channel runtime
+state, but they still operate as separate long-lived command paths.
+
+Current code already provides:
+
+- channel serve entrypoints such as `run_telegram_channel(...)` and
+  `run_feishu_channel(...)` in `crates/app/src/channel/mod.rs`
+- daemon-level wrappers that execute each serve flow individually from
+  `crates/daemon/src/main.rs` and `crates/daemon/src/lib.rs`
+- persisted per-channel runtime heartbeats in
+  `crates/app/src/channel/runtime_state.rs`
+
+That means the missing capability for `#301` is not "create a new channel
+runtime surface." The missing capability is process-level orchestration:
+
+- spawn multiple runtime surfaces together
+- observe their lifecycle coherently
+- shut them down together
+- fail coherently when one critical child fails
+
+## Design Goal
+
+Add a daemon-owned in-process runtime owner that composes existing channel and
+CLI entrypoints without moving channel-specific logic into a new subsystem.
+
+The runtime owner should be the smallest slice that makes concurrent MVP
+operation real while preserving the existing boundary:
+
+- `crates/app` owns channel execution
+- `crates/daemon` owns process orchestration
+
+## Chosen Design
+
+Add a new daemon-owned runtime owner entrypoint and module that:
+
+1. resolves which runtime surfaces should run
+2. constructs a typed supervisor spec
+3. keeps the interactive CLI in the foreground for the first slice
+4. spawns one Tokio task per background channel surface
+5. tracks each background task's lifecycle in shared in-memory state
+6. coordinates graceful shutdown across all children
+7. tears the whole runtime owner down if any required child fails unexpectedly
+
+The existing channel runtime files remain the persisted truth for per-channel
+serve instances. The new runtime owner adds a process-local view above that
+state; it does not replace channel runtime persistence.
+
+This first slice intentionally does **not** require the current blocking CLI
+REPL to become a homogeneous background child task. The existing CLI chat path
+is stdin-driven and blocking today, so the initial concurrency model should be:
+
+- foreground interactive CLI host
+- background supervised Telegram task
+- background supervised Feishu task
+
+That is enough to satisfy "CLI + Telegram + Feishu in one process" without
+inventing a fake symmetry that the current code does not support.
+
+To make that model operationally correct, the first slice must also add a small
+foreground CLI shutdown seam. The current REPL blocks on stdin reads, so the
+runtime owner needs an explicit way to interrupt or unwind the foreground host
+when:
+
+- root shutdown begins
+- a required background channel child fails
+
+The design should therefore extract a cancellable foreground host loop rather
+than keeping raw blocking stdin reads embedded in the top-level runtime owner.
+
+## Component Boundaries
+
+### `crates/daemon/src/supervisor.rs`
+
+Add a new daemon-owned module responsible for:
+
+- supervisor spec construction
+- child task spawn orchestration
+- in-memory lifecycle state map
+- shutdown fan-out
+- join handling and final exit semantics
+
+Suggested core types:
+
+- `SupervisorSpec`
+- `SupervisedSurface`
+- `SurfaceHandle`
+- `SurfaceState`
+- `SupervisorState`
+- `SupervisorShutdownReason`
+- `RuntimeOwnerMode`
+- `BackgroundChannelSurface`
+
+### `crates/daemon/src/lib.rs`
+
+Expose the supervisor entrypoint and any lightweight CLI-adjacent helpers:
+
+- parse high-level runtime selection
+- delegate execution to `supervisor.rs`
+- keep top-level CLI/business logic thin
+
+### `crates/daemon/src/main.rs`
+
+Add one new command surface that starts the concurrent supervisor. The command
+should remain narrowly scoped to MVP runtime ownership for CLI + Telegram +
+Feishu rather than attempting to solve the broader operator UX in `#217`.
+
+### `crates/app/src/channel/mod.rs`
+
+Keep existing channel serve logic in place. The supervisor should call existing
+entrypoints or small extracted helper seams from this module rather than
+rewriting Telegram or Feishu runtime behavior.
+
+This module will need one new cooperative stop seam. The daemon runtime owner
+must not rely on task abort as the normal shutdown path because channel runtime
+cleanup currently happens only when the serve future returns normally.
+
+The design should therefore add an app-layer contract such as:
+
+- a stop token / cancellation handle passed into serve execution
+- a shared shutdown future the serve loop can observe
+- a small wrapper that converts daemon shutdown intent into a normal channel
+  serve return path
+
+Forceful Tokio task abort should remain only a bounded fallback when graceful
+shutdown exceeds its deadline.
+
+### `crates/app/src/channel/runtime_state.rs`
+
+Keep existing persisted runtime state intact:
+
+- channel-specific heartbeat files
+- busy / running / stale semantics
+- per-account runtime visibility
+
+The supervisor should not fork or replace this model. If needed, it may read or
+align with it, but `#301` should not redesign runtime persistence.
+
+## Runtime Model
+
+Represent the runtime owner inputs explicitly. Initial variants should be:
+
+- `Telegram { account_id: Option<String> }`
+- `Feishu { account_id: Option<String> }`
+
+Represent the CLI separately as the foreground host mode in the first slice.
+This avoids pretending that the current blocking stdin REPL is already a normal
+supervised child.
+
+Each child should have a small process-local lifecycle record:
+
+- `starting`
+- `running`
+- `stopping`
+- `stopped`
+- `failed`
+
+Minimum state payload per background child:
+
+- surface id
+- task phase
+- start timestamp
+- stop timestamp
+- optional last error string
+- optional exit reason
+
+This state is process-local only for this phase. It is meant to support:
+
+- deterministic logging
+- supervisor-level assertions in tests
+- future integration into broader operator surfaces
+
+## Startup Flow
+
+1. CLI command enters the supervisor entrypoint in `crates/daemon`.
+2. Config is loaded once.
+3. The runtime owner resolves which background channel surfaces should be
+   launched.
+4. A `SupervisorSpec` is created.
+5. Shared shutdown and state containers are initialized.
+6. One Tokio task is spawned per selected background channel.
+7. Each background task wrapper:
+   - marks itself `starting`
+   - invokes the underlying surface runner
+   - transitions to `running` after startup succeeds
+   - transitions to `failed` on unexpected exit
+   - transitions to `stopped` on expected shutdown
+8. The foreground CLI host continues to own stdin / stdout interaction while the
+   background channel tasks run concurrently in the same process.
+
+Foreground CLI hosting must be cancellable in concurrent mode. The simplest
+design is to introduce a small host seam that:
+
+- reads stdin through a controllable adapter
+- observes a shutdown notification from the runtime owner
+- exits its loop cleanly when shutdown is requested or a required background
+  child fails
+
+That seam can be implemented with async stdin handling or with a blocking stdin
+reader bridged into a channel, but the important contract is that the runtime
+owner can terminate the CLI host coherently instead of leaving it hung on
+`read_line()`.
+
+## Shutdown Flow
+
+Graceful shutdown is coordinated at the runtime-owner root:
+
+1. receive Ctrl-C or another terminal shutdown trigger
+2. record shutdown intent
+3. signal all background channel tasks through a shared cooperative stop path
+4. signal the foreground CLI host through its dedicated shutdown path
+5. mark children `stopping`
+6. allow app-layer serve loops to exit normally and perform explicit runtime
+   tracker cleanup
+7. wait for bounded task joins and foreground host exit
+8. return success only when the runtime owner has shut down coherently
+
+If any child exits unexpectedly before shutdown begins:
+
+1. record the child failure
+2. mark the runtime owner as failed
+3. begin coordinated shutdown for the remaining children
+4. notify the foreground CLI host to unwind and exit
+5. return a summarized process-level error
+
+This keeps `#301` operationally honest: one required child dying means the
+multi-surface runtime is no longer healthy.
+
+## Health Semantics
+
+For this issue, "health monitoring per channel task" means:
+
+- the supervisor knows whether each child is starting, running, stopping,
+  stopped, or failed
+- the supervisor records the failing child and failure text on abnormal exit
+- tests and logs can observe that state deterministically
+
+It does **not** mean a new operator-facing `status` command in this slice.
+
+Reasoning:
+
+- `#301` needs lifecycle truth for concurrent runtime management
+- `#217` owns the broader operator-runtime UX problem
+- the repo already has adjacent `channels`, `doctor`, and ACP status surfaces,
+  so introducing a new status UX here would blur ownership and widen scope
+
+## Failure Policy
+
+This phase is intentionally fail-fast.
+
+### Included
+
+- fail startup if a required child cannot initialize
+- fail the supervisor if a running child exits unexpectedly
+- shut remaining children down when one required child fails
+
+### Deferred
+
+- automatic restarts
+- exponential backoff
+- retry budgets
+- stale-child reclamation policy beyond existing channel runtime semantics
+
+Those are real policy choices and belong in a follow-up issue rather than this
+first concurrency slice.
+
+## Session Isolation
+
+Issue `#301` requires per-session state isolation. That needs to be explicit in
+the design, not assumed.
+
+Isolation for the first slice should mean:
+
+- Telegram and Feishu continue to use their existing route-derived conversation
+  / session identities
+- the concurrent CLI host must not silently reuse the generic default session in
+  supervisor mode
+- the runtime owner must require or derive an explicit CLI session id when
+  launched in concurrent mode
+
+The simplest safe rule for the first slice is:
+
+- concurrent-mode CLI always runs with an explicit session id
+- channel turns continue to derive their own route/session identity
+- no background child may share CLI session identity implicitly
+
+That preserves SQLite-backed session separation without redesigning the session
+store.
+
+## Testing Strategy
+
+### Unit tests
+
+Add focused tests for the supervisor state machine:
+
+- startup state transitions
+- child failure propagation
+- coordinated shutdown transitions
+- final exit summarization
+
+### Integration tests
+
+Add deterministic integration tests for:
+
+- concurrent startup of multiple surfaces
+- one child failure triggering full supervisor shutdown
+- Ctrl-C / shutdown path joining all children cleanly
+- CLI session id staying distinct from Telegram / Feishu route-derived session
+  ids in concurrent mode
+- background child failure causing the foreground CLI host to exit with the
+  summarized shutdown reason
+- cooperative stop causing normal channel runtime cleanup instead of leaving
+  active heartbeat state behind
+
+Tests should prefer fake or controlled child runners over real network traffic
+where the goal is orchestration proof rather than transport proof.
+
+Channel-specific runtime correctness remains covered by existing channel tests.
+`#301` tests should mainly prove process orchestration, lifecycle tracking, and
+shutdown semantics.
+
+## Acceptance Criteria Mapping
+
+Issue `#301` acceptance criteria map to this design as follows:
+
+- **Session supervisor that spawns tokio tasks per channel**
+  - provided by the new daemon-owned supervisor module
+- **Concurrent CLI + Telegram + Feishu in one process**
+  - provided by one foreground CLI host plus supervised Telegram and Feishu
+    background tasks in a single runtime owner
+- **Per-session state isolation**
+  - preserved by explicit CLI session identity in concurrent mode plus existing
+    route-derived channel session identity
+- **Graceful shutdown across all channels**
+  - provided by one coordinated supervisor shutdown path
+- **Health monitoring per channel task**
+  - provided by process-local lifecycle state and failure recording
+
+## Out of Scope
+
+This design intentionally does not cover:
+
+- Matrix integration in the first `#301` slice
+- service install / daemonization UX
+- new operator status rendering
+- gateway route mounting
+- restart / backoff / resilience policy
+- cross-process supervisor persistence
+
+## Implementation Notes
+
+The safest implementation path is incremental:
+
+1. add supervisor types and in-memory state transitions
+2. wrap one fake child runner and prove lifecycle semantics in tests
+3. extract a cancellable foreground CLI host seam for concurrent mode
+4. wire in Telegram and Feishu serve children
+5. add coordinated shutdown and failure propagation tests
+
+That sequencing keeps the first risky step at the orchestration seam rather than
+mixing orchestration and transport changes at once.

--- a/docs/plans/2026-03-22-multi-session-concurrent-channel-dispatch-implementation-plan.md
+++ b/docs/plans/2026-03-22-multi-session-concurrent-channel-dispatch-implementation-plan.md
@@ -1,0 +1,560 @@
+# Multi-Session Concurrent Channel Dispatch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a daemon-owned `multi-channel-serve` runtime owner that keeps interactive CLI chat in the foreground while Telegram and Feishu run as supervised background tasks in the same process, with explicit session isolation, cooperative shutdown, and per-task health tracking.
+
+**Architecture:** Keep process orchestration in `crates/daemon` and keep channel execution in `crates/app`. Introduce a new `crates/daemon/src/supervisor.rs` module for the runtime owner/state machine, extract a cancellable concurrent-mode CLI host seam from `crates/app/src/chat.rs`, and add a cooperative stop contract for channel serve flows in `crates/app/src/channel/mod.rs` so background tasks can exit normally and let the existing runtime wrapper call `shutdown()`.
+
+**Tech Stack:** Rust, Tokio, Clap, existing LoongClaw daemon/app crates, SQLite-backed session state, existing daemon integration test harness
+
+---
+
+**Repo contract note:** Before **every commit** in this plan, run `task verify` from the repo root. This repo requires CI-parity checks at every commit, and `task verify` is the local superset gate.
+
+### Task 1: Lock The CLI Contract
+
+**Files:**
+- Create: `crates/daemon/src/supervisor.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Test: `crates/daemon/tests/integration/cli_tests.rs`
+
+- [ ] **Step 1: Write the failing parser/help tests for the new command**
+
+```rust
+#[test]
+fn multi_channel_serve_cli_requires_explicit_cli_session() {
+    let error = Cli::try_parse_from(["loongclaw", "multi-channel-serve"])
+        .expect_err("missing --session should fail");
+    assert!(error.to_string().contains("--session <SESSION>"));
+}
+
+#[test]
+fn multi_channel_serve_cli_parses_account_selection_flags() {
+    let cli = Cli::try_parse_from([
+        "loongclaw",
+        "multi-channel-serve",
+        "--session",
+        "cli-supervisor",
+        "--telegram-account",
+        "bot_123456",
+        "--feishu-account",
+        "alerts",
+    ])
+    .expect("multi-channel-serve should parse");
+
+    match cli.command {
+        Some(Commands::MultiChannelServe {
+            session,
+            telegram_account,
+            feishu_account,
+            ..
+        }) => {
+            assert_eq!(session, "cli-supervisor");
+            assert_eq!(telegram_account.as_deref(), Some("bot_123456"));
+            assert_eq!(feishu_account.as_deref(), Some("alerts"));
+        }
+        other => panic!("unexpected parse result: {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run the targeted parser tests and confirm they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon --test integration multi_channel_serve_cli_
+```
+
+Expected: failure because `Commands::MultiChannelServe` does not exist yet.
+
+- [ ] **Step 3: Add the command enum variant and dispatch stub**
+
+Use a narrow initial CLI contract:
+
+```rust
+MultiChannelServe {
+    #[arg(long)]
+    config: Option<String>,
+    #[arg(long)]
+    session: String,
+    #[arg(long)]
+    telegram_account: Option<String>,
+    #[arg(long)]
+    feishu_account: Option<String>,
+}
+```
+
+Add a daemon entrypoint stub in `crates/daemon/src/lib.rs` and route it from
+`crates/daemon/src/main.rs`:
+
+```rust
+pub async fn run_multi_channel_serve_cli(...) -> CliResult<()> {
+    supervisor::run_multi_channel_serve(...)
+        .await
+}
+```
+
+- [ ] **Step 4: Re-run the parser tests and confirm they pass**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon --test integration multi_channel_serve_cli_
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run repo verification for the CLI contract slice**
+
+Run:
+
+```bash
+task verify
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the CLI contract slice**
+
+```bash
+git add crates/daemon/src/lib.rs crates/daemon/src/main.rs crates/daemon/src/supervisor.rs crates/daemon/tests/integration/cli_tests.rs
+git commit -m "feat: add multi-channel-serve cli contract"
+```
+
+### Task 2: Build The Supervisor State Machine
+
+**Files:**
+- Modify: `crates/daemon/src/supervisor.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Test: `crates/daemon/src/supervisor.rs`
+
+- [ ] **Step 1: Write failing unit tests for the in-memory lifecycle model**
+
+Add unit tests covering:
+
+```rust
+#[tokio::test]
+async fn background_surface_startup_records_start_timestamp_and_running_phase() {
+    // start telegram child
+    // assert started_at_ms is set and phase becomes Running
+}
+
+#[tokio::test]
+async fn background_surface_failure_marks_runtime_owner_failed() {
+    // start with two background children
+    // mark telegram failed
+    // assert supervisor transitions to failed and requests shutdown
+}
+
+#[tokio::test]
+async fn graceful_shutdown_marks_running_children_stopping_then_stopped() {
+    // seed running telegram + feishu
+    // request shutdown
+    // assert stopping -> stopped transitions
+}
+
+#[tokio::test]
+async fn final_exit_reason_is_recorded_for_failed_child() {
+    // fail one child
+    // assert exit_reason and stopped_at_ms are populated
+}
+```
+
+- [ ] **Step 2: Run the targeted supervisor tests and confirm they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon supervisor::
+```
+
+Expected: failure because the state machine types/logic are not implemented yet.
+
+- [ ] **Step 3: Implement the daemon-owned supervisor core**
+
+Add focused types in `crates/daemon/src/supervisor.rs`:
+
+```rust
+pub enum BackgroundChannelSurface {
+    Telegram { account_id: Option<String> },
+    Feishu { account_id: Option<String> },
+}
+
+pub enum SurfacePhase {
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+    Failed,
+}
+
+pub struct SurfaceState {
+    pub surface: BackgroundChannelSurface,
+    pub phase: SurfacePhase,
+    pub started_at_ms: Option<u64>,
+    pub stopped_at_ms: Option<u64>,
+    pub last_error: Option<String>,
+    pub exit_reason: Option<String>,
+}
+```
+
+Implement:
+
+- `SupervisorSpec`
+- `SupervisorState`
+- failure summarization
+- startup-transition timestamps
+- final-exit summarization
+- shutdown-reason tracking
+- helper methods that task wrappers can call without knowing CLI details
+
+- [ ] **Step 4: Re-run the supervisor tests and confirm they pass**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon supervisor::
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run repo verification for the state machine slice**
+
+Run:
+
+```bash
+task verify
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the state machine slice**
+
+```bash
+git add crates/daemon/src/supervisor.rs crates/daemon/src/lib.rs
+git commit -m "feat: add multi-channel supervisor state machine"
+```
+
+### Task 3: Extract A Cancellable Foreground CLI Host
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+- Test: `crates/app/src/chat.rs`
+- Test: `crates/daemon/tests/integration/chat_cli.rs`
+
+- [ ] **Step 1: Write failing tests for concurrent-mode CLI session and shutdown behavior**
+
+Add unit tests in `crates/app/src/chat.rs` for:
+
+```rust
+#[tokio::test]
+async fn concurrent_cli_host_requires_explicit_session_id() {
+    // concurrent mode should reject the implicit "default" session fallback
+}
+
+#[tokio::test]
+async fn concurrent_cli_host_exits_when_shutdown_is_requested() {
+    // host loop should stop without waiting forever on raw stdin read_line()
+}
+```
+
+Add an integration test in `crates/daemon/tests/integration/chat_cli.rs` for
+the user-visible contract if needed:
+
+```rust
+#[test]
+fn multi_channel_serve_requires_explicit_session_flag() {
+    // exercise binary parse/help path
+}
+```
+
+- [ ] **Step 2: Run the targeted chat tests and confirm they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app concurrent_cli_host_
+```
+
+Expected: failure because the concurrent-mode host seam does not exist yet.
+
+- [ ] **Step 3: Extract the foreground host seam**
+
+Refactor `crates/app/src/chat.rs` so concurrent mode uses a dedicated host path
+instead of embedding raw blocking stdin ownership in the daemon runtime owner:
+
+```rust
+pub struct ConcurrentCliHostOptions {
+    pub resolved_path: PathBuf,
+    pub config: LoongClawConfig,
+    pub session_id: String,
+    pub shutdown: Arc<Notify>,
+}
+
+pub async fn run_concurrent_cli_host(
+    options: &ConcurrentCliHostOptions,
+) -> CliResult<()> {
+    // initialize runtime from preloaded config + resolved path
+    // drive input through a controllable loop
+    // exit cleanly when shutdown is requested
+}
+```
+
+Key requirements:
+
+- do not allow implicit `"default"` session in concurrent mode
+- keep ordinary `chat` behavior unchanged
+- allow the runtime owner to stop the foreground host coherently
+- do not reload config inside the concurrent host path
+
+- [ ] **Step 4: Re-run the targeted chat tests and confirm they pass**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app concurrent_cli_host_
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run repo verification for the concurrent CLI host slice**
+
+Run:
+
+```bash
+task verify
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the concurrent CLI host slice**
+
+```bash
+git add crates/app/src/chat.rs crates/daemon/tests/integration/chat_cli.rs
+git commit -m "feat: add cancellable concurrent cli host"
+```
+
+### Task 4: Add Cooperative Stop For Channel Serve Tasks
+
+**Files:**
+- Modify: `crates/app/src/channel/mod.rs`
+- Test: `crates/app/src/channel/mod.rs`
+
+- [ ] **Step 1: Write the failing cooperative-stop test around the existing serve wrapper**
+
+Add a new targeted test near the existing `with_channel_serve_runtime_*` tests:
+
+```rust
+#[tokio::test]
+async fn with_channel_serve_runtime_shuts_down_cleanly_after_cooperative_stop() {
+    // start runtime wrapper
+    // trigger cooperative stop
+    // assert wrapper returns normally
+    // assert runtime file is no longer running
+}
+```
+
+- [ ] **Step 2: Run the targeted channel-runtime tests and confirm they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app with_channel_serve_runtime_
+```
+
+Expected: failure because there is no cooperative stop seam yet.
+
+- [ ] **Step 3: Add the cooperative stop contract in `channel/mod.rs`**
+
+Introduce a small app-layer stop abstraction using existing Tokio primitives:
+
+```rust
+pub struct ChannelServeStopHandle {
+    stop: Arc<Notify>,
+}
+
+async fn run_channel_serve_command_with_stop<R, V, F>(..., stop: ChannelServeStopHandle, run: F) -> CliResult<()>
+```
+
+Requirements:
+
+- background serve loops can observe stop intent
+- background serve setup uses preloaded config + resolved path via the existing
+  `build_telegram_command_context(...)` / `build_feishu_command_context(...)`
+  helpers instead of `load_*_command_context(...)`
+- normal return path still runs through `with_channel_serve_runtime(...)`
+- Tokio task abort remains fallback only, not the primary shutdown path
+
+Do **not** redesign `ChannelOperationRuntimeTracker`; reuse the existing
+`runtime.shutdown().await` call that already runs when the serve future returns.
+
+- [ ] **Step 4: Re-run the targeted channel-runtime tests and confirm they pass**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app with_channel_serve_runtime_
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run repo verification for the cooperative-stop slice**
+
+Run:
+
+```bash
+task verify
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the cooperative-stop slice**
+
+```bash
+git add crates/app/src/channel/mod.rs
+git commit -m "feat: add cooperative stop for channel serve tasks"
+```
+
+### Task 5: Wire `multi-channel-serve` End To End
+
+**Files:**
+- Modify: `crates/daemon/src/supervisor.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Modify: `crates/daemon/tests/integration/mod.rs`
+- Create: `crates/daemon/tests/integration/multi_channel_serve_cli.rs`
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/app/src/channel/mod.rs`
+
+- [ ] **Step 1: Write failing daemon integration tests for concurrent ownership**
+
+Create `crates/daemon/tests/integration/multi_channel_serve_cli.rs` and register
+it in `crates/daemon/tests/integration/mod.rs`.
+
+Add tests for:
+
+```rust
+#[tokio::test]
+async fn multi_channel_serve_starts_telegram_and_feishu_background_tasks() {}
+
+#[tokio::test]
+async fn multi_channel_serve_background_failure_exits_foreground_cli_host_with_summarized_shutdown_reason() {}
+
+#[tokio::test]
+async fn multi_channel_serve_keeps_cli_session_distinct_from_channel_sessions() {}
+
+#[tokio::test]
+async fn multi_channel_serve_loads_config_once_before_spawning_children() {}
+
+#[tokio::test]
+async fn multi_channel_serve_ctrl_c_waits_for_background_joins_and_reports_shutdown_reason() {}
+
+#[tokio::test]
+async fn multi_channel_serve_cooperative_stop_clears_channel_runtime_running_state() {}
+```
+
+Use test doubles / injected runners rather than real network traffic.
+
+- [ ] **Step 2: Run the new integration tests and confirm they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon --test integration multi_channel_serve_
+```
+
+Expected: failure because the runtime owner is not wired end to end yet.
+
+- [ ] **Step 3: Implement the runtime owner orchestration**
+
+Wire the daemon entrypoint to:
+
+- load config once at the runtime-owner root
+- construct `SupervisorSpec` from CLI flags and the preloaded config
+- start background Telegram and Feishu tasks
+- start the foreground concurrent CLI host
+- forward child failure into root shutdown
+- forward root shutdown into:
+  - foreground CLI host stop
+  - cooperative channel stop handles
+
+Representative shape:
+
+```rust
+pub async fn run_multi_channel_serve(...) -> CliResult<()> {
+    let (resolved_path, config) = mvp::config::load(config_path)?;
+    let mut owner = Supervisor::from_loaded_config(resolved_path, config, ...)?;
+    owner.spawn_telegram_if_enabled().await?;
+    owner.spawn_feishu_if_enabled().await?;
+    owner.run_foreground_cli_host().await
+}
+```
+
+- [ ] **Step 4: Re-run the new integration tests and confirm they pass**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon --test integration multi_channel_serve_
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run repo verification for the end-to-end runtime owner slice**
+
+Run:
+
+```bash
+task verify
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the end-to-end runtime owner slice**
+
+```bash
+git add crates/daemon/src/supervisor.rs crates/daemon/src/lib.rs crates/daemon/src/main.rs crates/daemon/tests/integration/mod.rs crates/daemon/tests/integration/multi_channel_serve_cli.rs crates/app/src/chat.rs crates/app/src/channel/mod.rs
+git commit -m "feat: add multi-channel serve runtime owner"
+```
+
+### Task 6: Update Operator Docs And Run Final Verification
+
+**Files:**
+- Modify: `docs/PRODUCT_SENSE.md`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+
+- [ ] **Step 1: Update the user-facing docs**
+
+Document the new surface consistently:
+
+- `docs/PRODUCT_SENSE.md`
+  - add `multi-channel-serve` to the command table
+- `README.md`
+  - explain the one-process concurrent runtime use case
+- `README.zh-CN.md`
+  - keep the Chinese surface aligned
+
+- [ ] **Step 2: Run the canonical repo verification gate**
+
+Run:
+
+```bash
+task verify
+```
+
+Expected:
+
+- `task verify` exits 0
+- CI-parity cargo checks pass under the repo Taskfile
+- docs, architecture, dependency, and harness checks pass
+
+- [ ] **Step 3: Commit the docs + verification slice**
+
+```bash
+git add docs/PRODUCT_SENSE.md README.md README.zh-CN.md
+git commit -m "docs: document multi-channel serve runtime"
+```


### PR DESCRIPTION
## Summary

- Problem: issue #301 needs one in-process runtime owner for interactive CLI chat plus Telegram and Feishu service channels instead of forcing separate serve processes with fragmented shutdown behavior.
- Why it matters: the MVP needs one supervised runtime that can keep the CLI in the foreground while background channels share the same process, fail loudly, and unwind cleanly.
- What changed: added `multi-channel-serve`; introduced a daemon-owned supervisor state machine and runtime owner; extracted a cancellable concurrent CLI host; added cooperative stop plumbing for channel serve tasks; hardened disabled-surface selection and join-error shutdown paths; documented the new operator surface.
- What did not change (scope boundary): no restart/backoff policy, no new user-visible status surface, and no removal of the existing standalone `telegram-serve` / `feishu-serve` entrypoints.

## Linked Issues

- Closes #301
- Related #293, #217

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this change spans daemon orchestration, CLI cancellation, and channel stop semantics. The main failure modes are hung shutdown, stale running-state bookkeeping, or disabled surfaces being started unexpectedly.
- Rollout / guardrails: new behavior is isolated behind explicit `multi-channel-serve`; the supervisor fails closed on unexpected child exits and join errors; disabled surfaces are derived from the loaded config before spawn; existing standalone serve commands remain available.
- Rollback path: stop using `multi-channel-serve`, fall back to `telegram-serve` / `feishu-serve`, or revert this PR.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
task verify
- current HEAD: fmt, clippy, architecture, dep-graph, conventions, harness, and docs checks passed
- current HEAD: failed only in daemon integration on:
  * integration::migration::migration_classify_current_setup_distinguishes_basic_states
  * integration::migration::migration_compose_recommended_candidate_ignores_home_drift_for_default_memory_path
- both failures also reproduce on baseline commit c68cbf6 in a detached worktree, so this PR is not the source of that red

cargo test -p loongclaw-daemon --test integration multi_channel_serve_
- passed: 13 passed, 0 failed

cargo clippy -p loongclaw-daemon --tests -- -D warnings
- passed

Config/runtime regression coverage added in crates/daemon/tests/integration/multi_channel_serve_cli.rs:
- explicit account selection flags
- loaded-config surface selection skips disabled Telegram and Feishu surfaces, including stale account selectors
- foreground CLI shutdown after background task failure and background JoinError/panic
- Ctrl-C and cooperative stop path behavior
- distinct CLI-vs-channel session identity

Process-global test state:
- crates/app/src/tools/runtime_config.rs wraps shell-env-sensitive tests with ScopedEnv
- crates/app/src/memory/sqlite.rs drops the cwd guard before temp cleanup so cwd is restored deterministically
```

## User-visible / Operator-visible Changes

- New command: `loongclaw multi-channel-serve --session <id> [--telegram-account <id>] [--feishu-account <id>] [--config <path>]`
- README and PRODUCT_SENSE now document the one-process concurrent runtime and the required `--session` flag

## Failure Recovery

- Fast rollback or disable path: fall back to the existing `loongclaw telegram-serve` and `loongclaw feishu-serve` commands and do not use `multi-channel-serve`
- Observable failure symptoms reviewers should watch for: CLI hang during shutdown, orphaned channel runtime state after child failure, disabled surface spawning, or incorrect final shutdown reason after child panic/join error

## Reviewer Focus

- `crates/daemon/src/supervisor.rs` for failure attribution, shutdown sequencing, and loaded-config surface selection
- `crates/app/src/chat.rs` and `crates/app/src/channel/mod.rs` for cancellable foreground CLI hosting and cooperative stop behavior
- `crates/daemon/tests/integration/multi_channel_serve_cli.rs` for disabled-surface, panic/join-error, and shutdown-race coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `multi-channel-serve` command to run Telegram and Feishu channels concurrently with an interactive foreground CLI.
  * Requires `--session` and supports `--telegram-account` and `--feishu-account` selectors.
  * Background channels now support cooperative/graceful shutdown.

* **Documentation**
  * Added Multi-Channel Serve usage to README (EN/ZH) with examples.
  * Added design and implementation plans detailing multi-session concurrent channel dispatch.

* **Tests**
  * Added CLI parsing and integration tests for the new command and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->