### PR TITLE
feat(spec): inject explicit plugin setup readiness context

### DIFF
--- a/crates/bench/tests/bench_integration.rs
+++ b/crates/bench/tests/bench_integration.rs
@@ -57,6 +57,7 @@ async fn run_spec_pressure_once_rejects_native_claw_migrate_scenarios() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
             tool_name: "claw.migrate".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -105,6 +106,7 @@ async fn run_spec_pressure_once_uses_native_executor_when_present() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
             tool_name: "claw.migrate".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -155,6 +157,7 @@ async fn run_spec_pressure_once_errors_when_executor_declines_native_request() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
             tool_name: "claw.migrate".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -208,6 +211,7 @@ fn spec_requires_native_tool_executor_detects_claw_migration_extension() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolExtension {
             extension_action: "plan".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),

--- a/crates/daemon/tests/integration/architecture.rs
+++ b/crates/daemon/tests/integration/architecture.rs
@@ -43,6 +43,7 @@ async fn execute_spec_allows_execution_with_clean_architecture_guard() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-guard-clean".to_owned(),
             objective: "run with clean guard".to_owned(),
@@ -111,6 +112,7 @@ async fn execute_spec_blocks_when_architecture_guard_detects_core_mutation() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-guard".to_owned(),
             objective: "should not run".to_owned(),

--- a/crates/daemon/tests/integration/programmatic.rs
+++ b/crates/daemon/tests/integration/programmatic.rs
@@ -28,6 +28,7 @@ async fn execute_spec_programmatic_tool_call_supports_templates_and_steps() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-alpha".to_owned(),
             max_calls: 3,
@@ -115,6 +116,7 @@ async fn execute_spec_programmatic_tool_call_enforces_max_call_budget() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-beta".to_owned(),
             max_calls: 1,
