### PR TITLE
refactor(kernel): remove dead low-evidence capabilities

### DIFF
--- a/crates/contracts/src/contracts.rs
+++ b/crates/contracts/src/contracts.rs
@@ -12,8 +12,6 @@ pub enum Capability {
     MemoryWrite,
     FilesystemRead,
     FilesystemWrite,
-    NetworkEgress,
-    ScheduleTask,
     ObserveTelemetry,
 }
 
@@ -26,8 +24,6 @@ impl Capability {
             Self::MemoryWrite => "memory_write",
             Self::FilesystemRead => "filesystem_read",
             Self::FilesystemWrite => "filesystem_write",
-            Self::NetworkEgress => "network_egress",
-            Self::ScheduleTask => "schedule_task",
             Self::ObserveTelemetry => "observe_telemetry",
         }
     }
@@ -40,8 +36,6 @@ impl Capability {
             "memory_write" => Some(Self::MemoryWrite),
             "filesystem_read" => Some(Self::FilesystemRead),
             "filesystem_write" => Some(Self::FilesystemWrite),
-            "network_egress" => Some(Self::NetworkEgress),
-            "schedule_task" => Some(Self::ScheduleTask),
             "observe_telemetry" => Some(Self::ObserveTelemetry),
             _ => None,
         }
@@ -123,8 +117,6 @@ mod tests {
             (Capability::MemoryWrite, "memory_write"),
             (Capability::FilesystemRead, "filesystem_read"),
             (Capability::FilesystemWrite, "filesystem_write"),
-            (Capability::NetworkEgress, "network_egress"),
-            (Capability::ScheduleTask, "schedule_task"),
             (Capability::ObserveTelemetry, "observe_telemetry"),
         ];
 
@@ -147,5 +139,7 @@ mod tests {
         assert_eq!(Capability::parse("totally_unknown"), None);
         assert_eq!(Capability::parse(""), None);
         assert_eq!(Capability::parse("   "), None);
+        assert_eq!(Capability::parse("network_egress"), None);
+        assert_eq!(Capability::parse("schedule_task"), None);
     }
 }

--- a/crates/kernel/src/test_support.rs
+++ b/crates/kernel/src/test_support.rs
@@ -43,7 +43,8 @@ pub struct MockCoreTool;
 pub struct MockToolExtension;
 pub struct MockCoreMemory;
 pub struct MockMemoryExtension;
-pub struct NoNetworkEgressPolicyExtension;
+pub struct NoFilesystemWritePolicyExtension;
+pub const TEST_CAPABILITY_VARIANT_COUNT: u8 = 7;
 #[derive(Debug, Clone, Copy)]
 pub enum ToolGateMode {
     Deny,
@@ -297,18 +298,18 @@ impl MemoryExtensionAdapter for MockMemoryExtension {
         })
     }
 }
