### PR TITLE
refactor(contracts): remove dead schedule task capability

### DIFF
--- a/crates/contracts/src/contracts.rs
+++ b/crates/contracts/src/contracts.rs
@@ -13,7 +13,6 @@ pub enum Capability {
     FilesystemRead,
     FilesystemWrite,
     NetworkEgress,
-    ScheduleTask,
     ObserveTelemetry,
 }
 
@@ -27,7 +26,6 @@ impl Capability {
             Self::FilesystemRead => "filesystem_read",
             Self::FilesystemWrite => "filesystem_write",
             Self::NetworkEgress => "network_egress",
-            Self::ScheduleTask => "schedule_task",
             Self::ObserveTelemetry => "observe_telemetry",
         }
     }
@@ -41,7 +39,6 @@ impl Capability {
             "filesystem_read" => Some(Self::FilesystemRead),
             "filesystem_write" => Some(Self::FilesystemWrite),
             "network_egress" => Some(Self::NetworkEgress),
-            "schedule_task" => Some(Self::ScheduleTask),
             "observe_telemetry" => Some(Self::ObserveTelemetry),
             _ => None,
         }
@@ -124,7 +121,6 @@ mod tests {
             (Capability::FilesystemRead, "filesystem_read"),
             (Capability::FilesystemWrite, "filesystem_write"),
             (Capability::NetworkEgress, "network_egress"),
-            (Capability::ScheduleTask, "schedule_task"),
             (Capability::ObserveTelemetry, "observe_telemetry"),
         ];
 
@@ -147,5 +143,6 @@ mod tests {
         assert_eq!(Capability::parse("totally_unknown"), None);
         assert_eq!(Capability::parse(""), None);
         assert_eq!(Capability::parse("   "), None);
+        assert_eq!(Capability::parse("schedule_task"), None);
     }
 }

--- a/crates/kernel/src/test_support.rs
+++ b/crates/kernel/src/test_support.rs
@@ -44,6 +44,17 @@ pub struct MockToolExtension;
 pub struct MockCoreMemory;
 pub struct MockMemoryExtension;
 pub struct NoNetworkEgressPolicyExtension;
+pub const TEST_CAPABILITY_VARIANTS: [Capability; 8] = [
+    Capability::InvokeTool,
+    Capability::InvokeConnector,
+    Capability::MemoryRead,
+    Capability::MemoryWrite,
+    Capability::FilesystemRead,
+    Capability::FilesystemWrite,
+    Capability::NetworkEgress,
+    Capability::ObserveTelemetry,
+];
+pub const TEST_CAPABILITY_VARIANT_COUNT: u8 = TEST_CAPABILITY_VARIANTS.len() as u8;
 #[derive(Debug, Clone, Copy)]
 pub enum ToolGateMode {
     Deny,
@@ -370,23 +381,19 @@ pub fn acp_pack_without_explicit_adapter() -> VerticalPackManifest {
     }
 }
 pub fn capability_from_bit(bit: u8) -> Capability {
-    match bit {
-        0 => Capability::InvokeTool,
-        1 => Capability::InvokeConnector,
-        2 => Capability::MemoryRead,
-        3 => Capability::MemoryWrite,
-        4 => Capability::FilesystemRead,
-        5 => Capability::FilesystemWrite,
-        6 => Capability::NetworkEgress,
-        7 => Capability::ScheduleTask,
-        _ => Capability::ObserveTelemetry,
-    }
+    let bit_index = usize::from(bit);
+    TEST_CAPABILITY_VARIANTS
+        .get(bit_index)
+        .copied()
+        .expect("test capability bit should be in range")
 }
 pub fn capability_set_from_mask(mask: u16) -> BTreeSet<Capability> {
     let mut capabilities = BTreeSet::new();
-    for bit in 0_u8..9 {
-        if (mask & (1_u16 << bit)) != 0 {
-            capabilities.insert(capability_from_bit(bit));
+    for (bit_index, capability) in TEST_CAPABILITY_VARIANTS.iter().copied().enumerate() {
+        let bit_mask = 1_u16 << bit_index;
+        let is_enabled = (mask & bit_mask) != 0;
+        if is_enabled {
+            capabilities.insert(capability);
         }
     }
     capabilities

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -228,8 +228,8 @@ proptest! {
 
     #[test]
     fn prop_pack_capability_boundary_for_task_dispatch(
-        pack_mask in 1_u16..(1_u16 << 9),
-        required_mask in 0_u16..(1_u16 << 9)
+        pack_mask in 1_u16..(1_u16 << TEST_CAPABILITY_VARIANT_COUNT),
+        required_mask in 0_u16..(1_u16 << TEST_CAPABILITY_VARIANT_COUNT)
     ) {
         let pack_capabilities = capability_set_from_mask(pack_mask);
         let required_capabilities = capability_set_from_mask(required_mask);

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -49,7 +49,7 @@ Tool-specific request approval currently lives in the `PolicyExtensionChain`; th
 
 ### Capability Tokens
 
-- 9 capability types with generation-based revocation
+- 8 capability types with generation-based revocation
 - `AtomicU64` threshold: revoke all tokens with generation <= N
 - TTL enforcement on every authorization check
 - `membrane` field exists but not enforced (TD-003)


### PR DESCRIPTION
## Summary

- Problem:
  - issue #457 still tracked `ScheduleTask` and `NetworkEgress` together, but the current `dev` audit no longer supports removing both.
  - `ScheduleTask` remained only in the shared contracts surface plus kernel test helpers.
- Why it matters:
  - keeping a dead capability in the shared contract keeps the governance surface larger than the runtime actually uses.
  - it also lets tests and docs drift around a capability that no longer exists in live execution paths.
- What changed:
  - removed `ScheduleTask` from `loongclaw_contracts::Capability` and from its canonical string mappings
  - tightened contract coverage so `schedule_task` now fails parsing explicitly
  - replaced hardcoded kernel test capability ranges with an explicit live capability list and derived count
  - updated the capability count in `docs/SECURITY.md`
- What did not change (scope boundary):
  - no `NetworkEgress` removal
  - no policy-engine or token-issuance redesign
  - no broader governance cleanup outside the narrow dead-surface audit

## Linked Issues

- Closes #457
- Related #544
- Related #563

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo test -p loongclaw-contracts --locked -- --test-threads=1
cargo test -p loongclaw-kernel --locked -- --test-threads=1
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
cargo clippy --workspace --all-targets --all-features -- -D warnings
rg -n --glob '!target/**' "schedule_task|ScheduleTask|schedule task|scheduled task" .

Result:
- all listed cargo checks passed
- the remaining repository match for `schedule_task` is the new rejection test that proves the removed legacy name no longer parses
```

## User-visible / Operator-visible Changes

- none for normal operators; this is a contract-surface cleanup plus test/doc drift removal

## Failure Recovery

- Fast rollback or disable path:
  - revert this PR to restore the removed contract variant and the previous test-helper surface
- Observable failure symptoms reviewers should watch for:
  - unexpected downstream parse failures in fixtures or tooling that still send `schedule_task`

## Reviewer Focus

- verify the dead-surface claim that `ScheduleTask` had no live runtime, spec, daemon, or integration consumer on current `dev`
- verify the test-helper cleanup removed hardcoded capability-count assumptions without touching the still-live `NetworkEgress` seam
- verify the scope boundary: this PR should not change `NetworkEgress` behavior, which remains tracked separately in #563


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the ScheduleTask capability variant, reducing available capability types from 9 to 8.

* **Documentation**
  * Updated security documentation to reflect the current set of 8 capability types and their generation-based revocation semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->