### PR TITLE
feat(memory): add typed compact stage seam

### DIFF
--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2337,13 +2337,25 @@ async fn maybe_compact_context<R: ConversationRuntime + ?Sized>(
             .map(|_| config.tools.resolved_file_root());
 
         let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-        let durable_flush_result = crate::memory::flush_pre_compaction_durable_memory(
-            session_id,
-            workspace_root.as_deref(),
-            &memory_config,
-        )
-        .await;
-        match durable_flush_result {
+        let compact_stage_result =
+            crate::memory::run_compact_stage(session_id, workspace_root.as_deref(), &memory_config)
+                .await;
+        match compact_stage_result {
+            Ok(diagnostics)
+                if matches!(diagnostics.outcome, crate::memory::StageOutcome::Fallback) =>
+            {
+                if config.conversation.compaction_fail_open() {
+                    return Ok(ContextCompactionOutcome::FailedOpen);
+                }
+
+                return Err(format!(
+                    "pre-compaction durable memory flush failed: {}",
+                    diagnostics
+                        .message
+                        .as_deref()
+                        .unwrap_or("compact stage fallback without error detail")
+                ));
+            }
             Ok(_) => {}
             Err(_error) if config.conversation.compaction_fail_open() => {
                 return Ok(ContextCompactionOutcome::FailedOpen);

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -43,7 +43,7 @@ pub(crate) use durable_recall::load_durable_recall_entries;
 pub use kernel_adapter::MvpMemoryAdapter;
 pub use orchestrator::{
     BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,
-    hydrate_memory_context_with_workspace_root, hydrate_stage_envelope,
+    hydrate_memory_context_with_workspace_root, hydrate_stage_envelope, run_compact_stage,
 };
 #[cfg(test)]
 pub use orchestrator::{MemoryOrchestratorTestFaults, ScopedMemoryOrchestratorTestFaults};

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -41,9 +41,10 @@ pub use context::load_prompt_context;
 pub(crate) use durable_flush::flush_pre_compaction_durable_memory;
 pub(crate) use durable_recall::load_durable_recall_entries;
 pub use kernel_adapter::MvpMemoryAdapter;
+pub(crate) use orchestrator::run_compact_stage;
 pub use orchestrator::{
     BuiltinMemoryOrchestrator, HydratedMemoryContext, MemoryDiagnostics, hydrate_memory_context,
-    hydrate_memory_context_with_workspace_root, hydrate_stage_envelope, run_compact_stage,
+    hydrate_memory_context_with_workspace_root, hydrate_stage_envelope,
 };
 #[cfg(test)]
 pub use orchestrator::{MemoryOrchestratorTestFaults, ScopedMemoryOrchestratorTestFaults};

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -253,6 +253,51 @@ fn run_rank_stage(entries: Vec<MemoryContextEntry>) -> StageRunResult {
     }
 }
 
+pub async fn run_compact_stage(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+) -> Result<StageDiagnostics, String> {
+    match config.system {
+        MemorySystemKind::Builtin => {
+            run_builtin_compact_stage(session_id, workspace_root, config).await
+        }
+    }
+}
+
+async fn run_builtin_compact_stage(
+    session_id: &str,
+    workspace_root: Option<&Path>,
+    config: &MemoryRuntimeConfig,
+) -> Result<StageDiagnostics, String> {
+    match super::flush_pre_compaction_durable_memory(session_id, workspace_root, config).await {
+        Ok(super::durable_flush::PreCompactionDurableFlushOutcome::Flushed { .. })
+        | Ok(super::durable_flush::PreCompactionDurableFlushOutcome::SkippedDuplicate) => {
+            Ok(StageDiagnostics::succeeded(MemoryStageFamily::Compact))
+        }
+        Ok(super::durable_flush::PreCompactionDurableFlushOutcome::SkippedMissingWorkspaceRoot)
+        | Ok(super::durable_flush::PreCompactionDurableFlushOutcome::SkippedNoSummary) => {
+            Ok(StageDiagnostics {
+                family: MemoryStageFamily::Compact,
+                outcome: StageOutcome::Skipped,
+                budget_ms: None,
+                elapsed_ms: None,
+                fallback_activated: false,
+                message: None,
+            })
+        }
+        Err(error) if config.effective_fail_open() => Ok(StageDiagnostics {
+            family: MemoryStageFamily::Compact,
+            outcome: StageOutcome::Fallback,
+            budget_ms: None,
+            elapsed_ms: None,
+            fallback_activated: true,
+            message: Some(error),
+        }),
+        Err(error) => Err(format!("memory compact stage failed: {error}")),
+    }
+}
+
 fn build_builtin_retrieval_request(
     session_id: &str,
     config: &MemoryRuntimeConfig,
@@ -717,6 +762,75 @@ mod tests {
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn compact_stage_emits_succeeded_diagnostics_when_durable_flush_runs() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-compact-stage-succeeded");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("compact-stage.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("compact-stage-succeeded", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("compact-stage-succeeded", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("compact-stage-succeeded", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let diagnostics =
+            run_compact_stage("compact-stage-succeeded", Some(tmp.as_path()), &config)
+                .await
+                .expect("run compact stage");
+
+        assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
+        assert_eq!(diagnostics.outcome, StageOutcome::Succeeded);
+        assert!(!diagnostics.fallback_activated);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn compact_stage_skips_when_workspace_root_is_absent() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-compact-stage-skipped");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("compact-stage-skipped.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("compact-stage-skipped", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("compact-stage-skipped", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+
+        let diagnostics = run_compact_stage("compact-stage-skipped", None, &config)
+            .await
+            .expect("run compact stage");
+
+        assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
+        assert_eq!(diagnostics.outcome, StageOutcome::Skipped);
+        assert!(!diagnostics.fallback_activated);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -265,17 +265,34 @@ pub async fn run_compact_stage(
     }
 }
 
+#[cfg(not(feature = "memory-sqlite"))]
+async fn run_builtin_compact_stage(
+    _session_id: &str,
+    _workspace_root: Option<&Path>,
+    _config: &MemoryRuntimeConfig,
+) -> Result<StageDiagnostics, String> {
+    Ok(StageDiagnostics {
+        family: MemoryStageFamily::Compact,
+        outcome: StageOutcome::Skipped,
+        budget_ms: None,
+        elapsed_ms: None,
+        fallback_activated: false,
+        message: None,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
 async fn run_builtin_compact_stage(
     session_id: &str,
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
 ) -> Result<StageDiagnostics, String> {
     match super::flush_pre_compaction_durable_memory(session_id, workspace_root, config).await {
-        Ok(super::durable_flush::PreCompactionDurableFlushOutcome::Flushed { .. })
-        | Ok(super::durable_flush::PreCompactionDurableFlushOutcome::SkippedDuplicate) => {
+        Ok(super::durable_flush::PreCompactionDurableFlushOutcome::Flushed { .. }) => {
             Ok(StageDiagnostics::succeeded(MemoryStageFamily::Compact))
         }
-        Ok(super::durable_flush::PreCompactionDurableFlushOutcome::SkippedMissingWorkspaceRoot)
+        Ok(super::durable_flush::PreCompactionDurableFlushOutcome::SkippedDuplicate)
+        | Ok(super::durable_flush::PreCompactionDurableFlushOutcome::SkippedMissingWorkspaceRoot)
         | Ok(super::durable_flush::PreCompactionDurableFlushOutcome::SkippedNoSummary) => {
             Ok(StageDiagnostics {
                 family: MemoryStageFamily::Compact,
@@ -824,6 +841,46 @@ mod tests {
         let diagnostics = run_compact_stage("compact-stage-skipped", None, &config)
             .await
             .expect("run compact stage");
+
+        assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
+        assert_eq!(diagnostics.outcome, StageOutcome::Skipped);
+        assert!(!diagnostics.fallback_activated);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn compact_stage_skips_when_durable_flush_is_duplicate() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-compact-stage-duplicate");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("compact-stage-duplicate.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct("compact-stage-duplicate", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("compact-stage-duplicate", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("compact-stage-duplicate", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        run_compact_stage("compact-stage-duplicate", Some(tmp.as_path()), &config)
+            .await
+            .expect("first compact stage run");
+
+        let diagnostics =
+            run_compact_stage("compact-stage-duplicate", Some(tmp.as_path()), &config)
+                .await
+                .expect("second compact stage run");
 
         assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
         assert_eq!(diagnostics.outcome, StageOutcome::Skipped);

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-24T09:17:14Z
+- Generated at: 2026-03-25T00:59:36Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -14,7 +14,7 @@
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 365 | 1000 | 635 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 352 | 650 | 298 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 353 | 650 | 297 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -42,7 +42,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=365 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=352 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=353 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- add a typed built-in compact-stage seam around pre-compaction durable flush so compaction-owned memory work reports `StageDiagnostics` under `MemoryStageFamily::Compact`
- route `maybe_compact_context(...)` through the central memory compact-stage entrypoint while preserving current fail-open behavior and runtime-owned compaction policy
- add regression coverage for compact-stage diagnostics so the built-in contract distinguishes succeeded and skipped compact-stage outcomes without widening the current runtime boundary

## Scope

- [x] Small and focused
- [ ] Includes docs updates (if needed)
- [x] No unrelated refactors

Scope note: this is a follow-up slice after `#464`, limited to the compaction-owned durable-flush path and its typed stage contract.

## Risk Track

- [ ] Track A (routine/low-risk)
- [x] Track B (higher-risk/policy-impacting)

Risk note: this changes the runtime-to-memory contract on the pre-compaction path, so the main risk is preserving the existing fail-open and skip behavior exactly.

## Validation

- [x] `/home/kasumi/.cargo/bin/cargo fmt --all -- --check`
- [x] `/home/kasumi/.cargo/bin/cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `/home/kasumi/.cargo/bin/cargo test --workspace --all-features --locked`
- [x] Additional scenario/benchmark checks (if applicable)
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Additional checks executed:

- [x] `/home/kasumi/.cargo/bin/cargo test -p loongclaw-app compact_stage -- --nocapture`
- [x] `/home/kasumi/.cargo/bin/cargo test -p loongclaw-app handle_turn_with_runtime_flushes_durable_memory_before_compaction -- --nocapture`
- [x] `/home/kasumi/.cargo/bin/cargo test -p loongclaw-app handle_turn_with_runtime_does_not_flush_durable_memory_when_compaction_is_skipped -- --nocapture`
- [x] `/home/kasumi/.cargo/bin/cargo test -p loongclaw-app maybe_compact_context_fails_open_when_durable_flush_cannot_write_workspace_export -- --nocapture`
- [x] `/home/kasumi/.cargo/bin/cargo test -p loongclaw-app default_runtime_kernel_build_context -- --nocapture`
- [x] `/home/kasumi/.cargo/bin/cargo test --workspace --locked`

## Linked Issues

Refs #455


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved memory compaction flow with richer diagnostics and controlled fail‑open behavior for clearer outcomes and more reliable recovery.
* **Tests**
  * Added tests covering compaction diagnostics: success, skipped conditions, and repeated-run behavior.
* **Documentation**
  * Updated architecture drift metadata and tracked metrics for the memory module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->