### PR TITLE
fix(labeler): narrow docs surface routing for contributor references

### DIFF
--- a/.github/label_taxonomy.json
+++ b/.github/label_taxonomy.json
@@ -303,6 +303,7 @@
       "color": "0075ca",
       "description": "Improvements or additions to documentation.",
       "paths": [
+        "*.md",
         "**/*.md",
         ".github/ISSUE_TEMPLATE/**",
         ".github/PULL_REQUEST_TEMPLATE.md"

--- a/.github/label_taxonomy.json
+++ b/.github/label_taxonomy.json
@@ -143,7 +143,7 @@
       "color": "0891b2",
       "description": "Contributor docs, references, and issue/PR guidance.",
       "paths": [
-        "docs/**",
+        "docs/references/**",
         "README.md",
         "README.zh-CN.md",
         "CONTRIBUTING.md",

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -84,7 +84,7 @@
 "docs":
   - changed-files:
       - any-glob-to-any-file:
-          - "docs/**"
+          - "docs/references/**"
           - "README.md"
           - "README.zh-CN.md"
           - "CONTRIBUTING.md"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -113,6 +113,7 @@
 "documentation":
   - changed-files:
       - any-glob-to-any-file:
+          - "*.md"
           - "**/*.md"
           - ".github/ISSUE_TEMPLATE/**"
           - ".github/PULL_REQUEST_TEMPLATE.md"


### PR DESCRIPTION
## Summary

- Problem:
  The managed labeler still treated nearly every file under `docs/` as the contributor-facing `docs` surface, which made that label overlap with the broader `documentation` work-type signal.
- Why it matters:
  That overlap weakens triage and routing quality. PRs touching subsystem design docs, planning docs, or broad documentation updates were getting the same surface label as contributor reference material, which blurs the intended distinction in the taxonomy.
- What changed:
  Narrowed the `docs` surface rule so it only tracks contributor-facing reference docs, kept `documentation` as the broad documentation work-type label, regenerated the managed labeler artifact, and added root markdown coverage so top-level documentation files still route to the broad documentation label.
- What did not change (scope boundary):
  This PR does not redesign the label taxonomy, does not change unrelated surface labels, and does not alter GitHub workflow behavior outside the managed label-routing rules.

## Linked Issues

- Closes #502
- Related: none

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
python3 scripts/sync_github_labels.py --write
- regenerated the managed labeler artifact from the taxonomy source.

python3 scripts/sync_github_labels.py --check
- passed after regeneration.

bash scripts/test_sync_github_labels.sh
- passed, including the root markdown routing update added in the follow-up commit.
```

## User-visible / Operator-visible Changes

- PRs that touch contributor-facing reference docs continue to receive the `docs` surface label.
- PRs that touch broader documentation surfaces keep routing through the broader `documentation` work-type label instead of inheriting the narrower contributor-docs surface.
- Top-level markdown files now remain covered by the broad documentation routing path.

## Failure Recovery

- Fast rollback or disable path:
  Revert the PR branch commits or restore the previous managed labeler rules and regenerate `.github/labeler.yml` from the taxonomy source.
- Observable failure symptoms reviewers should watch for:
  Documentation-heavy PRs missing the `documentation` label, contributor reference docs no longer receiving the `docs` surface label, or root markdown files failing to route as documentation.

## Reviewer Focus

- `.github/label_taxonomy.json`: confirm the narrowed `docs` surface intent and the root markdown coverage are both represented in the source taxonomy.
- `.github/labeler.yml`: confirm the generated rules match the taxonomy and preserve the intended split between `docs` and `documentation`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated labeling configuration to improve categorization of documentation and reference materials in pull requests and issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
