### PR TITLE
test(labeler): add taxonomy semantic regression checks

### DIFF
--- a/scripts/sync_github_labels.py
+++ b/scripts/sync_github_labels.py
@@ -44,6 +44,47 @@ def normalize_repo_path(repo_path: str) -> str:
     return normalized_path
 
 
+def validate_supported_glob_pattern(pattern: str) -> str:
+    normalized_pattern = normalize_repo_path(pattern)
+
+    if not normalized_pattern:
+        raise ValueError("empty patterns are not supported")
+
+    if "//" in normalized_pattern:
+        raise ValueError("empty path segments are not supported")
+
+    unsupported_characters = "[]{}!+@()"
+    found_unsupported_characters: list[str] = []
+    for character in unsupported_characters:
+        if character not in normalized_pattern:
+            continue
+        found_unsupported_characters.append(character)
+
+    if found_unsupported_characters:
+        unsupported_summary = " ".join(found_unsupported_characters)
+        raise ValueError(
+            "unsupported glob tokens found; "
+            "semantic matcher only supports literals, *, ?, and ** path segments "
+            f"({unsupported_summary})"
+        )
+
+    segments = normalized_pattern.split("/")
+    for segment in segments:
+        if segment:
+            has_double_star = "**" in segment
+            is_double_star_segment = segment == "**"
+            if has_double_star and not is_double_star_segment:
+                raise ValueError(
+                    "semantic matcher only supports ** as a full path segment "
+                    f"(pattern: {normalized_pattern})"
+                )
+            continue
+
+        raise ValueError("empty path segments are not supported")
+
+    return normalized_pattern
+
+
 def glob_segment_to_regex(segment: str) -> str:
     regex_parts: list[str] = []
     for character in segment:
@@ -59,7 +100,7 @@ def glob_segment_to_regex(segment: str) -> str:
 
 def glob_pattern_to_regex(pattern: str) -> str:
     # The managed taxonomy uses a small glob subset, so the matcher stays deliberately narrow.
-    normalized_pattern = normalize_repo_path(pattern)
+    normalized_pattern = validate_supported_glob_pattern(pattern)
     segments = normalized_pattern.split("/")
     regex_parts: list[str] = ["^"]
     segment_count = len(segments)
@@ -109,6 +150,27 @@ def labels_for_path(taxonomy: dict, repo_path: str) -> list[str]:
             break
     matching_labels.sort()
     return matching_labels
+
+
+def check_semantic_matcher_support(taxonomy: dict) -> list[str]:
+    failures: list[str] = []
+    entries = path_labeled_entries(taxonomy)
+
+    for entry in entries:
+        label_name = entry["name"]
+        patterns = entry["paths"]
+
+        for pattern in patterns:
+            try:
+                compile_glob_pattern(pattern)
+            except ValueError as error:
+                failure_message = (
+                    f"unsupported semantic matcher pattern for {label_name}: "
+                    f"{pattern} ({error})"
+                )
+                failures.append(failure_message)
+
+    return failures
 
 
 def semantic_regression_cases() -> list[dict]:
@@ -162,7 +224,7 @@ def semantic_regression_cases() -> list[dict]:
 
 
 def check_semantic_regression_cases(taxonomy: dict) -> list[str]:
-    failures: list[str] = []
+    failures = check_semantic_matcher_support(taxonomy)
     cases = semantic_regression_cases()
 
     for case in cases:

--- a/scripts/sync_github_labels.py
+++ b/scripts/sync_github_labels.py
@@ -229,7 +229,7 @@ def check_semantic_regression_cases(taxonomy: dict) -> list[str]:
 
     for case in cases:
         case_path = case["path"]
-        expected_labels = list(case["labels"])
+        expected_labels = sorted(case["labels"])
         actual_labels = labels_for_path(taxonomy, case_path)
 
         if actual_labels == expected_labels:

--- a/scripts/sync_github_labels.py
+++ b/scripts/sync_github_labels.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import functools
 import json
+import re
 import sys
 from pathlib import Path
 from textwrap import dedent, indent
@@ -33,6 +35,151 @@ def path_labeled_entries(taxonomy: dict) -> list[dict]:
             if entry.get("paths"):
                 entries.append(entry)
     return entries
