### PR TITLE
feat(tools): add tool execution timeout framework

### DIFF
--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeSet, path::PathBuf};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -70,7 +73,7 @@ pub struct ToolExecutionToolConfig {
     #[serde(default)]
     pub default_timeout_seconds: Option<u64>,
     #[serde(default)]
-    pub per_tool_timeout: std::collections::HashMap<String, u64>,
+    pub per_tool_timeout: BTreeMap<String, u64>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -602,6 +605,25 @@ impl ToolConfig {
         ) {
             issues.push(*issue);
         }
+        if self.tool_execution.default_timeout_seconds == Some(0)
+            && let Err(issue) = validate_numeric_range(
+                "tools.tool_execution.default_timeout_seconds",
+                0,
+                1,
+                usize::MAX,
+            )
+        {
+            issues.push(*issue);
+        }
+        for (tool_name, timeout_seconds) in &self.tool_execution.per_tool_timeout {
+            if *timeout_seconds != 0 {
+                continue;
+            }
+            let field_path = format!("tools.tool_execution.per_tool_timeout.{tool_name}");
+            if let Err(issue) = validate_numeric_range(&field_path, 0, 1, usize::MAX) {
+                issues.push(*issue);
+            }
+        }
         if let Some(max_sessions) = self.delegate.child_runtime.browser.max_sessions
             && let Err(issue) = validate_numeric_range(
                 "tools.delegate.child_runtime.browser.max_sessions",
@@ -724,49 +746,6 @@ impl ToolConfig {
                 suggested_env_name: Some("LOONGCLAW_WEB_SEARCH_PROVIDER".to_owned()),
                 extra_message_variables,
             });
-        }
-        if let Some(v) = self.tool_execution.default_timeout_seconds
-            && v == 0
-        {
-            let mut vars = std::collections::BTreeMap::new();
-            vars.insert("actual_value".to_owned(), v.to_string());
-            issues.push(super::shared::ConfigValidationIssue {
-                severity: super::shared::ConfigValidationSeverity::Error,
-                code: super::shared::ConfigValidationCode::NumericRange,
-                field_path: "tools.tool_execution.default_timeout_seconds".to_owned(),
-                inline_field_path: "tools.tool_execution.default_timeout_seconds".to_owned(),
-                example_env_name: "LOONGCLAW_TOOL_DEFAULT_TIMEOUT_SECONDS".to_owned(),
-                suggested_env_name: Some("LOONGCLAW_TOOL_DEFAULT_TIMEOUT_SECONDS".to_owned()),
-                extra_message_variables: vars,
-            });
-        }
-        for (key, &value) in &self.tool_execution.per_tool_timeout {
-            if value == 0 {
-                let mut vars = std::collections::BTreeMap::new();
-                vars.insert("tool_name".to_owned(), key.clone());
-                vars.insert("actual_value".to_owned(), value.to_string());
-                let env_tool_name: String = key
-                    .chars()
-                    .map(|ch| {
-                        if ch.is_ascii_alphanumeric() {
-                            ch.to_ascii_uppercase()
-                        } else {
-                            '_'
-                        }
-                    })
-                    .collect();
-                issues.push(super::shared::ConfigValidationIssue {
-                    severity: super::shared::ConfigValidationSeverity::Error,
-                    code: super::shared::ConfigValidationCode::NumericRange,
-                    field_path: format!("tools.tool_execution.per_tool_timeout[\"{key}\"]"),
-                    inline_field_path: format!("tools.tool_execution.per_tool_timeout[\"{key}\"]"),
-                    example_env_name: format!("LOONGCLAW_TOOL_{env_tool_name}_TIMEOUT_SECONDS"),
-                    suggested_env_name: Some(format!(
-                        "LOONGCLAW_TOOL_{env_tool_name}_TIMEOUT_SECONDS"
-                    )),
-                    extra_message_variables: vars,
-                });
-            }
         }
         issues
     }
@@ -1166,6 +1145,72 @@ mod tests {
                 )
             }),
             "unexpected web_search validation issues: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_zero_tool_execution_default_timeout() {
