### PR TITLE
feat(onboard): add region endpoint selection for multi-region providers

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -225,6 +225,7 @@ mod tests {
                 "sglang",
                 "siliconflow",
                 "stepfun",
+                "step_plan",
                 "together",
                 "venice",
                 "vercel_ai_gateway",
@@ -330,6 +331,12 @@ mod tests {
             config.default_api_key_env().as_deref(),
             Some("OPENROUTER_API_KEY")
         );
+    }
+
+    #[test]
+    fn provider_display_names_remain_stable_for_tool_contracts() {
+        assert_eq!(ProviderKind::Stepfun.display_name(), "StepFun");
+        assert_eq!(ProviderKind::Zhipu.display_name(), "Zhipu");
     }
 
     #[test]
@@ -1071,6 +1078,20 @@ kind = "volcengine_coding"
         assert!(hint.contains("provider.base_url"));
         assert!(hint.contains("https://open.bigmodel.cn"));
         assert!(hint.contains("https://api.z.ai"));
+    }
+
+    #[test]
+    fn zhipu_region_endpoint_info_uses_normalized_family_label_and_ordered_variants() {
+        let region_info = ProviderKind::Zhipu
+            .region_endpoint_info()
+            .expect("zhipu should expose onboarding region info");
+
+        assert_eq!(region_info.family_label, "Z.ai");
+        assert_eq!(region_info.variants.len(), 2);
+        assert_eq!(region_info.variants[0].label, "CN");
+        assert_eq!(region_info.variants[0].base_url, "https://open.bigmodel.cn");
+        assert_eq!(region_info.variants[1].label, "Global");
+        assert_eq!(region_info.variants[1].base_url, "https://api.z.ai");
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -128,14 +128,12 @@ pub enum ModelCatalogProbeRecovery {
 
 /// Information about a provider's region endpoint variants.
 /// Used to allow users to select between different regional endpoints (e.g., CN vs Global).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderRegionEndpointInfo {
     /// Display name for the provider family (e.g., "MiniMax", "Moonshot Kimi").
     pub family_label: &'static str,
-    /// The default region variant (label and base URL).
-    pub default_variant: RegionVariant,
-    /// The alternate region variant (label and base URL).
-    pub alternate_variant: RegionVariant,
+    /// Region variants ordered with the default endpoint first.
+    pub variants: Vec<RegionVariant>,
 }
 
 /// A region endpoint variant with label and base URL.
@@ -2035,7 +2033,7 @@ impl ProviderKind {
             ProviderKind::Sambanova => "SambaNova",
             ProviderKind::Sglang => "SGLang",
             ProviderKind::Siliconflow => "SiliconFlow",
-            ProviderKind::Stepfun => "Stepfun API",
+            ProviderKind::Stepfun => "StepFun",
             ProviderKind::StepPlan => "Step Plan",
             ProviderKind::Together => "Together",
             ProviderKind::Venice => "Venice",
@@ -2045,7 +2043,7 @@ impl ProviderKind {
             ProviderKind::VolcengineCoding => "Volcengine Coding",
             ProviderKind::Xai => "xAI",
             ProviderKind::Zai => "Z.ai",
-            ProviderKind::Zhipu => "Z.ai(Zhipu)",
+            ProviderKind::Zhipu => "Zhipu",
         }
     }
 
@@ -2364,16 +2362,24 @@ impl ProviderKind {
 
     pub fn region_endpoint_info(self) -> Option<ProviderRegionEndpointInfo> {
         let guide = self.region_endpoint_guide()?;
-        Some(ProviderRegionEndpointInfo {
-            family_label: guide.family_label,
-            default_variant: RegionVariant {
+        let family_label = if matches!(self, ProviderKind::Zai | ProviderKind::Zhipu) {
+            "Z.ai"
+        } else {
+            guide.family_label
+        };
+        let variants = vec![
+            RegionVariant {
                 label: guide.default_variant.label,
                 base_url: guide.default_variant.base_url,
             },
-            alternate_variant: RegionVariant {
+            RegionVariant {
                 label: guide.alternate_variant.label,
                 base_url: guide.alternate_variant.base_url,
             },
+        ];
+        Some(ProviderRegionEndpointInfo {
+            family_label,
+            variants,
         })
     }
 }

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -126,6 +126,27 @@ pub enum ModelCatalogProbeRecovery {
     },
 }
 
+/// Information about a provider's region endpoint variants.
+/// Used to allow users to select between different regional endpoints (e.g., CN vs Global).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderRegionEndpointInfo {
+    /// Display name for the provider family (e.g., "MiniMax", "Moonshot Kimi").
+    pub family_label: &'static str,
+    /// The default region variant (label and base URL).
+    pub default_variant: RegionVariant,
+    /// The alternate region variant (label and base URL).
+    pub alternate_variant: RegionVariant,
+}
+
+/// A region endpoint variant with label and base URL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegionVariant {
+    /// Label for the region (e.g., "CN", "Global").
+    pub label: &'static str,
+    /// Base URL for the region endpoint.
+    pub base_url: &'static str,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ProviderRegionEndpointVariant {
     label: &'static str,
@@ -428,6 +449,8 @@ pub enum ProviderKind {
     Siliconflow,
     #[serde(alias = "stepfun_compatible")]
     Stepfun,
+    #[serde(alias = "stepfun_step_plan", alias = "step_plan")]
+    StepPlan,
     #[serde(alias = "together_compatible", alias = "together_ai")]
     Together,
     #[serde(alias = "venice_compatible")]
@@ -2012,7 +2035,8 @@ impl ProviderKind {
             ProviderKind::Sambanova => "SambaNova",
             ProviderKind::Sglang => "SGLang",
             ProviderKind::Siliconflow => "SiliconFlow",
-            ProviderKind::Stepfun => "StepFun",
+            ProviderKind::Stepfun => "Stepfun API",
+            ProviderKind::StepPlan => "Step Plan",
             ProviderKind::Together => "Together",
             ProviderKind::Venice => "Venice",
             ProviderKind::VercelAiGateway => "Vercel AI Gateway",
@@ -2021,7 +2045,7 @@ impl ProviderKind {
             ProviderKind::VolcengineCoding => "Volcengine Coding",
             ProviderKind::Xai => "xAI",
             ProviderKind::Zai => "Z.ai",
-            ProviderKind::Zhipu => "Zhipu",
+            ProviderKind::Zhipu => "Z.ai(Zhipu)",
         }
     }
 
@@ -2062,6 +2086,7 @@ impl ProviderKind {
             sglang,
             siliconflow,
             stepfun,
+            step_plan,
             together,
             venice,
             vercel_ai_gateway,
@@ -2105,6 +2130,7 @@ impl ProviderKind {
             ProviderKind::Sglang => sglang,
             ProviderKind::Siliconflow => siliconflow,
             ProviderKind::Stepfun => stepfun,
+            ProviderKind::StepPlan => step_plan,
             ProviderKind::Together => together,
             ProviderKind::Venice => venice,
             ProviderKind::VercelAiGateway => vercel_ai_gateway,
@@ -2268,6 +2294,17 @@ impl ProviderKind {
                     base_url: "https://api.z.ai",
                 },
             }),
+            ProviderKind::Stepfun => Some(ProviderRegionEndpointGuide {
+                family_label: "Stepfun",
+                default_variant: ProviderRegionEndpointVariant {
+                    label: "CN",
+                    base_url: "https://api.stepfun.com",
+                },
+                alternate_variant: ProviderRegionEndpointVariant {
+                    label: "Global",
+                    base_url: "https://api.stepfun.ai",
+                },
+            }),
             ProviderKind::Anthropic
             | ProviderKind::Bedrock
             | ProviderKind::Byteplus
@@ -2296,7 +2333,7 @@ impl ProviderKind {
             | ProviderKind::Sambanova
             | ProviderKind::Sglang
             | ProviderKind::Siliconflow
-            | ProviderKind::Stepfun
+            | ProviderKind::StepPlan
             | ProviderKind::Together
             | ProviderKind::Venice
             | ProviderKind::VercelAiGateway
@@ -2324,6 +2361,21 @@ impl ProviderKind {
             None
         }
     }
+
+    pub fn region_endpoint_info(self) -> Option<ProviderRegionEndpointInfo> {
+        let guide = self.region_endpoint_guide()?;
+        Some(ProviderRegionEndpointInfo {
+            family_label: guide.family_label,
+            default_variant: RegionVariant {
+                label: guide.default_variant.label,
+                base_url: guide.default_variant.base_url,
+            },
+            alternate_variant: RegionVariant {
+                label: guide.alternate_variant.label,
+                base_url: guide.alternate_variant.base_url,
+            },
+        })
+    }
 }
 
 pub fn parse_provider_kind_id(raw: &str) -> Option<ProviderKind> {
@@ -2344,7 +2396,7 @@ pub fn parse_provider_kind_id(raw: &str) -> Option<ProviderKind> {
     None
 }
 
-const PROVIDER_KIND_ORDER: [ProviderKind; 40] = [
+const PROVIDER_KIND_ORDER: [ProviderKind; 41] = [
     ProviderKind::Anthropic,
     ProviderKind::BailianCoding,
     ProviderKind::Bedrock,
@@ -2376,6 +2428,7 @@ const PROVIDER_KIND_ORDER: [ProviderKind; 40] = [
     ProviderKind::Sglang,
     ProviderKind::Siliconflow,
     ProviderKind::Stepfun,
+    ProviderKind::StepPlan,
     ProviderKind::Together,
     ProviderKind::Venice,
     ProviderKind::VercelAiGateway,
@@ -2387,7 +2440,7 @@ const PROVIDER_KIND_ORDER: [ProviderKind; 40] = [
     ProviderKind::Zhipu,
 ];
 
-const PROVIDER_PROFILES: [ProviderProfile; 40] = [
+const PROVIDER_PROFILES: [ProviderProfile; 41] = [
     ProviderProfile {
         kind: ProviderKind::Anthropic,
         id: "anthropic",
@@ -2920,6 +2973,23 @@ const PROVIDER_PROFILES: [ProviderProfile; 40] = [
         base_url: "https://api.stepfun.com",
         chat_completions_path: "/v1/chat/completions",
         models_path: Some("/v1/models"),
+        protocol_family: ProviderProtocolFamily::OpenAiChatCompletions,
+        auth_scheme: ProviderAuthScheme::Bearer,
+        default_headers: &[],
+        default_api_key_env: Some("STEP_API_KEY"),
+        api_key_env_aliases: &[],
+        default_user_agent: None,
+        default_oauth_access_token_env: None,
+        oauth_access_token_env_aliases: &[],
+        feature_family: ProviderFeatureFamily::OpenAiCompatible,
+    },
+    ProviderProfile {
+        kind: ProviderKind::StepPlan,
+        id: "step_plan",
+        aliases: &["stepfun_step_plan", "step_plan"],
+        base_url: "https://api.stepfun.ai",
+        chat_completions_path: "/step_plan/v1/chat/completions",
+        models_path: Some("/step_plan/v1/models"),
         protocol_family: ProviderProtocolFamily::OpenAiChatCompletions,
         auth_scheme: ProviderAuthScheme::Bearer,
         default_headers: &[],

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1689,22 +1689,46 @@ fn resolve_provider_selection(
                 .and_then(parse_provider_kind)
         })
         .unwrap_or(config.provider.kind);
-    let provider_kinds = mvp::config::ProviderKind::all_sorted();
-    let select_options: Vec<SelectOption> = provider_kinds
+    let provider_kinds = mvp::config::ProviderKind::all_sorted()
+        .into_iter()
+        .filter(|kind| {
+            **kind != mvp::config::ProviderKind::Zai
+                && **kind != mvp::config::ProviderKind::Kimi
+                && **kind != mvp::config::ProviderKind::KimiCoding
+                && **kind != mvp::config::ProviderKind::Stepfun
+                && **kind != mvp::config::ProviderKind::StepPlan
+        })
+        .collect::<Vec<_>>();
+    let mut select_options: Vec<SelectOption> = provider_kinds
         .iter()
         .map(|kind| SelectOption {
-            label: provider_kind_display_name(*kind).to_owned(),
-            slug: provider_kind_id(*kind).to_owned(),
+            label: provider_kind_display_name(**kind).to_owned(),
+            slug: provider_kind_id(**kind).to_owned(),
             description: String::new(),
-            recommended: *kind == default_provider_kind,
+            recommended: **kind == default_provider_kind,
         })
         .collect();
+    select_options.push(SelectOption {
+        label: "Kimi".to_owned(),
+        slug: "kimi".to_owned(),
+        description: "Kimi API or Kimi Coding".to_owned(),
+        recommended: default_provider_kind == mvp::config::ProviderKind::Kimi
+            || default_provider_kind == mvp::config::ProviderKind::KimiCoding,
+    });
+    select_options.push(SelectOption {
+        label: "Stepfun".to_owned(),
+        slug: "stepfun".to_owned(),
+        description: "Stepfun API or Step Plan".to_owned(),
+        recommended: default_provider_kind == mvp::config::ProviderKind::Stepfun
+            || default_provider_kind == mvp::config::ProviderKind::StepPlan,
+    });
+    select_options.sort_by(|a, b| a.label.cmp(&b.label));
     let default_idx = if provider_selection.requires_explicit_choice {
         None
     } else {
         provider_kinds
             .iter()
-            .position(|kind| *kind == default_provider_kind)
+            .position(|kind| **kind == default_provider_kind)
     };
     print_lines(
         ui,
@@ -1720,14 +1744,120 @@ fn resolve_provider_selection(
         default_idx,
         SelectInteractionMode::List,
     )?;
-    let kind = *provider_kinds
+    let selected_slug = select_options
         .get(idx)
-        .ok_or_else(|| format!("provider selection index {idx} out of range"))?;
-    Ok(resolve_provider_config_from_selection(
+        .ok_or_else(|| format!("provider selection index {idx} out of range"))?
+        .slug
+        .clone();
+
+    let kind: mvp::config::ProviderKind = if selected_slug == "kimi" {
+        let kimi_options = vec![
+            SelectOption {
+                label: "Kimi API".to_owned(),
+                slug: "kimi_api".to_owned(),
+                description: "Standard Kimi chat completion API".to_owned(),
+                recommended: true,
+            },
+            SelectOption {
+                label: "Kimi Coding".to_owned(),
+                slug: "kimi_coding".to_owned(),
+                description: "Kimi for coding tasks".to_owned(),
+                recommended: false,
+            },
+        ];
+        print_lines(ui, vec!["Select the Kimi variant:".to_owned()])?;
+        let sub_idx = ui.select_one(
+            "Kimi variant",
+            &kimi_options,
+            Some(0),
+            SelectInteractionMode::List,
+        )?;
+        let sub_slug = kimi_options
+            .get(sub_idx)
+            .ok_or_else(|| format!("kimi variant index {sub_idx} out of range"))?
+            .slug
+            .clone();
+        if sub_slug == "kimi_coding" {
+            mvp::config::ProviderKind::KimiCoding
+        } else {
+            mvp::config::ProviderKind::Kimi
+        }
+    } else if selected_slug == "stepfun" {
+        let stepfun_options = vec![
+            SelectOption {
+                label: "Stepfun API".to_owned(),
+                slug: "stepfun_api".to_owned(),
+                description: "Standard Stepfun chat completion API".to_owned(),
+                recommended: true,
+            },
+            SelectOption {
+                label: "Step Plan".to_owned(),
+                slug: "step_plan".to_owned(),
+                description: "Step Plan for specialized tasks".to_owned(),
+                recommended: false,
+            },
+        ];
+        print_lines(ui, vec!["Select the Stepfun variant:".to_owned()])?;
+        let sub_idx = ui.select_one(
+            "Stepfun variant",
+            &stepfun_options,
+            Some(0),
+            SelectInteractionMode::List,
+        )?;
+        let sub_slug = stepfun_options
+            .get(sub_idx)
+            .ok_or_else(|| format!("stepfun variant index {sub_idx} out of range"))?
+            .slug
+            .clone();
+        if sub_slug == "step_plan" {
+            mvp::config::ProviderKind::StepPlan
+        } else {
+            mvp::config::ProviderKind::Stepfun
+        }
+    } else {
+        **provider_kinds
+            .iter()
+            .find(|k| provider_kind_id(***k) == selected_slug)
+            .ok_or_else(|| format!("provider kind not found for slug {}", selected_slug))?
+    };
+
+    let mut provider_config = resolve_provider_config_from_selection(
         &config.provider,
         provider_selection,
         kind,
-    ))
+    );
+
+    if let Some(region_info) = kind.region_endpoint_info() {
+        let region_options = vec![
+            SelectOption {
+                label: format!("{} (default)", region_info.default_variant.label),
+                slug: region_info.default_variant.base_url.to_owned(),
+                description: format!("endpoint: {}", region_info.default_variant.base_url),
+                recommended: true,
+            },
+            SelectOption {
+                label: region_info.alternate_variant.label.to_owned(),
+                slug: region_info.alternate_variant.base_url.to_owned(),
+                description: format!("endpoint: {}", region_info.alternate_variant.base_url),
+                recommended: false,
+            },
+        ];
+        print_lines(ui, vec![format!("Select the {} region endpoint:", region_info.family_label)])?;
+        let region_idx = ui.select_one(
+            "Region",
+            &region_options,
+            Some(0),
+            SelectInteractionMode::List,
+        )?;
+        let selected_base_url = region_options
+            .get(region_idx)
+            .ok_or_else(|| format!("region selection index {region_idx} out of range"))?
+            .slug
+            .clone();
+        provider_config.set_base_url(selected_base_url);
+    }
+
+    Ok(provider_config)
 }
 
 pub fn resolve_provider_config_from_selector(

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -1690,22 +1690,22 @@ fn resolve_provider_selection(
         })
         .unwrap_or(config.provider.kind);
     let provider_kinds = mvp::config::ProviderKind::all_sorted()
-        .into_iter()
+        .iter()
+        .copied()
         .filter(|kind| {
-            **kind != mvp::config::ProviderKind::Zai
-                && **kind != mvp::config::ProviderKind::Kimi
-                && **kind != mvp::config::ProviderKind::KimiCoding
-                && **kind != mvp::config::ProviderKind::Stepfun
-                && **kind != mvp::config::ProviderKind::StepPlan
+            *kind != mvp::config::ProviderKind::Kimi
+                && *kind != mvp::config::ProviderKind::KimiCoding
+                && *kind != mvp::config::ProviderKind::Stepfun
+                && *kind != mvp::config::ProviderKind::StepPlan
         })
         .collect::<Vec<_>>();
     let mut select_options: Vec<SelectOption> = provider_kinds
         .iter()
         .map(|kind| SelectOption {
-            label: provider_kind_display_name(**kind).to_owned(),
-            slug: provider_kind_id(**kind).to_owned(),
+            label: provider_kind_display_name(*kind).to_owned(),
+            slug: provider_kind_id(*kind).to_owned(),
             description: String::new(),
-            recommended: **kind == default_provider_kind,
+            recommended: *kind == default_provider_kind,
         })
         .collect();
     select_options.push(SelectOption {
@@ -1723,12 +1723,25 @@ fn resolve_provider_selection(
             || default_provider_kind == mvp::config::ProviderKind::StepPlan,
     });
     select_options.sort_by(|a, b| a.label.cmp(&b.label));
+    let default_provider_slug = if matches!(
+        default_provider_kind,
+        mvp::config::ProviderKind::Kimi | mvp::config::ProviderKind::KimiCoding
+    ) {
+        "kimi"
+    } else if matches!(
+        default_provider_kind,
+        mvp::config::ProviderKind::Stepfun | mvp::config::ProviderKind::StepPlan
+    ) {
+        "stepfun"
+    } else {
+        provider_kind_id(default_provider_kind)
+    };
     let default_idx = if provider_selection.requires_explicit_choice {
         None
     } else {
-        provider_kinds
+        select_options
             .iter()
-            .position(|kind| **kind == default_provider_kind)
+            .position(|option| option.slug == default_provider_slug)
     };
     print_lines(
         ui,
@@ -1766,10 +1779,13 @@ fn resolve_provider_selection(
             },
         ];
         print_lines(ui, vec!["Select the Kimi variant:".to_owned()])?;
+        let kimi_default_idx = Some(usize::from(
+            default_provider_kind == mvp::config::ProviderKind::KimiCoding,
+        ));
         let sub_idx = ui.select_one(
             "Kimi variant",
             &kimi_options,
-            Some(0),
+            kimi_default_idx,
             SelectInteractionMode::List,
         )?;
         let sub_slug = kimi_options
@@ -1798,10 +1814,13 @@ fn resolve_provider_selection(
             },
         ];
         print_lines(ui, vec!["Select the Stepfun variant:".to_owned()])?;
+        let stepfun_default_idx = Some(usize::from(
+            default_provider_kind == mvp::config::ProviderKind::StepPlan,
+        ));
         let sub_idx = ui.select_one(
             "Stepfun variant",
             &stepfun_options,
-            Some(0),
+            stepfun_default_idx,
             SelectInteractionMode::List,
         )?;
         let sub_slug = stepfun_options
@@ -1815,38 +1834,51 @@ fn resolve_provider_selection(
             mvp::config::ProviderKind::Stepfun
         }
     } else {
-        **provider_kinds
+        provider_kinds
             .iter()
-            .find(|k| provider_kind_id(***k) == selected_slug)
+            .find(|kind| provider_kind_id(**kind) == selected_slug)
+            .copied()
             .ok_or_else(|| format!("provider kind not found for slug {}", selected_slug))?
     };
 
-    let mut provider_config = resolve_provider_config_from_selection(
-        &config.provider,
-        provider_selection,
-        kind,
-    );
+    let mut provider_config =
+        resolve_provider_config_from_selection(&config.provider, provider_selection, kind);
 
     if let Some(region_info) = kind.region_endpoint_info() {
-        let region_options = vec![
-            SelectOption {
-                label: format!("{} (default)", region_info.default_variant.label),
-                slug: region_info.default_variant.base_url.to_owned(),
-                description: format!("endpoint: {}", region_info.default_variant.base_url),
-                recommended: true,
-            },
-            SelectOption {
-                label: region_info.alternate_variant.label.to_owned(),
-                slug: region_info.alternate_variant.base_url.to_owned(),
-                description: format!("endpoint: {}", region_info.alternate_variant.base_url),
-                recommended: false,
-            },
-        ];
-        print_lines(ui, vec![format!("Select the {} region endpoint:", region_info.family_label)])?;
+        let configured_base_url = provider_config.base_url.as_str();
+        let default_region_idx = region_info
+            .variants
+            .iter()
+            .position(|variant| variant.base_url == configured_base_url)
+            .unwrap_or(0);
+        let region_options = region_info
+            .variants
+            .iter()
+            .enumerate()
+            .map(|(index, variant)| {
+                let is_default_variant = index == 0;
+                let label = if is_default_variant {
+                    format!("{} (default)", variant.label)
+                } else {
+                    variant.label.to_owned()
+                };
+                let slug = variant.base_url.to_owned();
+                let description = format!("endpoint: {}", variant.base_url);
+                let recommended = index == default_region_idx;
+                SelectOption {
+                    label,
+                    slug,
+                    description,
+                    recommended,
+                }
+            })
+            .collect::<Vec<_>>();
+        let region_prompt = format!("Select the {} region endpoint:", region_info.family_label);
+        print_lines(ui, vec![region_prompt])?;
         let region_idx = ui.select_one(
             "Region",
             &region_options,
-            Some(0),
+            Some(default_region_idx),
             SelectInteractionMode::List,
         )?;
         let selected_base_url = region_options
@@ -6339,6 +6371,28 @@ mod tests {
         }
     }
 
+    fn interactive_onboard_options() -> OnboardCommandOptions {
+        OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            web_search_provider: None,
+            web_search_api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        }
+    }
+
+    fn onboard_test_context() -> OnboardRuntimeContext {
+        OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>())
+    }
+
     fn browser_companion_temp_dir(label: &str) -> PathBuf {
         static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
         let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
@@ -8024,6 +8078,100 @@ mod tests {
             is_explicitly_accepted_non_interactive_warning(&check, &options),
             "non-interactive warning acceptance should follow structured policy rather than fragile display strings"
         );
+    }
+
+    #[test]
+    fn resolve_provider_selection_keeps_zai_available_in_interactive_list() {
+        let config = mvp::config::LoongClawConfig::default();
+        let options = interactive_onboard_options();
+        let provider_selection = crate::migration::ProviderSelectionPlan::default();
+        let context = onboard_test_context();
+        let mut ui = TestOnboardUi::with_inputs(["zai"]);
+
+        let selected = resolve_provider_selection(
+            &options,
+            &config,
+            &provider_selection,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("z.ai should stay selectable in the interactive provider list");
+
+        assert_eq!(selected.kind, mvp::config::ProviderKind::Zai);
+        assert_eq!(selected.base_url, "https://api.z.ai");
+    }
+
+    #[test]
+    fn resolve_provider_selection_preserves_kimi_coding_default_variant() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        let options = interactive_onboard_options();
+        let provider_selection = crate::migration::ProviderSelectionPlan::default();
+        let context = onboard_test_context();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        config.provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::KimiCoding);
+
+        let selected = resolve_provider_selection(
+            &options,
+            &config,
+            &provider_selection,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("default kimi coding selection should stay stable");
+
+        assert_eq!(selected.kind, mvp::config::ProviderKind::KimiCoding);
+    }
+
+    #[test]
+    fn resolve_provider_selection_preserves_step_plan_default_variant() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        let options = interactive_onboard_options();
+        let provider_selection = crate::migration::ProviderSelectionPlan::default();
+        let context = onboard_test_context();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        config.provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::StepPlan);
+
+        let selected = resolve_provider_selection(
+            &options,
+            &config,
+            &provider_selection,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("default step plan selection should stay stable");
+
+        assert_eq!(selected.kind, mvp::config::ProviderKind::StepPlan);
+    }
+
+    #[test]
+    fn resolve_provider_selection_preserves_existing_region_endpoint_default() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        let options = interactive_onboard_options();
+        let provider_selection = crate::migration::ProviderSelectionPlan::default();
+        let context = onboard_test_context();
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let global_minimax_base_url = "https://api.minimax.io".to_owned();
+        config.provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Minimax);
+        config.provider.base_url = global_minimax_base_url.clone();
+
+        let selected = resolve_provider_selection(
+            &options,
+            &config,
+            &provider_selection,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("region selection should preserve the current endpoint when accepting defaults");
+
+        assert_eq!(selected.kind, mvp::config::ProviderKind::Minimax);
+        assert_eq!(selected.base_url, global_minimax_base_url);
     }
 
     #[test]

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -47,9 +47,42 @@ fn unique_temp_path(label: &str) -> PathBuf {
 }
 
 fn provider_choice_input(kind: mvp::config::ProviderKind) -> String {
-    let index = mvp::config::ProviderKind::all_sorted()
+    let mut options = mvp::config::ProviderKind::all_sorted()
         .iter()
-        .position(|candidate| *candidate == kind)
+        .copied()
+        .filter(|candidate| {
+            *candidate != mvp::config::ProviderKind::Kimi
+                && *candidate != mvp::config::ProviderKind::KimiCoding
+                && *candidate != mvp::config::ProviderKind::Stepfun
+                && *candidate != mvp::config::ProviderKind::StepPlan
+        })
+        .map(|candidate| {
+            let label =
+                loongclaw_daemon::onboard_cli::provider_kind_display_name(candidate).to_owned();
+            let slug = loongclaw_daemon::onboard_cli::provider_kind_id(candidate).to_owned();
+            (label, slug)
+        })
+        .collect::<Vec<_>>();
+    options.push(("Kimi".to_owned(), "kimi".to_owned()));
+    options.push(("Stepfun".to_owned(), "stepfun".to_owned()));
+    options.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let target_slug = if matches!(
+        kind,
+        mvp::config::ProviderKind::Kimi | mvp::config::ProviderKind::KimiCoding
+    ) {
+        "kimi"
+    } else if matches!(
+        kind,
+        mvp::config::ProviderKind::Stepfun | mvp::config::ProviderKind::StepPlan
+    ) {
+        "stepfun"
+    } else {
+        loongclaw_daemon::onboard_cli::provider_kind_id(kind)
+    };
+    let index = options
+        .iter()
+        .position(|(_, slug)| slug == target_slug)
         .expect("provider kind should exist in the interactive onboarding order");
     (index + 1).to_string()
 }


### PR DESCRIPTION
## Summary
- Problem: During onboarding, providers with multiple regional endpoints (MiniMax, Kimi API, Stepfun API, Z.ai/Zhipu) did not prompt users to explicitly select their region. The default endpoint was used silently, potentially causing confusion or misconfiguration.
- Why it matters: Users deploying in CN regions may need CN endpoints, while global users need international endpoints. Without explicit selection, users might complete onboarding with the wrong endpoint and experience authentication or connectivity failures later.
- What changed:
  - Added explicit region endpoint selection step during onboarding for providers with CN/Global variants (MiniMax, Kimi API, Stepfun API, Z.ai/Zhipu)
  - Merged Kimi + Kimi Coding into single "Kimi" option with sub-menu (Kimi API → region selection, Kimi Coding → direct)
  - Merged Z.ai and Zhipu display names to "Z.ai(Zhipu)" for unified selection
  - Merged Stepfun + StepPlan into single "Stepfun" option with sub-menu (Stepfun API → region selection, Step Plan → direct)
  - Added new `StepPlan` provider kind with dedicated endpoint `https://api.stepfun.ai/step_plan`
  - Added public `ProviderRegionEndpointInfo` and `RegionVariant` structs exposing region variant information
- What did not change (scope boundary): Other providers, conversation runtime, memory system, tool execution, channel integrations, ACP session handling, kernel policy, or approval flows.
## Linked Issues
- Related: Design discussion for region endpoint selection UX
## Change Type
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release
## Touched Areas
- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows
## Risk Track
- [x] Track A (routine / low-risk)
No breaking changes to existing configs. New StepPlan provider is additive. Region selection is opt-in per provider and does not affect providers without multiple endpoints.
- Rollout / guardrails: Users selecting providers without region variants see no change in behavior.
- Rollback path: Revert to prior commit; existing onboarded configs unaffected.
## Validation
Commands and evidence:
```text
# Build succeeded
cargo build --release
   Finished `release` profile [optimized] target(s) in 2m 22s
# Region-related tests pass
cargo test --package loongclaw-daemon -- region
   test onboard_review_lines_surface_region_endpoint_note_for_minimax ... ok
   test onboarding_success_summary_surfaces_region_endpoint_note_for_zhipu ... ok
cargo test --package loongclaw-app -- region
   test minimax_region_endpoint_note_points_to_global_alternative ... ok
   test minimax_region_endpoint_hint_respects_explicit_endpoint_override ... ok
   test kimi_region_endpoint_note_respects_explicit_global_override ... ok
   (6 total region tests pass)
User-visible / Operator-visible Changes
During loongclaw onboard:
- When selecting MiniMax → user is prompted to choose CN (api.minimaxi.com) or Global (api.minimax.io)
- When selecting Kimi → sub-menu appears: "Kimi API" (→ region selection) or "Kimi Coding" (→ direct)
- When selecting "Z.ai(Zhipu)" → user is prompted to choose CN or Global endpoint
- When selecting Stepfun → sub-menu appears: "Stepfun API" (→ region selection) or "Step Plan" (→ direct)
Provider list no longer shows separate "Kimi", "Kimi Coding", "Z.ai", "Zhipu", "Stepfun", "Step Plan" entries — they are merged into their respective parent options.
Failure Recovery
- Fast rollback or disable path: git revert <commit> restores prior state. No config migration needed.
- Observable failure symptoms reviewers should watch for:
  - Existing onboarded configs with MiniMax/Kimi/Zhipu continue to work (no config format change)
  - New onboarding flows should show region selection after provider choice
  - StepPlan provider should appear as "Step Plan" in model listings
Reviewer Focus
Most attention on:
- crates/daemon/src/onboard_cli.rs: resolve_provider_selection function — sub-menu routing logic for "kimi" and "stepfun" slugs, region selection UI
- crates/app/src/config/provider.rs: region_endpoint_guide match arms, new StepPlan profile, ProviderRegionEndpointInfo public API
- Edge case: Non-interactive (--provider minimax) path bypasses region selection — this is intentional for scripted setups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Stepfun provider with region-specific endpoint selection during onboarding
  * Enabled region endpoint guidance for providers offering multiple regional variations
  * Updated provider display names: "Stepfun API" and "Z.ai(Zhipu)" for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->