### PR TITLE
feat(chat): add phase-aware live surfaces to interactive CLI chat

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -27,7 +27,8 @@ use super::conversation::TurnCheckpointTailRepairRuntimeProbe;
 use super::conversation::{
     ConversationRuntimeBinding, ConversationSessionAddress, ConversationTurnCoordinator,
     ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
-    ConversationTurnPhaseEvent, ExecutionLane, ProviderErrorMode, resolve_context_engine_selection,
+    ConversationTurnPhaseEvent, ConversationTurnToolEvent, ConversationTurnToolState,
+    ExecutionLane, ProviderErrorMode, resolve_context_engine_selection,
 };
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::conversation::{
@@ -248,18 +249,36 @@ struct CliChatLiveSurfaceSnapshot {
     tool_activity_lines: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct CliChatLiveToolState {
+    tool_call_id: String,
+    display_order: usize,
     name: Option<String>,
-    id: Option<String>,
     args: String,
+    status: ConversationTurnToolState,
+    detail: Option<String>,
+}
+
+impl CliChatLiveToolState {
+    fn new(tool_call_id: String, display_order: usize) -> Self {
+        Self {
+            tool_call_id,
+            display_order,
+            name: None,
+            args: String::new(),
+            status: ConversationTurnToolState::Running,
+            detail: None,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
 struct CliChatLiveSurfaceState {
     latest_phase_event: Option<ConversationTurnPhaseEvent>,
     draft_preview: String,
-    tool_states: BTreeMap<usize, CliChatLiveToolState>,
+    tool_states: BTreeMap<String, CliChatLiveToolState>,
+    tool_call_index_map: BTreeMap<usize, String>,
+    next_tool_display_order: usize,
     total_text_chars_seen: usize,
     last_preview_emit_chars_seen: usize,
     last_emitted_snapshot: Option<CliChatLiveSurfaceSnapshot>,
@@ -1105,10 +1124,31 @@ impl CliChatLiveSurfaceObserver {
         let lines_to_render = {
             let mut state = self.lock_state();
             state.latest_phase_event = Some(event.clone());
+            reconcile_cli_chat_live_tool_states_for_phase(&mut state.tool_states, event.phase);
             if !should_render_cli_chat_live_phase(event.phase) {
                 None
             } else {
                 self.prepare_live_surface_lines(&mut state)
+            }
+        };
+
+        if let Some(lines) = lines_to_render {
+            (self.render_sink)(lines);
+        }
+    }
+
+    fn record_tool_event(&self, event: ConversationTurnToolEvent) {
+        let lines_to_render = {
+            let mut state = self.lock_state();
+            apply_cli_chat_live_tool_event(&mut state, &event, self.render_width);
+            let current_phase = match state.latest_phase_event.as_ref() {
+                Some(phase_event) => phase_event.phase,
+                None => return,
+            };
+            if should_render_cli_chat_live_phase(current_phase) {
+                self.prepare_live_surface_lines(&mut state)
+            } else {
+                None
             }
         };
 
@@ -1155,7 +1195,7 @@ impl CliChatLiveSurfaceObserver {
 
             if let Some((tool_call_delta, index)) = tool_call_update {
                 update_cli_chat_live_tool_state(
-                    &mut state.tool_states,
+                    &mut state,
                     index,
                     &tool_call_delta,
                     self.render_width,
@@ -1199,6 +1239,10 @@ impl CliChatLiveSurfaceObserver {
 impl ConversationTurnObserver for CliChatLiveSurfaceObserver {
     fn on_phase(&self, event: ConversationTurnPhaseEvent) {
         self.record_phase_event(event);
+    }
+
+    fn on_tool(&self, event: ConversationTurnToolEvent) {
+        self.record_tool_event(event);
     }
 
     fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
@@ -1291,25 +1335,146 @@ fn trim_cli_chat_live_buffer(buffer: &mut String, char_limit: usize) {
     buffer.push_str(trimmed_tail.as_str());
 }
 
+fn truncate_cli_chat_live_text(value: &str, char_limit: usize) -> String {
+    let mut truncated = value.to_owned();
+    trim_cli_chat_live_buffer(&mut truncated, char_limit);
+    truncated
+}
+
+fn cli_chat_live_pending_tool_call_id(index: usize) -> String {
+    format!("pending-stream-tool-{index}")
+}
+
+fn ensure_cli_chat_live_tool_state<'a>(
+    state: &'a mut CliChatLiveSurfaceState,
+    tool_call_id: &str,
+) -> &'a mut CliChatLiveToolState {
+    let tool_call_key = tool_call_id.to_owned();
+    let entry = state.tool_states.entry(tool_call_key.clone());
+
+    match entry {
+        std::collections::btree_map::Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
+        std::collections::btree_map::Entry::Vacant(vacant_entry) => {
+            let display_order = state.next_tool_display_order;
+            let tool_state = CliChatLiveToolState::new(tool_call_key, display_order);
+            state.next_tool_display_order = state.next_tool_display_order.saturating_add(1);
+            vacant_entry.insert(tool_state)
+        }
+    }
+}
+
+fn merge_cli_chat_live_pending_tool_state(
+    state: &mut CliChatLiveSurfaceState,
+    pending_tool_call_id: &str,
+    tool_call_id: &str,
+) {
+    if pending_tool_call_id == tool_call_id {
+        return;
+    }
+
+    let pending_state = match state.tool_states.remove(pending_tool_call_id) {
+        Some(pending_state) => pending_state,
+        None => return,
+    };
+    let target_state = ensure_cli_chat_live_tool_state(state, tool_call_id);
+
+    if target_state.name.is_none() {
+        target_state.name = pending_state.name;
+    }
+    if target_state.args.is_empty() {
+        target_state.args = pending_state.args;
+    }
+    if target_state.detail.is_none() {
+        target_state.detail = pending_state.detail;
+    }
+    if target_state.status == ConversationTurnToolState::Running {
+        target_state.status = pending_state.status;
+    }
+}
+
 fn update_cli_chat_live_tool_state(
-    tool_states: &mut BTreeMap<usize, CliChatLiveToolState>,
+    state: &mut CliChatLiveSurfaceState,
     index: usize,
     delta: &crate::acp::ToolCallDelta,
     render_width: usize,
 ) {
-    let tool_state = tool_states.entry(index).or_default();
+    let pending_tool_call_id = cli_chat_live_pending_tool_call_id(index);
+    let tool_call_id = delta.id.clone().unwrap_or_else(|| {
+        state
+            .tool_call_index_map
+            .get(&index)
+            .cloned()
+            .unwrap_or_else(|| pending_tool_call_id.clone())
+    });
+    let args_char_limit = cli_chat_live_tool_args_char_limit(render_width);
+
+    state
+        .tool_call_index_map
+        .insert(index, tool_call_id.clone());
+    merge_cli_chat_live_pending_tool_state(
+        state,
+        pending_tool_call_id.as_str(),
+        tool_call_id.as_str(),
+    );
+
+    let tool_state = ensure_cli_chat_live_tool_state(state, tool_call_id.as_str());
+    tool_state.status = ConversationTurnToolState::Running;
+    tool_state.detail = None;
 
     if let Some(name) = delta.name.as_ref() {
         tool_state.name = Some(name.clone());
     }
 
-    if let Some(id) = delta.id.as_ref() {
-        tool_state.id = Some(id.clone());
-    }
-
     if let Some(args) = delta.args.as_ref() {
-        let args_char_limit = cli_chat_live_tool_args_char_limit(render_width);
         append_cli_chat_live_buffer(&mut tool_state.args, args.as_str(), args_char_limit);
+    }
+}
+
+fn apply_cli_chat_live_tool_event(
+    state: &mut CliChatLiveSurfaceState,
+    event: &ConversationTurnToolEvent,
+    render_width: usize,
+) {
+    let tool_state = ensure_cli_chat_live_tool_state(state, event.tool_call_id.as_str());
+    let detail_char_limit = cli_chat_live_tool_args_char_limit(render_width);
+
+    tool_state.name = Some(event.tool_name.clone());
+    tool_state.status = event.state;
+    tool_state.detail = event
+        .detail
+        .as_deref()
+        .map(|detail| truncate_cli_chat_live_text(detail, detail_char_limit));
+}
+
+fn reconcile_cli_chat_live_tool_states_for_phase(
+    tool_states: &mut BTreeMap<String, CliChatLiveToolState>,
+    phase: ConversationTurnPhase,
+) {
+    let fallback_status = match phase {
+        ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => Some(ConversationTurnToolState::Completed),
+        ConversationTurnPhase::Failed => Some(ConversationTurnToolState::Interrupted),
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools => None,
+    };
+    let Some(fallback_status) = fallback_status else {
+        return;
+    };
+
+    for tool_state in tool_states.values_mut() {
+        if tool_state.status != ConversationTurnToolState::Running {
+            continue;
+        }
+
+        tool_state.status = fallback_status;
+        if fallback_status == ConversationTurnToolState::Interrupted && tool_state.detail.is_none()
+        {
+            tool_state.detail =
+                Some("turn failed before a terminal tool result was recorded".to_owned());
+        }
     }
 }
 
@@ -1337,18 +1502,25 @@ fn build_cli_chat_live_surface_snapshot(
 }
 
 fn format_cli_chat_live_tool_activity_lines(
-    tool_states: &BTreeMap<usize, CliChatLiveToolState>,
+    tool_states: &BTreeMap<String, CliChatLiveToolState>,
 ) -> Vec<String> {
     let mut lines = Vec::new();
+    let mut ordered_states = tool_states.values().collect::<Vec<_>>();
+    ordered_states.sort_by_key(|tool_state| tool_state.display_order);
 
-    for (index, tool_state) in tool_states {
+    for tool_state in ordered_states {
+        let status = tool_state.status.as_str().replace('_', " ");
         let name = tool_state.name.as_deref().unwrap_or("pending");
-        let id = tool_state.id.as_deref().unwrap_or("-");
-        let tool_line = format!("tool {index}: {name} (id={id})");
+        let tool_call_id = tool_state.tool_call_id.as_str();
+        let tool_line = if let Some(detail) = tool_state.detail.as_deref() {
+            format!("[{status}] {name} (id={tool_call_id}) - {detail}")
+        } else {
+            format!("[{status}] {name} (id={tool_call_id})")
+        };
         lines.push(tool_line);
 
         if !tool_state.args.is_empty() {
-            let args_line = format!("args {index}: {}", tool_state.args);
+            let args_line = format!("args: {}", tool_state.args);
             lines.push(args_line);
         }
     }
@@ -5640,6 +5812,93 @@ println!(\"{value}\");
         assert!(
             preview_batch.iter().any(|line| line == "Draft response"),
             "preview batch should include the streamed text: {preview_batch:#?}"
+        );
+    }
+
+    #[test]
+    fn cli_chat_live_surface_observer_renders_tool_lifecycle_updates() {
+        let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+        let render_sink: CliChatLiveSurfaceSink = {
+            let captured_batches = Arc::clone(&captured_batches);
+            Arc::new(move |lines| {
+                let mut batches = captured_batches
+                    .lock()
+                    .expect("captured batches lock should not be poisoned");
+                batches.push(lines);
+            })
+        };
+        let observer = CliChatLiveSurfaceObserver::new(72, render_sink);
+
+        observer.on_phase(ConversationTurnPhaseEvent::running_tools(
+            1,
+            ExecutionLane::Fast,
+            1,
+        ));
+        observer.on_streaming_token(crate::acp::StreamingTokenEvent {
+            event_type: "tool_call_start".to_owned(),
+            delta: crate::acp::TokenDelta {
+                text: None,
+                tool_call: Some(crate::acp::ToolCallDelta {
+                    name: Some("file.read".to_owned()),
+                    args: None,
+                    id: Some("call-tool-1".to_owned()),
+                }),
+            },
+            index: Some(0),
+        });
+        observer.on_streaming_token(crate::acp::StreamingTokenEvent {
+            event_type: "tool_call_input_delta".to_owned(),
+            delta: crate::acp::TokenDelta {
+                text: None,
+                tool_call: Some(crate::acp::ToolCallDelta {
+                    name: None,
+                    args: Some("{\"path\":\"README.md\"}".to_owned()),
+                    id: None,
+                }),
+            },
+            index: Some(0),
+        });
+        observer.on_tool(ConversationTurnToolEvent::completed(
+            "call-tool-1",
+            "file.read",
+            Some("ok".to_owned()),
+        ));
+
+        let batches = captured_batches
+            .lock()
+            .expect("captured batches lock should not be poisoned");
+        let running_batch = batches
+            .iter()
+            .find(|lines| lines.iter().any(|line| line == "tool activity"))
+            .expect("running tool batch");
+        let completed_batch = batches
+            .iter()
+            .rev()
+            .find(|lines| {
+                lines
+                    .iter()
+                    .any(|line| line == "[completed] file.read (id=call-tool-1) - ok")
+            })
+            .expect("completed tool batch");
+
+        assert!(
+            running_batch
+                .iter()
+                .any(|line| line == "[running] file.read (id=call-tool-1)"),
+            "tool batch should surface the running tool state: {running_batch:#?}"
+        );
+
+        assert!(
+            completed_batch
+                .iter()
+                .any(|line| line == "[completed] file.read (id=call-tool-1) - ok"),
+            "tool batch should surface the completed tool state: {completed_batch:#?}"
+        );
+        assert!(
+            completed_batch
+                .iter()
+                .any(|line| line == "args: {\"path\":\"README.md\"}"),
+            "tool batch should preserve streamed tool args: {completed_batch:#?}"
         );
     }
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1123,6 +1123,9 @@ impl CliChatLiveSurfaceObserver {
     fn record_phase_event(&self, event: ConversationTurnPhaseEvent) {
         let lines_to_render = {
             let mut state = self.lock_state();
+            if cli_chat_live_phase_starts_provider_request(event.phase) {
+                reset_cli_chat_live_request_state(&mut state);
+            }
             state.latest_phase_event = Some(event.clone());
             reconcile_cli_chat_live_tool_states_for_phase(&mut state.tool_states, event.phase);
             if !should_render_cli_chat_live_phase(event.phase) {
@@ -1201,9 +1204,9 @@ impl CliChatLiveSurfaceObserver {
                     self.render_width,
                 );
 
-                if event.event_type == "tool_call_start"
-                    && should_render_cli_chat_live_phase(current_phase)
-                {
+                let render_tool_activity_now = event.event_type == "tool_call_start"
+                    && current_phase == ConversationTurnPhase::RunningTools;
+                if render_tool_activity_now {
                     should_render = true;
                 }
             }
@@ -1248,6 +1251,23 @@ impl ConversationTurnObserver for CliChatLiveSurfaceObserver {
     fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
         self.record_streaming_token_event(event);
     }
+}
+
+fn cli_chat_live_phase_starts_provider_request(phase: ConversationTurnPhase) -> bool {
+    matches!(
+        phase,
+        ConversationTurnPhase::RequestingProvider
+            | ConversationTurnPhase::RequestingFollowupProvider
+    )
+}
+
+fn reset_cli_chat_live_request_state(state: &mut CliChatLiveSurfaceState) {
+    state.draft_preview.clear();
+    state.tool_states.clear();
+    state.tool_call_index_map.clear();
+    state.next_tool_display_order = 0;
+    state.total_text_chars_seen = 0;
+    state.last_preview_emit_chars_seen = 0;
 }
 
 fn should_render_cli_chat_live_phase(phase: ConversationTurnPhase) -> bool {
@@ -5910,6 +5930,142 @@ println!(\"{value}\");
         assert_eq!(parse_markdown_heading("#NoSpace"), None);
         assert_eq!(parse_markdown_heading("#!/bin/bash"), None);
         assert_eq!(parse_markdown_heading("####### too many"), None);
+    }
+
+    #[test]
+    fn cli_chat_live_surface_observer_resets_request_scoped_buffers_between_rounds() {
+        let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+        let render_sink: CliChatLiveSurfaceSink = {
+            let captured_batches = Arc::clone(&captured_batches);
+            Arc::new(move |lines| {
+                let mut batches = captured_batches
+                    .lock()
+                    .expect("captured batches lock should not be poisoned");
+                batches.push(lines);
+            })
+        };
+        let observer = CliChatLiveSurfaceObserver::new(72, render_sink);
+
+        observer.on_phase(ConversationTurnPhaseEvent::requesting_provider(
+            1,
+            3,
+            Some(96),
+        ));
+        observer.on_streaming_token(crate::acp::StreamingTokenEvent {
+            event_type: "text_delta".to_owned(),
+            delta: crate::acp::TokenDelta {
+                text: Some("Draft response".to_owned()),
+                tool_call: None,
+            },
+            index: None,
+        });
+        observer.on_streaming_token(crate::acp::StreamingTokenEvent {
+            event_type: "tool_call_input_delta".to_owned(),
+            delta: crate::acp::TokenDelta {
+                text: None,
+                tool_call: Some(crate::acp::ToolCallDelta {
+                    name: None,
+                    args: Some("{\"query\":\"rust\"}".to_owned()),
+                    id: None,
+                }),
+            },
+            index: Some(0),
+        });
+        observer.on_phase(ConversationTurnPhaseEvent::requesting_followup_provider(
+            2,
+            ExecutionLane::Fast,
+            1,
+            5,
+            Some(128),
+        ));
+
+        let batches = captured_batches
+            .lock()
+            .expect("captured batches lock should not be poisoned");
+        let last_batch = batches.last().expect("follow-up request batch");
+
+        assert!(
+            !last_batch.iter().any(|line| line == "draft preview"),
+            "follow-up provider requests should reset the previous draft preview: {last_batch:#?}"
+        );
+        assert!(
+            !last_batch.iter().any(|line| line == "tool activity"),
+            "follow-up provider requests should not reuse prior tool activity lines: {last_batch:#?}"
+        );
+        assert!(
+            !last_batch.iter().any(|line| line == "Draft response"),
+            "follow-up provider requests should not carry the previous request preview text: {last_batch:#?}"
+        );
+    }
+
+    #[test]
+    fn cli_chat_live_surface_observer_waits_for_tools_phase_before_rendering_tool_activity() {
+        let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+        let render_sink: CliChatLiveSurfaceSink = {
+            let captured_batches = Arc::clone(&captured_batches);
+            Arc::new(move |lines| {
+                let mut batches = captured_batches
+                    .lock()
+                    .expect("captured batches lock should not be poisoned");
+                batches.push(lines);
+            })
+        };
+        let observer = CliChatLiveSurfaceObserver::new(72, render_sink);
+
+        observer.on_phase(ConversationTurnPhaseEvent::requesting_provider(
+            1,
+            3,
+            Some(96),
+        ));
+
+        let batch_count_before_tool_delta = captured_batches
+            .lock()
+            .expect("captured batches lock should not be poisoned")
+            .len();
+
+        observer.on_streaming_token(crate::acp::StreamingTokenEvent {
+            event_type: "tool_call_start".to_owned(),
+            delta: crate::acp::TokenDelta {
+                text: None,
+                tool_call: Some(crate::acp::ToolCallDelta {
+                    name: Some("search".to_owned()),
+                    args: None,
+                    id: Some("call_123".to_owned()),
+                }),
+            },
+            index: Some(0),
+        });
+
+        let batch_count_after_tool_delta = captured_batches
+            .lock()
+            .expect("captured batches lock should not be poisoned")
+            .len();
+        assert_eq!(
+            batch_count_after_tool_delta, batch_count_before_tool_delta,
+            "tool-call deltas should wait for the tools phase before re-rendering"
+        );
+
+        observer.on_phase(ConversationTurnPhaseEvent::running_tools(
+            1,
+            ExecutionLane::Fast,
+            1,
+        ));
+
+        let batches = captured_batches
+            .lock()
+            .expect("captured batches lock should not be poisoned");
+        let last_batch = batches.last().expect("running-tools batch");
+
+        assert!(
+            last_batch.iter().any(|line| line == "tool activity"),
+            "the tools phase should render the accumulated tool activity: {last_batch:#?}"
+        );
+        assert!(
+            last_batch
+                .iter()
+                .any(|line| line == "[running] search (id=call_123)"),
+            "the tools phase should surface the streamed tool metadata: {last_batch:#?}"
+        );
     }
 
     #[test]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeMap;
 #[cfg(feature = "memory-sqlite")]
 use std::collections::BTreeSet;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex as StdMutex;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -24,7 +26,8 @@ use super::config::{self, ConversationConfig, LoongClawConfig};
 use super::conversation::TurnCheckpointTailRepairRuntimeProbe;
 use super::conversation::{
     ConversationRuntimeBinding, ConversationSessionAddress, ConversationTurnCoordinator,
-    ProviderErrorMode, resolve_context_engine_selection,
+    ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
+    ConversationTurnPhaseEvent, ExecutionLane, ProviderErrorMode, resolve_context_engine_selection,
 };
 #[cfg(any(test, feature = "memory-sqlite"))]
 use super::conversation::{
@@ -45,12 +48,19 @@ use super::memory;
 #[cfg(feature = "memory-sqlite")]
 use super::memory::runtime_config::MemoryRuntimeConfig;
 use super::tui_surface::{
-    TuiActionSpec, TuiCalloutTone, TuiChoiceSpec, TuiHeaderStyle, TuiKeyValueSpec, TuiMessageSpec,
-    TuiScreenSpec, TuiSectionSpec, render_tui_message_spec, render_tui_screen_spec,
+    TuiActionSpec, TuiCalloutTone, TuiChecklistItemSpec, TuiChecklistStatus, TuiChoiceSpec,
+    TuiHeaderStyle, TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec,
+    render_tui_message_spec, render_tui_screen_spec,
 };
 
 pub const DEFAULT_FIRST_PROMPT: &str = "Summarize this repository and suggest the best next step.";
 const TEST_ONBOARD_EXECUTABLE_ENV: &str = "LOONGCLAW_TEST_ONBOARD_EXECUTABLE";
+const CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS: usize = 80;
+const CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS: usize = 240;
+const CLI_CHAT_LIVE_PREVIEW_MIN_BUFFER_CHARS: usize = 320;
+const CLI_CHAT_LIVE_PREVIEW_MAX_BUFFER_CHARS: usize = 4096;
+const CLI_CHAT_LIVE_TOOL_ARGS_MIN_BUFFER_CHARS: usize = 160;
+const CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS: usize = 1024;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CliChatOptions {
@@ -224,6 +234,43 @@ struct CliChatStartupSummary {
     working_directory: Option<String>,
 }
 
+type CliChatLiveSurfaceSink = Arc<dyn Fn(Vec<String>) + Send + Sync>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CliChatLiveSurfaceSnapshot {
+    phase: ConversationTurnPhase,
+    provider_round: Option<usize>,
+    lane: Option<ExecutionLane>,
+    tool_call_count: usize,
+    message_count: Option<usize>,
+    estimated_tokens: Option<usize>,
+    draft_preview: Option<String>,
+    tool_activity_lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct CliChatLiveToolState {
+    name: Option<String>,
+    id: Option<String>,
+    args: String,
+}
+
+#[derive(Debug, Default)]
+struct CliChatLiveSurfaceState {
+    latest_phase_event: Option<ConversationTurnPhaseEvent>,
+    draft_preview: String,
+    tool_states: BTreeMap<usize, CliChatLiveToolState>,
+    total_text_chars_seen: usize,
+    last_preview_emit_chars_seen: usize,
+    last_emitted_snapshot: Option<CliChatLiveSurfaceSnapshot>,
+}
+
+struct CliChatLiveSurfaceObserver {
+    render_width: usize,
+    render_sink: CliChatLiveSurfaceSink,
+    state: StdMutex<CliChatLiveSurfaceState>,
+}
+
 #[allow(clippy::print_stdout)] // CLI REPL output
 pub async fn run_cli_chat(
     config_path: Option<&str>,
@@ -341,10 +388,10 @@ pub async fn run_cli_ask(
     let assistant_text = run_cli_turn(
         &runtime,
         input,
-        options,
         acp_event_printer
             .as_ref()
             .map(|printer| printer as &dyn AcpTurnEventSink),
+        false,
     )
     .await?;
     println!("{assistant_text}");
@@ -553,7 +600,7 @@ async fn run_concurrent_cli_host_loop(
 async fn process_cli_chat_input(
     runtime: &CliTurnRuntime,
     input: &str,
-    options: &CliChatOptions,
+    _options: &CliChatOptions,
     event_sink: Option<&dyn AcpTurnEventSink>,
 ) -> CliResult<CliChatLoopControl> {
     if input.is_empty() {
@@ -660,7 +707,7 @@ async fn process_cli_chat_input(
     }
 
     Ok(CliChatLoopControl::AssistantText(
-        run_cli_turn(runtime, input, options, event_sink).await?,
+        run_cli_turn(runtime, input, event_sink, true).await?,
     ))
 }
 
@@ -1030,6 +1077,673 @@ fn build_cli_chat_assistant_message_spec(assistant_text: &str) -> TuiMessageSpec
     }
 }
 
+fn build_cli_chat_live_surface_observer(render_width: usize) -> ConversationTurnObserverHandle {
+    let render_sink: CliChatLiveSurfaceSink = Arc::new(|lines| {
+        print_rendered_cli_chat_lines(&lines);
+    });
+    let observer = CliChatLiveSurfaceObserver::new(render_width, render_sink);
+    Arc::new(observer)
+}
+
+impl CliChatLiveSurfaceObserver {
+    fn new(render_width: usize, render_sink: CliChatLiveSurfaceSink) -> Self {
+        Self {
+            render_width,
+            render_sink,
+            state: StdMutex::new(CliChatLiveSurfaceState::default()),
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, CliChatLiveSurfaceState> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned_state) => poisoned_state.into_inner(),
+        }
+    }
+
+    fn record_phase_event(&self, event: ConversationTurnPhaseEvent) {
+        let lines_to_render = {
+            let mut state = self.lock_state();
+            state.latest_phase_event = Some(event.clone());
+            if !should_render_cli_chat_live_phase(event.phase) {
+                None
+            } else {
+                self.prepare_live_surface_lines(&mut state)
+            }
+        };
+
+        if let Some(lines) = lines_to_render {
+            (self.render_sink)(lines);
+        }
+    }
+
+    fn record_streaming_token_event(&self, event: crate::acp::StreamingTokenEvent) {
+        let lines_to_render = {
+            let mut state = self.lock_state();
+            let current_phase = match state.latest_phase_event.as_ref() {
+                Some(phase_event) => phase_event.phase,
+                None => return,
+            };
+
+            let text_delta = event.delta.text;
+            let tool_call_delta = event.delta.tool_call;
+            let tool_call_index = event.index;
+            let mut should_render = false;
+
+            if let Some(text_delta) = text_delta {
+                let preview_char_limit = cli_chat_live_preview_char_limit(self.render_width);
+                append_cli_chat_live_buffer(
+                    &mut state.draft_preview,
+                    text_delta.as_str(),
+                    preview_char_limit,
+                );
+                let delta_chars = text_delta.chars().count();
+                state.total_text_chars_seen =
+                    state.total_text_chars_seen.saturating_add(delta_chars);
+
+                if should_emit_cli_chat_live_preview(&state, self.render_width)
+                    && phase_supports_cli_chat_live_preview(current_phase)
+                {
+                    should_render = true;
+                }
+            }
+
+            let tool_call_update = match (tool_call_delta, tool_call_index) {
+                (Some(tool_call_delta), Some(index)) => Some((tool_call_delta, index)),
+                (Some(_), None) | (None, Some(_)) | (None, None) => None,
+            };
+
+            if let Some((tool_call_delta, index)) = tool_call_update {
+                update_cli_chat_live_tool_state(
+                    &mut state.tool_states,
+                    index,
+                    &tool_call_delta,
+                    self.render_width,
+                );
+
+                if event.event_type == "tool_call_start"
+                    && should_render_cli_chat_live_phase(current_phase)
+                {
+                    should_render = true;
+                }
+            }
+
+            if should_render {
+                self.prepare_live_surface_lines(&mut state)
+            } else {
+                None
+            }
+        };
+
+        if let Some(lines) = lines_to_render {
+            (self.render_sink)(lines);
+        }
+    }
+
+    fn prepare_live_surface_lines(
+        &self,
+        state: &mut CliChatLiveSurfaceState,
+    ) -> Option<Vec<String>> {
+        let snapshot = build_cli_chat_live_surface_snapshot(state)?;
+        if state.last_emitted_snapshot.as_ref() == Some(&snapshot) {
+            return None;
+        }
+
+        let lines = render_cli_chat_live_surface_lines_with_width(&snapshot, self.render_width);
+        state.last_preview_emit_chars_seen = state.total_text_chars_seen;
+        state.last_emitted_snapshot = Some(snapshot);
+        Some(lines)
+    }
+}
+
+impl ConversationTurnObserver for CliChatLiveSurfaceObserver {
+    fn on_phase(&self, event: ConversationTurnPhaseEvent) {
+        self.record_phase_event(event);
+    }
+
+    fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
+        self.record_streaming_token_event(event);
+    }
+}
+
+fn should_render_cli_chat_live_phase(phase: ConversationTurnPhase) -> bool {
+    match phase {
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Failed => true,
+        ConversationTurnPhase::ContextReady | ConversationTurnPhase::Completed => false,
+    }
+}
+
+fn phase_supports_cli_chat_live_preview(phase: ConversationTurnPhase) -> bool {
+    match phase {
+        ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RequestingFollowupProvider => true,
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed
+        | ConversationTurnPhase::Failed => false,
+    }
+}
+
+fn should_emit_cli_chat_live_preview(state: &CliChatLiveSurfaceState, render_width: usize) -> bool {
+    if state.total_text_chars_seen == 0 {
+        return false;
+    }
+
+    if state.last_preview_emit_chars_seen == 0 {
+        return true;
+    }
+
+    let emit_stride = cli_chat_live_preview_emit_stride(render_width);
+    let unseen_chars = state
+        .total_text_chars_seen
+        .saturating_sub(state.last_preview_emit_chars_seen);
+    unseen_chars >= emit_stride
+}
+
+fn cli_chat_live_preview_emit_stride(render_width: usize) -> usize {
+    let doubled_width = render_width.saturating_mul(2);
+    doubled_width.clamp(
+        CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS,
+        CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS,
+    )
+}
+
+fn cli_chat_live_preview_char_limit(render_width: usize) -> usize {
+    let expanded_width = render_width.saturating_mul(16);
+    expanded_width.clamp(
+        CLI_CHAT_LIVE_PREVIEW_MIN_BUFFER_CHARS,
+        CLI_CHAT_LIVE_PREVIEW_MAX_BUFFER_CHARS,
+    )
+}
+
+fn cli_chat_live_tool_args_char_limit(render_width: usize) -> usize {
+    let expanded_width = render_width.saturating_mul(8);
+    expanded_width.clamp(
+        CLI_CHAT_LIVE_TOOL_ARGS_MIN_BUFFER_CHARS,
+        CLI_CHAT_LIVE_TOOL_ARGS_MAX_BUFFER_CHARS,
+    )
+}
+
+fn append_cli_chat_live_buffer(buffer: &mut String, chunk: &str, char_limit: usize) {
+    buffer.push_str(chunk);
+    trim_cli_chat_live_buffer(buffer, char_limit);
+}
+
+fn trim_cli_chat_live_buffer(buffer: &mut String, char_limit: usize) {
+    let current_char_count = buffer.chars().count();
+    if current_char_count <= char_limit {
+        return;
+    }
+
+    let retained_char_count = char_limit.saturating_sub(1);
+    let skipped_char_count = current_char_count.saturating_sub(retained_char_count);
+    let trimmed_tail = buffer.chars().skip(skipped_char_count).collect::<String>();
+
+    buffer.clear();
+    buffer.push('…');
+    buffer.push_str(trimmed_tail.as_str());
+}
+
+fn update_cli_chat_live_tool_state(
+    tool_states: &mut BTreeMap<usize, CliChatLiveToolState>,
+    index: usize,
+    delta: &crate::acp::ToolCallDelta,
+    render_width: usize,
+) {
+    let tool_state = tool_states.entry(index).or_default();
+
+    if let Some(name) = delta.name.as_ref() {
+        tool_state.name = Some(name.clone());
+    }
+
+    if let Some(id) = delta.id.as_ref() {
+        tool_state.id = Some(id.clone());
+    }
+
+    if let Some(args) = delta.args.as_ref() {
+        let args_char_limit = cli_chat_live_tool_args_char_limit(render_width);
+        append_cli_chat_live_buffer(&mut tool_state.args, args.as_str(), args_char_limit);
+    }
+}
+
+fn build_cli_chat_live_surface_snapshot(
+    state: &CliChatLiveSurfaceState,
+) -> Option<CliChatLiveSurfaceSnapshot> {
+    let phase_event = state.latest_phase_event.as_ref()?;
+    let draft_preview = if state.draft_preview.trim().is_empty() {
+        None
+    } else {
+        Some(state.draft_preview.clone())
+    };
+    let tool_activity_lines = format_cli_chat_live_tool_activity_lines(&state.tool_states);
+
+    Some(CliChatLiveSurfaceSnapshot {
+        phase: phase_event.phase,
+        provider_round: phase_event.provider_round,
+        lane: phase_event.lane,
+        tool_call_count: phase_event.tool_call_count,
+        message_count: phase_event.message_count,
+        estimated_tokens: phase_event.estimated_tokens,
+        draft_preview,
+        tool_activity_lines,
+    })
+}
+
+fn format_cli_chat_live_tool_activity_lines(
+    tool_states: &BTreeMap<usize, CliChatLiveToolState>,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    for (index, tool_state) in tool_states {
+        let name = tool_state.name.as_deref().unwrap_or("pending");
+        let id = tool_state.id.as_deref().unwrap_or("-");
+        let tool_line = format!("tool {index}: {name} (id={id})");
+        lines.push(tool_line);
+
+        if !tool_state.args.is_empty() {
+            let args_line = format!("args {index}: {}", tool_state.args);
+            lines.push(args_line);
+        }
+    }
+
+    lines
+}
+
+fn render_cli_chat_live_surface_lines_with_width(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+    width: usize,
+) -> Vec<String> {
+    let message_spec = build_cli_chat_live_surface_message_spec(snapshot);
+    render_tui_message_spec(&message_spec, width)
+}
+
+fn build_cli_chat_live_surface_message_spec(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+) -> TuiMessageSpec {
+    let phase_tone = cli_chat_live_surface_tone(snapshot.phase);
+    let phase_title = cli_chat_live_surface_title(snapshot.phase);
+    let phase_detail = cli_chat_live_surface_detail(snapshot);
+    let phase_section = TuiSectionSpec::Callout {
+        tone: phase_tone,
+        title: Some(phase_title.to_owned()),
+        lines: vec![phase_detail],
+    };
+    let pipeline_items = build_cli_chat_live_pipeline_items(snapshot);
+    let pipeline_section = TuiSectionSpec::Checklist {
+        title: Some("turn pipeline".to_owned()),
+        items: pipeline_items,
+    };
+    let status_items = build_cli_chat_live_status_items(snapshot);
+    let mut sections = vec![phase_section, pipeline_section];
+
+    if !status_items.is_empty() {
+        let status_section = TuiSectionSpec::KeyValues {
+            title: Some("status".to_owned()),
+            items: status_items,
+        };
+        sections.push(status_section);
+    }
+
+    if let Some(preview_section) = build_cli_chat_live_preview_section(snapshot) {
+        sections.push(preview_section);
+    }
+
+    if let Some(tool_section) = build_cli_chat_live_tool_section(snapshot) {
+        sections.push(tool_section);
+    }
+
+    TuiMessageSpec {
+        role: "loongclaw".to_owned(),
+        caption: Some("live".to_owned()),
+        sections,
+        footer_lines: Vec::new(),
+    }
+}
+
+fn cli_chat_live_surface_tone(phase: ConversationTurnPhase) -> TuiCalloutTone {
+    match phase {
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply => TuiCalloutTone::Info,
+        ConversationTurnPhase::Completed => TuiCalloutTone::Success,
+        ConversationTurnPhase::Failed => TuiCalloutTone::Warning,
+    }
+}
+
+fn cli_chat_live_surface_title(phase: ConversationTurnPhase) -> &'static str {
+    match phase {
+        ConversationTurnPhase::Preparing => "assembling context",
+        ConversationTurnPhase::ContextReady => "context ready",
+        ConversationTurnPhase::RequestingProvider => "querying model",
+        ConversationTurnPhase::RunningTools => "running tools",
+        ConversationTurnPhase::RequestingFollowupProvider => "requesting follow-up",
+        ConversationTurnPhase::FinalizingReply => "finalizing reply",
+        ConversationTurnPhase::Completed => "reply ready",
+        ConversationTurnPhase::Failed => "turn failed",
+    }
+}
+
+fn cli_chat_live_surface_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
+    match snapshot.phase {
+        ConversationTurnPhase::Preparing => {
+            "Building the session context and preparing the next provider turn.".to_owned()
+        }
+        ConversationTurnPhase::ContextReady => {
+            "Context is ready for the next provider round.".to_owned()
+        }
+        ConversationTurnPhase::RequestingProvider => {
+            let provider_round = snapshot.provider_round.unwrap_or(1);
+            format!("Requesting provider round {provider_round} and collecting live deltas.")
+        }
+        ConversationTurnPhase::RunningTools => {
+            let lane_label = snapshot
+                .lane
+                .map(format_cli_chat_live_lane)
+                .unwrap_or_else(|| "-".to_owned());
+            format!(
+                "Executing {} tool call(s) in the {lane_label} lane.",
+                snapshot.tool_call_count
+            )
+        }
+        ConversationTurnPhase::RequestingFollowupProvider => {
+            let provider_round = snapshot.provider_round.unwrap_or(1);
+            format!("Sending tool results back for provider round {provider_round}.")
+        }
+        ConversationTurnPhase::FinalizingReply => {
+            "Persisting the assistant reply and finishing after-turn work.".to_owned()
+        }
+        ConversationTurnPhase::Completed => "The assistant reply is ready.".to_owned(),
+        ConversationTurnPhase::Failed => {
+            "The turn failed before a stable reply could be finalized.".to_owned()
+        }
+    }
+}
+
+fn build_cli_chat_live_pipeline_items(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+) -> Vec<TuiChecklistItemSpec> {
+    let prepare_item = TuiChecklistItemSpec {
+        status: cli_chat_live_prepare_status(snapshot.phase),
+        label: "prepare context".to_owned(),
+        detail: cli_chat_live_prepare_detail(snapshot.phase),
+    };
+    let model_item = TuiChecklistItemSpec {
+        status: cli_chat_live_model_status(snapshot.phase),
+        label: "call model".to_owned(),
+        detail: cli_chat_live_model_detail(snapshot),
+    };
+    let tools_item = TuiChecklistItemSpec {
+        status: cli_chat_live_tools_status(snapshot),
+        label: "run tools".to_owned(),
+        detail: cli_chat_live_tools_detail(snapshot),
+    };
+    let finalize_item = TuiChecklistItemSpec {
+        status: cli_chat_live_finalize_status(snapshot.phase),
+        label: "finalize reply".to_owned(),
+        detail: cli_chat_live_finalize_detail(snapshot.phase),
+    };
+
+    vec![prepare_item, model_item, tools_item, finalize_item]
+}
+
+fn cli_chat_live_prepare_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
+    match phase {
+        ConversationTurnPhase::Preparing => TuiChecklistStatus::Warn,
+        ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed
+        | ConversationTurnPhase::Failed => TuiChecklistStatus::Pass,
+    }
+}
+
+fn cli_chat_live_prepare_detail(phase: ConversationTurnPhase) -> String {
+    match phase {
+        ConversationTurnPhase::Preparing => "assembling the next turn context".to_owned(),
+        ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed
+        | ConversationTurnPhase::Failed => "context assembled".to_owned(),
+    }
+}
+
+fn cli_chat_live_model_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
+    match phase {
+        ConversationTurnPhase::Preparing | ConversationTurnPhase::ContextReady => {
+            TuiChecklistStatus::Warn
+        }
+        ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
+        ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
+        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
+    }
+}
+
+fn cli_chat_live_model_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
+    match snapshot.phase {
+        ConversationTurnPhase::Preparing => "waiting for a provider round".to_owned(),
+        ConversationTurnPhase::ContextReady => "provider request is about to start".to_owned(),
+        ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RequestingFollowupProvider => {
+            let provider_round = snapshot.provider_round.unwrap_or(1);
+            format!("streaming provider round {provider_round}")
+        }
+        ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => "provider reply resolved".to_owned(),
+        ConversationTurnPhase::Failed => "provider step did not finish cleanly".to_owned(),
+    }
+}
+
+fn cli_chat_live_tools_status(snapshot: &CliChatLiveSurfaceSnapshot) -> TuiChecklistStatus {
+    let tools_needed = snapshot.tool_call_count > 0;
+    if !tools_needed {
+        return match snapshot.phase {
+            ConversationTurnPhase::FinalizingReply
+            | ConversationTurnPhase::Completed
+            | ConversationTurnPhase::Failed => TuiChecklistStatus::Pass,
+            ConversationTurnPhase::Preparing
+            | ConversationTurnPhase::ContextReady
+            | ConversationTurnPhase::RequestingProvider
+            | ConversationTurnPhase::RunningTools
+            | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
+        };
+    }
+
+    match snapshot.phase {
+        ConversationTurnPhase::RunningTools => TuiChecklistStatus::Warn,
+        ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
+        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider => TuiChecklistStatus::Warn,
+    }
+}
+
+fn cli_chat_live_tools_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
+    let tools_needed = snapshot.tool_call_count > 0;
+    if !tools_needed {
+        return match snapshot.phase {
+            ConversationTurnPhase::FinalizingReply | ConversationTurnPhase::Completed => {
+                "no tool calls were needed for this turn".to_owned()
+            }
+            ConversationTurnPhase::Failed => "no tool step was completed".to_owned(),
+            ConversationTurnPhase::Preparing
+            | ConversationTurnPhase::ContextReady
+            | ConversationTurnPhase::RequestingProvider
+            | ConversationTurnPhase::RunningTools
+            | ConversationTurnPhase::RequestingFollowupProvider => {
+                "waiting to see whether tools are needed".to_owned()
+            }
+        };
+    }
+
+    let lane_label = snapshot
+        .lane
+        .map(format_cli_chat_live_lane)
+        .unwrap_or_else(|| "-".to_owned());
+    match snapshot.phase {
+        ConversationTurnPhase::RunningTools => {
+            format!(
+                "{} tool call(s) currently running in the {lane_label} lane",
+                snapshot.tool_call_count
+            )
+        }
+        ConversationTurnPhase::RequestingFollowupProvider
+        | ConversationTurnPhase::FinalizingReply
+        | ConversationTurnPhase::Completed => {
+            format!(
+                "{} tool call(s) finished in the {lane_label} lane",
+                snapshot.tool_call_count
+            )
+        }
+        ConversationTurnPhase::Failed => {
+            format!(
+                "{} tool call(s) did not converge cleanly",
+                snapshot.tool_call_count
+            )
+        }
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider => {
+            format!(
+                "{} tool call(s) are queued if the provider asks for them",
+                snapshot.tool_call_count
+            )
+        }
+    }
+}
+
+fn cli_chat_live_finalize_status(phase: ConversationTurnPhase) -> TuiChecklistStatus {
+    match phase {
+        ConversationTurnPhase::FinalizingReply => TuiChecklistStatus::Warn,
+        ConversationTurnPhase::Completed => TuiChecklistStatus::Pass,
+        ConversationTurnPhase::Failed => TuiChecklistStatus::Fail,
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider => TuiChecklistStatus::Warn,
+    }
+}
+
+fn cli_chat_live_finalize_detail(phase: ConversationTurnPhase) -> String {
+    match phase {
+        ConversationTurnPhase::FinalizingReply => {
+            "persisting reply state and final runtime side effects".to_owned()
+        }
+        ConversationTurnPhase::Completed => "reply finalized".to_owned(),
+        ConversationTurnPhase::Failed => "reply finalization did not complete".to_owned(),
+        ConversationTurnPhase::Preparing
+        | ConversationTurnPhase::ContextReady
+        | ConversationTurnPhase::RequestingProvider
+        | ConversationTurnPhase::RunningTools
+        | ConversationTurnPhase::RequestingFollowupProvider => {
+            "waiting for a final reply".to_owned()
+        }
+    }
+}
+
+fn build_cli_chat_live_status_items(snapshot: &CliChatLiveSurfaceSnapshot) -> Vec<TuiKeyValueSpec> {
+    let mut items = Vec::new();
+
+    items.push(TuiKeyValueSpec::Plain {
+        key: "phase".to_owned(),
+        value: snapshot.phase.as_str().to_owned(),
+    });
+
+    if let Some(provider_round) = snapshot.provider_round {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "round".to_owned(),
+            value: provider_round.to_string(),
+        });
+    }
+
+    if let Some(lane) = snapshot.lane {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "lane".to_owned(),
+            value: format_cli_chat_live_lane(lane),
+        });
+    }
+
+    if snapshot.tool_call_count > 0 {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "tool calls".to_owned(),
+            value: snapshot.tool_call_count.to_string(),
+        });
+    }
+
+    if let Some(message_count) = snapshot.message_count {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "context messages".to_owned(),
+            value: message_count.to_string(),
+        });
+    }
+
+    if let Some(estimated_tokens) = snapshot.estimated_tokens {
+        items.push(TuiKeyValueSpec::Plain {
+            key: "estimated tokens".to_owned(),
+            value: estimated_tokens.to_string(),
+        });
+    }
+
+    items
+}
+
+fn format_cli_chat_live_lane(lane: ExecutionLane) -> String {
+    match lane {
+        ExecutionLane::Fast => "fast".to_owned(),
+        ExecutionLane::Safe => "safe".to_owned(),
+    }
+}
+
+fn build_cli_chat_live_preview_section(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+) -> Option<TuiSectionSpec> {
+    let preview = snapshot.draft_preview.as_ref()?;
+    let preview_lines = preview
+        .lines()
+        .map(|line| line.to_owned())
+        .collect::<Vec<_>>();
+
+    Some(TuiSectionSpec::Narrative {
+        title: Some("draft preview".to_owned()),
+        lines: preview_lines,
+    })
+}
+
+fn build_cli_chat_live_tool_section(
+    snapshot: &CliChatLiveSurfaceSnapshot,
+) -> Option<TuiSectionSpec> {
+    if snapshot.tool_activity_lines.is_empty() {
+        return None;
+    }
+
+    Some(TuiSectionSpec::Narrative {
+        title: Some("tool activity".to_owned()),
+        lines: snapshot.tool_activity_lines.clone(),
+    })
+}
+
 fn parse_cli_chat_markdown_sections(text: &str) -> Vec<TuiSectionSpec> {
     let mut sections = Vec::new();
     let mut pending_title = None;
@@ -1295,8 +2009,8 @@ fn normalize_markdown_display_line(line: &str) -> String {
 async fn run_cli_turn(
     runtime: &CliTurnRuntime,
     input: &str,
-    _options: &CliChatOptions,
     event_sink: Option<&dyn AcpTurnEventSink>,
+    live_surface_enabled: bool,
 ) -> CliResult<String> {
     let turn_config = reload_cli_turn_config(&runtime.config, runtime.resolved_path.as_path())?;
     let acp_options = if runtime.explicit_acp_request {
@@ -1307,15 +2021,22 @@ async fn run_cli_turn(
     .with_event_sink(event_sink)
     .with_additional_bootstrap_mcp_servers(&runtime.effective_bootstrap_mcp_servers)
     .with_working_directory(runtime.effective_working_directory.as_deref());
+    let live_surface_observer = if live_surface_enabled {
+        let render_width = detect_cli_chat_render_width();
+        Some(build_cli_chat_live_surface_observer(render_width))
+    } else {
+        None
+    };
     runtime
         .turn_coordinator
-        .handle_turn_with_address_and_acp_options(
+        .handle_turn_with_address_and_acp_options_and_observer(
             &turn_config,
             &runtime.session_address,
             input,
             ProviderErrorMode::InlineMessage,
             &acp_options,
             crate::conversation::ConversationRuntimeBinding::kernel(&runtime.kernel_ctx),
+            live_surface_observer,
         )
         .await
 }
@@ -4824,6 +5545,94 @@ println!(\"{value}\");
         assert!(
             lines.iter().any(|line| line == "Next"),
             "a trailing heading should still render even when it has no body lines yet: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn render_cli_chat_live_surface_lines_show_pipeline_status_and_preview() {
+        let snapshot = CliChatLiveSurfaceSnapshot {
+            phase: ConversationTurnPhase::RequestingProvider,
+            provider_round: Some(1),
+            lane: None,
+            tool_call_count: 0,
+            message_count: Some(4),
+            estimated_tokens: Some(128),
+            draft_preview: Some("Inspecting the repo layout...".to_owned()),
+            tool_activity_lines: Vec::new(),
+        };
+        let lines = render_cli_chat_live_surface_lines_with_width(&snapshot, 72);
+
+        assert_eq!(lines[0], "loongclaw: live");
+        assert!(
+            lines.iter().any(|line| line == "note: querying model"),
+            "live surface should explain the active phase through a callout: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "turn pipeline"),
+            "live surface should keep the pipeline checklist visible: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| {
+                line.starts_with("[WARN] call model") && line.contains("streaming provider round 1")
+            }),
+            "live surface should keep the model step actively highlighted: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "draft preview"),
+            "live surface should surface partial text as a dedicated preview block: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == "Inspecting the repo layout..."),
+            "live surface should preserve the partial preview text: {lines:#?}"
+        );
+    }
+
+    #[test]
+    fn cli_chat_live_surface_observer_emits_phase_and_stream_preview_batches() {
+        let captured_batches = Arc::new(StdMutex::new(Vec::<Vec<String>>::new()));
+        let render_sink: CliChatLiveSurfaceSink = {
+            let captured_batches = Arc::clone(&captured_batches);
+            Arc::new(move |lines| {
+                let mut batches = captured_batches
+                    .lock()
+                    .expect("captured batches lock should not be poisoned");
+                batches.push(lines);
+            })
+        };
+        let observer = CliChatLiveSurfaceObserver::new(72, render_sink);
+
+        observer.on_phase(ConversationTurnPhaseEvent::preparing());
+        observer.on_phase(ConversationTurnPhaseEvent::requesting_provider(
+            1,
+            3,
+            Some(96),
+        ));
+        observer.on_streaming_token(crate::acp::StreamingTokenEvent {
+            event_type: "text_delta".to_owned(),
+            delta: crate::acp::TokenDelta {
+                text: Some("Draft response".to_owned()),
+                tool_call: None,
+            },
+            index: None,
+        });
+
+        let batches = captured_batches
+            .lock()
+            .expect("captured batches lock should not be poisoned");
+        assert!(
+            batches.len() >= 3,
+            "observer should emit both phase updates and the first preview update: {batches:#?}"
+        );
+
+        let preview_batch = batches
+            .iter()
+            .find(|lines| lines.iter().any(|line| line == "draft preview"))
+            .expect("preview batch");
+        assert!(
+            preview_batch.iter().any(|line| line == "Draft response"),
+            "preview batch should include the streamed text: {preview_batch:#?}"
         );
     }
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -1443,7 +1443,7 @@ fn cli_chat_live_surface_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String
         }
         ConversationTurnPhase::RequestingProvider => {
             let provider_round = snapshot.provider_round.unwrap_or(1);
-            format!("Requesting provider round {provider_round} and collecting live deltas.")
+            format!("Requesting provider round {provider_round} and waiting for the reply.")
         }
         ConversationTurnPhase::RunningTools => {
             let lane_label = snapshot
@@ -1543,7 +1543,7 @@ fn cli_chat_live_model_detail(snapshot: &CliChatLiveSurfaceSnapshot) -> String {
         ConversationTurnPhase::RequestingProvider
         | ConversationTurnPhase::RequestingFollowupProvider => {
             let provider_round = snapshot.provider_round.unwrap_or(1);
-            format!("streaming provider round {provider_round}")
+            format!("provider round {provider_round} in progress")
         }
         ConversationTurnPhase::RunningTools
         | ConversationTurnPhase::FinalizingReply
@@ -5573,9 +5573,16 @@ println!(\"{value}\");
         );
         assert!(
             lines.iter().any(|line| {
-                line.starts_with("[WARN] call model") && line.contains("streaming provider round 1")
+                line.starts_with("[WARN] call model")
+                    && line.contains("provider round 1 in progress")
             }),
             "live surface should keep the model step actively highlighted: {lines:#?}"
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.contains("streaming provider round 1")),
+            "live surface should avoid claiming streaming when the snapshot does not encode that capability: {lines:#?}"
         );
         assert!(
             lines.iter().any(|line| line == "draft preview"),

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -20,6 +20,7 @@ pub mod turn_engine;
 mod turn_loop;
 mod turn_middleware;
 mod turn_middleware_registry;
+mod turn_observer;
 mod turn_shared;
 
 pub use analytics::{
@@ -100,6 +101,10 @@ pub use turn_middleware_registry::{
     TURN_MIDDLEWARE_ENV, default_turn_middleware_ids, describe_turn_middlewares,
     list_turn_middleware_ids, list_turn_middleware_metadata, register_turn_middleware,
     resolve_turn_middleware, resolve_turn_middlewares, turn_middleware_ids_from_env,
+};
+pub use turn_observer::{
+    ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
+    ConversationTurnPhaseEvent,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -104,7 +104,7 @@ pub use turn_middleware_registry::{
 };
 pub use turn_observer::{
     ConversationTurnObserver, ConversationTurnObserverHandle, ConversationTurnPhase,
-    ConversationTurnPhaseEvent,
+    ConversationTurnPhaseEvent, ConversationTurnToolEvent, ConversationTurnToolState,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -338,6 +338,25 @@ struct RecordingLifecycleContextEngine {
 }
 
 #[derive(Default)]
+struct RecordingTurnObserver {
+    phase_events: Mutex<Vec<ConversationTurnPhaseEvent>>,
+}
+
+impl ConversationTurnObserver for RecordingTurnObserver {
+    fn on_phase(&self, event: ConversationTurnPhaseEvent) {
+        let mut phase_events = self
+            .phase_events
+            .lock()
+            .expect("phase event lock should not be poisoned");
+        phase_events.push(event);
+    }
+
+    fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
+        let _ = event;
+    }
+}
+
+#[derive(Default)]
 struct RoutedAcpState {
     ensure_calls: usize,
     turn_calls: usize,
@@ -3648,6 +3667,65 @@ async fn handle_turn_with_runtime_routes_explicit_acp_turns_through_acp() {
             .get("loongclaw.acp.routing_origin")
             .map(String::as_str),
         Some("explicit_request")
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_observer_routes_explicit_acp_turns_through_acp() {
+    let (backend_id, shared) = register_routed_acp_backend("success-explicit-observer", false);
+    let coordinator = ConversationTurnCoordinator::new();
+    let mut config = test_config();
+    config.acp.enabled = true;
+    config.acp.default_agent = Some("claude".to_owned());
+    config.acp.allowed_agents = vec!["claude".to_owned()];
+    config.acp.backend = Some(backend_id.to_owned());
+    config.acp.bindings_enabled = true;
+    config.acp.dispatch.bootstrap_mcp_servers =
+        vec![" Filesystem ".to_owned(), "filesystem".to_owned()];
+    config.memory.sqlite_path = unique_acp_sqlite_path("success-explicit-observer");
+
+    let observer = Arc::new(RecordingTurnObserver::default());
+    let observer_handle: ConversationTurnObserverHandle = observer.clone();
+    let address = ConversationSessionAddress::from_session_id("telegram:42");
+    let acp_options = AcpConversationTurnOptions {
+        routing_intent: AcpRoutingIntent::Explicit,
+        ..AcpConversationTurnOptions::default()
+    };
+    let reply = coordinator
+        .handle_turn_with_address_and_acp_options_and_observer(
+            &config,
+            &address,
+            "hello from channel",
+            ProviderErrorMode::Propagate,
+            &acp_options,
+            ConversationRuntimeBinding::direct(),
+            Some(observer_handle),
+        )
+        .await
+        .expect("explicit ACP turn with observer should route through ACP");
+
+    assert_eq!(reply, "acp: hello from channel");
+
+    let state = shared.lock().expect("ACP shared state");
+    assert_eq!(state.ensure_calls, 1);
+    assert_eq!(state.turn_calls, 1);
+    drop(state);
+
+    let phase_events = observer
+        .phase_events
+        .lock()
+        .expect("phase event lock should not be poisoned");
+    let phase_names = phase_events
+        .iter()
+        .map(|event| event.phase)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        phase_names,
+        vec![
+            ConversationTurnPhase::Preparing,
+            ConversationTurnPhase::FinalizingReply,
+            ConversationTurnPhase::Completed,
+        ]
     );
 }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -31,7 +31,7 @@ use crate::acp::{
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::runtime_self_continuity;
 
-use super::super::config::LoongClawConfig;
+use super::super::config::{LoongClawConfig, ProviderProtocolFamily};
 use super::ConversationSessionAddress;
 use super::ProviderErrorMode;
 use super::analytics::{
@@ -82,6 +82,10 @@ use super::turn_budget::{
 use super::turn_engine::{
     AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolBatchExecutionTrace, ToolIntent,
     TurnEngine, TurnFailure, TurnFailureKind, TurnResult, TurnValidation,
+};
+use super::turn_observer::{
+    ConversationTurnObserverHandle, ConversationTurnPhaseEvent,
+    build_observer_streaming_token_callback,
 };
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
@@ -1083,7 +1087,9 @@ impl ProviderTurnContinuePhase {
         turn_loop_state: &mut ProviderTurnLoopState,
         remaining_provider_rounds: usize,
         binding: ConversationRuntimeBinding<'_>,
+        observer: Option<&ConversationTurnObserverHandle>,
     ) -> ResolvedProviderTurn {
+        observe_provider_turn_continue_phase(observer, self, 1);
         resolve_provider_turn_reply(
             runtime,
             &self.followup_config,
@@ -1096,6 +1102,7 @@ impl ProviderTurnContinuePhase {
             remaining_provider_rounds,
             binding,
             self.ingress.as_ref(),
+            observer,
         )
         .await
     }
@@ -1775,6 +1782,31 @@ impl ConversationTurnCoordinator {
         .await
     }
 
+    pub async fn handle_turn_with_address_and_acp_options_and_observer(
+        &self,
+        config: &LoongClawConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        observer: Option<ConversationTurnObserverHandle>,
+    ) -> CliResult<String> {
+        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+            config,
+            address,
+            user_input,
+            error_mode,
+            &runtime,
+            acp_options,
+            binding,
+            None,
+            observer,
+        )
+        .await
+    }
+
     pub async fn handle_turn_with_runtime<R: ConversationRuntime + ?Sized>(
         &self,
         config: &LoongClawConfig,
@@ -2060,92 +2092,154 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         ingress: Option<&ConversationIngressContext>,
     ) -> CliResult<String> {
-        let session_id = address.session_id.as_str();
-        match evaluate_acp_conversation_turn_entry_for_address(config, address, acp_options)? {
-            AcpConversationTurnEntryDecision::RejectExplicitWhenDisabled => {
-                let error = "ACP is disabled by policy (`acp.enabled=false`)".to_owned();
-                return match error_mode {
-                    ProviderErrorMode::Propagate => Err(error),
-                    ProviderErrorMode::InlineMessage => {
-                        let synthetic = format_provider_error_reply(&error);
-                        persist_reply_turns_raw_with_mode(
-                            runtime,
-                            session_id,
-                            user_input,
-                            &synthetic,
-                            ReplyPersistenceMode::InlineProviderError,
-                            binding,
-                        )
-                        .await?;
-                        Ok(synthetic)
-                    }
-                };
-            }
-            AcpConversationTurnEntryDecision::RouteViaAcp => {
-                return self
-                    .handle_turn_via_acp(
-                        config,
-                        address,
-                        user_input,
-                        error_mode,
-                        runtime,
-                        acp_options,
-                        binding,
-                    )
-                    .await;
-            }
-            AcpConversationTurnEntryDecision::StayOnProvider => {}
-        }
-
-        if let Some(kernel_ctx) = binding.kernel_context() {
-            runtime.bootstrap(config, session_id, kernel_ctx).await?;
-        }
-        let session_context = runtime.session_context(config, session_id, binding)?;
-        let tool_view = session_context.tool_view.clone();
-        let visible_ingress = ingress.filter(|value| value.has_contextual_hints());
-        emit_turn_ingress_event(runtime, session_id, visible_ingress, binding).await;
-        let turn_id = next_conversation_turn_id();
-        let preparation = ProviderTurnPreparation::from_assembled_context_with_turn_id(
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
             config,
-            runtime
-                .build_context(config, session_id, true, binding)
-                .await?,
+            address,
             user_input,
-            turn_id.as_str(),
-            visible_ingress,
-        );
-        let resolved_turn = resolve_provider_turn(
-            config,
-            runtime,
-            session_id,
-            user_input,
-            &preparation,
-            runtime
-                .request_turn(
-                    config,
-                    session_id,
-                    preparation.turn_id.as_str(),
-                    &preparation.session.messages,
-                    &tool_view,
-                    binding,
-                )
-                .await,
             error_mode,
+            runtime,
+            acp_options,
             binding,
             ingress,
-        )
-        .await;
-
-        apply_resolved_provider_turn(
-            config,
-            runtime,
-            session_id,
-            user_input,
-            &preparation,
-            &resolved_turn,
-            binding,
+            None,
         )
         .await
+    }
+
+    async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer<
+        R: ConversationRuntime + ?Sized,
+    >(
+        &self,
+        config: &LoongClawConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        runtime: &R,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+        observer: Option<ConversationTurnObserverHandle>,
+    ) -> CliResult<String> {
+        let turn_result: CliResult<String> = async {
+            let session_id = address.session_id.as_str();
+            match evaluate_acp_conversation_turn_entry_for_address(config, address, acp_options)? {
+                AcpConversationTurnEntryDecision::RejectExplicitWhenDisabled => {
+                    let error = "ACP is disabled by policy (`acp.enabled=false`)".to_owned();
+                    return match error_mode {
+                        ProviderErrorMode::Propagate => Err(error),
+                        ProviderErrorMode::InlineMessage => {
+                            let synthetic = format_provider_error_reply(&error);
+                            persist_reply_turns_raw_with_mode(
+                                runtime,
+                                session_id,
+                                user_input,
+                                &synthetic,
+                                ReplyPersistenceMode::InlineProviderError,
+                                binding,
+                            )
+                            .await?;
+                            Ok(synthetic)
+                        }
+                    };
+                }
+                AcpConversationTurnEntryDecision::RouteViaAcp => {
+                    return self
+                        .handle_turn_via_acp(
+                            config,
+                            address,
+                            user_input,
+                            error_mode,
+                            runtime,
+                            acp_options,
+                            binding,
+                        )
+                        .await;
+                }
+                AcpConversationTurnEntryDecision::StayOnProvider => {}
+            }
+
+            observe_turn_phase(observer.as_ref(), ConversationTurnPhaseEvent::preparing());
+
+            if let Some(kernel_ctx) = binding.kernel_context() {
+                runtime.bootstrap(config, session_id, kernel_ctx).await?;
+            }
+
+            let session_context = runtime.session_context(config, session_id, binding)?;
+            let tool_view = session_context.tool_view.clone();
+            let visible_ingress = ingress.filter(|value| value.has_contextual_hints());
+            emit_turn_ingress_event(runtime, session_id, visible_ingress, binding).await;
+
+            let turn_id = next_conversation_turn_id();
+            let assembled_context = runtime
+                .build_context(config, session_id, true, binding)
+                .await?;
+            let preparation = ProviderTurnPreparation::from_assembled_context_with_turn_id(
+                config,
+                assembled_context,
+                user_input,
+                turn_id.as_str(),
+                visible_ingress,
+            );
+            let context_message_count = preparation.session.messages.len();
+            let context_estimated_tokens = preparation.session.estimated_tokens;
+            let initial_request_event = ConversationTurnPhaseEvent::requesting_provider(
+                1,
+                context_message_count,
+                context_estimated_tokens,
+            );
+            observe_turn_phase(
+                observer.as_ref(),
+                ConversationTurnPhaseEvent::context_ready(
+                    context_message_count,
+                    context_estimated_tokens,
+                ),
+            );
+            observe_turn_phase(observer.as_ref(), initial_request_event);
+
+            let provider_turn_result = request_provider_turn_with_observer(
+                config,
+                runtime,
+                session_id,
+                preparation.turn_id.as_str(),
+                &preparation.session.messages,
+                &tool_view,
+                binding,
+                observer.as_ref(),
+            )
+            .await;
+            let resolved_turn = resolve_provider_turn(
+                config,
+                runtime,
+                session_id,
+                user_input,
+                &preparation,
+                provider_turn_result,
+                error_mode,
+                binding,
+                ingress,
+                observer.as_ref(),
+            )
+            .await;
+
+            apply_resolved_provider_turn(
+                config,
+                runtime,
+                session_id,
+                user_input,
+                &preparation,
+                &resolved_turn,
+                binding,
+                observer.as_ref(),
+            )
+            .await
+        }
+        .await;
+
+        if turn_result.is_err() {
+            observe_turn_phase(observer.as_ref(), ConversationTurnPhaseEvent::failed());
+        }
+
+        turn_result
     }
 
     fn reload_followup_provider_config_after_tool_turn(
@@ -2532,6 +2626,70 @@ fn disabled_lane_decision(user_input: &str) -> LaneDecision {
     }
 }
 
+fn observe_turn_phase(
+    observer: Option<&ConversationTurnObserverHandle>,
+    event: ConversationTurnPhaseEvent,
+) {
+    let Some(observer) = observer else {
+        return;
+    };
+
+    observer.on_phase(event);
+}
+
+fn observe_provider_turn_continue_phase(
+    observer: Option<&ConversationTurnObserverHandle>,
+    continue_phase: &ProviderTurnContinuePhase,
+    provider_round: usize,
+) {
+    let tool_call_count = continue_phase.tool_intent_count();
+    if tool_call_count == 0 {
+        return;
+    }
+
+    let lane = continue_phase.lane_execution.lane;
+    let event = ConversationTurnPhaseEvent::running_tools(provider_round, lane, tool_call_count);
+    observe_turn_phase(observer, event);
+}
+
+fn provider_turn_observer_supports_streaming(
+    config: &LoongClawConfig,
+    observer: Option<&ConversationTurnObserverHandle>,
+) -> bool {
+    if observer.is_none() {
+        return false;
+    }
+
+    let protocol_family = config.provider.kind.protocol_family();
+    protocol_family == ProviderProtocolFamily::AnthropicMessages
+}
+
+async fn request_provider_turn_with_observer<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    turn_id: &str,
+    messages: &[Value],
+    tool_view: &crate::tools::ToolView,
+    binding: ConversationRuntimeBinding<'_>,
+    observer: Option<&ConversationTurnObserverHandle>,
+) -> CliResult<ProviderTurn> {
+    if let Some(observer) = observer
+        && provider_turn_observer_supports_streaming(config, Some(observer))
+    {
+        let on_token = build_observer_streaming_token_callback(observer);
+        return runtime
+            .request_turn_streaming(
+                config, session_id, turn_id, messages, tool_view, binding, on_token,
+            )
+            .await;
+    }
+
+    runtime
+        .request_turn(config, session_id, turn_id, messages, tool_view, binding)
+        .await
+}
+
 async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
@@ -2542,6 +2700,7 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
     error_mode: ProviderErrorMode,
     binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
+    observer: Option<&ConversationTurnObserverHandle>,
 ) -> ResolvedProviderTurn {
     let turn_loop_policy = ProviderTurnLoopPolicy::from_config(config);
     let mut turn_loop_state = ProviderTurnLoopState::default();
@@ -2586,6 +2745,7 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
                         .max_discovery_followup_rounds
                         .max(1),
                     binding,
+                    observer,
                 )
                 .await
         }
@@ -2686,6 +2846,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     remaining_provider_rounds: usize,
     binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
+    observer: Option<&ConversationTurnObserverHandle>,
 ) -> ResolvedProviderTurn {
     enum ReplyLoopDecision {
         FinalizeDirect(String),
@@ -2709,6 +2870,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     let kernel_ctx = binding.kernel_context();
 
     loop {
+        let current_provider_round = provider_round_index.saturating_add(1);
         if current_continue_phase
             .lane_execution
             .requires_provider_turn_followup
@@ -2811,14 +2973,15 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                     .requires_provider_turn_followup
                     && remaining_provider_rounds > 1
                 {
+                    let next_provider_round = current_provider_round.saturating_add(1);
                     remaining_provider_rounds -= 1;
                     let initial_estimated_tokens = estimate_tokens_for_messages(
                         current_preparation.session.estimated_tokens,
                         &current_preparation.session.messages,
                     );
-                    let followup_estimated_tokens = estimate_tokens(&follow_up_messages);
+                    let followup_request_estimated_tokens = estimate_tokens(&follow_up_messages);
                     let followup_added_estimated_tokens = initial_estimated_tokens
-                        .zip(followup_estimated_tokens)
+                        .zip(followup_request_estimated_tokens)
                         .map(|(initial, followup)| followup.saturating_sub(initial));
                     let followup_preparation =
                         current_preparation.for_followup_messages(follow_up_messages);
@@ -2837,6 +3000,18 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                             return ResolvedProviderTurn::persist_reply(raw_reply, checkpoint);
                         }
                     };
+                    let followup_message_count = followup_preparation.session.messages.len();
+                    let followup_context_estimated_tokens =
+                        followup_preparation.session.estimated_tokens;
+                    let followup_request_event =
+                        ConversationTurnPhaseEvent::requesting_followup_provider(
+                            next_provider_round,
+                            current_continue_phase.lane_execution.lane,
+                            current_continue_phase.tool_intent_count(),
+                            followup_message_count,
+                            followup_context_estimated_tokens,
+                        );
+                    observe_turn_phase(observer, followup_request_event);
                     emit_discovery_first_event(
                         runtime,
                         session_id,
@@ -2847,23 +3022,24 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                 .lane_execution
                                 .raw_tool_output_requested,
                             "initial_estimated_tokens": initial_estimated_tokens,
-                            "followup_estimated_tokens": followup_estimated_tokens,
+                            "followup_estimated_tokens": followup_request_estimated_tokens,
                             "followup_added_estimated_tokens": followup_added_estimated_tokens,
                         }),
                         kernel_ctx,
                     )
                     .await;
                     match decide_provider_turn_request_action(
-                        runtime
-                            .request_turn(
-                                &current_continue_phase.followup_config,
-                                session_id,
-                                followup_preparation.turn_id.as_str(),
-                                &followup_preparation.session.messages,
-                                &followup_tool_view,
-                                binding,
-                            )
-                            .await,
+                        request_provider_turn_with_observer(
+                            &current_continue_phase.followup_config,
+                            runtime,
+                            session_id,
+                            followup_preparation.turn_id.as_str(),
+                            &followup_preparation.session.messages,
+                            &followup_tool_view,
+                            binding,
+                            observer,
+                        )
+                        .await,
                         ProviderErrorMode::Propagate,
                     ) {
                         ProviderTurnRequestAction::Continue { turn } => {
@@ -2915,6 +3091,11 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                             .await;
                             current_preparation = followup_preparation;
                             provider_round_index = provider_round_index.saturating_add(1);
+                            observe_provider_turn_continue_phase(
+                                observer,
+                                &current_continue_phase,
+                                next_provider_round,
+                            );
                             continue;
                         }
                         ProviderTurnRequestAction::FinalizeInlineProviderError { .. }
@@ -3770,11 +3951,37 @@ async fn apply_resolved_provider_turn<R: ConversationRuntime + ?Sized>(
     preparation: &ProviderTurnPreparation,
     resolved: &ResolvedProviderTurn,
     binding: ConversationRuntimeBinding<'_>,
+    observer: Option<&ConversationTurnObserverHandle>,
 ) -> CliResult<String> {
-    resolved
-        .terminal_phase(&preparation.session)
+    let terminal_phase = resolved.terminal_phase(&preparation.session);
+    let completion_event = match &terminal_phase {
+        ProviderTurnTerminalPhase::PersistReply(phase) => {
+            let message_count = phase.tail_phase.after_turn_messages().len();
+            let estimated_tokens = phase.tail_phase.estimated_tokens();
+            let finalizing_event =
+                ConversationTurnPhaseEvent::finalizing_reply(message_count, estimated_tokens);
+            observe_turn_phase(observer, finalizing_event);
+            Some(ConversationTurnPhaseEvent::completed(
+                message_count,
+                estimated_tokens,
+            ))
+        }
+        ProviderTurnTerminalPhase::ReturnError(_) => None,
+    };
+    let apply_result = terminal_phase
         .apply(config, runtime, session_id, user_input, binding)
-        .await
+        .await;
+
+    let completion_observation = match (completion_event, apply_result.is_ok()) {
+        (Some(event), true) => Some(event),
+        (Some(_), false) | (None, true) | (None, false) => None,
+    };
+
+    if let Some(event) = completion_observation {
+        observe_turn_phase(observer, event);
+    }
+
+    apply_result
 }
 
 fn effective_tool_config_for_session(
@@ -6766,8 +6973,10 @@ async fn execute_single_tool_intent(
 mod tests {
     use super::*;
     use crate::context::bootstrap_test_kernel_context;
+    use crate::conversation::{ConversationTurnObserver, ConversationTurnPhase};
     use crate::session::repository::FinalizeSessionTerminalResult;
     use std::path::PathBuf;
+    use std::sync::Arc;
     use std::sync::Mutex as StdMutex;
 
     fn unique_sqlite_path(label: &str) -> PathBuf {
@@ -6875,6 +7084,173 @@ mod tests {
             *compact_calls += 1;
             Ok(())
         }
+    }
+
+    #[derive(Default)]
+    struct ObserverStreamingRuntime {
+        streaming_calls: StdMutex<usize>,
+    }
+
+    #[async_trait]
+    impl ConversationRuntime for ObserverStreamingRuntime {
+        async fn build_messages(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _include_system_prompt: bool,
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<Vec<Value>> {
+            Ok(vec![json!({
+                "role": "system",
+                "content": "stay focused"
+            })])
+        }
+
+        async fn request_completion(
+            &self,
+            _config: &LoongClawConfig,
+            _messages: &[Value],
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<String> {
+            Ok("completion".to_owned())
+        }
+
+        async fn request_turn(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<ProviderTurn> {
+            panic!("request_turn should not be called when observer streaming is enabled")
+        }
+
+        async fn request_turn_streaming(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+            on_token: crate::provider::StreamingTokenCallback,
+        ) -> CliResult<ProviderTurn> {
+            let mut streaming_calls = self
+                .streaming_calls
+                .lock()
+                .expect("streaming call lock should not be poisoned");
+            *streaming_calls += 1;
+
+            if let Some(on_token) = on_token {
+                on_token(crate::provider::StreamingCallbackData::Text {
+                    text: "draft".to_owned(),
+                });
+            }
+
+            Ok(ProviderTurn {
+                assistant_text: "final reply".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            })
+        }
+
+        async fn persist_turn(
+            &self,
+            _session_id: &str,
+            _role: &str,
+            _content: &str,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingTurnObserver {
+        phase_events: StdMutex<Vec<ConversationTurnPhaseEvent>>,
+        token_events: StdMutex<Vec<crate::acp::StreamingTokenEvent>>,
+    }
+
+    impl ConversationTurnObserver for RecordingTurnObserver {
+        fn on_phase(&self, event: ConversationTurnPhaseEvent) {
+            let mut phase_events = self
+                .phase_events
+                .lock()
+                .expect("phase event lock should not be poisoned");
+            phase_events.push(event);
+        }
+
+        fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
+            let mut token_events = self
+                .token_events
+                .lock()
+                .expect("token event lock should not be poisoned");
+            token_events.push(event);
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_turn_with_observer_uses_streaming_request_and_emits_live_events() {
+        let mut config = LoongClawConfig::default();
+        config.provider.kind = crate::config::ProviderKind::Anthropic;
+
+        let runtime = ObserverStreamingRuntime::default();
+        let observer = Arc::new(RecordingTurnObserver::default());
+        let observer_handle: ConversationTurnObserverHandle = observer.clone();
+        let acp_options = AcpConversationTurnOptions::automatic();
+        let address = ConversationSessionAddress::from_session_id("observer-session");
+        let reply = ConversationTurnCoordinator::new()
+            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+                &config,
+                &address,
+                "say hello",
+                ProviderErrorMode::Propagate,
+                &runtime,
+                &acp_options,
+                ConversationRuntimeBinding::direct(),
+                None,
+                Some(observer_handle),
+            )
+            .await
+            .expect("observer turn should succeed");
+
+        assert_eq!(reply, "final reply");
+
+        let streaming_calls = runtime
+            .streaming_calls
+            .lock()
+            .expect("streaming call lock should not be poisoned");
+        assert_eq!(*streaming_calls, 1);
+
+        let phase_events = observer
+            .phase_events
+            .lock()
+            .expect("phase event lock should not be poisoned");
+        let phase_names = phase_events
+            .iter()
+            .map(|event| event.phase)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            phase_names,
+            vec![
+                ConversationTurnPhase::Preparing,
+                ConversationTurnPhase::ContextReady,
+                ConversationTurnPhase::RequestingProvider,
+                ConversationTurnPhase::FinalizingReply,
+                ConversationTurnPhase::Completed,
+            ]
+        );
+
+        let token_events = observer
+            .token_events
+            .lock()
+            .expect("token event lock should not be poisoned");
+        assert_eq!(token_events.len(), 1);
+        assert_eq!(token_events[0].event_type, "text_delta");
+        assert_eq!(token_events[0].delta.text.as_deref(), Some("draft"));
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "memory-sqlite")]
 use std::any::Any;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 #[cfg(feature = "memory-sqlite")]
 use std::future::Future;
 #[cfg(feature = "memory-sqlite")]
@@ -80,11 +80,12 @@ use super::turn_budget::{
     SafeLaneFailureRouteReason, SafeLaneReplanBudget,
 };
 use super::turn_engine::{
-    AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolBatchExecutionTrace, ToolIntent,
-    TurnEngine, TurnFailure, TurnFailureKind, TurnResult, TurnValidation,
+    AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolBatchExecutionIntentStatus,
+    ToolBatchExecutionTrace, ToolIntent, TurnEngine, TurnFailure, TurnFailureKind, TurnResult,
+    TurnValidation, effective_result_tool_name,
 };
 use super::turn_observer::{
-    ConversationTurnObserverHandle, ConversationTurnPhaseEvent,
+    ConversationTurnObserverHandle, ConversationTurnPhaseEvent, ConversationTurnToolEvent,
     build_observer_streaming_token_callback,
 };
 use super::turn_shared::{
@@ -896,6 +897,7 @@ struct ProviderTurnLaneExecution {
     raw_tool_output_requested: bool,
     turn_result: TurnResult,
     safe_lane_terminal_route: Option<SafeLaneFailureRoute>,
+    tool_events: Vec<ConversationTurnToolEvent>,
 }
 
 impl ProviderTurnLaneExecution {
@@ -1089,7 +1091,6 @@ impl ProviderTurnContinuePhase {
         binding: ConversationRuntimeBinding<'_>,
         observer: Option<&ConversationTurnObserverHandle>,
     ) -> ResolvedProviderTurn {
-        observe_provider_turn_continue_phase(observer, self, 1);
         resolve_provider_turn_reply(
             runtime,
             &self.followup_config,
@@ -2637,19 +2638,151 @@ fn observe_turn_phase(
     observer.on_phase(event);
 }
 
-fn observe_provider_turn_continue_phase(
+fn observe_provider_turn_tool_batch_started(
     observer: Option<&ConversationTurnObserverHandle>,
-    continue_phase: &ProviderTurnContinuePhase,
-    provider_round: usize,
+    turn: &ProviderTurn,
 ) {
-    let tool_call_count = continue_phase.tool_intent_count();
-    if tool_call_count == 0 {
+    let Some(observer) = observer else {
         return;
+    };
+
+    for intent in &turn.tool_intents {
+        let tool_name = effective_result_tool_name(intent);
+        let event = ConversationTurnToolEvent::running(intent.tool_call_id.clone(), tool_name);
+        observer.on_tool(event);
+    }
+}
+
+fn observe_provider_turn_tool_batch_terminal(
+    observer: Option<&ConversationTurnObserverHandle>,
+    tool_events: &[ConversationTurnToolEvent],
+) {
+    let Some(observer) = observer else {
+        return;
+    };
+
+    for tool_event in tool_events {
+        observer.on_tool(tool_event.clone());
+    }
+}
+
+fn build_provider_turn_tool_terminal_events(
+    turn: &ProviderTurn,
+    turn_result: &TurnResult,
+    trace: Option<&ToolBatchExecutionTrace>,
+) -> Vec<ConversationTurnToolEvent> {
+    let mut trace_events = BTreeMap::new();
+    if let Some(trace) = trace {
+        for intent_outcome in &trace.intent_outcomes {
+            let event = match intent_outcome.status {
+                ToolBatchExecutionIntentStatus::Completed => ConversationTurnToolEvent::completed(
+                    intent_outcome.tool_call_id.clone(),
+                    intent_outcome.tool_name.clone(),
+                    intent_outcome.detail.clone(),
+                ),
+                ToolBatchExecutionIntentStatus::NeedsApproval => {
+                    let detail = intent_outcome.detail.clone().unwrap_or_default();
+                    ConversationTurnToolEvent::needs_approval(
+                        intent_outcome.tool_call_id.clone(),
+                        intent_outcome.tool_name.clone(),
+                        detail,
+                    )
+                }
+                ToolBatchExecutionIntentStatus::Denied => {
+                    let detail = intent_outcome.detail.clone().unwrap_or_default();
+                    ConversationTurnToolEvent::denied(
+                        intent_outcome.tool_call_id.clone(),
+                        intent_outcome.tool_name.clone(),
+                        detail,
+                    )
+                }
+                ToolBatchExecutionIntentStatus::Failed => {
+                    let detail = intent_outcome.detail.clone().unwrap_or_default();
+                    ConversationTurnToolEvent::failed(
+                        intent_outcome.tool_call_id.clone(),
+                        intent_outcome.tool_name.clone(),
+                        detail,
+                    )
+                }
+            };
+            trace_events.insert(intent_outcome.tool_call_id.clone(), event);
+        }
     }
 
-    let lane = continue_phase.lane_execution.lane;
-    let event = ConversationTurnPhaseEvent::running_tools(provider_round, lane, tool_call_count);
-    observe_turn_phase(observer, event);
+    let mut events = Vec::new();
+    let mut unresolved_failure_emitted = false;
+
+    for intent in &turn.tool_intents {
+        if let Some(event) = trace_events.remove(intent.tool_call_id.as_str()) {
+            events.push(event);
+            continue;
+        }
+
+        let tool_name = effective_result_tool_name(intent);
+        let fallback_event = match turn_result {
+            TurnResult::FinalText(_)
+            | TurnResult::StreamingText(_)
+            | TurnResult::StreamingDone(_) => Some(ConversationTurnToolEvent::completed(
+                intent.tool_call_id.clone(),
+                tool_name,
+                None,
+            )),
+            TurnResult::NeedsApproval(requirement) => {
+                if unresolved_failure_emitted {
+                    None
+                } else {
+                    unresolved_failure_emitted = true;
+                    Some(ConversationTurnToolEvent::needs_approval(
+                        intent.tool_call_id.clone(),
+                        tool_name,
+                        requirement.reason.clone(),
+                    ))
+                }
+            }
+            TurnResult::ToolDenied(failure) => {
+                if unresolved_failure_emitted {
+                    None
+                } else {
+                    unresolved_failure_emitted = true;
+                    Some(ConversationTurnToolEvent::denied(
+                        intent.tool_call_id.clone(),
+                        tool_name,
+                        failure.reason.clone(),
+                    ))
+                }
+            }
+            TurnResult::ToolError(failure) => {
+                if unresolved_failure_emitted {
+                    None
+                } else {
+                    unresolved_failure_emitted = true;
+                    Some(ConversationTurnToolEvent::failed(
+                        intent.tool_call_id.clone(),
+                        tool_name,
+                        failure.reason.clone(),
+                    ))
+                }
+            }
+            TurnResult::ProviderError(failure) => {
+                if unresolved_failure_emitted {
+                    None
+                } else {
+                    unresolved_failure_emitted = true;
+                    Some(ConversationTurnToolEvent::interrupted(
+                        intent.tool_call_id.clone(),
+                        tool_name,
+                        failure.reason.clone(),
+                    ))
+                }
+            }
+        };
+
+        if let Some(fallback_event) = fallback_event {
+            events.push(fallback_event);
+        }
+    }
+
+    events
 }
 
 fn provider_turn_observer_supports_streaming(
@@ -2729,6 +2862,8 @@ async fn resolve_provider_turn<R: ConversationRuntime + ?Sized>(
                 &mut turn_loop_state,
                 binding,
                 ingress,
+                observer,
+                1,
             )
             .await;
             continue_phase
@@ -2810,8 +2945,17 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
     turn_loop_state: &mut ProviderTurnLoopState,
     binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
+    observer: Option<&ConversationTurnObserverHandle>,
+    provider_round: usize,
 ) -> ProviderTurnContinuePhase {
     let tool_intents = turn.tool_intents.len();
+    let lane = preparation.lane_plan.decision.lane;
+    if tool_intents > 0 {
+        let running_tools_event =
+            ConversationTurnPhaseEvent::running_tools(provider_round, lane, tool_intents);
+        observe_turn_phase(observer, running_tools_event);
+        observe_provider_turn_tool_batch_started(observer, &turn);
+    }
     let lane_execution = execute_provider_turn_lane(
         config,
         runtime,
@@ -2822,6 +2966,7 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
         ingress,
     )
     .await;
+    observe_provider_turn_tool_batch_terminal(observer, &lane_execution.tool_events);
     let loop_verdict = turn_loop_state.observe_turn(turn_loop_policy, &turn);
     let followup_config =
         ConversationTurnCoordinator::reload_followup_provider_config_after_tool_turn(config, &turn);
@@ -3087,15 +3232,12 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                 turn_loop_state,
                                 binding,
                                 ingress,
+                                observer,
+                                next_provider_round,
                             )
                             .await;
                             current_preparation = followup_preparation;
                             provider_round_index = provider_round_index.saturating_add(1);
-                            observe_provider_turn_continue_phase(
-                                observer,
-                                &current_continue_phase,
-                                next_provider_round,
-                            );
                             continue;
                         }
                         ProviderTurnRequestAction::FinalizeInlineProviderError { .. }
@@ -5125,14 +5267,17 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     let session_context = match runtime.session_context(config, session_id, binding) {
         Ok(session_context) => session_context,
         Err(error) => {
+            let turn_result = TurnResult::non_retryable_tool_error("session_context_failed", error);
+            let tool_events = build_provider_turn_tool_terminal_events(turn, &turn_result, None);
             return ProviderTurnLaneExecution {
                 lane,
                 assistant_preface,
                 had_tool_intents,
                 requires_provider_turn_followup,
                 raw_tool_output_requested: preparation.raw_tool_output_requested,
-                turn_result: TurnResult::non_retryable_tool_error("session_context_failed", error),
+                turn_result,
                 safe_lane_terminal_route: None,
+                tool_events,
             };
         }
     };
@@ -5226,6 +5371,12 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         );
     }
 
+    let tool_events = build_provider_turn_tool_terminal_events(
+        turn,
+        &turn_result,
+        fast_lane_tool_batch_trace.as_ref(),
+    );
+
     ProviderTurnLaneExecution {
         lane,
         assistant_preface,
@@ -5234,6 +5385,7 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         raw_tool_output_requested: preparation.raw_tool_output_requested,
         turn_result,
         safe_lane_terminal_route,
+        tool_events,
     }
 }
 
@@ -6973,7 +7125,10 @@ async fn execute_single_tool_intent(
 mod tests {
     use super::*;
     use crate::context::bootstrap_test_kernel_context;
-    use crate::conversation::{ConversationTurnObserver, ConversationTurnPhase};
+    use crate::conversation::turn_engine::ToolBatchExecutionIntentTrace;
+    use crate::conversation::{
+        ConversationTurnObserver, ConversationTurnPhase, ConversationTurnToolState,
+    };
     use crate::session::repository::FinalizeSessionTerminalResult;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -7171,6 +7326,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingTurnObserver {
         phase_events: StdMutex<Vec<ConversationTurnPhaseEvent>>,
+        tool_events: StdMutex<Vec<ConversationTurnToolEvent>>,
         token_events: StdMutex<Vec<crate::acp::StreamingTokenEvent>>,
     }
 
@@ -7181,6 +7337,14 @@ mod tests {
                 .lock()
                 .expect("phase event lock should not be poisoned");
             phase_events.push(event);
+        }
+
+        fn on_tool(&self, event: ConversationTurnToolEvent) {
+            let mut tool_events = self
+                .tool_events
+                .lock()
+                .expect("tool event lock should not be poisoned");
+            tool_events.push(event);
         }
 
         fn on_streaming_token(&self, event: crate::acp::StreamingTokenEvent) {
@@ -7251,6 +7415,67 @@ mod tests {
         assert_eq!(token_events.len(), 1);
         assert_eq!(token_events[0].event_type, "text_delta");
         assert_eq!(token_events[0].delta.text.as_deref(), Some("draft"));
+    }
+
+    #[test]
+    fn build_provider_turn_tool_terminal_events_prefers_trace_outcomes_over_generic_fallbacks() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![
+                ToolIntent {
+                    tool_name: "sessions_list".to_owned(),
+                    args_json: json!({}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-a".to_owned(),
+                    turn_id: "turn-a".to_owned(),
+                    tool_call_id: "call-1".to_owned(),
+                },
+                ToolIntent {
+                    tool_name: "session_status".to_owned(),
+                    args_json: json!({"session_id": "session-a"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-a".to_owned(),
+                    turn_id: "turn-a".to_owned(),
+                    tool_call_id: "call-2".to_owned(),
+                },
+            ],
+            raw_meta: Value::Null,
+        };
+        let turn_result = TurnResult::ToolError(TurnFailure::retryable(
+            "tool_execution_failed",
+            "second tool failed",
+        ));
+        let trace = ToolBatchExecutionTrace {
+            total_intents: 2,
+            parallel_execution_enabled: false,
+            parallel_execution_max_in_flight: 1,
+            observed_peak_in_flight: 1,
+            observed_wall_time_ms: 10,
+            segments: Vec::new(),
+            intent_outcomes: vec![
+                ToolBatchExecutionIntentTrace {
+                    tool_call_id: "call-1".to_owned(),
+                    tool_name: "sessions_list".to_owned(),
+                    status: ToolBatchExecutionIntentStatus::Completed,
+                    detail: None,
+                },
+                ToolBatchExecutionIntentTrace {
+                    tool_call_id: "call-2".to_owned(),
+                    tool_name: "session_status".to_owned(),
+                    status: ToolBatchExecutionIntentStatus::Failed,
+                    detail: Some("second tool failed".to_owned()),
+                },
+            ],
+        };
+
+        let events = build_provider_turn_tool_terminal_events(&turn, &turn_result, Some(&trace));
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].tool_call_id, "call-1");
+        assert_eq!(events[0].state, ConversationTurnToolState::Completed);
+        assert_eq!(events[1].tool_call_id, "call-2");
+        assert_eq!(events[1].state, ConversationTurnToolState::Failed);
+        assert_eq!(events[1].detail.as_deref(), Some("second tool failed"));
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -8349,6 +8574,7 @@ mod tests {
                     reason: SafeLaneFailureRouteReason::SessionGovernorNoReplan,
                     source: SafeLaneFailureRouteSource::SessionGovernor,
                 }),
+                tool_events: Vec::new(),
             },
             None,
             config,
@@ -8560,6 +8786,7 @@ mod tests {
                 raw_tool_output_requested: false,
                 turn_result: TurnResult::FinalText("hello there".to_owned()),
                 safe_lane_terminal_route: None,
+                tool_events: Vec::new(),
             },
             None,
             LoongClawConfig::default(),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -85,8 +85,8 @@ use super::turn_engine::{
     TurnValidation, effective_result_tool_name,
 };
 use super::turn_observer::{
-    ConversationTurnObserverHandle, ConversationTurnPhaseEvent, ConversationTurnToolEvent,
-    build_observer_streaming_token_callback,
+    ConversationTurnObserverHandle, ConversationTurnPhase, ConversationTurnPhaseEvent,
+    ConversationTurnToolEvent, build_observer_streaming_token_callback,
 };
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
@@ -2121,12 +2121,17 @@ impl ConversationTurnCoordinator {
         ingress: Option<&ConversationIngressContext>,
         observer: Option<ConversationTurnObserverHandle>,
     ) -> CliResult<String> {
-        let turn_result: CliResult<String> = async {
+        let turn_result: CliResult<(String, bool)> = async {
             let session_id = address.session_id.as_str();
-            match evaluate_acp_conversation_turn_entry_for_address(config, address, acp_options)? {
+            let preparing_event = ConversationTurnPhaseEvent::preparing();
+            observe_turn_phase(observer.as_ref(), preparing_event);
+
+            let acp_entry_decision =
+                evaluate_acp_conversation_turn_entry_for_address(config, address, acp_options)?;
+            match acp_entry_decision {
                 AcpConversationTurnEntryDecision::RejectExplicitWhenDisabled => {
                     let error = "ACP is disabled by policy (`acp.enabled=false`)".to_owned();
-                    return match error_mode {
+                    let turn_result = match error_mode {
                         ProviderErrorMode::Propagate => Err(error),
                         ProviderErrorMode::InlineMessage => {
                             let synthetic = format_provider_error_reply(&error);
@@ -2142,9 +2147,11 @@ impl ConversationTurnCoordinator {
                             Ok(synthetic)
                         }
                     };
+                    let reply = turn_result?;
+                    return Ok((reply, true));
                 }
                 AcpConversationTurnEntryDecision::RouteViaAcp => {
-                    return self
+                    let reply = self
                         .handle_turn_via_acp(
                             config,
                             address,
@@ -2154,12 +2161,11 @@ impl ConversationTurnCoordinator {
                             acp_options,
                             binding,
                         )
-                        .await;
+                        .await?;
+                    return Ok((reply, true));
                 }
                 AcpConversationTurnEntryDecision::StayOnProvider => {}
             }
-
-            observe_turn_phase(observer.as_ref(), ConversationTurnPhaseEvent::preparing());
 
             if let Some(kernel_ctx) = binding.kernel_context() {
                 runtime.bootstrap(config, session_id, kernel_ctx).await?;
@@ -2233,14 +2239,22 @@ impl ConversationTurnCoordinator {
                 observer.as_ref(),
             )
             .await
+            .map(|reply| (reply, false))
         }
         .await;
 
-        if turn_result.is_err() {
-            observe_turn_phase(observer.as_ref(), ConversationTurnPhaseEvent::failed());
+        match turn_result {
+            Ok((reply, true)) => {
+                observe_non_provider_turn_terminal_success_phases(observer.as_ref());
+                Ok(reply)
+            }
+            Ok((reply, false)) => Ok(reply),
+            Err(error) => {
+                let failed_event = ConversationTurnPhaseEvent::failed();
+                observe_turn_phase(observer.as_ref(), failed_event);
+                Err(error)
+            }
         }
-
-        turn_result
     }
 
     fn reload_followup_provider_config_after_tool_turn(
@@ -2636,6 +2650,30 @@ fn observe_turn_phase(
     };
 
     observer.on_phase(event);
+}
+
+fn observe_non_provider_turn_terminal_success_phases(
+    observer: Option<&ConversationTurnObserverHandle>,
+) {
+    let finalizing_event = ConversationTurnPhaseEvent {
+        phase: ConversationTurnPhase::FinalizingReply,
+        provider_round: None,
+        lane: None,
+        tool_call_count: 0,
+        message_count: None,
+        estimated_tokens: None,
+    };
+    observe_turn_phase(observer, finalizing_event);
+
+    let completed_event = ConversationTurnPhaseEvent {
+        phase: ConversationTurnPhase::Completed,
+        provider_round: None,
+        lane: None,
+        tool_call_count: 0,
+        message_count: None,
+        estimated_tokens: None,
+    };
+    observe_turn_phase(observer, completed_event);
 }
 
 fn observe_provider_turn_tool_batch_started(
@@ -7415,6 +7453,69 @@ mod tests {
         assert_eq!(token_events.len(), 1);
         assert_eq!(token_events[0].event_type, "text_delta");
         assert_eq!(token_events[0].delta.text.as_deref(), Some("draft"));
+    }
+
+    #[tokio::test]
+    async fn handle_turn_with_observer_emits_lifecycle_for_explicit_acp_inline_message() {
+        let config = LoongClawConfig::default();
+        let runtime = ObserverStreamingRuntime::default();
+        let observer = Arc::new(RecordingTurnObserver::default());
+        let observer_handle: ConversationTurnObserverHandle = observer.clone();
+        let acp_options = AcpConversationTurnOptions::explicit();
+        let address = ConversationSessionAddress::from_session_id("observer-session");
+        let reply = ConversationTurnCoordinator::new()
+            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+                &config,
+                &address,
+                "say hello",
+                ProviderErrorMode::InlineMessage,
+                &runtime,
+                &acp_options,
+                ConversationRuntimeBinding::direct(),
+                None,
+                Some(observer_handle),
+            )
+            .await
+            .expect("ACP inline reply should succeed");
+
+        let expected_reply =
+            format_provider_error_reply("ACP is disabled by policy (`acp.enabled=false`)");
+        assert_eq!(reply, expected_reply);
+
+        let phase_events = observer
+            .phase_events
+            .lock()
+            .expect("phase event lock should not be poisoned");
+        let phase_names = phase_events
+            .iter()
+            .map(|event| event.phase)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            phase_names,
+            vec![
+                ConversationTurnPhase::Preparing,
+                ConversationTurnPhase::FinalizingReply,
+                ConversationTurnPhase::Completed,
+            ]
+        );
+
+        let tool_events = observer
+            .tool_events
+            .lock()
+            .expect("tool event lock should not be poisoned");
+        assert!(tool_events.is_empty());
+
+        let token_events = observer
+            .token_events
+            .lock()
+            .expect("token event lock should not be poisoned");
+        assert!(token_events.is_empty());
+
+        let streaming_calls = runtime
+            .streaming_calls
+            .lock()
+            .expect("streaming call lock should not be poisoned");
+        assert_eq!(*streaming_calls, 0);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -814,7 +814,7 @@ fn effective_payload_summary_limit(intent: &ToolIntent, default_limit: usize) ->
     default_limit
 }
 
-fn effective_result_tool_name(intent: &ToolIntent) -> String {
+pub(crate) fn effective_result_tool_name(intent: &ToolIntent) -> String {
     let canonical_tool_name = crate::tools::canonical_tool_name(intent.tool_name.as_str());
     if canonical_tool_name != "tool.invoke" {
         return canonical_tool_name.to_owned();
@@ -830,6 +830,59 @@ fn effective_result_tool_name(intent: &ToolIntent) -> String {
         .filter(|tool_name| !crate::tools::is_provider_exposed_tool_name(tool_name))
         .unwrap_or(canonical_tool_name)
         .to_owned()
+}
+
+fn build_tool_intent_completed_trace(
+    intent: &ToolIntent,
+    outcome: &ToolCoreOutcome,
+) -> ToolBatchExecutionIntentTrace {
+    let tool_name = effective_result_tool_name(intent);
+    let normalized_status = outcome.status.trim();
+    let detail = if normalized_status.is_empty() || normalized_status == "ok" {
+        None
+    } else {
+        Some(normalized_status.to_owned())
+    };
+
+    ToolBatchExecutionIntentTrace {
+        tool_call_id: intent.tool_call_id.clone(),
+        tool_name,
+        status: ToolBatchExecutionIntentStatus::Completed,
+        detail,
+    }
+}
+
+fn build_tool_intent_failure_trace(
+    intent: &ToolIntent,
+    turn_result: &TurnResult,
+) -> Option<ToolBatchExecutionIntentTrace> {
+    let tool_name = effective_result_tool_name(intent);
+
+    match turn_result {
+        TurnResult::NeedsApproval(requirement) => Some(ToolBatchExecutionIntentTrace {
+            tool_call_id: intent.tool_call_id.clone(),
+            tool_name,
+            status: ToolBatchExecutionIntentStatus::NeedsApproval,
+            detail: Some(requirement.reason.clone()),
+        }),
+        TurnResult::ToolDenied(failure) => Some(ToolBatchExecutionIntentTrace {
+            tool_call_id: intent.tool_call_id.clone(),
+            tool_name,
+            status: ToolBatchExecutionIntentStatus::Denied,
+            detail: Some(failure.reason.clone()),
+        }),
+        TurnResult::ToolError(failure) | TurnResult::ProviderError(failure) => {
+            Some(ToolBatchExecutionIntentTrace {
+                tool_call_id: intent.tool_call_id.clone(),
+                tool_name,
+                status: ToolBatchExecutionIntentStatus::Failed,
+                detail: Some(failure.reason.clone()),
+            })
+        }
+        TurnResult::FinalText(_) | TurnResult::StreamingText(_) | TurnResult::StreamingDone(_) => {
+            None
+        }
+    }
 }
 
 fn truncate_by_chars(value: &str, limit: usize) -> (String, usize, bool) {
@@ -976,6 +1029,22 @@ pub(crate) struct ToolBatchExecutionSegmentTrace {
     pub observed_wall_time_ms: Option<u64>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolBatchExecutionIntentStatus {
+    Completed,
+    NeedsApproval,
+    Denied,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolBatchExecutionIntentTrace {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub status: ToolBatchExecutionIntentStatus,
+    pub detail: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ToolBatchExecutionTrace {
     pub total_intents: usize,
@@ -984,6 +1053,7 @@ pub(crate) struct ToolBatchExecutionTrace {
     pub observed_peak_in_flight: usize,
     pub observed_wall_time_ms: u64,
     pub segments: Vec<ToolBatchExecutionSegmentTrace>,
+    pub intent_outcomes: Vec<ToolBatchExecutionIntentTrace>,
 }
 
 impl ToolBatchExecutionSegmentTrace {
@@ -1374,6 +1444,7 @@ impl TurnEngine {
                             session_context,
                             app_dispatcher,
                             binding,
+                            &mut trace.intent_outcomes,
                             trace_segment,
                         )
                         .await?
@@ -1384,6 +1455,7 @@ impl TurnEngine {
                             session_context,
                             app_dispatcher,
                             binding,
+                            &mut trace.intent_outcomes,
                             trace_segment,
                         )
                         .await?
@@ -1423,6 +1495,7 @@ impl TurnEngine {
                     observed_wall_time_ms: None,
                 })
                 .collect(),
+            intent_outcomes: Vec::new(),
         }
     }
 
@@ -1471,20 +1544,35 @@ impl TurnEngine {
         session_context: &SessionContext,
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
+        intent_outcomes: &mut Vec<ToolBatchExecutionIntentTrace>,
         trace_segment: &mut ToolBatchExecutionSegmentTrace,
     ) -> Result<Vec<String>, TurnResult> {
         let started_at = Instant::now();
         let result = async {
             let mut outputs = Vec::with_capacity(prepared.len());
             for prepared_intent in prepared {
-                let outcome = self
+                let outcome = match self
                     .execute_prepared_tool_intent(
                         prepared_intent,
                         session_context,
                         app_dispatcher,
                         binding,
                     )
-                    .await?;
+                    .await
+                {
+                    Ok(outcome) => outcome,
+                    Err(turn_result) => {
+                        let intent_outcome =
+                            build_tool_intent_failure_trace(&prepared_intent.intent, &turn_result);
+                        if let Some(intent_outcome) = intent_outcome {
+                            intent_outcomes.push(intent_outcome);
+                        }
+                        return Err(turn_result);
+                    }
+                };
+                let intent_outcome =
+                    build_tool_intent_completed_trace(&prepared_intent.intent, &outcome);
+                intent_outcomes.push(intent_outcome);
                 outputs.push(format_tool_result_line_with_limit(
                     &prepared_intent.intent,
                     &outcome,
@@ -1507,6 +1595,7 @@ impl TurnEngine {
         session_context: &SessionContext,
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
+        intent_outcomes: &mut Vec<ToolBatchExecutionIntentTrace>,
         trace_segment: &mut ToolBatchExecutionSegmentTrace,
     ) -> Result<Vec<String>, TurnResult> {
         let started_at = Instant::now();
@@ -1530,11 +1619,23 @@ impl TurnEngine {
                         )
                         .await
                         .map(|outcome| {
-                            format_tool_result_line_with_limit(
+                            let output = format_tool_result_line_with_limit(
                                 &prepared_intent.intent,
                                 &outcome,
                                 payload_summary_limit_chars,
-                            )
+                            );
+                            let intent_outcome = build_tool_intent_completed_trace(
+                                &prepared_intent.intent,
+                                &outcome,
+                            );
+                            (output, intent_outcome)
+                        })
+                        .map_err(|turn_result| {
+                            let intent_outcome = build_tool_intent_failure_trace(
+                                &prepared_intent.intent,
+                                &turn_result,
+                            );
+                            (turn_result, intent_outcome)
                         });
                     in_flight.fetch_sub(1, Ordering::Relaxed);
                     (index, result)
@@ -1546,8 +1647,16 @@ impl TurnEngine {
         let result = async {
             while let Some((index, result)) = executions.next().await {
                 match result {
-                    Ok(output) => results.push((index, output)),
-                    Err(turn_result) => return Err(turn_result),
+                    Ok((output, intent_outcome)) => {
+                        intent_outcomes.push(intent_outcome);
+                        results.push((index, output));
+                    }
+                    Err((turn_result, intent_outcome)) => {
+                        if let Some(intent_outcome) = intent_outcome {
+                            intent_outcomes.push(intent_outcome);
+                        }
+                        return Err(turn_result);
+                    }
                 }
             }
             Ok(())
@@ -1908,6 +2017,53 @@ mod tests {
                     "session_id": session_context.session_id,
                 }),
             })
+        }
+    }
+
+    fn partially_failing_observed_execution_turn(session_id: &str, turn_id: &str) -> ProviderTurn {
+        ProviderTurn {
+            assistant_text: "observing a partial tool failure".to_owned(),
+            tool_intents: vec![
+                provider_app_tool_intent(
+                    "sessions_list",
+                    json!({}),
+                    session_id,
+                    turn_id,
+                    "call-partial-1",
+                ),
+                provider_app_tool_intent(
+                    "session_status",
+                    json!({"session_id": session_id}),
+                    session_id,
+                    turn_id,
+                    "call-partial-2",
+                ),
+            ],
+            raw_meta: json!({}),
+        }
+    }
+
+    struct PartiallyFailingObservedExecutionDispatcher;
+
+    #[async_trait::async_trait]
+    impl AppToolDispatcher for PartiallyFailingObservedExecutionDispatcher {
+        async fn execute_app_tool(
+            &self,
+            session_context: &SessionContext,
+            request: ToolCoreRequest,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            match request.tool_name.as_str() {
+                "sessions_list" => Ok(ToolCoreOutcome {
+                    status: "ok".to_owned(),
+                    payload: json!({
+                        "tool": request.tool_name,
+                        "session_id": session_context.session_id,
+                    }),
+                }),
+                "session_status" => Err("simulated observed tool failure".to_owned()),
+                other => Err(format!("app_tool_not_found: {other}")),
+            }
         }
     }
 
@@ -2641,6 +2797,56 @@ mod tests {
                 .segments
                 .iter()
                 .all(|segment| segment.execution_mode == ToolBatchExecutionMode::Sequential)
+        );
+    }
+
+    #[tokio::test]
+    async fn observed_fast_lane_execution_trace_records_partial_tool_failure_outcomes() {
+        let turn = partially_failing_observed_execution_turn(
+            "session-observed-partial-failure",
+            "turn-observed-partial-failure",
+        );
+        let session_context = SessionContext::root_with_tool_view(
+            "session-observed-partial-failure",
+            runtime_tool_view(),
+        );
+        let dispatcher = PartiallyFailingObservedExecutionDispatcher;
+        let engine = TurnEngine::with_parallel_tool_execution(4, 512, false, 1);
+
+        let (result, trace) = engine
+            .execute_turn_in_context_with_trace(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        assert!(
+            matches!(result, TurnResult::ToolError(_)),
+            "expected ToolError, got {result:?}"
+        );
+
+        let trace = trace.expect("trace should exist");
+        assert_eq!(trace.intent_outcomes.len(), 2);
+        assert_eq!(
+            trace.intent_outcomes[0].status,
+            ToolBatchExecutionIntentStatus::Completed
+        );
+        assert_eq!(trace.intent_outcomes[0].tool_call_id, "call-partial-1");
+        assert_eq!(
+            trace.intent_outcomes[1].status,
+            ToolBatchExecutionIntentStatus::Failed
+        );
+        assert_eq!(trace.intent_outcomes[1].tool_call_id, "call-partial-2");
+        assert!(
+            trace.intent_outcomes[1]
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("simulated observed tool failure")),
+            "expected failure detail in trace, got {:?}",
+            trace.intent_outcomes[1].detail
         );
     }
 

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use serde_json::{Value, json};
 
 use crate::CliResult;
-use crate::acp::{AcpTurnEventSink, JsonlAcpTurnEventSink, StreamingTokenEvent, TokenDelta};
+use crate::acp::{AcpTurnEventSink, JsonlAcpTurnEventSink};
 use crate::config::ProviderProtocolFamily;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
@@ -18,6 +18,7 @@ use super::turn_budget::{TurnRoundBudget, TurnRoundBudgetDecision};
 use super::turn_engine::{
     DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnResult, TurnValidation,
 };
+use super::turn_observer::map_streaming_callback_data_to_token_event;
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupPayload,
     ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
@@ -136,52 +137,7 @@ impl ConversationTurnLoop {
                 let sink = JsonlAcpTurnEventSink::stderr_with_prefix("");
                 Some(Arc::new(
                     move |data: crate::provider::StreamingCallbackData| {
-                        let (event_type, delta, index) = match data {
-                            crate::provider::StreamingCallbackData::Text { text } => (
-                                "text_delta".to_owned(),
-                                TokenDelta {
-                                    text: Some(text),
-                                    tool_call: None,
-                                },
-                                None,
-                            ),
-                            crate::provider::StreamingCallbackData::ToolCallStart {
-                                index,
-                                name,
-                                id,
-                            } => (
-                                "tool_call_start".to_owned(),
-                                TokenDelta {
-                                    text: None,
-                                    tool_call: Some(crate::acp::ToolCallDelta {
-                                        name: Some(name),
-                                        args: None,
-                                        id: Some(id),
-                                    }),
-                                },
-                                Some(index),
-                            ),
-                            crate::provider::StreamingCallbackData::ToolCallInput {
-                                index,
-                                partial_json,
-                            } => (
-                                "tool_call_input_delta".to_owned(),
-                                TokenDelta {
-                                    text: None,
-                                    tool_call: Some(crate::acp::ToolCallDelta {
-                                        name: None,
-                                        args: Some(partial_json),
-                                        id: None,
-                                    }),
-                                },
-                                Some(index),
-                            ),
-                        };
-                        let event = StreamingTokenEvent {
-                            event_type,
-                            delta,
-                            index,
-                        };
+                        let event = map_streaming_callback_data_to_token_event(data);
                         let _ = sink.on_event(&serde_json::to_value(&event).unwrap_or_default());
                     },
                 ))

--- a/crates/app/src/conversation/turn_observer.rs
+++ b/crates/app/src/conversation/turn_observer.rs
@@ -1,0 +1,252 @@
+use std::sync::Arc;
+
+use crate::acp::{StreamingTokenEvent, TokenDelta, ToolCallDelta};
+
+use super::lane_arbiter::ExecutionLane;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversationTurnPhase {
+    Preparing,
+    ContextReady,
+    RequestingProvider,
+    RunningTools,
+    RequestingFollowupProvider,
+    FinalizingReply,
+    Completed,
+    Failed,
+}
+
+impl ConversationTurnPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Preparing => "preparing",
+            Self::ContextReady => "context_ready",
+            Self::RequestingProvider => "requesting_provider",
+            Self::RunningTools => "running_tools",
+            Self::RequestingFollowupProvider => "requesting_followup_provider",
+            Self::FinalizingReply => "finalizing_reply",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversationTurnPhaseEvent {
+    pub phase: ConversationTurnPhase,
+    pub provider_round: Option<usize>,
+    pub lane: Option<ExecutionLane>,
+    pub tool_call_count: usize,
+    pub message_count: Option<usize>,
+    pub estimated_tokens: Option<usize>,
+}
+
+impl ConversationTurnPhaseEvent {
+    pub fn preparing() -> Self {
+        Self {
+            phase: ConversationTurnPhase::Preparing,
+            provider_round: None,
+            lane: None,
+            tool_call_count: 0,
+            message_count: None,
+            estimated_tokens: None,
+        }
+    }
+
+    pub fn context_ready(message_count: usize, estimated_tokens: Option<usize>) -> Self {
+        Self {
+            phase: ConversationTurnPhase::ContextReady,
+            provider_round: None,
+            lane: None,
+            tool_call_count: 0,
+            message_count: Some(message_count),
+            estimated_tokens,
+        }
+    }
+
+    pub fn requesting_provider(
+        provider_round: usize,
+        message_count: usize,
+        estimated_tokens: Option<usize>,
+    ) -> Self {
+        Self {
+            phase: ConversationTurnPhase::RequestingProvider,
+            provider_round: Some(provider_round),
+            lane: None,
+            tool_call_count: 0,
+            message_count: Some(message_count),
+            estimated_tokens,
+        }
+    }
+
+    pub fn running_tools(
+        provider_round: usize,
+        lane: ExecutionLane,
+        tool_call_count: usize,
+    ) -> Self {
+        Self {
+            phase: ConversationTurnPhase::RunningTools,
+            provider_round: Some(provider_round),
+            lane: Some(lane),
+            tool_call_count,
+            message_count: None,
+            estimated_tokens: None,
+        }
+    }
+
+    pub fn requesting_followup_provider(
+        provider_round: usize,
+        lane: ExecutionLane,
+        tool_call_count: usize,
+        message_count: usize,
+        estimated_tokens: Option<usize>,
+    ) -> Self {
+        Self {
+            phase: ConversationTurnPhase::RequestingFollowupProvider,
+            provider_round: Some(provider_round),
+            lane: Some(lane),
+            tool_call_count,
+            message_count: Some(message_count),
+            estimated_tokens,
+        }
+    }
+
+    pub fn finalizing_reply(message_count: usize, estimated_tokens: Option<usize>) -> Self {
+        Self {
+            phase: ConversationTurnPhase::FinalizingReply,
+            provider_round: None,
+            lane: None,
+            tool_call_count: 0,
+            message_count: Some(message_count),
+            estimated_tokens,
+        }
+    }
+
+    pub fn completed(message_count: usize, estimated_tokens: Option<usize>) -> Self {
+        Self {
+            phase: ConversationTurnPhase::Completed,
+            provider_round: None,
+            lane: None,
+            tool_call_count: 0,
+            message_count: Some(message_count),
+            estimated_tokens,
+        }
+    }
+
+    pub fn failed() -> Self {
+        Self {
+            phase: ConversationTurnPhase::Failed,
+            provider_round: None,
+            lane: None,
+            tool_call_count: 0,
+            message_count: None,
+            estimated_tokens: None,
+        }
+    }
+}
+
+pub trait ConversationTurnObserver: Send + Sync {
+    fn on_phase(&self, _event: ConversationTurnPhaseEvent) {}
+
+    fn on_streaming_token(&self, _event: StreamingTokenEvent) {}
+}
+
+pub type ConversationTurnObserverHandle = Arc<dyn ConversationTurnObserver>;
+
+pub(crate) fn build_observer_streaming_token_callback(
+    observer: &ConversationTurnObserverHandle,
+) -> crate::provider::StreamingTokenCallback {
+    let observer = Arc::clone(observer);
+    let callback = move |data: crate::provider::StreamingCallbackData| {
+        let event = map_streaming_callback_data_to_token_event(data);
+        observer.on_streaming_token(event);
+    };
+    Some(Arc::new(callback))
+}
+
+pub(crate) fn map_streaming_callback_data_to_token_event(
+    data: crate::provider::StreamingCallbackData,
+) -> StreamingTokenEvent {
+    match data {
+        crate::provider::StreamingCallbackData::Text { text } => StreamingTokenEvent {
+            event_type: "text_delta".to_owned(),
+            delta: TokenDelta {
+                text: Some(text),
+                tool_call: None,
+            },
+            index: None,
+        },
+        crate::provider::StreamingCallbackData::ToolCallStart { index, name, id } => {
+            let tool_call = ToolCallDelta {
+                name: Some(name),
+                args: None,
+                id: Some(id),
+            };
+            let delta = TokenDelta {
+                text: None,
+                tool_call: Some(tool_call),
+            };
+            StreamingTokenEvent {
+                event_type: "tool_call_start".to_owned(),
+                delta,
+                index: Some(index),
+            }
+        }
+        crate::provider::StreamingCallbackData::ToolCallInput {
+            index,
+            partial_json,
+        } => {
+            let tool_call = ToolCallDelta {
+                name: None,
+                args: Some(partial_json),
+                id: None,
+            };
+            let delta = TokenDelta {
+                text: None,
+                tool_call: Some(tool_call),
+            };
+            StreamingTokenEvent {
+                event_type: "tool_call_input_delta".to_owned(),
+                delta,
+                index: Some(index),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_streaming_callback_data_to_token_event_keeps_text_delta_shape() {
+        let data = crate::provider::StreamingCallbackData::Text {
+            text: "hello".to_owned(),
+        };
+        let event = map_streaming_callback_data_to_token_event(data);
+
+        assert_eq!(event.event_type, "text_delta");
+        assert_eq!(event.delta.text.as_deref(), Some("hello"));
+        assert!(event.delta.tool_call.is_none());
+        assert!(event.index.is_none());
+    }
+
+    #[test]
+    fn map_streaming_callback_data_to_token_event_keeps_tool_call_delta_shape() {
+        let data = crate::provider::StreamingCallbackData::ToolCallInput {
+            index: 2,
+            partial_json: "{\"query\":\"rust\"}".to_owned(),
+        };
+        let event = map_streaming_callback_data_to_token_event(data);
+        let tool_call = event
+            .delta
+            .tool_call
+            .expect("tool call delta should be present");
+
+        assert_eq!(event.event_type, "tool_call_input_delta");
+        assert_eq!(event.index, Some(2));
+        assert_eq!(tool_call.args.as_deref(), Some("{\"query\":\"rust\"}"));
+        assert!(tool_call.name.is_none());
+        assert!(tool_call.id.is_none());
+    }
+}

--- a/crates/app/src/conversation/turn_observer.rs
+++ b/crates/app/src/conversation/turn_observer.rs
@@ -145,8 +145,117 @@ impl ConversationTurnPhaseEvent {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversationTurnToolState {
+    Running,
+    Completed,
+    NeedsApproval,
+    Denied,
+    Failed,
+    Interrupted,
+}
+
+impl ConversationTurnToolState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::NeedsApproval => "needs_approval",
+            Self::Denied => "denied",
+            Self::Failed => "failed",
+            Self::Interrupted => "interrupted",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversationTurnToolEvent {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub state: ConversationTurnToolState,
+    pub detail: Option<String>,
+}
+
+impl ConversationTurnToolEvent {
+    pub fn running(tool_call_id: impl Into<String>, tool_name: impl Into<String>) -> Self {
+        Self {
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            state: ConversationTurnToolState::Running,
+            detail: None,
+        }
+    }
+
+    pub fn completed(
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        detail: Option<String>,
+    ) -> Self {
+        Self {
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            state: ConversationTurnToolState::Completed,
+            detail,
+        }
+    }
+
+    pub fn needs_approval(
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            state: ConversationTurnToolState::NeedsApproval,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn denied(
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            state: ConversationTurnToolState::Denied,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn failed(
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            state: ConversationTurnToolState::Failed,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn interrupted(
+        tool_call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool_call_id: tool_call_id.into(),
+            tool_name: tool_name.into(),
+            state: ConversationTurnToolState::Interrupted,
+            detail: Some(detail.into()),
+        }
+    }
+}
+
 pub trait ConversationTurnObserver: Send + Sync {
     fn on_phase(&self, _event: ConversationTurnPhaseEvent) {}
+
+    fn on_tool(&self, _event: ConversationTurnToolEvent) {}
 
     fn on_streaming_token(&self, _event: StreamingTokenEvent) {}
 }

--- a/crates/app/src/conversation/turn_observer.rs
+++ b/crates/app/src/conversation/turn_observer.rs
@@ -358,4 +358,24 @@ mod tests {
         assert!(tool_call.name.is_none());
         assert!(tool_call.id.is_none());
     }
+
+    #[test]
+    fn map_streaming_callback_data_to_token_event_keeps_tool_call_start_shape() {
+        let data = crate::provider::StreamingCallbackData::ToolCallStart {
+            index: 1,
+            name: "search".to_owned(),
+            id: "call_123".to_owned(),
+        };
+        let event = map_streaming_callback_data_to_token_event(data);
+        let tool_call = event
+            .delta
+            .tool_call
+            .expect("tool call delta should be present");
+
+        assert_eq!(event.event_type, "tool_call_start");
+        assert_eq!(event.index, Some(1));
+        assert_eq!(tool_call.name.as_deref(), Some("search"));
+        assert_eq!(tool_call.id.as_deref(), Some("call_123"));
+        assert!(tool_call.args.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

- Problem: interactive `loongclaw chat` no longer goes fully silent during a turn, but the live tool stage still had a trust gap: `running_tools` could appear after tool execution had already finished, per-tool terminal states could collapse into generic fallbacks, and provider-facing status copy could sound too specific while tools were still running.
- Why it matters: a generative TUI only feels reliable if it reflects real runtime state rather than replaying it after the fact. If the tool phase looks delayed or misleading, operators lose confidence in the live surface exactly where chat needs the most clarity.
- What changed: kept the observer-based live surface architecture, extended the turn observer contract with explicit tool lifecycle events, emitted `running_tools` before tool execution starts, recorded per-tool terminal outcomes in the tool execution trace, mapped chat live tool state by stable `tool_call_id` instead of only streamed index order, preserved streamed tool args across lifecycle transitions, and kept provider status wording generic while tools are active.
- What did not change (scope boundary): no full-screen TUI runtime, no second renderer, no change to `loongclaw ask`, and no ACP or provider architecture redesign.

## Linked Issues

- Closes #531
- Related # none

## Change Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS

cargo test -p loongclaw-app --lib conversation::turn_engine::tests::observed_fast_lane_execution_trace_records_partial_tool_failure_outcomes
  PASS

cargo test -p loongclaw-app --lib conversation::turn_coordinator::tests::build_provider_turn_tool_terminal_events_prefers_trace_outcomes_over_generic_fallbacks
  PASS

cargo test -p loongclaw-app --lib chat::tests::cli_chat_live_surface_observer_renders_tool_lifecycle_updates
  PASS

cargo test -p loongclaw-app --lib
  PASS

cargo test --workspace --locked
  PASS

cargo test --workspace --all-features --locked
  PASS
```

## User-visible / Operator-visible Changes

- `loongclaw chat` now surfaces live tool lifecycle updates that feel current instead of replayed: running, completed, failed, denied, approval-required, and interrupted states can all render on the chat surface with stable tool call identities.
- Streamed tool arguments now stay attached to the same live tool card as execution progresses, so compact tool activity lines remain readable across start, update, and terminal states.
- Provider status text stays intentionally generic while tools are active, which avoids implying a follow-up provider request before one actually starts.

## Failure Recovery

- Fast rollback or disable path: revert this PR to remove the observer-backed live chat refinements; one-shot `loongclaw ask` output remains unchanged if operators need a non-live path immediately.
- Observable failure symptoms reviewers should watch for: tool rows that never leave `running`, duplicate tool lifecycle lines for the same `tool_call_id`, missing tool args after completion, or provider/live status copy drifting away from actual runtime phase order.

## Reviewer Focus

- Review `crates/app/src/chat.rs` for stable `tool_call_id` reconciliation, lifecycle rendering, snapshot deduplication, and fallback status transitions.
- Review `crates/app/src/conversation/turn_coordinator.rs` for the pre-execution `running_tools` emission order and the mapping from tool execution traces into terminal observer events.
- Review `crates/app/src/conversation/turn_engine.rs` and `crates/app/src/conversation/turn_observer.rs` for per-tool trace fidelity and the shared observer contract.
