### PR TITLE
fix(ci): merge same label between docs and documentation.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -84,14 +84,9 @@
 "docs":
   - changed-files:
       - any-glob-to-any-file:
+          - "**/*.md"
           - "docs/**"
-          - "README.md"
-          - "README.zh-CN.md"
-          - "CONTRIBUTING.md"
-          - "SECURITY.md"
-          - "CODE_OF_CONDUCT.md"
           - ".github/ISSUE_TEMPLATE/**"
-          - ".github/PULL_REQUEST_TEMPLATE.md"
 
 "ci":
   - changed-files:
@@ -109,13 +104,6 @@
           - "scripts/release_artifact_lib.sh"
           - "scripts/sync_github_labels.py"
           - "scripts/test_*.sh"
-
-"documentation":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "**/*.md"
-          - ".github/ISSUE_TEMPLATE/**"
-          - ".github/PULL_REQUEST_TEMPLATE.md"
 
 "dependencies":
   - changed-files:


### PR DESCRIPTION
## Summary

- Problem: `labeler.yml` has two overlapping label rules — "docs" and "documentation" — and "docs" lists redundant root-level `.md` entries
- Why it matters: Duplicate labels cause the same PR to receive two semantically identical tags, adding noise to triage
- What changed: Removed the "documentation" label and merged its coverage into "docs"; replaced individual root `.md` entries with `**/*.md`
- What did not change (scope boundary): All other label rules unchanged; effective file matching scope unchanged

## Linked Issues

- Related #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
Confirmed actions/labeler v5 uses picomatch where **/*.md matches root-level files.
Verified via git diff that the merged rule covers the same file set as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub repository labeling automation to improve label consistency for documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->