### PR TITLE
fix(daemon): derive channel doctor checks from registry metadata

### DIFF
--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -987,7 +987,7 @@ fn build_feishu_inbound_support_check(
     snapshot: &mvp::channel::ChannelStatusSnapshot,
     scoped: bool,
 ) -> Option<DoctorCheck> {
-    if snapshot.id != "feishu" {
+    if !snapshot_matches_channel_id(snapshot, "feishu") {
         return None;
     }
     let serve = snapshot.operation("serve")?;
@@ -1016,6 +1016,14 @@ fn build_feishu_inbound_support_check(
             "message_types={message_types} non_text_mode={non_text_mode} binary_fetch={binary_fetch} resource_download_tool={resource_download_tool} resource_selection_mode={resource_selection_mode} callback_event_types={callback_event_types} callback_response_mode={callback_response_mode}"
         ),
     })
+}
+
+fn snapshot_matches_channel_id(
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+    expected_channel_id: &str,
+) -> bool {
+    let normalized_channel_id = mvp::channel::normalize_channel_catalog_id(snapshot.id);
+    normalized_channel_id == Some(expected_channel_id)
 }
 
 fn snapshot_note_value<'a>(
@@ -1979,6 +1987,41 @@ mod tests {
     }
 
     #[test]
+    fn build_channel_surface_checks_omit_disabled_registry_operations() {
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "telegram",
+            configured_account_id: "ops".to_owned(),
+            configured_account_label: "ops".to_owned(),
+            is_default_account: true,
+            default_account_source:
+                mvp::config::ChannelDefaultAccountSelectionSource::ExplicitDefault,
+            label: "Telegram",
+            aliases: Vec::new(),
+            transport: "telegram_bot_api",
+            compiled: true,
+            enabled: false,
+            api_base_url: Some("https://api.telegram.org".to_owned()),
+            notes: Vec::new(),
+            operations: vec![ChannelOperationStatus {
+                id: "serve",
+                label: "event listener",
+                command: "telegram-serve",
+                health: ChannelOperationHealth::Disabled,
+                detail: "disabled by telegram account configuration".to_owned(),
+                issues: Vec::new(),
+                runtime: None,
+            }],
+        }];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(
+            checks.is_empty(),
+            "disabled registry-backed operations should not emit live doctor checks: {checks:#?}"
+        );
+    }
+
+    #[test]
     fn channel_doctor_checks_report_enabled_channels_from_registry() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.telegram.enabled = true;