-impl PolicyExtension for NoNetworkEgressPolicyExtension {
+impl PolicyExtension for NoFilesystemWritePolicyExtension {
     fn name(&self) -> &str {
-        "no-network-egress"
+        "no-filesystem-write"
     }
     fn authorize_extension(&self, context: &PolicyExtensionContext<'_>) -> Result<(), PolicyError> {
         if context
             .required_capabilities
-            .contains(&Capability::NetworkEgress)
+            .contains(&Capability::FilesystemWrite)
         {
             return Err(PolicyError::ExtensionDenied {
                 extension: self.name().to_owned(),
-                reason: "network egress is blocked for this environment".to_owned(),
+                reason: "filesystem write is blocked for this environment".to_owned(),
             });
         }
         Ok(())
@@ -377,14 +378,12 @@ pub fn capability_from_bit(bit: u8) -> Capability {
         3 => Capability::MemoryWrite,
         4 => Capability::FilesystemRead,
         5 => Capability::FilesystemWrite,
-        6 => Capability::NetworkEgress,
-        7 => Capability::ScheduleTask,
         _ => Capability::ObserveTelemetry,
     }
 }
 pub fn capability_set_from_mask(mask: u16) -> BTreeSet<Capability> {
     let mut capabilities = BTreeSet::new();
-    for bit in 0_u8..9 {
+    for bit in 0_u8..TEST_CAPABILITY_VARIANT_COUNT {
         if (mask & (1_u16 << bit)) != 0 {
             capabilities.insert(capability_from_bit(bit));
         }

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -228,8 +228,8 @@ proptest! {
 
     #[test]
     fn prop_pack_capability_boundary_for_task_dispatch(
-        pack_mask in 1_u16..(1_u16 << 9),
-        required_mask in 0_u16..(1_u16 << 9)
+        pack_mask in 1_u16..(1_u16 << TEST_CAPABILITY_VARIANT_COUNT),
+        required_mask in 0_u16..(1_u16 << TEST_CAPABILITY_VARIANT_COUNT)
     ) {
         let pack_capabilities = capability_set_from_mask(pack_mask);
         let required_capabilities = capability_set_from_mask(required_mask);
@@ -321,7 +321,7 @@ fn fault_from_kernel_error_maps_policy() {
 fn fault_from_kernel_error_maps_pack_boundary() {
     let kernel_err = KernelError::PackCapabilityBoundary {
         pack_id: "my-pack".to_owned(),
-        capability: Capability::NetworkEgress,
+        capability: Capability::FilesystemWrite,
     };
     let fault = Fault::from_kernel_error(kernel_err);
     assert!(matches!(fault, Fault::CapabilityViolation { .. }));

--- a/crates/kernel/tests/kernel_integration.rs
+++ b/crates/kernel/tests/kernel_integration.rs
@@ -854,7 +854,7 @@ async fn policy_extension_chain_can_block_high_risk_capabilities() {
             allowed_connectors: BTreeSet::new(),
             granted_capabilities: BTreeSet::from([
                 Capability::InvokeTool,
-                Capability::NetworkEgress,
+                Capability::FilesystemWrite,
             ]),
             metadata: BTreeMap::new(),
         })
@@ -862,17 +862,17 @@ async fn policy_extension_chain_can_block_high_risk_capabilities() {
     kernel.register_harness_adapter(MockEmbeddedPiHarness {
         seen_tasks: Mutex::new(Vec::new()),
     });
-    kernel.register_policy_extension(NoNetworkEgressPolicyExtension);
+    kernel.register_policy_extension(NoFilesystemWritePolicyExtension);
 
     let token = kernel
         .issue_token("strict-env", "agent-secure", 120)
         .expect("token should issue");
 
     let risky_task = TaskIntent {
-        task_id: "task-net-01".to_owned(),
-        objective: "fetch external url".to_owned(),
-        required_capabilities: BTreeSet::from([Capability::NetworkEgress]),
-        payload: json!({"url": "https://example.com"}),
+        task_id: "task-fs-01".to_owned(),
+        objective: "write local file".to_owned(),
+        required_capabilities: BTreeSet::from([Capability::FilesystemWrite]),
+        payload: json!({"path": "/tmp/output.txt"}),
     };
 
     let error = kernel
@@ -882,7 +882,7 @@ async fn policy_extension_chain_can_block_high_risk_capabilities() {
 
     assert!(matches!(
         error,
-        KernelError::Policy(PolicyError::ExtensionDenied { extension, .. }) if extension == "no-network-egress"
+        KernelError::Policy(PolicyError::ExtensionDenied { extension, .. }) if extension == "no-filesystem-write"
     ));
 }
 


### PR DESCRIPTION
## Summary

- Problem:
  - issue #457 asked for an evidence-backed audit of the low-evidence capability surfaces `ScheduleTask` and `NetworkEgress`.
  - both capability names still existed in the shared contracts enum, but no runtime plane, spec fixture, plugin manifest, docs surface, or daemon integration path consumed them.
- Why it matters:
  - leaving dead contract variants behind keeps the governance surface larger than the codebase actually needs and makes future capability work harder to reason about.
- What changed:
  - removed `NetworkEgress` and `ScheduleTask` from `loongclaw_contracts::Capability`
  - updated capability parsing tests so the removed legacy names are now rejected explicitly
  - rewired the one remaining kernel policy-extension test seam from the dead `NetworkEgress` capability to the still-live `FilesystemWrite` capability
  - shrank the test-only capability mask helper to the current real capability set
- What did not change (scope boundary):
  - no broader governance redesign
  - no changes to `allowed_capabilities`, token issuance, or policy-engine semantics
  - no changes to the still-structural `ObserveTelemetry` capability

## Linked Issues

- Closes #457
- Related #402
- Related #458

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo check --workspace --locked
cargo test --workspace --locked
cargo clippy --workspace --all-targets --all-features -- -D warnings

Result:
- workspace check passed
- workspace test suite passed
- workspace clippy passed with -D warnings
```

Evidence summary:
- `ScheduleTask` only remained in the shared contracts enum and kernel test helpers.
- `NetworkEgress` only remained in the shared contracts enum plus one kernel policy-extension test seam.
- `ObserveTelemetry` stays because it is still referenced by integration planning, plugin examples, spec fixtures, and daemon integration tests.

Before/after behavior:
- before: `Capability` still accepted `network_egress` and `schedule_task` even though the repo had no real runtime consumers for them
- after: those legacy names are rejected at parse time, and the kernel policy-extension test uses the still-real `FilesystemWrite` capability instead

## User-visible / Operator-visible Changes

- none for normal operators; this is a governance-surface cleanup.

## Failure Recovery

- Fast rollback or disable path:
  - revert this PR to restore the removed capability variants and the old test seam.
- Observable failure symptoms reviewers should watch for:
  - unexpected deserialization or parse failures for `network_egress` / `schedule_task` in downstream fixtures, examples, or external tooling that were missed by the workspace test suite.

## Reviewer Focus

- verify the evidence claim that `ScheduleTask` and `NetworkEgress` had no live runtime or spec consumers before removal
- verify that the replacement `FilesystemWrite` policy-extension test still proves the intended extension-chain behavior without preserving dead capability surface area
- verify that `ObserveTelemetry` remains untouched because it is still structural


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed network egress capability from the system
  * Removed task scheduling capability from the system
  * Updated capability authorization and enforcement logic
  * Adjusted system capability boundary validation
* **Tests**
  * Revised test fixtures to reflect capability changes
  * Updated test framework configuration and capability validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->