### PR TITLE
feat(plugin): add manifest/source conflict diagnostics

### DIFF
--- a/crates/contracts/src/errors.rs
+++ b/crates/contracts/src/errors.rs
@@ -127,6 +127,16 @@ pub enum IntegrationError {
     PluginFileRead { path: String, reason: String },
     #[error("invalid plugin manifest in {path}: {reason}")]
     PluginManifestParse { path: String, reason: String },
+    #[error(
+        "plugin manifest conflict between package {package_manifest_path} and source {source_path} on {field}: package {package_value} vs source {source_value}"
+    )]
+    PluginManifestConflict {
+        package_manifest_path: String,
+        source_path: String,
+        field: String,
+        package_value: String,
+        source_value: String,
+    },
     #[error("awareness root does not exist: {0}")]
     AwarenessRootNotFound(String),
     #[error("failed to inspect awareness file {path}: {reason}")]

--- a/crates/daemon/tests/integration/spec_runtime.rs
+++ b/crates/daemon/tests/integration/spec_runtime.rs
@@ -5410,6 +5410,114 @@ async fn execute_spec_plugin_scan_is_transactional_when_blocked() {
 }
 
 #[tokio::test]
+async fn execute_spec_blocks_when_package_manifest_conflicts_with_source_manifest() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+
+    let plugin_root = std::env::temp_dir().join(format!("loongclaw-plugin-conflict-{unique}"));
+    fs::create_dir_all(&plugin_root).expect("create plugin root");
+
+    fs::write(
+        plugin_root.join("loongclaw.plugin.json"),
+        r#"
+{
+  "plugin_id": "conflict-plugin",
+  "provider_id": "package-provider",
+  "connector_name": "conflict-connector",
+  "channel_id": "primary",
+  "endpoint": "https://package.example.com/invoke",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json",
+    "version": "1.0.0"
+  }
+}
+"#,
+    )
+    .expect("write package manifest");
+
+    fs::write(
+        plugin_root.join("plugin.py"),
+        r#"
+# LOONGCLAW_PLUGIN_START
+# {
+#   "plugin_id": "conflict-plugin",
+#   "provider_id": "source-provider",
+#   "connector_name": "conflict-connector",
+#   "channel_id": "primary",
+#   "endpoint": "https://package.example.com/invoke",
+#   "capabilities": ["InvokeConnector"],
+#   "metadata": {"bridge_kind":"http_json","version":"1.0.0"}
+# }
+# LOONGCLAW_PLUGIN_END
+"#,
+    )
+    .expect("write conflicting source manifest");
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-plugin-manifest-conflict".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::new(),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-plugin-manifest-conflict".to_owned(),
+        ttl_s: 120,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: Some(PluginScanSpec {
+            enabled: true,
+            roots: vec![plugin_root.display().to_string()],
+        }),
+        bridge_support: None,
+        bootstrap: None,
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        operation: OperationSpec::Task {
+            task_id: "t-plugin-manifest-conflict".to_owned(),
+            objective: "plugin scan should fail on package/source drift".to_owned(),
+            required_capabilities: BTreeSet::new(),
+            payload: json!({}),
+        },
+    };
+
+    let report = execute_spec(&spec, true).await;
+
+    assert_eq!(report.operation_kind, "blocked");
+    assert!(
+        report
+            .blocked_reason
+            .expect("blocked reason should exist")
+            .contains("plugin manifest conflict")
+    );
+    assert!(report.plugin_scan_reports.is_empty());
+    assert!(report.plugin_absorb_reports.is_empty());
+    assert!(
+        report
+            .integration_catalog
+            .provider("package-provider")
+            .is_none()
+    );
+    assert!(
+        report
+            .integration_catalog
+            .provider("source-provider")
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn execute_spec_bootstrap_budget_is_global_across_multiple_roots() {
     use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/kernel/src/plugin.rs
+++ b/crates/kernel/src/plugin.rs
@@ -1160,11 +1160,10 @@ mod tests {
         assert!(report.descriptors[0].manifest.tags.is_empty());
         assert!(report.descriptors[0].manifest.input_examples.is_empty());
         assert!(
-            report.descriptors[0]
+            !report.descriptors[0]
                 .manifest
                 .metadata
-                .get("legacy_source")
-                .is_none()
+                .contains_key("legacy_source")
         );
         assert_eq!(
             report.descriptors[0].manifest.provider_id,

--- a/crates/kernel/src/plugin.rs
+++ b/crates/kernel/src/plugin.rs
@@ -545,16 +545,13 @@ fn first_manifest_conflict(
         return capabilities_conflict;
     }
 
-    let metadata_conflict = compare_manifest_value(
-        "metadata",
-        &package_manifest.metadata,
-        &source_manifest.metadata,
-    );
+    let metadata_conflict =
+        first_shared_metadata_conflict(&package_manifest.metadata, &source_manifest.metadata);
     if metadata_conflict.is_some() {
         return metadata_conflict;
     }
 
-    let summary_conflict = compare_manifest_value(
+    let summary_conflict = compare_optional_fill_value(
         "summary",
         &package_manifest.summary,
         &source_manifest.summary,
@@ -564,12 +561,12 @@ fn first_manifest_conflict(
     }
 
     let tags_conflict =
-        compare_manifest_value("tags", &package_manifest.tags, &source_manifest.tags);
+        compare_optional_fill_sequence("tags", &package_manifest.tags, &source_manifest.tags);
     if tags_conflict.is_some() {
         return tags_conflict;
     }
 
-    let input_examples_conflict = compare_manifest_value(
+    let input_examples_conflict = compare_optional_fill_sequence(
         "input_examples",
         &package_manifest.input_examples,
         &source_manifest.input_examples,
@@ -578,7 +575,7 @@ fn first_manifest_conflict(
         return input_examples_conflict;
     }
 
-    let output_examples_conflict = compare_manifest_value(
+    let output_examples_conflict = compare_optional_fill_sequence(
         "output_examples",
         &package_manifest.output_examples,
         &source_manifest.output_examples,
@@ -1100,6 +1097,80 @@ mod tests {
                 .iter()
                 .any(|descriptor| descriptor.path == inner_manifest_file.display().to_string())
         );
+    }
+
+    #[test]
+    fn scanner_allows_source_only_optional_fields_under_package_manifest() {
+        let root = unique_tmp_dir("loongclaw-plugin-optional-source-fields");
+        let package_root = root.join("pkg");
+        fs::create_dir_all(&package_root).expect("create temp root");
+
+        let manifest_file = package_root.join(PACKAGE_MANIFEST_FILE_NAME);
+        fs::write(
+            &manifest_file,
+            r#"
+{
+  "plugin_id": "package-plugin",
+  "provider_id": "package-provider",
+  "connector_name": "package-connector",
+  "channel_id": "package-channel",
+  "endpoint": "https://package.example/invoke",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json"
+  }
+}
+"#,
+        )
+        .expect("write package manifest");
+
+        let source_file = package_root.join("plugin.py");
+        fs::write(
+            &source_file,
+            r#"
+# LOONGCLAW_PLUGIN_START
+# {
+#   "plugin_id": "package-plugin",
+#   "provider_id": "package-provider",
+#   "connector_name": "package-connector",
+#   "channel_id": "package-channel",
+#   "endpoint": "https://package.example/invoke",
+#   "capabilities": ["InvokeConnector"],
+#   "metadata": {"bridge_kind":"http_json","legacy_source":"true"},
+#   "summary": "legacy source summary",
+#   "tags": ["legacy", "source"],
+#   "input_examples": [{"query":"hello"}]
+# }
+# LOONGCLAW_PLUGIN_END
+"#,
+        )
+        .expect("write source plugin");
+
+        let scanner = PluginScanner::new();
+        let report = scanner.scan_path(&root).expect("scan should succeed");
+
+        assert_eq!(report.scanned_files, 2);
+        assert_eq!(report.matched_plugins, 1);
+        assert_eq!(report.descriptors.len(), 1);
+        assert_eq!(
+            report.descriptors[0].path,
+            manifest_file.display().to_string()
+        );
+        assert_eq!(report.descriptors[0].manifest.summary, None);
+        assert!(report.descriptors[0].manifest.tags.is_empty());
+        assert!(report.descriptors[0].manifest.input_examples.is_empty());
+        assert!(
+            report.descriptors[0]
+                .manifest
+                .metadata
+                .get("legacy_source")
+                .is_none()
+        );
+        assert_eq!(
+            report.descriptors[0].manifest.provider_id,
+            "package-provider"
+        );
+        assert_eq!(report.descriptors[0].language, "manifest");
     }
 
     #[test]

--- a/crates/kernel/src/plugin.rs
+++ b/crates/kernel/src/plugin.rs
@@ -84,7 +84,14 @@ impl PluginScanner {
         report.scanned_files = files.len();
 
         let package_manifest_descriptors = collect_package_manifest_descriptors(&files)?;
-        let package_roots = collect_package_roots(&package_manifest_descriptors);
+        let source_manifest_descriptors = collect_source_manifest_descriptors(&files)?;
+        let package_manifests_by_root =
+            collect_package_manifest_descriptors_by_root(&package_manifest_descriptors);
+
+        validate_package_manifest_conflicts(
+            &package_manifests_by_root,
+            &source_manifest_descriptors,
+        )?;
 
         for path in &files {
             if let Some(descriptor) = package_manifest_descriptors.get(path) {
@@ -92,12 +99,15 @@ impl PluginScanner {
                 continue;
             }
 
-            if path_is_covered_by_package_manifest(path, &package_roots) {
+            let covering_package_manifest =
+                find_covering_package_manifest_descriptor(path, &package_manifests_by_root);
+
+            if covering_package_manifest.is_some() {
                 continue;
             }
 
-            if let Some(descriptor) = parse_source_manifest_descriptor(path)? {
-                push_descriptor(&mut report, descriptor);
+            if let Some(descriptor) = source_manifest_descriptors.get(path) {
+                push_descriptor(&mut report, descriptor.clone());
             }
         }
 
@@ -291,19 +301,40 @@ fn collect_package_manifest_descriptors(
     Ok(descriptors)
 }
 
-fn collect_package_roots(descriptors: &BTreeMap<PathBuf, PluginDescriptor>) -> BTreeSet<PathBuf> {
-    let mut package_roots = BTreeSet::new();
+fn collect_source_manifest_descriptors(
+    files: &[PathBuf],
+) -> Result<BTreeMap<PathBuf, PluginDescriptor>, IntegrationError> {
+    let mut descriptors = BTreeMap::new();
 
-    for path in descriptors.keys() {
+    for path in files {
+        let descriptor = parse_source_manifest_descriptor(path)?;
+        let Some(descriptor) = descriptor else {
+            continue;
+        };
+
+        descriptors.insert(path.clone(), descriptor);
+    }
+
+    Ok(descriptors)
+}
+
+fn collect_package_manifest_descriptors_by_root(
+    descriptors: &BTreeMap<PathBuf, PluginDescriptor>,
+) -> BTreeMap<PathBuf, PluginDescriptor> {
+    let mut manifests_by_root = BTreeMap::new();
+
+    for (path, descriptor) in descriptors {
         let Some(parent) = path.parent() else {
             continue;
         };
 
         let package_root = parent.to_path_buf();
-        package_roots.insert(package_root);
+        let descriptor = descriptor.clone();
+
+        manifests_by_root.insert(package_root, descriptor);
     }
 
-    package_roots
+    manifests_by_root
 }
 
 fn push_descriptor(report: &mut PluginScanReport, descriptor: PluginDescriptor) {
@@ -391,10 +422,270 @@ fn is_package_manifest_file(path: &Path) -> bool {
     matches!(file_name, Some(PACKAGE_MANIFEST_FILE_NAME))
 }
 
-fn path_is_covered_by_package_manifest(path: &Path, package_roots: &BTreeSet<PathBuf>) -> bool {
-    package_roots
-        .iter()
-        .any(|package_root| path.starts_with(package_root))
+fn find_covering_package_manifest_descriptor<'a>(
+    path: &Path,
+    package_manifests_by_root: &'a BTreeMap<PathBuf, PluginDescriptor>,
+) -> Option<&'a PluginDescriptor> {
+    let mut best_match: Option<(&PathBuf, &PluginDescriptor)> = None;
+
+    for (package_root, descriptor) in package_manifests_by_root {
+        if !path.starts_with(package_root) {
+            continue;
+        }
+
+        let candidate_depth = package_root.components().count();
+        let Some((best_root, _)) = best_match else {
+            best_match = Some((package_root, descriptor));
+            continue;
+        };
+
+        let best_depth = best_root.components().count();
+
+        if candidate_depth > best_depth {
+            best_match = Some((package_root, descriptor));
+        }
+    }
+
+    best_match.map(|(_, descriptor)| descriptor)
+}
+
+fn validate_package_manifest_conflicts(
+    package_manifests_by_root: &BTreeMap<PathBuf, PluginDescriptor>,
+    source_manifest_descriptors: &BTreeMap<PathBuf, PluginDescriptor>,
+) -> Result<(), IntegrationError> {
+    for (source_path, source_descriptor) in source_manifest_descriptors {
+        let package_descriptor =
+            find_covering_package_manifest_descriptor(source_path, package_manifests_by_root);
+
+        let Some(package_descriptor) = package_descriptor else {
+            continue;
+        };
+
+        validate_package_manifest_pair(package_descriptor, source_descriptor)?;
+    }
+
+    Ok(())
+}
+
+fn validate_package_manifest_pair(
+    package_descriptor: &PluginDescriptor,
+    source_descriptor: &PluginDescriptor,
+) -> Result<(), IntegrationError> {
+    let conflict =
+        first_manifest_conflict(&package_descriptor.manifest, &source_descriptor.manifest);
+
+    let Some(conflict) = conflict else {
+        return Ok(());
+    };
+
+    Err(IntegrationError::PluginManifestConflict {
+        package_manifest_path: package_descriptor.path.clone(),
+        source_path: source_descriptor.path.clone(),
+        field: conflict.field,
+        package_value: conflict.package_value,
+        source_value: conflict.source_value,
+    })
+}
+
+fn first_manifest_conflict(
+    package_manifest: &PluginManifest,
+    source_manifest: &PluginManifest,
+) -> Option<ManifestFieldConflict> {
+    let plugin_id_conflict = compare_manifest_value(
+        "plugin_id",
+        &package_manifest.plugin_id,
+        &source_manifest.plugin_id,
+    );
+    if plugin_id_conflict.is_some() {
+        return plugin_id_conflict;
+    }
+
+    let provider_id_conflict = compare_manifest_value(
+        "provider_id",
+        &package_manifest.provider_id,
+        &source_manifest.provider_id,
+    );
+    if provider_id_conflict.is_some() {
+        return provider_id_conflict;
+    }
+
+    let connector_name_conflict = compare_manifest_value(
+        "connector_name",
+        &package_manifest.connector_name,
+        &source_manifest.connector_name,
+    );
+    if connector_name_conflict.is_some() {
+        return connector_name_conflict;
+    }
+
+    let channel_id_conflict = compare_manifest_value(
+        "channel_id",
+        &package_manifest.channel_id,
+        &source_manifest.channel_id,
+    );
+    if channel_id_conflict.is_some() {
+        return channel_id_conflict;
+    }
+
+    let endpoint_conflict = compare_manifest_value(
+        "endpoint",
+        &package_manifest.endpoint,
+        &source_manifest.endpoint,
+    );
+    if endpoint_conflict.is_some() {
+        return endpoint_conflict;
+    }
+
+    let capabilities_conflict = compare_manifest_value(
+        "capabilities",
+        &package_manifest.capabilities,
+        &source_manifest.capabilities,
+    );
+    if capabilities_conflict.is_some() {
+        return capabilities_conflict;
+    }
+
+    let metadata_conflict = compare_manifest_value(
+        "metadata",
+        &package_manifest.metadata,
+        &source_manifest.metadata,
+    );
+    if metadata_conflict.is_some() {
+        return metadata_conflict;
+    }
+
+    let summary_conflict = compare_manifest_value(
+        "summary",
+        &package_manifest.summary,
+        &source_manifest.summary,
+    );
+    if summary_conflict.is_some() {
+        return summary_conflict;
+    }
+
+    let tags_conflict =
+        compare_manifest_value("tags", &package_manifest.tags, &source_manifest.tags);
+    if tags_conflict.is_some() {
+        return tags_conflict;
+    }
+
+    let input_examples_conflict = compare_manifest_value(
+        "input_examples",
+        &package_manifest.input_examples,
+        &source_manifest.input_examples,
+    );
+    if input_examples_conflict.is_some() {
+        return input_examples_conflict;
+    }
+
+    let output_examples_conflict = compare_manifest_value(
+        "output_examples",
+        &package_manifest.output_examples,
+        &source_manifest.output_examples,
+    );
+    if output_examples_conflict.is_some() {
+        return output_examples_conflict;
+    }
+
+    compare_manifest_value(
+        "defer_loading",
+        &package_manifest.defer_loading,
+        &source_manifest.defer_loading,
+    )
+}
+
+fn compare_manifest_value<T>(
+    field: &str,
+    package_value: &T,
+    source_value: &T,
+) -> Option<ManifestFieldConflict>
+where
+    T: ?Sized + PartialEq + Serialize,
+{
+    if package_value == source_value {
+        return None;
+    }
+
+    let package_value = serialize_manifest_value(package_value);
+    let source_value = serialize_manifest_value(source_value);
+
+    Some(ManifestFieldConflict {
+        field: field.to_owned(),
+        package_value,
+        source_value,
+    })
+}
+
+fn compare_optional_fill_value<T>(
+    field: &str,
+    package_value: &Option<T>,
+    source_value: &Option<T>,
+) -> Option<ManifestFieldConflict>
+where
+    T: PartialEq + Serialize,
+{
+    let package_value = package_value.as_ref()?;
+    let source_value = source_value.as_ref()?;
+
+    compare_manifest_value(field, package_value, source_value)
+}
+
+fn compare_optional_fill_sequence<T>(
+    field: &str,
+    package_value: &[T],
+    source_value: &[T],
+) -> Option<ManifestFieldConflict>
+where
+    T: PartialEq + Serialize,
+{
+    if package_value.is_empty() {
+        return None;
+    }
+
+    if source_value.is_empty() {
+        return None;
+    }
+
+    compare_manifest_value(field, package_value, source_value)
+}
+
+fn first_shared_metadata_conflict(
+    package_metadata: &BTreeMap<String, String>,
+    source_metadata: &BTreeMap<String, String>,
+) -> Option<ManifestFieldConflict> {
+    for (key, package_value) in package_metadata {
+        let Some(source_value) = source_metadata.get(key) else {
+            continue;
+        };
+
+        if package_value == source_value {
+            continue;
+        }
+
+        let field = format!("metadata.{key}");
+        let package_value = serialize_manifest_value(package_value);
+        let source_value = serialize_manifest_value(source_value);
+
+        return Some(ManifestFieldConflict {
+            field,
+            package_value,
+            source_value,
+        });
+    }
+
+    None
+}
+
+fn serialize_manifest_value<T>(value: &T) -> String
+where
+    T: ?Sized + Serialize,
+{
+    let serialized = serde_json::to_string(value);
+
+    match serialized {
+        Ok(serialized) => serialized,
+        Err(error) => format!("\"<serialization_error:{error}>\""),
+    }
 }
 
 fn should_skip_dir(path: &Path) -> bool {
@@ -458,6 +749,13 @@ fn detect_language(path: &Path) -> String {
         .and_then(|ext| ext.to_str())
         .map(|ext| ext.to_lowercase())
         .unwrap_or_else(|| "unknown".to_owned())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManifestFieldConflict {
+    field: String,
+    package_value: String,
+    source_value: String,
 }
 
 #[cfg(test)]
@@ -630,13 +928,13 @@ mod tests {
             r#"
 # LOONGCLAW_PLUGIN_START
 # {
-#   "plugin_id": "source-plugin",
-#   "provider_id": "source-provider",
-#   "connector_name": "source-connector",
-#   "channel_id": "source-channel",
-#   "endpoint": "https://source.example/invoke",
+#   "plugin_id": "package-plugin",
+#   "provider_id": "package-provider",
+#   "connector_name": "package-connector",
+#   "channel_id": "package-channel",
+#   "endpoint": "https://package.example/invoke",
 #   "capabilities": ["InvokeConnector"],
-#   "metadata": {"bridge_kind":"process_stdio"}
+#   "metadata": {"bridge_kind":"http_json"}
 # }
 # LOONGCLAW_PLUGIN_END
 "#,
@@ -657,6 +955,150 @@ mod tests {
         assert_eq!(
             report.descriptors[0].manifest.provider_id,
             "package-provider"
+        );
+    }
+
+    #[test]
+    fn scanner_fails_when_package_manifest_conflicts_with_source_manifest() {
+        let root = unique_tmp_dir("loongclaw-plugin-conflict");
+        let package_root = root.join("pkg");
+        fs::create_dir_all(&package_root).expect("create temp root");
+
+        let manifest_file = package_root.join(PACKAGE_MANIFEST_FILE_NAME);
+        fs::write(
+            &manifest_file,
+            r#"
+{
+  "plugin_id": "package-plugin",
+  "provider_id": "package-provider",
+  "connector_name": "package-connector",
+  "channel_id": "package-channel",
+  "endpoint": "https://package.example/invoke",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json"
+  }
+}
+"#,
+        )
+        .expect("write package manifest");
+
+        let source_file = package_root.join("plugin.py");
+        fs::write(
+            &source_file,
+            r#"
+# LOONGCLAW_PLUGIN_START
+# {
+#   "plugin_id": "package-plugin",
+#   "provider_id": "source-provider",
+#   "connector_name": "package-connector",
+#   "channel_id": "package-channel",
+#   "endpoint": "https://package.example/invoke",
+#   "capabilities": ["InvokeConnector"],
+#   "metadata": {"bridge_kind":"http_json"}
+# }
+# LOONGCLAW_PLUGIN_END
+"#,
+        )
+        .expect("write source plugin");
+
+        let scanner = PluginScanner::new();
+        let error = scanner
+            .scan_path(&root)
+            .expect_err("conflicting manifests should fail");
+
+        assert_eq!(
+            error,
+            IntegrationError::PluginManifestConflict {
+                package_manifest_path: manifest_file.display().to_string(),
+                source_path: source_file.display().to_string(),
+                field: "provider_id".to_owned(),
+                package_value: "\"package-provider\"".to_owned(),
+                source_value: "\"source-provider\"".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn scanner_uses_nearest_package_manifest_for_nested_package_roots() {
+        let root = unique_tmp_dir("loongclaw-plugin-nested-package-root");
+        let outer_root = root.join("outer");
+        let inner_root = outer_root.join("inner");
+        fs::create_dir_all(&inner_root).expect("create nested root");
+
+        let outer_manifest_file = outer_root.join(PACKAGE_MANIFEST_FILE_NAME);
+        fs::write(
+            &outer_manifest_file,
+            r#"
+{
+  "plugin_id": "outer-plugin",
+  "provider_id": "outer-provider",
+  "connector_name": "outer-connector",
+  "channel_id": "outer-channel",
+  "endpoint": "https://outer.example/invoke",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json"
+  }
+}
+"#,
+        )
+        .expect("write outer package manifest");
+
+        let inner_manifest_file = inner_root.join(PACKAGE_MANIFEST_FILE_NAME);
+        fs::write(
+            &inner_manifest_file,
+            r#"
+{
+  "plugin_id": "inner-plugin",
+  "provider_id": "inner-provider",
+  "connector_name": "inner-connector",
+  "channel_id": "inner-channel",
+  "endpoint": "https://inner.example/invoke",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json"
+  }
+}
+"#,
+        )
+        .expect("write inner package manifest");
+
+        let source_file = inner_root.join("plugin.py");
+        fs::write(
+            &source_file,
+            r#"
+# LOONGCLAW_PLUGIN_START
+# {
+#   "plugin_id": "inner-plugin",
+#   "provider_id": "inner-provider",
+#   "connector_name": "inner-connector",
+#   "channel_id": "inner-channel",
+#   "endpoint": "https://inner.example/invoke",
+#   "capabilities": ["InvokeConnector"],
+#   "metadata": {"bridge_kind":"http_json"}
+# }
+# LOONGCLAW_PLUGIN_END
+"#,
+        )
+        .expect("write nested source plugin");
+
+        let scanner = PluginScanner::new();
+        let report = scanner.scan_path(&root).expect("scan should succeed");
+
+        assert_eq!(report.matched_plugins, 2);
+        assert_eq!(report.descriptors.len(), 2);
+        assert!(
+            report
+                .descriptors
+                .iter()
+                .any(|descriptor| descriptor.path == outer_manifest_file.display().to_string())
+        );
+        assert!(
+            report
+                .descriptors
+                .iter()
+                .any(|descriptor| descriptor.path == inner_manifest_file.display().to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

- Problem:
  Manifest-first plugin discovery now finds package manifests before embedded source markers, but same-package source manifests still need explicit drift validation so package metadata cannot silently diverge from nearby source markers.
- Why it matters:
  Silent package/source drift would weaken the manifest-first package contract and create bad inputs for future onboarding, doctor, inventory, and registry surfaces.
- What changed:
  Added scan-time conflict validation between package manifests and embedded source manifests under the same package root, introduced a typed `PluginManifestConflict` integration error, taught root resolution to prefer the nearest package manifest for nested package layouts, and kept additive compatibility by allowing source-only optional fields or source-only metadata keys without absorbing them into the package descriptor.
- What did not change:
  No setup metadata surfaces, no implicit source-to-package merge rules, no slot ownership semantics, and no trust or provenance policy were added in this slice.

## Linked Issues

- Closes #537

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes plugin scan behavior from silent precedence to explicit blocking when same-package manifests disagree on shared normalized fields. Packages that relied on stale embedded source markers will now fail fast instead of being silently accepted.
- Rollout / guardrails:
  The change stays limited to same-package package/source pairs. Source-only plugins still work, agreeing package/source pairs still prefer the package manifest, and source-only optional fields remain compatibility artifacts instead of becoming implicit merge inputs.
- Rollback path:
  Revert this PR or temporarily remove the validation path to restore precedence-only behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-kernel plugin -- --nocapture
cargo test -p loongclaw-daemon execute_spec_blocks_when_package_manifest_conflicts_with_source_manifest -- --nocapture
cargo fmt --all
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test -p loongclaw-app acp::acpx::tests::runtime_backend_executes_session_turn_and_controls -- --nocapture
cargo test --workspace --all-features --locked

Result summary:
- kernel plugin tests passed
- daemon conflict regression passed
- fmt / clippy passed
- workspace locked tests passed
- the first all-features workspace run hit a transient ACP test failure (`acp::acpx::tests::runtime_backend_executes_session_turn_and_controls`) that passed on isolated rerun
- the second full all-features workspace run passed
```

## User-visible / Operator-visible Changes

- Plugin scan now fails with an explicit `PluginManifestConflict` when a package manifest and embedded source manifest disagree on a shared normalized field inside the same package root, including the conflicting field and both source paths.
- Same-package source markers can still carry source-only optional compatibility data without blocking discovery, and that extra data is not merged back into the authoritative package descriptor.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR or temporarily retarget plugin intake to precedence-only behavior while investigating conflicting packages.
- Observable failure symptoms reviewers should watch for:
  `plugin scan failed for root ... plugin manifest conflict between package ... and source ... on <field>` during spec execution or scanner use.

## Reviewer Focus

- `crates/kernel/src/plugin.rs`: nearest-package-root resolution, shared-field conflict comparison, and the rule that source-only optional fields remain non-authoritative compatibility artifacts.
- `crates/daemon/tests/integration/spec_runtime.rs`: the end-to-end blocked scan path and proof that conflicting scans do not partially absorb providers.
