### PR TITLE
test(onboard): restore the valid gpt-5.4 shortcut fixture

### DIFF
--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -3780,7 +3780,7 @@ fn onboard_current_setup_shortcut_is_disabled_by_web_search_provider_option() {
 #[test]
 fn onboard_detected_setup_shortcut_screen_summarizes_starting_point_and_choices() {
     let mut config = mvp::config::LoongClawConfig::default();
-    config.provider.model = "gpt-5.2".to_owned();
+    config.provider.model = "gpt-5.4".to_owned();
     config.telegram.enabled = true;
 
     let lines = loongclaw_daemon::onboard_cli::render_continue_detected_setup_screen_lines(
@@ -3807,7 +3807,7 @@ fn onboard_detected_setup_shortcut_screen_summarizes_starting_point_and_choices(
         "detected-setup shortcut should summarize the active provider with the guided display name: {lines:#?}"
     );
     assert!(
-        lines.iter().any(|line| line.contains("- model: gpt-5.2")),
+        lines.iter().any(|line| line.contains("- model: gpt-5.4")),
         "detected-setup shortcut should summarize the active model: {lines:#?}"
     );
     assert!(


### PR DESCRIPTION
## summary

- restore the original valid `gpt-5.4` fixture in the onboarding shortcut summary integration coverage
- keep the rest of the `#519` follow-up intact and limit this PR to the mistaken model-name downgrade

## why

A follow-up in `#519` replaced this fixture with `gpt-5.2` after an incorrect documentation check. The scenario under test only needs a valid configured model string, and `gpt-5.4` is a valid current OpenAI model, so the earlier fixture should stay intact.

Fixes #529

## validation

- `cargo fmt --all -- --check`
- `cargo test -p loongclaw-daemon onboard_detected_setup_shortcut_screen_summarizes_starting_point_and_choices --locked`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test configuration values and their corresponding assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->