### PR TITLE
fix(labeler): allow literal path characters in semantic matcher

### DIFF
--- a/scripts/sync_github_labels.py
+++ b/scripts/sync_github_labels.py
@@ -44,6 +44,31 @@ def normalize_repo_path(repo_path: str) -> str:
     return normalized_path
 
 
+def unsupported_glob_constructs(normalized_pattern: str) -> list[str]:
+    found_unsupported_characters: list[str] = []
+    extglob_tokens = ("@(", "+(", "*(", "?(", "!(")
+
+    for token in extglob_tokens:
+        if token not in normalized_pattern:
+            continue
+        found_unsupported_characters.append(token)
+
+    has_leading_negation = normalized_pattern.startswith("!")
+    has_negation_extglob = "!(" in normalized_pattern
+    if has_leading_negation and not has_negation_extglob:
+        found_unsupported_characters.append("leading !")
+
+    has_character_class = re.search(r"\[[^][]+\]", normalized_pattern) is not None
+    if has_character_class:
+        found_unsupported_characters.append("[]")
+
+    has_brace_expansion = re.search(r"\{[^{}]*,[^{}]*\}", normalized_pattern) is not None
+    if has_brace_expansion:
+        found_unsupported_characters.append("{,}")
+
+    return found_unsupported_characters
+
+
 def validate_supported_glob_pattern(pattern: str) -> str:
     normalized_pattern = normalize_repo_path(pattern)
 
@@ -53,12 +78,7 @@ def validate_supported_glob_pattern(pattern: str) -> str:
     if "//" in normalized_pattern:
         raise ValueError("empty path segments are not supported")
 
-    unsupported_characters = "[]{}!+@()"
-    found_unsupported_characters: list[str] = []
-    for character in unsupported_characters:
-        if character not in normalized_pattern:
-            continue
-        found_unsupported_characters.append(character)
+    found_unsupported_characters = unsupported_glob_constructs(normalized_pattern)
 
     if found_unsupported_characters:
         unsupported_summary = " ".join(found_unsupported_characters)
@@ -225,6 +245,9 @@ def semantic_regression_cases() -> list[dict]:
 
 def check_semantic_regression_cases(taxonomy: dict) -> list[str]:
     failures = check_semantic_matcher_support(taxonomy)
+    if failures:
+        return failures
+
     cases = semantic_regression_cases()
 
     for case in cases:

--- a/scripts/test_sync_github_labels.sh
+++ b/scripts/test_sync_github_labels.sh
@@ -131,6 +131,64 @@ import sys
 from pathlib import Path
 
 script_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("sync_github_labels", script_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+literal_patterns = []
+literal_patterns.append("packages/@scope/pkg/package.json")
+literal_patterns.append("docs/design (draft).md")
+
+for literal_pattern in literal_patterns:
+    does_match = module.path_matches_pattern(literal_pattern, literal_pattern)
+    if does_match:
+        continue
+
+    print(
+        f"expected literal pattern {literal_pattern!r} to match itself",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+
+python3 - "$SYNC_SCRIPT" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("sync_github_labels", script_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+taxonomy = {
+    "surfaces": [
+        {
+            "name": "docs",
+            "paths": ["docs/@(references|design-docs)/**"],
+        }
+    ],
+    "general_labels": [],
+}
+
+failures = module.check_semantic_regression_cases(taxonomy)
+
+if not failures:
+    print("expected matcher-support failures for unsupported extglob patterns", file=sys.stderr)
+    sys.exit(1)
+
+first_failure = failures[0]
+if "unsupported semantic matcher pattern for docs" not in first_failure:
+    print(f"expected matcher-support failure text, got: {first_failure!r}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+python3 - "$SYNC_SCRIPT" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
 repo_root = script_path.parents[1]
 spec = importlib.util.spec_from_file_location("sync_github_labels", script_path)
 module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary

- Problem: the semantic matcher added in #510 rejects raw `@`, `+`, `!`, and parentheses anywhere in a pattern, which over-constrains legal literal paths, and `check_semantic_regression_cases()` keeps evaluating fixtures even after matcher-support validation has already failed.
- Why it matters: maintainers cannot represent some valid literal repo paths in taxonomy patterns, and invalid matcher-support states can still fall through into a noisier exception path instead of returning the collected validation failures.
- What changed: replaced the raw-character gate with targeted detection of unsupported glob constructs, allowed ordinary literal characters such as `@` and parentheses, added an early return when matcher-support validation fails, and extended the regression script with literal-path and early-return coverage.
- What did not change (scope boundary): this does not expand the matcher to full picomatch semantics, redesign the taxonomy model, or change live repository labels by itself.

## Linked Issues

- Closes #511
- Related #510

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [ ] cargo fmt --all -- --check
- [ ] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [ ] cargo test --workspace --locked
- [ ] cargo test --workspace --all-features --locked
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
python3 -m py_compile scripts/sync_github_labels.py
  passed

python3 scripts/sync_github_labels.py --check
  passed

bash scripts/test_sync_github_labels.sh
  passed

new focused checks covered by scripts/test_sync_github_labels.sh:
- literal path patterns with @ scope segments now match themselves
- literal path patterns with parentheses now match themselves
- unsupported extglob patterns still fail matcher-support validation
- matcher-support failures now return cleanly without falling through into fixture evaluation
```

## User-visible / Operator-visible Changes

- None in runtime behavior. This only corrects the semantic regression harness contract and its failure mode.

## Failure Recovery

- Fast rollback or disable path: revert this PR to restore the previous literal-character rejection and non-early-return behavior.
- Observable failure symptoms reviewers should watch for: literal-path regression checks start failing again, or unsupported matcher patterns raise from fixture evaluation instead of returning matcher-support failures.

## Reviewer Focus

- Confirm the matcher still rejects unsupported glob constructs such as brace expansion, character classes, extglobs, and leading negation.
- Confirm literal `@` and parentheses remain usable when they are just path characters.
- Confirm matcher-support failures now short-circuit before case evaluation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage with new pattern matching validation checks ensuring literal patterns correctly match themselves
  * Added regression tests for semantic pattern matching with explicit error condition validation for unsupported pattern constructs

* **Improvements**
  * Enhanced glob pattern validation to more accurately detect unsupported constructs
  * Optimized semantic regression checking with early failure detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->