@@ -2822,7 +2865,15 @@ mod tests {
             compiled: true,
             enabled: true,
             api_base_url: Some("https://open.feishu.cn".to_owned()),
-            notes: Vec::new(),
+            notes: vec![
+                "webhook_inbound_message_types=text,image,file".to_owned(),
+                "webhook_inbound_non_text_mode=structured_text_summary".to_owned(),
+                "webhook_inbound_binary_fetch=disabled".to_owned(),
+                "webhook_resource_download_tool=feishu.messages.resource.get".to_owned(),
+                "webhook_resource_selection_mode=single_resource_default_or_unique_partial_inference_or_resource_inventory".to_owned(),
+                "webhook_callback_event_types=card.action.trigger".to_owned(),
+                "webhook_callback_response_mode=noop_json".to_owned(),
+            ],
             operations: vec![ChannelOperationStatus {
                 id: "serve",
                 label: "inbound reply service",
@@ -2860,6 +2911,12 @@ mod tests {
                 .iter()
                 .any(|check| check.name == "feishu serve runtime"),
             "alias channel ids should reuse registry-backed runtime metadata: {checks:#?}"
+        );
+        assert!(
+            checks
+                .iter()
+                .any(|check| check.name == "feishu webhook inbound support"),
+            "alias channel ids should preserve feishu inbound support checks: {checks:#?}"
         );
     }
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -40,12 +40,6 @@ struct DoctorSummary {
     fail: usize,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct DoctorChannelCheckSpec {
-    config_name: &'static str,
-    runtime_name: Option<&'static str>,
-}
-
 pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
     let (config_path, mut config) = mvp::config::load(options.config.as_deref())?;
     let mut checks = Vec::new();
@@ -966,23 +960,9 @@ fn build_channel_surface_checks(
             });
         }
         for operation in &snapshot.operations {
-            let Some(spec) = doctor_check_spec(snapshot.id, operation.id) else {
-                continue;
-            };
-            checks.push(DoctorCheck {
-                name: scoped_doctor_check_name(spec.config_name, snapshot, scoped),
-                level: doctor_check_level_for_health(operation.health),
-                detail: operation.detail.clone(),
-            });
-
-            if let Some(runtime_name) = spec.runtime_name
-                && operation.health == mvp::channel::ChannelOperationHealth::Ready
-            {
-                checks.push(build_channel_runtime_check(
-                    scoped_doctor_check_name(runtime_name, snapshot, scoped).as_str(),
-                    operation,
-                ));
-            }
+            let operation_checks =
+                build_channel_operation_doctor_checks(snapshot, scoped, operation);
+            checks.extend(operation_checks);
         }
         if let Some(check) = build_feishu_inbound_support_check(snapshot, scoped) {
             checks.push(check);
@@ -1049,29 +1029,54 @@ fn snapshot_note_value<'a>(
         .find_map(|note| note.strip_prefix(prefix.as_str()))
 }
 
-fn doctor_check_spec(channel_id: &str, operation_id: &str) -> Option<DoctorChannelCheckSpec> {
-    match (channel_id, operation_id) {
-        ("telegram", "serve") => Some(DoctorChannelCheckSpec {
-            config_name: "telegram channel",
-            runtime_name: Some("telegram channel runtime"),
-        }),
-        ("feishu", "send") => Some(DoctorChannelCheckSpec {
-            config_name: "feishu channel",
-            runtime_name: None,
-        }),
-        ("feishu", "serve") => Some(DoctorChannelCheckSpec {
-            config_name: "feishu inbound transport",
-            runtime_name: Some("feishu serve runtime"),
-        }),
-        ("matrix", "send") => Some(DoctorChannelCheckSpec {
-            config_name: "matrix channel",
-            runtime_name: None,
-        }),
-        ("matrix", "serve") => Some(DoctorChannelCheckSpec {
-            config_name: "matrix room sync",
-            runtime_name: Some("matrix channel runtime"),
-        }),
-        _ => None,
+fn build_channel_operation_doctor_checks(
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+    scoped: bool,
+    operation: &mvp::channel::ChannelOperationStatus,
+) -> Vec<DoctorCheck> {
+    let doctor_spec =
+        mvp::channel::resolve_channel_doctor_operation_spec(snapshot.id, operation.id);
+    let Some(doctor_spec) = doctor_spec else {
+        return Vec::new();
+    };
+
+    let mut checks = Vec::new();
+    for check_spec in doctor_spec.checks {
+        let doctor_check =
+            build_channel_operation_doctor_check(snapshot, scoped, operation, check_spec);
+        if let Some(doctor_check) = doctor_check {
+            checks.push(doctor_check);
+        }
+    }
+    checks
+}
+
+fn build_channel_operation_doctor_check(
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+    scoped: bool,
+    operation: &mvp::channel::ChannelOperationStatus,
+    check_spec: &mvp::channel::ChannelDoctorCheckSpec,
+) -> Option<DoctorCheck> {
+    let check_name = scoped_doctor_check_name(check_spec.name, snapshot, scoped);
+    match check_spec.trigger {
+        mvp::channel::ChannelDoctorCheckTrigger::OperationHealth => {
+            if operation.health == mvp::channel::ChannelOperationHealth::Disabled {
+                return None;
+            }
+
+            Some(DoctorCheck {
+                name: check_name,
+                level: doctor_check_level_for_health(operation.health),
+                detail: operation.detail.clone(),
+            })
+        }
+        mvp::channel::ChannelDoctorCheckTrigger::ReadyRuntime => {
+            if operation.health != mvp::channel::ChannelOperationHealth::Ready {
+                return None;
+            }
+            let runtime_check = build_channel_runtime_check(check_name.as_str(), operation);
+            Some(runtime_check)
+        }
     }
 }
 
@@ -1351,22 +1356,6 @@ fn provider_model_probe_requires_explicit_model_detail(
             "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); current config still uses `model = auto`; set `provider.model` explicitly or configure `preferred_models` before retrying"
         ),
     }
-}
-
-#[allow(dead_code)]
-fn collect_channel_doctor_checks(config: &mvp::config::LoongClawConfig) -> Vec<DoctorCheck> {
-    crate::migration::channels::collect_channel_doctor_checks(config)
-        .into_iter()
-        .map(|check| DoctorCheck {
-            name: check.name.to_owned(),
-            level: match check.level {
-                crate::migration::channels::ChannelCheckLevel::Pass => DoctorCheckLevel::Pass,
-                crate::migration::channels::ChannelCheckLevel::Warn => DoctorCheckLevel::Warn,
-                crate::migration::channels::ChannelCheckLevel::Fail => DoctorCheckLevel::Fail,
-            },
-            detail: check.detail,
-        })
-        .collect()
 }
 
 async fn collect_browser_companion_doctor_checks(
@@ -1980,8 +1969,9 @@ mod tests {
     }
 
     #[test]
-    fn channel_doctor_checks_omit_disabled_channels() {
-        let checks = collect_channel_doctor_checks(&mvp::config::LoongClawConfig::default());
+    fn check_channel_surfaces_omit_disabled_channels() {
+        let config = mvp::config::LoongClawConfig::default();
+        let checks = check_channel_surfaces(&config);
         assert!(
             checks.is_empty(),
             "disabled optional channels should not generate doctor warnings by default: {checks:#?}"
@@ -2814,6 +2804,62 @@ mod tests {
                     && check.detail.contains("running_instances=2")
             }),
             "duplicate running telegram runtimes should emit runtime warning"
+        );
+    }
+
+    #[test]
+    fn build_channel_surface_checks_resolves_alias_metadata_from_channel_registry() {
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "lark",
+            configured_account_id: "feishu_main".to_owned(),
+            configured_account_label: "feishu_main".to_owned(),
+            is_default_account: true,
+            default_account_source:
+                mvp::config::ChannelDefaultAccountSelectionSource::ExplicitDefault,
+            label: "Feishu/Lark",
+            aliases: vec!["feishu"],
+            transport: "feishu_openapi_webhook_or_websocket",
+            compiled: true,
+            enabled: true,
+            api_base_url: Some("https://open.feishu.cn".to_owned()),
+            notes: Vec::new(),
+            operations: vec![ChannelOperationStatus {
+                id: "serve",
+                label: "inbound reply service",
+                command: "feishu-serve",
+                health: ChannelOperationHealth::Ready,
+                detail: "ready".to_owned(),
+                issues: Vec::new(),
+                runtime: Some(ChannelOperationRuntime {
+                    running: true,
+                    stale: false,
+                    busy: false,
+                    active_runs: 1,
+                    last_run_activity_at: Some(1_700_000_000_000),
+                    last_heartbeat_at: Some(1_700_000_005_000),
+                    pid: Some(4242),
+                    account_id: Some("feishu_main".to_owned()),
+                    account_label: Some("feishu:main".to_owned()),
+                    instance_count: 1,
+                    running_instances: 1,
+                    stale_instances: 0,
+                }),
+            }],
+        }];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(
+            checks
+                .iter()
+                .any(|check| check.name == "feishu inbound transport"),
+            "alias channel ids should reuse registry-backed operation-health metadata: {checks:#?}"
+        );
+        assert!(
+            checks
+                .iter()
+                .any(|check| check.name == "feishu serve runtime"),
+            "alias channel ids should reuse registry-backed runtime metadata: {checks:#?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- derive live daemon channel doctor checks from app-side registry metadata
- remove the local handwritten channel doctor spec table in `crates/daemon/src/doctor_cli.rs`
- keep disabled optional channel surfaces out of default live `doctor` output
- add regression coverage for alias-backed channel ids such as `lark` -> `feishu`

## Why

The channel registry already owns operation doctor metadata and alias normalization. Rebuilding those mappings again in the daemon creates avoidable drift and makes new channel surfaces harder to extend safely.

This PR moves the live doctor path onto the registry-backed metadata projection so future channel doctor changes have one source of truth.

## Validation

- `cargo test --manifest-path /tmp/loongclaw-feature-channel-doctor-registry/Cargo.toml -p loongclaw-daemon doctor_cli::tests -- --nocapture`
- `cargo test --manifest-path /tmp/loongclaw-feature-channel-doctor-registry/Cargo.toml -p loongclaw-app resolve_channel_doctor_operation_spec_uses_registry_metadata -- --nocapture`

Part of #404

Closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Doctor health checks now derive per-operation checks from channel specifications (no static mappings), with smarter handling of operation health and runtime readiness.
  * Channel aliasing and registry-backed operation metadata are resolved so aliases reuse canonical operation health/runtime info.

* **Bug Fixes**
  * Normalized channel ID matching for inbound support checks to avoid hardcoded comparisons.
  * Disabled registry-backed operations no longer emit live doctor checks.

* **Tests**
  * Added and updated tests for omitted disabled operations, alias metadata resolution, and channel surface checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->