### PR TITLE
feat: add registry-backed external stage selection

### DIFF
--- a/crates/app/src/config/memory.rs
+++ b/crates/app/src/config/memory.rs
@@ -18,6 +18,8 @@ pub struct MemoryConfig {
     pub profile: MemoryProfile,
     #[serde(default)]
     pub system: MemorySystemKind,
+    #[serde(default, deserialize_with = "deserialize_memory_system_id")]
+    pub system_id: Option<String>,
     #[serde(default = "default_true")]
     pub fail_open: bool,
     #[serde(default)]
@@ -191,6 +193,7 @@ impl Default for MemoryConfig {
             backend: MemoryBackendKind::default(),
             profile: MemoryProfile::default(),
             system: MemorySystemKind::default(),
+            system_id: None,
             fail_open: default_true(),
             ingest_mode: MemoryIngestMode::default(),
             sqlite_path: default_sqlite_path(),
@@ -231,6 +234,12 @@ impl MemoryConfig {
         self.system
     }
 
+    pub fn resolved_system_id(&self) -> String {
+        self.system_id
+            .clone()
+            .unwrap_or_else(|| self.system.as_str().to_owned())
+    }
+
     pub const fn resolved_mode(&self) -> MemoryMode {
         self.profile.mode()
     }
@@ -260,6 +269,14 @@ impl MemoryConfig {
     }
 }
 
+fn deserialize_memory_system_id<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<String>::deserialize(deserializer)?;
+    Ok(raw.and_then(|value| crate::memory::normalize_system_id(value.as_str())))
+}
+
 fn default_sqlite_path() -> String {
     default_loongclaw_home()
         .join(DEFAULT_SQLITE_FILE)
@@ -283,6 +300,7 @@ const fn default_summary_max_chars() -> usize {
 mod tests {
     use super::*;
     use crate::memory::DEFAULT_MEMORY_SYSTEM_ID;
+    use serde_json::json;
 
     #[test]
     fn memory_profile_defaults_to_window_only() {
@@ -303,6 +321,18 @@ mod tests {
     #[test]
     fn memory_system_rejects_unimplemented_future_variant_ids() {
         assert_eq!(MemorySystemKind::parse_id("lucid"), None);
+    }
+
+    #[test]
+    fn memory_system_field_accepts_registry_backed_string_ids() {
+        let raw = json!({
+            "system_id": "Lucid"
+        });
+
+        let config: MemoryConfig =
+            serde_json::from_value(raw).expect("registry-backed memory.system should deserialize");
+
+        assert_eq!(config.system_id.as_deref(), Some("lucid"));
     }
 
     #[test]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -2228,6 +2228,18 @@ system = " Builtin "
 
     #[test]
     #[cfg(feature = "config-toml")]
+    fn memory_system_id_field_parses_and_normalizes() {
+        let raw = r#"
+[memory]
+system_id = " LuCid "
+"#;
+        let parsed = toml::from_str::<LoongClawConfig>(raw).expect("parse memory.system_id");
+        assert_eq!(parsed.memory.system_id.as_deref(), Some("lucid"));
+        assert_eq!(parsed.memory.resolved_system_id(), "lucid");
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
     fn memory_system_field_rejects_unimplemented_future_variant() {
         let raw = r#"
 [memory]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -32,6 +32,10 @@ use crate::memory::MEMORY_OP_WINDOW;
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
+use crate::memory::{
+    MemorySystem, MemorySystemCapability, MemorySystemMetadata, register_memory_system,
+};
+#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository, SessionState,
 };
@@ -77,6 +81,25 @@ enum FakeTurnResponse {
 }
 
 type CompactHook = Arc<dyn Fn(&str, &[Value]) -> Result<(), String> + Send + Sync>;
+
+#[cfg(feature = "memory-sqlite")]
+struct RegistryRetrieveOnlyConversationMemorySystem;
+
+#[cfg(feature = "memory-sqlite")]
+impl MemorySystem for RegistryRetrieveOnlyConversationMemorySystem {
+    fn id(&self) -> &'static str {
+        "registry-retrieve-only-conversation"
+    }
+
+    fn metadata(&self) -> MemorySystemMetadata {
+        MemorySystemMetadata::new(
+            "registry-retrieve-only-conversation",
+            [MemorySystemCapability::PromptHydration],
+            "Conversation test registry-selected memory system",
+        )
+        .with_supported_pre_assembly_stage_families([crate::memory::MemoryStageFamily::Retrieve])
+    }
+}
 
 struct TraitDefaultToolViewRuntime;
 struct NoopTurnMiddleware {
@@ -3077,6 +3100,73 @@ async fn default_runtime_kernel_build_context_preserves_profile_projection() {
                 && artifact.message_index < assembled.messages.len()
         }),
         "expected a profile artifact descriptor for the injected profile block"
+    );
+
+    let _ = std::fs::remove_file(sqlite_path);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_runtime_build_context_with_registry_selected_system_skips_builtin_memory_projection()
+ {
+    register_memory_system("registry-retrieve-only-conversation", || {
+        Box::new(RegistryRetrieveOnlyConversationMemorySystem)
+    })
+    .expect("register conversation registry-selected memory system");
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_id = unique_acp_test_id("default-runtime-context", "registry-selected-system");
+    let sqlite_path = unique_memory_sqlite_path("registry-selected-system");
+    let mut config = test_config();
+    config.memory.system_id = Some("registry-retrieve-only-conversation".to_owned());
+    config.memory.profile = MemoryProfile::WindowPlusSummary;
+    config.memory.sliding_window = 2;
+    config.memory.sqlite_path = sqlite_path.clone();
+
+    let runtime_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    crate::memory::append_turn_direct(&session_id, "user", "turn 1", &runtime_config)
+        .expect("append turn 1 should succeed");
+    crate::memory::append_turn_direct(&session_id, "assistant", "turn 2", &runtime_config)
+        .expect("append turn 2 should succeed");
+    crate::memory::append_turn_direct(&session_id, "user", "turn 3", &runtime_config)
+        .expect("append turn 3 should succeed");
+
+    let assembled = runtime
+        .build_context(
+            &config,
+            &session_id,
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("build context with registry-selected system");
+
+    let projected_turns = assembled
+        .messages
+        .iter()
+        .filter_map(|message| {
+            let role = message.get("role")?.as_str()?;
+            let content = message.get("content")?.as_str()?;
+            matches!(role, "user" | "assistant").then_some((role.to_owned(), content.to_owned()))
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        projected_turns,
+        vec![
+            ("assistant".to_owned(), "turn 2".to_owned()),
+            ("user".to_owned(), "turn 3".to_owned()),
+        ]
+    );
+    assert!(
+        !assembled.messages.iter().any(|message| {
+            message["role"] == "system"
+                && message["content"]
+                    .as_str()
+                    .is_some_and(|content| content.contains("## Memory Summary"))
+        }),
+        "registry-selected systems without executors should not reuse builtin summary projection"
     );
 
     let _ = std::fs::remove_file(sqlite_path);

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -74,6 +74,9 @@ pub use system_registry::{
     memory_system_id_from_env, register_memory_system, resolve_memory_system,
     resolve_memory_system_selection, supported_memory_system_kind_from_env,
 };
+pub(crate) use system_registry::{
+    registered_memory_system_id, registered_memory_system_id_from_env,
+};
 pub(crate) use workspace_files::{
     WorkspaceMemoryDocumentKind, WorkspaceMemoryDocumentLocation,
     collect_workspace_memory_document_locations,

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -2,12 +2,13 @@ use std::path::Path;
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
-use crate::config::{MemoryMode, MemorySystemKind};
+use crate::config::MemoryMode;
 
 use super::{
-    DerivedMemoryKind, MemoryContextEntry, MemoryRetrievalRequest, MemoryScope, MemoryStageFamily,
-    StageDiagnostics, StageEnvelope, StageOutcome, WindowTurn, load_prompt_context,
-    runtime_config::MemoryRuntimeConfig,
+    DEFAULT_MEMORY_SYSTEM_ID, DerivedMemoryKind, MemoryContextEntry, MemoryRetrievalRequest,
+    MemoryScope, MemoryStageFamily, MemorySystemMetadata, StageDiagnostics, StageEnvelope,
+    StageOutcome, WindowTurn, builtin_pre_assembly_stage_families, describe_memory_system,
+    load_prompt_context, runtime_config::MemoryRuntimeConfig,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,22 +117,27 @@ impl BuiltinMemoryOrchestrator {
         session_id: &str,
         workspace_root: Option<&Path>,
         config: &MemoryRuntimeConfig,
+        metadata: &MemorySystemMetadata,
     ) -> Result<StageEnvelope, String> {
         let recent_window = recent_window_records(session_id, config)?;
         let mut entries = load_prompt_context(session_id, config)?;
-        let retrieval_request = build_builtin_retrieval_request(session_id, config);
+        let retrieval_request = metadata
+            .supports_pre_assembly_stage_family(MemoryStageFamily::Retrieve)
+            .then(|| build_builtin_retrieval_request(session_id, config))
+            .flatten();
 
-        let derive = run_pre_assembly_stage(MemoryStageFamily::Derive, config, || {
+        let derive = run_pre_assembly_stage(MemoryStageFamily::Derive, metadata, config, || {
             run_derivation_stage(session_id, config, &recent_window)
         })?;
         entries.extend(derive.records);
 
-        let retrieve = run_pre_assembly_stage(MemoryStageFamily::Retrieve, config, || {
-            run_retrieval_stage(session_id, workspace_root, config, &recent_window)
-        })?;
+        let retrieve =
+            run_pre_assembly_stage(MemoryStageFamily::Retrieve, metadata, config, || {
+                run_retrieval_stage(session_id, workspace_root, config, &recent_window)
+            })?;
         entries.extend(retrieve.records);
 
-        let rank = run_rank_stage(entries);
+        let rank = run_rank_stage(entries, metadata);
         let diagnostics = vec![derive.diagnostics, retrieve.diagnostics, rank.diagnostics];
 
         Ok(StageEnvelope {
@@ -139,6 +145,7 @@ impl BuiltinMemoryOrchestrator {
                 rank.records,
                 recent_window,
                 diagnostics.as_slice(),
+                metadata.id,
                 config,
             ),
             retrieval_request,
@@ -151,9 +158,10 @@ impl BuiltinMemoryOrchestrator {
         session_id: &str,
         workspace_root: Option<&Path>,
         config: &MemoryRuntimeConfig,
+        metadata: &MemorySystemMetadata,
     ) -> Result<HydratedMemoryContext, String> {
         Ok(self
-            .hydrate_stage_envelope(session_id, workspace_root, config)?
+            .hydrate_stage_envelope(session_id, workspace_root, config, metadata)?
             .hydrated)
     }
 }
@@ -163,6 +171,7 @@ impl HydratedMemoryContext {
         entries: Vec<MemoryContextEntry>,
         recent_window: Vec<WindowTurn>,
         stage_diagnostics: &[StageDiagnostics],
+        system_id: &str,
         config: &MemoryRuntimeConfig,
     ) -> Self {
         let diagnostics = MemoryDiagnostics::from_stage_diagnostics(
@@ -170,6 +179,7 @@ impl HydratedMemoryContext {
             &recent_window,
             &entries,
             stage_diagnostics,
+            system_id,
         );
 
         Self {
@@ -186,6 +196,7 @@ impl MemoryDiagnostics {
         recent_window: &[WindowTurn],
         entries: &[MemoryContextEntry],
         stage_diagnostics: &[StageDiagnostics],
+        system_id: &str,
     ) -> Self {
         let derivation_error = stage_error_message(stage_diagnostics, MemoryStageFamily::Derive);
         let retrieval_error = stage_error_message(stage_diagnostics, MemoryStageFamily::Retrieve);
@@ -197,8 +208,8 @@ impl MemoryDiagnostics {
         });
 
         Self {
-            system_id: MemoryDiagnostics::normalize_system_id(config.system.as_str())
-                .unwrap_or_else(|| config.system.as_str().to_owned()),
+            system_id: MemoryDiagnostics::normalize_system_id(system_id)
+                .unwrap_or_else(|| system_id.to_owned()),
             fail_open: config.effective_fail_open(),
             strict_mode_requested: config.strict_mode_requested(),
             strict_mode_active: config.strict_mode_active(),
@@ -218,12 +229,20 @@ struct StageRunResult {
 
 fn run_pre_assembly_stage<F>(
     family: MemoryStageFamily,
+    metadata: &MemorySystemMetadata,
     config: &MemoryRuntimeConfig,
     runner: F,
 ) -> Result<StageRunResult, String>
 where
     F: FnOnce() -> Result<Vec<MemoryContextEntry>, String>,
 {
+    if !metadata.supports_pre_assembly_stage_family(family) {
+        return Ok(StageRunResult {
+            records: Vec::new(),
+            diagnostics: skipped_stage_diagnostics(family, None),
+        });
+    }
+
     match runner() {
         Ok(records) => Ok(StageRunResult {
             records,
@@ -244,7 +263,17 @@ where
     }
 }
 
-fn run_rank_stage(entries: Vec<MemoryContextEntry>) -> StageRunResult {
+fn run_rank_stage(
+    entries: Vec<MemoryContextEntry>,
+    metadata: &MemorySystemMetadata,
+) -> StageRunResult {
+    if !metadata.supports_pre_assembly_stage_family(MemoryStageFamily::Rank) {
+        return StageRunResult {
+            records: entries,
+            diagnostics: skipped_stage_diagnostics(MemoryStageFamily::Rank, None),
+        };
+    }
+
     // Slice 1 keeps ranking as an identity stage until compaction and external
     // ranking hooks graduate beyond the built-in pipeline contract.
     StageRunResult {
@@ -253,15 +282,39 @@ fn run_rank_stage(entries: Vec<MemoryContextEntry>) -> StageRunResult {
     }
 }
 
+fn skipped_stage_diagnostics(
+    family: MemoryStageFamily,
+    message: Option<String>,
+) -> StageDiagnostics {
+    StageDiagnostics {
+        family,
+        outcome: StageOutcome::Skipped,
+        budget_ms: None,
+        elapsed_ms: None,
+        fallback_activated: false,
+        message,
+    }
+}
+
 pub async fn run_compact_stage(
     session_id: &str,
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
 ) -> Result<StageDiagnostics, String> {
-    match config.system {
-        MemorySystemKind::Builtin => {
+    let selected_system_id = super::registered_memory_system_id(Some(config.selected_system_id()))
+        .unwrap_or_else(|| DEFAULT_MEMORY_SYSTEM_ID.to_owned());
+
+    match selected_system_id.as_str() {
+        DEFAULT_MEMORY_SYSTEM_ID => {
             run_builtin_compact_stage(session_id, workspace_root, config).await
         }
+        _ => Ok(skipped_stage_diagnostics(
+            MemoryStageFamily::Compact,
+            Some(
+                "memory system is registered but has no compact-stage execution adapter yet"
+                    .to_owned(),
+            ),
+        )),
     }
 }
 
@@ -403,11 +456,60 @@ pub(crate) fn hydrate_stage_envelope_with_workspace_root(
     workspace_root: Option<&Path>,
     config: &MemoryRuntimeConfig,
 ) -> Result<StageEnvelope, String> {
-    match config.system {
-        MemorySystemKind::Builtin => {
-            BuiltinMemoryOrchestrator.hydrate_stage_envelope(session_id, workspace_root, config)
-        }
+    let selected_system_id = super::registered_memory_system_id(Some(config.selected_system_id()))
+        .unwrap_or_else(|| DEFAULT_MEMORY_SYSTEM_ID.to_owned());
+    let metadata = describe_memory_system(Some(selected_system_id.as_str()))?;
+
+    if metadata.id == DEFAULT_MEMORY_SYSTEM_ID {
+        return BuiltinMemoryOrchestrator.hydrate_stage_envelope(
+            session_id,
+            workspace_root,
+            config,
+            &metadata,
+        );
     }
+
+    hydrate_stage_envelope_without_execution_adapter(session_id, config, &metadata)
+}
+
+fn hydrate_stage_envelope_without_execution_adapter(
+    session_id: &str,
+    config: &MemoryRuntimeConfig,
+    metadata: &MemorySystemMetadata,
+) -> Result<StageEnvelope, String> {
+    let recent_window = recent_window_records(session_id, config)?;
+    let entries = recent_window
+        .iter()
+        .map(|turn| MemoryContextEntry {
+            kind: super::MemoryContextKind::Turn,
+            role: turn.role.clone(),
+            content: turn.content.clone(),
+        })
+        .collect::<Vec<_>>();
+    let diagnostics = builtin_pre_assembly_stage_families()
+        .into_iter()
+        .map(|family| {
+            let message = metadata
+                .supports_pre_assembly_stage_family(family)
+                .then(|| {
+                    "memory system is registered but has no pre-assembly execution adapter yet"
+                        .to_owned()
+                });
+            skipped_stage_diagnostics(family, message)
+        })
+        .collect::<Vec<_>>();
+
+    Ok(StageEnvelope {
+        hydrated: HydratedMemoryContext::from_stage_parts(
+            entries,
+            recent_window,
+            &diagnostics,
+            metadata.id,
+            config,
+        ),
+        retrieval_request: None,
+        diagnostics,
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -439,7 +541,28 @@ fn recent_window_records(
 mod tests {
     use super::*;
     use crate::config::{MemoryMode, MemoryProfile};
-    use crate::memory::{MemoryContextKind, MemoryStageFamily, StageOutcome, append_turn_direct};
+    use crate::memory::{
+        MemoryContextKind, MemoryStageFamily, MemorySystem, MemorySystemCapability,
+        MemorySystemMetadata, StageOutcome, append_turn_direct,
+        builtin_pre_assembly_stage_families, register_memory_system,
+    };
+
+    struct RegistryRetrieveOnlyMemorySystem;
+
+    impl MemorySystem for RegistryRetrieveOnlyMemorySystem {
+        fn id(&self) -> &'static str {
+            "registry-retrieve-only"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-retrieve-only",
+                [MemorySystemCapability::PromptHydration],
+                "Registry system without an execution adapter yet",
+            )
+            .with_supported_pre_assembly_stage_families([MemoryStageFamily::Retrieve])
+        }
+    }
 
     fn hydrated_memory_temp_dir(prefix: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()))
@@ -782,6 +905,114 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn registry_selected_system_skips_builtin_pre_assembly_execution() {
+        register_memory_system("registry-retrieve-only", || {
+            Box::new(RegistryRetrieveOnlyMemorySystem)
+        })
+        .expect("register registry-selected memory system");
+
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-registry-selected");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("registry-selected.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        config.resolved_system_id = Some("registry-retrieve-only".to_owned());
+
+        append_turn_direct("registry-selected", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("registry-selected", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("registry-selected", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let envelope = hydrate_stage_envelope("registry-selected", &config)
+            .expect("hydrate staged envelope for registry-selected system");
+
+        assert_eq!(
+            envelope.hydrated.diagnostics.system_id,
+            "registry-retrieve-only"
+        );
+        assert_eq!(envelope.hydrated.recent_window.len(), 2);
+        assert_eq!(
+            envelope
+                .hydrated
+                .entries
+                .iter()
+                .filter(|entry| entry.kind == MemoryContextKind::Turn)
+                .map(|entry| (entry.role.as_str(), entry.content.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("assistant", "turn 2"), ("user", "turn 3")]
+        );
+        assert_eq!(envelope.retrieval_request, None);
+        assert_eq!(
+            envelope
+                .diagnostics
+                .iter()
+                .map(|diag| (diag.family, diag.outcome))
+                .collect::<Vec<_>>(),
+            builtin_pre_assembly_stage_families()
+                .into_iter()
+                .map(|family| (family, StageOutcome::Skipped))
+                .collect::<Vec<_>>()
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn unknown_registry_selected_system_falls_back_to_builtin_hydration() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-unknown-selected");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("unknown-selected.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        config.resolved_system_id = Some("lucid".to_owned());
+
+        append_turn_direct("unknown-selected", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct("unknown-selected", "assistant", "turn 2", &config)
+            .expect("append turn 2 should succeed");
+        append_turn_direct("unknown-selected", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let envelope = hydrate_stage_envelope("unknown-selected", &config)
+            .expect("unknown selected system should fall back to builtin");
+
+        assert_eq!(
+            envelope.hydrated.diagnostics.system_id,
+            DEFAULT_MEMORY_SYSTEM_ID
+        );
+        assert!(
+            envelope
+                .hydrated
+                .entries
+                .iter()
+                .any(|entry| entry.kind == MemoryContextKind::Summary),
+            "builtin summary projection should remain available after fallback"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
     #[tokio::test]
     async fn compact_stage_emits_succeeded_diagnostics_when_durable_flush_runs() {
         let tmp = hydrated_memory_temp_dir("loongclaw-compact-stage-succeeded");
@@ -881,6 +1112,56 @@ mod tests {
             run_compact_stage("compact-stage-duplicate", Some(tmp.as_path()), &config)
                 .await
                 .expect("second compact stage run");
+
+        assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
+        assert_eq!(diagnostics.outcome, StageOutcome::Skipped);
+        assert!(!diagnostics.fallback_activated);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn compact_stage_skips_for_registry_selected_system_without_executor() {
+        register_memory_system("registry-retrieve-only", || {
+            Box::new(RegistryRetrieveOnlyMemorySystem)
+        })
+        .expect("register registry-selected memory system");
+
+        let tmp = hydrated_memory_temp_dir("loongclaw-compact-stage-registry-selected");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("compact-stage-registry-selected.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let mut config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        config.resolved_system_id = Some("registry-retrieve-only".to_owned());
+
+        append_turn_direct("compact-stage-registry-selected", "user", "turn 1", &config)
+            .expect("append turn 1 should succeed");
+        append_turn_direct(
+            "compact-stage-registry-selected",
+            "assistant",
+            "turn 2",
+            &config,
+        )
+        .expect("append turn 2 should succeed");
+        append_turn_direct("compact-stage-registry-selected", "user", "turn 3", &config)
+            .expect("append turn 3 should succeed");
+
+        let diagnostics = run_compact_stage(
+            "compact-stage-registry-selected",
+            Some(tmp.as_path()),
+            &config,
+        )
+        .await
+        .expect("run compact stage");
 
         assert_eq!(diagnostics.family, MemoryStageFamily::Compact);
         assert_eq!(diagnostics.outcome, StageOutcome::Skipped);

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -15,6 +15,7 @@ pub struct MemoryRuntimeConfig {
     pub backend: MemoryBackendKind,
     pub profile: MemoryProfile,
     pub system: MemorySystemKind,
+    pub resolved_system_id: Option<String>,
     pub mode: MemoryMode,
     pub fail_open: bool,
     pub ingest_mode: MemoryIngestMode,
@@ -31,6 +32,7 @@ impl Default for MemoryRuntimeConfig {
             backend: defaults.backend,
             profile: defaults.profile,
             system: defaults.system,
+            resolved_system_id: Some(defaults.resolved_system_id()),
             mode: defaults.resolved_mode(),
             fail_open: defaults.fail_open,
             ingest_mode: defaults.ingest_mode,
@@ -48,6 +50,7 @@ impl MemoryRuntimeConfig {
             backend: config.resolved_backend(),
             profile: config.resolved_profile(),
             system: config.resolved_system(),
+            resolved_system_id: Some(config.resolved_system_id()),
             mode: config.resolved_mode(),
             fail_open: config.fail_open,
             ingest_mode: config.ingest_mode,
@@ -76,8 +79,9 @@ impl MemoryRuntimeConfig {
             self.mode = profile.mode();
         }
 
-        if let Some(system) = crate::memory::supported_memory_system_kind_from_env() {
-            self.system = system;
+        if let Some(system_id) = crate::memory::registered_memory_system_id_from_env() {
+            self.system = MemorySystemKind::parse_id(system_id.as_str()).unwrap_or_default();
+            self.resolved_system_id = Some(system_id);
         }
 
         if let Some(fail_open) = parse_bool(std::env::var("LOONGCLAW_MEMORY_FAIL_OPEN").ok()) {
@@ -149,6 +153,12 @@ impl MemoryRuntimeConfig {
     pub const fn effective_fail_open(&self) -> bool {
         !self.strict_mode_active()
     }
+
+    pub fn selected_system_id(&self) -> &str {
+        self.resolved_system_id
+            .as_deref()
+            .unwrap_or(crate::memory::DEFAULT_MEMORY_SYSTEM_ID)
+    }
 }
 
 fn parse_positive_usize(raw: Option<String>) -> Option<usize> {
@@ -188,7 +198,27 @@ pub fn get_memory_runtime_config() -> &'static MemoryRuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::{
+        MEMORY_SYSTEM_ENV, MemorySystem, MemorySystemCapability, MemorySystemMetadata,
+        register_memory_system,
+    };
     use crate::test_support::ScopedEnv;
+
+    struct RuntimeConfigRegistryMemorySystem;
+
+    impl MemorySystem for RuntimeConfigRegistryMemorySystem {
+        fn id(&self) -> &'static str {
+            "registry-runtime-config"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-runtime-config",
+                [MemorySystemCapability::PromptHydration],
+                "Runtime config registry test system",
+            )
+        }
+    }
 
     #[test]
     fn parse_sliding_window_accepts_positive_integer() {
@@ -233,6 +263,7 @@ mod tests {
             backend: MemoryBackendKind::Sqlite,
             profile: MemoryProfile::WindowOnly,
             system: MemorySystemKind::Builtin,
+            resolved_system_id: Some(crate::memory::DEFAULT_MEMORY_SYSTEM_ID.to_owned()),
             mode: MemoryMode::WindowOnly,
             fail_open: true,
             ingest_mode: MemoryIngestMode::SyncMinimal,
@@ -277,6 +308,10 @@ mod tests {
         let runtime = MemoryRuntimeConfig::from_memory_config(&config);
 
         assert_eq!(runtime.system, crate::config::MemorySystemKind::Builtin);
+        assert_eq!(
+            runtime.resolved_system_id.as_deref(),
+            Some(crate::memory::DEFAULT_MEMORY_SYSTEM_ID)
+        );
         assert!(!runtime.fail_open);
         assert!(runtime.strict_mode_requested());
         assert!(!runtime.strict_mode_active());
@@ -321,5 +356,23 @@ mod tests {
             Some(PathBuf::from("/tmp/env-memory.sqlite3"))
         );
         assert_eq!(runtime.profile_note.as_deref(), Some("env profile note"));
+    }
+
+    #[test]
+    fn memory_system_field_preserves_registry_backed_env_selection() {
+        register_memory_system("registry-runtime-config", || {
+            Box::new(RuntimeConfigRegistryMemorySystem)
+        })
+        .expect("register runtime-config registry system");
+        let mut env = ScopedEnv::new();
+        env.set(MEMORY_SYSTEM_ENV, "registry-runtime-config");
+
+        let config = MemoryConfig::default();
+        let runtime = MemoryRuntimeConfig::from_memory_config(&config);
+
+        assert_eq!(
+            runtime.resolved_system_id.as_deref(),
+            Some("registry-runtime-config")
+        );
     }
 }

--- a/crates/app/src/memory/system.rs
+++ b/crates/app/src/memory/system.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+use super::{MemoryStageFamily, builtin_pre_assembly_stage_families};
+
 pub const MEMORY_SYSTEM_API_VERSION: u16 = 1;
 pub const DEFAULT_MEMORY_SYSTEM_ID: &str = "builtin";
 
@@ -28,6 +30,7 @@ pub struct MemorySystemMetadata {
     pub api_version: u16,
     pub capabilities: BTreeSet<MemorySystemCapability>,
     pub summary: &'static str,
+    pub supported_pre_assembly_stage_families: Vec<MemoryStageFamily>,
 }
 
 impl MemorySystemMetadata {
@@ -41,7 +44,16 @@ impl MemorySystemMetadata {
             api_version: MEMORY_SYSTEM_API_VERSION,
             capabilities: capabilities.into_iter().collect(),
             summary,
+            supported_pre_assembly_stage_families: Vec::new(),
         }
+    }
+
+    pub fn with_supported_pre_assembly_stage_families(
+        mut self,
+        families: impl IntoIterator<Item = MemoryStageFamily>,
+    ) -> Self {
+        self.supported_pre_assembly_stage_families = families.into_iter().collect();
+        self
     }
 
     pub fn capability_names(&self) -> Vec<&'static str> {
@@ -53,6 +65,10 @@ impl MemorySystemMetadata {
             .collect::<Vec<_>>();
         names.sort_unstable();
         names
+    }
+
+    pub fn supports_pre_assembly_stage_family(&self, family: MemoryStageFamily) -> bool {
+        self.supported_pre_assembly_stage_families.contains(&family)
     }
 }
 
@@ -94,12 +110,30 @@ impl MemorySystem for BuiltinMemorySystem {
             ],
             "Built-in SQLite-backed canonical memory with deterministic prompt hydration.",
         )
+        .with_supported_pre_assembly_stage_families(builtin_pre_assembly_stage_families())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct StageAwareRegistryMemorySystem;
+
+    impl MemorySystem for StageAwareRegistryMemorySystem {
+        fn id(&self) -> &'static str {
+            "registry-stage-aware"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-stage-aware",
+                [MemorySystemCapability::PromptHydration],
+                "Registry stage-aware test system",
+            )
+            .with_supported_pre_assembly_stage_families([MemoryStageFamily::Retrieve])
+        }
+    }
 
     #[test]
     fn builtin_memory_system_metadata_is_stable() {
@@ -114,6 +148,25 @@ mod tests {
                 "profile_note_projection",
                 "prompt_hydration",
             ]
+        );
+    }
+
+    #[test]
+    fn memory_system_field_exposes_builtin_pre_assembly_stage_families() {
+        let metadata = BuiltinMemorySystem.metadata();
+        assert_eq!(
+            metadata.supported_pre_assembly_stage_families,
+            builtin_pre_assembly_stage_families()
+        );
+    }
+
+    #[test]
+    fn memory_system_field_allows_custom_registry_stage_family_sets() {
+        let custom = StageAwareRegistryMemorySystem.metadata();
+        assert_eq!(custom.id, "registry-stage-aware");
+        assert_eq!(
+            custom.supported_pre_assembly_stage_families,
+            vec![MemoryStageFamily::Retrieve]
         );
     }
 

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -183,21 +183,39 @@ pub fn memory_system_id_from_env() -> Option<String> {
         .and_then(|value| super::normalize_system_id(value.as_str()))
 }
 
+pub(crate) fn registered_memory_system_id(id: Option<&str>) -> Option<String> {
+    let normalized = id.and_then(super::normalize_system_id)?;
+    let guard = registry().read().ok()?;
+    guard.contains_key(&normalized).then_some(normalized)
+}
+
+pub(crate) fn registered_memory_system_id_from_env() -> Option<String> {
+    let env_id = memory_system_id_from_env();
+    registered_memory_system_id(env_id.as_deref())
+}
+
 pub fn supported_memory_system_kind_from_env() -> Option<MemorySystemKind> {
-    memory_system_id_from_env()
+    registered_memory_system_id_from_env()
         .as_deref()
         .and_then(MemorySystemKind::parse_id)
 }
 
 pub fn resolve_memory_system_selection(config: &LoongClawConfig) -> MemorySystemSelection {
-    if let Some(system) = supported_memory_system_kind_from_env() {
+    if let Some(system_id) = registered_memory_system_id_from_env() {
         return MemorySystemSelection {
-            id: system.as_str().to_owned(),
+            id: system_id,
             source: MemorySystemSelectionSource::Env,
         };
     }
 
-    if config.memory.resolved_system() != MemorySystemKind::default() {
+    if let Some(config_system_id) = config.memory.system_id.as_deref() {
+        if let Some(system_id) = registered_memory_system_id(Some(config_system_id)) {
+            return MemorySystemSelection {
+                id: system_id,
+                source: MemorySystemSelectionSource::Config,
+            };
+        }
+    } else if config.memory.resolved_system() != MemorySystemKind::default() {
         return MemorySystemSelection {
             id: config.memory.resolved_system().as_str().to_owned(),
             source: MemorySystemSelectionSource::Config,
@@ -289,6 +307,44 @@ mod tests {
                 [MemorySystemCapability::PromptHydration],
                 "Mismatched registry system",
             )
+        }
+    }
+
+    struct StageAwareRegistrySystem;
+
+    impl MemorySystem for StageAwareRegistrySystem {
+        fn id(&self) -> &'static str {
+            "registry-stage-aware-snapshot"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-stage-aware-snapshot",
+                [MemorySystemCapability::PromptHydration],
+                "Registry snapshot system",
+            )
+            .with_supported_pre_assembly_stage_families([
+                crate::memory::MemoryStageFamily::Retrieve,
+            ])
+        }
+    }
+
+    struct StageAwareRegistrySystemForConfigSelection;
+
+    impl MemorySystem for StageAwareRegistrySystemForConfigSelection {
+        fn id(&self) -> &'static str {
+            "registry-stage-aware-snapshot-config"
+        }
+
+        fn metadata(&self) -> MemorySystemMetadata {
+            MemorySystemMetadata::new(
+                "registry-stage-aware-snapshot-config",
+                [MemorySystemCapability::PromptHydration],
+                "Registry config snapshot system",
+            )
+            .with_supported_pre_assembly_stage_families([
+                crate::memory::MemoryStageFamily::Retrieve,
+            ])
         }
     }
 
@@ -456,12 +512,115 @@ mod tests {
     }
 
     #[test]
+    fn registry_backed_memory_system_env_surfaces_in_runtime_snapshot() {
+        let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
+        register_memory_system("registry-custom", || Box::new(MatchingRegistrySystem))
+            .expect("register custom registry system");
+        env.set(MEMORY_SYSTEM_ENV, "registry-custom");
+
+        let config = LoongClawConfig::default();
+        let snapshot =
+            collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
+
+        assert_eq!(snapshot.selected.id, "registry-custom");
+        assert_eq!(snapshot.selected.source, MemorySystemSelectionSource::Env);
+    }
+
+    #[test]
     fn invalid_memory_system_env_is_ignored_so_snapshot_matches_runtime_behavior() {
         let mut env = ScopedEnv::new();
         clear_memory_runtime_env_overrides(&mut env);
         env.set(MEMORY_SYSTEM_ENV, "lucid");
 
         let config = LoongClawConfig::default();
+        let snapshot =
+            collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
+
+        assert_eq!(snapshot.selected.id, DEFAULT_MEMORY_SYSTEM_ID);
+        assert_eq!(
+            snapshot.selected.source,
+            MemorySystemSelectionSource::Default
+        );
+    }
+
+    #[test]
+    fn memory_system_field_surfaces_registry_backed_selection_and_stage_metadata_in_snapshot() {
+        register_memory_system("registry-stage-aware-snapshot", || {
+            Box::new(StageAwareRegistrySystem)
+        })
+        .expect("register stage-aware registry system");
+
+        let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
+        env.set(MEMORY_SYSTEM_ENV, "registry-stage-aware-snapshot");
+
+        let config = LoongClawConfig::default();
+        let snapshot =
+            collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
+
+        assert_eq!(snapshot.selected.id, "registry-stage-aware-snapshot");
+        assert_eq!(snapshot.selected.source, MemorySystemSelectionSource::Env);
+        assert_eq!(
+            snapshot.selected_metadata.id,
+            "registry-stage-aware-snapshot"
+        );
+        assert_eq!(
+            snapshot
+                .selected_metadata
+                .supported_pre_assembly_stage_families,
+            vec![crate::memory::MemoryStageFamily::Retrieve]
+        );
+    }
+
+    #[test]
+    fn registry_backed_memory_system_config_selection_surfaces_in_runtime_snapshot() {
+        let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
+        register_memory_system("registry-stage-aware-snapshot-config", || {
+            Box::new(StageAwareRegistrySystemForConfigSelection)
+        })
+        .expect("register config-selected registry system");
+
+        let config = LoongClawConfig {
+            memory: crate::config::MemoryConfig {
+                system_id: Some("registry-stage-aware-snapshot-config".to_owned()),
+                ..crate::config::MemoryConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
+        let snapshot =
+            collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
+
+        assert_eq!(snapshot.selected.id, "registry-stage-aware-snapshot-config");
+        assert_eq!(
+            snapshot.selected.source,
+            MemorySystemSelectionSource::Config
+        );
+        assert_eq!(
+            snapshot.selected_metadata.id,
+            "registry-stage-aware-snapshot-config"
+        );
+        assert_eq!(
+            snapshot
+                .selected_metadata
+                .supported_pre_assembly_stage_families,
+            vec![crate::memory::MemoryStageFamily::Retrieve]
+        );
+    }
+
+    #[test]
+    fn unknown_config_selected_memory_system_falls_back_to_builtin_snapshot() {
+        let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
+
+        let config = LoongClawConfig {
+            memory: crate::config::MemoryConfig {
+                system_id: Some("lucid".to_owned()),
+                ..crate::config::MemoryConfig::default()
+            },
+            ..LoongClawConfig::default()
+        };
         let snapshot =
             collect_memory_system_runtime_snapshot(&config).expect("collect runtime snapshot");
 

--- a/crates/app/src/memory/system_registry.rs
+++ b/crates/app/src/memory/system_registry.rs
@@ -246,21 +246,6 @@ pub fn collect_memory_system_runtime_snapshot(
 }
 
 #[cfg(test)]
-pub(crate) fn set_memory_system_env_override(value: Option<&str>) {
-    let normalized = value.and_then(super::normalize_system_id);
-    if let Ok(mut guard) = env_override().lock() {
-        *guard = Some(normalized);
-    }
-}
-
-#[cfg(test)]
-pub(crate) fn clear_memory_system_env_override() {
-    if let Ok(mut guard) = env_override().lock() {
-        *guard = None;
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::memory::{MEMORY_SYSTEM_API_VERSION, MemorySystemCapability};
@@ -414,13 +399,13 @@ mod tests {
 
     #[test]
     fn memory_system_env_overrides_default_selection() {
-        let _env = ScopedEnv::new();
-        set_memory_system_env_override(Some("builtin"));
+        let mut env = ScopedEnv::new();
+        clear_memory_runtime_env_overrides(&mut env);
+        env.set(MEMORY_SYSTEM_ENV, "builtin");
         let config = LoongClawConfig::default();
         let selection = resolve_memory_system_selection(&config);
         assert_eq!(selection.id, DEFAULT_MEMORY_SYSTEM_ID);
         assert_eq!(selection.source, MemorySystemSelectionSource::Env);
-        clear_memory_system_env_override();
     }
 
     #[test]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -4307,6 +4307,12 @@ pub fn memory_system_metadata_json(
     metadata: &mvp::memory::MemorySystemMetadata,
     source: Option<&str>,
 ) -> Value {
+    let supported_pre_assembly_stage_families = metadata
+        .supported_pre_assembly_stage_families
+        .iter()
+        .copied()
+        .map(mvp::memory::MemoryStageFamily::as_str)
+        .collect::<Vec<_>>();
     let mut payload = serde_json::Map::new();
     payload.insert("id".to_owned(), json!(metadata.id));
     payload.insert("api_version".to_owned(), json!(metadata.api_version));
@@ -4314,11 +4320,24 @@ pub fn memory_system_metadata_json(
         "capabilities".to_owned(),
         json!(metadata.capability_names()),
     );
+    payload.insert(
+        "supported_pre_assembly_stage_families".to_owned(),
+        json!(supported_pre_assembly_stage_families),
+    );
     payload.insert("summary".to_owned(), json!(metadata.summary));
     if let Some(source) = source {
         payload.insert("source".to_owned(), json!(source));
     }
     Value::Object(payload)
+}
+
+fn format_memory_stage_family_names(families: &[mvp::memory::MemoryStageFamily]) -> String {
+    let names = families
+        .iter()
+        .copied()
+        .map(mvp::memory::MemoryStageFamily::as_str)
+        .collect::<Vec<_>>();
+    render_string_list(names)
 }
 
 pub fn memory_system_policy_json(policy: &mvp::memory::MemorySystemPolicySnapshot) -> Value {
@@ -4357,14 +4376,21 @@ pub fn render_memory_system_snapshot_text(
     config_path: &str,
     snapshot: &mvp::memory::MemorySystemRuntimeSnapshot,
 ) -> String {
+    let selected_capabilities = snapshot.selected_metadata.capability_names();
+    let selected_pre_assembly_stages = format_memory_stage_family_names(
+        &snapshot
+            .selected_metadata
+            .supported_pre_assembly_stage_families,
+    );
     let mut lines = vec![
         format!("config={config_path}"),
         format!(
-            "selected={} source={} api_version={} capabilities={} summary={}",
+            "selected={} source={} api_version={} capabilities={} pre_assembly_stages={} summary={}",
             snapshot.selected_metadata.id,
             snapshot.selected.source.as_str(),
             snapshot.selected_metadata.api_version,
-            format_capability_names(&snapshot.selected_metadata.capability_names()),
+            format_capability_names(&selected_capabilities),
+            selected_pre_assembly_stages,
             snapshot.selected_metadata.summary
         ),
         format!(
@@ -4382,11 +4408,15 @@ pub fn render_memory_system_snapshot_text(
     ];
 
     for metadata in &snapshot.available {
+        let capabilities = metadata.capability_names();
+        let pre_assembly_stages =
+            format_memory_stage_family_names(&metadata.supported_pre_assembly_stage_families);
         lines.push(format!(
-            "- {} api_version={} capabilities={} summary={}",
+            "- {} api_version={} capabilities={} pre_assembly_stages={} summary={}",
             metadata.id,
             metadata.api_version,
-            format_capability_names(&metadata.capability_names()),
+            format_capability_names(&capabilities),
+            pre_assembly_stages,
             metadata.summary
         ));
     }

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -514,7 +514,7 @@ fn render_channel_surfaces_text_reports_catalog_only_channels() {
 }
 
 #[test]
-fn memory_system_metadata_json_includes_summary_and_source() {
+fn memory_system_metadata_json_includes_stage_families_summary_and_source() {
     use mvp::memory::MemorySystem as _;
 
     let metadata = mvp::memory::BuiltinMemorySystem.metadata();
@@ -535,6 +535,10 @@ fn memory_system_metadata_json_includes_summary_and_source() {
             .expect("capabilities should be an array")
             .iter()
             .any(|entry| entry == "canonical_store")
+    );
+    assert_eq!(
+        payload["supported_pre_assembly_stage_families"],
+        json!(["derive", "retrieve", "rank"])
     );
 }
 
@@ -557,6 +561,10 @@ fn build_memory_systems_cli_json_payload_includes_runtime_policy() {
     assert_eq!(payload["config"], "/tmp/loongclaw.toml");
     assert_eq!(payload["selected"]["id"], "builtin");
     assert_eq!(payload["selected"]["source"], "default");
+    assert_eq!(
+        payload["selected"]["supported_pre_assembly_stage_families"],
+        json!(["derive", "retrieve", "rank"])
+    );
     assert_eq!(payload["policy"]["backend"], "sqlite");
     assert_eq!(payload["policy"]["profile"], "window_plus_summary");
     assert_eq!(payload["policy"]["mode"], "window_plus_summary");
@@ -584,8 +592,13 @@ fn render_memory_system_snapshot_text_reports_fail_open_policy() {
     let rendered = render_memory_system_snapshot_text("/tmp/loongclaw.toml", &snapshot);
 
     assert!(rendered.contains("config=/tmp/loongclaw.toml"));
-    assert!(rendered.contains("selected=builtin source=default api_version=1"));
+    assert!(rendered.contains(
+        "selected=builtin source=default api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration pre_assembly_stages=derive,retrieve,rank"
+    ));
     assert!(rendered.contains("policy=backend:sqlite profile:window_plus_summary mode:window_plus_summary ingest_mode:async_background fail_open:false strict_mode_requested:true strict_mode_active:false effective_fail_open:true"));
+    assert!(rendered.contains(
+        "- builtin api_version=1 capabilities=canonical_store,deterministic_summary,profile_note_projection,prompt_hydration pre_assembly_stages=derive,retrieve,rank"
+    ));
 }
 
 #[test]

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-25T00:59:36Z
+- Generated at: 2026-03-25T04:00:09Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -14,7 +14,7 @@
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 365 | 1000 | 635 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 353 | 650 | 297 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| memory_mod | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -42,7 +42,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
 <!-- arch-hotspot key=provider_mod lines=365 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=353 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  The staged memory contract added in `#464` and `#515` is still builtin-only. LoongClaw can describe memory systems in the registry, but config/runtime selection and pre-assembly execution still collapse back to builtin behavior, so there is no governed path toward external stage registration.
- Why it matters:
  The next step toward a scriptable memory system is letting runtime selection resolve registered external systems without surrendering runtime ownership. We need a typed way to select a registered system, surface its stage-family metadata, and keep builtin as the safe fallback when the selected id is unknown or has no execution adapter yet.
- What changed:
  Added string-backed `memory.system_id` config support, carried the resolved registered system id through `MemoryRuntimeConfig`, exposed `supported_pre_assembly_stage_families` on `MemorySystemMetadata`, surfaced registry-backed selection in runtime snapshots, and taught pre-assembly hydration / compact-stage dispatch to respect the resolved registered system id. Registered non-builtin systems without execution adapters now skip builtin stage execution while preserving recent-window turn projection.
- What did not change (scope boundary):
  This PR does not add arbitrary scripting, external execution adapters, compact-stage registration for custom systems, or candidate-pipeline evolution. Builtin remains the default, and runtime-owned ordering / final prompt assembly stay unchanged.

## Linked Issues

- Closes none; follow-up only
- Related #455

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
$ cargo fmt --all -- --check
Passed.

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Passed with no warnings.

$ cargo test --workspace --locked
Passed.

$ cargo test --workspace --all-features --locked
Passed.

$ bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
Initially failed because memory_mod line count drifted from 353 to 356 after this slice.

$ bash scripts/generate_architecture_drift_report.sh docs/releases/architecture-drift-2026-03.md
Regenerated the tracked report.

$ bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
Passed after refresh.
```

Before / after behavior and regression coverage:
- Explicit registered path: `[memory].system_id = "registry-stage-aware-snapshot-config"` and `LOONGCLAW_MEMORY_SYSTEM=registry-runtime-config` now survive config/env resolution and surface in runtime snapshots.
- Fallback path: unknown config/env ids like `lucid` now fall back to builtin selection and builtin hydration instead of becoming hard failures or leaking unresolved ids into diagnostics.
- Boundary path: registry-selected systems with no execution adapter skip builtin summary/profile projection and compact-stage execution, but still preserve recent-window turns.
- Regression coverage: config TOML parse tests, runtime-config env tests, runtime snapshot tests for explicit and fallback selection, orchestrator tests for inert registry systems and unknown-id fallback, and a conversation runtime integration test for recent-window-only projection.
- Process-global env tests use `ScopedEnv`, which restores environment state at the end of each test and serializes the temporary override scope.

## User-visible / Operator-visible Changes

- Operators can now select a registered memory system by string id via `[memory].system_id` or `LOONGCLAW_MEMORY_SYSTEM`.
- Runtime snapshots now report the selected registered memory system and its supported pre-assembly stage families.
- If a selected registered system has no execution adapter yet, LoongClaw preserves recent-window context but skips builtin summary/profile and compact-stage execution instead of silently treating the system as builtin.

## Failure Recovery

- Fast rollback or disable path:
  Remove `memory.system_id` / `LOONGCLAW_MEMORY_SYSTEM`, or point them back to `builtin`.
- Observable failure symptoms reviewers should watch for:
  Missing builtin summary/profile context when a non-builtin registered system is selected without an execution adapter, or runtime snapshots reporting an unexpected selected id/source.

## Reviewer Focus

- `crates/app/src/memory/system_registry.rs` for registered-id resolution, fallback semantics, and snapshot selection/source behavior.
- `crates/app/src/memory/orchestrator.rs` for the inert external-system path, especially preserving recent turns while skipping builtin stage execution and compact dispatch.
- `crates/app/src/conversation/tests.rs` for the integration expectation that registry-selected systems do not reuse builtin summary projection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `system_id` configuration option to select specific memory systems
  * Memory systems now declare and advertise their supported processing stages
  * Enabled registry-based memory system selection via configuration and environment variables
  * Enhanced reporting displays which processing stages each memory system supports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->