### PR TITLE
refactor(conversation): keep app tool paths binding-first

### DIFF
--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -2706,7 +2706,6 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     let mut current_continue_phase = continue_phase.clone();
     let mut remaining_provider_rounds = remaining_provider_rounds.max(1);
     let mut provider_round_index = 0usize;
-    let kernel_ctx = binding.kernel_context();
 
     loop {
         if current_continue_phase
@@ -2728,7 +2727,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                         &current_preparation.session.messages,
                     ),
                 }),
-                kernel_ctx,
+                binding,
             )
             .await;
         }
@@ -2850,7 +2849,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                             "followup_estimated_tokens": followup_estimated_tokens,
                             "followup_added_estimated_tokens": followup_added_estimated_tokens,
                         }),
-                        kernel_ctx,
+                        binding,
                     )
                     .await;
                     match decide_provider_turn_request_action(
@@ -2888,7 +2887,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                         .lane_execution
                                         .raw_tool_output_requested,
                                 }),
-                                kernel_ctx,
+                                binding,
                             )
                             .await;
                             if let Some(reply) = turn_loop_state
@@ -2933,7 +2932,7 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                         .lane_execution
                                         .raw_tool_output_requested,
                                 }),
-                                kernel_ctx,
+                                binding,
                             )
                             .await;
                             let checkpoint = current_continue_phase.checkpoint(
@@ -3141,11 +3140,10 @@ async fn emit_discovery_first_event<R: ConversationRuntime + ?Sized>(
     session_id: &str,
     event_name: &str,
     payload: Value,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
 ) {
-    let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
     let _ = persist_conversation_event(runtime, session_id, event_name, payload, binding).await;
-    if let Some(ctx) = kernel_ctx {
+    if let Some(ctx) = binding.kernel_context() {
         let _ = ctx.kernel.record_audit_event(
             Some(ctx.agent_id()),
             AuditEventKind::PlaneInvoked {
@@ -4122,8 +4120,20 @@ where
         descriptor: &crate::tools::ToolDescriptor,
         kernel_ctx: Option<&KernelContext>,
     ) -> Result<Option<super::turn_engine::ApprovalRequirement>, String> {
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
+        self.maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
+            .await
+    }
+
+    async fn maybe_require_approval_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<Option<super::turn_engine::ApprovalRequirement>, String> {
         self.fallback
-            .maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
+            .maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
             .await
     }
 
@@ -5454,7 +5464,7 @@ async fn evaluate_safe_lane_round(
         turn.tool_intents.as_slice(),
         session_context,
         app_dispatcher,
-        binding.kernel_context(),
+        binding,
         ingress,
         config.conversation.safe_lane_verify_output_non_empty,
         state.seed_tool_outputs.clone(),
@@ -6623,7 +6633,7 @@ struct SafeLanePlanNodeExecutor<'a> {
     tool_intents: &'a [ToolIntent],
     session_context: &'a SessionContext,
     app_dispatcher: &'a dyn AppToolDispatcher,
-    kernel_ctx: Option<&'a KernelContext>,
+    binding: ConversationRuntimeBinding<'a>,
     ingress: Option<&'a ConversationIngressContext>,
     verify_output_non_empty: bool,
     tool_outputs: Mutex<Vec<String>>,
@@ -6635,7 +6645,7 @@ impl<'a> SafeLanePlanNodeExecutor<'a> {
         tool_intents: &'a [ToolIntent],
         session_context: &'a SessionContext,
         app_dispatcher: &'a dyn AppToolDispatcher,
-        kernel_ctx: Option<&'a KernelContext>,
+        binding: ConversationRuntimeBinding<'a>,
         ingress: Option<&'a ConversationIngressContext>,
         verify_output_non_empty: bool,
         seed_tool_outputs: Vec<String>,
@@ -6645,7 +6655,7 @@ impl<'a> SafeLanePlanNodeExecutor<'a> {
             tool_intents,
             session_context,
             app_dispatcher,
-            kernel_ctx,
+            binding,
             ingress,
             verify_output_non_empty,
             tool_outputs: Mutex::new(seed_tool_outputs),
@@ -6674,7 +6684,7 @@ impl PlanNodeExecutor for SafeLanePlanNodeExecutor<'_> {
                     intent,
                     self.session_context,
                     self.app_dispatcher,
-                    self.kernel_ctx,
+                    self.binding,
                     self.ingress,
                     self.tool_result_payload_summary_limit_chars,
                 )
@@ -6718,7 +6728,7 @@ async fn execute_single_tool_intent(
     intent: &ToolIntent,
     session_context: &SessionContext,
     app_dispatcher: &dyn AppToolDispatcher,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     ingress: Option<&ConversationIngressContext>,
     payload_summary_limit_chars: usize,
 ) -> Result<String, PlanNodeError> {
@@ -6730,13 +6740,7 @@ async fn execute_single_tool_intent(
     };
 
     match engine
-        .execute_turn_in_context(
-            &turn,
-            session_context,
-            app_dispatcher,
-            ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx),
-            ingress,
-        )
+        .execute_turn_in_context(&turn, session_context, app_dispatcher, binding, ingress)
         .await
     {
         TurnResult::FinalText(output) => Ok(output),
@@ -6769,6 +6773,43 @@ mod tests {
     use crate::session::repository::FinalizeSessionTerminalResult;
     use std::path::PathBuf;
     use std::sync::Mutex as StdMutex;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_single_tool_intent_direct_binding_reports_no_kernel_context() {
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "file.read",
+            json!({
+                "path": "README.md",
+            }),
+            Some("root-session"),
+            Some("turn-direct-core"),
+        );
+        let intent = ToolIntent {
+            tool_name,
+            args_json,
+            source: "provider_tool_call".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-direct-core".to_owned(),
+            tool_call_id: "call-direct-core".to_owned(),
+        };
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::planned_root_tool_view(),
+        );
+        let error = execute_single_tool_intent(
+            &intent,
+            &session_context,
+            &crate::conversation::NoopAppToolDispatcher,
+            ConversationRuntimeBinding::direct(),
+            None,
+            2_048,
+        )
+        .await
+        .expect_err("direct core execution should fail closed without kernel context");
+
+        assert_eq!(error.kind, PlanNodeErrorKind::PolicyDenied);
+        assert_eq!(error.message, "no_kernel_context");
+    }
 
     fn unique_sqlite_path(label: &str) -> PathBuf {
         std::env::temp_dir().join(format!(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -268,6 +268,18 @@ pub trait AppToolDispatcher: Send + Sync {
         Ok(None)
     }
 
+    async fn maybe_require_approval_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<Option<ApprovalRequirement>, String> {
+        let kernel_ctx = binding.kernel_context();
+        self.maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
+            .await
+    }
+
     async fn execute_app_tool(
         &self,
         session_context: &SessionContext,
@@ -459,16 +471,29 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
         session_context: &SessionContext,
         intent: &ToolIntent,
         descriptor: &crate::tools::ToolDescriptor,
-        _kernel_ctx: Option<&KernelContext>,
+        kernel_ctx: Option<&KernelContext>,
+    ) -> Result<Option<ApprovalRequirement>, String> {
+        let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
+        self.maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
+            .await
+    }
+
+    async fn maybe_require_approval_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<Option<ApprovalRequirement>, String> {
         #[cfg(not(feature = "memory-sqlite"))]
         {
-            let _ = (session_context, intent, descriptor);
+            let _ = (session_context, intent, descriptor, binding);
             Ok(None)
         }
 
         #[cfg(feature = "memory-sqlite")]
         {
+            let _ = binding;
             let governance = governance_profile_for_descriptor(descriptor);
             if descriptor.execution_kind != ToolExecutionKind::App
                 || governance.approval_mode != ToolApprovalMode::PolicyDriven
@@ -1630,13 +1655,12 @@ impl TurnEngine {
                 }
             }
             ToolExecutionKind::App => {
-                let kernel_ctx = binding.kernel_context();
                 match app_dispatcher
-                    .maybe_require_approval(
+                    .maybe_require_approval_with_binding(
                         session_context,
                         &effective_intent,
                         descriptor,
-                        kernel_ctx,
+                        binding,
                     )
                     .await
                 {


### PR DESCRIPTION
## Summary

- Problem:
  active conversation runtime paths still unpacked `Option<&KernelContext>` after already holding `ConversationRuntimeBinding`, which kept governed and direct execution seams less explicit than the runtime contract claims.
- Why it matters:
  this keeps workstream 2 under `#196` harder to reason about, because app-tool approval, discovery-event persistence, and safe-lane tool execution still re-materialized raw optional kernel authority inside active paths.
- What changed:
  added a binding-first approval hook on `AppToolDispatcher`, switched the active app-tool approval path to use it, carried `ConversationRuntimeBinding` directly through discovery-event emission and safe-lane tool execution, and added a regression test that direct safe-lane execution still fails closed with `no_kernel_context`.
- What did not change (scope boundary):
  this does not attempt repo-wide kernelization, ACP routing redesign, durable audit work, or the broader handle-model replacement tracked elsewhere.

## Linked Issues

- Closes #552
- Related #196

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  this changes governed/direct seam propagation in conversation runtime, so the main risk is accidentally changing approval gating or fail-closed behavior for app-tool execution.
- Rollout / guardrails:
  kept the legacy `Option<&KernelContext>` entrypoints as compatibility shims, limited the active-path rewrite to two conversation files, and added regression coverage for direct safe-lane failure semantics.
- Rollback path:
  revert this PR to restore the pre-existing optional-kernel plumbing.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all -- --check
cargo test -p loongclaw-app execute_single_tool_intent_direct_binding_reports_no_kernel_context -- --test-threads=1
cargo test -p loongclaw-app turn_engine_fails_closed_before -- --test-threads=1
cargo test -p loongclaw-app turn_engine_routes_direct_binding_to_app_dispatcher -- --test-threads=1
cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app --all-features -- --test-threads=1
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked

Result:
- all commands completed successfully
- targeted regression confirms direct safe-lane execution still fails closed without kernel context
- workspace clippy and both workspace test matrices stayed green after the binding-first seam rewrite
```

## User-visible / Operator-visible Changes

- no direct surface change; internally, governed conversation app-tool paths now preserve binding-first semantics instead of unpacking raw optional kernel context mid-flight

## Failure Recovery

- Fast rollback or disable path:
  revert this PR
- Observable failure symptoms reviewers should watch for:
  unexpected `no_kernel_context` denials on governed paths that should still have kernel authority, or missing approval prompts for policy-driven app tools

## Reviewer Focus

- check `turn_engine.rs` app-tool approval preflight to confirm active governed paths now use `ConversationRuntimeBinding` directly
- check `turn_coordinator.rs` discovery-event emission and safe-lane plan execution to confirm legacy raw `kernel_ctx` plumbing is gone from the active path and only remains in compatibility shims
