### PR TITLE
fix(onboard): refresh MiniMax reviewed default to MiniMax-M2.7

### DIFF
--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -2354,7 +2354,7 @@ impl ProviderKind {
         if matches!(self, ProviderKind::Deepseek) {
             Some("deepseek-chat")
         } else if matches!(self, ProviderKind::Minimax) {
-            Some("MiniMax-M2.5")
+            Some("MiniMax-M2.7")
         } else {
             None
         }
@@ -3617,7 +3617,7 @@ api_key_env = "OPENAI_API_KEY"
         );
         assert_eq!(
             ProviderKind::Minimax.recommended_onboarding_model(),
-            Some("MiniMax-M2.5")
+            Some("MiniMax-M2.7")
         );
         assert_eq!(
             ProviderKind::KimiCoding.recommended_onboarding_model(),

--- a/crates/app/src/provider/model_candidate_resolver_runtime.rs
+++ b/crates/app/src/provider/model_candidate_resolver_runtime.rs
@@ -176,16 +176,16 @@ mod tests {
             kind: ProviderKind::Minimax,
             model: "auto".to_owned(),
             preferred_models: vec![
-                "MiniMax-M1".to_owned(),
-                "MiniMax-M1".to_owned(),
-                "MiniMax-Text-01".to_owned(),
+                "MiniMax-M2.5".to_owned(),
+                "MiniMax-M2.5".to_owned(),
+                "MiniMax-M2.7-highspeed".to_owned(),
             ],
             ..ProviderConfig::default()
         };
 
         assert_eq!(
             preferred_model_fallback_candidates(&provider),
-            vec!["MiniMax-M1", "MiniMax-Text-01"],
+            vec!["MiniMax-M2.5", "MiniMax-M2.7-highspeed"],
         );
     }
 
