### PR TITLE
feat(spec): inject explicit plugin setup readiness context

### DIFF
--- a/crates/bench/tests/bench_integration.rs
+++ b/crates/bench/tests/bench_integration.rs
@@ -57,6 +57,7 @@ async fn run_spec_pressure_once_rejects_native_claw_migrate_scenarios() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
             tool_name: "claw.migrate".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -105,6 +106,7 @@ async fn run_spec_pressure_once_uses_native_executor_when_present() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
             tool_name: "claw.migrate".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -155,6 +157,7 @@ async fn run_spec_pressure_once_errors_when_executor_declines_native_request() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
             tool_name: "claw.migrate".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -208,6 +211,7 @@ fn spec_requires_native_tool_executor_detects_claw_migration_extension() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolExtension {
             extension_action: "plan".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),

--- a/crates/daemon/tests/integration/architecture.rs
+++ b/crates/daemon/tests/integration/architecture.rs
@@ -43,6 +43,7 @@ async fn execute_spec_allows_execution_with_clean_architecture_guard() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-guard-clean".to_owned(),
             objective: "run with clean guard".to_owned(),
@@ -111,6 +112,7 @@ async fn execute_spec_blocks_when_architecture_guard_detects_core_mutation() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-guard".to_owned(),
             objective: "should not run".to_owned(),

--- a/crates/daemon/tests/integration/programmatic.rs
+++ b/crates/daemon/tests/integration/programmatic.rs
@@ -28,6 +28,7 @@ async fn execute_spec_programmatic_tool_call_supports_templates_and_steps() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-alpha".to_owned(),
             max_calls: 3,
@@ -115,6 +116,7 @@ async fn execute_spec_programmatic_tool_call_enforces_max_call_budget() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-beta".to_owned(),
             max_calls: 1,