+
+
+def normalize_repo_path(repo_path: str) -> str:
+    normalized_path = repo_path.replace("\\", "/")
+    while normalized_path.startswith("./"):
+        normalized_path = normalized_path[2:]
+    return normalized_path
+
+
+def glob_segment_to_regex(segment: str) -> str:
+    regex_parts: list[str] = []
+    for character in segment:
+        if character == "*":
+            regex_parts.append("[^/]*")
+            continue
+        if character == "?":
+            regex_parts.append("[^/]")
+            continue
+        regex_parts.append(re.escape(character))
+    return "".join(regex_parts)
+
+
+def glob_pattern_to_regex(pattern: str) -> str:
+    # The managed taxonomy uses a small glob subset, so the matcher stays deliberately narrow.
+    normalized_pattern = normalize_repo_path(pattern)
+    segments = normalized_pattern.split("/")
+    regex_parts: list[str] = ["^"]
+    segment_count = len(segments)
+
+    for index, segment in enumerate(segments):
+        is_last_segment = index == segment_count - 1
+
+        if segment == "**":
+            if is_last_segment:
+                regex_parts.append(".*")
+            else:
+                regex_parts.append("(?:[^/]+/)*")
+            continue
+
+        segment_regex = glob_segment_to_regex(segment)
+        regex_parts.append(segment_regex)
+
+        if not is_last_segment:
+            regex_parts.append("/")
+
+    regex_parts.append("$")
+    return "".join(regex_parts)
+
+
+@functools.lru_cache(maxsize=None)
+def compile_glob_pattern(pattern: str) -> re.Pattern[str]:
+    regex_text = glob_pattern_to_regex(pattern)
+    return re.compile(regex_text)
+
+
+def path_matches_pattern(repo_path: str, pattern: str) -> bool:
+    normalized_path = normalize_repo_path(repo_path)
+    compiled_pattern = compile_glob_pattern(pattern)
+    return compiled_pattern.match(normalized_path) is not None
+
+
+def labels_for_path(taxonomy: dict, repo_path: str) -> list[str]:
+    matching_labels: list[str] = []
+    entries = path_labeled_entries(taxonomy)
+    for entry in entries:
+        patterns = entry["paths"]
+        for pattern in patterns:
+            does_match = path_matches_pattern(repo_path, pattern)
+            if not does_match:
+                continue
+            matching_labels.append(entry["name"])
+            break
+    matching_labels.sort()
+    return matching_labels
+
+
+def semantic_regression_cases() -> list[dict]:
+    # These representative paths lock the intended routing semantics without duplicating the full repo tree.
+    cases: list[dict] = []
+
+    cases.append(
+        {
+            "path": "README.md",
+            "labels": ["docs", "documentation"],
+        }
+    )
+    cases.append(
+        {
+            "path": "docs/references/github-collaboration.md",
+            "labels": ["docs", "documentation"],
+        }
+    )
+    cases.append(
+        {
+            "path": "docs/design-docs/provider-runtime-roadmap.md",
+            "labels": ["documentation", "spec"],
+        }
+    )
+    cases.append(
+        {
+            "path": "docs/releases/v0.1.0-alpha.2.md",
+            "labels": ["documentation"],
+        }
+    )
+    cases.append(
+        {
+            "path": ".github/workflows/labeler.yml",
+            "labels": ["ci", "github_actions"],
+        }
+    )
+    cases.append(
+        {
+            "path": "Cargo.toml",
+            "labels": ["dependencies"],
+        }
+    )
+    cases.append(
+        {
+            "path": "crates/app/Cargo.toml",
+            "labels": ["dependencies"],
+        }
+    )
+
+    return cases
+
+
+def check_semantic_regression_cases(taxonomy: dict) -> list[str]:
+    failures: list[str] = []
+    cases = semantic_regression_cases()
+
+    for case in cases:
+        case_path = case["path"]
+        expected_labels = list(case["labels"])
+        actual_labels = labels_for_path(taxonomy, case_path)
+
+        if actual_labels == expected_labels:
+            continue
+
+        failure_message = (
+            f"semantic label mismatch for {case_path}: "
+            f"expected {expected_labels}, got {actual_labels}"
+        )
+        failures.append(failure_message)
+
+    return failures
 
 
 def render_labeler(taxonomy: dict) -> str:

