### PR TITLE
docs: fix broken README install script links

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ On Linux x86_64, the installer now treats GNU and musl as distinct release artif
 <summary>Linux / macOS</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts/install.sh | bash -s -- --onboard
+curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/dev/scripts/install.sh | bash -s -- --onboard
 ```
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts/install.sh | bash -s -- --target-libc musl
+curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/dev/scripts/install.sh | bash -s -- --target-libc musl
 ```
 
 </details>
@@ -184,7 +184,7 @@ curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts
 
 ```powershell
 $script = Join-Path $env:TEMP "loongclaw-install.ps1"
-Invoke-WebRequest https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts/install.ps1 -OutFile $script
+Invoke-WebRequest https://raw.githubusercontent.com/loongclaw-ai/loongclaw/dev/scripts/install.ps1 -OutFile $script
 pwsh $script -Onboard
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -143,7 +143,7 @@ LoongClaw 的目标不只是个人助手。
 <summary>Linux / macOS</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts/install.sh | bash -s -- --onboard
+curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/dev/scripts/install.sh | bash -s -- --onboard
 ```
 </details>
 
@@ -152,7 +152,7 @@ curl -fsSL https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts
 
 ```powershell
 $script = Join-Path $env:TEMP "loongclaw-install.ps1"
-Invoke-WebRequest https://raw.githubusercontent.com/loongclaw-ai/loongclaw/main/scripts/install.ps1 -OutFile $script
+Invoke-WebRequest https://raw.githubusercontent.com/loongclaw-ai/loongclaw/dev/scripts/install.ps1 -OutFile $script
 pwsh $script -Onboard
 ```
 </details>


### PR DESCRIPTION
## Summary

- Problem: The quick-start install commands in both `README.md` and `README.zh-CN.md` pointed at `main/scripts/install.*`, but those raw GitHub URLs return 404 in this repository.
- Why it matters: The first documented install step is broken for both English and Chinese readers, so onboarding fails before the installer even runs.
- What changed: Updated the raw install script URLs in the README quick-start snippets from `main` to `dev` for both shell and PowerShell examples.
- What did not change (scope boundary): No installer logic changes, no release artifact changes, and no website or broader onboarding flow changes.

## Linked Issues

- Closes #474
- Related #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
curl -I -sS https://raw.githubusercontent.com/loongclaw-ai/loongclaw/dev/scripts/install.sh
  -> HTTP 200 OK
curl -I -sS https://raw.githubusercontent.com/loongclaw-ai/loongclaw/dev/scripts/install.ps1
  -> HTTP 200 OK
bash scripts/check-docs.sh
  -> Passed doc governance checks; internal links clean
cargo test --workspace --locked --quiet
  -> Passed
```

## User-visible / Operator-visible Changes

- The README quick-start install commands now fetch the live installer scripts instead of a 404 path.

## Failure Recovery

- Fast rollback or disable path: Revert this docs-only commit if the repository later standardizes the raw installer URLs on another branch or release path.
- Observable failure symptoms reviewers should watch for: The raw installer URLs in the README returning non-200 responses again.

## Reviewer Focus

- Confirm the repo branch strategy still expects raw installer references to come from `dev`.
- Confirm both English and Chinese quick-start snippets now stay aligned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions across English and Chinese README files to point to the latest installation sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->