### PR TITLE
[FEATURE] Drive onboarding channel handoff from the channel registry

### DIFF
--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1782,14 +1782,13 @@ fn select_doctor_first_turn_actions(
         action.kind == crate::next_actions::SetupNextActionKind::Chat
     });
     push_first_matching_action(&mut prioritized, &actions, |action| {
-        action.kind == crate::next_actions::SetupNextActionKind::BrowserPreview
-            && matches!(
-                action.browser_preview_phase,
-                Some(crate::next_actions::BrowserPreviewActionPhase::Ready)
-                    | Some(crate::next_actions::BrowserPreviewActionPhase::Unblock)
-                    | Some(crate::next_actions::BrowserPreviewActionPhase::Enable)
-                    | Some(crate::next_actions::BrowserPreviewActionPhase::InstallRuntime)
-            )
+        is_repair_priority_browser_preview_action(action)
+    });
+    push_first_matching_action(&mut prioritized, &actions, |action| {
+        is_channel_catalog_action(action)
+    });
+    push_first_matching_action(&mut prioritized, &actions, |action| {
+        is_general_browser_preview_action(action)
     });
 
     for action in actions {
@@ -1801,6 +1800,38 @@ fn select_doctor_first_turn_actions(
 
     prioritized.truncate(3);
     prioritized
+}
+
+fn is_channel_catalog_action(action: &crate::next_actions::SetupNextAction) -> bool {
+    let kind = &action.kind;
+    let channel_action_id = action.channel_action_id;
+    *kind == crate::next_actions::SetupNextActionKind::Channel
+        && channel_action_id == Some(crate::migration::channels::CHANNEL_CATALOG_ACTION_ID)
+}
+
+fn is_repair_priority_browser_preview_action(
+    action: &crate::next_actions::SetupNextAction,
+) -> bool {
+    let kind = &action.kind;
+    let phase = action.browser_preview_phase;
+    *kind == crate::next_actions::SetupNextActionKind::BrowserPreview
+        && matches!(
+            phase,
+            Some(crate::next_actions::BrowserPreviewActionPhase::Unblock)
+                | Some(crate::next_actions::BrowserPreviewActionPhase::InstallRuntime)
+        )
+}
+
+fn is_general_browser_preview_action(action: &crate::next_actions::SetupNextAction) -> bool {
+    let kind = &action.kind;
+    let phase = action.browser_preview_phase;
+    let is_browser_preview = *kind == crate::next_actions::SetupNextActionKind::BrowserPreview;
+    let is_general_phase = matches!(
+        phase,
+        Some(crate::next_actions::BrowserPreviewActionPhase::Ready)
+            | Some(crate::next_actions::BrowserPreviewActionPhase::Enable)
+    );
+    is_browser_preview && is_general_phase
 }
 
 fn push_first_matching_action<F>(
@@ -3570,9 +3601,15 @@ mod tests {
         );
         assert!(
             next_steps.iter().any(|step| {
+                step == "Open a channel: loongclaw channels --config '/tmp/loongclaw.toml'"
+            }),
+            "green doctor runs should surface the channel catalog when no service channel is enabled yet: {next_steps:#?}"
+        );
+        assert!(
+            !next_steps.iter().any(|step| {
                 step == "Optional browser preview: loongclaw skills enable-browser-preview --config '/tmp/loongclaw.toml'"
             }),
-            "green doctor runs should surface the optional browser preview with a single concrete command: {next_steps:#?}"
+            "green doctor runs should prioritize the channel catalog ahead of optional browser preview when no service channel is enabled yet: {next_steps:#?}"
         );
         assert!(
             !next_steps.iter().any(|step| {

--- a/crates/daemon/src/migration/channels/mod.rs
+++ b/crates/daemon/src/migration/channels/mod.rs
@@ -45,6 +45,9 @@ pub struct ChannelNextAction {
     pub command: String,
 }
 
+const CHANNEL_CATALOG_ACTION_ID: &str = "channel_catalog";
+const CHANNEL_CATALOG_ACTION_LABEL: &str = "channels";
+
 struct ChannelAdapter {
     id: &'static str,
     collect_preview:
@@ -186,23 +189,60 @@ pub fn collect_channel_next_actions(
     config: &mvp::config::LoongClawConfig,
     config_path: &str,
 ) -> Vec<ChannelNextAction> {
-    enabled_channel_adapters(config)
+    let configured_actions = collect_configured_runtime_channel_next_actions(config, config_path);
+    if !configured_actions.is_empty() {
+        return configured_actions;
+    }
+
+    vec![build_channel_catalog_next_action(config_path)]
+}
+
+fn collect_configured_runtime_channel_next_actions(
+    config: &mvp::config::LoongClawConfig,
+    config_path: &str,
+) -> Vec<ChannelNextAction> {
+    let enabled_channel_ids = collect_enabled_service_channel_ids(config);
+    if enabled_channel_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let inventory = mvp::channel::channel_inventory(config);
+    inventory
+        .channel_surfaces
         .into_iter()
-        .filter_map(|adapter| {
-            mvp::config::channel_descriptor(adapter.id).and_then(|descriptor| {
-                descriptor
-                    .serve_subcommand
-                    .map(|subcommand| ChannelNextAction {
-                        id: adapter.id,
-                        label: descriptor.label,
-                        command: crate::cli_handoff::format_subcommand_with_config(
-                            subcommand,
-                            config_path,
-                        ),
-                    })
+        .filter(|surface| enabled_channel_ids.contains(surface.catalog.id))
+        .filter_map(|surface| {
+            let serve_operation = surface
+                .catalog
+                .operation(mvp::channel::CHANNEL_OPERATION_SERVE_ID)?;
+            if serve_operation.availability
+                != mvp::channel::ChannelCatalogOperationAvailability::Implemented
+            {
+                return None;
+            }
+
+            Some(ChannelNextAction {
+                id: surface.catalog.id,
+                label: surface.catalog.id,
+                command: crate::cli_handoff::format_subcommand_with_config(
+                    serve_operation.command,
+                    config_path,
+                ),
             })
         })
         .collect()
+}
+
+fn collect_enabled_service_channel_ids(config: &mvp::config::LoongClawConfig) -> BTreeSet<String> {
+    config.enabled_service_channel_ids().into_iter().collect()
+}
+
+fn build_channel_catalog_next_action(config_path: &str) -> ChannelNextAction {
+    ChannelNextAction {
+        id: CHANNEL_CATALOG_ACTION_ID,
+        label: CHANNEL_CATALOG_ACTION_LABEL,
+        command: crate::cli_handoff::format_subcommand_with_config("channels", config_path),
+    }
 }
 
 fn enabled_channel_adapters(config: &mvp::config::LoongClawConfig) -> Vec<&'static ChannelAdapter> {

--- a/crates/daemon/src/migration/channels/mod.rs
+++ b/crates/daemon/src/migration/channels/mod.rs
@@ -45,7 +45,7 @@ pub struct ChannelNextAction {
     pub command: String,
 }
 
-const CHANNEL_CATALOG_ACTION_ID: &str = "channel_catalog";
+pub(crate) const CHANNEL_CATALOG_ACTION_ID: &str = "channel_catalog";
 const CHANNEL_CATALOG_ACTION_LABEL: &str = "channels";
 
 struct ChannelAdapter {
@@ -223,7 +223,7 @@ fn collect_configured_runtime_channel_next_actions(
 
             Some(ChannelNextAction {
                 id: surface.catalog.id,
-                label: surface.catalog.id,
+                label: surface.catalog.label,
                 command: crate::cli_handoff::format_subcommand_with_config(
                     serve_operation.command,
                     config_path,

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -174,6 +174,16 @@ mod tests {
         fs::set_permissions(&path, permissions).expect("clear executable bit");
     }
 
+    fn assert_channel_catalog_action(action: &SetupNextAction) {
+        assert_eq!(action.kind, SetupNextActionKind::Channel);
+        assert_eq!(action.browser_preview_phase, None);
+        assert_eq!(action.label, "channels");
+        assert_eq!(
+            action.command,
+            "loongclaw channels --config '/tmp/loongclaw.toml'"
+        );
+    }
+
     #[test]
     fn collect_setup_next_actions_promotes_browser_companion_preview_when_ready() {
         let root = unique_temp_dir("loongclaw-next-actions-browser-companion");
@@ -201,14 +211,15 @@ mod tests {
 
         assert_eq!(actions[0].kind, SetupNextActionKind::Ask);
         assert_eq!(actions[1].kind, SetupNextActionKind::Chat);
-        assert_eq!(actions[2].kind, SetupNextActionKind::BrowserPreview);
+        assert_channel_catalog_action(&actions[2]);
+        assert_eq!(actions[3].kind, SetupNextActionKind::BrowserPreview);
         assert_eq!(
-            actions[2].browser_preview_phase,
+            actions[3].browser_preview_phase,
             Some(BrowserPreviewActionPhase::Ready)
         );
-        assert_eq!(actions[2].label, "browser companion preview");
+        assert_eq!(actions[3].label, "browser companion preview");
         assert!(
-            actions[2]
+            actions[3]
                 .command
                 .contains("Use the browser companion preview to open https://example.com"),
             "ready preview action should hand users into a task-shaped first browser recipe: {actions:#?}"
@@ -242,14 +253,15 @@ mod tests {
             Some(bin_dir.as_os_str()),
         );
 
-        assert_eq!(actions[2].kind, SetupNextActionKind::BrowserPreview);
+        assert_channel_catalog_action(&actions[2]);
+        assert_eq!(actions[3].kind, SetupNextActionKind::BrowserPreview);
         assert_eq!(
-            actions[2].browser_preview_phase,
+            actions[3].browser_preview_phase,
             Some(BrowserPreviewActionPhase::Unblock)
         );
-        assert_eq!(actions[2].label, "allow agent-browser");
+        assert_eq!(actions[3].label, "allow agent-browser");
         assert!(
-            actions[2]
+            actions[3]
                 .command
                 .contains("remove `agent-browser` from [tools].shell_deny"),
             "shell hard-deny should produce an unblock step instead of looping back to enable-browser-preview: {actions:#?}"
@@ -273,13 +285,14 @@ mod tests {
             Some(bin_dir.as_os_str()),
         );
 
-        assert_eq!(actions[2].kind, SetupNextActionKind::BrowserPreview);
+        assert_channel_catalog_action(&actions[2]);
+        assert_eq!(actions[3].kind, SetupNextActionKind::BrowserPreview);
         assert_eq!(
-            actions[2].browser_preview_phase,
+            actions[3].browser_preview_phase,
             Some(BrowserPreviewActionPhase::Enable)
         );
         assert!(
-            actions[2].command.contains("enable-browser-preview"),
+            actions[3].command.contains("enable-browser-preview"),
             "browser preview enable action should point operators at the preview bootstrap command: {actions:#?}"
         );
 
@@ -312,17 +325,18 @@ mod tests {
             Some(bin_dir.as_os_str()),
         );
 
-        assert_eq!(actions[2].kind, SetupNextActionKind::BrowserPreview);
+        assert_channel_catalog_action(&actions[2]);
+        assert_eq!(actions[3].kind, SetupNextActionKind::BrowserPreview);
         assert_eq!(
-            actions[2].browser_preview_phase,
+            actions[3].browser_preview_phase,
             Some(BrowserPreviewActionPhase::InstallRuntime)
         );
         assert_eq!(
-            actions[2].label,
+            actions[3].label,
             format!("install {}", mvp::tools::BROWSER_COMPANION_COMMAND)
         );
         assert_eq!(
-            actions[2].command,
+            actions[3].command,
             format!(
                 "npm install -g {} && {} install",
                 mvp::tools::BROWSER_COMPANION_COMMAND,

--- a/crates/daemon/src/next_actions.rs
+++ b/crates/daemon/src/next_actions.rs
@@ -24,6 +24,7 @@ pub(crate) enum BrowserPreviewActionPhase {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupNextAction {
     pub kind: SetupNextActionKind,
+    pub channel_action_id: Option<&'static str>,
     pub browser_preview_phase: Option<BrowserPreviewActionPhase>,
     pub label: String,
     pub command: String,
@@ -48,6 +49,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
     if config.cli.enabled {
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Ask,
+            channel_action_id: None,
             browser_preview_phase: None,
             label: "first answer".to_owned(),
             command: crate::cli_handoff::format_ask_with_config(
@@ -57,6 +59,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
         });
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Chat,
+            channel_action_id: None,
             browser_preview_phase: None,
             label: "chat".to_owned(),
             command: crate::cli_handoff::format_subcommand_with_config("chat", config_path),
@@ -67,6 +70,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
             .into_iter()
             .map(|action| SetupNextAction {
                 kind: SetupNextActionKind::Channel,
+                channel_action_id: Some(action.id),
                 browser_preview_phase: None,
                 label: action.label.to_owned(),
                 command: action.command,
@@ -76,6 +80,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
         let preview_action = if browser_preview.ready() {
             Some(SetupNextAction {
                 kind: SetupNextActionKind::BrowserPreview,
+                channel_action_id: None,
                 browser_preview_phase: Some(BrowserPreviewActionPhase::Ready),
                 label: crate::browser_preview::BROWSER_PREVIEW_READY_LABEL.to_owned(),
                 command: crate::browser_preview::browser_preview_ready_command(config_path),
@@ -83,6 +88,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
         } else if browser_preview.needs_shell_unblock() {
             Some(SetupNextAction {
                 kind: SetupNextActionKind::BrowserPreview,
+                channel_action_id: None,
                 browser_preview_phase: Some(BrowserPreviewActionPhase::Unblock),
                 label: crate::browser_preview::BROWSER_PREVIEW_UNBLOCK_LABEL.to_owned(),
                 command: crate::browser_preview::browser_preview_unblock_command(config_path),
@@ -90,6 +96,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
         } else if browser_preview.needs_enable_command() {
             Some(SetupNextAction {
                 kind: SetupNextActionKind::BrowserPreview,
+                channel_action_id: None,
                 browser_preview_phase: Some(BrowserPreviewActionPhase::Enable),
                 label: crate::browser_preview::BROWSER_PREVIEW_ENABLE_LABEL.to_owned(),
                 command: crate::browser_preview::browser_preview_enable_command(config_path),
@@ -97,6 +104,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
         } else if browser_preview.needs_runtime_install() {
             Some(SetupNextAction {
                 kind: SetupNextActionKind::BrowserPreview,
+                channel_action_id: None,
                 browser_preview_phase: Some(BrowserPreviewActionPhase::InstallRuntime),
                 label: format!("install {}", mvp::tools::BROWSER_COMPANION_COMMAND),
                 command: crate::browser_preview::browser_preview_install_command().to_owned(),
@@ -111,6 +119,7 @@ pub(crate) fn collect_setup_next_actions_with_path_env(
     if actions.is_empty() {
         actions.push(SetupNextAction {
             kind: SetupNextActionKind::Doctor,
+            channel_action_id: None,
             browser_preview_phase: None,
             label: "doctor".to_owned(),
             command: crate::cli_handoff::format_subcommand_with_config("doctor", config_path),
@@ -176,6 +185,10 @@ mod tests {
 
     fn assert_channel_catalog_action(action: &SetupNextAction) {
         assert_eq!(action.kind, SetupNextActionKind::Channel);
+        assert_eq!(
+            action.channel_action_id,
+            Some(crate::migration::channels::CHANNEL_CATALOG_ACTION_ID)
+        );
         assert_eq!(action.browser_preview_phase, None);
         assert_eq!(action.label, "channels");
         assert_eq!(

--- a/crates/daemon/src/onboard_finalize.rs
+++ b/crates/daemon/src/onboard_finalize.rs
@@ -9,6 +9,8 @@ use time::macros::format_description;
 
 const BACKUP_TIMESTAMP_FORMAT: &[FormatItem<'static>] =
     format_description!("[year][month][day]-[hour][minute][second]");
+const CLI_CHANNEL_ID: &str = "cli";
+const MAX_SUGGESTED_RUNTIME_CHANNELS: usize = 3;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ConfigWritePlan {
@@ -40,6 +42,7 @@ pub struct OnboardingSuccessSummary {
     pub memory_profile: String,
     pub memory_path: Option<String>,
     pub channels: Vec<String>,
+    pub suggested_channels: Vec<String>,
     pub domain_outcomes: Vec<OnboardingDomainOutcome>,
     pub next_actions: Vec<OnboardingAction>,
 }
@@ -121,6 +124,7 @@ pub(crate) fn build_onboarding_success_summary_with_memory(
     let credential = crate::onboard_cli::summarize_provider_credential(&config.provider);
     let domain_outcomes = collect_onboarding_domain_outcomes(review_candidate);
     let channels = config.enabled_channel_ids();
+    let suggested_channels = collect_onboarding_suggested_channels(config);
 
     OnboardingSuccessSummary {
         import_source: import_source.map(str::to_owned),
@@ -138,6 +142,7 @@ pub(crate) fn build_onboarding_success_summary_with_memory(
         memory_profile: config.memory.profile.as_str().to_owned(),
         memory_path: memory_path.map(str::to_owned),
         channels,
+        suggested_channels,
         domain_outcomes,
         next_actions,
     }
@@ -302,6 +307,40 @@ fn collect_onboarding_domain_outcomes(
                 decision,
             })
         })
+        .collect()
+}
+
+fn collect_onboarding_suggested_channels(config: &mvp::config::LoongClawConfig) -> Vec<String> {
+    let enabled_service_channel_ids = config.enabled_service_channel_ids();
+    if !enabled_service_channel_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let inventory = mvp::channel::channel_inventory(config);
+    inventory
+        .channel_surfaces
+        .into_iter()
+        .filter_map(|surface| {
+            let serve_operation = surface
+                .catalog
+                .operation(mvp::channel::CHANNEL_OPERATION_SERVE_ID)?;
+            let implementation_status = surface.catalog.implementation_status;
+            let availability = serve_operation.availability;
+            if implementation_status
+                != mvp::channel::ChannelCatalogImplementationStatus::RuntimeBacked
+            {
+                return None;
+            }
+            if availability != mvp::channel::ChannelCatalogOperationAvailability::Implemented {
+                return None;
+            }
+
+            let label = surface.catalog.label;
+            let selection_label = surface.catalog.selection_label;
+            let suggested_channel = format!("{label} ({selection_label})");
+            Some(suggested_channel)
+        })
+        .take(MAX_SUGGESTED_RUNTIME_CHANNELS)
         .collect()
 }
 
@@ -480,16 +519,30 @@ fn render_onboarding_success_summary_with_style(
         ));
     }
 
-    if !summary.channels.is_empty() {
-        let channels = summary
-            .channels
+    let channels = summary
+        .channels
+        .iter()
+        .filter(|channel| channel.as_str() != CLI_CHANNEL_ID)
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if !channels.is_empty() {
+        lines.extend(mvp::presentation::render_wrapped_csv_line(
+            "- channels: ",
+            &channels,
+            width,
+        ));
+    }
+
+    if !summary.suggested_channels.is_empty() {
+        let suggested_channels = summary
+            .suggested_channels
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
 
         lines.extend(mvp::presentation::render_wrapped_csv_line(
-            "- channels: ",
-            &channels,
+            "- suggested channels: ",
+            &suggested_channels,
             width,
         ));
     }

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -626,7 +626,7 @@ fn import_cli_apply_summary_includes_registry_channel_actions() {
     assert!(
         lines.iter().any(|line| {
             line
-                == "also available: telegram · loongclaw telegram-serve --config '/tmp/loongclaw-config.toml'"
+                == "also available: Telegram · loongclaw telegram-serve --config '/tmp/loongclaw-config.toml'"
         }),
         "apply summary should continue surfacing registry-driven channel handoff commands after ask/chat: {lines:#?}"
     );
@@ -659,7 +659,7 @@ fn import_cli_apply_summary_shell_quotes_config_paths_with_single_quotes() {
     );
     assert!(
         rendered.contains(
-            "also available: telegram · loongclaw telegram-serve --config '/tmp/loongclaw'\"'\"'s config.toml'"
+            "also available: Telegram · loongclaw telegram-serve --config '/tmp/loongclaw'\"'\"'s config.toml'"
         ),
         "apply summary should shell-quote single quotes in channel handoff commands: {lines:#?}"
     );

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -945,6 +945,24 @@ fn channel_registry_collects_serve_actions_for_enabled_channels() {
 }
 
 #[test]
+fn channel_registry_collects_catalog_action_when_no_service_channels_are_enabled() {
+    let config = mvp::config::LoongClawConfig::default();
+
+    let actions = loongclaw_daemon::migration::channels::collect_channel_next_actions(
+        &config,
+        "/tmp/loongclaw-config.toml",
+    );
+
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].id, "channel_catalog");
+    assert_eq!(actions[0].label, "channels");
+    assert_eq!(
+        actions[0].command,
+        "loongclaw channels --config '/tmp/loongclaw-config.toml'"
+    );
+}
+
+#[test]
 fn migration_render_preview_compacts_for_narrow_width() {
     let candidate = loongclaw_daemon::migration::types::ImportCandidate {
         source_kind: loongclaw_daemon::migration::types::ImportSourceKind::CodexConfig,

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -932,12 +932,12 @@ fn channel_registry_collects_serve_actions_for_enabled_channels() {
     );
 
     assert_eq!(actions.len(), 2);
-    assert_eq!(actions[0].label, "telegram");
+    assert_eq!(actions[0].label, "Telegram");
     assert_eq!(
         actions[0].command,
         "loongclaw telegram-serve --config '/tmp/loongclaw-config.toml'"
     );
-    assert_eq!(actions[1].label, "feishu");
+    assert_eq!(actions[1].label, "Feishu/Lark");
     assert_eq!(
         actions[1].command,
         "loongclaw feishu-serve --config '/tmp/loongclaw-config.toml'"

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4766,6 +4766,7 @@ fn onboarding_success_summary_reports_import_source_and_enabled_channels() {
         summary.channels,
         vec!["cli".to_owned(), "telegram".to_owned(), "feishu".to_owned()]
     );
+    assert!(summary.suggested_channels.is_empty());
     assert!(
         summary.next_actions.iter().any(|action| action
             .command
@@ -4809,6 +4810,52 @@ fn onboarding_success_summary_derives_structured_actions() {
     assert_eq!(summary.next_actions[2].label, "telegram");
     assert_eq!(summary.next_actions[3].label, "feishu");
     assert_eq!(summary.next_actions[4].label, "enable browser preview");
+}
+
+#[test]
+fn onboarding_success_summary_suggests_registry_backed_channels_when_none_are_enabled() {
+    let path = PathBuf::from("/tmp/loongclaw-config.toml");
+    let summary = crate::onboard_cli::build_onboarding_success_summary(
+        &path,
+        &mvp::config::LoongClawConfig::default(),
+        None,
+    );
+    let lines = crate::onboard_cli::render_onboarding_success_summary_with_width(&summary, 140);
+    let saved_setup_index = lines
+        .iter()
+        .position(|line| line == "saved setup")
+        .expect("saved setup heading");
+
+    assert_eq!(
+        summary.suggested_channels,
+        vec![
+            "Telegram (personal and group chat bot)".to_owned(),
+            "Feishu/Lark (enterprise chat app)".to_owned(),
+            "Matrix (federated room sync bot)".to_owned(),
+        ]
+    );
+    assert_eq!(
+        summary.next_actions[2].kind,
+        crate::onboard_cli::OnboardingActionKind::Channel
+    );
+    assert_eq!(summary.next_actions[2].label, "channels");
+    assert_eq!(
+        summary.next_actions[2].command,
+        "loongclaw channels --config '/tmp/loongclaw-config.toml'"
+    );
+    assert!(
+        lines
+            .iter()
+            .skip(saved_setup_index + 1)
+            .all(|line| !line.starts_with("- channels: ")),
+        "success summary should not render cli-only channel state as a service-channel list: {lines:#?}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line == "- suggested channels: Telegram (personal and group chat bot), Feishu/Lark (enterprise chat app), Matrix (federated room sync bot)"
+        }),
+        "success summary should render registry-backed suggested runtime channels when no service channels are enabled: {lines:#?}"
+    );
 }
 
 #[test]
@@ -6359,6 +6406,7 @@ fn onboarding_success_summary_reports_existing_config_kept() {
         memory_profile: "window_only".to_owned(),
         memory_path: None,
         channels: vec!["cli".to_owned()],
+        suggested_channels: Vec::new(),
         domain_outcomes: Vec::new(),
         next_actions: vec![loongclaw_daemon::onboard_cli::OnboardingAction {
             kind: loongclaw_daemon::onboard_cli::OnboardingActionKind::Ask,
@@ -6437,6 +6485,7 @@ fn onboarding_success_summary_groups_domain_outcomes_by_decision() {
         memory_profile: "profile_plus_window".to_owned(),
         memory_path: None,
         channels: vec!["cli".to_owned()],
+        suggested_channels: Vec::new(),
         domain_outcomes: vec![
             loongclaw_daemon::onboard_cli::OnboardingDomainOutcome {
                 kind: loongclaw_daemon::migration::types::SetupDomainKind::Provider,
@@ -6502,6 +6551,7 @@ fn onboarding_success_summary_wraps_domain_outcomes_for_narrow_width() {
         memory_profile: "profile_plus_window".to_owned(),
         memory_path: None,
         channels: vec!["cli".to_owned()],
+        suggested_channels: Vec::new(),
         domain_outcomes: vec![
             loongclaw_daemon::onboard_cli::OnboardingDomainOutcome {
                 kind: loongclaw_daemon::migration::types::SetupDomainKind::Provider,
@@ -6610,6 +6660,33 @@ fn onboarding_success_summary_uses_channel_handoff_when_cli_is_disabled() {
             .iter()
             .all(|line| line != "start here: loongclaw chat --config '/tmp/loongclaw-config.toml'"),
         "success summary should not keep chat as the primary handoff once cli is disabled: {lines:#?}"
+    );
+}
+
+#[test]
+fn onboarding_success_summary_uses_channel_catalog_handoff_when_cli_is_disabled_and_no_service_channels_are_enabled()
+ {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.cli.enabled = false;
+
+    let path = PathBuf::from("/tmp/loongclaw-config.toml");
+    let summary =
+        loongclaw_daemon::onboard_cli::build_onboarding_success_summary(&path, &config, None);
+    let lines =
+        loongclaw_daemon::onboard_cli::render_onboarding_success_summary_with_width(&summary, 80);
+
+    assert_eq!(
+        summary.next_actions[0].kind,
+        loongclaw_daemon::onboard_cli::OnboardingActionKind::Channel,
+        "channel catalog should become the primary handoff when cli and service channels are both unavailable: {summary:#?}"
+    );
+    assert_eq!(summary.next_actions[0].label, "channels");
+    assert!(
+        lines
+            .iter()
+            .any(|line| line
+                == "start here: loongclaw channels --config '/tmp/loongclaw-config.toml'"),
+        "success summary should fall back to the channel catalog when no direct cli or service-channel handoff exists: {lines:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4807,8 +4807,8 @@ fn onboarding_success_summary_derives_structured_actions() {
     );
     assert_eq!(summary.next_actions[0].label, "first answer");
     assert_eq!(summary.next_actions[1].label, "chat");
-    assert_eq!(summary.next_actions[2].label, "telegram");
-    assert_eq!(summary.next_actions[3].label, "feishu");
+    assert_eq!(summary.next_actions[2].label, "Telegram");
+    assert_eq!(summary.next_actions[3].label, "Feishu/Lark");
     assert_eq!(summary.next_actions[4].label, "enable browser preview");
 }
 
@@ -6233,7 +6233,7 @@ fn render_onboarding_success_summary_compacts_for_narrow_width() {
             .any(|line| line == "- chat: loongclaw chat --config")
             && lines
                 .iter()
-                .any(|line| line == "- telegram: loongclaw telegram-serve --config"),
+                .any(|line| line == "- Telegram: loongclaw telegram-serve --config"),
         "narrow renderer should keep secondary chat and channel actions visible after the primary ask example: {lines:#?}"
     );
 }
@@ -6621,14 +6621,12 @@ fn onboarding_success_summary_groups_secondary_channel_actions_after_primary_han
     );
     assert!(
         lines.iter().any(|line| line
-            == "- telegram: loongclaw telegram-serve --config '/tmp/loongclaw-config.toml'"),
+            == "- Telegram: loongclaw telegram-serve --config '/tmp/loongclaw-config.toml'"),
         "wide success summary should list telegram as a secondary action: {lines:#?}"
     );
     assert!(
-        lines
-            .iter()
-            .any(|line| line
-                == "- feishu: loongclaw feishu-serve --config '/tmp/loongclaw-config.toml'"),
+        lines.iter().any(|line| line
+            == "- Feishu/Lark: loongclaw feishu-serve --config '/tmp/loongclaw-config.toml'"),
         "wide success summary should list feishu as a secondary action: {lines:#?}"
     );
 }


### PR DESCRIPTION
## Summary
- drive daemon channel next actions from the app channel registry and fall back to the channel catalog when no service channel is enabled
- surface registry-backed suggested runtime channels in onboarding success summaries while hiding CLI-only channel state from the saved setup inventory
- cover the new catalog fallback and onboarding handoff behavior with regression tests

## Validation
- cargo test -p loongclaw-daemon next_actions -- --test-threads=1
- cargo test -p loongclaw-daemon channel_registry_collects_ -- --test-threads=1
- cargo test -p loongclaw-daemon onboarding_success_summary -- --test-threads=1
- cargo test -p loongclaw-daemon --all-features -- --test-threads=1
- cargo clippy --workspace --all-targets --all-features -- -D warnings

Closes #505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now shows suggested registry-backed channels when no service channels are enabled.
  * Channel actions are included in the next-actions workflow so channel management is surfaced during onboarding and doctor flows.
  * Onboarding output separates configured channels from suggested channels for clearer guidance.

* **Tests**
  * Integration tests updated/added to validate suggested-channel suggestions, channel-catalog handoff, and display casing for channel names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->