### PR TITLE
refactor(daemon): extract shared provider model probe policy

### DIFF
--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1328,10 +1328,10 @@ fn provider_model_probe_failure_check(
 fn is_provider_model_probe_failure_check(check: &DoctorCheck) -> bool {
     let is_provider_model_probe = check.name == "provider model probe";
     let is_failure = check.level != DoctorCheckLevel::Pass;
-    let is_probe_failure =
+    let has_probe_failure_detail =
         provider_model_probe_policy::provider_model_probe_failed_detail(check.detail.as_str());
 
-    is_provider_model_probe && is_failure && is_probe_failure
+    is_provider_model_probe && is_failure && has_probe_failure_detail
 }
 
 fn is_transport_style_provider_model_probe_failure_check(check: &DoctorCheck) -> bool {

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -11,8 +11,7 @@ use loongclaw_spec::CliResult;
 use serde_json::json;
 
 use crate::provider_credential_policy;
-
-const MODEL_CATALOG_PROBE_FAILED_MARKER: &str = "model catalog probe failed";
+use crate::provider_model_probe_policy;
 
 #[derive(Debug, Clone)]
 pub struct DoctorCommandOptions {
@@ -80,12 +79,17 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
                 detail: format!("{} model(s) available", models.len()),
             }),
             Err(error) => {
-                let transport_style_failure =
-                    crate::provider_route_diagnostics::is_transport_style_model_probe_failure(
-                        error.as_str(),
-                    );
-                checks.push(provider_model_probe_failure_check(&config, error));
-                if transport_style_failure
+                let probe_failure = provider_model_probe_policy::provider_model_probe_failure(
+                    &config,
+                    error.as_str(),
+                );
+                let should_collect_route_probe = matches!(
+                    &probe_failure.kind,
+                    provider_model_probe_policy::ProviderModelProbeFailureKind::TransportFailure
+                );
+                let check = doctor_check_from_provider_model_probe_failure(probe_failure);
+                checks.push(check);
+                if should_collect_route_probe
                     && let Some(route_probe) =
                         crate::provider_route_diagnostics::collect_provider_route_probe(
                             &config.provider,
@@ -1296,79 +1300,58 @@ fn provider_credentials_doctor_check(
     }
 }
 
-fn provider_model_probe_failure_check(
-    config: &mvp::config::LoongClawConfig,
-    error: String,
+fn doctor_check_from_provider_model_probe_failure(
+    probe_failure: provider_model_probe_policy::ProviderModelProbeFailure,
 ) -> DoctorCheck {
-    let provider_prefix = crate::provider_presentation::active_provider_detail_label(config);
-    if crate::provider_route_diagnostics::is_transport_style_model_probe_failure(error.as_str()) {
-        return DoctorCheck {
-            name: "provider model probe".to_owned(),
-            level: DoctorCheckLevel::Fail,
-            detail: format!(
-                "{provider_prefix}: {} ({error}); runtime could not verify the provider route. inspect provider route diagnostics and retry once dns / proxy / TUN routing is stable",
-                crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER
-            ),
-        };
-    }
-    let auth_style_failure = mvp::provider::is_auth_style_failure_message(error.as_str());
-    let append_region_hint = |mut detail: String| {
-        if auth_style_failure && let Some(hint) = config.provider.region_endpoint_failure_hint() {
-            detail.push(' ');
-            detail.push_str(hint.as_str());
-        }
-        detail
-    };
-    let (level, detail) = match config.provider.model_catalog_probe_recovery() {
-        mvp::config::ModelCatalogProbeRecovery::ExplicitModel(model) => (
-            DoctorCheckLevel::Warn,
-            append_region_hint(format!(
-                "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); chat may still work because model `{model}` is explicitly configured"
-            )),
-        ),
-        mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(fallback_models) => (
-            DoctorCheckLevel::Warn,
-            append_region_hint(format!(
-                "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); runtime will try configured preferred model fallback(s): {}",
-                fallback_models
-                    .iter()
-                    .map(|model| format!("`{model}`"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )),
-        ),
-        mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
-            recommended_onboarding_model,
-        } => (
-            DoctorCheckLevel::Fail,
-            append_region_hint(provider_model_probe_requires_explicit_model_detail(
-                provider_prefix.as_str(),
-                error.as_str(),
-                recommended_onboarding_model,
-            )),
-        ),
+    let level = match probe_failure.level {
+        provider_model_probe_policy::ProviderModelProbeFailureLevel::Warn => DoctorCheckLevel::Warn,
+        provider_model_probe_policy::ProviderModelProbeFailureLevel::Fail => DoctorCheckLevel::Fail,
     };
 
     DoctorCheck {
         name: "provider model probe".to_owned(),
         level,
-        detail,
+        detail: probe_failure.detail,
     }
 }
 
-fn provider_model_probe_requires_explicit_model_detail(
-    provider_prefix: &str,
-    error: &str,
-    recommended_onboarding_model: Option<&str>,
-) -> String {
-    match recommended_onboarding_model {
-        Some(model) => format!(
-            "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); current config still uses `model = auto`; rerun onboarding and accept reviewed model `{model}`, or set `provider.model` / `preferred_models` explicitly"
-        ),
-        None => format!(
-            "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); current config still uses `model = auto`; set `provider.model` explicitly or configure `preferred_models` before retrying"
-        ),
+#[cfg(test)]
+fn provider_model_probe_failure_check(
+    config: &mvp::config::LoongClawConfig,
+    error: String,
+) -> DoctorCheck {
+    let probe_failure =
+        provider_model_probe_policy::provider_model_probe_failure(config, error.as_str());
+    doctor_check_from_provider_model_probe_failure(probe_failure)
+}
+
+fn is_provider_model_probe_failure_check(check: &DoctorCheck) -> bool {
+    let is_provider_model_probe = check.name == "provider model probe";
+    let is_failure = check.level != DoctorCheckLevel::Pass;
+    let is_probe_failure =
+        provider_model_probe_policy::provider_model_probe_failed_detail(check.detail.as_str());
+
+    is_provider_model_probe && is_failure && is_probe_failure
+}
+
+fn is_transport_style_provider_model_probe_failure_check(check: &DoctorCheck) -> bool {
+    let is_provider_model_probe_failure = is_provider_model_probe_failure_check(check);
+    if !is_provider_model_probe_failure {
+        return false;
     }
+
+    provider_model_probe_policy::provider_model_probe_transport_failure_detail(
+        check.detail.as_str(),
+    )
+}
+
+fn is_auth_style_provider_model_probe_failure_check(check: &DoctorCheck) -> bool {
+    let is_provider_model_probe_failure = is_provider_model_probe_failure_check(check);
+    if !is_provider_model_probe_failure {
+        return false;
+    }
+
+    provider_model_probe_policy::provider_model_probe_auth_failure_detail(check.detail.as_str())
 }
 
 async fn collect_browser_companion_doctor_checks(
@@ -1527,21 +1510,11 @@ fn build_doctor_next_steps_with_path_env(
         }
     }
 
-    if checks.iter().any(|check| {
-        check.name == "provider model probe"
-            && check.level != DoctorCheckLevel::Pass
-            && (check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
-                || check.detail.contains(
-                    crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER,
-                ))
-    }) {
-        let provider_model_probe_transport_failure = checks.iter().any(|check| {
-            check.name == "provider model probe"
-                && check.level != DoctorCheckLevel::Pass
-                && check.detail.contains(
-                    crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER,
-                )
-        });
+    let has_provider_model_probe_failure = checks.iter().any(is_provider_model_probe_failure_check);
+    if has_provider_model_probe_failure {
+        let provider_model_probe_transport_failure = checks
+            .iter()
+            .any(is_transport_style_provider_model_probe_failure_check);
         if provider_model_probe_transport_failure {
             if checks.iter().any(|check| {
                 check.name == crate::provider_route_diagnostics::PROVIDER_ROUTE_PROBE_CHECK_NAME
@@ -1571,12 +1544,9 @@ fn build_doctor_next_steps_with_path_env(
                 );
             }
         } else {
-            let provider_model_probe_auth_failure = checks.iter().any(|check| {
-                check.name == "provider model probe"
-                    && check.level != DoctorCheckLevel::Pass
-                    && check.detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER)
-                    && mvp::provider::is_auth_style_failure_message(check.detail.as_str())
-            });
+            let provider_model_probe_auth_failure = checks
+                .iter()
+                .any(is_auth_style_provider_model_probe_failure_check);
             match config.provider.model_catalog_probe_recovery() {
                 mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
                     recommended_onboarding_model: Some(model),

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -90,6 +90,7 @@ mod onboard_finalize;
 mod onboard_preflight;
 pub mod onboard_presentation;
 mod provider_credential_policy;
+mod provider_model_probe_policy;
 pub mod provider_presentation;
 mod provider_route_diagnostics;
 pub mod runtime_capability_cli;

--- a/crates/daemon/src/onboard_preflight.rs
+++ b/crates/daemon/src/onboard_preflight.rs
@@ -80,14 +80,19 @@ pub(crate) async fn run_preflight_checks(
                 });
             }
             Err(error) => {
-                let transport_style_failure =
-                    crate::provider_route_diagnostics::is_transport_style_model_probe_failure(
+                let probe_failure =
+                    crate::provider_model_probe_policy::provider_model_probe_failure(
+                        config,
                         error.as_str(),
                     );
+                let should_collect_route_probe = matches!(
+                    &probe_failure.kind,
+                    crate::provider_model_probe_policy::ProviderModelProbeFailureKind::TransportFailure
+                );
+                let check = onboard_check_from_provider_model_probe_failure(probe_failure);
+                checks.push(check);
 
-                checks.push(provider_model_probe_failure_check(config, error));
-
-                if transport_style_failure
+                if should_collect_route_probe
                     && let Some(route_probe) =
                         crate::provider_route_diagnostics::collect_provider_route_probe(
                             &config.provider,
@@ -441,84 +446,51 @@ fn provider_check_detail_prefix(config: &mvp::config::LoongClawConfig) -> String
     crate::provider_presentation::active_provider_detail_label(config)
 }
 
-fn render_onboard_model_candidate_list(models: &[String]) -> String {
-    models
-        .iter()
-        .map(|model| format!("`{model}`"))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-pub(crate) fn provider_model_probe_failure_check(
-    config: &mvp::config::LoongClawConfig,
-    error: String,
+fn onboard_check_from_provider_model_probe_failure(
+    probe_failure: crate::provider_model_probe_policy::ProviderModelProbeFailure,
 ) -> OnboardCheck {
-    let provider_prefix = provider_check_detail_prefix(config);
-
-    if crate::provider_route_diagnostics::is_transport_style_model_probe_failure(error.as_str()) {
-        return OnboardCheck {
-            name: "provider model probe",
-            level: OnboardCheckLevel::Fail,
-            detail: format!(
-                "{provider_prefix}: {} ({error}); runtime could not verify the provider route. inspect provider route diagnostics and retry once dns / proxy / TUN routing is stable",
-                crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER
-            ),
-            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
-        };
-    }
-
-    let auth_style_failure = mvp::provider::is_auth_style_failure_message(error.as_str());
-    let append_region_hint = |mut detail: String| {
-        if auth_style_failure && let Some(hint) = config.provider.region_endpoint_failure_hint() {
-            detail.push(' ');
-            detail.push_str(hint.as_str());
+    let level = match probe_failure.level {
+        crate::provider_model_probe_policy::ProviderModelProbeFailureLevel::Warn => {
+            OnboardCheckLevel::Warn
         }
-
-        detail
+        crate::provider_model_probe_policy::ProviderModelProbeFailureLevel::Fail => {
+            OnboardCheckLevel::Fail
+        }
     };
-
-    let recovery = config.provider.model_catalog_probe_recovery();
-    let (level, detail, non_interactive_warning_policy) = match recovery {
-        mvp::config::ModelCatalogProbeRecovery::ExplicitModel(model) => (
-            OnboardCheckLevel::Warn,
-            append_region_hint(format!(
-                "{provider_prefix}: model catalog probe failed ({error}); chat may still work because model `{model}` is explicitly configured"
-            )),
-            OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel,
-        ),
-        mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(fallback_models) => (
-            OnboardCheckLevel::Warn,
-            append_region_hint(format!(
-                "{provider_prefix}: model catalog probe failed ({error}); runtime will try configured preferred model fallback(s): {}",
-                render_onboard_model_candidate_list(&fallback_models)
-            )),
-            OnboardNonInteractiveWarningPolicy::AcceptedByPreferredModels,
-        ),
-        mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
-            recommended_onboarding_model,
-        } => {
-            let detail = provider_model_probe_requires_explicit_model_detail(
-                provider_prefix.as_str(),
-                error.as_str(),
-                recommended_onboarding_model,
-            );
-            let detail = append_region_hint(detail);
-            let policy = if recommended_onboarding_model.is_some() {
-                OnboardNonInteractiveWarningPolicy::RequiresExplicitModel
-            } else {
-                OnboardNonInteractiveWarningPolicy::RequiresExplicitModelWithoutReviewedDefault
-            };
-
-            (OnboardCheckLevel::Fail, detail, policy)
+    let non_interactive_warning_policy = match probe_failure.kind {
+        crate::provider_model_probe_policy::ProviderModelProbeFailureKind::TransportFailure => {
+            OnboardNonInteractiveWarningPolicy::Block
         }
+        crate::provider_model_probe_policy::ProviderModelProbeFailureKind::ExplicitModel {
+            ..
+        } => OnboardNonInteractiveWarningPolicy::AcceptedByExplicitModel,
+        crate::provider_model_probe_policy::ProviderModelProbeFailureKind::PreferredModels {
+            ..
+        } => OnboardNonInteractiveWarningPolicy::AcceptedByPreferredModels,
+        crate::provider_model_probe_policy::ProviderModelProbeFailureKind::RequiresExplicitModel {
+            recommended_onboarding_model: Some(_),
+        } => OnboardNonInteractiveWarningPolicy::RequiresExplicitModel,
+        crate::provider_model_probe_policy::ProviderModelProbeFailureKind::RequiresExplicitModel {
+            recommended_onboarding_model: None,
+        } => OnboardNonInteractiveWarningPolicy::RequiresExplicitModelWithoutReviewedDefault,
     };
 
     OnboardCheck {
         name: "provider model probe",
         level,
-        detail,
+        detail: probe_failure.detail,
         non_interactive_warning_policy,
     }
+}
+
+#[cfg(test)]
+pub(crate) fn provider_model_probe_failure_check(
+    config: &mvp::config::LoongClawConfig,
+    error: String,
+) -> OnboardCheck {
+    let probe_failure =
+        crate::provider_model_probe_policy::provider_model_probe_failure(config, error.as_str());
+    onboard_check_from_provider_model_probe_failure(probe_failure)
 }
 
 async fn collect_browser_companion_preflight_checks(
@@ -549,21 +521,6 @@ async fn collect_browser_companion_preflight_checks(
         detail,
         non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
     }]
-}
-
-fn provider_model_probe_requires_explicit_model_detail(
-    provider_prefix: &str,
-    error: &str,
-    recommended_onboarding_model: Option<&str>,
-) -> String {
-    match recommended_onboarding_model {
-        Some(model) => format!(
-            "{provider_prefix}: model catalog probe failed ({error}); current config still uses `model = auto`; rerun onboarding and accept reviewed model `{model}`, or set `provider.model` / `preferred_models` explicitly"
-        ),
-        None => format!(
-            "{provider_prefix}: model catalog probe failed ({error}); current config still uses `model = auto`; set `provider.model` explicitly or configure `preferred_models` before retrying"
-        ),
-    }
 }
 
 fn provider_transport_check(config: &mvp::config::LoongClawConfig) -> OnboardCheck {

--- a/crates/daemon/src/onboard_preflight.rs
+++ b/crates/daemon/src/onboard_preflight.rs
@@ -136,8 +136,8 @@ pub(crate) fn non_interactive_preflight_failure_message(checks: &[OnboardCheck])
             let mut detail = check.detail.clone();
 
             if check.name == "provider model probe"
-                && check.detail.contains(
-                    crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER,
+                && crate::provider_model_probe_policy::provider_model_probe_transport_failure_detail(
+                    check.detail.as_str(),
                 )
                 && let Some(route_probe) = checks.iter().find(|candidate| {
                     candidate.name

--- a/crates/daemon/src/provider_model_probe_policy.rs
+++ b/crates/daemon/src/provider_model_probe_policy.rs
@@ -1,0 +1,247 @@
+use loongclaw_app as mvp;
+
+pub(crate) const MODEL_CATALOG_PROBE_FAILED_MARKER: &str = "model catalog probe failed";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProviderModelProbeFailureLevel {
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProviderModelProbeFailureKind {
+    TransportFailure,
+    ExplicitModel {
+        model: String,
+    },
+    PreferredModels {
+        fallback_models: Vec<String>,
+    },
+    RequiresExplicitModel {
+        recommended_onboarding_model: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProviderModelProbeFailure {
+    pub(crate) level: ProviderModelProbeFailureLevel,
+    pub(crate) detail: String,
+    pub(crate) kind: ProviderModelProbeFailureKind,
+}
+
+pub(crate) fn provider_model_probe_failure(
+    config: &mvp::config::LoongClawConfig,
+    error: &str,
+) -> ProviderModelProbeFailure {
+    let provider_prefix = crate::provider_presentation::active_provider_detail_label(config);
+    let is_transport_failure =
+        crate::provider_route_diagnostics::is_transport_style_model_probe_failure(error);
+    if is_transport_failure {
+        let detail = render_transport_failure_detail(provider_prefix.as_str(), error);
+        return ProviderModelProbeFailure {
+            level: ProviderModelProbeFailureLevel::Fail,
+            detail,
+            kind: ProviderModelProbeFailureKind::TransportFailure,
+        };
+    }
+
+    let configured_recovery = config.provider.model_catalog_probe_recovery();
+    let kind = configured_recovery_kind(configured_recovery);
+    let detail = render_provider_model_probe_failure_detail(provider_prefix.as_str(), error, &kind);
+    let detail = append_region_hint(config, error, detail);
+    let level = provider_model_probe_failure_level(&kind);
+
+    ProviderModelProbeFailure {
+        level,
+        detail,
+        kind,
+    }
+}
+
+pub(crate) fn provider_model_probe_failed_detail(detail: &str) -> bool {
+    let has_model_catalog_failure = detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER);
+    let has_transport_failure =
+        detail.contains(crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER);
+
+    has_model_catalog_failure || has_transport_failure
+}
+
+pub(crate) fn provider_model_probe_transport_failure_detail(detail: &str) -> bool {
+    detail.contains(crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER)
+}
+
+pub(crate) fn provider_model_probe_auth_failure_detail(detail: &str) -> bool {
+    let has_model_catalog_failure = detail.contains(MODEL_CATALOG_PROBE_FAILED_MARKER);
+    if !has_model_catalog_failure {
+        return false;
+    }
+
+    mvp::provider::is_auth_style_failure_message(detail)
+}
+
+fn configured_recovery_kind(
+    configured_recovery: mvp::config::ModelCatalogProbeRecovery,
+) -> ProviderModelProbeFailureKind {
+    match configured_recovery {
+        mvp::config::ModelCatalogProbeRecovery::ExplicitModel(model) => {
+            ProviderModelProbeFailureKind::ExplicitModel { model }
+        }
+        mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(fallback_models) => {
+            ProviderModelProbeFailureKind::PreferredModels { fallback_models }
+        }
+        mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+            recommended_onboarding_model,
+        } => ProviderModelProbeFailureKind::RequiresExplicitModel {
+            recommended_onboarding_model: recommended_onboarding_model.map(str::to_owned),
+        },
+    }
+}
+
+fn provider_model_probe_failure_level(
+    kind: &ProviderModelProbeFailureKind,
+) -> ProviderModelProbeFailureLevel {
+    match kind {
+        ProviderModelProbeFailureKind::TransportFailure => ProviderModelProbeFailureLevel::Fail,
+        ProviderModelProbeFailureKind::ExplicitModel { .. } => ProviderModelProbeFailureLevel::Warn,
+        ProviderModelProbeFailureKind::PreferredModels { .. } => {
+            ProviderModelProbeFailureLevel::Warn
+        }
+        ProviderModelProbeFailureKind::RequiresExplicitModel { .. } => {
+            ProviderModelProbeFailureLevel::Fail
+        }
+    }
+}
+
+fn render_provider_model_probe_failure_detail(
+    provider_prefix: &str,
+    error: &str,
+    kind: &ProviderModelProbeFailureKind,
+) -> String {
+    match kind {
+        ProviderModelProbeFailureKind::TransportFailure => {
+            render_transport_failure_detail(provider_prefix, error)
+        }
+        ProviderModelProbeFailureKind::ExplicitModel { model } => format!(
+            "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); chat may still work because model `{model}` is explicitly configured"
+        ),
+        ProviderModelProbeFailureKind::PreferredModels { fallback_models } => format!(
+            "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); runtime will try configured preferred model fallback(s): {}",
+            render_model_candidate_list(fallback_models)
+        ),
+        ProviderModelProbeFailureKind::RequiresExplicitModel {
+            recommended_onboarding_model,
+        } => render_requires_explicit_model_detail(
+            provider_prefix,
+            error,
+            recommended_onboarding_model.as_deref(),
+        ),
+    }
+}
+
+fn render_transport_failure_detail(provider_prefix: &str, error: &str) -> String {
+    let marker = crate::provider_route_diagnostics::MODEL_CATALOG_TRANSPORT_FAILED_MARKER;
+    format!(
+        "{provider_prefix}: {marker} ({error}); runtime could not verify the provider route. inspect provider route diagnostics and retry once dns / proxy / TUN routing is stable"
+    )
+}
+
+fn render_requires_explicit_model_detail(
+    provider_prefix: &str,
+    error: &str,
+    recommended_onboarding_model: Option<&str>,
+) -> String {
+    match recommended_onboarding_model {
+        Some(model) => format!(
+            "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); current config still uses `model = auto`; rerun onboarding and accept reviewed model `{model}`, or set `provider.model` / `preferred_models` explicitly"
+        ),
+        None => format!(
+            "{provider_prefix}: {MODEL_CATALOG_PROBE_FAILED_MARKER} ({error}); current config still uses `model = auto`; set `provider.model` explicitly or configure `preferred_models` before retrying"
+        ),
+    }
+}
+
+fn render_model_candidate_list(models: &[String]) -> String {
+    models
+        .iter()
+        .map(|model| format!("`{model}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn append_region_hint(
+    config: &mvp::config::LoongClawConfig,
+    error: &str,
+    mut detail: String,
+) -> String {
+    let is_auth_style_failure = mvp::provider::is_auth_style_failure_message(error);
+    if !is_auth_style_failure {
+        return detail;
+    }
+
+    let Some(hint) = config.provider.region_endpoint_failure_hint() else {
+        return detail;
+    };
+
+    detail.push(' ');
+    detail.push_str(hint.as_str());
+    detail
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_model_probe_failure_marks_transport_route_failures() {
+        let config = mvp::config::LoongClawConfig::default();
+        let failure = provider_model_probe_failure(
+            &config,
+            "provider model-list request failed on attempt 3/3: operation timed out",
+        );
+
+        assert_eq!(failure.level, ProviderModelProbeFailureLevel::Fail);
+        assert_eq!(
+            failure.kind,
+            ProviderModelProbeFailureKind::TransportFailure
+        );
+        assert!(
+            provider_model_probe_transport_failure_detail(failure.detail.as_str()),
+            "transport-style failures should keep the route-focused marker in the rendered detail"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_preserves_reviewed_model_recovery() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+
+        let failure = provider_model_probe_failure(&config, "401 Unauthorized");
+
+        assert_eq!(failure.level, ProviderModelProbeFailureLevel::Fail);
+        assert_eq!(
+            failure.kind,
+            ProviderModelProbeFailureKind::RequiresExplicitModel {
+                recommended_onboarding_model: Some("deepseek-chat".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_failure_appends_region_hint_for_auth_failures() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+
+        let failure = provider_model_probe_failure(&config, "provider returned status 401");
+
+        assert!(
+            failure.detail.contains("https://api.minimax.io"),
+            "auth-style failures should keep provider-specific endpoint guidance in the shared policy detail"
+        );
+        assert!(
+            provider_model_probe_auth_failure_detail(failure.detail.as_str()),
+            "the shared detail classifier should recognize auth-style model probe failures"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- extract `provider_model_probe_policy` so provider probe failure classification and detail rendering live behind one daemon-local policy seam
- reuse that shared policy from onboarding preflight and doctor while keeping command-specific warning mapping and next-step wording local
- add focused regression coverage for transport failures, reviewed onboarding defaults, and auth-style endpoint hints

## Testing
- cargo fmt --all --check
- cargo test -p loongclaw-daemon -- --test-threads=1
- cargo clippy -p loongclaw-daemon --all-targets -- -D warnings

## Notes
- this clean upstream rebuild supersedes the earlier stacked review branch in chumyin/loongclaw#11

Closes #504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized model probe failure handling and improved error classification to provide consistent diagnostic messaging across configuration and onboarding workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->