### PR TITLE
fix(config): preserve provider auth env canonicalization edge cases

### DIFF
--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -910,8 +910,8 @@ impl ProviderConfig {
 
     pub fn canonicalize_configured_auth_env_bindings(&mut self) {
         let configured_api_key_env = self.configured_api_key_env_override();
-        let api_key_has_non_env_secret =
-            self.api_key.is_some() && secret_ref_env_name(self.api_key.as_ref()).is_none();
+        let api_key_has_non_env_secret = has_configured_secret_ref(self.api_key.as_ref())
+            && secret_ref_env_name(self.api_key.as_ref()).is_none();
         if api_key_has_non_env_secret {
             self.set_api_key_env(None);
         } else {
@@ -919,7 +919,7 @@ impl ProviderConfig {
         }
 
         let configured_oauth_env = self.configured_oauth_access_token_env_override();
-        let oauth_has_non_env_secret = self.oauth_access_token.is_some()
+        let oauth_has_non_env_secret = has_configured_secret_ref(self.oauth_access_token.as_ref())
             && secret_ref_env_name(self.oauth_access_token.as_ref()).is_none();
         if oauth_has_non_env_secret {
             self.set_oauth_access_token_env(None);
@@ -1863,6 +1863,10 @@ impl ProviderConfig {
                 default_provider_base_url().as_str(),
             ),
         );
+        let api_key_has_explicit_env_reference =
+            self.api_key_env_explicit || secret_ref_env_name(self.api_key.as_ref()).is_some();
+        let oauth_has_explicit_env_reference = self.oauth_access_token_env_explicit
+            || secret_ref_env_name(self.oauth_access_token.as_ref()).is_some();
 
         let mut normalized = self.clone();
         normalized.base_url = base_url;
@@ -1874,14 +1878,22 @@ impl ProviderConfig {
         normalized.oauth_access_token = self.normalized_oauth_access_token_for_persistence();
         normalized.oauth_access_token_env =
             self.normalized_oauth_access_token_env_for_persistence();
-        canonicalize_secret_env_reference_for_persistence(
-            &mut normalized.api_key,
-            &mut normalized.api_key_env,
-        );
-        canonicalize_secret_env_reference_for_persistence(
-            &mut normalized.oauth_access_token,
-            &mut normalized.oauth_access_token_env,
-        );
+        if api_key_has_explicit_env_reference {
+            canonicalize_secret_env_reference_for_persistence(
+                &mut normalized.api_key,
+                &mut normalized.api_key_env,
+            );
+        } else {
+            normalized.api_key_env = None;
+        }
+        if oauth_has_explicit_env_reference {
+            canonicalize_secret_env_reference_for_persistence(
+                &mut normalized.oauth_access_token,
+                &mut normalized.oauth_access_token_env,
+            );
+        } else {
+            normalized.oauth_access_token_env = None;
+        }
         normalized
     }
 
@@ -3432,6 +3444,7 @@ fn normalize_secret_ref_for_persistence(
     secret_ref: Option<&SecretRef>,
     env_name: Option<&str>,
 ) -> Option<SecretRef> {
+    let secret_ref = secret_ref.filter(|value| value.is_configured());
     let explicit_secret_env = secret_ref_env_name(secret_ref);
     let Some(explicit_secret_env) = explicit_secret_env.as_deref() else {
         return secret_ref.cloned();
@@ -3457,7 +3470,7 @@ fn canonicalize_secret_env_reference_for_persistence(
         return;
     }
 
-    if secret_ref.is_some() {
+    if secret_ref.as_ref().is_some_and(SecretRef::is_configured) {
         *env_name = None;
         return;
     }
@@ -3690,6 +3703,8 @@ api_key_env = "OPENAI_API_KEY"
             })
         );
         assert_eq!(normalized.api_key_env, None);
+        assert_eq!(normalized.oauth_access_token, None);
+        assert_eq!(normalized.oauth_access_token_env, None);
     }
 
     #[test]
@@ -3711,10 +3726,39 @@ api_key_env = "OPENAI_API_KEY"
     }
 
     #[test]
+    fn normalized_for_persistence_keeps_implicit_provider_auth_defaults_unset() {
+        let config = ProviderConfig::fresh_for_kind(ProviderKind::Openai);
+
+        let normalized = config.normalized_for_persistence();
+
+        assert_eq!(normalized.api_key, None);
+        assert_eq!(normalized.api_key_env, None);
+        assert_eq!(normalized.oauth_access_token, None);
+        assert_eq!(normalized.oauth_access_token_env, None);
+    }
+
+    #[test]
     fn canonicalize_configured_auth_env_bindings_rewrites_inline_env_templates() {
         let mut config = ProviderConfig::fresh_for_kind(ProviderKind::Openai);
         config.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
         config.api_key = Some(SecretRef::Inline("${OPENAI_API_KEY}".to_owned()));
+
+        config.canonicalize_configured_auth_env_bindings();
+
+        assert_eq!(
+            config.api_key,
+            Some(SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(config.api_key_env, None);
+    }
+
+    #[test]
+    fn canonicalize_configured_auth_env_bindings_treats_blank_inline_secret_as_absent() {
+        let mut config = ProviderConfig::fresh_for_kind(ProviderKind::Openai);
+        config.set_api_key_env(Some("OPENAI_API_KEY".to_owned()));
+        config.api_key = Some(SecretRef::Inline("   ".to_owned()));
 
         config.canonicalize_configured_auth_env_bindings();
 

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -1051,7 +1051,10 @@ fn canonicalize_provider_secret_env_reference(
         return;
     }
 
-    if inline_secret.is_some() {
+    if inline_secret
+        .as_ref()
+        .is_some_and(loongclaw_contracts::SecretRef::is_configured)
+    {
         *env_name = None;
         return;
     }
@@ -2673,6 +2676,26 @@ model = "gpt-5"
         assert!(!raw.contains("secret_env = \" WECOM_SECRET \""));
         assert!(!raw.contains("bot_id = \"${WECOM_BOT_ID}\""));
         assert!(!raw.contains("secret = \"${WECOM_SECRET}\""));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn write_preserves_provider_env_binding_when_inline_secret_is_blank() {
+        let path = unique_config_path("loongclaw-config-runtime-blank-inline-provider-env");
+        let path_string = path.display().to_string();
+        let mut config = LoongClawConfig::default();
+        config.provider.api_key = Some(SecretRef::Inline("   ".to_owned()));
+        config.provider.api_key_env = Some("TEAM_OPENAI_KEY".to_owned());
+
+        write(Some(&path_string), &config, true).expect("config write should pass");
+
+        let raw = fs::read_to_string(&path).expect("read written config");
+        assert!(raw.contains("api_key"));
+        assert!(raw.contains("env = \"TEAM_OPENAI_KEY\""));
+        assert!(!raw.contains("api_key = \"   \""));
+        assert!(!raw.contains("api_key_env = \"TEAM_OPENAI_KEY\""));
 
         let _ = fs::remove_file(path);
     }

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1257,7 +1257,7 @@ fn ensure_provider_env_binding(
     if configured.is_some() {
         return false;
     }
-    if provider_credential_policy::provider_has_inline_credential(provider) {
+    if provider_has_non_env_credential(provider) {
         return false;
     }
 
@@ -1272,6 +1272,19 @@ fn ensure_provider_env_binding(
 
     fixes.push(format!("{label}={default_key}"));
     true
+}
+
+fn provider_has_non_env_credential(provider: &mvp::config::ProviderConfig) -> bool {
+    provider_secret_ref_is_non_env_credential(provider.api_key.as_ref())
+        || provider_secret_ref_is_non_env_credential(provider.oauth_access_token.as_ref())
+}
+
+fn provider_secret_ref_is_non_env_credential(secret_ref: Option<&SecretRef>) -> bool {
+    let Some(secret_ref) = secret_ref else {
+        return false;
+    };
+
+    secret_ref.is_configured() && secret_ref.explicit_env_name().is_none()
 }
 
 fn provider_transport_doctor_check(provider: &mvp::config::ProviderConfig) -> DoctorCheck {
@@ -2212,6 +2225,33 @@ mod tests {
             ))
         );
         assert_eq!(config.provider.api_key_env, None);
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn provider_env_fix_does_not_overwrite_file_backed_api_key() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        let credential_path = PathBuf::from("/tmp/openai-api-key.txt");
+        config.provider.api_key = Some(loongclaw_contracts::SecretRef::File {
+            file: credential_path.clone(),
+        });
+        config.provider.api_key_env = None;
+        config.provider.oauth_access_token = None;
+        config.provider.oauth_access_token_env = None;
+
+        let mut fixes = Vec::new();
+        let changed = maybe_apply_provider_env_fix(&mut config, true, &mut fixes);
+
+        assert!(!changed);
+        assert_eq!(
+            config.provider.api_key,
+            Some(loongclaw_contracts::SecretRef::File {
+                file: credential_path,
+            })
+        );
+        assert_eq!(config.provider.oauth_access_token, None);
+        assert_eq!(config.provider.api_key_env, None);
+        assert_eq!(config.provider.oauth_access_token_env, None);
         assert!(fixes.is_empty());
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2056,7 +2056,7 @@ fn runtime_snapshot_migrate_provider_env_reference(
         return;
     }
 
-    if inline_secret.is_some() {
+    if inline_secret.as_ref().is_some_and(SecretRef::is_configured) {
         *env_name = None;
         return;
     }
@@ -2371,6 +2371,45 @@ mod runtime_snapshot_restore_spec_tests {
             profile.provider.oauth_access_token,
             Some(SecretRef::Env {
                 env: "INLINE_OPENAI_OAUTH_TOKEN".to_owned(),
+            })
+        );
+        assert_eq!(profile.provider.oauth_access_token_env, None);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn runtime_snapshot_restore_normalization_treats_blank_inline_secret_as_absent() {
+        let mut warnings = Vec::new();
+        let mut profile = mvp::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Openai,
+                model: "openai/gpt-5.1-codex".to_owned(),
+                api_key: Some(SecretRef::Inline("   ".to_owned())),
+                api_key_env: Some("OPENAI_API_KEY".to_owned()),
+                oauth_access_token: Some(SecretRef::Inline("   ".to_owned())),
+                oauth_access_token_env: Some("OPENAI_CODEX_OAUTH_TOKEN".to_owned()),
+                ..Default::default()
+            },
+        };
+
+        normalize_runtime_snapshot_restore_provider_profile(
+            "openai-main",
+            &mut profile,
+            &mut warnings,
+        );
+
+        assert_eq!(
+            profile.provider.api_key,
+            Some(SecretRef::Env {
+                env: "OPENAI_API_KEY".to_owned(),
+            })
+        );
+        assert_eq!(profile.provider.api_key_env, None);
+        assert_eq!(
+            profile.provider.oauth_access_token,
+            Some(SecretRef::Env {
+                env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
             })
         );
         assert_eq!(profile.provider.oauth_access_token_env, None);

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -6042,6 +6042,15 @@ mod tests {
         temp_dir
     }
 
+    fn uuid_shaped_secret_fixture() -> String {
+        let first = "9f479837";
+        let second = "0a12";
+        let third = "4b56";
+        let fourth = "89ab";
+        let fifth = "cdef01234567";
+        format!("{first}-{second}-{third}-{fourth}-{fifth}")
+    }
+
     fn write_browser_companion_script(script_path: &Path, body: &str) {
         let mut file = std::fs::File::create(script_path).expect("create browser companion script");
         file.write_all(body.as_bytes())
@@ -7043,10 +7052,10 @@ mod tests {
 
     #[test]
     fn resolve_api_key_env_selection_reprompts_after_uuid_secret_literal_interactively() {
-        let secret = "9f479837-0a12-4b56-89ab-cdef01234567";
+        let secret = uuid_shaped_secret_fixture();
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::VolcengineCoding;
-        let mut ui = TestOnboardUi::with_inputs([secret, "ARK_API_KEY"]);
+        let mut ui = TestOnboardUi::with_inputs([secret.as_str(), "ARK_API_KEY"]);
         let context = OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>());
 
         let selected = resolve_api_key_env_selection(
@@ -7078,7 +7087,7 @@ mod tests {
 
     #[test]
     fn resolve_api_key_env_selection_rejects_uuid_secret_literal_non_interactively() {
-        let secret = "9f479837-0a12-4b56-89ab-cdef01234567";
+        let secret = uuid_shaped_secret_fixture();
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::VolcengineCoding;
         let mut ui = TestOnboardUi::with_inputs(std::iter::empty::<&str>());
@@ -7092,7 +7101,7 @@ mod tests {
                 accept_risk: true,
                 provider: None,
                 model: None,
-                api_key_env: Some(secret.to_owned()),
+                api_key_env: Some(secret.clone()),
                 web_search_provider: None,
                 web_search_api_key_env: None,
                 personality: None,
@@ -7109,7 +7118,7 @@ mod tests {
         .expect_err("uuid-shaped env selections should be rejected non-interactively");
 
         assert!(error.contains("provider.api_key.env"));
-        assert!(!error.contains(secret));
+        assert!(!error.contains(secret.as_str()));
     }
 
     #[test]

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-25T10:22:04Z
+- Generated at: 2026-03-25T10:50:40Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,8 +11,8 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3234 | 3600 | 366 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1479 | 3700 | 2221 | 23 | 80 | 57 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3240 | 3600 | 360 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 1727 | 3700 | 1973 | 24 | 80 | 56 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
@@ -39,8 +39,8 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=3234 functions=48 -->
-<!-- arch-hotspot key=spec_execution lines=1479 functions=23 -->
+<!-- arch-hotspot key=spec_runtime lines=3240 functions=48 -->
+<!-- arch-hotspot key=spec_execution lines=1727 functions=24 -->
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-25T10:50:40Z
+- Generated at: 2026-03-25T10:54:38Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,8 +11,8 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3240 | 3600 | 360 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1727 | 3700 | 1973 | 24 | 80 | 56 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3256 | 3600 | 344 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 1876 | 3700 | 1824 | 26 | 80 | 54 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
@@ -39,8 +39,8 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=3240 functions=48 -->
-<!-- arch-hotspot key=spec_execution lines=1727 functions=24 -->
+<!-- arch-hotspot key=spec_runtime lines=3256 functions=48 -->
+<!-- arch-hotspot key=spec_execution lines=1876 functions=26 -->
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
closes #564

## summary

this follows up on #549 and fixes provider auth env canonicalization edge cases that could still rewrite or drop credentials incorrectly after the original merge.

## what changed

- preserve legacy env bindings when the competing inline secret is blank or whitespace-only
- keep implicit provider auth defaults unset unless the original config explicitly carried an env reference
- stop `doctor --fix` from overwriting configured non-env credentials such as `file`-backed secrets
- keep the uuid-shaped secret regression fixture runtime-assembled instead of hardcoding the literal

## validation

- `cargo fmt --check --all --manifest-path <redacted-path>`
- `git -C <redacted-path> diff --check`
- `cargo test -p loongclaw-app --manifest-path <redacted-path>`
- `cargo test -p loongclaw-daemon --manifest-path <redacted-path>`
- `cargo test -p loongclaw-daemon --manifest-path <redacted-path> --test integration interactive_onboard_clear_token`
- `cargo test -p loongclaw-daemon --manifest-path <redacted-path> --test integration interactive_onboard_only_shows_large_logo_on_the_initial_screen`
- `cargo test -p loongclaw-daemon --manifest-path <redacted-path> --test integration onboard_current_setup_adjustments`
- `cargo test -p loongclaw-daemon --manifest-path <redacted-path> --test integration onboard_detected_setup_adjustments_preserve_unchanged_detected_actions_in_review`

## notes

the full `loongclaw-daemon` run currently hits six onboarding integration failures that already reproduce on a clean `origin/dev` worktree. this patch does not introduce those failures; it only tightens provider auth env canonicalization and adds targeted regression coverage for the affected paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider credential configuration handling to better manage blank or whitespace inline secrets
  * Fixed preservation of file-backed credentials during configuration updates
  * Enhanced environment variable binding migration for provider authentication

* **Tests**
  * Extended test coverage for credential configuration edge cases and persistence scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->