### PR TITLE
fix(onboard): canonicalize provider env auth bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ instability from true upstream unavailability.
 
 ## Configuration
 
-`loongclaw onboard` uses `provider.api_key_env` to reference provider credentials, so secrets stay
+`loongclaw onboard` uses `provider.api_key = { env = "..." }` to reference provider credentials, so secrets stay
 outside the config file:
 
 ```toml
@@ -334,7 +334,7 @@ active_provider = "openai"
 
 [providers.openai]
 kind = "openai"
-api_key_env = "PROVIDER_API_KEY"
+api_key = { env = "PROVIDER_API_KEY" }
 ```
 
 Guided onboarding now also lets you choose the default web search backend.
@@ -373,12 +373,12 @@ active_provider = "volcengine"
 [providers.volcengine]
 kind = "volcengine"
 model = "your-coding-plan-model-id"
-api_key_env = "ARK_API_KEY"
+api_key = { env = "ARK_API_KEY" }
 base_url = "https://ark.cn-beijing.volces.com"
 chat_completions_path = "/api/v3/chat/completions"
 ```
 
-Both `volcengine` and `volcengine_coding` use `api_key_env = "ARK_API_KEY"`. LoongClaw resolves that environment variable and sends it as `Authorization: Bearer <ARK_API_KEY>` on the OpenAI-compatible Volcengine path; AK/SK request signing is not used there.
+Both `volcengine` and `volcengine_coding` use `api_key = { env = "ARK_API_KEY" }`. LoongClaw resolves that environment variable and sends it as `Authorization: Bearer <ARK_API_KEY>` on the OpenAI-compatible Volcengine path; AK/SK request signing is not used there.
 
 Feishu channel example (webhook mode):
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -220,14 +220,14 @@ cargo install --path crates/daemon
 
 ## 配置
 
-`loongclaw onboard` 默认通过 `provider.api_key_env` 引用 provider 凭据，让密钥不直接写进配置文件：
+`loongclaw onboard` 默认通过 `provider.api_key = { env = "..." }` 引用 provider 凭据，让密钥不直接写进配置文件：
 
 ```toml
 active_provider = "openai"
 
 [providers.openai]
 kind = "openai"
-api_key_env = "PROVIDER_API_KEY"
+api_key = { env = "PROVIDER_API_KEY" }
 ```
 
 现在 onboarding 也支持选择默认的 web search backend。当前支持
@@ -263,7 +263,7 @@ active_provider = "volcengine"
 [providers.volcengine]
 kind = "volcengine"
 model = "your-coding-plan-model-id"
-api_key_env = "ARK_API_KEY"
+api_key = { env = "ARK_API_KEY" }
 base_url = "https://ark.cn-beijing.volces.com"
 chat_completions_path = "/api/v3/chat/completions"
 ```

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -1761,6 +1761,18 @@ bot_token = { file = "/run/secrets/telegram" }
     }
 
     #[test]
