### PR TITLE
fix(tools): derive network egress for kernel-bound web tools

### DIFF
--- a/crates/app/src/context.rs
+++ b/crates/app/src/context.rs
@@ -40,8 +40,8 @@ impl KernelContext {
 
 /// Bootstrap a minimal in-memory kernel suitable for tests.
 ///
-/// Registers a default pack manifest with `InvokeTool`, `MemoryRead`, and
-/// `MemoryWrite` capabilities, then issues a long-lived token for the given
+/// Registers a default pack manifest with the MVP tool, memory, filesystem,
+/// and public-web capabilities, then issues a long-lived token for the given
 /// `agent_id`.
 ///
 /// Production-facing runtime entrypoints should prefer
@@ -120,6 +120,7 @@ fn bootstrap_kernel_context_with_audit_sink(
         allowed_connectors: BTreeSet::new(),
         granted_capabilities: BTreeSet::from([
             Capability::InvokeTool,
+            Capability::NetworkEgress,
             Capability::MemoryRead,
             Capability::MemoryWrite,
             Capability::FilesystemRead,
@@ -227,6 +228,24 @@ mod tests {
         assert!(
             journal.contains("\"TokenIssued\"") || journal.contains("\"token_id\""),
             "fanout journal should capture token issuance"
+        );
+    }
+
+    #[test]
+    fn bootstrap_kernel_context_with_config_grants_network_egress() {
+        let context =
+            bootstrap_kernel_context_with_config("test-agent", 60, &LoongClawConfig::default())
+                .expect("bootstrap with default config should succeed");
+
+        let allowed_capabilities = &context.token.allowed_capabilities;
+
+        assert!(
+            allowed_capabilities.contains(&Capability::InvokeTool),
+            "bootstrap token should retain invoke tool capability"
+        );
+        assert!(
+            allowed_capabilities.contains(&Capability::NetworkEgress),
+            "bootstrap token should grant network egress for kernel-bound web tools"
         );
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -11158,7 +11158,7 @@ async fn turn_engine_injects_browser_scope_into_kernel_request() {
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");
@@ -14716,7 +14716,7 @@ async fn handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_k
             adapter: None,
         },
         allowed_connectors: BTreeSet::new(),
-        granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress]),
         metadata: BTreeMap::new(),
     };
     kernel.register_pack(pack).expect("register pack");

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -471,6 +471,9 @@ fn required_capabilities_for_tool_name_and_payload(
     payload: &Value,
 ) -> BTreeSet<Capability> {
     let mut caps = BTreeSet::from([Capability::InvokeTool]);
+    if tool_requires_network_egress(tool_name) {
+        caps.insert(Capability::NetworkEgress);
+    }
     match tool_name {
         "tool.invoke" => {
             let Some((invoked_tool_name, invoked_payload)) =
@@ -530,6 +533,13 @@ fn claw_migrate_mode_requires_write(payload: &Value) -> bool {
             .filter(|value| !value.is_empty())
             .unwrap_or("plan"),
         "apply" | "apply_selected" | "rollback_last_apply"
+    )
+}
+
+fn tool_requires_network_egress(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "web.fetch" | "web.search" | "browser.open" | "browser.click"
     )
 }
 
@@ -2456,6 +2466,51 @@ mod tests {
             BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
         );
 
+        let direct_web_fetch = ToolCoreRequest {
+            tool_name: "web.fetch".to_owned(),
+            payload: json!({"url": "https://example.com"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_web_fetch),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
+        let direct_web_search = ToolCoreRequest {
+            tool_name: "web.search".to_owned(),
+            payload: json!({"query": "loongclaw"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_web_search),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
+        let direct_browser_open = ToolCoreRequest {
+            tool_name: "browser.open".to_owned(),
+            payload: json!({"url": "https://example.com"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_browser_open),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
+        let direct_browser_extract = ToolCoreRequest {
+            tool_name: "browser.extract".to_owned(),
+            payload: json!({"mode": "page_text"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_browser_extract),
+            BTreeSet::from([Capability::InvokeTool])
+        );
+
+        let direct_browser_click = ToolCoreRequest {
+            tool_name: "browser.click".to_owned(),
+            payload: json!({"id": 1}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_browser_click),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
         let invoked_file_read = ToolCoreRequest {
             tool_name: "tool.invoke".to_owned(),
             payload: json!({
@@ -2480,6 +2535,19 @@ mod tests {
         assert_eq!(
             required_capabilities_for_request(&invoked_memory_search),
             BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let invoked_web_fetch = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "web.fetch",
+                "lease": "unused",
+                "arguments": {"url": "https://example.com"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_web_fetch),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
         );
 
         let invoked_claw_plan = ToolCoreRequest {
@@ -13809,7 +13877,10 @@ mod tests {
                 adapter: None,
             },
             allowed_connectors: BTreeSet::new(),
-            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            granted_capabilities: BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::NetworkEgress,
+            ]),
             metadata: BTreeMap::new(),
         };
         kernel.register_pack(pack).expect("register pack");
@@ -13856,7 +13927,10 @@ mod tests {
                 adapter: None,
             },
             allowed_connectors: BTreeSet::new(),
-            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            granted_capabilities: BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::NetworkEgress,
+            ]),
             metadata: BTreeMap::new(),
         };
         kernel.register_pack(pack).expect("register pack");
@@ -13924,5 +13998,131 @@ mod tests {
             err.contains("denied") || err.contains("capability") || err.contains("Capability"),
             "error should mention denial or capability, got: {err}"
         );
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn web_fetch_through_kernel_requires_network_egress_capability() {
+        use kernel_adapter::MvpToolAdapter;
+
+        let audit = Arc::new(InMemoryAuditSink::default());
+        let clock = Arc::new(FixedClock::new(1_700_000_000));
+        let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+        let pack = VerticalPackManifest {
+            pack_id: "test-pack".to_owned(),
+            domain: "testing".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: None,
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::NetworkEgress,
+            ]),
+            metadata: BTreeMap::new(),
+        };
+        kernel.register_pack(pack).expect("register pack");
+
+        let mut config = runtime_config::ToolRuntimeConfig::default();
+        config.web_fetch.enabled = true;
+        kernel.register_core_tool_adapter(MvpToolAdapter::with_config(config));
+        kernel
+            .set_default_core_tool_adapter("mvp-tools")
+            .expect("set default");
+
+        let mut token = kernel
+            .issue_token("test-pack", "test-agent", 3600)
+            .expect("issue token");
+        let removed_network_egress = token
+            .allowed_capabilities
+            .remove(&Capability::NetworkEgress);
+        assert!(
+            removed_network_egress,
+            "issued token should include network egress before we remove it for the test"
+        );
+
+        let ctx = KernelContext {
+            kernel: Arc::new(kernel),
+            token,
+        };
+        let request = ToolCoreRequest {
+            tool_name: "web.fetch".to_owned(),
+            payload: json!({"url": "https://example.com"}),
+        };
+
+        let error = execute_kernel_tool_request(&ctx, request, false)
+            .await
+            .expect_err("web.fetch should fail closed without network egress capability");
+
+        assert!(matches!(
+            error,
+            loongclaw_kernel::KernelError::Policy(
+                loongclaw_kernel::PolicyError::MissingCapability { capability, .. }
+            ) if capability == Capability::NetworkEgress
+        ));
+    }
+
+    #[cfg(feature = "tool-webfetch")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn web_fetch_through_kernel_exposes_network_egress_to_policy_extensions() {
+        use kernel_adapter::MvpToolAdapter;
+
+        let audit = Arc::new(InMemoryAuditSink::default());
+        let clock = Arc::new(FixedClock::new(1_700_000_000));
+        let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+        let pack = VerticalPackManifest {
+            pack_id: "test-pack".to_owned(),
+            domain: "testing".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: None,
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::NetworkEgress,
+            ]),
+            metadata: BTreeMap::new(),
+        };
+        kernel.register_pack(pack).expect("register pack");
+        kernel.register_policy_extension(
+            loongclaw_kernel::test_support::NoNetworkEgressPolicyExtension,
+        );
+
+        let mut config = runtime_config::ToolRuntimeConfig::default();
+        config.web_fetch.enabled = true;
+        kernel.register_core_tool_adapter(MvpToolAdapter::with_config(config));
+        kernel
+            .set_default_core_tool_adapter("mvp-tools")
+            .expect("set default");
+
+        let token = kernel
+            .issue_token("test-pack", "test-agent", 3600)
+            .expect("issue token");
+
+        let ctx = KernelContext {
+            kernel: Arc::new(kernel),
+            token,
+        };
+        let request = ToolCoreRequest {
+            tool_name: "web.fetch".to_owned(),
+            payload: json!({"url": "https://example.com"}),
+        };
+
+        let error = execute_kernel_tool_request(&ctx, request, false)
+            .await
+            .expect_err("policy extension should block web.fetch network egress");
+
+        assert!(matches!(
+            error,
+            loongclaw_kernel::KernelError::Policy(
+                loongclaw_kernel::PolicyError::ExtensionDenied { ref extension, .. }
+            ) if extension == "no-network-egress"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Problem: kernel-bound `web.fetch`, `web.search`, `browser.open`, and `browser.click` requests were still deriving only `Capability::InvokeTool`, so active outbound web paths bypassed the shared `NetworkEgress` capability contract.
- Why it matters: token issuance and policy extensions could not fail closed on outbound web authority, which made the live runtime drift away from the shared contracts and kernel governance seams.
- What changed: added explicit `NetworkEgress` derivation for bounded public-web tools, added direct and `tool.invoke` capability regression coverage, added kernel-routed tests that prove missing `NetworkEgress` now denies `web.fetch`, and updated the two conversation fixtures that intentionally exercise kernel-bound browser/web paths.
- What did not change (scope boundary): this does not redesign tool execution, change browser companion capabilities, or broaden `browser.extract` into a network-egress path.

## Linked Issues

- Closes #561
- Related #457, #544

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [x] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this intentionally makes kernel-bound web requests fail closed when packs or tokens do not grant `Capability::NetworkEgress`.
- Rollout / guardrails: the change is constrained to capability derivation for bounded public-web tools and is covered by direct, `tool.invoke`, kernel-routed, and conversation-runtime regression tests.
- Rollback path: revert this PR to restore the previous capability derivation behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all -- --check
cargo test -p loongclaw-app turn_engine_injects_browser_scope_into_kernel_request -- --test-threads=1
cargo test -p loongclaw-app handle_turn_with_runtime_child_session_injects_runtime_narrowing_into_kernel_payload -- --test-threads=1
cargo test -p loongclaw-app --all-features -- --test-threads=1
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
cargo clippy --workspace --all-targets --all-features -- -D warnings

all commands passed.

architecture/docs check:
- confirmed `docs/SECURITY.md` already treats `web.fetch`, `web.search`, and shared browser URL validation under the same SSRF / public-web safety boundary
- confirmed `docs/product-specs/browser-automation.md` already describes browser tools as sharing the same public-web safety model as `web.fetch`
```

## User-visible / Operator-visible Changes

- Kernel-bound public-web tool requests now require `Capability::NetworkEgress` in addition to `Capability::InvokeTool`.
- Missing network authority now surfaces as an explicit kernel policy denial instead of silently executing under the narrower capability set.

## Failure Recovery

- Fast rollback or disable path: revert this PR, or remove `NetworkEgress` from the derived capability set while investigating follow-up policy changes.
- Observable failure symptoms reviewers should watch for: `kernel_policy_denied` / `MissingCapability(NetworkEgress)` on kernel-bound `web.fetch`, `web.search`, `browser.open`, or `browser.click` paths when packs were previously relying on the old under-scoped behavior.

## Reviewer Focus

- Review `required_capabilities_for_tool_name_and_payload()` and `tool_requires_network_egress()` for scope accuracy.
- Review the new kernel-routed tests to confirm they prove fail-closed token enforcement and policy-extension visibility, not just direct helper behavior.
- Review the two conversation fixture updates to confirm they are the minimal test-only capability grants required by the new contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools that perform web or browser network actions now require a network-egress capability.

* **Tests**
  * Added tests validating network egress is required and that missing capability yields a policy failure.
  * Added tests for policy-based denial of network operations.

* **Documentation**
  * Updated test/bootstrap docs to note network egress is included in the default test pack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->