### PR TITLE
fix: hide session mutation tools by default

### DIFF
--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -101,6 +101,8 @@ pub struct SessionToolConfig {
     pub list_limit: usize,
     #[serde(default = "default_session_history_limit")]
     pub history_limit: usize,
+    #[serde(default)]
+    pub allow_mutation: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -445,6 +447,7 @@ impl Default for SessionToolConfig {
             visibility: SessionVisibility::default(),
             list_limit: default_session_list_limit(),
             history_limit: default_session_history_limit(),
+            allow_mutation: false,
         }
     }
 }
@@ -916,6 +919,7 @@ mod tests {
         assert_eq!(config.sessions.visibility, SessionVisibility::Children);
         assert_eq!(config.sessions.list_limit, 100);
         assert_eq!(config.sessions.history_limit, 200);
+        assert!(!config.sessions.allow_mutation);
         assert!(!config.messages.enabled);
         assert!(config.delegate.enabled);
         assert_eq!(config.delegate.max_depth, 1);
@@ -1128,6 +1132,7 @@ denied_calls = ["tool:session_cancel"]
 visibility = "self"
 list_limit = 12
 history_limit = 34
+allow_mutation = true
 
 [tools.messages]
 enabled = true
@@ -1171,6 +1176,7 @@ max_text_chars = 1024
         );
         assert_eq!(parsed.tools.sessions.list_limit, 12);
         assert_eq!(parsed.tools.sessions.history_limit, 34);
+        assert!(parsed.tools.sessions.allow_mutation);
         assert!(parsed.tools.messages.enabled);
         assert!(!parsed.tools.delegate.enabled);
         assert_eq!(parsed.tools.delegate.max_depth, 2);

--- a/crates/app/src/runtime_env.rs
+++ b/crates/app/src/runtime_env.rs
@@ -54,6 +54,10 @@ pub fn initialize_runtime_environment(
         bool_env(config.tools.sessions.enabled),
     );
     set_env_var(
+        "LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION",
+        bool_env(config.tools.sessions.allow_mutation),
+    );
+    set_env_var(
         "LOONGCLAW_TOOL_MESSAGES_ENABLED",
         bool_env(config.tools.messages.enabled),
     );