+        let mut config = ToolConfig::default();
+        config.tool_execution.default_timeout_seconds = Some(0);
+
+        let issues = config.validate();
+
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.field_path == "tools.tool_execution.default_timeout_seconds"),
+            "expected default timeout validation issue, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_zero_tool_execution_per_tool_timeout() {
+        let mut config = ToolConfig::default();
+        config
+            .tool_execution
+            .per_tool_timeout
+            .insert("file.read".to_owned(), 0);
+
+        let issues = config.validate();
+
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.field_path == "tools.tool_execution.per_tool_timeout.file.read"),
+            "expected per-tool timeout validation issue, got {issues:?}"
+        );
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn tool_config_parses_tool_execution_settings_from_toml() {
+        let raw = r#"
+[tools.tool_execution]
+default_timeout_seconds = 12
+per_tool_timeout = { "file.read" = 3, "web.search" = 9 }
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+
+        assert_eq!(
+            parsed.tools.tool_execution.default_timeout_seconds,
+            Some(12)
+        );
+        assert_eq!(
+            parsed
+                .tools
+                .tool_execution
+                .per_tool_timeout
+                .get("file.read"),
+            Some(&3)
+        );
+        assert_eq!(
+            parsed
+                .tools
+                .tool_execution
+                .per_tool_timeout
+                .get("web.search"),
+            Some(&9)
         );
     }
 

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -61,6 +61,16 @@ pub struct ToolConfig {
     pub web: WebToolConfig,
     #[serde(default)]
     pub web_search: WebSearchToolConfig,
+    #[serde(default)]
+    pub tool_execution: ToolExecutionToolConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ToolExecutionToolConfig {
+    #[serde(default)]
+    pub default_timeout_seconds: Option<u64>,
+    #[serde(default)]
+    pub per_tool_timeout: std::collections::HashMap<String, u64>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -404,6 +414,7 @@ impl Default for ToolConfig {
             browser_companion: BrowserCompanionToolConfig::default(),
             web: WebToolConfig::default(),
             web_search: WebSearchToolConfig::default(),
+            tool_execution: ToolExecutionToolConfig::default(),
         }
     }
 }

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -725,6 +725,43 @@ impl ToolConfig {
                 extra_message_variables,
             });
         }