@@ -193,8 +193,11 @@ mod tests {
     fn preferred_model_fallback_candidates_ignore_explicit_model() {
         let provider = ProviderConfig {
             kind: ProviderKind::Minimax,
-            model: "MiniMax-M1".to_owned(),
-            preferred_models: vec!["MiniMax-M1".to_owned(), "MiniMax-Text-01".to_owned()],
+            model: "MiniMax-M2.5".to_owned(),
+            preferred_models: vec![
+                "MiniMax-M2.5".to_owned(),
+                "MiniMax-M2.7-highspeed".to_owned(),
+            ],
             ..ProviderConfig::default()
         };
 

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -1246,7 +1246,7 @@ mod tests {
             &provider,
             ProviderFailoverReason::AuthRejected,
             401,
-            "MiniMax-M2.5",
+            "MiniMax-M2.7",
             1,
             3,
             &json!({

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -2251,7 +2251,7 @@ mod tests {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
-        config.provider.preferred_models = vec!["MiniMax-M1".to_owned()];
+        config.provider.preferred_models = vec!["MiniMax-M2.5".to_owned()];
 
         let check = provider_model_probe_failure_check(
             &config,
@@ -2265,7 +2265,7 @@ mod tests {
             "doctor should only advertise fallback continuation for explicitly configured preferred models: {check:#?}"
         );
         assert!(
-            check.detail.contains("MiniMax-M1"),
+            check.detail.contains("MiniMax-M2.5"),
             "doctor warning should surface the fallback candidate to keep remediation concrete: {check:#?}"
         );
     }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -6580,9 +6580,9 @@ mod tests {
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
         config.provider.preferred_models = vec![
-            "MiniMax-M1".to_owned(),
-            "MiniMax-M1".to_owned(),
-            "MiniMax-Text-01".to_owned(),
+            "MiniMax-M2.5".to_owned(),
+            "MiniMax-M2.5".to_owned(),
+            "MiniMax-M2.7-highspeed".to_owned(),
         ];
 
         let check = provider_model_probe_failure_check(
@@ -6597,7 +6597,7 @@ mod tests {
             "onboarding should only advertise fallback continuation for explicitly configured preferred models: {check:#?}"
         );
         assert!(
-            check.detail.contains("MiniMax-M1"),
+            check.detail.contains("MiniMax-M2.5"),
             "onboard warning should surface the first fallback model to keep the first-run path actionable: {check:#?}"
         );
     }
@@ -6702,7 +6702,7 @@ mod tests {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
-        config.provider.preferred_models = vec!["MiniMax-M1".to_owned()];
+        config.provider.preferred_models = vec!["MiniMax-M2.5".to_owned()];
         let check = provider_model_probe_failure_check(
             &config,
             "provider rejected the model list".to_owned(),
@@ -7840,7 +7840,7 @@ mod tests {
         .expect("resolve model selection");
 
         assert!(
-            selected == "MiniMax-M2.5",
+            selected == "MiniMax-M2.7",
             "interactive onboarding should prefill the provider-recommended explicit model for MiniMax instead of leaving the operator on hidden runtime fallbacks: {selected:?}"
         );
     }
@@ -7878,7 +7878,7 @@ mod tests {
         .expect("resolve model selection");
 
         assert!(
-            selected == "MiniMax-M2.5",
+            selected == "MiniMax-M2.7",
             "non-interactive onboarding should use the reviewed provider default for MiniMax instead of carrying auto into preflight: {selected:?}"
         );
     }
@@ -8930,15 +8930,15 @@ mod tests {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
-        config.provider.preferred_models = vec!["MiniMax-M1".to_owned()];
+        config.provider.preferred_models = vec!["MiniMax-M2.5".to_owned()];
 
-        let lines = render_model_selection_screen_lines_with_default(&config, "MiniMax-M2.5", 80);
+        let lines = render_model_selection_screen_lines_with_default(&config, "MiniMax-M2.7", 80);
         let rendered = lines.join("\n");
 
         assert!(
             rendered.contains("type `auto`")
                 && rendered.contains("configured preferred fallbacks first")
-                && rendered.contains("MiniMax-M1"),
+                && rendered.contains("MiniMax-M2.5"),
             "explicit prefill flows should tell users to type `auto` when they want configured fallback behavior: {lines:#?}"
         );
         assert!(

--- a/crates/daemon/src/onboarding_model_policy.rs
+++ b/crates/daemon/src/onboarding_model_policy.rs
@@ -181,7 +181,7 @@ mod tests {
         let prompt_default = resolve_onboarding_model_prompt_default(&config.provider, None)
             .expect("resolve prompt default");
 
-        assert_eq!(prompt_default, "MiniMax-M2.5");
+        assert_eq!(prompt_default, "MiniMax-M2.7");
     }
 
     #[test]
@@ -201,13 +201,13 @@ mod tests {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;
         config.provider.model = "auto".to_owned();
-        config.provider.preferred_models = vec!["MiniMax-M1".to_owned()];
+        config.provider.preferred_models = vec!["MiniMax-M2.5".to_owned()];
 
         let context = onboarding_model_selection_context(&config.provider);
 
         assert_eq!(context.current_model, "auto");
-        assert_eq!(context.recommended_model, Some("MiniMax-M2.5".to_owned()));
-        assert_eq!(context.preferred_fallback_models, vec!["MiniMax-M1"]);
+        assert_eq!(context.recommended_model, Some("MiniMax-M2.7".to_owned()));
+        assert_eq!(context.preferred_fallback_models, vec!["MiniMax-M2.5"]);
         assert!(context.allows_auto_fallback_hint);
     }
 


### PR DESCRIPTION
## Summary

- refresh the reviewed MiniMax onboarding default from `MiniMax-M2.5` to `MiniMax-M2.7`
- align directly coupled onboarding, doctor, and policy tests with the refreshed reviewed default
- replace outdated MiniMax fallback examples in touched tests with currently documented MiniMax ids

## Why

MiniMax now leads with the M2.7 family in its current model surface, but LoongClaw still seeds `MiniMax-M2.5` as the reviewed onboarding default for `provider = minimax`.

That drift means fresh onboarding can write an outdated explicit model and the surrounding tests continue to encode stale provider guidance.

## What Changed

- updated `ProviderKind::Minimax.recommended_onboarding_model()` to return `MiniMax-M2.7`
- updated onboarding and policy expectations that assert the reviewed MiniMax default
- refreshed touched fallback examples from older ids like `MiniMax-M1` / `MiniMax-Text-01` to `MiniMax-M2.5` and `MiniMax-M2.7-highspeed`
- kept historical dated plan docs unchanged so they continue to reflect the earlier decision as historical record rather than current product behavior

## Linked Issues

- Closes #554

## Validation

```text
cargo fmt --all -- --check
cargo test -p loongclaw-app --locked
cargo test -p loongclaw-daemon --locked -- --test-threads=1
```

Result:
- cargo fmt passed
- loongclaw-app tests passed
- loongclaw-daemon tests passed

## Scope Boundary

- no runtime fallback-policy expansion beyond refreshing the reviewed MiniMax default and the test fixtures directly coupled to it
- no historical plan-doc rewrites in this PR