+    fn config_validation_rejects_uuid_shaped_secret_in_env_pointer() {
+        let mut config = LoongClawConfig::default();
+        config.provider.api_key_env = Some("9f479837-0a12-4b56-89ab-cdef01234567".to_owned());
+
+        let error = config
+            .validate()
+            .expect_err("uuid-shaped provider secrets should be rejected in env pointer fields");
+        assert!(error.contains("provider.api_key_env"));
+        assert!(error.contains("secret literal"));
+    }
+
+    #[test]
     fn config_validation_rejects_invalid_typed_secret_ref_env_names() {
         let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
             "provider": {

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -848,9 +848,59 @@ impl ProviderConfig {
         self.api_key_env = api_key_env;
     }
 
+    pub fn set_api_key_env_binding(&mut self, api_key_env: Option<String>) {
+        let normalized = api_key_env
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
+        self.api_key = normalized.map(|env| SecretRef::Env { env });
+        self.set_api_key_env(None);
+    }
+
+    pub fn clear_api_key_env_binding(&mut self) {
+        if secret_ref_env_name(self.api_key.as_ref()).is_some() {
+            self.api_key = None;
+        }
+        self.set_api_key_env(None);
+    }
+
     pub fn set_oauth_access_token_env(&mut self, oauth_access_token_env: Option<String>) {
         self.oauth_access_token_env_explicit = oauth_access_token_env.is_some();
         self.oauth_access_token_env = oauth_access_token_env;
+    }
+
+    pub fn set_oauth_access_token_env_binding(&mut self, oauth_access_token_env: Option<String>) {
+        let normalized = oauth_access_token_env
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
+        self.oauth_access_token = normalized.map(|env| SecretRef::Env { env });
+        self.set_oauth_access_token_env(None);
+    }
+
+    pub fn clear_oauth_access_token_env_binding(&mut self) {
+        if secret_ref_env_name(self.oauth_access_token.as_ref()).is_some() {
+            self.oauth_access_token = None;
+        }
+        self.set_oauth_access_token_env(None);
+    }
+
+    pub fn canonicalize_configured_auth_env_bindings(&mut self) {
+        let configured_api_key_env = self.configured_api_key_env_override();
+        if self.api_key.is_some() {
+            self.set_api_key_env(None);
+        } else {
+            self.set_api_key_env_binding(configured_api_key_env);
+        }
+
+        let configured_oauth_env = self.configured_oauth_access_token_env_override();
+        if self.oauth_access_token.is_some() {
+            self.set_oauth_access_token_env(None);
+        } else {
+            self.set_oauth_access_token_env_binding(configured_oauth_env);
+        }
     }
 
     pub fn fresh_for_kind(kind: ProviderKind) -> Self {
@@ -1799,6 +1849,14 @@ impl ProviderConfig {
         normalized.oauth_access_token = self.normalized_oauth_access_token_for_persistence();
         normalized.oauth_access_token_env =
             self.normalized_oauth_access_token_env_for_persistence();
+        canonicalize_secret_env_reference_for_persistence(
+            &mut normalized.api_key,
+            &mut normalized.api_key_env,
+        );
+        canonicalize_secret_env_reference_for_persistence(
+            &mut normalized.oauth_access_token,
+            &mut normalized.oauth_access_token_env,
+        );
         normalized
     }
 
@@ -3307,6 +3365,36 @@ fn normalize_secret_ref_for_persistence(
     }
 }
 
+fn canonicalize_secret_env_reference_for_persistence(
+    secret_ref: &mut Option<SecretRef>,
+    env_name: &mut Option<String>,
+) {
+    if let Some(explicit_env_name) = secret_ref_env_name(secret_ref.as_ref()) {
+        *secret_ref = Some(SecretRef::Env {
+            env: explicit_env_name,
+        });
+        *env_name = None;
+        return;
+    }
+
+    if secret_ref.is_some() {
+        *env_name = None;
+        return;
+    }
+
+    let normalized_env_name = env_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    if let Some(normalized_env_name) = normalized_env_name {
+        *secret_ref = Some(SecretRef::Env {
+            env: normalized_env_name,
+        });
+    }
+    *env_name = None;
+}
+
 fn split_secret_candidates(raw: &str) -> Vec<String> {
     let mut values = Vec::new();
     for value in raw.split([',', ';', '\n', '\r']) {
@@ -3506,6 +3594,40 @@ api_key_env = "OPENAI_API_KEY"
             config.authorization_header().as_deref(),
             Some("Bearer api-key-wins")
         );
+    }
+
+    #[test]
+    fn normalized_for_persistence_canonicalizes_legacy_api_key_env_binding() {
+        let mut config = ProviderConfig::fresh_for_kind(ProviderKind::Openai);
+        config.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
+
+        let normalized = config.normalized_for_persistence();
+
+        assert_eq!(
+            normalized.api_key,
+            Some(SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(normalized.api_key_env, None);
+    }
+
+    #[test]
+    fn normalized_for_persistence_keeps_secret_ref_env_binding_canonical() {
+        let mut config = ProviderConfig::fresh_for_kind(ProviderKind::Openai);
+        config.api_key = Some(SecretRef::Env {
+            env: "OPENAI_API_KEY".to_owned(),
+        });
+
+        let normalized = config.normalized_for_persistence();
+
+        assert_eq!(
+            normalized.api_key,
+            Some(SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(normalized.api_key_env, None);
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -889,14 +889,18 @@ impl ProviderConfig {
 
     pub fn canonicalize_configured_auth_env_bindings(&mut self) {
         let configured_api_key_env = self.configured_api_key_env_override();
-        if self.api_key.is_some() {
+        let api_key_has_non_env_secret =
+            self.api_key.is_some() && secret_ref_env_name(self.api_key.as_ref()).is_none();
+        if api_key_has_non_env_secret {
             self.set_api_key_env(None);
         } else {
             self.set_api_key_env_binding(configured_api_key_env);
         }
 
         let configured_oauth_env = self.configured_oauth_access_token_env_override();
-        if self.oauth_access_token.is_some() {
+        let oauth_has_non_env_secret = self.oauth_access_token.is_some()
+            && secret_ref_env_name(self.oauth_access_token.as_ref()).is_none();
+        if oauth_has_non_env_secret {
             self.set_oauth_access_token_env(None);
         } else {
             self.set_oauth_access_token_env_binding(configured_oauth_env);
@@ -3628,6 +3632,23 @@ api_key_env = "OPENAI_API_KEY"
             })
         );
         assert_eq!(normalized.api_key_env, None);
+    }
+
+    #[test]
+    fn canonicalize_configured_auth_env_bindings_rewrites_inline_env_templates() {
+        let mut config = ProviderConfig::fresh_for_kind(ProviderKind::Openai);
+        config.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
+        config.api_key = Some(SecretRef::Inline("${OPENAI_API_KEY}".to_owned()));
+
+        config.canonicalize_configured_auth_env_bindings();
+
+        assert_eq!(
+            config.api_key,
+            Some(SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(config.api_key_env, None);
     }
 
     #[test]

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -28,7 +28,7 @@ use super::{
         WEB_SEARCH_PROVIDER_VALID_VALUES, WEB_SEARCH_TAVILY_API_KEY_ENV,
     },
 };
-use crate::secrets::canonicalize_env_secret_reference;
+use crate::secrets::{canonicalize_env_secret_reference, secret_ref_env_name};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConfigValidationDiagnostic {
@@ -1027,7 +1027,30 @@ fn canonicalize_provider_secret_env_reference(
     inline_secret: &mut Option<loongclaw_contracts::SecretRef>,
     env_name: &mut Option<String>,
 ) {
-    canonicalize_env_secret_reference(inline_secret, env_name);
+    if let Some(explicit_env_name) = secret_ref_env_name(inline_secret.as_ref()) {
+        *inline_secret = Some(loongclaw_contracts::SecretRef::Env {
+            env: explicit_env_name,
+        });
+        *env_name = None;
+        return;
+    }
+
+    if inline_secret.is_some() {
+        *env_name = None;
+        return;
+    }
+
+    let normalized_env_name = env_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    if let Some(normalized_env_name) = normalized_env_name {
+        *inline_secret = Some(loongclaw_contracts::SecretRef::Env {
+            env: normalized_env_name,
+        });
+    }
+    *env_name = None;
 }
 
 fn normalize_acp_agent_id(raw: &str) -> Option<String> {
@@ -1727,9 +1750,9 @@ fn encode_toml_config(_config: &LoongClawConfig) -> CliResult<String> {
 
 fn template_secret_usage_comment() -> &'static str {
     "# Secret configuration notes:\n\
-# - Preferred provider credential form: `providers.<profile_id>.api_key_env = \"PROVIDER_API_KEY\"`.\n\
-# - Inline fields like `providers.<profile_id>.api_key` still accept direct literals and explicit env refs like `$VAR`, `env:VAR`, and `%VAR%`.\n\
-# - When LoongClaw writes config back to disk, explicit env refs are persisted as `*_env` fields.\n\
+# - Preferred provider credential form: `providers.<profile_id>.api_key = { env = \"PROVIDER_API_KEY\" }`.\n\
+# - `providers.<profile_id>.api_key` still accepts direct literals and explicit env refs like `$VAR`, `env:VAR`, and `%VAR%`.\n\
+# - Legacy `*_env` provider fields still load, but LoongClaw now writes provider env refs back into the main secret field.\n\
 \n"
 }
 
@@ -1814,7 +1837,7 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_template_prefers_generic_provider_api_key_env_example() {
+    fn write_template_prefers_generic_provider_api_key_env_secret_ref_example() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock before unix epoch")
@@ -1827,8 +1850,8 @@ bot_token_env = "123456789:telegram-inline-secret-literal"
             .expect("write template should succeed");
 
         let raw = std::fs::read_to_string(&config_path).expect("read template");
-        assert!(raw.contains("providers.<profile_id>.api_key_env = \"PROVIDER_API_KEY\""));
-        assert!(!raw.contains("providers.<profile_id>.api_key = \"${PROVIDER_API_KEY}\""));
+        assert!(raw.contains("providers.<profile_id>.api_key = { env = \"PROVIDER_API_KEY\" }"));
+        assert!(!raw.contains("providers.<profile_id>.api_key_env = \"PROVIDER_API_KEY\""));
 
         std::fs::remove_file(&config_path).ok();
         std::fs::remove_dir_all(&temp_dir).ok();
@@ -2546,7 +2569,7 @@ model = "gpt-5"
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_persists_provider_env_pointers_as_env_name_fields() {
+    fn write_persists_provider_env_pointers_as_secret_refs() {
         let path = unique_config_path("loongclaw-config-runtime-canonical-provider-env");
         let path_string = path.display().to_string();
         let mut config = LoongClawConfig::default();
@@ -2555,15 +2578,16 @@ model = "gpt-5"
         write(Some(&path_string), &config, true).expect("config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read written config");
-        assert!(raw.contains("api_key_env = \"OPENAI_API_KEY\""));
-        assert!(!raw.contains("api_key = \"${OPENAI_API_KEY}\""));
+        assert!(raw.contains("api_key"));
+        assert!(raw.contains("env = \"OPENAI_API_KEY\""));
+        assert!(!raw.contains("api_key_env = \"OPENAI_API_KEY\""));
 
         let _ = fs::remove_file(path);
     }
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_migrates_inline_provider_env_references_to_env_name_fields() {
+    fn write_migrates_inline_provider_env_references_to_secret_refs() {
         let path = unique_config_path("loongclaw-config-runtime-inline-provider-env");
         let path_string = path.display().to_string();
         let mut config = LoongClawConfig::default();
@@ -2581,8 +2605,8 @@ model = "gpt-5"
 
             let raw = fs::read_to_string(&path).expect("read written config");
             assert!(
-                raw.contains("api_key_env = \"TEAM_OPENAI_KEY\""),
-                "expected api_key_env writeback for {inline_reference}"
+                raw.contains("api_key") && raw.contains("env = \"TEAM_OPENAI_KEY\""),
+                "expected api_key secret-ref writeback for {inline_reference}"
             );
             assert!(
                 !raw.contains(inline_reference),
@@ -2595,7 +2619,7 @@ model = "gpt-5"
 
     #[test]
     #[cfg(feature = "config-toml")]
-    fn write_canonicalizes_matching_provider_env_name_fields() {
+    fn write_canonicalizes_matching_provider_env_name_fields_into_secret_refs() {
         let path = unique_config_path("loongclaw-config-runtime-trimmed-provider-env");
         let path_string = path.display().to_string();
         let mut config = LoongClawConfig::default();
@@ -2605,8 +2629,9 @@ model = "gpt-5"
         write(Some(&path_string), &config, true).expect("config write should pass");
 
         let raw = fs::read_to_string(&path).expect("read written config");
-        assert!(raw.contains("api_key_env = \"TEAM_OPENAI_KEY\""));
-        assert!(!raw.contains("api_key_env = \" TEAM_OPENAI_KEY \""));
+        assert!(raw.contains("api_key"));
+        assert!(raw.contains("env = \"TEAM_OPENAI_KEY\""));
+        assert!(!raw.contains("api_key_env = \"TEAM_OPENAI_KEY\""));
         assert!(!raw.contains("api_key = \"${TEAM_OPENAI_KEY}\""));
 
         let _ = fs::remove_file(path);

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -611,6 +611,10 @@ fn looks_like_secret_literal(raw: &str, detect_telegram_token_shape: bool) -> bo
         return true;
     }
 
+    if looks_like_uuid_shaped_secret_literal(trimmed) {
+        return true;
+    }
+
     if looks_like_compatible_env_name(trimmed) {
         return false;
     }
@@ -620,6 +624,22 @@ fn looks_like_secret_literal(raw: &str, detect_telegram_token_shape: bool) -> bo
         && trimmed
             .chars()
             .any(|ch| matches!(ch, '-' | '.' | ':' | '/' | '+'))
+}
+
+fn looks_like_uuid_shaped_secret_literal(raw: &str) -> bool {
+    let mut groups = raw.split('-');
+    let expected_lengths = [8usize, 4, 4, 4, 12];
+
+    for expected_length in expected_lengths {
+        let Some(group) = groups.next() else {
+            return false;
+        };
+        if group.len() != expected_length || !group.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            return false;
+        }
+    }
+
+    groups.next().is_none()
 }
 
 fn looks_like_compatible_env_name(raw: &str) -> bool {
@@ -748,6 +768,14 @@ mod tests {
             parse_env_assignment("set OPENAI_API_KEY=sk-value"),
             Some(("OPENAI_API_KEY", "sk-value"))
         );
+    }
+
+    #[test]
+    fn uuid_shaped_values_are_treated_as_secret_literals() {
+        assert!(looks_like_secret_literal(
+            "9f479837-0a12-4b56-89ab-cdef01234567",
+            false
+        ));
     }
 
     #[test]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1253,6 +1253,9 @@ fn ensure_provider_env_binding(
     if configured.is_some() {
         return false;
     }
+    if provider_credential_policy::provider_has_inline_credential(provider) {
+        return false;
+    }
 
     match field {
         provider_credential_policy::ProviderCredentialEnvField::ApiKey => {
@@ -2218,6 +2221,30 @@ mod tests {
             fixes,
             vec!["set provider.oauth_access_token.env=OPENAI_CODEX_OAUTH_TOKEN".to_owned()]
         );
+    }
+
+    #[test]
+    fn provider_env_fix_does_not_overwrite_inline_api_key() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.api_key = Some(loongclaw_contracts::SecretRef::Inline(
+            "inline-secret".to_owned(),
+        ));
+        config.provider.api_key_env = None;
+        config.provider.oauth_access_token = None;
+        config.provider.oauth_access_token_env = None;
+
+        let mut fixes = Vec::new();
+        let changed = maybe_apply_provider_env_fix(&mut config, true, &mut fixes);
+
+        assert!(!changed);
+        assert_eq!(
+            config.provider.api_key,
+            Some(loongclaw_contracts::SecretRef::Inline(
+                "inline-secret".to_owned(),
+            ))
+        );
+        assert_eq!(config.provider.api_key_env, None);
+        assert!(fixes.is_empty());
     }
 
     #[test]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1180,18 +1180,22 @@ fn maybe_apply_provider_env_fix(
         return false;
     };
     match binding.field {
-        provider_credential_policy::ProviderCredentialEnvField::ApiKey => ensure_env_binding(
-            &mut config.provider.api_key_env,
-            &binding.env_name,
-            fixes,
-            "set provider.api_key_env",
-        ),
-        provider_credential_policy::ProviderCredentialEnvField::OAuthAccessToken => {
-            ensure_env_binding(
-                &mut config.provider.oauth_access_token_env,
+        provider_credential_policy::ProviderCredentialEnvField::ApiKey => {
+            ensure_provider_env_binding(
+                &mut config.provider,
+                provider_credential_policy::ProviderCredentialEnvField::ApiKey,
                 &binding.env_name,
                 fixes,
-                "set provider.oauth_access_token_env",
+                "set provider.api_key.env",
+            )
+        }
+        provider_credential_policy::ProviderCredentialEnvField::OAuthAccessToken => {
+            ensure_provider_env_binding(
+                &mut config.provider,
+                provider_credential_policy::ProviderCredentialEnvField::OAuthAccessToken,
+                &binding.env_name,
+                fixes,
+                "set provider.oauth_access_token.env",
             )
         }
     }
@@ -1211,6 +1215,7 @@ fn maybe_apply_channel_env_fix(
     changed
 }
 
+#[cfg(test)]
 fn ensure_env_binding(
     slot: &mut Option<String>,
     default_key: &str,
@@ -1226,6 +1231,38 @@ fn ensure_env_binding(
         return false;
     }
     *slot = Some(default_key.to_owned());
+    fixes.push(format!("{label}={default_key}"));
+    true
+}
+
+fn ensure_provider_env_binding(
+    provider: &mut mvp::config::ProviderConfig,
+    field: provider_credential_policy::ProviderCredentialEnvField,
+    default_key: &str,
+    fixes: &mut Vec<String>,
+    label: &'static str,
+) -> bool {
+    let configured = match field {
+        provider_credential_policy::ProviderCredentialEnvField::ApiKey => {
+            provider.configured_api_key_env_override()
+        }
+        provider_credential_policy::ProviderCredentialEnvField::OAuthAccessToken => {
+            provider.configured_oauth_access_token_env_override()
+        }
+    };
+    if configured.is_some() {
+        return false;
+    }
+
+    match field {
+        provider_credential_policy::ProviderCredentialEnvField::ApiKey => {
+            provider.set_api_key_env_binding(Some(default_key.to_owned()));
+        }
+        provider_credential_policy::ProviderCredentialEnvField::OAuthAccessToken => {
+            provider.set_oauth_access_token_env_binding(Some(default_key.to_owned()));
+        }
+    }
+
     fixes.push(format!("{label}={default_key}"));
     true
 }
@@ -2171,13 +2208,15 @@ mod tests {
 
         assert!(changed);
         assert_eq!(
-            config.provider.oauth_access_token_env.as_deref(),
-            Some("OPENAI_CODEX_OAUTH_TOKEN")
+            config.provider.oauth_access_token,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+            })
         );
         assert_eq!(config.provider.api_key_env, None);
         assert_eq!(
             fixes,
-            vec!["set provider.oauth_access_token_env=OPENAI_CODEX_OAUTH_TOKEN".to_owned()]
+            vec!["set provider.oauth_access_token.env=OPENAI_CODEX_OAUTH_TOKEN".to_owned()]
         );
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2020,24 +2020,30 @@ fn runtime_snapshot_migrate_provider_env_reference(
     let explicit_env_name = inline_secret
         .as_ref()
         .and_then(SecretRef::explicit_env_name);
-    let Some(explicit_env_name) = explicit_env_name else {
+    if let Some(explicit_env_name) = explicit_env_name {
+        *inline_secret = Some(SecretRef::Env {
+            env: explicit_env_name,
+        });
+        *env_name = None;
         return;
-    };
-    let configured_env_name = env_name.as_deref();
-    let configured_env_name = configured_env_name.map(str::trim);
-    let configured_env_name = configured_env_name.filter(|value| !value.is_empty());
-
-    match configured_env_name {
-        None => {
-            *env_name = Some(explicit_env_name);
-            *inline_secret = None;
-        }
-        Some(configured_env_name) if configured_env_name == explicit_env_name => {
-            *env_name = Some(explicit_env_name);
-            *inline_secret = None;
-        }
-        Some(_) => {}
     }
+
+    if inline_secret.is_some() {
+        *env_name = None;
+        return;
+    }
+
+    let configured_env_name = env_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    if let Some(configured_env_name) = configured_env_name {
+        *inline_secret = Some(SecretRef::Env {
+            env: configured_env_name,
+        });
+    }
+    *env_name = None;
 }
 
 fn runtime_snapshot_is_env_reference_literal(raw: &str) -> bool {
@@ -2224,7 +2230,7 @@ mod runtime_snapshot_restore_spec_tests {
     }
 
     #[test]
-    fn runtime_snapshot_restore_normalization_keeps_provider_env_name_fields() {
+    fn runtime_snapshot_restore_normalization_moves_provider_env_name_fields_into_secret_refs() {
         let mut warnings = Vec::new();
         let mut profile = mvp::config::ProviderProfileConfig {
             default_for_kind: true,
@@ -2243,16 +2249,20 @@ mod runtime_snapshot_restore_spec_tests {
             &mut warnings,
         );
 
-        assert_eq!(profile.provider.api_key, None);
         assert_eq!(
-            profile.provider.api_key_env.as_deref(),
-            Some("OPENAI_API_KEY")
+            profile.provider.api_key,
+            Some(SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
         );
-        assert_eq!(profile.provider.oauth_access_token, None);
+        assert_eq!(profile.provider.api_key_env, None);
         assert_eq!(
-            profile.provider.oauth_access_token_env.as_deref(),
-            Some("OPENAI_CODEX_OAUTH_TOKEN")
+            profile.provider.oauth_access_token,
+            Some(SecretRef::Env {
+                env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+            })
         );
+        assert_eq!(profile.provider.oauth_access_token_env, None);
         assert!(warnings.is_empty());
     }
 
@@ -2280,21 +2290,26 @@ mod runtime_snapshot_restore_spec_tests {
             &mut warnings,
         );
 
-        assert_eq!(profile.provider.api_key, None);
         assert_eq!(
-            profile.provider.api_key_env.as_deref(),
-            Some("INLINE_OPENAI_API_KEY")
+            profile.provider.api_key,
+            Some(SecretRef::Env {
+                env: "INLINE_OPENAI_API_KEY".to_owned(),
+            })
         );
-        assert_eq!(profile.provider.oauth_access_token, None);
+        assert_eq!(profile.provider.api_key_env, None);
         assert_eq!(
-            profile.provider.oauth_access_token_env.as_deref(),
-            Some("INLINE_OPENAI_OAUTH_TOKEN")
+            profile.provider.oauth_access_token,
+            Some(SecretRef::Env {
+                env: "INLINE_OPENAI_OAUTH_TOKEN".to_owned(),
+            })
         );
+        assert_eq!(profile.provider.oauth_access_token_env, None);
         assert!(warnings.is_empty());
     }
 
     #[test]
-    fn runtime_snapshot_restore_normalization_keeps_conflicting_explicit_env_reference() {
+    fn runtime_snapshot_restore_normalization_prefers_explicit_env_reference_over_legacy_env_field()
+    {
         let mut warnings = Vec::new();
         let mut profile = mvp::config::ProviderProfileConfig {
             default_for_kind: true,
@@ -2319,20 +2334,18 @@ mod runtime_snapshot_restore_spec_tests {
 
         assert_eq!(
             profile.provider.api_key,
-            Some(SecretRef::Inline("${INLINE_OPENAI_API_KEY}".to_owned()))
+            Some(SecretRef::Env {
+                env: "INLINE_OPENAI_API_KEY".to_owned(),
+            })
         );
-        assert_eq!(
-            profile.provider.api_key_env.as_deref(),
-            Some("CONFIGURED_OPENAI_API_KEY")
-        );
+        assert_eq!(profile.provider.api_key_env, None);
         assert_eq!(
             profile.provider.oauth_access_token,
-            Some(SecretRef::Inline("$INLINE_OPENAI_OAUTH_TOKEN".to_owned()))
+            Some(SecretRef::Env {
+                env: "INLINE_OPENAI_OAUTH_TOKEN".to_owned(),
+            })
         );
-        assert_eq!(
-            profile.provider.oauth_access_token_env.as_deref(),
-            Some("CONFIGURED_OPENAI_OAUTH_TOKEN")
-        );
+        assert_eq!(profile.provider.oauth_access_token_env, None);
         assert!(warnings.is_empty());
     }
 

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -520,7 +520,9 @@ fn codex_import_config_to_loongclaw(
             .kind
             .default_api_key_env()
             .unwrap_or("OPENAI_API_KEY");
-        config.provider.api_key_env = Some(suggested_env.to_owned());
+        config
+            .provider
+            .set_api_key_env_binding(Some(suggested_env.to_owned()));
     }
 
     Ok(Some(config))
@@ -531,9 +533,9 @@ fn baseline_codex_import_provider_config(
 ) -> mvp::config::ProviderConfig {
     let mut provider = mvp::config::ProviderConfig {
         kind: provider_kind,
-        api_key_env: provider_kind.default_api_key_env().map(str::to_owned),
         ..mvp::config::ProviderConfig::default()
     };
+    provider.set_api_key_env_binding(provider_kind.default_api_key_env().map(str::to_owned));
     ImportedProviderTransport::default_for_kind(provider_kind).apply_to_provider(&mut provider);
     provider
 }

--- a/crates/daemon/src/migration/planner.rs
+++ b/crates/daemon/src/migration/planner.rs
@@ -259,6 +259,9 @@ fn supplement_provider_config(
     if target.kind != source.kind {
         return false;
     }
+    target.canonicalize_configured_auth_env_bindings();
+    let mut source = source.clone();
+    source.canonicalize_configured_auth_env_bindings();
     let default_provider = mvp::config::ProviderConfig::default();
     let target_has_auth = target.authorization_header().is_some();
     let source_has_auth = source.authorization_header().is_some();
@@ -269,31 +272,19 @@ fn supplement_provider_config(
         target.model = source.model.clone();
         changed = true;
     }
-    changed |= provider_transport::supplement_provider_transport(target, source);
+    changed |= provider_transport::supplement_provider_transport(target, &source);
     if (target.api_key.is_none() || (!target_has_auth && source_has_auth))
         && source.api_key.is_some()
+        && target.api_key != source.api_key
     {
         target.api_key = source.api_key.clone();
         changed = true;
     }
-    if (target.api_key_env.is_none() || (!target_has_auth && source_has_auth))
-        && source.api_key_env.is_some()
-        && target.api_key_env != source.api_key_env
-    {
-        target.api_key_env = source.api_key_env.clone();
-        changed = true;
-    }
     if (target.oauth_access_token.is_none() || (!target_has_auth && source_has_auth))
         && source.oauth_access_token.is_some()
+        && target.oauth_access_token != source.oauth_access_token
     {
         target.oauth_access_token = source.oauth_access_token.clone();
-        changed = true;
-    }
-    if (target.oauth_access_token_env.is_none() || (!target_has_auth && source_has_auth))
-        && source.oauth_access_token_env.is_some()
-        && target.oauth_access_token_env != source.oauth_access_token_env
-    {
-        target.oauth_access_token_env = source.oauth_access_token_env.clone();
         changed = true;
     }
     if target.endpoint.is_none() && source.endpoint.is_some() {
@@ -359,6 +350,34 @@ fn supplement_provider_config(
         }
     }
     changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supplement_provider_config_canonicalizes_legacy_api_key_env_binding() {
+        let mut target =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        target.api_key = None;
+        target.set_api_key_env(None);
+
+        let mut source =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        source.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
+
+        let changed = supplement_provider_config(&mut target, &source);
+
+        assert!(changed);
+        assert_eq!(
+            target.api_key,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(target.api_key_env, None);
+    }
 }
 
 fn compose_cli_domain(

--- a/crates/daemon/src/migration/planner.rs
+++ b/crates/daemon/src/migration/planner.rs
@@ -157,6 +157,9 @@ fn compose_provider_domain(
     } else {
         chosen.config.provider.clone()
     };
+    merged_config
+        .provider
+        .canonicalize_configured_auth_env_bindings();
     let mut supplemented_from = Vec::new();
     for candidate in candidates {
         if Some(candidate.source.as_str()) == base_source.as_deref() {
@@ -377,6 +380,44 @@ mod tests {
             })
         );
         assert_eq!(target.api_key_env, None);
+    }
+
+    #[test]
+    fn compose_provider_domain_canonicalizes_selected_current_provider() {
+        let mut merged_config = mvp::config::LoongClawConfig::default();
+        let mut current = ImportCandidate {
+            source_kind: ImportSourceKind::ExistingLoongClawConfig,
+            source: "current config".to_owned(),
+            config: mvp::config::LoongClawConfig::default(),
+            surfaces: Vec::new(),
+            domains: Vec::new(),
+            channel_candidates: Vec::new(),
+            workspace_guidance: Vec::new(),
+        };
+        current.config.provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        current
+            .config
+            .provider
+            .set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
+        current.domains.push(DomainPreview {
+            kind: SetupDomainKind::Provider,
+            status: PreviewStatus::Ready,
+            decision: Some(PreviewDecision::KeepCurrent),
+            source: current.source.clone(),
+            summary: String::new(),
+        });
+
+        let domain = compose_provider_domain(&mut merged_config, &[current]);
+
+        assert!(domain.is_some());
+        assert_eq!(
+            merged_config.provider.api_key,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(merged_config.provider.api_key_env, None);
     }
 }
 

--- a/crates/daemon/src/migration/provider_selection.rs
+++ b/crates/daemon/src/migration/provider_selection.rs
@@ -181,21 +181,18 @@ pub fn merge_provider_config(
     incoming: &mvp::config::ProviderConfig,
 ) -> mvp::config::ProviderConfig {
     let mut merged = existing.clone();
+    merged.canonicalize_configured_auth_env_bindings();
+    let mut incoming = incoming.clone();
+    incoming.canonicalize_configured_auth_env_bindings();
     if merged.model.trim().is_empty() || merged.model.eq_ignore_ascii_case("auto") {
         merged.model = incoming.model.clone();
     }
-    super::provider_transport::supplement_provider_transport(&mut merged, incoming);
+    super::provider_transport::supplement_provider_transport(&mut merged, &incoming);
     if merged.api_key.is_none() {
         merged.api_key = incoming.api_key.clone();
     }
-    if merged.api_key_env.is_none() {
-        merged.api_key_env = incoming.api_key_env.clone();
-    }
     if merged.oauth_access_token.is_none() {
         merged.oauth_access_token = incoming.oauth_access_token.clone();
-    }
-    if merged.oauth_access_token_env.is_none() {
-        merged.oauth_access_token_env = incoming.oauth_access_token_env.clone();
     }
     if merged.endpoint.is_none() {
         merged.endpoint = incoming.endpoint.clone();
@@ -220,6 +217,30 @@ pub fn merge_provider_config(
         merged.reasoning_effort = incoming.reasoning_effort;
     }
     merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_provider_config_canonicalizes_legacy_api_key_env_binding() {
+        let existing =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        let mut incoming =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        incoming.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
+
+        let merged = merge_provider_config(&existing, &incoming);
+
+        assert_eq!(
+            merged.api_key,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(merged.api_key_env, None);
+    }
 }
 
 pub fn resolve_choice_by_selector_resolution(

--- a/crates/daemon/src/migration/provider_selection.rs
+++ b/crates/daemon/src/migration/provider_selection.rs
@@ -66,13 +66,14 @@ pub fn build_provider_selection_plan_for_candidate(
         else {
             continue;
         };
+        let incoming_config = canonicalized_provider_config(&candidate.config.provider);
 
         let incoming = ImportedProviderChoice {
             profile_id: String::new(),
             kind: candidate.config.provider.kind,
             source: candidate.source.clone(),
             summary: provider_domain.summary.clone(),
-            config: candidate.config.provider.clone(),
+            config: incoming_config,
         };
         if let Some(existing) = imported_choices.iter_mut().find(|choice| {
             provider_profile_merge_key(&choice.config)
@@ -145,16 +146,24 @@ pub fn resolve_provider_config_from_selection(
         .iter()
         .find(|choice| choice.kind == selected_kind)
     {
-        return choice.config.clone();
+        return canonicalized_provider_config(&choice.config);
     }
     if current_provider.kind == selected_kind {
-        return current_provider.clone();
+        return canonicalized_provider_config(current_provider);
     }
     fresh_provider_config_for_kind(selected_kind)
 }
 
 fn fresh_provider_config_for_kind(kind: mvp::config::ProviderKind) -> mvp::config::ProviderConfig {
     mvp::config::ProviderConfig::fresh_for_kind(kind)
+}
+
+fn canonicalized_provider_config(
+    provider: &mvp::config::ProviderConfig,
+) -> mvp::config::ProviderConfig {
+    let mut provider = provider.clone();
+    provider.canonicalize_configured_auth_env_bindings();
+    provider
 }
 
 pub fn provider_profile_merge_key(provider: &mvp::config::ProviderConfig) -> String {
@@ -217,30 +226,6 @@ pub fn merge_provider_config(
         merged.reasoning_effort = incoming.reasoning_effort;
     }
     merged
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn merge_provider_config_canonicalizes_legacy_api_key_env_binding() {
-        let existing =
-            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
-        let mut incoming =
-            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
-        incoming.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
-
-        let merged = merge_provider_config(&existing, &incoming);
-
-        assert_eq!(
-            merged.api_key,
-            Some(loongclaw_contracts::SecretRef::Env {
-                env: "OPENAI_API_KEY".to_owned(),
-            })
-        );
-        assert_eq!(merged.api_key_env, None);
-    }
 }
 
 pub fn resolve_choice_by_selector_resolution(
@@ -511,4 +496,106 @@ fn normalize_provider_profile_id_segment(raw: &str) -> Option<String> {
         normalized.pop();
     }
     (!normalized.is_empty()).then_some(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::types::{DomainPreview, PreviewDecision};
+
+    fn provider_candidate(
+        source_kind: ImportSourceKind,
+        source: &str,
+        kind: mvp::config::ProviderKind,
+        credential_env: &str,
+    ) -> ImportCandidate {
+        let mut provider = mvp::config::ProviderConfig::fresh_for_kind(kind);
+        provider.set_api_key_env(Some(credential_env.to_owned()));
+
+        let config = mvp::config::LoongClawConfig {
+            provider,
+            ..mvp::config::LoongClawConfig::default()
+        };
+
+        ImportCandidate {
+            source_kind,
+            source: source.to_owned(),
+            config,
+            surfaces: Vec::new(),
+            domains: vec![DomainPreview {
+                kind: SetupDomainKind::Provider,
+                status: PreviewStatus::Ready,
+                decision: Some(PreviewDecision::UseDetected),
+                source: source.to_owned(),
+                summary: String::new(),
+            }],
+            channel_candidates: Vec::new(),
+            workspace_guidance: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn merge_provider_config_canonicalizes_legacy_api_key_env_binding() {
+        let existing =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        let mut incoming =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        incoming.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
+
+        let merged = merge_provider_config(&existing, &incoming);
+
+        assert_eq!(
+            merged.api_key,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(merged.api_key_env, None);
+    }
+
+    #[test]
+    fn build_provider_selection_plan_canonicalizes_single_choice() {
+        let selected = provider_candidate(
+            ImportSourceKind::Environment,
+            "your current environment",
+            mvp::config::ProviderKind::Deepseek,
+            "DEEPSEEK_API_KEY",
+        );
+
+        let plan = build_provider_selection_plan_for_candidate(&selected, &[]);
+
+        let choice = plan
+            .imported_choices
+            .first()
+            .expect("single provider choice should exist");
+
+        assert_eq!(
+            choice.config.api_key,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "DEEPSEEK_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(choice.config.api_key_env, None);
+    }
+
+    #[test]
+    fn resolve_provider_config_from_selection_canonicalizes_current_provider() {
+        let mut current =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        current.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
+
+        let resolved = resolve_provider_config_from_selection(
+            &current,
+            &ProviderSelectionPlan::default(),
+            mvp::config::ProviderKind::Openai,
+        );
+
+        assert_eq!(
+            resolved.api_key,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(resolved.api_key_env, None);
+    }
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2034,8 +2034,8 @@ fn apply_selected_api_key_env(
 ) {
     let selected_api_key_env = selected_api_key_env.trim();
     if selected_api_key_env.is_empty() {
-        provider.set_api_key_env(None);
-        provider.set_oauth_access_token_env(None);
+        provider.clear_api_key_env_binding();
+        provider.clear_oauth_access_token_env_binding();
         return;
     }
 
@@ -2046,12 +2046,12 @@ fn apply_selected_api_key_env(
         selected_api_key_env,
     ) {
         provider_credential_policy::ProviderCredentialEnvField::ApiKey => {
-            provider.set_oauth_access_token_env(None);
-            provider.set_api_key_env(Some(selected_api_key_env.to_owned()));
+            provider.clear_oauth_access_token_env_binding();
+            provider.set_api_key_env_binding(Some(selected_api_key_env.to_owned()));
         }
         provider_credential_policy::ProviderCredentialEnvField::OAuthAccessToken => {
-            provider.set_api_key_env(None);
-            provider.set_oauth_access_token_env(Some(selected_api_key_env.to_owned()));
+            provider.clear_api_key_env_binding();
+            provider.set_oauth_access_token_env_binding(Some(selected_api_key_env.to_owned()));
         }
     }
 }
@@ -2827,8 +2827,10 @@ fn onboard_credential_env_name_is_safe(raw: &str) -> bool {
     }
 
     let mut config = mvp::config::LoongClawConfig::default();
-    config.provider.api_key = None;
-    config.provider.api_key_env = Some(trimmed.to_owned());
+    config.provider.api_key = Some(SecretRef::Env {
+        env: trimmed.to_owned(),
+    });
+    config.provider.api_key_env = None;
 
     config.validate().is_ok()
 }
@@ -3051,15 +3053,18 @@ fn non_interactive_preflight_warning_message(
 fn render_configured_provider_credential_source_value(
     provider: &mvp::config::ProviderConfig,
 ) -> Option<String> {
-    let configured_oauth = provider.oauth_access_token_env.as_deref();
-    let rendered_oauth =
-        provider_credential_policy::render_provider_credential_source_value(configured_oauth);
+    let configured_oauth = provider.configured_oauth_access_token_env_override();
+    let rendered_oauth = provider_credential_policy::render_provider_credential_source_value(
+        configured_oauth.as_deref(),
+    );
     if rendered_oauth.is_some() {
         return rendered_oauth;
     }
 
-    let configured_api_key = provider.api_key_env.as_deref();
-    provider_credential_policy::render_provider_credential_source_value(configured_api_key)
+    let configured_api_key = provider.configured_api_key_env_override();
+    provider_credential_policy::render_provider_credential_source_value(
+        configured_api_key.as_deref(),
+    )
 }
 
 pub fn preferred_api_key_env_default(config: &mvp::config::LoongClawConfig) -> String {
@@ -7243,13 +7248,84 @@ mod tests {
         .expect_err("non-interactive onboarding should reject secret-like env selections");
 
         assert!(
-            error.contains("provider.api_key_env"),
+            error.contains("provider.api_key.env"),
             "the validation error should identify the bad field: {error}"
         );
         assert!(
             !error.contains(secret),
             "non-interactive validation must not echo the secret-like input: {error}"
         );
+    }
+
+    #[test]
+    fn resolve_api_key_env_selection_reprompts_after_uuid_secret_literal_interactively() {
+        let secret = "9f479837-0a12-4b56-89ab-cdef01234567";
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::VolcengineCoding;
+        let mut ui = TestOnboardUi::with_inputs([secret, "ARK_API_KEY"]);
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let selected = resolve_api_key_env_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: false,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: None,
+                web_search_provider: None,
+                web_search_api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            "ARK_API_KEY".to_owned(),
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("uuid-shaped credential input should be rejected and reprompted");
+
+        assert_eq!(selected, "ARK_API_KEY");
+    }
+
+    #[test]
+    fn resolve_api_key_env_selection_rejects_uuid_secret_literal_non_interactively() {
+        let secret = "9f479837-0a12-4b56-89ab-cdef01234567";
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::VolcengineCoding;
+        let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
+        let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
+
+        let error = resolve_api_key_env_selection(
+            &OnboardCommandOptions {
+                output: None,
+                force: false,
+                non_interactive: true,
+                accept_risk: true,
+                provider: None,
+                model: None,
+                api_key_env: Some(secret.to_owned()),
+                web_search_provider: None,
+                web_search_api_key_env: None,
+                personality: None,
+                memory_profile: None,
+                system_prompt: None,
+                skip_model_probe: false,
+            },
+            &config,
+            "ARK_API_KEY".to_owned(),
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect_err("uuid-shaped env selections should be rejected non-interactively");
+
+        assert!(error.contains("provider.api_key.env"));
+        assert!(!error.contains(secret));
     }
 
     #[test]
@@ -7572,41 +7648,51 @@ mod tests {
     fn apply_selected_api_key_env_routes_openai_oauth_env_to_oauth_binding() {
         let mut provider = mvp::config::ProviderConfig {
             kind: mvp::config::ProviderKind::Openai,
-            api_key_env: Some("OPENAI_API_KEY".to_owned()),
+            api_key: Some(SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            }),
             ..mvp::config::ProviderConfig::default()
         };
 
         apply_selected_api_key_env(&mut provider, "OPENAI_CODEX_OAUTH_TOKEN".to_owned());
 
         assert_eq!(
-            provider.oauth_access_token_env.as_deref(),
-            Some("OPENAI_CODEX_OAUTH_TOKEN")
+            provider.oauth_access_token,
+            Some(SecretRef::Env {
+                env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+            })
         );
         assert_eq!(
             provider.api_key_env, None,
             "switching to the OpenAI oauth env should clear the stale api-key env binding"
         );
+        assert_eq!(provider.api_key, None);
     }
 
     #[test]
     fn apply_selected_api_key_env_routes_unknown_openai_env_to_api_key_binding() {
         let mut provider = mvp::config::ProviderConfig {
             kind: mvp::config::ProviderKind::Openai,
-            oauth_access_token_env: Some("OPENAI_CODEX_OAUTH_TOKEN".to_owned()),
+            oauth_access_token: Some(SecretRef::Env {
+                env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+            }),
             ..mvp::config::ProviderConfig::default()
         };
 
         apply_selected_api_key_env(&mut provider, "OPENAI_ALT_BEARER".to_owned());
 
         assert_eq!(
-            provider.api_key_env.as_deref(),
-            Some("OPENAI_ALT_BEARER"),
+            provider.api_key,
+            Some(SecretRef::Env {
+                env: "OPENAI_ALT_BEARER".to_owned(),
+            }),
             "unknown env names should stay on the explicit api-key field instead of being silently rebound to oauth"
         );
         assert_eq!(
             provider.oauth_access_token_env, None,
             "switching to a custom env name should clear the stale oauth binding"
         );
+        assert_eq!(provider.oauth_access_token, None);
     }
 
     #[test]
@@ -7620,18 +7706,30 @@ mod tests {
 
         let mut api_key_env_update = current.clone();
         apply_selected_api_key_env(&mut api_key_env_update, "OPENAI_API_KEY".to_owned());
-        assert!(api_key_env_update.api_key_env_explicit);
+        assert_eq!(
+            api_key_env_update.api_key,
+            Some(SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert!(!api_key_env_update.api_key_env_explicit);
         assert!(
             provider_matches_for_review(&current, &api_key_env_update),
-            "review matching should ignore explicit api_key_env metadata when the provider identity is otherwise unchanged"
+            "review matching should ignore credential binding rewrites when the provider identity is otherwise unchanged"
         );
 
         let mut oauth_env_update = current.clone();
         apply_selected_api_key_env(&mut oauth_env_update, "OPENAI_CODEX_OAUTH_TOKEN".to_owned());
-        assert!(oauth_env_update.oauth_access_token_env_explicit);
+        assert_eq!(
+            oauth_env_update.oauth_access_token,
+            Some(SecretRef::Env {
+                env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+            })
+        );
+        assert!(!oauth_env_update.oauth_access_token_env_explicit);
         assert!(
             provider_matches_for_review(&current, &oauth_env_update),
-            "review matching should ignore explicit oauth_access_token_env metadata when the provider identity is otherwise unchanged"
+            "review matching should ignore credential binding rewrites when the provider identity is otherwise unchanged"
         );
     }
 

--- a/crates/daemon/src/provider_credential_policy.rs
+++ b/crates/daemon/src/provider_credential_policy.rs
@@ -15,13 +15,13 @@ pub(crate) struct ProviderCredentialEnvBinding {
 
 pub(crate) fn provider_credential_env_hints(provider: &mvp::config::ProviderConfig) -> Vec<String> {
     let mut hints = Vec::new();
-    let configured_oauth = provider.oauth_access_token_env.as_deref();
-    let configured_api_key = provider.api_key_env.as_deref();
+    let configured_oauth = provider.configured_oauth_access_token_env_override();
+    let configured_api_key = provider.configured_api_key_env_override();
     let default_oauth = provider.kind.default_oauth_access_token_env();
     let default_api_key = provider.kind.default_api_key_env();
 
-    push_provider_credential_env_hint(&mut hints, configured_oauth);
-    push_provider_credential_env_hint(&mut hints, configured_api_key);
+    push_provider_credential_env_hint(&mut hints, configured_oauth.as_deref());
+    push_provider_credential_env_hint(&mut hints, configured_api_key.as_deref());
     push_provider_credential_env_hint(&mut hints, default_oauth);
     push_provider_credential_env_hint(&mut hints, default_api_key);
 
@@ -38,13 +38,15 @@ pub(crate) fn provider_credential_env_hint(
 pub(crate) fn preferred_provider_credential_env_binding(
     provider: &mvp::config::ProviderConfig,
 ) -> Option<ProviderCredentialEnvBinding> {
+    let configured_oauth = provider.configured_oauth_access_token_env_override();
+    let configured_api_key = provider.configured_api_key_env_override();
     let configured_oauth = binding_for_env_name(
         ProviderCredentialEnvField::OAuthAccessToken,
-        provider.oauth_access_token_env.as_deref(),
+        configured_oauth.as_deref(),
     );
     let configured_api_key = binding_for_env_name(
         ProviderCredentialEnvField::ApiKey,
-        provider.api_key_env.as_deref(),
+        configured_api_key.as_deref(),
     );
     let default_oauth = binding_for_env_name(
         ProviderCredentialEnvField::OAuthAccessToken,
@@ -64,13 +66,15 @@ pub(crate) fn preferred_provider_credential_env_binding(
 pub(crate) fn configured_provider_credential_env_binding(
     provider: &mvp::config::ProviderConfig,
 ) -> Option<ProviderCredentialEnvBinding> {
+    let configured_oauth = provider.configured_oauth_access_token_env_override();
+    let configured_api_key = provider.configured_api_key_env_override();
     let configured_oauth = binding_for_env_name(
         ProviderCredentialEnvField::OAuthAccessToken,
-        provider.oauth_access_token_env.as_deref(),
+        configured_oauth.as_deref(),
     );
     let configured_api_key = binding_for_env_name(
         ProviderCredentialEnvField::ApiKey,
-        provider.api_key_env.as_deref(),
+        configured_api_key.as_deref(),
     );
 
     configured_oauth.or(configured_api_key)
@@ -86,18 +90,10 @@ pub(crate) fn provider_has_inline_credential(provider: &mvp::config::ProviderCon
 pub(crate) fn provider_has_configured_credential_env(
     provider: &mvp::config::ProviderConfig,
 ) -> bool {
-    let oauth_env_present = provider
-        .oauth_access_token_env
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|value| !value.is_empty());
-    let api_key_env_present = provider
-        .api_key_env
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|value| !value.is_empty());
-
-    oauth_env_present || api_key_env_present
+    provider
+        .configured_oauth_access_token_env_override()
+        .is_some()
+        || provider.configured_api_key_env_override().is_some()
 }
 
 pub(crate) fn selected_provider_credential_env_field(
@@ -145,7 +141,7 @@ fn env_name_matches_oauth_binding(provider: &mvp::config::ProviderConfig, env_na
     let default_oauth = provider.kind.default_oauth_access_token_env();
     let oauth_aliases = provider.kind.oauth_access_token_env_aliases();
     let configured_oauth = provider
-        .oauth_access_token_env
+        .configured_oauth_access_token_env_override()
         .as_deref()
         .and_then(normalize_provider_credential_env_name);
 
@@ -166,7 +162,7 @@ fn env_name_matches_api_key_binding(
     let default_api_key = provider.kind.default_api_key_env();
     let api_key_aliases = provider.kind.api_key_env_aliases();
     let configured_api_key = provider
-        .api_key_env
+        .configured_api_key_env_override()
         .as_deref()
         .and_then(normalize_provider_credential_env_name);
 
@@ -201,8 +197,10 @@ fn provider_credential_env_name_is_safe(raw: &str) -> bool {
     }
 
     let mut config = mvp::config::LoongClawConfig::default();
-    config.provider.api_key = None;
-    config.provider.api_key_env = Some(trimmed.to_owned());
+    config.provider.api_key = Some(SecretRef::Env {
+        env: trimmed.to_owned(),
+    });
+    config.provider.api_key_env = None;
 
     config.validate().is_ok()
 }

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -95,7 +95,9 @@ fn sample_import_candidate() -> loongclaw_daemon::migration::types::ImportCandid
     let mut config = mvp::config::LoongClawConfig::default();
     config.provider.kind = mvp::config::ProviderKind::Openrouter;
     config.provider.model = "openrouter/openai/gpt-5.1".to_owned();
-    config.provider.api_key_env = Some("OPENROUTER_API_KEY".to_owned());
+    config
+        .provider
+        .set_api_key_env_binding(Some("OPENROUTER_API_KEY".to_owned()));
     config.cli.system_prompt = "Imported CLI prompt".to_owned();
     config.telegram.enabled = true;
     config.telegram.bot_token_env = Some("TELEGRAM_BOT_TOKEN".to_owned());
@@ -175,7 +177,10 @@ fn import_candidate_with_provider(
     candidate.config.provider.base_url = profile.base_url.to_owned();
     candidate.config.provider.chat_completions_path = profile.chat_completions_path.to_owned();
     candidate.config.provider.model = model.to_owned();
-    candidate.config.provider.api_key_env = Some(credential_env.to_owned());
+    candidate
+        .config
+        .provider
+        .set_api_key_env_binding(Some(credential_env.to_owned()));
     candidate.domains.retain(|domain| {
         domain.kind != loongclaw_daemon::migration::types::SetupDomainKind::Provider
     });
@@ -1312,13 +1317,15 @@ model = "deepseek-chat"
     );
     assert_eq!(imported.provider.model, "deepseek-chat");
     assert_eq!(
-        imported.provider.api_key, None,
-        "source-path-selected provider should not keep the legacy inline api_key field once the env name field is persisted"
+        imported.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "DEEPSEEK_API_KEY".to_owned(),
+        }),
+        "source-path-selected provider should keep its credential binding in the canonical api_key field"
     );
     assert_eq!(
-        imported.provider.api_key_env.as_deref(),
-        Some("DEEPSEEK_API_KEY"),
-        "source-path-selected provider should retain its provider-specific credential binding as an env name field"
+        imported.provider.api_key_env, None,
+        "source-path-selected provider should not keep the legacy api_key_env field once the canonical api_key binding is persisted"
     );
     assert_eq!(
         imported.provider.authorization_header().as_deref(),
@@ -1426,13 +1433,15 @@ requires_openai_auth = true
         mvp::config::ProviderWireApi::Responses
     );
     assert_eq!(
-        imported.provider.api_key, None,
-        "codex import should not keep the legacy inline api_key field once the env name field is persisted"
+        imported.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "OPENAI_API_KEY".to_owned(),
+        }),
+        "codex import should keep OpenAI auth in the canonical api_key field"
     );
     assert_eq!(
-        imported.provider.api_key_env.as_deref(),
-        Some("OPENAI_API_KEY"),
-        "codex import should persist OpenAI auth as an env name field"
+        imported.provider.api_key_env, None,
+        "codex import should not keep the legacy api_key_env field once the canonical api_key binding is persisted"
     );
 
     let models = mvp::provider::fetch_available_models(&imported)
@@ -1919,7 +1928,13 @@ fn import_cli_provider_selection_accepts_manual_choice_for_unresolved_recommende
 
     assert_eq!(provider.kind, mvp::config::ProviderKind::Deepseek);
     assert_eq!(provider.model, "deepseek-chat");
-    assert_eq!(provider.api_key_env.as_deref(), Some("DEEPSEEK_API_KEY"));
+    assert_eq!(
+        provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "DEEPSEEK_API_KEY".to_owned(),
+        })
+    );
+    assert_eq!(provider.api_key_env, None);
 }
 
 #[test]

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -275,9 +275,11 @@ model = "deepseek-chat"
         mvp::config::ProviderKind::Deepseek
     );
     assert_eq!(
-        codex_candidate.config.provider.api_key_env.as_deref(),
-        Some("DEEPSEEK_API_KEY"),
-        "recognized Codex providers should start from their provider baseline so imports keep the correct credential env even without an explicit provider section"
+        codex_candidate.config.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "DEEPSEEK_API_KEY".to_owned(),
+        }),
+        "recognized Codex providers should start from their provider baseline so imports keep the correct canonical credential binding even without an explicit provider section"
     );
     assert_eq!(
         codex_candidate.config.provider.oauth_access_token_env, None,
@@ -354,9 +356,12 @@ model = "openai/gpt-5.1-codex"
         mvp::config::ProviderKind::Openai
     );
     assert_eq!(
-        codex_candidate.config.provider.api_key_env.as_deref(),
-        Some("OPENAI_API_KEY")
+        codex_candidate.config.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "OPENAI_API_KEY".to_owned(),
+        })
     );
+    assert_eq!(codex_candidate.config.provider.api_key_env, None);
     assert_eq!(
         codex_candidate.config.provider.oauth_access_token_env, None,
         "Codex imports should keep the portable API-key path by default instead of auto-enabling machine-local OAuth envs"
@@ -1524,9 +1529,12 @@ fn migration_compose_recommended_candidate_upgrades_incomplete_provider_from_com
         "compatible ready provider should upgrade an incomplete current provider"
     );
     assert_eq!(
-        composed.config.provider.api_key_env.as_deref(),
-        Some("KIMI_CODING_API_KEY")
+        composed.config.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Inline(
+            "kimi-coding-secret".to_owned(),
+        ))
     );
+    assert_eq!(composed.config.provider.api_key_env, None);
 }
 
 #[test]
@@ -1639,10 +1647,13 @@ fn migration_compose_recommended_candidate_preserves_current_custom_provider_end
         "recommended plan should preserve the current compatible endpoint path when only credentials are supplemented"
     );
     assert_eq!(
-        composed.config.provider.api_key_env.as_deref(),
-        Some("OPENROUTER_API_KEY"),
-        "recommended plan should still upgrade missing credentials from the compatible source"
+        composed.config.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Inline(
+            "openrouter-secret".to_owned(),
+        )),
+        "recommended plan should still upgrade missing credentials from the compatible source into the canonical api_key field"
     );
+    assert_eq!(composed.config.provider.api_key_env, None);
 }
 
 #[test]

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -937,12 +937,13 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     assert!(
-        raw.contains("oauth_access_token_env = \"OPENAI_CODEX_OAUTH_TOKEN\""),
-        "onboarding should persist the openai oauth env name after provider-aligned credential routing: {raw}"
+        raw.contains("[providers.openai.oauth_access_token]")
+            && raw.contains("env = \"OPENAI_CODEX_OAUTH_TOKEN\""),
+        "onboarding should persist the routed openai oauth env binding in the canonical secret field: {raw}"
     );
     assert!(
-        !raw.contains("oauth_access_token = "),
-        "provider-aligned onboarding should not fall back to the legacy oauth_access_token field for the openai oauth route: {raw}"
+        !raw.contains("oauth_access_token_env = "),
+        "provider-aligned onboarding should not keep the legacy oauth_access_token_env field for the openai oauth route: {raw}"
     );
     assert!(
         !raw.contains("api_key = "),
@@ -953,13 +954,15 @@ async fn non_interactive_onboard_allows_explicit_skip_model_probe_warning() {
         .expect("load written onboarding config");
     assert_eq!(config.provider.model, "openai/gpt-5.1-codex");
     assert_eq!(
-        config.provider.oauth_access_token, None,
-        "reloaded config should not repopulate the legacy oauth_access_token field for the oauth-backed openai route"
+        config.provider.oauth_access_token,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+        }),
+        "reloaded config should keep the routed oauth env binding in the canonical oauth_access_token field"
     );
     assert_eq!(
-        config.provider.oauth_access_token_env.as_deref(),
-        Some("OPENAI_CODEX_OAUTH_TOKEN"),
-        "reloaded config should keep the routed oauth env name after provider-aligned onboarding"
+        config.provider.oauth_access_token_env, None,
+        "reloaded config should not keep the legacy oauth_access_token_env field after provider-aligned onboarding"
     );
     assert_eq!(
         config.provider.authorization_header(),
@@ -1132,8 +1135,8 @@ async fn non_interactive_api_key_env_override_clears_existing_oauth_credentials(
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     assert!(
-        raw.contains("api_key_env = \"OPENAI_API_KEY\""),
-        "api key env override should persist the selected api key source: {raw}"
+        raw.contains("[providers.openai.api_key]") && raw.contains("env = \"OPENAI_API_KEY\""),
+        "api key env override should persist the selected api key source in the canonical secret field: {raw}"
     );
     assert!(
         !raw.contains("OPENAI_CODEX_OAUTH_TOKEN"),
@@ -1145,13 +1148,15 @@ async fn non_interactive_api_key_env_override_clears_existing_oauth_credentials(
     assert_eq!(config.provider.oauth_access_token, None);
     assert_eq!(config.provider.oauth_access_token_env, None);
     assert_eq!(
-        config.provider.api_key, None,
-        "reloaded config should not keep the legacy inline api_key field once the env name field is persisted"
+        config.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "OPENAI_API_KEY".to_owned(),
+        }),
+        "reloaded config should keep only the selected api key env binding in the canonical api_key field"
     );
     assert_eq!(
-        config.provider.api_key_env.as_deref(),
-        Some("OPENAI_API_KEY"),
-        "reloaded config should keep only the selected api key credential source"
+        config.provider.api_key_env, None,
+        "reloaded config should not keep the legacy api_key_env field after persisting the selected api key source"
     );
 }
 
@@ -1188,8 +1193,8 @@ async fn non_interactive_api_key_env_override_clears_existing_inline_api_key() {
 
     let raw = std::fs::read_to_string(&output).expect("read written onboarding config");
     assert!(
-        raw.contains("api_key_env = \"OPENAI_API_KEY\""),
-        "api key env override should persist the selected api key source: {raw}"
+        raw.contains("[providers.openai.api_key]") && raw.contains("env = \"OPENAI_API_KEY\""),
+        "api key env override should persist the selected api key source in the canonical secret field: {raw}"
     );
     assert!(
         !raw.contains("inline-secret"),
@@ -1199,13 +1204,15 @@ async fn non_interactive_api_key_env_override_clears_existing_inline_api_key() {
     let (_, config) = mvp::config::load(Some(output.to_string_lossy().as_ref()))
         .expect("load written onboarding config");
     assert_eq!(
-        config.provider.api_key, None,
-        "reloaded config should not keep the legacy inline api_key field once the env name field is persisted"
+        config.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "OPENAI_API_KEY".to_owned(),
+        }),
+        "reloaded config should keep only the selected api key env binding in the canonical api_key field"
     );
     assert_eq!(
-        config.provider.api_key_env.as_deref(),
-        Some("OPENAI_API_KEY"),
-        "reloaded config should keep only the selected api key env reference"
+        config.provider.api_key_env, None,
+        "reloaded config should not keep the legacy api_key_env field after persisting the selected api key source"
     );
 }
 
@@ -2345,9 +2352,12 @@ requires_openai_auth = true
         mvp::config::ProviderKind::KimiCoding
     );
     assert_eq!(
-        codex_candidate.config.provider.api_key_env.as_deref(),
-        Some("KIMI_CODING_API_KEY")
+        codex_candidate.config.provider.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "KIMI_CODING_API_KEY".to_owned(),
+        })
     );
+    assert_eq!(codex_candidate.config.provider.api_key_env, None);
 }
 
 #[test]
@@ -4688,8 +4698,9 @@ fn onboard_model_selection_screen_wraps_compact_header_and_progress_on_narrow_wi
 fn onboard_api_key_env_screen_explains_suggested_env_and_blank_behavior() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.provider.kind = mvp::config::ProviderKind::Openai;
-    config.provider.api_key_env = None;
-    config.provider.oauth_access_token_env = Some("OPENAI_CODEX_OAUTH_TOKEN".to_owned());
+    config.provider.oauth_access_token = Some(loongclaw_contracts::SecretRef::Env {
+        env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+    });
 
     let lines = loongclaw_daemon::onboard_cli::render_api_key_env_selection_screen_lines(
         &config,
@@ -4749,7 +4760,9 @@ fn onboard_api_key_env_screen_explains_suggested_env_and_blank_behavior() {
 fn onboard_api_key_env_screen_shows_prefilled_env_when_enter_default_is_overridden() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.provider.kind = mvp::config::ProviderKind::Openai;
-    config.provider.api_key_env = Some("OPENAI_API_KEY".to_owned());
+    config.provider.api_key = Some(loongclaw_contracts::SecretRef::Env {
+        env: "OPENAI_API_KEY".to_owned(),
+    });
 
     let lines =
         loongclaw_daemon::onboard_cli::render_api_key_env_selection_screen_lines_with_default(
@@ -6403,7 +6416,9 @@ fn onboard_review_lines_include_core_setup_summary_for_fresh_setup() {
 #[test]
 fn onboard_review_lines_prefer_oauth_env_over_api_key_env_when_both_are_configured() {
     let mut config = mvp::config::LoongClawConfig::default();
-    config.provider.oauth_access_token_env = Some("OPENAI_CODEX_OAUTH_TOKEN".to_owned());
+    config.provider.oauth_access_token = Some(loongclaw_contracts::SecretRef::Env {
+        env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+    });
 
     let lines = loongclaw_daemon::onboard_cli::render_onboard_review_lines_with_guidance(
         &config,
@@ -6772,7 +6787,9 @@ fn onboarding_success_summary_shell_quotes_config_paths_with_single_quotes() {
 fn onboarding_success_summary_prefers_oauth_env_over_api_key_env_when_both_are_configured() {
     let path = PathBuf::from("/tmp/loongclaw-config.toml");
     let mut config = mvp::config::LoongClawConfig::default();
-    config.provider.oauth_access_token_env = Some("OPENAI_CODEX_OAUTH_TOKEN".to_owned());
+    config.provider.oauth_access_token = Some(loongclaw_contracts::SecretRef::Env {
+        env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+    });
 
     let summary =
         loongclaw_daemon::onboard_cli::build_onboarding_success_summary(&path, &config, None);

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -207,7 +207,10 @@ fn import_candidate_with_provider(
     candidate.config.provider.base_url = profile.base_url.to_owned();
     candidate.config.provider.chat_completions_path = profile.chat_completions_path.to_owned();
     candidate.config.provider.model = model.to_owned();
-    candidate.config.provider.api_key_env = Some(credential_env.to_owned());
+    candidate
+        .config
+        .provider
+        .set_api_key_env_binding(Some(credential_env.to_owned()));
     candidate
         .domains
         .push(loongclaw_daemon::migration::types::DomainPreview {
@@ -5096,7 +5099,13 @@ fn onboard_provider_selection_uses_imported_provider_config_for_selected_choice(
 
     assert_eq!(resolved.kind, mvp::config::ProviderKind::Deepseek);
     assert_eq!(resolved.model, "deepseek-chat");
-    assert_eq!(resolved.api_key_env.as_deref(), Some("DEEPSEEK_API_KEY"));
+    assert_eq!(
+        resolved.api_key,
+        Some(loongclaw_contracts::SecretRef::Env {
+            env: "DEEPSEEK_API_KEY".to_owned(),
+        })
+    );
+    assert_eq!(resolved.api_key_env, None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- canonicalize env-backed provider auth into `SecretRef::Env` and stop writing fresh `api_key_env` / `oauth_access_token_env` provider entries
- reject UUID-shaped provider secrets in env-name validation so Volcengine / ARK secrets are not misclassified as environment variable names
- update onboarding, doctor, import, migration, runtime-restore, and docs to prefer `api_key = { env = "..." }`

## Root cause
Compatibility support for legacy provider `*_env` fields was still leaking into new persistence paths. At the same time, env-name validation was permissive enough to accept UUID-shaped credential literals, which let onboarding persist a real secret into `provider.api_key_env` and later treat it as an env var name at runtime.

## Validation
- `cargo test -p loongclaw-app`
- `cargo test -p loongclaw-daemon`
- `cargo fmt --check`
- `git diff --check`

Closes #548


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider credentials now use a canonical env-reference form (api_key = { env = "..." }) and are persisted/printed in that form.

* **Documentation**
  * Updated configuration examples and onboarding guides to show the new provider credential reference format.

* **Bug Fixes**
  * Validation now rejects UUID-shaped credential literals to avoid accidental secret exposure.

* **Chores**
  * Onboarding and import flows updated to migrate legacy env fields into the canonical secret format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->