@@ -237,6 +239,7 @@ async fn execute_spec_programmatic_tool_call_blocks_when_caller_not_allowlisted(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-denied".to_owned(),
             max_calls: 2,
@@ -301,6 +304,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_parallel_succeeds()
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-batch".to_owned(),
             max_calls: 4,
@@ -394,6 +398,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_continue_on_error()
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-batch-errors".to_owned(),
             max_calls: 5,
@@ -502,6 +507,7 @@ async fn execute_spec_programmatic_tool_call_conditional_step_routes_branch() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-conditional".to_owned(),
             max_calls: 2,
@@ -589,6 +595,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_budget_checks_total
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-batch-budget".to_owned(),
             max_calls: 1,
@@ -679,6 +686,7 @@ async fn execute_spec_programmatic_tool_call_retry_recovers_transient_failure() 
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-retry".to_owned(),
             max_calls: 2,
@@ -754,6 +762,7 @@ async fn execute_spec_programmatic_tool_call_applies_connector_rate_limits() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-rate".to_owned(),
             max_calls: 2,
@@ -835,6 +844,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_rate_limit_policy()
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-rate-invalid".to_owned(),
             max_calls: 1,
@@ -911,6 +921,7 @@ async fn execute_spec_programmatic_tool_call_circuit_breaker_blocks_followup_bat
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-circuit-open".to_owned(),
             max_calls: 2,
@@ -1017,6 +1028,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_circuit_policy() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-circuit-invalid".to_owned(),
             max_calls: 1,
@@ -1098,6 +1110,7 @@ async fn execute_spec_programmatic_tool_call_retry_jitter_tracks_backoff_budget(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-retry-jitter".to_owned(),
             max_calls: 1,
@@ -1180,6 +1193,7 @@ async fn execute_spec_programmatic_tool_call_parallel_batch_caps_peak_inflight_b
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-concurrency-cap".to_owned(),
             max_calls: 6,
@@ -1304,6 +1318,7 @@ async fn execute_spec_programmatic_tool_call_weighted_fairness_avoids_low_priori
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-fairness".to_owned(),
             max_calls: 8,
@@ -1431,6 +1446,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_budget_reduces_on_failures
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-adaptive-budget".to_owned(),
             max_calls: 8,
@@ -1565,6 +1581,7 @@ async fn execute_spec_programmatic_tool_call_default_adaptive_policy_skips_not_f
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-adaptive-skip-not-found".to_owned(),
             max_calls: 6,
@@ -1678,6 +1695,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_policy_can_reduce_on_any_e
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-adaptive-any-error".to_owned(),
             max_calls: 6,
@@ -1794,6 +1812,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_concurrency_policy(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-concurrency-invalid".to_owned(),
             max_calls: 1,
@@ -1869,6 +1888,7 @@ async fn execute_spec_programmatic_tool_call_rejects_empty_adaptive_reduce_on_po
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-concurrency-empty-reduce-on".to_owned(),
             max_calls: 1,
@@ -2015,6 +2035,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_budget_respects_min_floor_
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-adaptive-floor-recover".to_owned(),
             max_calls: 8,

--- a/crates/daemon/tests/integration/spec_runtime.rs
+++ b/crates/daemon/tests/integration/spec_runtime.rs
@@ -6,6 +6,11 @@ fn template_spec_is_json_roundtrip_stable() {
     let encoded = serde_json::to_string_pretty(&spec).expect("encode spec");
     let decoded: RunnerSpec = serde_json::from_str(&encoded).expect("decode spec");
     assert_eq!(decoded.pack.pack_id, "sales-intel-local");
+    let readiness = decoded
+        .plugin_setup_readiness
+        .expect("template should expose plugin setup readiness shape");
+    assert!(readiness.inherit_process_env);
+    assert!(!readiness.config_keys_verified);
     assert!(matches!(
         decoded.operation,
         OperationSpec::RuntimeExtension { .. }
@@ -19,6 +24,7 @@ fn runtime_extension_fixture_uses_backward_compatible_spec_defaults() {
     let parsed: RunnerSpec = serde_json::from_str(&raw)
         .expect("runtime-extension fixture should parse when hotfixes is omitted");
     assert!(parsed.hotfixes.is_empty());
+    assert!(parsed.plugin_setup_readiness.is_none());
 }
 
 #[tokio::test]
@@ -46,6 +52,7 @@ async fn execute_spec_returns_blocked_instead_of_panicking_on_operation_error() 
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "non-existent".to_owned(),
             operation: "notify".to_owned(),
@@ -236,6 +243,7 @@ fn security_scan_profile_path_overrides_bundled_defaults() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-profile-path".to_owned(),
             objective: "verify profile loading".to_owned(),
@@ -344,6 +352,7 @@ fn security_scan_profile_sha256_pin_accepts_matching_profile() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-profile-pin".to_owned(),
             objective: "verify profile sha pin".to_owned(),
@@ -444,6 +453,7 @@ async fn execute_spec_blocks_when_security_scan_profile_sha256_mismatches() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-profile-mismatch".to_owned(),
             objective: "mismatch pin should block".to_owned(),
@@ -552,6 +562,7 @@ fn security_scan_profile_signature_accepts_matching_signature() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-signature-pin".to_owned(),
             objective: "verify profile signature pin".to_owned(),
@@ -665,6 +676,7 @@ async fn execute_spec_blocks_when_security_scan_profile_signature_mismatches() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-signature-mismatch".to_owned(),
             objective: "signature mismatch should block".to_owned(),
@@ -713,6 +725,7 @@ async fn execute_spec_runs_runtime_extension_and_captures_audit() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::RuntimeExtension {
             action: "start".to_owned(),
             required_capabilities: BTreeSet::from([Capability::ObserveTelemetry]),
@@ -770,6 +783,7 @@ async fn execute_spec_auto_provisions_provider_and_channel_when_missing() {
             required_capabilities: BTreeSet::from([Capability::InvokeConnector]),
         }),
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "openrouter".to_owned(),
             operation: "chat".to_owned(),
@@ -825,6 +839,7 @@ async fn execute_spec_applies_hotfix_endpoint_before_invocation() {
             channel_id: "alerts".to_owned(),
             new_endpoint: "https://hooks.slack.com/services/new".to_owned(),
         }],
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "slack".to_owned(),
             operation: "notify".to_owned(),
@@ -897,6 +912,7 @@ async fn execute_spec_scans_plugin_files_and_absorbs_them_for_hotplug() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "openrouter".to_owned(),
             operation: "chat".to_owned(),
@@ -994,6 +1010,7 @@ async fn execute_spec_blocks_when_bridge_matrix_does_not_support_plugin() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "openrouter".to_owned(),
             operation: "chat".to_owned(),
@@ -1105,6 +1122,7 @@ async fn execute_spec_skips_blocked_plugins_when_bridge_enforcement_is_disabled(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "webhookx".to_owned(),
             operation: "notify".to_owned(),
@@ -1228,6 +1246,7 @@ async fn execute_spec_bootstrap_applies_only_bridges_allowed_by_bootstrap_policy
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-provider".to_owned(),
             operation: "notify".to_owned(),
@@ -1344,6 +1363,7 @@ async fn execute_spec_bootstrap_enforcement_blocks_when_ready_plugins_are_deferr
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bootstrap-enforce".to_owned(),
             objective: "must be blocked by bootstrap enforcement".to_owned(),
@@ -1415,6 +1435,7 @@ async fn execute_spec_blocks_on_bridge_support_checksum_mismatch() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bridge-checksum".to_owned(),
             objective: "should be blocked before execution".to_owned(),
@@ -1477,6 +1498,7 @@ async fn execute_spec_blocks_on_bridge_support_sha256_mismatch() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bridge-sha256".to_owned(),
             objective: "should be blocked before execution".to_owned(),
@@ -1538,6 +1560,7 @@ async fn execute_spec_allows_execution_when_bridge_support_sha256_matches() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bridge-sha256-match".to_owned(),
             objective: "should pass".to_owned(),
@@ -1636,6 +1659,7 @@ async fn execute_spec_enriches_plugin_bridge_metadata_and_emits_bridge_execution
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "ffi-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -1779,6 +1803,7 @@ async fn execute_spec_wasm_component_bridge_executes_when_runtime_enabled() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2009,6 +2034,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_component_sha256_mismatc
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-hash-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2147,6 +2173,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_metadata_pin_conflicts_w
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-pin-conflict-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2281,6 +2308,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_hash_pin_required_but_mi
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-pin-required-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2420,6 +2448,7 @@ async fn execute_spec_wasm_component_bridge_blocks_artifact_outside_runtime_pref
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-path-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2563,6 +2592,7 @@ async fn execute_spec_wasm_component_bridge_blocks_symlink_escape_under_allowed_
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-symlink-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2697,6 +2727,7 @@ async fn execute_spec_wasm_component_bridge_blocks_non_regular_artifact_path() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-regular-file-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2832,6 +2863,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_module_size_exceeds_runt
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-size-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2924,6 +2956,7 @@ async fn execute_spec_blocks_when_wasm_runtime_enabled_without_allowed_prefixes(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-wasm-runtime-invalid-policy".to_owned(),
             objective: "runtime policy should fail closed".to_owned(),
@@ -3052,6 +3085,7 @@ async fn execute_spec_security_scan_blocks_wasm_plugin_with_wasi_import() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-block".to_owned(),
             objective: "security scan should block risky wasm".to_owned(),
@@ -3201,6 +3235,7 @@ async fn execute_spec_security_scan_allows_clean_wasm_with_hash_pin() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-pass".to_owned(),
             objective: "security scan should allow clean wasm".to_owned(),
@@ -3332,6 +3367,7 @@ async fn execute_spec_security_scan_allows_clean_wasm_with_metadata_hash_pin() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-pass-metadata".to_owned(),
             objective: "security scan should accept metadata hash pin".to_owned(),
@@ -3468,6 +3504,7 @@ async fn execute_spec_security_scan_blocks_when_metadata_hash_pin_is_invalid() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-invalid-pin".to_owned(),
             objective: "security scan should block invalid metadata hash pin".to_owned(),
@@ -3601,6 +3638,7 @@ async fn execute_spec_security_scan_blocks_when_metadata_pin_conflicts_with_poli
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-pin-conflict".to_owned(),
             objective: "security scan should block conflicting wasm hash pins".to_owned(),
@@ -3725,6 +3763,7 @@ async fn execute_spec_security_scan_emits_audit_summary_when_not_blocking() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-audit-pass".to_owned(),
             objective: "security scan should emit audit summary".to_owned(),
@@ -3882,6 +3921,7 @@ async fn execute_spec_security_scan_exports_siem_record_with_truncation() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-siem-pass".to_owned(),
             objective: "security scan should export siem record".to_owned(),
@@ -4025,6 +4065,7 @@ async fn execute_spec_security_scan_siem_fail_closed_blocks_execution() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-siem-block".to_owned(),
             objective: "siem fail closed should block".to_owned(),
@@ -4175,6 +4216,7 @@ async fn execute_spec_security_scan_covers_deferred_plugins_not_only_applied_sub
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-deferred-ready".to_owned(),
             objective: "security scan must inspect deferred ready plugins".to_owned(),
@@ -4234,6 +4276,7 @@ async fn execute_spec_default_medium_policy_blocks_high_risk_tool_call_without_a
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4285,6 +4328,7 @@ async fn execute_spec_per_call_approval_allows_high_risk_tool_call() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4330,6 +4374,7 @@ async fn execute_spec_one_time_full_access_allows_high_risk_tool_call() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4374,6 +4419,7 @@ async fn execute_spec_strict_mode_requires_approval_for_low_risk_tool_call() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "read-schema".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4413,6 +4459,7 @@ async fn execute_spec_default_medium_policy_allows_low_risk_tool_call_without_ap
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "list-schema".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4489,6 +4536,7 @@ async fn execute_spec_tool_core_can_run_claw_migrate_plan_via_native_tool_runtim
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "claw.migrate".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4575,6 +4623,7 @@ async fn execute_spec_tool_extension_can_hot_handle_claw_migrate_via_core_wrappe
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolExtension {
             extension_action: "plan".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4678,6 +4727,7 @@ async fn execute_spec_tool_extension_can_discover_multiple_sources() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolExtension {
             extension_action: "discover".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4776,6 +4826,7 @@ async fn execute_spec_tool_extension_can_merge_profiles_without_merging_prompt_l
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolExtension {
             extension_action: "merge_profiles".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4880,6 +4931,7 @@ async fn execute_spec_tool_extension_apply_selected_safe_merge_keeps_native_prom
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolExtension {
             extension_action: "apply_selected".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4956,6 +5008,7 @@ async fn execute_spec_denylist_overrides_other_approvals() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -5009,6 +5062,7 @@ async fn execute_spec_one_time_full_access_expired_is_rejected() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -5054,6 +5108,7 @@ async fn execute_spec_one_time_full_access_with_zero_remaining_uses_is_rejected(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -5170,6 +5225,7 @@ async fn execute_spec_bootstrap_max_tasks_limits_applied_plugins() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bootstrap-limit".to_owned(),
             objective: "run regardless of selective bootstrap".to_owned(),
@@ -5292,6 +5348,7 @@ async fn execute_spec_scans_multiple_roots_and_absorbs_per_root() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-multi-root".to_owned(),
             objective: "validate multi-root scan".to_owned(),
@@ -5407,6 +5464,7 @@ async fn execute_spec_plugin_scan_is_transactional_when_blocked() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-plugin-rollback".to_owned(),
             objective: "must block and rollback staged plugin absorb".to_owned(),
@@ -5504,6 +5562,7 @@ async fn execute_spec_blocks_when_package_manifest_conflicts_with_source_manifes
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-plugin-manifest-conflict".to_owned(),
             objective: "plugin scan should fail on package/source drift".to_owned(),
@@ -5641,6 +5700,7 @@ async fn execute_spec_bootstrap_budget_is_global_across_multiple_roots() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bootstrap-global".to_owned(),
             objective: "max_tasks must be global across roots".to_owned(),
@@ -5785,6 +5845,7 @@ async fn execute_spec_tool_search_honors_deferred_filter_and_examples() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolSearch {
             query: "web search".to_owned(),
             limit: 5,
@@ -5823,6 +5884,137 @@ async fn execute_spec_tool_search_honors_deferred_filter_and_examples() {
     assert_eq!(
         report_visible_deferred.outcome["results"][0]["input_examples"][0]["query"],
         "search best rust crates"
+    );
+}
+
+#[tokio::test]
+async fn execute_spec_tool_search_uses_explicit_plugin_setup_readiness_context() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    let plugin_root =
+        std::env::temp_dir().join(format!("loongclaw-tool-search-readiness-{unique}"));
+    fs::create_dir_all(&plugin_root).expect("create plugin root");
+
+    fs::write(
+        plugin_root.join("loongclaw.plugin.json"),
+        r#"
+{
+  "plugin_id": "tavily-search",
+  "provider_id": "tavily",
+  "connector_name": "tavily-http",
+  "endpoint": "https://api.tavily.com/search",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json",
+    "adapter_family": "web-search"
+  },
+  "summary": "Manifest-discovered Tavily package",
+  "tags": ["search", "provider"],
+  "setup": {
+    "mode": "metadata_only",
+    "surface": "web_search",
+    "required_env_vars": ["TAVILY_API_KEY"],
+    "required_config_keys": ["tools.web_search.default_provider"],
+    "default_env_var": "TAVILY_API_KEY",
+    "docs_urls": ["https://docs.example.com/tavily"],
+    "remediation": "set a Tavily credential before enabling search"
+  }
+}
+"#,
+    )
+    .expect("write plugin manifest");
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-tool-search-readiness".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::ObserveTelemetry]),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-tool-search-readiness".to_owned(),
+        ttl_s: 120,
+        approval: Some(HumanApprovalSpec {
+            mode: HumanApprovalMode::Disabled,
+            ..HumanApprovalSpec::default()
+        }),
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: Some(PluginScanSpec {
+            enabled: true,
+            roots: vec![plugin_root.display().to_string()],
+        }),
+        bridge_support: Some(BridgeSupportSpec {
+            enabled: true,
+            supported_bridges: vec![PluginBridgeKind::HttpJson],
+            supported_adapter_families: Vec::new(),
+            enforce_supported: true,
+            policy_version: None,
+            expected_checksum: None,
+            expected_sha256: None,
+            execute_process_stdio: false,
+            execute_http_json: false,
+            allowed_process_commands: Vec::new(),
+            enforce_execution_success: false,
+            security_scan: None,
+        }),
+        bootstrap: Some(BootstrapSpec {
+            enabled: true,
+            allow_http_json_auto_apply: Some(false),
+            allow_process_stdio_auto_apply: Some(false),
+            allow_native_ffi_auto_apply: Some(false),
+            allow_wasm_component_auto_apply: Some(false),
+            allow_mcp_server_auto_apply: Some(false),
+            allow_acp_bridge_auto_apply: Some(false),
+            allow_acp_runtime_auto_apply: Some(false),
+            enforce_ready_execution: Some(false),
+            max_tasks: Some(8),
+        }),
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        plugin_setup_readiness: Some(loongclaw_spec::PluginSetupReadinessSpec {
+            inherit_process_env: false,
+            available_env_vars: vec!["TAVILY_API_KEY".to_owned()],
+            configured_keys: vec!["tools.web_search.default_provider".to_owned()],
+            config_keys_verified: true,
+        }),
+        operation: OperationSpec::ToolSearch {
+            query: "tavily".to_owned(),
+            limit: 5,
+            include_deferred: true,
+            include_examples: false,
+        },
+    };
+
+    let report = execute_spec(&spec, true).await;
+    assert_eq!(report.operation_kind, "tool_search");
+    assert_eq!(report.plugin_activation_plans.len(), 1);
+    assert_eq!(report.plugin_activation_plans[0].ready_plugins, 1);
+    assert_eq!(report.plugin_activation_plans[0].pending_plugins, 0);
+    assert!(matches!(
+        report.plugin_activation_plans[0].candidates[0].status,
+        loongclaw_daemon::kernel::PluginActivationStatus::Ready
+    ));
+    assert_eq!(report.outcome["returned"], 1);
+    assert_eq!(report.outcome["results"][0]["provider_id"], "tavily");
+    assert_eq!(report.outcome["results"][0]["setup_ready"], true);
+    assert!(report.outcome["results"][0]["setup_readiness_reason"].is_null());
+    assert_eq!(
+        report.outcome["results"][0]["setup_missing_required_env_vars"],
+        json!([])
+    );
+    assert_eq!(
+        report.outcome["results"][0]["setup_missing_required_config_keys"],
+        json!([])
     );
 }
 
@@ -5910,6 +6102,7 @@ async fn execute_spec_tool_search_uses_translation_bridge_kind_for_unabsorbed_pl
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolSearch {
             query: "rusty".to_owned(),
             limit: 5,

--- a/crates/daemon/tests/integration/spec_runtime_bridge/http_json.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/http_json.rs
@@ -96,6 +96,7 @@ async fn execute_spec_http_json_bridge_executes_against_local_server() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-runtime".to_owned(),
             operation: "invoke".to_owned(),
@@ -207,6 +208,7 @@ async fn execute_spec_http_json_bridge_blocks_when_protocol_authorization_fails(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-authz-block".to_owned(),
             operation: "invoke".to_owned(),
@@ -345,6 +347,7 @@ async fn execute_spec_http_json_bridge_strict_contract_fails_on_method_mismatch(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-strict-method".to_owned(),
             operation: "invoke".to_owned(),
@@ -469,6 +472,7 @@ async fn execute_spec_http_json_bridge_strict_contract_fails_on_id_mismatch() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-strict-id".to_owned(),
             operation: "invoke".to_owned(),
@@ -597,6 +601,7 @@ async fn execute_spec_http_json_bridge_strict_contract_executes_on_matching_fram
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-strict-pass".to_owned(),
             operation: "invoke".to_owned(),

--- a/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
@@ -99,6 +99,7 @@ async fn execute_spec_process_stdio_bridge_executes_when_enabled_and_allowed() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -225,6 +226,7 @@ async fn execute_spec_process_stdio_bridge_blocks_when_command_not_allowlisted()
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -335,6 +337,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_invalid_json_line_response()
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-invalid-frame-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -454,6 +457,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_id_mismatch() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-mismatch-id-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -567,6 +571,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_method_mismatch() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-mismatch-method-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -678,6 +683,7 @@ async fn execute_spec_process_stdio_bridge_blocks_when_protocol_authorization_fa
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-authz-block-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -805,6 +811,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_recv_timeout() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-timeout-provider".to_owned(),
             operation: "invoke".to_owned(),

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -76,7 +76,7 @@ pub async fn execute_spec_with_native_tool_executor(
     let mut plugin_bootstrap_reports = Vec::new();
     let mut plugin_bootstrap_queue = Vec::new();
     let mut plugin_absorb_reports = Vec::new();
-    let plugin_setup_readiness_context = default_plugin_setup_readiness_context();
+    let plugin_setup_readiness_context = resolve_plugin_setup_readiness_context(spec);
     let security_scan_policy = match security_scan_policy(spec) {
         Ok(policy) => policy,
         Err(error) => {
@@ -859,8 +859,13 @@ fn bootstrap_policy(spec: &RunnerSpec) -> Option<BootstrapPolicy> {
     Some(policy)
 }
 
-fn default_plugin_setup_readiness_context() -> PluginSetupReadinessContext {
-    PluginSetupReadinessContext::from_process_env()
+fn resolve_plugin_setup_readiness_context(spec: &RunnerSpec) -> PluginSetupReadinessContext {
+    let readiness_spec = spec.plugin_setup_readiness.as_ref();
+    let Some(readiness_spec) = readiness_spec else {
+        return PluginSetupReadinessContext::from_process_env();
+    };
+
+    readiness_spec.to_context()
 }
 
 fn filter_scan_report_by_activation(
@@ -1559,6 +1564,7 @@ fn apply_default_selection(
 mod bootstrap_policy_tests {
     use super::*;
     use crate::spec_runtime::BootstrapSpec;
+    use std::collections::BTreeSet;
 
     #[test]
     fn bootstrap_policy_maps_distinct_acp_bridge_and_runtime_flags() {
@@ -1579,6 +1585,46 @@ mod bootstrap_policy_tests {
         let policy = bootstrap_policy(&spec).expect("bootstrap policy should resolve");
         assert!(policy.allow_acp_bridge_auto_apply);
         assert!(!policy.allow_acp_runtime_auto_apply);
+    }
+
+    #[test]
+    fn resolve_plugin_setup_readiness_context_uses_explicit_verified_keys() {
+        let mut spec = RunnerSpec::template();
+        spec.plugin_setup_readiness = Some(PluginSetupReadinessSpec {
+            inherit_process_env: false,
+            available_env_vars: vec![
+                " TAVILY_API_KEY ".to_owned(),
+                String::new(),
+                "TAVILY_API_KEY".to_owned(),
+            ],
+            configured_keys: vec![
+                " tools.web_search.default_provider ".to_owned(),
+                String::new(),
+                "tools.web_search.default_provider".to_owned(),
+            ],
+            config_keys_verified: true,
+        });
+
+        let context = resolve_plugin_setup_readiness_context(&spec);
+
+        assert_eq!(
+            context.available_env_vars,
+            BTreeSet::from(["TAVILY_API_KEY".to_owned()])
+        );
+        assert_eq!(
+            context.configured_keys,
+            BTreeSet::from(["tools.web_search.default_provider".to_owned()])
+        );
+        assert!(context.config_keys_verified);
+    }
+
+    #[test]
+    fn resolve_plugin_setup_readiness_context_falls_back_to_process_env_when_omitted() {
+        let spec = RunnerSpec::template();
+        let context = resolve_plugin_setup_readiness_context(&spec);
+
+        assert!(!context.config_keys_verified);
+        assert!(context.configured_keys.is_empty());
     }
 }
 

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -16,10 +16,10 @@ use kernel::{
     HarnessOutcome, HarnessRequest, IntegrationCatalog, IntegrationHotfix, MemoryCoreOutcome,
     MemoryCoreRequest, MemoryExtensionAdapter, MemoryExtensionOutcome, MemoryExtensionRequest,
     PluginAbsorbReport, PluginActivationPlan, PluginBridgeKind, PluginScanReport,
-    PluginTranslationReport, ProvisionPlan, RuntimeCoreOutcome, RuntimeCoreRequest,
-    RuntimeExtensionAdapter, RuntimeExtensionOutcome, RuntimeExtensionRequest, ToolCoreOutcome,
-    ToolCoreRequest, ToolExtensionAdapter, ToolExtensionOutcome, ToolExtensionRequest,
-    VerticalPackManifest,
+    PluginSetupReadinessContext, PluginTranslationReport, ProvisionPlan, RuntimeCoreOutcome,
+    RuntimeCoreRequest, RuntimeExtensionAdapter, RuntimeExtensionOutcome, RuntimeExtensionRequest,
+    ToolCoreOutcome, ToolCoreRequest, ToolExtensionAdapter, ToolExtensionOutcome,
+    ToolExtensionRequest, VerticalPackManifest,
 };
 use loongclaw_contracts::ExecutionSecurityTier;
 use loongclaw_protocol::{
@@ -530,6 +530,8 @@ pub struct RunnerSpec {
     pub auto_provision: Option<AutoProvisionSpec>,
     #[serde(default)]
     pub hotfixes: Vec<HotfixSpec>,
+    #[serde(default)]
+    pub plugin_setup_readiness: Option<PluginSetupReadinessSpec>,
     pub operation: OperationSpec,
 }
 
@@ -680,6 +682,63 @@ pub struct SelfAwarenessSpec {
     pub immutable_core_paths: Vec<String>,
     #[serde(default)]
     pub mutable_extension_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginSetupReadinessSpec {
+    #[serde(default = "default_true")]
+    pub inherit_process_env: bool,
+    #[serde(default)]
+    pub available_env_vars: Vec<String>,
+    #[serde(default)]
+    pub configured_keys: Vec<String>,
+    #[serde(default)]
+    pub config_keys_verified: bool,
+}
+
+impl Default for PluginSetupReadinessSpec {
+    fn default() -> Self {
+        Self {
+            inherit_process_env: true,
+            available_env_vars: Vec::new(),
+            configured_keys: Vec::new(),
+            config_keys_verified: false,
+        }
+    }
+}
+
+impl PluginSetupReadinessSpec {
+    #[must_use]
+    pub fn to_context(&self) -> PluginSetupReadinessContext {
+        let mut context = if self.inherit_process_env {
+            PluginSetupReadinessContext::from_process_env()
+        } else {
+            PluginSetupReadinessContext::default()
+        };
+
+        for raw_env_var in &self.available_env_vars {
+            let env_var = raw_env_var.trim();
+            let env_var_is_empty = env_var.is_empty();
+            if env_var_is_empty {
+                continue;
+            }
+
+            context.available_env_vars.insert(env_var.to_owned());
+        }
+
+        for raw_key in &self.configured_keys {
+            let configured_key = raw_key.trim();
+            let configured_key_is_empty = configured_key.is_empty();
+            if configured_key_is_empty {
+                continue;
+            }
+
+            context.configured_keys.insert(configured_key.to_owned());
+        }
+
+        context.config_keys_verified = self.config_keys_verified;
+        context
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1059,6 +1118,7 @@ impl RunnerSpec {
                 required_capabilities: BTreeSet::from([Capability::InvokeConnector]),
             }),
             hotfixes: Vec::new(),
+            plugin_setup_readiness: Some(PluginSetupReadinessSpec::default()),
             operation: OperationSpec::RuntimeExtension {
                 action: "start-session".to_owned(),
                 required_capabilities: BTreeSet::from([Capability::ObserveTelemetry]),

--- a/crates/spec/src/test_support.rs
+++ b/crates/spec/src/test_support.rs
@@ -28,6 +28,7 @@ pub fn make_runner_spec(operation: OperationSpec) -> RunnerSpec {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation,
     }
 }


### PR DESCRIPTION
## Summary

- Problem:
  The parent readiness slice made manifest-declared setup metadata affect activation and tool search, but spec runners still had no explicit way to inject verified setup state. They could only fall back to ambient process env, which left config-key readiness unverified in hermetic runs.
- Why it matters:
  Spec and integration harnesses need to model verified onboarding state without coupling `loongclaw-spec` to `loongclaw-app` config types and without depending on the operator machine's live environment.
- What changed:
  Added a generic `PluginSetupReadinessSpec` on `RunnerSpec`, taught spec execution to resolve an explicit `PluginSetupReadinessContext` when present and to preserve the existing process-env fallback when omitted, exposed the new shape in the template spec, and added regression plus end-to-end coverage for explicit verified setup injection.
- What did not change (scope boundary):
  No `spec` dependency on `app`, no provider-specific setup heuristics, and no onboarding / doctor / config mutation flow in this slice.

## Linked Issues

- Closes #560
- Related #551
- Depends on #553

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo test -p loongclaw-spec spec_execution -- --nocapture
cargo test -p loongclaw-daemon spec_runtime -- --nocapture
cargo test --workspace --locked
cargo test --workspace --all-features --locked
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
git diff --check

All commands passed.

Before:
- Spec runners could only rely on process-env fallback for setup readiness, so config-key readiness stayed unverified in hermetic or fixture-driven runs.

After:
- Spec runners can inject explicit available env vars, configured keys, and a config verification flag.
- Omitting the field preserves the existing process-env fallback.

Regression coverage:
- Unit coverage asserts explicit verified-key injection and omission fallback.
- Integration coverage asserts tool search reports a manifest-backed Tavily plugin as ready when explicit setup readiness is injected.
- Template and backward-compatibility coverage assert the new field is exposed in generated specs and remains optional for older fixtures.
```

## User-visible / Operator-visible Changes

- Spec fixtures can model verified plugin setup state without mutating process env and without importing app config types into the spec crate.
- Tool-search behavior under spec execution now reflects injected setup readiness when a runner provides it.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to return spec runners to the previous process-env-only readiness fallback.
- Observable failure symptoms reviewers should watch for:
  Spec-based tool search still showing missing env/config requirements after explicit readiness injection, or omitted readiness fields no longer preserving the fallback behavior.

## Reviewer Focus

- `crates/spec/src/spec_runtime.rs`: generic setup-readiness contract shape, normalization, and template exposure
- `crates/spec/src/spec_execution.rs`: explicit-versus-fallback context resolution and compatibility semantics
- `crates/daemon/tests/integration/spec_runtime.rs`: end-to-end readiness injection coverage and backward-compatible fixture parsing
