### PR TITLE
fix(onboard): keep current web-search provider as interactive default

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -42,9 +42,10 @@ use crate::onboard_web_search::{
 use crate::onboard_web_search::{
     configured_web_search_provider_credential_source_value,
     configured_web_search_provider_env_name, configured_web_search_provider_secret,
-    preferred_web_search_credential_env_default, resolve_effective_web_search_default_provider,
-    resolve_web_search_provider_recommendation, summarize_web_search_provider_credential,
-    web_search_provider_display_name, web_search_provider_has_inline_credential,
+    current_web_search_provider, preferred_web_search_credential_env_default,
+    resolve_effective_web_search_default_provider, resolve_web_search_provider_recommendation,
+    summarize_web_search_provider_credential, web_search_provider_display_name,
+    web_search_provider_has_inline_credential,
 };
 use crate::onboarding_model_policy;
 use crate::provider_credential_policy;
@@ -2415,6 +2416,7 @@ async fn resolve_web_search_provider_selection(
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
     let recommendation = resolve_web_search_provider_recommendation(options, config).await?;
+    let recommended_provider = recommendation.provider;
     let default_provider =
         resolve_effective_web_search_default_provider(options, config, &recommendation);
 
@@ -2422,14 +2424,17 @@ async fn resolve_web_search_provider_selection(
         return Ok(default_provider.to_owned());
     }
 
-    let screen_options = build_web_search_provider_screen_options(config, default_provider);
+    let screen_options = build_web_search_provider_screen_options(config, recommended_provider);
     let select_options = select_options_from_screen_options(&screen_options);
-    let default_idx = screen_options.iter().position(|option| option.recommended);
+    let default_idx = screen_options
+        .iter()
+        .position(|option| option.key == default_provider);
 
     print_lines(
         ui,
         render_web_search_provider_selection_screen_lines_with_style(
             config,
+            recommended_provider,
             default_provider,
             recommendation.reason.as_str(),
             guided_prompt_path,
@@ -2564,18 +2569,22 @@ fn build_web_search_provider_screen_options(
 fn render_web_search_provider_selection_screen_lines_with_style(
     config: &mvp::config::LoongClawConfig,
     recommended_provider: &str,
+    default_provider: &str,
     recommendation_reason: &str,
     guided_prompt_path: GuidedPromptPath,
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
-    let current_provider = mvp::config::normalize_web_search_provider(
-        config.tools.web_search.default_provider.as_str(),
-    )
-    .unwrap_or(mvp::config::DEFAULT_WEB_SEARCH_PROVIDER);
+    let current_provider = current_web_search_provider(config);
     let current_provider_label = web_search_provider_display_name(current_provider);
     let recommended_provider_label = web_search_provider_display_name(recommended_provider);
+    let default_provider_label = web_search_provider_display_name(default_provider);
     let options = build_web_search_provider_screen_options(config, recommended_provider);
+    let default_footer_description = if default_provider == current_provider {
+        format!("keep {current_provider_label}")
+    } else {
+        format!("use {default_provider_label}")
+    };
 
     render_onboard_choice_screen(
         OnboardHeaderStyle::Compact,
@@ -2591,7 +2600,7 @@ fn render_web_search_provider_selection_screen_lines_with_style(
         options,
         vec![render_default_choice_footer_line(
             "Enter",
-            format!("use {recommended_provider_label}").as_str(),
+            default_footer_description.as_str(),
         )],
         true,
         color_enabled,
@@ -7327,6 +7336,73 @@ mod tests {
         assert_eq!(
             recommendation.source,
             WebSearchProviderRecommendationSource::ExplicitCli
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resolve_web_search_provider_selection_keeps_current_provider_on_blank_interactive_input_when_recommendation_differs()
+     {
+        let options = interactive_onboard_options();
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.web_search.tavily_api_key = Some("${TAVILY_API_KEY}".to_owned());
+
+        let mut env = ScopedEnv::new();
+        env.set("TAVILY_API_KEY", "tavily-test-token");
+
+        let mut ui = TestOnboardUi::with_inputs([""]);
+        let context = onboard_test_context();
+        let selected = resolve_web_search_provider_selection(
+            &options,
+            &config,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .await
+        .expect("blank interactive input should keep the current web search provider");
+
+        assert_eq!(
+            selected,
+            mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
+            "interactive enter should preserve the current provider even when another provider is recommended"
+        );
+    }
+
+    #[test]
+    fn render_web_search_provider_selection_screen_uses_actual_default_provider_in_footer() {
+        let config = mvp::config::LoongClawConfig::default();
+        let current_provider = mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO;
+        let recommended_provider = mvp::config::WEB_SEARCH_PROVIDER_TAVILY;
+        let current_provider_label = web_search_provider_display_name(current_provider);
+        let recommended_provider_label = web_search_provider_display_name(recommended_provider);
+        let footer_description = format!("keep {current_provider_label}");
+        let expected_footer =
+            render_default_choice_footer_line("Enter", footer_description.as_str());
+        let lines = render_web_search_provider_selection_screen_lines_with_style(
+            &config,
+            recommended_provider,
+            current_provider,
+            "found a ready credential",
+            GuidedPromptPath::NativePromptPack,
+            80,
+            false,
+        );
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == &format!("- current provider: {current_provider_label}")),
+            "web search provider screen should show the current provider separately: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(
+                |line| line == &format!("- recommended provider: {recommended_provider_label}")
+            ),
+            "web search provider screen should show the recommendation separately: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == &expected_footer),
+            "web search provider footer should describe the real Enter default instead of the recommendation: {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_web_search.rs
+++ b/crates/daemon/src/onboard_web_search.rs
@@ -70,13 +70,36 @@ fn configured_default_web_search_provider(
     mvp::config::normalize_web_search_provider(configured_provider)
 }
 
+pub(crate) fn current_web_search_provider(config: &mvp::config::LoongClawConfig) -> &'static str {
+    let configured_provider = config.tools.web_search.default_provider.as_str();
+    let normalized_provider = mvp::config::normalize_web_search_provider(configured_provider);
+    normalized_provider.unwrap_or(mvp::config::DEFAULT_WEB_SEARCH_PROVIDER)
+}
+
 pub(crate) fn resolve_effective_web_search_default_provider(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
     recommendation: &WebSearchProviderRecommendation,
 ) -> &'static str {
     if !options.non_interactive {
-        return recommendation.provider;
+        let current_provider = current_web_search_provider(config);
+        match recommendation.source {
+            WebSearchProviderRecommendationSource::ExplicitCli => {
+                return recommendation.provider;
+            }
+            WebSearchProviderRecommendationSource::ExplicitEnv => {
+                return recommendation.provider;
+            }
+            WebSearchProviderRecommendationSource::Configured => {
+                return current_provider;
+            }
+            WebSearchProviderRecommendationSource::DetectedCredential => {
+                return current_provider;
+            }
+            WebSearchProviderRecommendationSource::DetectedSignals => {
+                return current_provider;
+            }
+        }
     }
 
     match recommendation.source {
@@ -595,6 +618,48 @@ mod tests {
         assert_eq!(
             recommendation.source,
             WebSearchProviderRecommendationSource::Configured
+        );
+    }
+
+    #[test]
+    fn resolve_effective_web_search_default_provider_keeps_current_interactive_provider_for_detected_recommendations()
+     {
+        let options = default_options();
+        let config = mvp::config::LoongClawConfig::default();
+        let recommendation = WebSearchProviderRecommendation {
+            provider: mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            reason: "domestic locale or timezone was detected".to_owned(),
+            source: WebSearchProviderRecommendationSource::DetectedSignals,
+        };
+
+        let selected =
+            resolve_effective_web_search_default_provider(&options, &config, &recommendation);
+
+        assert_eq!(
+            selected,
+            mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
+            "interactive onboarding should keep the current draft provider on enter even when a different provider is recommended"
+        );
+    }
+
+    #[test]
+    fn resolve_effective_web_search_default_provider_keeps_explicit_interactive_override() {
+        let mut options = default_options();
+        options.web_search_provider = Some("tavily".to_owned());
+        let config = mvp::config::LoongClawConfig::default();
+        let recommendation = WebSearchProviderRecommendation {
+            provider: mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            reason: "set by --web-search-provider".to_owned(),
+            source: WebSearchProviderRecommendationSource::ExplicitCli,
+        };
+
+        let selected =
+            resolve_effective_web_search_default_provider(&options, &config, &recommendation);
+
+        assert_eq!(
+            selected,
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            "explicit interactive overrides should still become the default selection"
         );
     }
 


### PR DESCRIPTION
## summary

- keep the current interactive web-search provider as the enter default unless the operator explicitly overrides it
- keep the recommended provider highlight and explanation separate from the actual enter default in the onboarding ui
- add regression coverage for the interactive selection path and the footer copy

## testing

- cargo test -p loongclaw-daemon --manifest-path <redacted-path> --lib web_search_provider -- --nocapture
- cargo test -p loongclaw-daemon --manifest-path <redacted-path> --test integration interactive_onboard_clear_token -- --nocapture
- cargo test -p loongclaw-daemon --manifest-path <redacted-path> --test integration interactive_onboard_only_shows_large_logo_on_the_initial_screen -- --nocapture
- cargo test -p loongclaw-daemon --manifest-path <redacted-path> --test integration onboard_current_setup_adjustments -- --nocapture
- cargo test -p loongclaw-daemon --manifest-path <redacted-path> --test integration onboard_detected_setup_adjustments_preserve_unchanged_detected_actions_in_review -- --nocapture
- cargo test -p loongclaw-daemon --manifest-path <redacted-path>

Closes #567


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved web search provider selection flow by distinguishing between recommended and default provider options.
  * Updated selection screen footer to accurately display the actual default provider behavior ("keep current" or "use alternative").
  * Corrected current provider detection to use actual configuration values.

* **Tests**
  * Added validation for interactive selection behavior when recommendations differ from the current provider.
  * Added tests verifying footer display accuracy for default provider selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->