--- a/scripts/test_sync_github_labels.sh
+++ b/scripts/test_sync_github_labels.sh
@@ -97,6 +97,26 @@ if "out of date" not in output:
     sys.exit(1)
 PY
 
+python3 - "$SYNC_SCRIPT" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+repo_root = script_path.parents[1]
+spec = importlib.util.spec_from_file_location("sync_github_labels", script_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+taxonomy = module.load_taxonomy(repo_root)
+failures = module.check_semantic_regression_cases(taxonomy)
+
+if failures:
+    for failure in failures:
+        print(failure, file=sys.stderr)
+    sys.exit(1)
+PY
+
 assert_not_contains_regex "$REPO_ROOT/.github/labeler.yml" '(^|[[:space:]])"?rust"?[[:space:]]*:'
 assert_not_contains "$REPO_ROOT/docs/references/github-collaboration.md" "area:"
 assert_not_contains "$REPO_ROOT/docs/references/github-collaboration.md" "domain:"

--- a/scripts/test_sync_github_labels.sh
+++ b/scripts/test_sync_github_labels.sh
@@ -103,6 +103,34 @@ import sys
 from pathlib import Path
 
 script_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("sync_github_labels", script_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+unsupported_pattern = "docs/{references,design-docs}/**"
+
+try:
+    module.compile_glob_pattern(unsupported_pattern)
+except ValueError as error:
+    error_message = str(error)
+else:
+    print(
+        f"expected unsupported pattern {unsupported_pattern!r} to fail semantic matcher validation",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if "semantic matcher only supports" not in error_message:
+    print(f"expected semantic matcher guidance in error, got: {error_message!r}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+python3 - "$SYNC_SCRIPT" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
 repo_root = script_path.parents[1]
 spec = importlib.util.spec_from_file_location("sync_github_labels", script_path)
 module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary

- Problem: the current label taxonomy governance only checks whether generated artifacts are in sync, so routing semantics can drift without tripping CI.
- Why it matters: a path rule can become too broad or too narrow while generation checks stay green, which weakens triage signal and lets taxonomy regressions land silently.
- What changed: added a small taxonomy path matcher plus representative semantic regression cases in scripts/sync_github_labels.py, and wired scripts/test_sync_github_labels.sh to fail when those cases resolve to the wrong label set.
- What did not change (scope boundary): this does not redesign the taxonomy model, replace the generated artifact sync checks, or change live repository labels by itself.

## Linked Issues

- Closes #506
- Related #502

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [ ] cargo fmt --all -- --check
- [ ] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [ ] cargo test --workspace --locked
- [ ] cargo test --workspace --all-features --locked
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

~~~text
python3 -m py_compile scripts/sync_github_labels.py
  passed

python3 scripts/sync_github_labels.py --check
  passed

bash scripts/test_sync_github_labels.sh
  passed

manual semantic spot-checks from the new fixture set:
- README.md -> docs, documentation
- docs/references/github-collaboration.md -> docs, documentation
- docs/design-docs/provider-runtime-roadmap.md -> documentation, spec
- docs/releases/v0.1.0-alpha.2.md -> documentation
- .github/workflows/labeler.yml -> ci, github_actions
- Cargo.toml -> dependencies
- crates/app/Cargo.toml -> dependencies
~~~

## User-visible / Operator-visible Changes

- None. This only hardens taxonomy regression detection in CI.

## Failure Recovery

- Fast rollback or disable path: revert this commit to return to the previous generated-artifact-only governance behavior.
- Observable failure symptoms reviewers should watch for: scripts/test_sync_github_labels.sh starts failing with a semantic label mismatch for a representative path.

## Reviewer Focus

- Confirm the matcher stays intentionally narrow and only supports the glob subset the managed taxonomy actually uses.
- Confirm the representative cases cover the routing seams that recently drifted: contributor docs, design docs, release docs, workflow files, and dependency manifests.
- Confirm the harness complements the existing generated-artifact sync check instead of replacing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced label taxonomy pattern matching with improved path normalization, stricter pattern validation, and deterministic label resolution

* **Tests**
  * Added regression tests to validate label assignment consistency and a check that unsupported patterns produce a clear validation error
<!-- end of auto-generated comment: release notes by coderabbit.ai -->