### PR TITLE
refactor(doctor): reuse shared provider model probe recovery advice

### DIFF
--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1328,30 +1328,24 @@ fn provider_model_probe_failure_check(
 fn is_provider_model_probe_failure_check(check: &DoctorCheck) -> bool {
     let is_provider_model_probe = check.name == "provider model probe";
     let is_failure = check.level != DoctorCheckLevel::Pass;
-    let has_probe_failure_detail =
+    let matches_probe_failure_detail =
         provider_model_probe_policy::provider_model_probe_failed_detail(check.detail.as_str());
 
-    is_provider_model_probe && is_failure && has_probe_failure_detail
+    is_provider_model_probe && is_failure && matches_probe_failure_detail
 }
 
-fn is_transport_style_provider_model_probe_failure_check(check: &DoctorCheck) -> bool {
-    let is_provider_model_probe_failure = is_provider_model_probe_failure_check(check);
-    if !is_provider_model_probe_failure {
-        return false;
-    }
-
-    provider_model_probe_policy::provider_model_probe_transport_failure_detail(
-        check.detail.as_str(),
-    )
-}
-
-fn is_auth_style_provider_model_probe_failure_check(check: &DoctorCheck) -> bool {
-    let is_provider_model_probe_failure = is_provider_model_probe_failure_check(check);
-    if !is_provider_model_probe_failure {
-        return false;
-    }
-
-    provider_model_probe_policy::provider_model_probe_auth_failure_detail(check.detail.as_str())
+fn provider_model_probe_recovery_advice_for_checks(
+    checks: &[DoctorCheck],
+    config: &mvp::config::LoongClawConfig,
+) -> Option<provider_model_probe_policy::ProviderModelProbeRecoveryAdvice> {
+    let probe_failure_check = checks
+        .iter()
+        .find(|check| is_provider_model_probe_failure_check(check))?;
+    let recovery_advice = provider_model_probe_policy::provider_model_probe_recovery_advice(
+        config,
+        probe_failure_check.detail.as_str(),
+    )?;
+    Some(recovery_advice)
 }
 
 async fn collect_browser_companion_doctor_checks(
@@ -1510,12 +1504,18 @@ fn build_doctor_next_steps_with_path_env(
         }
     }
 
-    let has_provider_model_probe_failure = checks.iter().any(is_provider_model_probe_failure_check);
-    if has_provider_model_probe_failure {
-        let provider_model_probe_transport_failure = checks
-            .iter()
-            .any(is_transport_style_provider_model_probe_failure_check);
-        if provider_model_probe_transport_failure {
+    let provider_model_probe_recovery =
+        provider_model_probe_recovery_advice_for_checks(checks, config);
+    if let Some(provider_model_probe_recovery) = provider_model_probe_recovery {
+        let provider_model_probe_policy::ProviderModelProbeRecoveryAdvice {
+            kind: provider_model_probe_kind,
+            region_endpoint_hint,
+        } = provider_model_probe_recovery;
+        let is_transport_failure = matches!(
+            provider_model_probe_kind,
+            provider_model_probe_policy::ProviderModelProbeFailureKind::TransportFailure
+        );
+        if is_transport_failure {
             if checks.iter().any(|check| {
                 check.name == crate::provider_route_diagnostics::PROVIDER_ROUTE_PROBE_CHECK_NAME
                     && check.level != DoctorCheckLevel::Pass
@@ -1544,11 +1544,9 @@ fn build_doctor_next_steps_with_path_env(
                 );
             }
         } else {
-            let provider_model_probe_auth_failure = checks
-                .iter()
-                .any(is_auth_style_provider_model_probe_failure_check);
-            match config.provider.model_catalog_probe_recovery() {
-                mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+            match provider_model_probe_kind {
+                provider_model_probe_policy::ProviderModelProbeFailureKind::TransportFailure => {}
+                provider_model_probe_policy::ProviderModelProbeFailureKind::RequiresExplicitModel {
                     recommended_onboarding_model: Some(model),
                 } => {
                     push_unique_step(
@@ -1564,7 +1562,7 @@ fn build_doctor_next_steps_with_path_env(
                         ),
                     );
                 }
-                mvp::config::ModelCatalogProbeRecovery::RequiresExplicitModel {
+                provider_model_probe_policy::ProviderModelProbeFailureKind::RequiresExplicitModel {
                     recommended_onboarding_model: None,
                 } => {
                     push_unique_step(
@@ -1574,8 +1572,10 @@ fn build_doctor_next_steps_with_path_env(
                         ),
                     );
                 }
-                mvp::config::ModelCatalogProbeRecovery::ExplicitModel(_)
-                | mvp::config::ModelCatalogProbeRecovery::ConfiguredPreferredModels(_) => {
+                provider_model_probe_policy::ProviderModelProbeFailureKind::ExplicitModel { .. }
+                | provider_model_probe_policy::ProviderModelProbeFailureKind::PreferredModels {
+                    ..
+                } => {
                     push_unique_step(
                         &mut steps,
                         format!(
@@ -1590,9 +1590,7 @@ fn build_doctor_next_steps_with_path_env(
                     );
                 }
             }
-            if provider_model_probe_auth_failure
-                && let Some(hint) = config.provider.region_endpoint_failure_hint()
-            {
+            if let Some(hint) = region_endpoint_hint {
                 push_unique_step(&mut steps, hint);
             }
         }

--- a/crates/daemon/src/provider_model_probe_policy.rs
+++ b/crates/daemon/src/provider_model_probe_policy.rs
@@ -29,6 +29,12 @@ pub(crate) struct ProviderModelProbeFailure {
     pub(crate) kind: ProviderModelProbeFailureKind,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProviderModelProbeRecoveryAdvice {
+    pub(crate) kind: ProviderModelProbeFailureKind,
+    pub(crate) region_endpoint_hint: Option<String>,
+}
+
 pub(crate) fn provider_model_probe_failure(
     config: &mvp::config::LoongClawConfig,
     error: &str,
@@ -77,6 +83,29 @@ pub(crate) fn provider_model_probe_auth_failure_detail(detail: &str) -> bool {
     }
 
     mvp::provider::is_auth_style_failure_message(detail)
+}
+
+pub(crate) fn provider_model_probe_recovery_advice(
+    config: &mvp::config::LoongClawConfig,
+    detail: &str,
+) -> Option<ProviderModelProbeRecoveryAdvice> {
+    let matches_probe_failure_detail = provider_model_probe_failed_detail(detail);
+    if !matches_probe_failure_detail {
+        return None;
+    }
+
+    let kind = if provider_model_probe_transport_failure_detail(detail) {
+        ProviderModelProbeFailureKind::TransportFailure
+    } else {
+        let configured_recovery = config.provider.model_catalog_probe_recovery();
+        configured_recovery_kind(configured_recovery)
+    };
+    let region_endpoint_hint = provider_model_probe_region_endpoint_hint(config, detail);
+
+    Some(ProviderModelProbeRecoveryAdvice {
+        kind,
+        region_endpoint_hint,
+    })
 }
 
 fn configured_recovery_kind(
@@ -187,6 +216,18 @@ fn append_region_hint(
     detail
 }
 
+fn provider_model_probe_region_endpoint_hint(
+    config: &mvp::config::LoongClawConfig,
+    detail: &str,
+) -> Option<String> {
+    let is_auth_style_failure = provider_model_probe_auth_failure_detail(detail);
+    if !is_auth_style_failure {
+        return None;
+    }
+
+    config.provider.region_endpoint_failure_hint()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,6 +283,57 @@ mod tests {
         assert!(
             provider_model_probe_auth_failure_detail(failure.detail.as_str()),
             "the shared detail classifier should recognize auth-style model probe failures"
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_recovery_advice_reconstructs_transport_failures_from_detail() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.model = "custom-explicit-model".to_owned();
+
+        let failure = provider_model_probe_failure(
+            &config,
+            "provider model-list request failed on attempt 3/3: operation timed out",
+        );
+        let advice =
+            provider_model_probe_recovery_advice(&config, failure.detail.as_str()).unwrap();
+
+        assert_eq!(advice.kind, ProviderModelProbeFailureKind::TransportFailure);
+        assert_eq!(advice.region_endpoint_hint, None);
+    }
+
+    #[test]
+    fn provider_model_probe_recovery_advice_preserves_reviewed_default_recovery() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Deepseek;
+        config.provider.model = "auto".to_owned();
+
+        let failure = provider_model_probe_failure(&config, "provider returned status 401");
+        let advice =
+            provider_model_probe_recovery_advice(&config, failure.detail.as_str()).unwrap();
+
+        assert_eq!(
+            advice.kind,
+            ProviderModelProbeFailureKind::RequiresExplicitModel {
+                recommended_onboarding_model: Some("deepseek-chat".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn provider_model_probe_recovery_advice_keeps_region_hint_for_auth_failures() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Minimax;
+        config.provider.model = "auto".to_owned();
+
+        let failure = provider_model_probe_failure(&config, "provider returned status 401");
+        let advice =
+            provider_model_probe_recovery_advice(&config, failure.detail.as_str()).unwrap();
+        let region_endpoint_hint = advice.region_endpoint_hint.unwrap();
+
+        assert!(
+            region_endpoint_hint.contains("https://api.minimax.io"),
+            "recovery advice should keep provider-specific region guidance for auth-style failures"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Problem:
  - `doctor_cli` still re-derived provider model-probe recovery semantics from rendered check detail and config state even though the shared provider model-probe policy already owned the same recovery classification.
- Why it matters:
  - this kept provider-specific recovery branching split across the shared policy layer and doctor next-step generation, which made future onboarding and provider changes easier to drift.
- What changed:
  - added `ProviderModelProbeRecoveryAdvice` to `provider_model_probe_policy`
  - added `provider_model_probe_recovery_advice(...)` so doctor can reconstruct recovery kind and optional auth-region hint from shared probe-failure detail
  - switched doctor next-step generation to consume the shared recovery advice instead of branching directly on `config.provider.model_catalog_probe_recovery()` and ad hoc auth/transport detail checks
  - added regression tests for transport reconstruction, reviewed-default recovery reconstruction, and auth-region hint preservation
- What did not change (scope boundary):
  - no onboarding copy changes
  - no provider recovery semantic changes
  - no expansion of the shared policy surface beyond provider model-probe recovery advice

## Linked Issues

- Closes #534
- Related #504

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo check -p loongclaw-daemon
cargo test -p loongclaw-daemon -- --test-threads=1
cargo clippy -p loongclaw-daemon --all-targets --all-features -- -D warnings

Result:
- cargo check passed
- daemon unit tests: 274 passed, 0 failed
- daemon integration tests: 624 passed, 0 failed
- clippy passed with -D warnings
```

Before/after behavior:
- before: doctor reconstructed provider model-probe recovery from local transport/auth helpers plus direct branching on `config.provider.model_catalog_probe_recovery()`
- after: doctor consumes shared recovery advice reconstructed by `provider_model_probe_policy`, while keeping CLI-specific next-step rendering local
- regression coverage: added tests for transport reconstruction, reviewed `model = auto` recovery reconstruction, and auth-region hint preservation

## User-visible / Operator-visible Changes

- doctor next steps stay behaviorally consistent, but the recovery classification now comes from a single shared provider model-probe policy seam.

## Failure Recovery

- Fast rollback or disable path:
  - revert this PR to restore the previous doctor-local recovery branching.
- Observable failure symptoms reviewers should watch for:
  - wrong doctor guidance after provider model-probe failures, especially for transport failures, reviewed defaults, or region-sensitive auth failures.

## Reviewer Focus

- verify that `provider_model_probe_recovery_advice(...)` is the only new shared seam and that CLI-specific wording still stays in `doctor_cli`
- verify that reviewed-default, preferred-model, explicit-model, transport, and auth-hint next steps still match current behavior
- verify that the new tests cover reconstruction from rendered detail rather than only direct config-state branches
