### PR TITLE
refactor(daemon): extract onboarding model selection policy

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -89,6 +89,7 @@ pub mod onboard_cli;
 mod onboard_finalize;
 mod onboard_preflight;
 pub mod onboard_presentation;
+mod onboarding_model_policy;
 mod provider_credential_policy;
 pub mod provider_presentation;
 mod provider_route_diagnostics;

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -32,6 +32,7 @@ use crate::onboard_preflight::{
     non_interactive_preflight_failure_message, render_preflight_summary_screen_lines_with_progress,
     run_preflight_checks,
 };
+use crate::onboarding_model_policy;
 use crate::provider_credential_policy;
 #[cfg(test)]
 use std::fs;
@@ -1769,25 +1770,20 @@ fn resolve_model_selection(
     ui: &mut impl OnboardUi,
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
-    if let Some(model) = options.model.as_deref()
-        && model.trim().is_empty()
-    {
-        return Err("model cannot be empty".to_owned());
-    }
+    let prompt_default = onboarding_model_policy::resolve_onboarding_model_prompt_default(
+        &config.provider,
+        options.model.as_deref(),
+    )?;
 
     if options.non_interactive {
-        if let Some(model) = options.model.as_deref() {
-            return Ok(model.trim().to_owned());
-        }
-        return Ok(resolve_onboarding_model_prompt_default(options, config));
+        return Ok(prompt_default);
     }
 
-    let default_model = resolve_onboarding_model_prompt_default(options, config);
     print_lines(
         ui,
         render_model_selection_screen_lines_with_style(
             config,
-            default_model.as_str(),
+            prompt_default.as_str(),
             guided_prompt_path,
             context.render_width,
             true,
@@ -1795,8 +1791,11 @@ fn resolve_model_selection(
         ),
     )?;
     if !available_models.is_empty() {
-        let (select_options, default_idx) =
-            build_model_selection_options(default_model.as_str(), available_models);
+        let catalog_choices = onboarding_model_policy::onboarding_model_catalog_choices(
+            prompt_default.as_str(),
+            available_models,
+        );
+        let (select_options, default_idx) = build_model_selection_options(&catalog_choices);
         let idx = ui.select_one(
             "Model",
             &select_options,
@@ -1809,14 +1808,14 @@ fn resolve_model_selection(
         if selected.slug != ONBOARD_CUSTOM_MODEL_OPTION_SLUG {
             return Ok(selected.slug.clone());
         }
-        let custom_model = ui.prompt_with_default("Custom model id", default_model.as_str())?;
+        let custom_model = ui.prompt_with_default("Custom model id", prompt_default.as_str())?;
         let trimmed = custom_model.trim();
         if trimmed.is_empty() {
             return Err("model cannot be empty".to_owned());
         }
         return Ok(trimmed.to_owned());
     }
-    let value = ui.prompt_with_default("Model", default_model.as_str())?;
+    let value = ui.prompt_with_default("Model", prompt_default.as_str())?;
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return Err("model cannot be empty".to_owned());
@@ -1840,38 +1839,28 @@ async fn load_onboarding_model_catalog(
 }
 
 fn build_model_selection_options(
-    default_model: &str,
-    available_models: &[String],
+    catalog_choices: &onboarding_model_policy::OnboardingModelCatalogChoices,
 ) -> (Vec<SelectOption>, Option<usize>) {
-    let default_model = default_model.trim();
-    let mut models = Vec::new();
-    if !default_model.is_empty() {
-        models.push(default_model.to_owned());
-    }
-    for model in available_models {
-        let trimmed = model.trim();
-        if trimmed.is_empty() || models.iter().any(|existing| existing == trimmed) {
-            continue;
-        }
-        models.push(trimmed.to_owned());
-    }
+    let default_idx = catalog_choices.default_index;
+    let mut options = Vec::new();
 
-    let mut options = models
-        .iter()
-        .map(|model| SelectOption {
+    for (index, model) in catalog_choices.ordered_models.iter().enumerate() {
+        let is_default_model = default_idx == Some(index);
+        let description = if is_default_model {
+            "current or suggested default".to_owned()
+        } else {
+            String::new()
+        };
+
+        let option = SelectOption {
             label: model.clone(),
             slug: model.clone(),
-            description: if model == default_model {
-                "current or suggested default".to_owned()
-            } else {
-                String::new()
-            },
-            recommended: model == default_model,
-        })
-        .collect::<Vec<_>>();
-    let default_idx = options
-        .iter()
-        .position(|option| option.slug == default_model);
+            description,
+            recommended: is_default_model,
+        };
+        options.push(option);
+    }
+
     options.push(SelectOption {
         label: "enter custom model id".to_owned(),
         slug: ONBOARD_CUSTOM_MODEL_OPTION_SLUG.to_owned(),
@@ -1880,28 +1869,6 @@ fn build_model_selection_options(
     });
 
     (options, default_idx)
-}
-
-fn resolve_onboarding_model_prompt_default(
-    options: &OnboardCommandOptions,
-    config: &mvp::config::LoongClawConfig,
-) -> String {
-    if let Some(model) = options.model.as_deref() {
-        return model.trim().to_owned();
-    }
-
-    if let Some(model) = config.provider.explicit_model() {
-        return model;
-    }
-
-    let configured_model = config.provider.configured_model_value();
-    if configured_model.eq_ignore_ascii_case("auto")
-        && let Some(model) = config.provider.kind.recommended_onboarding_model()
-    {
-        return model.to_owned();
-    }
-
-    configured_model
 }
 
 fn resolve_api_key_env_selection(
@@ -4279,26 +4246,26 @@ fn render_model_selection_screen_lines_with_style(
     color_enabled: bool,
     catalog_models_available: bool,
 ) -> Vec<String> {
-    let preferred_fallback_models = config.provider.configured_auto_model_candidates();
+    let selection_context =
+        onboarding_model_policy::onboarding_model_selection_context(&config.provider);
+    let current_model = selection_context.current_model;
+    let recommended_model = selection_context.recommended_model;
+    let preferred_fallback_models = selection_context.preferred_fallback_models;
+    let allows_auto_fallback_hint = selection_context.allows_auto_fallback_hint;
     let mut context_lines = vec![
         format!(
             "- provider: {}",
             crate::provider_presentation::guided_provider_label(config.provider.kind)
         ),
-        format!("- current model: {}", config.provider.model),
+        format!("- current model: {current_model}"),
     ];
-    if let Some(default_model) = config
-        .provider
-        .kind
-        .recommended_onboarding_model()
-        .filter(|default_model| *default_model != config.provider.model)
-    {
-        context_lines.push(format!("- recommended model: {default_model}"));
+    if let Some(recommended_model) = recommended_model {
+        context_lines.push(format!("- recommended model: {recommended_model}"));
     }
     if !preferred_fallback_models.is_empty() {
+        let preferred_fallback_summary = preferred_fallback_models.join(", ");
         context_lines.push(format!(
-            "- configured preferred fallback: {}",
-            preferred_fallback_models.join(", ")
+            "- configured preferred fallback: {preferred_fallback_summary}",
         ));
     }
 
@@ -4316,10 +4283,10 @@ fn render_model_selection_screen_lines_with_style(
     } else {
         hint_lines.push("- type any provider model id to override it".to_owned());
     }
-    if !preferred_fallback_models.is_empty() && config.provider.explicit_model().is_none() {
+    if allows_auto_fallback_hint {
+        let preferred_fallback_summary = preferred_fallback_models.join(", ");
         hint_lines.push(format!(
-            "- type `auto` to let runtime try configured preferred fallbacks first: {}",
-            preferred_fallback_models.join(", ")
+            "- type `auto` to let runtime try configured preferred fallbacks first: {preferred_fallback_summary}",
         ));
     }
 

--- a/crates/daemon/src/onboarding_model_policy.rs
+++ b/crates/daemon/src/onboarding_model_policy.rs
@@ -1,0 +1,242 @@
+use loongclaw_app as mvp;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OnboardingModelSelectionContext {
+    pub(crate) current_model: String,
+    pub(crate) recommended_model: Option<String>,
+    pub(crate) preferred_fallback_models: Vec<String>,
+    pub(crate) allows_auto_fallback_hint: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OnboardingModelCatalogChoices {
+    pub(crate) ordered_models: Vec<String>,
+    pub(crate) default_index: Option<usize>,
+}
+
+pub(crate) fn onboarding_model_selection_context(
+    provider: &mvp::config::ProviderConfig,
+) -> OnboardingModelSelectionContext {
+    let current_model = provider.model.clone();
+    let recommended_model = recommended_onboarding_model_for_context(provider);
+    let preferred_fallback_models = provider.configured_auto_model_candidates();
+    let has_preferred_fallback_models = !preferred_fallback_models.is_empty();
+    let explicit_model = provider.explicit_model();
+    let has_explicit_model = explicit_model.is_some();
+    let allows_auto_fallback_hint = !has_explicit_model && has_preferred_fallback_models;
+
+    OnboardingModelSelectionContext {
+        current_model,
+        recommended_model,
+        preferred_fallback_models,
+        allows_auto_fallback_hint,
+    }
+}
+
+pub(crate) fn resolve_onboarding_model_prompt_default(
+    provider: &mvp::config::ProviderConfig,
+    explicit_model_override: Option<&str>,
+) -> Result<String, String> {
+    let explicit_model_override = validated_explicit_model_override(explicit_model_override)?;
+    if let Some(explicit_model_override) = explicit_model_override {
+        return Ok(explicit_model_override);
+    }
+
+    let explicit_model = provider.explicit_model();
+    if let Some(explicit_model) = explicit_model {
+        return Ok(explicit_model);
+    }
+
+    let configured_model = provider.configured_model_value();
+    let uses_auto_discovery = configured_model.eq_ignore_ascii_case("auto");
+    if !uses_auto_discovery {
+        return Ok(configured_model);
+    }
+
+    let recommended_model = provider.kind.recommended_onboarding_model();
+    let Some(recommended_model) = recommended_model else {
+        return Ok(configured_model);
+    };
+
+    let recommended_model = recommended_model.to_owned();
+    Ok(recommended_model)
+}
+
+pub(crate) fn onboarding_model_catalog_choices(
+    prompt_default: &str,
+    available_models: &[String],
+) -> OnboardingModelCatalogChoices {
+    let trimmed_default_model = prompt_default.trim();
+    let mut ordered_models = Vec::new();
+
+    if !trimmed_default_model.is_empty() {
+        let default_model = trimmed_default_model.to_owned();
+        ordered_models.push(default_model);
+    }
+
+    for raw_model in available_models {
+        let trimmed_model = raw_model.trim();
+        let model_is_blank = trimmed_model.is_empty();
+        if model_is_blank {
+            continue;
+        }
+
+        let model_is_duplicate = ordered_models
+            .iter()
+            .any(|existing_model| existing_model == trimmed_model);
+        if model_is_duplicate {
+            continue;
+        }
+
+        let model = trimmed_model.to_owned();
+        ordered_models.push(model);
+    }
+
+    let default_index = ordered_models
+        .iter()
+        .position(|model| model == trimmed_default_model);
+
+    OnboardingModelCatalogChoices {
+        ordered_models,
+        default_index,
+    }
+}
+
+fn validated_explicit_model_override(
+    explicit_model_override: Option<&str>,
+) -> Result<Option<String>, String> {
+    let Some(raw_model) = explicit_model_override else {
+        return Ok(None);
+    };
+
+    let trimmed_model = raw_model.trim();
+    let model_is_blank = trimmed_model.is_empty();
+    if model_is_blank {
+        return Err("model cannot be empty".to_owned());
+    }
+
+    let validated_model = trimmed_model.to_owned();
+    Ok(Some(validated_model))
+}
+
+fn recommended_onboarding_model_for_context(
+    provider: &mvp::config::ProviderConfig,
+) -> Option<String> {
+    let current_model = provider.model.as_str();
+    let recommended_model = provider.kind.recommended_onboarding_model()?;
+    let recommended_matches_current_model = recommended_model == current_model;
+    if recommended_matches_current_model {
+        return None;
+    }
+
+    let recommended_model = recommended_model.to_owned();
+    Some(recommended_model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_onboarding_model_prompt_default_prefers_explicit_override() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+
+        let prompt_default =
+            resolve_onboarding_model_prompt_default(&config.provider, Some("deepseek-reasoner"))
+                .expect("resolve prompt default");
+
+        assert_eq!(prompt_default, "deepseek-reasoner");
+    }
+
+    #[test]
+    fn resolve_onboarding_model_prompt_default_rejects_blank_override() {
+        let config = mvp::config::LoongClawConfig::default();
+
+        let error = resolve_onboarding_model_prompt_default(&config.provider, Some("   "))
+            .expect_err("blank explicit override should fail");
+
+        assert_eq!(error, "model cannot be empty");
+    }
+
+    #[test]
+    fn resolve_onboarding_model_prompt_default_keeps_explicit_model() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "deepseek-chat".to_owned();
+
+        let prompt_default = resolve_onboarding_model_prompt_default(&config.provider, None)
+            .expect("resolve prompt default");
+
+        assert_eq!(prompt_default, "deepseek-chat");
+    }
+
+    #[test]
+    fn resolve_onboarding_model_prompt_default_uses_reviewed_default_for_auto() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+
+        let prompt_default = resolve_onboarding_model_prompt_default(&config.provider, None)
+            .expect("resolve prompt default");
+
+        assert_eq!(prompt_default, "MiniMax-M2.5");
+    }
+
+    #[test]
+    fn resolve_onboarding_model_prompt_default_keeps_auto_for_unreviewed_provider() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Custom;
+        config.provider.model = "auto".to_owned();
+
+        let prompt_default = resolve_onboarding_model_prompt_default(&config.provider, None)
+            .expect("resolve prompt default");
+
+        assert_eq!(prompt_default, "auto");
+    }
+
+    #[test]
+    fn onboarding_model_selection_context_surfaces_preferred_fallback_hint() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+        config.provider.preferred_models = vec!["MiniMax-M1".to_owned()];
+
+        let context = onboarding_model_selection_context(&config.provider);
+
+        assert_eq!(context.current_model, "auto");
+        assert_eq!(context.recommended_model, Some("MiniMax-M2.5".to_owned()));
+        assert_eq!(context.preferred_fallback_models, vec!["MiniMax-M1"]);
+        assert!(context.allows_auto_fallback_hint);
+    }
+
+    #[test]
+    fn onboarding_model_selection_context_hides_duplicate_reviewed_model_note() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "deepseek-chat".to_owned();
+
+        let context = onboarding_model_selection_context(&config.provider);
+
+        assert_eq!(context.recommended_model, None);
+    }
+
+    #[test]
+    fn onboarding_model_catalog_choices_keep_default_first_and_deduplicate() {
+        let available_models = vec![
+            " deepseek-chat ".to_owned(),
+            "deepseek-reasoner".to_owned(),
+            "deepseek-chat".to_owned(),
+            "   ".to_owned(),
+        ];
+
+        let choices = onboarding_model_catalog_choices("deepseek-chat", &available_models);
+
+        assert_eq!(
+            choices.ordered_models,
+            vec!["deepseek-chat".to_owned(), "deepseek-reasoner".to_owned(),]
+        );
+        assert_eq!(choices.default_index, Some(0));
+    }
+}


### PR DESCRIPTION
## Summary
- extract `onboarding_model_policy` so provider-aware onboarding model defaults, reviewed-model notes, and preferred fallback hints are computed in one daemon-local policy module
- route onboarding prompt default resolution and interactive catalog ordering through that shared policy instead of re-deriving the same branching in `onboard_cli`
- keep rendering and ui wording in `onboard_cli` while adding focused regression coverage for explicit overrides, reviewed defaults, preferred fallback hints, and catalog dedupe ordering

## Testing
- cargo fmt --all --check
- cargo test -p loongclaw-daemon onboarding_model -- --test-threads=1
- cargo test -p loongclaw-daemon resolve_model_selection -- --test-threads=1
- cargo test -p loongclaw-daemon model_selection_screen -- --test-threads=1
- cargo test -p loongclaw-daemon -- --test-threads=1
- cargo clippy -p loongclaw-daemon --all-targets -- -D warnings

## Notes
- this clean upstream rebuild supersedes the earlier stacked review branch in chumyin/loongclaw#12
- reviewed default model names referenced here were rechecked against the current DeepSeek and MiniMax official docs while rebuilding this slice

Closes #508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized model selection validation logic for improved code organization.
  * Enhanced error handling and validation in model selection workflows.
  * Optimized display of model auto-fallback hint suggestions based on configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->