+        if let Some(v) = self.tool_execution.default_timeout_seconds
+            && v == 0
+        {
+            let mut vars = std::collections::BTreeMap::new();
+            vars.insert("actual_value".to_owned(), v.to_string());
+            issues.push(super::shared::ConfigValidationIssue {
+                severity: super::shared::ConfigValidationSeverity::Error,
+                code: super::shared::ConfigValidationCode::NumericRange,
+                field_path: "tools.tool_execution.default_timeout_seconds".to_owned(),
+                inline_field_path: "tools.tool_execution.default_timeout_seconds".to_owned(),
+                example_env_name: "LOONGCLAW_TOOL_DEFAULT_TIMEOUT_SECONDS".to_owned(),
+                suggested_env_name: Some("LOONGCLAW_TOOL_DEFAULT_TIMEOUT_SECONDS".to_owned()),
+                extra_message_variables: vars,
+            });
+        }
+        for (key, &value) in &self.tool_execution.per_tool_timeout {
+            if value == 0 {
+                let mut vars = std::collections::BTreeMap::new();
+                vars.insert("tool_name".to_owned(), key.clone());
+                vars.insert("actual_value".to_owned(), value.to_string());
+                issues.push(super::shared::ConfigValidationIssue {
+                    severity: super::shared::ConfigValidationSeverity::Error,
+                    code: super::shared::ConfigValidationCode::NumericRange,
+                    field_path: format!("tools.tool_execution.per_tool_timeout[\"{key}\"]"),
+                    inline_field_path: format!("tools.tool_execution.per_tool_timeout[\"{key}\"]"),
+                    example_env_name: format!(
+                        "LOONGCLAW_TOOL_{}_TIMEOUT_SECONDS",
+                        key.to_uppercase()
+                    ),
+                    suggested_env_name: Some(format!(
+                        "LOONGCLAW_TOOL_{}_TIMEOUT_SECONDS",
+                        key.to_uppercase()
+                    )),
+                    extra_message_variables: vars,
+                });
+            }
+        }
         issues
     }
 }

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -745,18 +745,24 @@ impl ToolConfig {
                 let mut vars = std::collections::BTreeMap::new();
                 vars.insert("tool_name".to_owned(), key.clone());
                 vars.insert("actual_value".to_owned(), value.to_string());
+                let env_tool_name: String = key
+                    .chars()
+                    .map(|ch| {
+                        if ch.is_ascii_alphanumeric() {
+                            ch.to_ascii_uppercase()
+                        } else {
+                            '_'
+                        }
+                    })
+                    .collect();
                 issues.push(super::shared::ConfigValidationIssue {
                     severity: super::shared::ConfigValidationSeverity::Error,
                     code: super::shared::ConfigValidationCode::NumericRange,
                     field_path: format!("tools.tool_execution.per_tool_timeout[\"{key}\"]"),
                     inline_field_path: format!("tools.tool_execution.per_tool_timeout[\"{key}\"]"),
-                    example_env_name: format!(
-                        "LOONGCLAW_TOOL_{}_TIMEOUT_SECONDS",
-                        key.to_uppercase()
-                    ),
+                    example_env_name: format!("LOONGCLAW_TOOL_{env_tool_name}_TIMEOUT_SECONDS"),
                     suggested_env_name: Some(format!(
-                        "LOONGCLAW_TOOL_{}_TIMEOUT_SECONDS",
-                        key.to_uppercase()
+                        "LOONGCLAW_TOOL_{env_tool_name}_TIMEOUT_SECONDS"
                     )),
                     extra_message_variables: vars,
                 });

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -5,8 +5,8 @@ use std::{
     ffi::OsString,
     future::Future,
     path::{Path, PathBuf},
-    sync::OnceLock,
-    time::{SystemTime, UNIX_EPOCH},
+    sync::{OnceLock, mpsc},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -75,22 +75,12 @@ pub const BROWSER_COMPANION_PREVIEW_SKILL_ID: &str =
     bundled_skills::BROWSER_COMPANION_PREVIEW_SKILL_ID;
 pub const BROWSER_COMPANION_COMMAND: &str = bundled_skills::BROWSER_COMPANION_COMMAND;
 
-const TOOLS_WITH_OWN_TIMEOUT: &[&str] = &[
-    "shell.exec",
-    "web.fetch",
-    "web.search",
-    "browser.companion.session.start",
-    "browser.companion.navigate",
-    "browser.companion.snapshot",
-    "browser.companion.wait",
-    "browser.companion.session.stop",
-    "browser.companion.click",
-    "browser.companion.type",
-];
-
-fn tool_has_own_timeout(tool_name: &str) -> bool {
-    TOOLS_WITH_OWN_TIMEOUT.contains(&tool_name)
-}
+const BROWSER_COMPANION_TOOL_PREFIX: &str = "browser.companion.";
+const DELEGATE_ASYNC_TOOL_NAME: &str = "delegate_async";
+const DELEGATE_TOOL_NAME: &str = "delegate";
+pub(crate) const SHELL_EXEC_TOOL_NAME: &str = "shell.exec";
+const WEB_FETCH_TOOL_NAME: &str = "web.fetch";
+const WEB_SEARCH_TOOL_NAME: &str = "web.search";
 
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
@@ -714,7 +704,6 @@ fn execute_discoverable_tool_core_with_config(
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let tool_name = request.tool_name.clone();
-
     let timeout_seconds = config.tool_execution.timeout_for_tool(&tool_name);
 
     let inner = {
@@ -723,11 +712,30 @@ fn execute_discoverable_tool_core_with_config(
     };
 
     match timeout_seconds {
-        Some(seconds) if seconds > 0 && !tool_has_own_timeout(&tool_name) => {
+        Some(seconds) if seconds > 0 && !tool_uses_dedicated_timeout(&tool_name) => {
             run_blocking_with_timeout(inner, seconds, &tool_name)
         }
         _ => inner(),
     }
+}
+
+fn tool_uses_dedicated_timeout(tool_name: &str) -> bool {
+    if tool_name == SHELL_EXEC_TOOL_NAME {
+        return true;
+    }
+    if tool_name == WEB_FETCH_TOOL_NAME {
+        return true;
+    }
+    if tool_name == WEB_SEARCH_TOOL_NAME {
+        return true;
+    }
+    if tool_name == DELEGATE_TOOL_NAME {
+        return true;
+    }
+    if tool_name == DELEGATE_ASYNC_TOOL_NAME {
+        return true;
+    }
+    tool_name.starts_with(BROWSER_COMPANION_TOOL_PREFIX)
 }
 
 fn dispatch_tool_request(
@@ -799,28 +807,44 @@ where
     F: FnOnce() -> Result<T, String> + Send + 'static,
     T: Send + 'static,
 {
-    let timeout = tokio::time::Duration::from_secs(timeout_seconds);
+    let timeout = Duration::from_secs(timeout_seconds);
     let tool_name = tool_name.to_owned();
+    let worker_name = format!("tool-timeout:{tool_name}");
+    let (sender, receiver) = mpsc::sync_channel(1);
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| format!("failed to create tokio runtime for timeout: {error}"))?;
+    let worker = std::thread::Builder::new()
+        .name(worker_name)
+        .spawn(move || {
+            let result = f();
+            let _ = sender.send(result);
+        })
+        .map_err(|error| format!("failed to spawn tool timeout worker for {tool_name}: {error}"))?;
 
-    rt.block_on(async move {
-        let join_handle = tokio::task::spawn_blocking(f);
-
-        match tokio::time::timeout(timeout, join_handle).await {
-            Ok(Ok(Ok(result))) => Ok(result),
-            Ok(Ok(Err(e))) => Err(e),
-            Ok(Err(join_error)) => Err(format!(
-                "tool_execution_join_error: {tool_name} panicked: {join_error}"
-            )),
-            Err(_) => Err(format!(
-                "tool_execution_timeout: {tool_name} exceeded {timeout_seconds}s"
-            )),
+    match receiver.recv_timeout(timeout) {
+        Ok(result) => {
+            let join_result = worker.join();
+            if join_result.is_err() {
+                return Err(format!(
+                    "tool_execution_join_error: {tool_name} worker thread panicked"
+                ));
+            }
+            result
         }
-    })
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(format!(
+            "tool_execution_timeout: {tool_name} exceeded {timeout_seconds}s"
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let join_result = worker.join();
+            if join_result.is_err() {
+                return Err(format!(
+                    "tool_execution_join_error: {tool_name} worker thread panicked"
+                ));
+            }
+            Err(format!(
+                "tool_execution_join_error: {tool_name} worker thread exited without returning a result"
+            ))
+        }
+    }
 }
 
 /// Tool registry entry for capability snapshot disclosure.
@@ -2977,6 +3001,20 @@ mod tests {
     }
 
     #[test]
+    fn framework_timeout_excludes_tools_with_dedicated_timeout_controls() {
+        assert!(tool_uses_dedicated_timeout(
+            "browser.companion.session.start"
+        ));
+        assert!(tool_uses_dedicated_timeout("browser.companion.wait"));
+        assert!(tool_uses_dedicated_timeout("delegate"));
+        assert!(tool_uses_dedicated_timeout("delegate_async"));
+        assert!(tool_uses_dedicated_timeout("shell.exec"));
+        assert!(tool_uses_dedicated_timeout("web.fetch"));
+        assert!(tool_uses_dedicated_timeout("web.search"));
+        assert!(!tool_uses_dedicated_timeout("file.read"));
+    }
+
+    #[test]
     fn tool_without_timeout_config_completes_normally() {
         use std::fs;
 
@@ -2999,6 +3037,58 @@ mod tests {
         assert!(
             result.is_ok(),
             "tool should complete normally without timeout, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn framework_timeout_returns_without_waiting_for_worker_completion() {
+        let start = std::time::Instant::now();
+
+        let error = run_blocking_with_timeout(
+            || {
+                let (_sender, receiver) = mpsc::channel::<()>();
+                let _ = receiver.recv_timeout(Duration::from_secs(3));
+                Ok::<(), String>(())
+            },
+            1,
+            "file.read",
+        )
+        .expect_err("timeout should be reported");
+
+        let elapsed = start.elapsed();
+
+        assert_eq!(error, "tool_execution_timeout: file.read exceeded 1s");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "timeout helper should return promptly, got {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn framework_timeout_supports_async_core_tool_calls() {
+        use std::fs;
+
+        let root = unique_temp_dir("tool-timeout-async-core");
+        fs::create_dir_all(&root).expect("create temp dir");
+        let readme_path = root.join("README.md");
+        fs::write(&readme_path, "readme content").expect("write test file");
+
+        let mut config = test_tool_runtime_config(root);
+        config.tool_execution.default_timeout_seconds = Some(1);
+
+        let adapter = MvpToolAdapter::with_config(config);
+        let request = ToolCoreRequest {
+            tool_name: "file.read".to_owned(),
+            payload: json!({
+                "path": "README.md"
+            }),
+        };
+
+        let result = loongclaw_kernel::CoreToolAdapter::execute_core_tool(&adapter, request).await;
+
+        assert!(
+            result.is_ok(),
+            "async core tool execution should stay usable with framework timeouts, got: {result:?}"
         );
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -75,6 +75,8 @@ pub const BROWSER_COMPANION_PREVIEW_SKILL_ID: &str =
     bundled_skills::BROWSER_COMPANION_PREVIEW_SKILL_ID;
 pub const BROWSER_COMPANION_COMMAND: &str = bundled_skills::BROWSER_COMPANION_COMMAND;
 
+pub(crate) const SHELL_EXEC_TOOL_NAME: &str = "shell.exec";
+
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: &str = "visible_tool_ids";
@@ -706,7 +708,7 @@ fn execute_discoverable_tool_core_with_config(
     };
 
     match timeout_seconds {
-        Some(seconds) if seconds > 0 && tool_name != "shell.exec" => {
+        Some(seconds) if seconds > 0 && tool_name != SHELL_EXEC_TOOL_NAME => {
             run_blocking_with_timeout(inner, seconds, &tool_name)
         }
         _ => inner(),
@@ -785,10 +787,14 @@ where
     let timeout = tokio::time::Duration::from_secs(timeout_seconds);
     let tool_name = tool_name.to_owned();
 
-    let handle = tokio::runtime::Handle::current();
-    let join_handle = handle.spawn_blocking(f);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("failed to create tokio runtime for timeout: {error}"))?;
 
-    handle.block_on(async move {
+    rt.block_on(async move {
+        let join_handle = tokio::task::spawn_blocking(f);
+
         match tokio::time::timeout(timeout, join_handle).await {
             Ok(Ok(Ok(result))) => Ok(result),
             Ok(Ok(Err(e))) => Err(e),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -75,7 +75,22 @@ pub const BROWSER_COMPANION_PREVIEW_SKILL_ID: &str =
     bundled_skills::BROWSER_COMPANION_PREVIEW_SKILL_ID;
 pub const BROWSER_COMPANION_COMMAND: &str = bundled_skills::BROWSER_COMPANION_COMMAND;
 
-pub(crate) const SHELL_EXEC_TOOL_NAME: &str = "shell.exec";
+const TOOLS_WITH_OWN_TIMEOUT: &[&str] = &[
+    "shell.exec",
+    "web.fetch",
+    "web.search",
+    "browser.companion.session.start",
+    "browser.companion.navigate",
+    "browser.companion.snapshot",
+    "browser.companion.wait",
+    "browser.companion.session.stop",
+    "browser.companion.click",
+    "browser.companion.type",
+];
+
+fn tool_has_own_timeout(tool_name: &str) -> bool {
+    TOOLS_WITH_OWN_TIMEOUT.contains(&tool_name)
+}
 
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
 const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
@@ -708,7 +723,7 @@ fn execute_discoverable_tool_core_with_config(
     };
 
     match timeout_seconds {
-        Some(seconds) if seconds > 0 && tool_name != SHELL_EXEC_TOOL_NAME => {
+        Some(seconds) if seconds > 0 && !tool_has_own_timeout(&tool_name) => {
             run_blocking_with_timeout(inner, seconds, &tool_name)
         }
         _ => inner(),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -696,6 +696,27 @@ fn execute_discoverable_tool_core_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let tool_name = request.tool_name.clone();
+
+    let timeout_seconds = config.tool_execution.timeout_for_tool(&tool_name);
+
+    let inner = {
+        let config = config.clone();
+        move || dispatch_tool_request(request, &config)
+    };
+
+    match timeout_seconds {
+        Some(seconds) if seconds > 0 && tool_name != "shell.exec" => {
+            run_blocking_with_timeout(inner, seconds, &tool_name)
+        }
+        _ => inner(),
+    }
+}
+
+fn dispatch_tool_request(
+    request: ToolCoreRequest,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
     match request.tool_name.as_str() {
         "claw.migrate" => claw_migrate::execute_claw_migrate_tool_with_config(request, config),
         "external_skills.inspect" => {
@@ -754,6 +775,31 @@ fn execute_discoverable_tool_core_with_config(
             request.tool_name
         )),
     }
+}
+
+fn run_blocking_with_timeout<F, T>(f: F, timeout_seconds: u64, tool_name: &str) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    let timeout = tokio::time::Duration::from_secs(timeout_seconds);
+    let tool_name = tool_name.to_owned();
+
+    let handle = tokio::runtime::Handle::current();
+    let join_handle = handle.spawn_blocking(f);
+
+    handle.block_on(async move {
+        match tokio::time::timeout(timeout, join_handle).await {
+            Ok(Ok(Ok(result))) => Ok(result),
+            Ok(Ok(Err(e))) => Err(e),
+            Ok(Err(join_error)) => Err(format!(
+                "tool_execution_join_error: {tool_name} panicked: {join_error}"
+            )),
+            Err(_) => Err(format!(
+                "tool_execution_timeout: {tool_name} exceeded {timeout_seconds}s"
+            )),
+        }
+    })
 }
 
 /// Tool registry entry for capability snapshot disclosure.
@@ -2873,6 +2919,66 @@ mod tests {
                 "expected path separator rejection for `{cmd}`, got: {error}"
             );
         }
+    }
+
+    #[test]
+    fn tool_execution_config_timeout_for_tool_prefers_per_tool() {
+        use std::collections::BTreeMap;
+
+        let mut per_tool = BTreeMap::new();
+        per_tool.insert("file.read".to_owned(), 30u64);
+
+        let config = runtime_config::ToolExecutionConfig {
+            default_timeout_seconds: Some(60u64),
+            per_tool_timeout: per_tool,
+        };
+
+        assert_eq!(config.timeout_for_tool("file.read"), Some(30));
+        assert_eq!(config.timeout_for_tool("file.write"), Some(60));
+        assert_eq!(config.timeout_for_tool("unknown"), Some(60));
+    }
+
+    #[test]
+    fn tool_execution_config_timeout_for_tool_none_when_no_default() {
+        let config = runtime_config::ToolExecutionConfig {
+            default_timeout_seconds: None,
+            per_tool_timeout: BTreeMap::new(),
+        };
+
+        assert_eq!(config.timeout_for_tool("file.read"), None);
+    }
+
+    #[test]
+    fn tool_execution_config_default_is_no_timeout() {
+        let config = runtime_config::ToolExecutionConfig::default();
+        assert_eq!(config.default_timeout_seconds, None);
+        assert!(config.per_tool_timeout.is_empty());
+    }
+
+    #[test]
+    fn tool_without_timeout_config_completes_normally() {
+        use std::fs;
+
+        let root = unique_temp_dir("no-timeout-test");
+        fs::create_dir_all(&root).expect("create temp dir");
+        let readme_path = root.join("README.md");
+        fs::write(&readme_path, "readme content").expect("write test file");
+
+        let config = test_tool_runtime_config(root);
+
+        let request = ToolCoreRequest {
+            tool_name: "file.read".to_owned(),
+            payload: json!({
+                "path": "README.md"
+            }),
+        };
+
+        let result = execute_tool_core_with_test_context(request, &config);
+
+        assert!(
+            result.is_ok(),
+            "tool should complete normally without timeout, got: {result:?}"
+        );
     }
 
     #[cfg(feature = "tool-shell")]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -286,8 +286,9 @@ pub struct ToolExecutionConfig {
 
 impl ToolExecutionConfig {
     pub fn timeout_for_tool(&self, tool_name: &str) -> Option<u64> {
+        let key = tool_name.to_lowercase();
         self.per_tool_timeout
-            .get(tool_name)
+            .get(&key)
             .copied()
             .or(self.default_timeout_seconds)
     }
@@ -456,7 +457,16 @@ impl ToolRuntimeConfig {
                 install_root: config.external_skills.resolved_install_root(),
                 auto_expose_installed: config.external_skills.auto_expose_installed,
             },
-            tool_execution: ToolExecutionConfig::default(),
+            tool_execution: ToolExecutionConfig {
+                default_timeout_seconds: config.tools.tool_execution.default_timeout_seconds,
+                per_tool_timeout: config
+                    .tools
+                    .tool_execution
+                    .per_tool_timeout
+                    .iter()
+                    .map(|(k, v): (&String, &u64)| (k.to_lowercase(), *v))
+                    .collect(),
+            },
             #[cfg(feature = "feishu-integration")]
             feishu: FeishuToolRuntimeConfig::from_loongclaw_config(config),
         }

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -278,6 +278,21 @@ impl FeishuToolRuntimeConfig {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ToolExecutionConfig {
+    pub default_timeout_seconds: Option<u64>,
+    pub per_tool_timeout: BTreeMap<String, u64>,
+}
+
+impl ToolExecutionConfig {
+    pub fn timeout_for_tool(&self, tool_name: &str) -> Option<u64> {
+        self.per_tool_timeout
+            .get(tool_name)
+            .copied()
+            .or(self.default_timeout_seconds)
+    }
+}
+
 /// Typed runtime configuration for tool executors.
 ///
 /// Replaces per-call `std::env::var` lookups with a single read from a
@@ -298,6 +313,7 @@ pub struct ToolRuntimeConfig {
     pub web_fetch: WebFetchRuntimePolicy,
     pub web_search: WebSearchRuntimePolicy,
     pub external_skills: ExternalSkillsRuntimePolicy,
+    pub tool_execution: ToolExecutionConfig,
     #[cfg(feature = "feishu-integration")]
     pub feishu: Option<FeishuToolRuntimeConfig>,
 }
@@ -322,6 +338,7 @@ impl Default for ToolRuntimeConfig {
             web_fetch: WebFetchRuntimePolicy::default(),
             web_search: WebSearchRuntimePolicy::default(),
             external_skills: ExternalSkillsRuntimePolicy::default(),
+            tool_execution: ToolExecutionConfig::default(),
             #[cfg(feature = "feishu-integration")]
             feishu: None,
         }
@@ -439,6 +456,7 @@ impl ToolRuntimeConfig {
                 install_root: config.external_skills.resolved_install_root(),
                 auto_expose_installed: config.external_skills.auto_expose_installed,
             },
+            tool_execution: ToolExecutionConfig::default(),
             #[cfg(feature = "feishu-integration")]
             feishu: FeishuToolRuntimeConfig::from_loongclaw_config(config),
         }
@@ -549,6 +567,24 @@ impl ToolRuntimeConfig {
         let auto_expose_installed =
             parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED").unwrap_or(false);
 
+        let tool_execution_default_timeout =
+            parse_env_u64("LOONGCLAW_TOOL_DEFAULT_TIMEOUT_SECONDS");
+        let mut tool_execution_per_tool_timeout = BTreeMap::new();
+        for (key, value) in std::env::vars() {
+            if let Some(tool_name) = key.strip_prefix("LOONGCLAW_TOOL_")
+                && let Some(stripped) = tool_name.strip_suffix("_TIMEOUT_SECONDS")
+                && !stripped.is_empty()
+                && stripped != "DEFAULT"
+                && let Ok(timeout) = value.parse::<u64>()
+            {
+                tool_execution_per_tool_timeout.insert(stripped.to_lowercase(), timeout);
+            }
+        }
+        let tool_execution = ToolExecutionConfig {
+            default_timeout_seconds: tool_execution_default_timeout,
+            per_tool_timeout: tool_execution_per_tool_timeout,
+        };
+
         Self {
             file_root,
             config_path,
@@ -590,6 +626,7 @@ impl ToolRuntimeConfig {
                 timeout_seconds: web_search_timeout_seconds,
                 max_results: web_search_max_results,
             },
+            tool_execution,
             ..Self::default()
         }
         .with_external_skills_policy(ExternalSkillsRuntimePolicy {


### PR DESCRIPTION
## Summary

- **Problem**: Tools like `file.read`, `browser.open`, and `external_skills.*` had no execution timeout. A long-running or hung tool would block the agent loop indefinitely. Meanwhile, `shell.exec`, `web.fetch`, `web.search`, `browser.companion`, and `delegate` each had their own isolated timeout logic with no uniform enforcement surface.
- **Why it matters**: Prevents agent loops from blocking indefinitely on hung tools; gives operators a configurable safety net for all discoverable tools.
- **What changed**: Added `ToolExecutionConfig` to `ToolRuntimeConfig` with `default_timeout_seconds` and `per_tool_timeout` fields. Wired timeout enforcement into `execute_discoverable_tool_core_with_config` via `run_blocking_with_timeout`. `shell.exec` is excluded (has its own `timeout_ms`).
- **What did not change (scope boundary)**: `shell.exec`, `web.fetch`, `web.search`, `browser.companion`, and `delegate` retain their existing per-tool timeout mechanisms.

## Linked Issues

- Closes #524
- Related #292

## Change Type

- [x] Feature

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked` (2 pre-existing failures in `onboard_cli.rs` unrelated to this change)
- [x] `cargo test --workspace --all-features --locked` (app crate: 2008 tests pass)
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage

Commands and evidence:

```text
# Format check
$ cargo fmt --all -- --check
(correct - no output)

# Clippy
$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished dev profile [unoptimized + debuginfo] target(s) in 19.63s

# App crate tests
$ cargo test -p loongclaw-app --all-features
test result: ok. 2008 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

# Tool execution timeout tests
$ cargo test -p loongclaw-app tool_execution --all-features -- --nocapture
test tools::tests::tool_execution_config_default_is_no_timeout ... ok
test tools::tests::tool_execution_config_timeout_for_tool_none_when_no_default ... ok
test tools::tests::tool_execution_config_timeout_for_tool_prefers_per_tool ... ok
test tools::tests::tool_without_timeout_config_completes_normally ... ok
```

## User-visible / Operator-visible Changes

- **New env vars**: `LOONGCLAW_TOOL_DEFAULT_TIMEOUT_SECONDS` (global default) and `LOONGCLAW_TOOL_<NAME>_TIMEOUT_SECONDS` (per-tool override)
- **New config fields**: `tools.tool.default_timeout_seconds` and `tools.tool.per_tool_timeout` in `loongclaw.toml`
- **Behavior**: When timeout is configured and triggers, tool returns error: `tool_execution_timeout: {tool_name} exceeded {N}s`
- **Default**: No timeout (`None`) — fully backward-compatible

## Failure Recovery

- **Fast rollback or disable path**: Set env var to empty or remove config fields — returns to no timeout
- **Observable failure symptoms reviewers should watch for**: Tools that legitimately take longer than configured timeout will fail with timeout error instead of completing

## Reviewer Focus

- `crates/app/src/tools/runtime_config.rs`: New `ToolExecutionConfig` struct, `timeout_for_tool` method, env parsing logic
- `crates/app/src/tools/mod.rs`: `execute_discoverable_tool_core_with_config` timeout wiring, `run_blocking_with_timeout` function
- **Edge case**: `shell.exec` is explicitly excluded from framework timeout (has its own `timeout_ms`) — verify this exclusion is correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable execution timeouts for discoverable tools with a global default and per-tool overrides; values can be set via app config or environment variables.

* **Bug Fixes / Reliability**
  * Long-running tool dispatches now run with enforced timeouts and fail fast; tools that provide their own timeout behavior are excluded.

* **Validation**
  * Zero-second timeout values are rejected.

* **Tests**
  * Unit tests added for timeout precedence, no-default behavior, exclusion list, successful no-timeout runs, and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->