### PR TITLE
fix(provider): centralize turn streaming capability gating

### DIFF
--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -31,7 +31,7 @@ use crate::acp::{
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 use crate::runtime_self_continuity;
 
-use super::super::config::{LoongClawConfig, ProviderProtocolFamily};
+use super::super::config::LoongClawConfig;
 use super::ConversationSessionAddress;
 use super::ProviderErrorMode;
 use super::analytics::{
@@ -2831,8 +2831,7 @@ fn provider_turn_observer_supports_streaming(
         return false;
     }
 
-    let protocol_family = config.provider.kind.protocol_family();
-    protocol_family == ProviderProtocolFamily::AnthropicMessages
+    crate::provider::supports_turn_streaming_events(config)
 }
 
 async fn request_provider_turn_with_observer<R: ConversationRuntime + ?Sized>(
@@ -7362,6 +7361,88 @@ mod tests {
     }
 
     #[derive(Default)]
+    struct ObserverFallbackRuntime {
+        request_turn_calls: StdMutex<usize>,
+        request_turn_streaming_calls: StdMutex<usize>,
+    }
+
+    #[async_trait]
+    impl ConversationRuntime for ObserverFallbackRuntime {
+        async fn build_messages(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _include_system_prompt: bool,
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<Vec<Value>> {
+            Ok(vec![json!({
+                "role": "system",
+                "content": "stay focused"
+            })])
+        }
+
+        async fn request_completion(
+            &self,
+            _config: &LoongClawConfig,
+            _messages: &[Value],
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<String> {
+            Ok("completion".to_owned())
+        }
+
+        async fn request_turn(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<ProviderTurn> {
+            let mut request_turn_calls = self
+                .request_turn_calls
+                .lock()
+                .expect("request-turn call lock should not be poisoned");
+            *request_turn_calls += 1;
+
+            Ok(ProviderTurn {
+                assistant_text: "final reply".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            })
+        }
+
+        async fn request_turn_streaming(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            _binding: ConversationRuntimeBinding<'_>,
+            _on_token: crate::provider::StreamingTokenCallback,
+        ) -> CliResult<ProviderTurn> {
+            let mut request_turn_streaming_calls = self
+                .request_turn_streaming_calls
+                .lock()
+                .expect("request-turn-streaming call lock should not be poisoned");
+            *request_turn_streaming_calls += 1;
+            panic!("request_turn_streaming should not be called for unsupported transports")
+        }
+
+        async fn persist_turn(
+            &self,
+            _session_id: &str,
+            _role: &str,
+            _content: &str,
+            _binding: ConversationRuntimeBinding<'_>,
+        ) -> CliResult<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
     struct RecordingTurnObserver {
         phase_events: StdMutex<Vec<ConversationTurnPhaseEvent>>,
         tool_events: StdMutex<Vec<ConversationTurnToolEvent>>,
@@ -7453,6 +7534,74 @@ mod tests {
         assert_eq!(token_events.len(), 1);
         assert_eq!(token_events[0].event_type, "text_delta");
         assert_eq!(token_events[0].delta.text.as_deref(), Some("draft"));
+    }
+
+    #[tokio::test]
+    async fn handle_turn_with_observer_falls_back_when_streaming_events_are_unsupported() {
+        let mut config = LoongClawConfig::default();
+        config.provider.kind = crate::config::ProviderKind::Openai;
+
+        let runtime = ObserverFallbackRuntime::default();
+        let observer = Arc::new(RecordingTurnObserver::default());
+        let observer_handle: ConversationTurnObserverHandle = observer.clone();
+        let acp_options = AcpConversationTurnOptions::automatic();
+        let address = ConversationSessionAddress::from_session_id("observer-session");
+        let reply = ConversationTurnCoordinator::new()
+            .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+                &config,
+                &address,
+                "say hello",
+                ProviderErrorMode::Propagate,
+                &runtime,
+                &acp_options,
+                ConversationRuntimeBinding::direct(),
+                None,
+                Some(observer_handle),
+            )
+            .await
+            .expect("observer turn should succeed");
+
+        assert_eq!(reply, "final reply");
+
+        let request_turn_calls = runtime
+            .request_turn_calls
+            .lock()
+            .expect("request-turn call lock should not be poisoned");
+        assert_eq!(*request_turn_calls, 1);
+
+        let request_turn_streaming_calls = runtime
+            .request_turn_streaming_calls
+            .lock()
+            .expect("request-turn-streaming call lock should not be poisoned");
+        assert_eq!(*request_turn_streaming_calls, 0);
+
+        let phase_events = observer
+            .phase_events
+            .lock()
+            .expect("phase event lock should not be poisoned");
+        let phase_names = phase_events
+            .iter()
+            .map(|event| event.phase)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            phase_names,
+            vec![
+                ConversationTurnPhase::Preparing,
+                ConversationTurnPhase::ContextReady,
+                ConversationTurnPhase::RequestingProvider,
+                ConversationTurnPhase::FinalizingReply,
+                ConversationTurnPhase::Completed,
+            ]
+        );
+
+        let token_events = observer
+            .token_events
+            .lock()
+            .expect("token event lock should not be poisoned");
+        assert!(
+            token_events.is_empty(),
+            "unsupported transports should not emit streaming token events: {token_events:#?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -6,7 +6,6 @@ use serde_json::{Value, json};
 
 use crate::CliResult;
 use crate::acp::{AcpTurnEventSink, JsonlAcpTurnEventSink};
-use crate::config::ProviderProtocolFamily;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
 use super::super::config::LoongClawConfig;
@@ -131,8 +130,7 @@ impl ConversationTurnLoop {
         );
 
         for round_index in 0..policy.max_rounds {
-            let use_streaming =
-                config.provider.kind.protocol_family() == ProviderProtocolFamily::AnthropicMessages;
+            let use_streaming = crate::provider::supports_turn_streaming_events(config);
             let on_token: crate::provider::StreamingTokenCallback = if use_streaming {
                 let sink = JsonlAcpTurnEventSink::stderr_with_prefix("");
                 Some(Arc::new(

--- a/crates/app/src/provider/contracts.rs
+++ b/crates/app/src/provider/contracts.rs
@@ -59,6 +59,10 @@ impl ProviderTransportMode {
             }
         }
     }
+
+    pub(super) fn supports_turn_streaming_events(self) -> bool {
+        matches!(self, Self::AnthropicMessages)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -149,6 +153,12 @@ pub(super) struct ProviderRuntimeContract {
     pub(super) validation: ProviderValidationContract,
     pub(super) error_classification: ProviderErrorClassificationContract,
     pub(super) capability: ProviderCapabilityContract,
+}
+
+impl ProviderRuntimeContract {
+    pub(super) fn supports_turn_streaming_events(self) -> bool {
+        self.transport_mode.supports_turn_streaming_events()
+    }
 }
 
 pub(super) fn provider_runtime_contract(provider: &ProviderConfig) -> ProviderRuntimeContract {

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -69,6 +69,9 @@ use catalog_runtime::{ModelCatalogCacheLookup, fetch_model_catalog_singleflight}
 #[cfg(test)]
 use contracts::ProviderApiError;
 #[cfg(test)]
+use contracts::ProviderFeatureFamily;
+use contracts::provider_runtime_contract;
+#[cfg(test)]
 use contracts::should_disable_tool_schema_for_error;
 #[cfg(test)]
 use contracts::{CompletionPayloadMode, ReasoningField, TemperatureField, TokenLimitField};
@@ -77,8 +80,6 @@ use contracts::{
     PayloadAdaptationAxis, ProviderReasoningExtraBodyMode, ProviderToolSchemaMode,
     ProviderTransportMode,
 };
-#[cfg(test)]
-use contracts::{ProviderFeatureFamily, provider_runtime_contract};
 #[cfg(test)]
 use contracts::{adapt_payload_mode_for_error, parse_provider_api_error};
 #[cfg(test)]
@@ -284,6 +285,11 @@ pub async fn request_turn_streaming(
     .await
 }
 
+pub fn supports_turn_streaming_events(config: &LoongClawConfig) -> bool {
+    let runtime_contract = provider_runtime_contract(&config.provider);
+    runtime_contract.supports_turn_streaming_events()
+}
+
 pub async fn request_turn_streaming_in_view(
     config: &LoongClawConfig,
     session_id: &str,
@@ -293,6 +299,10 @@ pub async fn request_turn_streaming_in_view(
     binding: ProviderRuntimeBinding<'_>,
     on_token: crate::provider::request_executor::StreamingTokenCallback,
 ) -> CliResult<crate::conversation::turn_engine::ProviderTurn> {
+    if !supports_turn_streaming_events(config) {
+        return Err("provider transport does not support live turn streaming events".to_owned());
+    }
+
     let session = prepare_provider_request_session(config).await?;
     let tool_runtime_config =
         crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None);

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -285,7 +285,7 @@ pub async fn request_turn_streaming(
     .await
 }
 
-pub fn supports_turn_streaming_events(config: &LoongClawConfig) -> bool {
+pub(crate) fn supports_turn_streaming_events(config: &LoongClawConfig) -> bool {
     let runtime_contract = provider_runtime_contract(&config.provider);
     runtime_contract.supports_turn_streaming_events()
 }

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -1738,6 +1738,7 @@ fn provider_runtime_contract_defaults_are_stable() {
         openai_contract.transport_mode,
         ProviderTransportMode::OpenAiChatCompletions
     );
+    assert!(!openai_contract.supports_turn_streaming_events());
     assert_eq!(
         openai_contract.profile_health_mode,
         ProviderProfileHealthMode::EnforceUnusableWindows
@@ -1797,10 +1798,22 @@ fn provider_runtime_contract_defaults_are_stable() {
         anthropic_contract.transport_mode,
         ProviderTransportMode::AnthropicMessages
     );
+    assert!(anthropic_contract.supports_turn_streaming_events());
     assert_eq!(
         anthropic_contract.default_reasoning_field,
         ReasoningField::Omit
     );
+
+    let responses_contract = provider_runtime_contract(&ProviderConfig {
+        kind: ProviderKind::Openai,
+        wire_api: crate::config::ProviderWireApi::Responses,
+        ..ProviderConfig::default()
+    });
+    assert_eq!(
+        responses_contract.transport_mode,
+        ProviderTransportMode::Responses
+    );
+    assert!(!responses_contract.supports_turn_streaming_events());
 
     let bedrock_contract = provider_runtime_contract(&ProviderConfig {
         kind: ProviderKind::Bedrock,
@@ -1814,6 +1827,7 @@ fn provider_runtime_contract_defaults_are_stable() {
         bedrock_contract.transport_mode,
         ProviderTransportMode::BedrockConverse
     );
+    assert!(!bedrock_contract.supports_turn_streaming_events());
     assert_eq!(
         bedrock_contract.default_reasoning_field,
         ReasoningField::Omit
@@ -1846,6 +1860,7 @@ fn provider_runtime_contract_defaults_are_stable() {
         kimi_coding_contract.transport_mode,
         ProviderTransportMode::KimiApi
     );
+    assert!(!kimi_coding_contract.supports_turn_streaming_events());
     assert!(!kimi_coding_contract.validation.forbid_kimi_coding_endpoint);
     assert!(
         kimi_coding_contract
@@ -1918,6 +1933,35 @@ fn provider_runtime_contract_defaults_are_stable() {
     assert_eq!(
         openai_observe_only_contract.profile_health_mode,
         ProviderProfileHealthMode::ObserveOnly
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn request_turn_streaming_rejects_unsupported_transport_modes() {
+    let config = test_config(ProviderConfig {
+        kind: ProviderKind::Openai,
+        ..ProviderConfig::default()
+    });
+
+    assert!(!supports_turn_streaming_events(&config));
+
+    let error = request_turn_streaming(
+        &config,
+        "session-provider-test",
+        "turn-provider-test",
+        &[json!({
+            "role": "user",
+            "content": "turn ping"
+        })],
+        ProviderRuntimeBinding::direct(),
+        None,
+    )
+    .await
+    .expect_err("unsupported transports should be rejected before any request is prepared");
+
+    assert!(
+        error.contains("does not support live turn streaming events"),
+        "the provider error should explain the unsupported transport: {error}"
     );
 }
 

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-25T04:00:09Z
+- Generated at: 2026-03-25T10:22:04Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -13,7 +13,7 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
 | spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
-| provider_mod | `crates/app/src/provider/mod.rs` | 365 | 1000 | 635 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
+| provider_mod | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
 ## Boundary Checks
@@ -41,7 +41,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
 <!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
-<!-- arch-hotspot key=provider_mod lines=365 functions=10 -->
+<!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: turn streaming eligibility lived in duplicated conversation-layer checks, while the provider streaming executor still parsed Anthropic-specific event shapes.
- Why it matters: that split ownership makes the live chat surface harder to evolve safely and leaves the provider streaming entry point without a transport capability guard.
- What changed: centralized turn streaming capability detection in the provider runtime contract, reused that helper from both conversation call sites, and rejected unsupported transports early at the provider streaming entry point. Added regression coverage for transport support and observer fallback behavior.
- What did not change (scope boundary): this does not expand streaming support to new providers or change the current Anthropic-shaped streaming parser.

## Linked Issues

- Closes #557
- Related #531

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app --lib provider::tests::request_turn_streaming_rejects_unsupported_transport_modes
cargo test -p loongclaw-app --lib conversation::turn_coordinator::tests::handle_turn_with_observer_falls_back_when_streaming_events_are_unsupported
cargo test -p loongclaw-app --lib
cargo test --workspace --locked
cargo test --workspace --all-features --locked

Result summary:
- Provider contract now owns turn streaming support decisions.
- Unsupported transports fail early at the provider streaming entry point.
- Observer-backed turns still stream on Anthropic transports and cleanly fall back on unsupported transports.
```

## User-visible / Operator-visible Changes

- Observer-backed and live-surface turn streaming now follows a provider-owned capability check instead of duplicated protocol-family checks.
- Unsupported transports no longer have a silent path toward the Anthropic-only streaming executor.

## Failure Recovery

- Fast rollback or disable path: revert commit `3c6bfa6` or fall back to the existing non-streaming turn request path.
- Observable failure symptoms reviewers should watch for: non-Anthropic providers should not emit live streaming token events; Anthropic providers should still emit them.

## Reviewer Focus

- `crates/app/src/provider/contracts.rs`: confirm the transport capability stays narrowly scoped to current parser support.
- `crates/app/src/provider/mod.rs`: confirm unsupported transports are rejected before any provider session/request preparation.
- `crates/app/src/conversation/turn_loop.rs` and `crates/app/src/conversation/turn_coordinator.rs`: confirm both callers now consume the shared provider helper and no protocol-family hardcoding remains.
- `crates/app/src/provider/tests.rs` and `crates/app/src/conversation/turn_coordinator.rs`: confirm regression coverage locks both the capability boundary and observer fallback behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback behavior when observers are present and the provider does not support streaming, ensuring non-streaming responses are used and no streaming tokens are emitted.
  * request_turn_streaming now fails early with a clear error when the selected provider transport does not support live turn streaming events.

* **Tests**
  * Added tests verifying fallback behavior, that streaming is never invoked for unsupported providers, and transport-mode compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->