### PR TITLE
feat(plugin): add package manifest file discovery precedence

### DIFF
--- a/crates/kernel/src/plugin.rs
+++ b/crates/kernel/src/plugin.rs
@@ -392,13 +392,9 @@ fn is_package_manifest_file(path: &Path) -> bool {
 }
 
 fn path_is_covered_by_package_manifest(path: &Path, package_roots: &BTreeSet<PathBuf>) -> bool {
-    for package_root in package_roots {
-        if path.starts_with(package_root) {
-            return true;
-        }
-    }
-
-    false
+    package_roots
+        .iter()
+        .any(|package_root| path.starts_with(package_root))
 }
 
 fn should_skip_dir(path: &Path) -> bool {

--- a/crates/kernel/src/plugin.rs
+++ b/crates/kernel/src/plugin.rs
@@ -14,6 +14,8 @@ use crate::{
     pack::VerticalPackManifest,
 };
 
+const PACKAGE_MANIFEST_FILE_NAME: &str = "loongclaw.plugin.json";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PluginManifest {
     pub plugin_id: String,
@@ -79,25 +81,23 @@ impl PluginScanner {
         let mut files = Vec::new();
         collect_files(root, &mut files)?;
         files.sort();
+        report.scanned_files = files.len();
 
-        for path in files {
-            report.scanned_files = report.scanned_files.saturating_add(1);
-            let bytes = fs::read(&path).map_err(|error| IntegrationError::PluginFileRead {
-                path: path.display().to_string(),
-                reason: error.to_string(),
-            })?;
-            let content = match String::from_utf8(bytes) {
-                Ok(content) => content,
-                Err(_) => continue,
-            };
+        let package_manifest_descriptors = collect_package_manifest_descriptors(&files)?;
+        let package_roots = collect_package_roots(&package_manifest_descriptors);
 
-            if let Some(manifest) = parse_manifest_block(&content, &path)? {
-                report.matched_plugins = report.matched_plugins.saturating_add(1);
-                report.descriptors.push(PluginDescriptor {
-                    path: path.display().to_string(),
-                    language: detect_language(&path),
-                    manifest,
-                });
+        for path in &files {
+            if let Some(descriptor) = package_manifest_descriptors.get(path) {
+                push_descriptor(&mut report, descriptor.clone());
+                continue;
+            }
+
+            if path_is_covered_by_package_manifest(path, &package_roots) {
+                continue;
+            }
+
+            if let Some(descriptor) = parse_source_manifest_descriptor(path)? {
+                push_descriptor(&mut report, descriptor);
             }
         }
 
@@ -234,6 +234,14 @@ impl PluginScanner {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct PackageManifestDocument {
+    #[serde(flatten)]
+    manifest: PluginManifest,
+    #[serde(default)]
+    version: Option<String>,
+}
+
 fn collect_files(path: &Path, acc: &mut Vec<PathBuf>) -> Result<(), IntegrationError> {
     let metadata = fs::metadata(path).map_err(|error| IntegrationError::PluginFileRead {
         path: path.display().to_string(),
@@ -264,6 +272,133 @@ fn collect_files(path: &Path, acc: &mut Vec<PathBuf>) -> Result<(), IntegrationE
         }
     }
     Ok(())
+}
+
+fn collect_package_manifest_descriptors(
+    files: &[PathBuf],
+) -> Result<BTreeMap<PathBuf, PluginDescriptor>, IntegrationError> {
+    let mut descriptors = BTreeMap::new();
+
+    for path in files {
+        if !is_package_manifest_file(path) {
+            continue;
+        }
+
+        let descriptor = parse_package_manifest_descriptor(path)?;
+        descriptors.insert(path.clone(), descriptor);
+    }
+
+    Ok(descriptors)
+}
+
+fn collect_package_roots(descriptors: &BTreeMap<PathBuf, PluginDescriptor>) -> BTreeSet<PathBuf> {
+    let mut package_roots = BTreeSet::new();
+
+    for path in descriptors.keys() {
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+
+        let package_root = parent.to_path_buf();
+        package_roots.insert(package_root);
+    }
+
+    package_roots
+}
+
+fn push_descriptor(report: &mut PluginScanReport, descriptor: PluginDescriptor) {
+    report.matched_plugins = report.matched_plugins.saturating_add(1);
+    report.descriptors.push(descriptor);
+}
+
+fn parse_package_manifest_descriptor(path: &Path) -> Result<PluginDescriptor, IntegrationError> {
+    let manifest = parse_package_manifest_file(path)?;
+    let descriptor = PluginDescriptor {
+        path: path.display().to_string(),
+        language: detect_language(path),
+        manifest,
+    };
+
+    Ok(descriptor)
+}
+
+fn parse_package_manifest_file(path: &Path) -> Result<PluginManifest, IntegrationError> {
+    let bytes = fs::read(path).map_err(|error| IntegrationError::PluginFileRead {
+        path: path.display().to_string(),
+        reason: error.to_string(),
+    })?;
+
+    let content =
+        String::from_utf8(bytes).map_err(|error| IntegrationError::PluginManifestParse {
+            path: path.display().to_string(),
+            reason: error.to_string(),
+        })?;
+
+    let mut document: PackageManifestDocument =
+        serde_json::from_str(content.trim()).map_err(|error| {
+            IntegrationError::PluginManifestParse {
+                path: path.display().to_string(),
+                reason: error.to_string(),
+            }
+        })?;
+
+    let version = document.version.take();
+
+    if let Some(version) = version {
+        let metadata_has_version = document.manifest.metadata.contains_key("version");
+
+        if !metadata_has_version {
+            document
+                .manifest
+                .metadata
+                .insert("version".to_owned(), version);
+        }
+    }
+
+    Ok(document.manifest)
+}
+
+fn parse_source_manifest_descriptor(
+    path: &Path,
+) -> Result<Option<PluginDescriptor>, IntegrationError> {
+    let bytes = fs::read(path).map_err(|error| IntegrationError::PluginFileRead {
+        path: path.display().to_string(),
+        reason: error.to_string(),
+    })?;
+
+    let content = match String::from_utf8(bytes) {
+        Ok(content) => content,
+        Err(_) => return Ok(None),
+    };
+
+    let Some(manifest) = parse_manifest_block(&content, path)? else {
+        return Ok(None);
+    };
+
+    let descriptor = PluginDescriptor {
+        path: path.display().to_string(),
+        language: detect_language(path),
+        manifest,
+    };
+
+    Ok(Some(descriptor))
+}
+
+fn is_package_manifest_file(path: &Path) -> bool {
+    let file_name = path.file_name();
+    let file_name = file_name.and_then(|value| value.to_str());
+
+    matches!(file_name, Some(PACKAGE_MANIFEST_FILE_NAME))
+}
+
+fn path_is_covered_by_package_manifest(path: &Path, package_roots: &BTreeSet<PathBuf>) -> bool {
+    for package_root in package_roots {
+        if path.starts_with(package_root) {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn should_skip_dir(path: &Path) -> bool {
@@ -319,6 +454,10 @@ fn clean_manifest_line(line: &str) -> String {
 }
 
 fn detect_language(path: &Path) -> String {
+    if is_package_manifest_file(path) {
+        return "manifest".to_owned();
+    }
+
     path.extension()
         .and_then(|ext| ext.to_str())
         .map(|ext| ext.to_lowercase())
@@ -410,6 +549,161 @@ mod tests {
                 .descriptors
                 .iter()
                 .any(|descriptor| descriptor.manifest.provider_id == "slack")
+        );
+    }
+
+    #[test]
+    fn scanner_finds_package_manifest_file() {
+        let root = unique_tmp_dir("loongclaw-plugin-package-manifest");
+        fs::create_dir_all(&root).expect("create temp root");
+
+        let manifest_file = root.join(PACKAGE_MANIFEST_FILE_NAME);
+        fs::write(
+            &manifest_file,
+            r#"
+{
+  "api_version": "v1alpha1",
+  "plugin_id": "tavily-search",
+  "version": "0.3.0",
+  "provider_id": "tavily",
+  "connector_name": "tavily-http",
+  "endpoint": "https://api.tavily.com/search",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json",
+    "adapter_family": "web-search"
+  },
+  "summary": "Manifest-discovered Tavily package",
+  "tags": ["search", "provider"]
+}
+"#,
+        )
+        .expect("write package manifest");
+
+        let scanner = PluginScanner::new();
+        let report = scanner.scan_path(&root).expect("scan should succeed");
+
+        assert_eq!(report.scanned_files, 1);
+        assert_eq!(report.matched_plugins, 1);
+        assert_eq!(report.descriptors.len(), 1);
+        assert_eq!(
+            report.descriptors[0].path,
+            manifest_file.display().to_string()
+        );
+        assert_eq!(report.descriptors[0].language, "manifest");
+        assert_eq!(report.descriptors[0].manifest.plugin_id, "tavily-search");
+        assert_eq!(report.descriptors[0].manifest.provider_id, "tavily");
+        assert_eq!(
+            report.descriptors[0]
+                .manifest
+                .metadata
+                .get("version")
+                .map(String::as_str),
+            Some("0.3.0")
+        );
+    }
+
+    #[test]
+    fn scanner_prefers_package_manifest_over_embedded_source_manifest() {
+        let root = unique_tmp_dir("loongclaw-plugin-precedence");
+        let package_root = root.join("pkg");
+        fs::create_dir_all(&package_root).expect("create temp root");
+
+        let manifest_file = package_root.join(PACKAGE_MANIFEST_FILE_NAME);
+        fs::write(
+            &manifest_file,
+            r#"
+{
+  "plugin_id": "package-plugin",
+  "provider_id": "package-provider",
+  "connector_name": "package-connector",
+  "channel_id": "package-channel",
+  "endpoint": "https://package.example/invoke",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json"
+  }
+}
+"#,
+        )
+        .expect("write package manifest");
+
+        let source_file = package_root.join("plugin.py");
+        fs::write(
+            &source_file,
+            r#"
+# LOONGCLAW_PLUGIN_START
+# {
+#   "plugin_id": "source-plugin",
+#   "provider_id": "source-provider",
+#   "connector_name": "source-connector",
+#   "channel_id": "source-channel",
+#   "endpoint": "https://source.example/invoke",
+#   "capabilities": ["InvokeConnector"],
+#   "metadata": {"bridge_kind":"process_stdio"}
+# }
+# LOONGCLAW_PLUGIN_END
+"#,
+        )
+        .expect("write source plugin");
+
+        let scanner = PluginScanner::new();
+        let report = scanner.scan_path(&root).expect("scan should succeed");
+
+        assert_eq!(report.scanned_files, 2);
+        assert_eq!(report.matched_plugins, 1);
+        assert_eq!(report.descriptors.len(), 1);
+        assert_eq!(
+            report.descriptors[0].path,
+            manifest_file.display().to_string()
+        );
+        assert_eq!(report.descriptors[0].manifest.plugin_id, "package-plugin");
+        assert_eq!(
+            report.descriptors[0].manifest.provider_id,
+            "package-provider"
+        );
+    }
+
+    #[test]
+    fn scanner_falls_back_to_embedded_source_manifest_without_package_manifest() {
+        let root = unique_tmp_dir("loongclaw-plugin-source-fallback");
+        let package_root = root.join("pkg");
+        fs::create_dir_all(&package_root).expect("create temp root");
+
+        let source_file = package_root.join("plugin.py");
+        fs::write(
+            &source_file,
+            r#"
+# LOONGCLAW_PLUGIN_START
+# {
+#   "plugin_id": "source-plugin",
+#   "provider_id": "source-provider",
+#   "connector_name": "source-connector",
+#   "channel_id": "source-channel",
+#   "endpoint": "https://source.example/invoke",
+#   "capabilities": ["InvokeConnector"],
+#   "metadata": {"bridge_kind":"process_stdio"}
+# }
+# LOONGCLAW_PLUGIN_END
+"#,
+        )
+        .expect("write source plugin");
+
+        let scanner = PluginScanner::new();
+        let report = scanner.scan_path(&root).expect("scan should succeed");
+
+        assert_eq!(report.scanned_files, 1);
+        assert_eq!(report.matched_plugins, 1);
+        assert_eq!(report.descriptors.len(), 1);
+        assert_eq!(
+            report.descriptors[0].path,
+            source_file.display().to_string()
+        );
+        assert_eq!(report.descriptors[0].language, "py");
+        assert_eq!(report.descriptors[0].manifest.plugin_id, "source-plugin");
+        assert_eq!(
+            report.descriptors[0].manifest.provider_id,
+            "source-provider"
         );
     }
 

--- a/crates/kernel/src/plugin_ir.rs
+++ b/crates/kernel/src/plugin_ir.rs
@@ -451,6 +451,18 @@ mod tests {
     }
 
     #[test]
+    fn translator_defaults_manifest_descriptor_with_endpoint_to_http_json() {
+        let descriptor = descriptor("manifest", BTreeMap::new());
+
+        let translator = PluginTranslator::new();
+        let ir = translator.translate_descriptor(&descriptor);
+
+        assert_eq!(ir.runtime.source_language, "manifest");
+        assert_eq!(ir.runtime.bridge_kind, PluginBridgeKind::HttpJson);
+        assert_eq!(ir.runtime.adapter_family, "http-adapter");
+    }
+
+    #[test]
     fn translator_accepts_acpx_runtime_alias() {
         let descriptor = descriptor(
             "js",


### PR DESCRIPTION
## Summary

- Problem:
  The manifest-first plugin package contract is documented, but `PluginScanner` still discovers plugins only from embedded source marker blocks.
- Why it matters:
  Until package manifests are part of the real intake path, onboarding/setup follow-on work remains blocked on source scanning and the package contract is not yet executable.
- What changed:
  Added `loongclaw.plugin.json` discovery, made package manifests authoritative within the same package root, preserved embedded source markers as the fallback path when no package manifest exists, normalized top-level package `version` into `metadata.version`, and added regression coverage for scanner precedence plus downstream translator behavior.
- What did not change (scope boundary):
  This PR does not add setup metadata rendering, slot ownership semantics, manifest/source field merge rules, or SDK/package authoring helpers.

## Linked Issues

- Closes #528
- Related #522

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  Plugin discovery is now package-aware. A package-level manifest can suppress embedded source manifests in the same package root, so scanner precedence is behavior-changing by design.
- Rollout / guardrails:
  The implementation stays additive: source-marker discovery still works unchanged when no package manifest exists. Regression tests lock discovery, precedence, fallback, and translator behavior.
- Rollback path:
  Revert this commit to restore source-marker-only discovery.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo test -p loongclaw-kernel plugin -- --nocapture
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked

Re-ran the same validation set after rebasing onto the latest origin/dev.
```

## User-visible / Operator-visible Changes

- Kernel plugin discovery now accepts `loongclaw.plugin.json` as a first-class package manifest.
- When a package manifest exists, embedded source manifests in the same package root no longer produce duplicate or conflicting plugin descriptors.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to return to source-marker-only discovery.
- Observable failure symptoms reviewers should watch for:
  Missing plugin descriptors from directories that now include a package manifest, unexpected `manifest` source-language translation for package-backed descriptors, or provider metadata missing the expected version mapping.

## Reviewer Focus

- `crates/kernel/src/plugin.rs`: package-manifest detection, package-root precedence, and fallback semantics.
- `crates/kernel/src/plugin.rs`: top-level package `version` normalization into `metadata.version` so existing absorb logic keeps a stable version source.
- `crates/kernel/src/plugin_ir.rs`: downstream translation of `manifest` descriptors with endpoint-based default bridge inference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for dedicated package manifest files during plugin scanning
  * Manifest-based plugins now detected explicitly and prioritized over embedded manifests

* **Improvements**
  * More accurate manifest language detection for manifest files
  * Scan reporting fixed to reflect total files scanned
  * Package manifest "version" merged into metadata when missing

* **Tests**
  * Added tests covering manifest precedence and translation defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->