@@ -207,6 +211,7 @@ mod tests {
             "LOONGCLAW_SHELL_DENY",
             "LOONGCLAW_SHELL_DEFAULT_MODE",
             "LOONGCLAW_FILE_ROOT",
+            "LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION",
             "LOONGCLAW_EXTERNAL_SKILLS_ENABLED",
             "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
             "LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS",
@@ -242,6 +247,7 @@ mod tests {
         config.memory.summary_max_chars = 900;
         config.memory.profile_note = Some("Imported NanoBot preferences".to_owned());
         config.tools.file_root = Some("/tmp/loongclaw-runtime-file-root".to_owned());
+        config.tools.sessions.allow_mutation = true;
         config.tools.browser.enabled = false;
         config.tools.browser.max_sessions = 4;
         config.tools.browser.max_links = 12;
@@ -285,6 +291,12 @@ mod tests {
         assert_eq!(
             std::env::var("LOONGCLAW_FILE_ROOT").ok().as_deref(),
             Some("/tmp/loongclaw-runtime-file-root")
+        );
+        assert_eq!(
+            std::env::var("LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION")
+                .ok()
+                .as_deref(),
+            Some("true")
         );
         assert_eq!(
             std::env::var("LOONGCLAW_EXTERNAL_SKILLS_ENABLED")

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -167,6 +167,7 @@ pub enum ToolExposureClass {
 pub enum ToolVisibilityGate {
     Always,
     Sessions,
+    SessionMutation,
     Messages,
     Delegate,
     Browser,
@@ -566,7 +567,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
-            visibility_gate: ToolVisibilityGate::Sessions,
+            visibility_gate: ToolVisibilityGate::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_archive_definition,
         },
@@ -578,7 +579,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
-            visibility_gate: ToolVisibilityGate::Sessions,
+            visibility_gate: ToolVisibilityGate::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_cancel_definition,
         },
@@ -602,7 +603,7 @@ pub fn tool_catalog() -> ToolCatalog {
             execution_kind: ToolExecutionKind::App,
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
-            visibility_gate: ToolVisibilityGate::Sessions,
+            visibility_gate: ToolVisibilityGate::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_recover_definition,
         },
@@ -1084,6 +1085,11 @@ fn tool_visibility_gate_enabled_for_runtime_view(
     match gate {
         ToolVisibilityGate::Always => true,
         ToolVisibilityGate::Sessions => config.sessions.enabled,
+        ToolVisibilityGate::SessionMutation => {
+            let sessions_enabled = config.sessions.enabled;
+            let allow_mutation = config.sessions.allow_mutation;
+            sessions_enabled && allow_mutation
+        }
         ToolVisibilityGate::Messages => config.messages.enabled,
         ToolVisibilityGate::Delegate => config.delegate.enabled,
         ToolVisibilityGate::Browser => config.browser.enabled,
@@ -1105,6 +1111,11 @@ fn tool_visibility_gate_enabled_for_runtime_policy(
     match gate {
         ToolVisibilityGate::Always => true,
         ToolVisibilityGate::Sessions => config.sessions_enabled,
+        ToolVisibilityGate::SessionMutation => {
+            let sessions_enabled = config.sessions_enabled;
+            let allow_mutation = config.sessions_allow_mutation;
+            sessions_enabled && allow_mutation
+        }
         ToolVisibilityGate::Messages => config.messages_enabled,
         ToolVisibilityGate::Delegate => config.delegate_enabled,
         ToolVisibilityGate::Browser => config.browser.enabled,

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::sync::OnceLock;
 
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -365,7 +366,7 @@ impl ToolCatalog {
     }
 }
 
-pub fn tool_catalog() -> ToolCatalog {
+fn build_tool_catalog() -> ToolCatalog {
     let mut descriptors = vec![
         ToolDescriptor {
             name: "tool.search",
@@ -909,6 +910,12 @@ pub fn tool_catalog() -> ToolCatalog {
 
     descriptors.sort_by(|left, right| left.name.cmp(right.name));
     ToolCatalog { descriptors }
+}
+
+pub fn tool_catalog() -> &'static ToolCatalog {
+    static TOOL_CATALOG: OnceLock<ToolCatalog> = OnceLock::new();
+
+    TOOL_CATALOG.get_or_init(build_tool_catalog)
 }
 
 pub fn runtime_tool_view() -> ToolView {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1803,7 +1803,7 @@ mod tests {
     fn tool_registry_returns_runtime_discoverable_tools_for_default_config() {
         let config = runtime_config::ToolRuntimeConfig::default();
         let entries = tool_registry_with_config(Some(&config));
-        assert_eq!(entries.len(), 24);
+        assert_eq!(entries.len(), 21);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"approval_request_resolve"));
         assert!(names.contains(&"approval_request_status"));
@@ -1818,10 +1818,7 @@ mod tests {
         assert!(names.contains(&"file.write"));
         assert!(names.contains(&"file.edit"));
         assert!(names.contains(&"provider.switch"));
-        assert!(names.contains(&"session_archive"));
-        assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
-        assert!(names.contains(&"session_recover"));
         assert!(names.contains(&"session_status"));
         assert!(names.contains(&"session_wait"));
         assert!(names.contains(&"sessions_history"));
@@ -1835,6 +1832,9 @@ mod tests {
         assert!(names.contains(&"external_skills.policy"));
         assert!(!names.contains(&"external_skills.remove"));
         assert!(!names.contains(&"shell.exec"));
+        assert!(!names.contains(&"session_archive"));
+        assert!(!names.contains(&"session_cancel"));
+        assert!(!names.contains(&"session_recover"));
         assert!(!names.contains(&"sessions_send"));
     }
 
@@ -1848,7 +1848,7 @@ mod tests {
     fn tool_registry_returns_runtime_discoverable_tools_for_default_config_no_websearch() {
         let config = runtime_config::ToolRuntimeConfig::default();
         let entries = tool_registry_with_config(Some(&config));
-        assert_eq!(entries.len(), 23);
+        assert_eq!(entries.len(), 20);
         let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
         assert!(names.contains(&"approval_request_resolve"));
         assert!(names.contains(&"approval_request_status"));
@@ -1863,10 +1863,7 @@ mod tests {
         assert!(names.contains(&"file.write"));
         assert!(names.contains(&"file.edit"));
         assert!(names.contains(&"provider.switch"));
-        assert!(names.contains(&"session_archive"));
-        assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_events"));
-        assert!(names.contains(&"session_recover"));
         assert!(names.contains(&"session_status"));
         assert!(names.contains(&"session_wait"));
         assert!(names.contains(&"sessions_history"));
@@ -1880,7 +1877,26 @@ mod tests {
         assert!(names.contains(&"external_skills.policy"));
         assert!(!names.contains(&"external_skills.remove"));
         assert!(!names.contains(&"shell.exec"));
+        assert!(!names.contains(&"session_archive"));
+        assert!(!names.contains(&"session_cancel"));
+        assert!(!names.contains(&"session_recover"));
         assert!(!names.contains(&"sessions_send"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn tool_registry_re_exposes_session_mutation_tools_when_runtime_policy_allows_them() {
+        let config = runtime_config::ToolRuntimeConfig {
+            sessions_allow_mutation: true,
+            ..runtime_config::ToolRuntimeConfig::default()
+        };
+
+        let entries = tool_registry_with_config(Some(&config));
+        let names: Vec<&str> = entries.iter().map(|entry| entry.name).collect();
+
+        assert!(names.contains(&"session_archive"));
+        assert!(names.contains(&"session_cancel"));
+        assert!(names.contains(&"session_recover"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
@@ -1913,7 +1929,7 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
-    fn runtime_tool_view_includes_runtime_session_tools_but_hides_planned_ones() {
+    fn runtime_tool_view_hides_session_mutation_tools_by_default() {
         let view = runtime_tool_view_for_config(&crate::config::ToolConfig::default());
 
         for tool_name in [
@@ -1922,10 +1938,7 @@ mod tests {
             "approval_requests_list",
             "delegate",
             "delegate_async",
-            "session_archive",
-            "session_cancel",
             "session_events",
-            "session_recover",
             "session_status",
             "session_wait",
             "sessions_history",
@@ -1940,12 +1953,32 @@ mod tests {
             );
         }
 
+        for tool_name in ["session_archive", "session_cancel", "session_recover"] {
+            assert!(
+                !view.contains(tool_name),
+                "expected runtime view to hide `{tool_name}` by default"
+            );
+        }
+
         let tool_name = "sessions_send";
         assert!(
             !view.contains(tool_name),
             "expected runtime view to keep `{tool_name}` hidden"
         );
         assert!(view.contains("web.fetch"));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn runtime_tool_view_re_exposes_session_mutation_tools_when_enabled() {
+        let mut config = crate::config::ToolConfig::default();
+        config.sessions.allow_mutation = true;
+
+        let view = runtime_tool_view_for_config(&config);
+
+        assert!(view.contains("session_archive"));
+        assert!(view.contains("session_cancel"));
+        assert!(view.contains("session_recover"));
     }
 
     #[test]
@@ -2013,6 +2046,7 @@ mod tests {
     fn capability_snapshot_with_config_uses_runtime_enabled_tool_view() {
         let config = runtime_config::ToolRuntimeConfig {
             sessions_enabled: false,
+            sessions_allow_mutation: false,
             messages_enabled: false,
             delegate_enabled: false,
             browser: runtime_config::BrowserRuntimePolicy {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -565,7 +565,7 @@ fn build_runtime_tool_view_for_runtime_config(
 ) -> ToolView {
     let catalog = tool_catalog();
     let mut names = runtime_tool_view_for_runtime_config(runtime_config)
-        .iter(&catalog)
+        .iter(catalog)
         .map(|descriptor| descriptor.name)
         .collect::<Vec<_>>();
     #[cfg(feature = "feishu-integration")]
@@ -1803,39 +1803,35 @@ mod tests {
     fn tool_registry_returns_runtime_discoverable_tools_for_default_config() {
         let config = runtime_config::ToolRuntimeConfig::default();
         let entries = tool_registry_with_config(Some(&config));
-        assert_eq!(entries.len(), 21);
-        let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
-        assert!(names.contains(&"approval_request_resolve"));
-        assert!(names.contains(&"approval_request_status"));
-        assert!(names.contains(&"approval_requests_list"));
-        assert!(names.contains(&"browser.click"));
-        assert!(names.contains(&"browser.extract"));
-        assert!(names.contains(&"browser.open"));
-        assert!(names.contains(&"claw.migrate"));
-        assert!(names.contains(&"delegate"));
-        assert!(names.contains(&"delegate_async"));
-        assert!(names.contains(&"file.read"));
-        assert!(names.contains(&"file.write"));
-        assert!(names.contains(&"file.edit"));
-        assert!(names.contains(&"provider.switch"));
-        assert!(names.contains(&"session_events"));
-        assert!(names.contains(&"session_status"));
-        assert!(names.contains(&"session_wait"));
-        assert!(names.contains(&"sessions_history"));
-        assert!(names.contains(&"sessions_list"));
-        assert!(names.contains(&"web.search"));
-        assert!(!names.contains(&"external_skills.fetch"));
-        assert!(!names.contains(&"external_skills.install"));
-        assert!(!names.contains(&"external_skills.inspect"));
-        assert!(!names.contains(&"external_skills.invoke"));
-        assert!(!names.contains(&"external_skills.list"));
-        assert!(names.contains(&"external_skills.policy"));
-        assert!(!names.contains(&"external_skills.remove"));
-        assert!(!names.contains(&"shell.exec"));
-        assert!(!names.contains(&"session_archive"));
-        assert!(!names.contains(&"session_cancel"));
-        assert!(!names.contains(&"session_recover"));
-        assert!(!names.contains(&"sessions_send"));
+        let names = entries
+            .iter()
+            .map(|entry| entry.name)
+            .collect::<BTreeSet<_>>();
+        let expected = BTreeSet::from([
+            "approval_request_resolve",
+            "approval_request_status",
+            "approval_requests_list",
+            "browser.click",
+            "browser.extract",
+            "browser.open",
+            "claw.migrate",
+            "delegate",
+            "delegate_async",
+            "external_skills.policy",
+            "file.edit",
+            "file.read",
+            "file.write",
+            "provider.switch",
+            "session_events",
+            "session_status",
+            "session_wait",
+            "sessions_history",
+            "sessions_list",
+            "web.fetch",
+            "web.search",
+        ]);
+
+        assert_eq!(names, expected);
     }
 
     #[cfg(all(
@@ -1848,45 +1844,41 @@ mod tests {
     fn tool_registry_returns_runtime_discoverable_tools_for_default_config_no_websearch() {
         let config = runtime_config::ToolRuntimeConfig::default();
         let entries = tool_registry_with_config(Some(&config));
-        assert_eq!(entries.len(), 20);
-        let names: Vec<&str> = entries.iter().map(|e| e.name).collect();
-        assert!(names.contains(&"approval_request_resolve"));
-        assert!(names.contains(&"approval_request_status"));
-        assert!(names.contains(&"approval_requests_list"));
-        assert!(names.contains(&"browser.click"));
-        assert!(names.contains(&"browser.extract"));
-        assert!(names.contains(&"browser.open"));
-        assert!(names.contains(&"claw.migrate"));
-        assert!(names.contains(&"delegate"));
-        assert!(names.contains(&"delegate_async"));
-        assert!(names.contains(&"file.read"));
-        assert!(names.contains(&"file.write"));
-        assert!(names.contains(&"file.edit"));
-        assert!(names.contains(&"provider.switch"));
-        assert!(names.contains(&"session_events"));
-        assert!(names.contains(&"session_status"));
-        assert!(names.contains(&"session_wait"));
-        assert!(names.contains(&"sessions_history"));
-        assert!(names.contains(&"sessions_list"));
-        assert!(!names.contains(&"web.search"));
-        assert!(!names.contains(&"external_skills.fetch"));
-        assert!(!names.contains(&"external_skills.install"));
-        assert!(!names.contains(&"external_skills.inspect"));
-        assert!(!names.contains(&"external_skills.invoke"));
-        assert!(!names.contains(&"external_skills.list"));
-        assert!(names.contains(&"external_skills.policy"));
-        assert!(!names.contains(&"external_skills.remove"));
-        assert!(!names.contains(&"shell.exec"));
-        assert!(!names.contains(&"session_archive"));
-        assert!(!names.contains(&"session_cancel"));
-        assert!(!names.contains(&"session_recover"));
-        assert!(!names.contains(&"sessions_send"));
+        let names = entries
+            .iter()
+            .map(|entry| entry.name)
+            .collect::<BTreeSet<_>>();
+        let expected = BTreeSet::from([
+            "approval_request_resolve",
+            "approval_request_status",
+            "approval_requests_list",
+            "browser.click",
+            "browser.extract",
+            "browser.open",
+            "claw.migrate",
+            "delegate",
+            "delegate_async",
+            "external_skills.policy",
+            "file.edit",
+            "file.read",
+            "file.write",
+            "provider.switch",
+            "session_events",
+            "session_status",
+            "session_wait",
+            "sessions_history",
+            "sessions_list",
+            "web.fetch",
+        ]);
+
+        assert_eq!(names, expected);
     }
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
     fn tool_registry_re_exposes_session_mutation_tools_when_runtime_policy_allows_them() {
         let config = runtime_config::ToolRuntimeConfig {
+            sessions_enabled: true,
             sessions_allow_mutation: true,
             ..runtime_config::ToolRuntimeConfig::default()
         };
@@ -1972,6 +1964,7 @@ mod tests {
     #[test]
     fn runtime_tool_view_re_exposes_session_mutation_tools_when_enabled() {
         let mut config = crate::config::ToolConfig::default();
+        config.sessions.enabled = true;
         config.sessions.allow_mutation = true;
 
         let view = runtime_tool_view_for_config(&config);

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -290,6 +290,7 @@ pub struct ToolRuntimeConfig {
     pub shell_default_mode: ShellPolicyDefault,
     pub config_path: Option<PathBuf>,
     pub sessions_enabled: bool,
+    pub sessions_allow_mutation: bool,
     pub messages_enabled: bool,
     pub delegate_enabled: bool,
     pub runtime_self: RuntimeSelfRuntimePolicy,
@@ -314,6 +315,7 @@ impl Default for ToolRuntimeConfig {
             shell_default_mode: ShellPolicyDefault::Deny,
             config_path: None,
             sessions_enabled: true,
+            sessions_allow_mutation: false,
             messages_enabled: false,
             delegate_enabled: true,
             runtime_self: RuntimeSelfRuntimePolicy::default(),
@@ -349,6 +351,7 @@ impl ToolRuntimeConfig {
             shell_default_mode: ShellPolicyDefault::parse(&config.tools.shell_default_mode),
             config_path: config_path.map(Path::to_path_buf),
             sessions_enabled: config.tools.sessions.enabled,
+            sessions_allow_mutation: config.tools.sessions.allow_mutation,
             messages_enabled: config.tools.messages.enabled,
             delegate_enabled: config.tools.delegate.enabled,
             runtime_self: RuntimeSelfRuntimePolicy::from_limits(
@@ -454,6 +457,8 @@ impl ToolRuntimeConfig {
             .ok()
             .map(PathBuf::from);
         let sessions_enabled = parse_env_bool("LOONGCLAW_TOOL_SESSIONS_ENABLED").unwrap_or(true);
+        let sessions_allow_mutation =
+            parse_env_bool("LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION").unwrap_or(false);
         let messages_enabled = parse_env_bool("LOONGCLAW_TOOL_MESSAGES_ENABLED").unwrap_or(false);
         let delegate_enabled = parse_env_bool("LOONGCLAW_TOOL_DELEGATE_ENABLED").unwrap_or(true);
         let runtime_self_max_source_chars =
@@ -553,6 +558,7 @@ impl ToolRuntimeConfig {
             file_root,
             config_path,
             sessions_enabled,
+            sessions_allow_mutation,
             messages_enabled,
             delegate_enabled,
             runtime_self: runtime_self_policy,
@@ -1022,6 +1028,7 @@ mod tests {
             "LOONGCLAW_CONFIG_PATH",
             "LOONGCLAW_FILE_ROOT",
             "LOONGCLAW_TOOL_SESSIONS_ENABLED",
+            "LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION",
             "LOONGCLAW_TOOL_MESSAGES_ENABLED",
             "LOONGCLAW_TOOL_DELEGATE_ENABLED",
             "LOONGCLAW_RUNTIME_SELF_MAX_SOURCE_CHARS",
@@ -1075,6 +1082,7 @@ mod tests {
         assert!(config.file_root.is_none());
         assert!(config.config_path.is_none());
         assert!(config.sessions_enabled);
+        assert!(!config.sessions_allow_mutation);
         assert!(!config.messages_enabled);
         assert!(config.delegate_enabled);
         assert_eq!(
@@ -1140,6 +1148,7 @@ mod tests {
     fn explicit_config_injection_overrides_defaults() {
         let config = ToolRuntimeConfig {
             sessions_enabled: false,
+            sessions_allow_mutation: true,
             messages_enabled: true,
             delegate_enabled: false,
             shell_allow: BTreeSet::from(["git".to_owned(), "cargo".to_owned()]),
@@ -1188,6 +1197,7 @@ mod tests {
             Some(PathBuf::from("/tmp/test-root/loongclaw.toml"))
         );
         assert!(!config.sessions_enabled);
+        assert!(config.sessions_allow_mutation);
         assert!(config.messages_enabled);
         assert!(!config.delegate_enabled);
         assert_eq!(config.runtime_self.max_source_chars, 4_096);
@@ -1296,6 +1306,22 @@ mod tests {
     }
 
     #[test]
+    fn from_loongclaw_config_projects_session_mutation_toggle() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        #[cfg(feature = "feishu-integration")]
+        clear_feishu_runtime_env(&mut env);
+
+        let mut config = crate::config::LoongClawConfig::default();
+        config.tools.sessions.allow_mutation = true;
+
+        let runtime = ToolRuntimeConfig::from_loongclaw_config(&config, None);
+
+        assert!(runtime.sessions_enabled);
+        assert!(runtime.sessions_allow_mutation);
+    }
+
+    #[test]
     fn from_loongclaw_config_canonicalizes_web_search_provider_alias() {
         let mut env = ScopedEnv::new();
         clear_tool_runtime_env(&mut env);
@@ -1347,6 +1373,7 @@ mod tests {
         #[cfg(feature = "feishu-integration")]
         clear_feishu_runtime_env(&mut env);
         env.set("LOONGCLAW_TOOL_SESSIONS_ENABLED", "false");
+        env.set("LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION", "true");
         env.set("LOONGCLAW_TOOL_MESSAGES_ENABLED", "true");
         env.set("LOONGCLAW_TOOL_DELEGATE_ENABLED", "false");
         env.set("LOONGCLAW_BROWSER_ENABLED", "false");
@@ -1392,6 +1419,7 @@ mod tests {
 
         let config = ToolRuntimeConfig::from_env();
         assert!(!config.sessions_enabled);
+        assert!(config.sessions_allow_mutation);
         assert!(config.messages_enabled);
         assert!(!config.delegate_enabled);
         assert!(!config.browser.enabled);

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -255,27 +255,41 @@ pub fn execute_session_tool_with_policies(
         if !tool_config.sessions.enabled {
             return Err("app_tool_disabled: session tools are disabled by config".to_owned());
         }
-        match request.tool_name.as_str() {
+        let ToolCoreRequest { tool_name, payload } = request;
+        let tool_catalog = super::tool_catalog();
+        let tool_descriptor = tool_catalog.resolve(tool_name.as_str());
+        let visibility_gate = tool_descriptor.map(|descriptor| descriptor.visibility_gate);
+        let mutation_gate = super::catalog::ToolVisibilityGate::SessionMutation;
+        let uses_mutation_gate = visibility_gate == Some(mutation_gate);
+        let mutation_disabled = !tool_config.sessions.allow_mutation;
+
+        if uses_mutation_gate && mutation_disabled {
+            return Err(format!(
+                "app_tool_disabled: session mutation tool `{tool_name}` is disabled by config"
+            ));
+        }
+
+        match tool_name.as_str() {
             "sessions_list" => {
-                execute_sessions_list(request.payload, current_session_id, config, tool_config)
+                execute_sessions_list(payload, current_session_id, config, tool_config)
             }
             "session_events" => {
-                execute_session_events(request.payload, current_session_id, config, tool_config)
+                execute_session_events(payload, current_session_id, config, tool_config)
             }
             "sessions_history" => {
-                execute_sessions_history(request.payload, current_session_id, config, tool_config)
+                execute_sessions_history(payload, current_session_id, config, tool_config)
             }
             "session_status" => {
-                execute_session_status(request.payload, current_session_id, config, tool_config)
+                execute_session_status(payload, current_session_id, config, tool_config)
             }
             "session_cancel" => {
-                execute_session_cancel(request.payload, current_session_id, config, tool_config)
+                execute_session_cancel(payload, current_session_id, config, tool_config)
             }
             "session_archive" => {
-                execute_session_archive(request.payload, current_session_id, config, tool_config)
+                execute_session_archive(payload, current_session_id, config, tool_config)
             }
             "session_recover" => {
-                execute_session_recover(request.payload, current_session_id, config, tool_config)
+                execute_session_recover(payload, current_session_id, config, tool_config)
             }
             other => Err(format!(
                 "app_tool_not_found: unknown session tool `{other}`"
@@ -2610,7 +2624,7 @@ fn session_terminal_outcome_json(
 mod tests {
     use std::fs;
 
-    use loongclaw_contracts::ToolCoreRequest;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
     use rusqlite::params;
     use serde_json::{Value, json};
 
@@ -2636,6 +2650,16 @@ mod tests {
             sqlite_path: Some(db_path),
             ..MemoryRuntimeConfig::default()
         }
+    }
+
+    fn execute_session_mutation_tool_with_config(
+        request: ToolCoreRequest,
+        current_session_id: &str,
+        config: &MemoryRuntimeConfig,
+    ) -> Result<ToolCoreOutcome, String> {
+        let mut tool_config = ToolConfig::default();
+        tool_config.sessions.allow_mutation = true;
+        execute_session_tool_with_policies(request, current_session_id, config, &tool_config)
     }
 
     fn overwrite_session_event_ts(
@@ -2667,6 +2691,32 @@ mod tests {
             .iter()
             .find(|item| item.get("session_id").and_then(Value::as_str) == Some(session_id))
             .unwrap_or_else(|| panic!("missing batch result for session `{session_id}`"))
+    }
+
+    #[test]
+    fn session_mutation_tools_are_disabled_by_default() {
+        let config = isolated_memory_config("session-mutation-disabled");
+        let expected_error =
+            "app_tool_disabled: session mutation tool `session_archive` is disabled by config";
+
+        let error = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_archive".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect_err("session mutation tools should require explicit opt-in");
+
+        let matches_expected_error = error.contains(expected_error);
+
+        assert!(
+            matches_expected_error,
+            "expected mutation gating error, got: {error}"
+        );
     }
 
     #[test]
@@ -2881,7 +2931,7 @@ mod tests {
             .expect("finalize child");
         }
 
-        execute_session_tool_with_config(
+        execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_archive".to_owned(),
                 payload: json!({
@@ -2949,7 +2999,7 @@ mod tests {
             },
         )
         .expect("finalize child");
-        execute_session_tool_with_config(
+        execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_archive".to_owned(),
                 payload: json!({
@@ -3446,7 +3496,7 @@ mod tests {
             super::current_unix_ts() - 90,
         );
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_recover".to_owned(),
                 payload: json!({
@@ -3509,7 +3559,7 @@ mod tests {
         })
         .expect("append queued event");
 
-        let error = execute_session_tool_with_config(
+        let error = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_recover".to_owned(),
                 payload: json!({
@@ -3580,7 +3630,7 @@ mod tests {
             super::current_unix_ts() - 90,
         );
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_recover".to_owned(),
                 payload: json!({
@@ -3658,7 +3708,7 @@ mod tests {
         })
         .expect("append started event");
 
-        let error = execute_session_tool_with_config(
+        let error = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_recover".to_owned(),
                 payload: json!({
@@ -3739,7 +3789,7 @@ mod tests {
             super::current_unix_ts() - 90,
         );
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_recover".to_owned(),
                 payload: json!({
@@ -3900,7 +3950,7 @@ mod tests {
             super::current_unix_ts() - 90,
         );
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_recover".to_owned(),
                 payload: json!({
@@ -4024,7 +4074,7 @@ mod tests {
         })
         .expect("append queued event");
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_cancel".to_owned(),
                 payload: json!({
@@ -4095,7 +4145,7 @@ mod tests {
         })
         .expect("append started event");
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_cancel".to_owned(),
                 payload: json!({
@@ -4203,7 +4253,7 @@ mod tests {
         })
         .expect("append running started event");
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_cancel".to_owned(),
                 payload: json!({
@@ -4333,7 +4383,7 @@ mod tests {
         })
         .expect("append running started event");
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_cancel".to_owned(),
                 payload: json!({
@@ -5058,7 +5108,7 @@ mod tests {
         )
         .expect("finalize child");
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_archive".to_owned(),
                 payload: json!({
@@ -5148,7 +5198,7 @@ mod tests {
             )
             .expect("finalize child");
         }
-        execute_session_tool_with_config(
+        execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_archive".to_owned(),
                 payload: json!({
@@ -5160,7 +5210,7 @@ mod tests {
         )
         .expect("archive already-archived child");
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_archive".to_owned(),
                 payload: json!({
@@ -5261,7 +5311,7 @@ mod tests {
             )
             .expect("finalize child");
         }
-        execute_session_tool_with_config(
+        execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_archive".to_owned(),
                 payload: json!({
@@ -5273,7 +5323,7 @@ mod tests {
         )
         .expect("archive already-archived child");
 
-        let outcome = execute_session_tool_with_config(
+        let outcome = execute_session_mutation_tool_with_config(
             ToolCoreRequest {
                 tool_name: "session_archive".to_owned(),
                 payload: json!({

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -2696,27 +2696,28 @@ mod tests {
     #[test]
     fn session_mutation_tools_are_disabled_by_default() {
         let config = isolated_memory_config("session-mutation-disabled");
-        let expected_error =
-            "app_tool_disabled: session mutation tool `session_archive` is disabled by config";
+        for tool_name in ["session_archive", "session_cancel", "session_recover"] {
+            let error = execute_session_tool_with_config(
+                ToolCoreRequest {
+                    tool_name: tool_name.to_owned(),
+                    payload: json!({
+                        "session_id": "child-session"
+                    }),
+                },
+                "root-session",
+                &config,
+            )
+            .expect_err("session mutation tools should require explicit opt-in");
+            let expected_error = format!(
+                "app_tool_disabled: session mutation tool `{tool_name}` is disabled by config"
+            );
+            let matches_expected_error = error.contains(expected_error.as_str());
 
-        let error = execute_session_tool_with_config(
-            ToolCoreRequest {
-                tool_name: "session_archive".to_owned(),
-                payload: json!({
-                    "session_id": "child-session"
-                }),
-            },
-            "root-session",
-            &config,
-        )
-        .expect_err("session mutation tools should require explicit opt-in");
-
-        let matches_expected_error = error.contains(expected_error);
-
-        assert!(
-            matches_expected_error,
-            "expected mutation gating error, got: {error}"
-        );
+            assert!(
+                matches_expected_error,
+                "expected mutation gating error for {tool_name}, got: {error}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Problem: session mutation tools shared the same default model-facing visibility path as read-only session tools whenever session tools were enabled.
- Why it matters: `session_archive`, `session_cancel`, and `session_recover` change session state and should not be exposed through the default LLM tool surface without explicit operator intent.
- What changed: added a dedicated session mutation config gate, wired it into catalog visibility and runtime policy evaluation, and enforced the same gate in direct execution so the path fails closed when mutation tools are disabled.
- What did not change (scope boundary): read-only session tools still follow the existing session gate, `sessions_send` still follows the messages gate, and the session tool module was not split or redesigned.

## Linked Issues

- Closes #411
- Related: none

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: operators that rely on session mutation tools now need explicit opt-in instead of inheriting access from the broad session tool toggle.
- Rollout / guardrails: set `tools.sessions.allow_mutation = true` or `LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION=true` where mutation tools are intentionally required.
- Rollback path: revert commit `aee02629`.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
  -> passed
cargo test -p loongclaw-app
  -> passed
cargo test --workspace
  -> passed
cargo fmt --all -- --check
  -> passed
cargo test --workspace --locked
  -> passed
cargo test --workspace --all-features --locked
  -> passed
cargo clippy --workspace --all-targets --all-features -- -D warnings
  -> passed

Targeted regression coverage added and executed for:
- runtime tool view hiding session mutation tools by default
- runtime policy re-exposing mutation tools only when explicitly allowed
- config parsing and project config mapping for the new allow_mutation toggle
- runtime environment export for `LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION`
- direct execution failing closed when mutation tools remain disabled
```

Before / after behavior for config and defaults:

- Before: enabling session tools exposed both read-only and mutating session operations through the same runtime surface.
- After: enabling session tools exposes read-only session tools, while mutation tools require explicit opt-in through config or env.
- Regression coverage: config parsing, runtime config translation, runtime env export, catalog visibility filtering, and direct execution gating all have test coverage.

## User-visible / Operator-visible Changes

- By default, the runtime tool surface no longer exposes `session_archive`, `session_cancel`, or `session_recover`.
- Operators can re-enable those tools explicitly through `tools.sessions.allow_mutation` or `LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION`.
- Direct calls to disabled mutation tools now return a config-disabled error instead of relying on visibility alone.

## Failure Recovery

- Fast rollback or disable path: opt in with `tools.sessions.allow_mutation = true` or `LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION=true` if the old behavior is temporarily required, or revert commit `aee02629`.
- Observable failure symptoms reviewers should watch for: mutation-oriented session tools are absent from runtime tool listings by default, and direct execution returns an `app_tool_disabled` error when the mutation gate is off.

## Reviewer Focus

- `crates/app/src/tools/catalog.rs` for the new `SessionMutation` visibility gate and descriptor classification.
- `crates/app/src/tools/runtime_config.rs` and `crates/app/src/config/tools.rs` for config defaults, project mapping, and env fallback alignment.
- `crates/app/src/tools/session.rs` for fail-closed execution behavior when a hidden mutation tool is called directly.
- `crates/app/src/runtime_env.rs` for exporting the new mutation gate into the runtime environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session mutation operations (archive, cancel, recover) are hidden by default and can be enabled via a new runtime/config flag.
  * Runtime now exposes a corresponding environment toggle so operators can enable session mutation when needed.

* **Chores**
  * Configuration and runtime handling updated to support session-mutation gating.
  * Tests and discovery/catalog behavior adjusted to reflect the new default and enablement paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->