@@ -237,6 +239,7 @@ async fn execute_spec_programmatic_tool_call_blocks_when_caller_not_allowlisted(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-denied".to_owned(),
             max_calls: 2,
@@ -301,6 +304,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_parallel_succeeds()
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-batch".to_owned(),
             max_calls: 4,
@@ -394,6 +398,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_continue_on_error()
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-batch-errors".to_owned(),
             max_calls: 5,
@@ -502,6 +507,7 @@ async fn execute_spec_programmatic_tool_call_conditional_step_routes_branch() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-conditional".to_owned(),
             max_calls: 2,
@@ -589,6 +595,7 @@ async fn execute_spec_programmatic_tool_call_connector_batch_budget_checks_total
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-batch-budget".to_owned(),
             max_calls: 1,
@@ -679,6 +686,7 @@ async fn execute_spec_programmatic_tool_call_retry_recovers_transient_failure() 
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-retry".to_owned(),
             max_calls: 2,
@@ -754,6 +762,7 @@ async fn execute_spec_programmatic_tool_call_applies_connector_rate_limits() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-rate".to_owned(),
             max_calls: 2,
@@ -835,6 +844,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_rate_limit_policy()
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-rate-invalid".to_owned(),
             max_calls: 1,
@@ -911,6 +921,7 @@ async fn execute_spec_programmatic_tool_call_circuit_breaker_blocks_followup_bat
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-circuit-open".to_owned(),
             max_calls: 2,
@@ -1017,6 +1028,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_circuit_policy() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-circuit-invalid".to_owned(),
             max_calls: 1,
@@ -1098,6 +1110,7 @@ async fn execute_spec_programmatic_tool_call_retry_jitter_tracks_backoff_budget(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-retry-jitter".to_owned(),
             max_calls: 1,
@@ -1180,6 +1193,7 @@ async fn execute_spec_programmatic_tool_call_parallel_batch_caps_peak_inflight_b
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-concurrency-cap".to_owned(),
             max_calls: 6,
@@ -1304,6 +1318,7 @@ async fn execute_spec_programmatic_tool_call_weighted_fairness_avoids_low_priori
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-fairness".to_owned(),
             max_calls: 8,
@@ -1431,6 +1446,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_budget_reduces_on_failures
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-adaptive-budget".to_owned(),
             max_calls: 8,
@@ -1565,6 +1581,7 @@ async fn execute_spec_programmatic_tool_call_default_adaptive_policy_skips_not_f
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-adaptive-skip-not-found".to_owned(),
             max_calls: 6,
@@ -1678,6 +1695,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_policy_can_reduce_on_any_e
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-adaptive-any-error".to_owned(),
             max_calls: 6,
@@ -1794,6 +1812,7 @@ async fn execute_spec_programmatic_tool_call_rejects_invalid_concurrency_policy(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-concurrency-invalid".to_owned(),
             max_calls: 1,
@@ -1869,6 +1888,7 @@ async fn execute_spec_programmatic_tool_call_rejects_empty_adaptive_reduce_on_po
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-concurrency-empty-reduce-on".to_owned(),
             max_calls: 1,
@@ -2015,6 +2035,7 @@ async fn execute_spec_programmatic_tool_call_adaptive_budget_respects_min_floor_
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ProgrammaticToolCall {
             caller: "planner-adaptive-floor-recover".to_owned(),
             max_calls: 8,

--- a/crates/daemon/tests/integration/spec_runtime.rs
+++ b/crates/daemon/tests/integration/spec_runtime.rs
@@ -6,6 +6,12 @@ fn template_spec_is_json_roundtrip_stable() {
     let encoded = serde_json::to_string_pretty(&spec).expect("encode spec");
     let decoded: RunnerSpec = serde_json::from_str(&encoded).expect("decode spec");
     assert_eq!(decoded.pack.pack_id, "sales-intel-local");
+    let readiness = decoded
+        .plugin_setup_readiness
+        .expect("template should expose plugin setup readiness");
+    assert!(readiness.inherit_process_env);
+    assert!(readiness.verified_env_vars.is_empty());
+    assert!(readiness.verified_config_keys.is_empty());
     assert!(matches!(
         decoded.operation,
         OperationSpec::RuntimeExtension { .. }
@@ -19,6 +25,7 @@ fn runtime_extension_fixture_uses_backward_compatible_spec_defaults() {
     let parsed: RunnerSpec = serde_json::from_str(&raw)
         .expect("runtime-extension fixture should parse when hotfixes is omitted");
     assert!(parsed.hotfixes.is_empty());
+    assert!(parsed.plugin_setup_readiness.is_none());
 }
 
 #[tokio::test]
@@ -46,6 +53,7 @@ async fn execute_spec_returns_blocked_instead_of_panicking_on_operation_error() 
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "non-existent".to_owned(),
             operation: "notify".to_owned(),
@@ -236,6 +244,7 @@ fn security_scan_profile_path_overrides_bundled_defaults() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-profile-path".to_owned(),
             objective: "verify profile loading".to_owned(),
@@ -344,6 +353,7 @@ fn security_scan_profile_sha256_pin_accepts_matching_profile() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-profile-pin".to_owned(),
             objective: "verify profile sha pin".to_owned(),
@@ -444,6 +454,7 @@ async fn execute_spec_blocks_when_security_scan_profile_sha256_mismatches() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-profile-mismatch".to_owned(),
             objective: "mismatch pin should block".to_owned(),
@@ -552,6 +563,7 @@ fn security_scan_profile_signature_accepts_matching_signature() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-signature-pin".to_owned(),
             objective: "verify profile signature pin".to_owned(),
@@ -665,6 +677,7 @@ async fn execute_spec_blocks_when_security_scan_profile_signature_mismatches() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-signature-mismatch".to_owned(),
             objective: "signature mismatch should block".to_owned(),
@@ -713,6 +726,7 @@ async fn execute_spec_runs_runtime_extension_and_captures_audit() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::RuntimeExtension {
             action: "start".to_owned(),
             required_capabilities: BTreeSet::from([Capability::ObserveTelemetry]),
@@ -770,6 +784,7 @@ async fn execute_spec_auto_provisions_provider_and_channel_when_missing() {
             required_capabilities: BTreeSet::from([Capability::InvokeConnector]),
         }),
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "openrouter".to_owned(),
             operation: "chat".to_owned(),
@@ -825,6 +840,7 @@ async fn execute_spec_applies_hotfix_endpoint_before_invocation() {
             channel_id: "alerts".to_owned(),
             new_endpoint: "https://hooks.slack.com/services/new".to_owned(),
         }],
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "slack".to_owned(),
             operation: "notify".to_owned(),
@@ -897,6 +913,7 @@ async fn execute_spec_scans_plugin_files_and_absorbs_them_for_hotplug() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "openrouter".to_owned(),
             operation: "chat".to_owned(),
@@ -994,6 +1011,7 @@ async fn execute_spec_blocks_when_bridge_matrix_does_not_support_plugin() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "openrouter".to_owned(),
             operation: "chat".to_owned(),
@@ -1105,6 +1123,7 @@ async fn execute_spec_skips_blocked_plugins_when_bridge_enforcement_is_disabled(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "webhookx".to_owned(),
             operation: "notify".to_owned(),
@@ -1206,6 +1225,7 @@ async fn execute_spec_surfaces_setup_incomplete_plugins_without_marking_them_rea
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolSearch {
             query: "tavily".to_owned(),
             limit: 5,
@@ -1346,6 +1366,7 @@ async fn execute_spec_bootstrap_applies_only_bridges_allowed_by_bootstrap_policy
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-provider".to_owned(),
             operation: "notify".to_owned(),
@@ -1462,6 +1483,7 @@ async fn execute_spec_bootstrap_enforcement_blocks_when_ready_plugins_are_deferr
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bootstrap-enforce".to_owned(),
             objective: "must be blocked by bootstrap enforcement".to_owned(),
@@ -1533,6 +1555,7 @@ async fn execute_spec_blocks_on_bridge_support_checksum_mismatch() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bridge-checksum".to_owned(),
             objective: "should be blocked before execution".to_owned(),
@@ -1595,6 +1618,7 @@ async fn execute_spec_blocks_on_bridge_support_sha256_mismatch() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bridge-sha256".to_owned(),
             objective: "should be blocked before execution".to_owned(),
@@ -1656,6 +1680,7 @@ async fn execute_spec_allows_execution_when_bridge_support_sha256_matches() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bridge-sha256-match".to_owned(),
             objective: "should pass".to_owned(),
@@ -1754,6 +1779,7 @@ async fn execute_spec_enriches_plugin_bridge_metadata_and_emits_bridge_execution
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "ffi-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -1897,6 +1923,7 @@ async fn execute_spec_wasm_component_bridge_executes_when_runtime_enabled() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2127,6 +2154,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_component_sha256_mismatc
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-hash-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2265,6 +2293,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_metadata_pin_conflicts_w
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-pin-conflict-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2399,6 +2428,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_hash_pin_required_but_mi
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-pin-required-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2538,6 +2568,7 @@ async fn execute_spec_wasm_component_bridge_blocks_artifact_outside_runtime_pref
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-path-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2681,6 +2712,7 @@ async fn execute_spec_wasm_component_bridge_blocks_symlink_escape_under_allowed_
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-symlink-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2815,6 +2847,7 @@ async fn execute_spec_wasm_component_bridge_blocks_non_regular_artifact_path() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-regular-file-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -2950,6 +2983,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_module_size_exceeds_runt
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "wasm-runtime-size-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -3042,6 +3076,7 @@ async fn execute_spec_blocks_when_wasm_runtime_enabled_without_allowed_prefixes(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-wasm-runtime-invalid-policy".to_owned(),
             objective: "runtime policy should fail closed".to_owned(),
@@ -3170,6 +3205,7 @@ async fn execute_spec_security_scan_blocks_wasm_plugin_with_wasi_import() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-block".to_owned(),
             objective: "security scan should block risky wasm".to_owned(),
@@ -3319,6 +3355,7 @@ async fn execute_spec_security_scan_allows_clean_wasm_with_hash_pin() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-pass".to_owned(),
             objective: "security scan should allow clean wasm".to_owned(),
@@ -3450,6 +3487,7 @@ async fn execute_spec_security_scan_allows_clean_wasm_with_metadata_hash_pin() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-pass-metadata".to_owned(),
             objective: "security scan should accept metadata hash pin".to_owned(),
@@ -3586,6 +3624,7 @@ async fn execute_spec_security_scan_blocks_when_metadata_hash_pin_is_invalid() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-invalid-pin".to_owned(),
             objective: "security scan should block invalid metadata hash pin".to_owned(),
@@ -3719,6 +3758,7 @@ async fn execute_spec_security_scan_blocks_when_metadata_pin_conflicts_with_poli
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-wasm-pin-conflict".to_owned(),
             objective: "security scan should block conflicting wasm hash pins".to_owned(),
@@ -3843,6 +3883,7 @@ async fn execute_spec_security_scan_emits_audit_summary_when_not_blocking() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-audit-pass".to_owned(),
             objective: "security scan should emit audit summary".to_owned(),
@@ -4000,6 +4041,7 @@ async fn execute_spec_security_scan_exports_siem_record_with_truncation() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-siem-pass".to_owned(),
             objective: "security scan should export siem record".to_owned(),
@@ -4143,6 +4185,7 @@ async fn execute_spec_security_scan_siem_fail_closed_blocks_execution() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-siem-block".to_owned(),
             objective: "siem fail closed should block".to_owned(),
@@ -4293,6 +4336,7 @@ async fn execute_spec_security_scan_covers_deferred_plugins_not_only_applied_sub
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-security-deferred-ready".to_owned(),
             objective: "security scan must inspect deferred ready plugins".to_owned(),
@@ -4352,6 +4396,7 @@ async fn execute_spec_default_medium_policy_blocks_high_risk_tool_call_without_a
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4403,6 +4448,7 @@ async fn execute_spec_per_call_approval_allows_high_risk_tool_call() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4448,6 +4494,7 @@ async fn execute_spec_one_time_full_access_allows_high_risk_tool_call() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4492,6 +4539,7 @@ async fn execute_spec_strict_mode_requires_approval_for_low_risk_tool_call() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "read-schema".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4531,6 +4579,7 @@ async fn execute_spec_default_medium_policy_allows_low_risk_tool_call_without_ap
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "list-schema".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4607,6 +4656,7 @@ async fn execute_spec_tool_core_can_run_claw_migrate_plan_via_native_tool_runtim
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "claw.migrate".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4693,6 +4743,7 @@ async fn execute_spec_tool_extension_can_hot_handle_claw_migrate_via_core_wrappe
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolExtension {
             extension_action: "plan".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4796,6 +4847,7 @@ async fn execute_spec_tool_extension_can_discover_multiple_sources() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolExtension {
             extension_action: "discover".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4894,6 +4946,7 @@ async fn execute_spec_tool_extension_can_merge_profiles_without_merging_prompt_l
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolExtension {
             extension_action: "merge_profiles".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -4998,6 +5051,7 @@ async fn execute_spec_tool_extension_apply_selected_safe_merge_keeps_native_prom
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolExtension {
             extension_action: "apply_selected".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -5074,6 +5128,7 @@ async fn execute_spec_denylist_overrides_other_approvals() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -5127,6 +5182,7 @@ async fn execute_spec_one_time_full_access_expired_is_rejected() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -5172,6 +5228,7 @@ async fn execute_spec_one_time_full_access_with_zero_remaining_uses_is_rejected(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
             tool_name: "delete-file".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -5288,6 +5345,7 @@ async fn execute_spec_bootstrap_max_tasks_limits_applied_plugins() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bootstrap-limit".to_owned(),
             objective: "run regardless of selective bootstrap".to_owned(),
@@ -5410,6 +5468,7 @@ async fn execute_spec_scans_multiple_roots_and_absorbs_per_root() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-multi-root".to_owned(),
             objective: "validate multi-root scan".to_owned(),
@@ -5525,6 +5584,7 @@ async fn execute_spec_plugin_scan_is_transactional_when_blocked() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-plugin-rollback".to_owned(),
             objective: "must block and rollback staged plugin absorb".to_owned(),
@@ -5622,6 +5682,7 @@ async fn execute_spec_blocks_when_package_manifest_conflicts_with_source_manifes
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-plugin-manifest-conflict".to_owned(),
             objective: "plugin scan should fail on package/source drift".to_owned(),
@@ -5759,6 +5820,7 @@ async fn execute_spec_bootstrap_budget_is_global_across_multiple_roots() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::Task {
             task_id: "t-bootstrap-global".to_owned(),
             objective: "max_tasks must be global across roots".to_owned(),
@@ -5903,6 +5965,7 @@ async fn execute_spec_tool_search_honors_deferred_filter_and_examples() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolSearch {
             query: "web search".to_owned(),
             limit: 5,
@@ -5941,6 +6004,140 @@ async fn execute_spec_tool_search_honors_deferred_filter_and_examples() {
     assert_eq!(
         report_visible_deferred.outcome["results"][0]["input_examples"][0]["query"],
         "search best rust crates"
+    );
+}
+
+#[tokio::test]
+async fn execute_spec_tool_search_uses_explicit_plugin_setup_readiness_context() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    let plugin_root =
+        std::env::temp_dir().join(format!("loongclaw-tool-search-readiness-{unique}"));
+    fs::create_dir_all(&plugin_root).expect("create plugin root");
+
+    let plugin_manifest_path = plugin_root.join("loongclaw.plugin.json");
+    fs::write(
+        &plugin_manifest_path,
+        r#"
+{
+  "plugin_id": "tavily-search",
+  "provider_id": "tavily",
+  "connector_name": "tavily-http",
+  "endpoint": "https://api.tavily.com/search",
+  "capabilities": ["InvokeConnector"],
+  "metadata": {
+    "bridge_kind": "http_json",
+    "adapter_family": "web-search"
+  },
+  "summary": "Manifest-discovered Tavily package",
+  "tags": ["search", "provider"],
+  "setup": {
+    "mode": "metadata_only",
+    "surface": "web_search",
+    "required_env_vars": ["TAVILY_API_KEY"],
+    "required_config_keys": ["tools.web_search.default_provider"],
+    "default_env_var": "TAVILY_API_KEY",
+    "docs_urls": ["https://docs.example.com/tavily"],
+    "remediation": "set a Tavily credential before enabling search"
+  }
+}
+"#,
+    )
+    .expect("write plugin manifest");
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-tool-search-readiness".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::ObserveTelemetry]),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-tool-search-readiness".to_owned(),
+        ttl_s: 120,
+        approval: Some(HumanApprovalSpec {
+            mode: HumanApprovalMode::Disabled,
+            ..HumanApprovalSpec::default()
+        }),
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: Some(PluginScanSpec {
+            enabled: true,
+            roots: vec![plugin_root.display().to_string()],
+        }),
+        bridge_support: Some(BridgeSupportSpec {
+            enabled: true,
+            supported_bridges: vec![PluginBridgeKind::HttpJson],
+            supported_adapter_families: Vec::new(),
+            enforce_supported: true,
+            policy_version: None,
+            expected_checksum: None,
+            expected_sha256: None,
+            execute_process_stdio: false,
+            execute_http_json: false,
+            allowed_process_commands: Vec::new(),
+            enforce_execution_success: false,
+            security_scan: None,
+        }),
+        bootstrap: Some(BootstrapSpec {
+            enabled: true,
+            allow_http_json_auto_apply: Some(false),
+            allow_process_stdio_auto_apply: Some(false),
+            allow_native_ffi_auto_apply: Some(false),
+            allow_wasm_component_auto_apply: Some(false),
+            allow_mcp_server_auto_apply: Some(false),
+            allow_acp_bridge_auto_apply: Some(false),
+            allow_acp_runtime_auto_apply: Some(false),
+            enforce_ready_execution: Some(false),
+            max_tasks: Some(8),
+        }),
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        plugin_setup_readiness: Some(PluginSetupReadinessSpec {
+            inherit_process_env: false,
+            verified_env_vars: vec!["TAVILY_API_KEY".to_owned()],
+            verified_config_keys: vec!["tools.web_search.default_provider".to_owned()],
+        }),
+        operation: OperationSpec::ToolSearch {
+            query: "tavily".to_owned(),
+            limit: 5,
+            include_deferred: true,
+            include_examples: false,
+        },
+    };
+
+    let report = execute_spec(&spec, true).await;
+
+    assert_eq!(report.operation_kind, "tool_search");
+    assert_eq!(report.plugin_activation_plans.len(), 1);
+    assert_eq!(report.plugin_activation_plans[0].ready_plugins, 1);
+    assert_eq!(
+        report.plugin_activation_plans[0].setup_incomplete_plugins,
+        0
+    );
+    assert!(matches!(
+        report.plugin_activation_plans[0].candidates[0].status,
+        loongclaw_daemon::kernel::PluginActivationStatus::Ready
+    ));
+    assert_eq!(report.outcome["returned"], 1);
+    assert_eq!(report.outcome["results"][0]["provider_id"], "tavily");
+    assert_eq!(report.outcome["results"][0]["setup_ready"], true);
+    assert_eq!(
+        report.outcome["results"][0]["missing_required_env_vars"],
+        json!([])
+    );
+    assert_eq!(
+        report.outcome["results"][0]["missing_required_config_keys"],
+        json!([])
     );
 }
 
@@ -6028,6 +6225,7 @@ async fn execute_spec_tool_search_uses_translation_bridge_kind_for_unabsorbed_pl
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ToolSearch {
             query: "rusty".to_owned(),
             limit: 5,

--- a/crates/daemon/tests/integration/spec_runtime.rs
+++ b/crates/daemon/tests/integration/spec_runtime.rs
@@ -1149,6 +1149,8 @@ async fn execute_spec_skips_blocked_plugins_when_bridge_enforcement_is_disabled(
 async fn execute_spec_surfaces_setup_incomplete_plugins_without_marking_them_ready() {
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    let _env_guard = MigrationEnvironmentGuard::set(&[("TAVILY_API_KEY", None)]);
+
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("clock should be monotonic")

--- a/crates/daemon/tests/integration/spec_runtime_bridge/http_json.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/http_json.rs
@@ -96,6 +96,7 @@ async fn execute_spec_http_json_bridge_executes_against_local_server() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-runtime".to_owned(),
             operation: "invoke".to_owned(),
@@ -207,6 +208,7 @@ async fn execute_spec_http_json_bridge_blocks_when_protocol_authorization_fails(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-authz-block".to_owned(),
             operation: "invoke".to_owned(),
@@ -345,6 +347,7 @@ async fn execute_spec_http_json_bridge_strict_contract_fails_on_method_mismatch(
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-strict-method".to_owned(),
             operation: "invoke".to_owned(),
@@ -469,6 +472,7 @@ async fn execute_spec_http_json_bridge_strict_contract_fails_on_id_mismatch() {
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-strict-id".to_owned(),
             operation: "invoke".to_owned(),
@@ -597,6 +601,7 @@ async fn execute_spec_http_json_bridge_strict_contract_executes_on_matching_fram
         bootstrap: None,
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "http-strict-pass".to_owned(),
             operation: "invoke".to_owned(),

--- a/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
@@ -99,6 +99,7 @@ async fn execute_spec_process_stdio_bridge_executes_when_enabled_and_allowed() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -225,6 +226,7 @@ async fn execute_spec_process_stdio_bridge_blocks_when_command_not_allowlisted()
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -335,6 +337,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_invalid_json_line_response()
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-invalid-frame-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -454,6 +457,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_id_mismatch() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-mismatch-id-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -567,6 +571,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_response_method_mismatch() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-mismatch-method-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -678,6 +683,7 @@ async fn execute_spec_process_stdio_bridge_blocks_when_protocol_authorization_fa
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-authz-block-provider".to_owned(),
             operation: "invoke".to_owned(),
@@ -805,6 +811,7 @@ async fn execute_spec_process_stdio_bridge_fails_on_recv_timeout() {
         }),
         auto_provision: None,
         hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
         operation: OperationSpec::ConnectorLegacy {
             connector_name: "stdio-timeout-provider".to_owned(),
             operation: "invoke".to_owned(),

--- a/crates/kernel/src/plugin_ir.rs
+++ b/crates/kernel/src/plugin_ir.rs
@@ -86,17 +86,6 @@ impl Default for PluginSetupReadiness {
     }
 }
 
-fn env_var_names_match(verified_name: &str, required_name: &str) -> bool {
-    #[cfg(windows)]
-    {
-        verified_name.eq_ignore_ascii_case(required_name)
-    }
-    #[cfg(not(windows))]
-    {
-        verified_name == required_name
-    }
-}
-
 /// Evaluates manifest-declared setup requirements against verified runtime context.
 pub fn evaluate_plugin_setup_requirements(
     required_env_vars: &[String],
@@ -105,10 +94,8 @@ pub fn evaluate_plugin_setup_requirements(
 ) -> PluginSetupReadiness {
     let mut missing_required_env_vars = Vec::new();
     for required_env_var in required_env_vars {
-        let env_var_is_verified = context
-            .verified_env_vars
-            .iter()
-            .any(|verified_env_var| env_var_names_match(verified_env_var, required_env_var));
+        let env_var_is_verified =
+            verified_env_var_names_contain(&context.verified_env_vars, required_env_var);
         if !env_var_is_verified {
             missing_required_env_vars.push(required_env_var.clone());
         }
@@ -133,6 +120,24 @@ pub fn evaluate_plugin_setup_requirements(
     }
 }
 
+fn verified_env_var_names_contain(
+    verified_env_vars: &BTreeSet<String>,
+    required_env_var: &str,
+) -> bool {
+    #[cfg(windows)]
+    {
+        let required_env_var = required_env_var;
+        verified_env_vars
+            .iter()
+            .any(|verified_env_var| verified_env_var.eq_ignore_ascii_case(required_env_var))
+    }
+
+    #[cfg(not(windows))]
+    {
+        verified_env_vars.contains(required_env_var)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PluginTranslationReport {
     pub translated_plugins: usize,
@@ -140,16 +145,16 @@ pub struct PluginTranslationReport {
     pub entries: Vec<PluginIR>,
 }
 
-/// Contract-facing activation status for manifest-backed plugin planning.
+/// Serialized activation outcomes are additive.
 ///
-/// Compatibility note: this enum is additive over time. Consumers that decode
-/// serialized activation payloads should handle newly introduced variants
-/// conservatively.
+/// Consumers that deserialize persisted or remote payloads should tolerate newer
+/// snake_case variants and treat unknown values as forward-compatible contract
+/// growth rather than a malformed payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginActivationStatus {
     Ready,
-    /// The runtime can host the plugin, but required setup is still missing.
+    /// The runtime surface is supported, but declared setup requirements are not.
     SetupIncomplete,
     BlockedUnsupportedBridge,
     BlockedUnsupportedAdapterFamily,
@@ -844,6 +849,92 @@ mod tests {
             plan.candidates[0].status,
             PluginActivationStatus::Ready
         ));
+        assert!(plan.candidates[0].missing_required_env_vars.is_empty());
+        assert!(plan.candidates[0].missing_required_config_keys.is_empty());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn activation_plan_matches_verified_env_vars_case_insensitively_on_windows() {
+        let descriptor = descriptor("manifest", BTreeMap::new());
+        let translator = PluginTranslator::new();
+        let translation = translator.translate_scan_report(&PluginScanReport {
+            scanned_files: 1,
+            matched_plugins: 1,
+            descriptors: vec![descriptor],
+        });
+
+        let matrix = BridgeSupportMatrix {
+            supported_bridges: BTreeSet::from([PluginBridgeKind::HttpJson]),
+            supported_adapter_families: BTreeSet::new(),
+        };
+        let setup_readiness_context = PluginSetupReadinessContext {
+            verified_env_vars: BTreeSet::from(["tavily_api_key".to_owned()]),
+            verified_config_keys: BTreeSet::from(["tools.web_search.default_provider".to_owned()]),
+        };
+        let plan = translator.plan_activation(&translation, &matrix, &setup_readiness_context);
+
+        assert!(matches!(
+            plan.candidates[0].status,
+            PluginActivationStatus::Ready
+        ));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn activation_plan_keeps_verified_env_vars_case_sensitive_off_windows() {
+        let descriptor = descriptor("manifest", BTreeMap::new());
+        let translator = PluginTranslator::new();
+        let translation = translator.translate_scan_report(&PluginScanReport {
+            scanned_files: 1,
+            matched_plugins: 1,
+            descriptors: vec![descriptor],
+        });
+
+        let matrix = BridgeSupportMatrix {
+            supported_bridges: BTreeSet::from([PluginBridgeKind::HttpJson]),
+            supported_adapter_families: BTreeSet::new(),
+        };
+        let setup_readiness_context = PluginSetupReadinessContext {
+            verified_env_vars: BTreeSet::from(["tavily_api_key".to_owned()]),
+            verified_config_keys: BTreeSet::from(["tools.web_search.default_provider".to_owned()]),
+        };
+        let plan = translator.plan_activation(&translation, &matrix, &setup_readiness_context);
+
+        assert!(matches!(
+            plan.candidates[0].status,
+            PluginActivationStatus::SetupIncomplete
+        ));
+    }
+
+    #[test]
+    fn activation_plan_deserializes_old_payload_without_new_readiness_fields() {
+        let raw = r#"
+{
+  "total_plugins": 1,
+  "ready_plugins": 0,
+  "blocked_plugins": 1,
+  "candidates": [
+    {
+      "plugin_id": "legacy-plugin",
+      "source_path": "/tmp/legacy-plugin.py",
+      "source_kind": "embedded_source",
+      "package_root": "/tmp",
+      "package_manifest_path": null,
+      "bridge_kind": "http_json",
+      "adapter_family": "web-search",
+      "status": "blocked_unsupported_bridge",
+      "reason": "legacy payload",
+      "bootstrap_hint": "skip"
+    }
+  ]
+}
+"#;
+
+        let plan: PluginActivationPlan =
+            serde_json::from_str(raw).expect("legacy activation payload should deserialize");
+
+        assert_eq!(plan.setup_incomplete_plugins, 0);
         assert!(plan.candidates[0].missing_required_env_vars.is_empty());
         assert!(plan.candidates[0].missing_required_config_keys.is_empty());
     }

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -92,7 +92,9 @@ pub async fn execute_spec_with_native_tool_executor(
         .as_ref()
         .map(|_| SecurityScanReport::default());
     let mut auto_provision_plan = None;
-    let setup_readiness_context = plugin_setup_readiness_context_from_process_env();
+    let plugin_setup_readiness = spec.plugin_setup_readiness.as_ref();
+    let setup_readiness_context =
+        resolve_plugin_setup_readiness_context(plugin_setup_readiness, std::env::vars_os());
 
     if !approval_guard.approved {
         blocked_reason = Some(approval_guard.reason.clone());
@@ -765,12 +767,35 @@ fn bridge_support_matrix(spec: &RunnerSpec) -> (BridgeSupportMatrix, bool) {
     }
 }
 
-fn plugin_setup_readiness_context_from_process_env() -> PluginSetupReadinessContext {
-    let verified_env_vars = collect_verified_env_var_names(std::env::vars_os());
+fn resolve_plugin_setup_readiness_context<I>(
+    readiness_spec: Option<&PluginSetupReadinessSpec>,
+    env_vars: I,
+) -> PluginSetupReadinessContext
+where
+    I: IntoIterator<Item = (OsString, OsString)>,
+{
+    let Some(readiness_spec) = readiness_spec else {
+        let verified_env_vars = collect_verified_env_var_names(env_vars);
+
+        return PluginSetupReadinessContext {
+            verified_env_vars,
+            verified_config_keys: BTreeSet::new(),
+        };
+    };
+
+    let mut verified_env_vars = BTreeSet::new();
+    if readiness_spec.inherit_process_env {
+        verified_env_vars = collect_verified_env_var_names(env_vars);
+    }
+
+    let explicit_verified_env_vars = collect_verified_name_list(&readiness_spec.verified_env_vars);
+    verified_env_vars.extend(explicit_verified_env_vars);
+
+    let verified_config_keys = collect_verified_name_list(&readiness_spec.verified_config_keys);
 
     PluginSetupReadinessContext {
         verified_env_vars,
-        verified_config_keys: BTreeSet::new(),
+        verified_config_keys,
     }
 }
 
@@ -797,6 +822,21 @@ where
     }
 
     verified_env_vars
+}
+
+fn collect_verified_name_list(values: &[String]) -> BTreeSet<String> {
+    let mut verified_names = BTreeSet::new();
+
+    for raw_value in values {
+        let value = raw_value.trim().to_owned();
+        if value.is_empty() {
+            continue;
+        }
+
+        verified_names.insert(value);
+    }
+
+    verified_names
 }
 
 fn bridge_runtime_policy(
@@ -1612,6 +1652,7 @@ mod bootstrap_policy_tests {
 #[cfg(test)]
 mod setup_readiness_context_tests {
     use super::*;
+    use crate::PluginSetupReadinessSpec;
 
     #[test]
     fn collect_verified_env_var_names_ignores_blank_names_and_values() {
@@ -1638,6 +1679,67 @@ mod setup_readiness_context_tests {
         assert_eq!(
             verified_env_vars,
             BTreeSet::from([" TAVILY_API_KEY".to_owned()])
+        );
+    }
+
+    #[test]
+    fn resolve_plugin_setup_readiness_context_falls_back_to_process_env_when_unspecified() {
+        let env_vars = vec![
+            (OsString::from("TAVILY_API_KEY"), OsString::from("secret")),
+            (OsString::from("EMPTY_VALUE"), OsString::from("   ")),
+        ];
+
+        let context = resolve_plugin_setup_readiness_context(None, env_vars);
+
+        assert_eq!(
+            context.verified_env_vars,
+            BTreeSet::from(["TAVILY_API_KEY".to_owned()])
+        );
+        assert!(context.verified_config_keys.is_empty());
+    }
+
+    #[test]
+    fn resolve_plugin_setup_readiness_context_uses_explicit_values_without_env_inheritance() {
+        let readiness_spec = PluginSetupReadinessSpec {
+            inherit_process_env: false,
+            verified_env_vars: vec![" TAVILY_API_KEY ".to_owned(), "".to_owned()],
+            verified_config_keys: vec![
+                " tools.web_search.default_provider ".to_owned(),
+                "   ".to_owned(),
+            ],
+        };
+        let env_vars = vec![(OsString::from("SHOULD_NOT_BE_USED"), OsString::from("set"))];
+
+        let context = resolve_plugin_setup_readiness_context(Some(&readiness_spec), env_vars);
+
+        assert_eq!(
+            context.verified_env_vars,
+            BTreeSet::from(["TAVILY_API_KEY".to_owned()])
+        );
+        assert_eq!(
+            context.verified_config_keys,
+            BTreeSet::from(["tools.web_search.default_provider".to_owned()])
+        );
+    }
+
+    #[test]
+    fn resolve_plugin_setup_readiness_context_merges_process_env_when_requested() {
+        let readiness_spec = PluginSetupReadinessSpec {
+            inherit_process_env: true,
+            verified_env_vars: vec!["TAVILY_API_KEY".to_owned()],
+            verified_config_keys: vec!["tools.web_search.default_provider".to_owned()],
+        };
+        let env_vars = vec![(OsString::from("OPENAI_API_KEY"), OsString::from("set"))];
+
+        let context = resolve_plugin_setup_readiness_context(Some(&readiness_spec), env_vars);
+
+        assert_eq!(
+            context.verified_env_vars,
+            BTreeSet::from(["OPENAI_API_KEY".to_owned(), "TAVILY_API_KEY".to_owned(),])
+        );
+        assert_eq!(
+            context.verified_config_keys,
+            BTreeSet::from(["tools.web_search.default_provider".to_owned()])
         );
     }
 }

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -1672,6 +1672,7 @@ mod setup_readiness_context_tests {
         );
     }
 
+    #[test]
     fn collect_verified_env_var_names_preserves_non_blank_name_spelling() {
         let env_vars = vec![
             (OsString::from(" TAVILY_API_KEY"), OsString::from("secret")),

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -807,13 +807,15 @@ where
 
     for (raw_name, raw_value) in env_vars {
         let name = raw_name.to_string_lossy().into_owned();
-        let name_is_blank = name.trim().is_empty();
+        let trimmed_name = name.trim();
+        let name_is_blank = trimmed_name.is_empty();
         if name_is_blank {
             continue;
         }
 
-        let value = raw_value.to_string_lossy();
-        let value_is_blank = value.trim().is_empty();
+        let value = raw_value.to_string_lossy().into_owned();
+        let trimmed_value = value.trim();
+        let value_is_blank = trimmed_value.is_empty();
         if value_is_blank {
             continue;
         }
@@ -1670,15 +1672,17 @@ mod setup_readiness_context_tests {
         );
     }
 
-    #[test]
-    fn collect_verified_env_var_names_preserves_non_blank_original_names() {
-        let env_vars = vec![(OsString::from(" TAVILY_API_KEY"), OsString::from("secret"))];
+    fn collect_verified_env_var_names_preserves_non_blank_name_spelling() {
+        let env_vars = vec![
+            (OsString::from(" TAVILY_API_KEY"), OsString::from("secret")),
+            (OsString::from("TAVILY_API_KEY "), OsString::from("secret")),
+        ];
 
         let verified_env_vars = collect_verified_env_var_names(env_vars);
 
         assert_eq!(
             verified_env_vars,
-            BTreeSet::from([" TAVILY_API_KEY".to_owned()])
+            BTreeSet::from([" TAVILY_API_KEY".to_owned(), "TAVILY_API_KEY ".to_owned(),])
         );
     }
 

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -525,6 +525,8 @@ pub struct RunnerSpec {
     pub defaults: Option<DefaultCoreSelection>,
     pub self_awareness: Option<SelfAwarenessSpec>,
     pub plugin_scan: Option<PluginScanSpec>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_setup_readiness: Option<PluginSetupReadinessSpec>,
     pub bridge_support: Option<BridgeSupportSpec>,
     pub bootstrap: Option<BootstrapSpec>,
     pub auto_provision: Option<AutoProvisionSpec>,
@@ -686,6 +688,26 @@ pub struct SelfAwarenessSpec {
 pub struct PluginScanSpec {
     pub enabled: bool,
     pub roots: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginSetupReadinessSpec {
+    #[serde(default = "default_true")]
+    pub inherit_process_env: bool,
+    #[serde(default)]
+    pub verified_env_vars: Vec<String>,
+    #[serde(default)]
+    pub verified_config_keys: Vec<String>,
+}
+
+impl Default for PluginSetupReadinessSpec {
+    fn default() -> Self {
+        Self {
+            inherit_process_env: true,
+            verified_env_vars: Vec::new(),
+            verified_config_keys: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1048,6 +1070,11 @@ impl RunnerSpec {
             }),
             self_awareness: None,
             plugin_scan: None,
+            plugin_setup_readiness: Some(PluginSetupReadinessSpec {
+                inherit_process_env: true,
+                verified_env_vars: Vec::new(),
+                verified_config_keys: Vec::new(),
+            }),
             bridge_support: None,
             bootstrap: None,
             auto_provision: Some(AutoProvisionSpec {

--- a/crates/spec/src/test_support.rs
+++ b/crates/spec/src/test_support.rs
@@ -24,6 +24,7 @@ pub fn make_runner_spec(operation: OperationSpec) -> RunnerSpec {
         defaults: None,
         self_awareness: None,
         plugin_scan: None,
+        plugin_setup_readiness: None,
         bridge_support: None,
         bootstrap: None,
         auto_provision: None,

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-26T04:01:02Z
+- Generated at: 2026-03-26T04:19:52Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -12,7 +12,7 @@
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
 | spec_runtime | `crates/spec/src/spec_runtime.rs` | 3289 | 3600 | 311 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 2055 | 3700 | 1645 | 29 | 80 | 51 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 2057 | 3700 | 1643 | 29 | 80 | 51 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
@@ -40,7 +40,7 @@
 - [CI workflow](../../.github/workflows/ci.yml)
 
 <!-- arch-hotspot key=spec_runtime lines=3289 functions=48 -->
-<!-- arch-hotspot key=spec_execution lines=2055 functions=29 -->
+<!-- arch-hotspot key=spec_execution lines=2057 functions=29 -->
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-26T04:10:02Z
+- Generated at: 2026-03-26T04:01:02Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 4
@@ -11,8 +11,8 @@
 ## Hotspot Metrics
 | Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3262 | 3600 | 338 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 1950 | 3700 | 1750 | 28 | 80 | 52 | n/a | n/a | N/A | n/a |
+| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3289 | 3600 | 311 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
+| spec_execution | `crates/spec/src/spec_execution.rs` | 2055 | 3700 | 1645 | 29 | 80 | 51 | n/a | n/a | N/A | n/a |
 | provider_mod | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
 | memory_mod | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
 
@@ -39,8 +39,8 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=3262 functions=48 -->
-<!-- arch-hotspot key=spec_execution lines=1950 functions=28 -->
+<!-- arch-hotspot key=spec_runtime lines=3289 functions=48 -->
+<!-- arch-hotspot key=spec_execution lines=2055 functions=29 -->
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  spec runners could only infer plugin setup readiness from ambient process env, so verified config-key readiness could not be modeled in hermetic specs or tests.
- Why it matters:
  that left a structural gap between manifest-declared setup contracts and the runner layer that should consume them, and it kept future daemon or app integration without a clean injection seam.
- What changed:
  this stacked follow-up re-lands the explicit readiness-context slice on top of #571.
  `RunnerSpec` now carries an optional `PluginSetupReadinessSpec` with `inherit_process_env`, `verified_env_vars`, and `verified_config_keys`.
  spec execution now resolves an explicit `PluginSetupReadinessContext` from that input, preserves the current process-env fallback when the field is omitted, and trims blank names before they become verified.
  the generated spec template now exposes the new shape, and regression coverage now covers fallback behavior, explicit injection, merge behavior, backward-compatible fixture parsing, and an end-to-end tool-search readiness case.
- What did not change (scope boundary):
  this does not depend on app config types, does not mutate user config, does not add value-level setup predicates, and does not add provider-specific heuristics.

## Linked Issues

- Closes #560
- Related #551
- Related #571
- Related #562

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked -- --test-threads=1`
- [x] `cargo test --workspace --all-features --locked -- --test-threads=1`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo test -p loongclaw-spec --locked -- --test-threads=1
cargo test --workspace --locked -- --test-threads=1
cargo test --workspace --all-features --locked -- --test-threads=1
cargo clippy --workspace --all-targets --all-features -- -D warnings

All commands passed.

Before:
- spec runners could only treat non-empty process env vars as verified setup input
- required config keys stayed unverified in hermetic specs and tests

After:
- spec runners can inject verified env vars and verified config keys explicitly
- spec runners can choose whether to inherit the ambient process env
- omitting the field preserves the previous fallback behavior
- blank names and blank values are filtered before they become verified inputs

Regression coverage:
- unit coverage for fallback, explicit-only, and merged readiness resolution
- template and backward-compatibility coverage for the new optional field
- end-to-end tool-search coverage proving explicit readiness injection upgrades a manifest-backed plugin to ready
```

## User-visible / Operator-visible Changes

- Generated spec templates now show how to declare verified plugin setup readiness explicitly.
- Spec fixtures can model configured plugin readiness without mutating the host environment.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR to return spec execution to the process-env-only readiness fallback.
- Observable failure symptoms reviewers should watch for:
  omitted readiness fields no longer preserving fallback behavior, or explicit verified config keys not making setup-aware plugins ready during spec-driven tool search.

## Reviewer Focus

- `crates/spec/src/spec_runtime.rs` for the new runner contract and template exposure.
- `crates/spec/src/spec_execution.rs` for explicit-versus-fallback readiness resolution and blank-value filtering.
- `crates/daemon/tests/integration/spec_runtime.rs` for the end-to-end readiness injection behavior and backward-compatibility assertions.
