### PR TITLE
feat(channel): bridge turn observer into channel feedback

### DIFF
--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -24,7 +24,8 @@ use crate::CliResult;
 use crate::KernelContext;
 use crate::channel::{
     ChannelAdapter, ChannelInboundMessage, ChannelOutboundMessage, ChannelOutboundTarget,
-    process_inbound_with_provider, runtime_state::ChannelOperationRuntimeTracker,
+    ChannelTurnFeedbackPolicy, process_inbound_with_provider,
+    runtime_state::ChannelOperationRuntimeTracker,
 };
 use crate::config::{LoongClawConfig, ResolvedFeishuChannelConfig};
 use crate::crypto::timing_safe_eq;
@@ -552,7 +553,8 @@ async fn handle_feishu_card_callback_event(
         &state.config,
         state.resolved_path.as_deref(),
         &inbound,
-        Some(state.kernel_ctx.as_ref()),
+        state.kernel_ctx.as_ref(),
+        ChannelTurnFeedbackPolicy::disabled(),
     )
     .await
     .map(|reply| {
@@ -602,7 +604,8 @@ async fn handle_feishu_inbound_event(
             &state.config,
             state.resolved_path.as_deref(),
             &channel_message,
-            Some(state.kernel_ctx.as_ref()),
+            state.kernel_ctx.as_ref(),
+            ChannelTurnFeedbackPolicy::final_trace_significant(),
         )
         .await
         .map_err(|error| {

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -91,7 +91,8 @@ use super::config::{ChannelResolvedAccountRoute, LoongClawConfig, normalize_chan
 use super::conversation::{
     ConversationIngressChannel, ConversationIngressContext, ConversationIngressDelivery,
     ConversationIngressDeliveryResource, ConversationIngressFeishuCallbackContext,
-    ConversationIngressPrivateContext, ConversationSessionAddress, encode_route_session_segment,
+    ConversationIngressPrivateContext, ConversationRuntime, ConversationRuntimeBinding,
+    ConversationSessionAddress, DefaultConversationRuntime, encode_route_session_segment,
     parse_route_session_id,
 };
 #[cfg(any(
@@ -111,6 +112,13 @@ mod runtime_state;
 pub(crate) mod sdk;
 #[cfg(feature = "channel-telegram")]
 mod telegram;
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom"
+))]
+mod turn_feedback;
 #[cfg(feature = "channel-wecom")]
 mod wecom;
 
@@ -139,6 +147,20 @@ pub use registry::{
 pub use runtime_state::ChannelOperationRuntime;
 use runtime_state::ChannelOperationRuntimeTracker;
 pub use sdk::{background_channel_runtime_descriptors, is_background_channel_surface_enabled};
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom"
+))]
+use turn_feedback::ChannelTurnFeedbackCapture;
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom"
+))]
+pub use turn_feedback::ChannelTurnFeedbackPolicy;
 
 #[derive(Debug, Clone, Default)]
 pub struct ChannelDelivery {
@@ -610,6 +632,9 @@ pub trait ChannelAdapter {
     fn streaming_mode(&self) -> ChannelStreamingMode {
         ChannelStreamingMode::Off
     }
+    fn turn_feedback_policy(&self) -> ChannelTurnFeedbackPolicy {
+        ChannelTurnFeedbackPolicy::final_trace_significant()
+    }
     async fn receive_batch(&mut self) -> CliResult<Vec<ChannelInboundMessage>>;
     async fn send_message(
         &self,
@@ -965,7 +990,7 @@ async fn process_channel_batch<A, F>(
 ) -> CliResult<bool>
 where
     A: ChannelAdapter + Send + ?Sized,
-    F: FnMut(ChannelInboundMessage) -> ChannelProcessFuture,
+    F: FnMut(ChannelInboundMessage, ChannelTurnFeedbackPolicy) -> ChannelProcessFuture,
 {
     if batch.is_empty() {
         adapter.complete_batch().await?;
@@ -978,7 +1003,8 @@ where
         }
 
         let result = async {
-            let reply = process(message.clone()).await?;
+            let turn_feedback_policy = adapter.turn_feedback_policy();
+            let reply = process(message.clone(), turn_feedback_policy).await?;
             let outbound = ChannelOutboundMessage::Text(reply);
             let streaming_mode = adapter.streaming_mode();
             adapter
@@ -1591,7 +1617,7 @@ async fn run_telegram_channel_with_context(
                     &mut adapter,
                     batch,
                     Some(runtime.as_ref()),
-                    |message| {
+                    |message, turn_feedback_policy| {
                         let config = config.clone();
                         let kernel_ctx = kernel_ctx.clone();
                         let resolved_path = resolved_path.clone();
@@ -1600,7 +1626,8 @@ async fn run_telegram_channel_with_context(
                                 &config,
                                 Some(resolved_path.as_path()),
                                 &message,
-                                Some(kernel_ctx.as_ref()),
+                                kernel_ctx.as_ref(),
+                                turn_feedback_policy,
                             )
                             .await
                         })
@@ -2082,7 +2109,7 @@ async fn run_matrix_channel_with_context(
                         &mut adapter,
                         batch,
                         Some(runtime.as_ref()),
-                        |message| {
+                        |message, turn_feedback_policy| {
                             let config = config.clone();
                             let kernel_ctx = batch_kernel_ctx.clone();
                             let resolved_path = resolved_path.clone();
@@ -2091,7 +2118,8 @@ async fn run_matrix_channel_with_context(
                                     &config,
                                     Some(resolved_path.as_path()),
                                     &message,
-                                    Some(kernel_ctx.as_ref()),
+                                    kernel_ctx.as_ref(),
+                                    turn_feedback_policy,
                                 )
                                 .await
                             })
@@ -2605,33 +2633,61 @@ pub(crate) async fn send_text_to_known_session(
     feature = "channel-matrix",
     feature = "channel-wecom"
 ))]
-pub(super) async fn process_inbound_with_provider(
+async fn process_inbound_with_runtime_and_feedback<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
-    resolved_path: Option<&std::path::Path>,
+    runtime: &R,
     message: &ChannelInboundMessage,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
+    feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<String> {
-    let turn_config = reload_channel_turn_config(config, resolved_path)?;
     let address = message.session.conversation_address();
-    let acp_turn_hints = resolve_channel_acp_turn_hints(&turn_config, &message.session)?;
+    let acp_turn_hints = resolve_channel_acp_turn_hints(config, &message.session)?;
     let acp_options = AcpConversationTurnOptions::automatic()
         .with_additional_bootstrap_mcp_servers(&acp_turn_hints.bootstrap_mcp_servers)
         .with_working_directory(acp_turn_hints.working_directory.as_deref())
         .with_provenance(channel_message_acp_turn_provenance(message));
     let ingress = channel_message_ingress_context(message);
-    ConversationTurnCoordinator::new()
-        .handle_turn_with_address_and_acp_options_and_ingress(
-            &turn_config,
+    let feedback_capture = ChannelTurnFeedbackCapture::new(feedback_policy);
+    let observer = feedback_capture.observer_handle();
+    let reply = ConversationTurnCoordinator::new()
+        .handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+            config,
             &address,
             &message.text,
             ProviderErrorMode::Propagate,
+            runtime,
             &acp_options,
-            crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
-                kernel_ctx,
-            ),
+            binding,
             ingress.as_ref(),
+            observer,
         )
-        .await
+        .await?;
+    Ok(feedback_capture.render_reply(reply))
+}
+
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-feishu",
+    feature = "channel-matrix",
+    feature = "channel-wecom"
+))]
+pub(super) async fn process_inbound_with_provider(
+    config: &LoongClawConfig,
+    resolved_path: Option<&std::path::Path>,
+    message: &ChannelInboundMessage,
+    kernel_ctx: &KernelContext,
+    feedback_policy: ChannelTurnFeedbackPolicy,
+) -> CliResult<String> {
+    let turn_config = reload_channel_turn_config(config, resolved_path)?;
+    let runtime = DefaultConversationRuntime::from_config_or_env(&turn_config)?;
+    process_inbound_with_runtime_and_feedback(
+        &turn_config,
+        &runtime,
+        message,
+        ConversationRuntimeBinding::kernel(kernel_ctx),
+        feedback_policy,
+    )
+    .await
 }
 
 #[cfg(any(
@@ -2988,6 +3044,7 @@ fn validate_wecom_security_config(config: &ResolvedWecomChannelConfig) -> CliRes
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use serde_json::Value;
     use std::{
         path::PathBuf,
         sync::{Arc, Mutex},
@@ -3010,6 +3067,132 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("clock")
             .as_millis() as u64
+    }
+
+    #[cfg(any(
+        feature = "channel-telegram",
+        feature = "channel-feishu",
+        feature = "channel-matrix"
+    ))]
+    #[derive(Default)]
+    struct ChannelTraceRuntime {
+        request_turn_calls: Arc<Mutex<usize>>,
+        request_turn_kernel_bindings: Arc<Mutex<Vec<bool>>>,
+    }
+
+    #[cfg(any(
+        feature = "channel-telegram",
+        feature = "channel-feishu",
+        feature = "channel-matrix"
+    ))]
+    #[async_trait]
+    impl crate::conversation::ConversationRuntime for ChannelTraceRuntime {
+        async fn build_messages(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            include_system_prompt: bool,
+            _tool_view: &crate::tools::ToolView,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> CliResult<Vec<Value>> {
+            let mut messages = Vec::new();
+
+            if include_system_prompt {
+                let system_message = serde_json::json!({
+                    "role": "system",
+                    "content": "system",
+                });
+                messages.push(system_message);
+            }
+
+            let user_message = serde_json::json!({
+                "role": "user",
+                "content": "hello",
+            });
+            messages.push(user_message);
+
+            Ok(messages)
+        }
+
+        async fn request_completion(
+            &self,
+            _config: &LoongClawConfig,
+            _messages: &[Value],
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> CliResult<String> {
+            Err("request_completion should not be used in channel trace runtime tests".to_owned())
+        }
+
+        async fn request_turn(
+            &self,
+            _config: &LoongClawConfig,
+            _session_id: &str,
+            _turn_id: &str,
+            _messages: &[Value],
+            _tool_view: &crate::tools::ToolView,
+            binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> CliResult<crate::conversation::ProviderTurn> {
+            self.request_turn_kernel_bindings
+                .lock()
+                .expect("request turn kernel binding log")
+                .push(binding.is_kernel_bound());
+
+            let mut request_turn_calls = self
+                .request_turn_calls
+                .lock()
+                .expect("request turn call count");
+            *request_turn_calls += 1;
+            let current_call = *request_turn_calls;
+            drop(request_turn_calls);
+
+            if current_call == 1 {
+                let tool_intent = crate::conversation::ToolIntent {
+                    tool_name: "tool.search".to_owned(),
+                    args_json: serde_json::json!({
+                        "query": "qzxwvvvjjjjkkk",
+                    }),
+                    source: "provider_test".to_owned(),
+                    session_id: String::new(),
+                    turn_id: String::new(),
+                    tool_call_id: "call-1".to_owned(),
+                };
+                return Ok(crate::conversation::ProviderTurn {
+                    assistant_text: String::new(),
+                    tool_intents: vec![tool_intent],
+                    raw_meta: Value::Null,
+                });
+            }
+
+            Ok(crate::conversation::ProviderTurn {
+                assistant_text: "final reply".to_owned(),
+                tool_intents: Vec::new(),
+                raw_meta: Value::Null,
+            })
+        }
+
+        async fn request_turn_streaming(
+            &self,
+            config: &LoongClawConfig,
+            session_id: &str,
+            turn_id: &str,
+            messages: &[Value],
+            tool_view: &crate::tools::ToolView,
+            binding: crate::conversation::ConversationRuntimeBinding<'_>,
+            _on_token: crate::provider::StreamingTokenCallback,
+        ) -> CliResult<crate::conversation::ProviderTurn> {
+            self.request_turn(config, session_id, turn_id, messages, tool_view, binding)
+                .await
+        }
+
+        async fn persist_turn(
+            &self,
+            _session_id: &str,
+            _role: &str,
+            _content: &str,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> CliResult<()> {
+            Ok(())
+        }
     }
 
     #[cfg(any(
@@ -3150,7 +3333,7 @@ mod tests {
             &mut adapter,
             batch,
             None,
-            |message: ChannelInboundMessage| {
+            |message: ChannelInboundMessage, _turn_feedback_policy| {
                 Box::pin(async move { Ok(format!("reply: {}", message.text)) })
             },
         )
@@ -3170,6 +3353,122 @@ mod tests {
             &[Some("101".to_owned())]
         );
         assert_eq!(*adapter.completed_batches.lock().expect("completed"), 1);
+    }
+
+    #[cfg(any(
+        feature = "channel-telegram",
+        feature = "channel-feishu",
+        feature = "channel-matrix"
+    ))]
+    #[tokio::test]
+    async fn process_inbound_with_runtime_and_feedback_appends_significant_trace() {
+        let mut config = LoongClawConfig::default();
+        config.provider.kind = crate::config::ProviderKind::Openai;
+        config.telegram = serde_json::from_value(serde_json::json!({
+            "default_account": "Work Bot",
+            "accounts": {
+                "Work Bot": {
+                    "account_id": "ops-bot",
+                    "bot_token": "test-token"
+                }
+            }
+        }))
+        .expect("deserialize telegram channel config");
+
+        let message = ChannelInboundMessage {
+            session: ChannelSession::with_account(ChannelPlatform::Telegram, "ops-bot", "chat-1"),
+            reply_target: ChannelOutboundTarget::telegram_chat(1),
+            text: "hello".to_owned(),
+            delivery: ChannelDelivery {
+                ack_cursor: None,
+                source_message_id: Some("msg-1".to_owned()),
+                sender_principal_key: None,
+                thread_root_id: None,
+                parent_message_id: None,
+                resources: Vec::new(),
+                feishu_callback: None,
+            },
+        };
+        let runtime = ChannelTraceRuntime::default();
+        let kernel_ctx = crate::context::bootstrap_test_kernel_context("channel-test", 60)
+            .expect("bootstrap test kernel context");
+
+        let reply = process_inbound_with_runtime_and_feedback(
+            &config,
+            &runtime,
+            &message,
+            crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
+            ChannelTurnFeedbackPolicy::final_trace_significant(),
+        )
+        .await
+        .expect("channel trace reply should succeed");
+
+        assert!(reply.contains("final reply"));
+        assert!(reply.contains("execution trace:"));
+        assert!(reply.contains("tool.search completed: returned 0 results"));
+
+        let request_turn_calls = runtime
+            .request_turn_calls
+            .lock()
+            .expect("request turn call count");
+        assert_eq!(*request_turn_calls, 2);
+
+        let request_turn_kernel_bindings = runtime
+            .request_turn_kernel_bindings
+            .lock()
+            .expect("request turn kernel binding log");
+        assert_eq!(request_turn_kernel_bindings.as_slice(), &[true, true]);
+    }
+
+    #[cfg(any(
+        feature = "channel-telegram",
+        feature = "channel-feishu",
+        feature = "channel-matrix"
+    ))]
+    #[tokio::test]
+    async fn process_inbound_with_runtime_and_feedback_can_disable_trace_rendering() {
+        let mut config = LoongClawConfig::default();
+        config.provider.kind = crate::config::ProviderKind::Openai;
+        config.telegram = serde_json::from_value(serde_json::json!({
+            "default_account": "Work Bot",
+            "accounts": {
+                "Work Bot": {
+                    "account_id": "ops-bot",
+                    "bot_token": "test-token"
+                }
+            }
+        }))
+        .expect("deserialize telegram channel config");
+
+        let message = ChannelInboundMessage {
+            session: ChannelSession::with_account(ChannelPlatform::Telegram, "ops-bot", "chat-1"),
+            reply_target: ChannelOutboundTarget::telegram_chat(1),
+            text: "hello".to_owned(),
+            delivery: ChannelDelivery {
+                ack_cursor: None,
+                source_message_id: Some("msg-1".to_owned()),
+                sender_principal_key: None,
+                thread_root_id: None,
+                parent_message_id: None,
+                resources: Vec::new(),
+                feishu_callback: None,
+            },
+        };
+        let runtime = ChannelTraceRuntime::default();
+        let kernel_ctx = crate::context::bootstrap_test_kernel_context("channel-test", 60)
+            .expect("bootstrap test kernel context");
+
+        let reply = process_inbound_with_runtime_and_feedback(
+            &config,
+            &runtime,
+            &message,
+            crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
+            ChannelTurnFeedbackPolicy::disabled(),
+        )
+        .await
+        .expect("channel reply should succeed when trace rendering is disabled");
+
+        assert_eq!(reply, "final reply");
     }
 
     #[cfg(any(

--- a/crates/app/src/channel/turn_feedback.rs
+++ b/crates/app/src/channel/turn_feedback.rs
@@ -1,0 +1,304 @@
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use crate::conversation::ConversationTurnObserver;
+use crate::conversation::ConversationTurnObserverHandle;
+use crate::conversation::ConversationTurnPhase;
+use crate::conversation::ConversationTurnPhaseEvent;
+use crate::conversation::ConversationTurnToolEvent;
+use crate::conversation::ConversationTurnToolState;
+
+const CHANNEL_TURN_TRACE_MAX_LINES: usize = 4;
+const CHANNEL_TURN_TRACE_MAX_DETAIL_CHARS: usize = 160;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ChannelTurnTraceMode {
+    #[default]
+    Off,
+    Significant,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ChannelTurnFeedbackPolicy {
+    trace_mode: ChannelTurnTraceMode,
+}
+
+impl ChannelTurnFeedbackPolicy {
+    pub const fn disabled() -> Self {
+        Self {
+            trace_mode: ChannelTurnTraceMode::Off,
+        }
+    }
+
+    pub const fn final_trace_significant() -> Self {
+        Self {
+            trace_mode: ChannelTurnTraceMode::Significant,
+        }
+    }
+
+    pub const fn requires_observer(self) -> bool {
+        !matches!(self.trace_mode, ChannelTurnTraceMode::Off)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ChannelTurnFeedbackState {
+    latest_phase: Option<ConversationTurnPhase>,
+    latest_tool_events: Vec<ConversationTurnToolEvent>,
+}
+
+#[derive(Debug, Default)]
+struct ChannelTurnFeedbackObserver {
+    state: StdMutex<ChannelTurnFeedbackState>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ChannelTurnFeedbackCapture {
+    policy: ChannelTurnFeedbackPolicy,
+    observer: Option<Arc<ChannelTurnFeedbackObserver>>,
+}
+
+impl ChannelTurnFeedbackCapture {
+    pub(super) fn new(policy: ChannelTurnFeedbackPolicy) -> Self {
+        let observer = if policy.requires_observer() {
+            Some(Arc::new(ChannelTurnFeedbackObserver::default()))
+        } else {
+            None
+        };
+
+        Self { policy, observer }
+    }
+
+    pub(super) fn observer_handle(&self) -> Option<ConversationTurnObserverHandle> {
+        let observer = self.observer.as_ref()?;
+        let handle: ConversationTurnObserverHandle = observer.clone();
+        Some(handle)
+    }
+
+    pub(super) fn render_reply(&self, reply: String) -> String {
+        let Some(observer) = self.observer.as_ref() else {
+            return reply;
+        };
+
+        let Some(trace) = observer.render_trace(self.policy) else {
+            return reply;
+        };
+
+        format_channel_turn_reply_with_trace(reply, trace)
+    }
+}
+
+impl ChannelTurnFeedbackObserver {
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, ChannelTurnFeedbackState> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned_state) => poisoned_state.into_inner(),
+        }
+    }
+
+    fn record_phase(&self, event: ConversationTurnPhaseEvent) {
+        let mut state = self.lock_state();
+        state.latest_phase = Some(event.phase);
+    }
+
+    fn record_tool(&self, event: ConversationTurnToolEvent) {
+        let mut state = self.lock_state();
+        upsert_channel_turn_tool_event(&mut state.latest_tool_events, event);
+    }
+
+    fn render_trace(&self, policy: ChannelTurnFeedbackPolicy) -> Option<String> {
+        let state = self.lock_state();
+        render_channel_turn_trace(&state, policy)
+    }
+}
+
+impl ConversationTurnObserver for ChannelTurnFeedbackObserver {
+    fn on_phase(&self, event: ConversationTurnPhaseEvent) {
+        self.record_phase(event);
+    }
+
+    fn on_tool(&self, event: ConversationTurnToolEvent) {
+        self.record_tool(event);
+    }
+}
+
+fn upsert_channel_turn_tool_event(
+    latest_tool_events: &mut Vec<ConversationTurnToolEvent>,
+    event: ConversationTurnToolEvent,
+) {
+    let position = latest_tool_events
+        .iter()
+        .position(|existing| existing.tool_call_id == event.tool_call_id);
+
+    match position {
+        Some(index) => {
+            if let Some(existing_event) = latest_tool_events.get_mut(index) {
+                *existing_event = event;
+            }
+        }
+        None => {
+            latest_tool_events.push(event);
+        }
+    }
+}
+
+fn render_channel_turn_trace(
+    state: &ChannelTurnFeedbackState,
+    policy: ChannelTurnFeedbackPolicy,
+) -> Option<String> {
+    match policy.trace_mode {
+        ChannelTurnTraceMode::Off => None,
+        ChannelTurnTraceMode::Significant => {
+            render_significant_channel_turn_trace(state.latest_phase, &state.latest_tool_events)
+        }
+    }
+}
+
+fn render_significant_channel_turn_trace(
+    latest_phase: Option<ConversationTurnPhase>,
+    latest_tool_events: &[ConversationTurnToolEvent],
+) -> Option<String> {
+    let mut trace_lines = latest_tool_events
+        .iter()
+        .filter_map(format_significant_channel_turn_tool_event)
+        .collect::<Vec<_>>();
+
+    if trace_lines.is_empty() && latest_phase == Some(ConversationTurnPhase::Failed) {
+        trace_lines.push("- turn failed before a stable reply was produced".to_owned());
+    }
+
+    if trace_lines.is_empty() {
+        return None;
+    }
+
+    if trace_lines.len() > CHANNEL_TURN_TRACE_MAX_LINES {
+        let visible_line_limit = CHANNEL_TURN_TRACE_MAX_LINES.saturating_sub(1);
+        let remaining_count = trace_lines.len().saturating_sub(visible_line_limit);
+        trace_lines.truncate(visible_line_limit);
+        let noun = if remaining_count == 1 {
+            "event"
+        } else {
+            "events"
+        };
+        let summary_line = format!("- ... and {remaining_count} more {noun}");
+        trace_lines.push(summary_line);
+    }
+
+    let trace_body = trace_lines.join("\n");
+    Some(format!("execution trace:\n{trace_body}"))
+}
+
+fn format_significant_channel_turn_tool_event(event: &ConversationTurnToolEvent) -> Option<String> {
+    let detail = event
+        .detail
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let is_significant =
+        !matches!(event.state, ConversationTurnToolState::Completed) || detail.is_some();
+    if !is_significant {
+        return None;
+    }
+
+    let state = event.state.as_str();
+    match detail {
+        Some(detail) => {
+            let summarized_detail = summarize_channel_turn_trace_detail(detail);
+            Some(format!(
+                "- {} {}: {}",
+                event.tool_name, state, summarized_detail
+            ))
+        }
+        None => Some(format!("- {} {}", event.tool_name, state)),
+    }
+}
+
+fn summarize_channel_turn_trace_detail(detail: &str) -> String {
+    let trimmed = detail.trim();
+    let total_chars = trimmed.chars().count();
+    if total_chars <= CHANNEL_TURN_TRACE_MAX_DETAIL_CHARS {
+        return trimmed.to_owned();
+    }
+
+    let summarized = trimmed
+        .chars()
+        .take(CHANNEL_TURN_TRACE_MAX_DETAIL_CHARS)
+        .collect::<String>();
+    format!("{summarized}...")
+}
+
+fn format_channel_turn_reply_with_trace(reply: String, trace: String) -> String {
+    let trimmed_reply = reply.trim();
+    if trimmed_reply.is_empty() {
+        return trace;
+    }
+
+    format!("{reply}\n\n{trace}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversation::ConversationTurnToolEvent;
+
+    #[test]
+    fn channel_turn_feedback_capture_renders_significant_final_trace() {
+        let capture =
+            ChannelTurnFeedbackCapture::new(ChannelTurnFeedbackPolicy::final_trace_significant());
+        let observer = capture
+            .observer_handle()
+            .expect("significant trace policy should attach an observer");
+
+        observer.on_tool(ConversationTurnToolEvent::running("call-1", "tool.search"));
+        observer.on_tool(ConversationTurnToolEvent::completed(
+            "call-1",
+            "tool.search",
+            Some("returned 0 results".to_owned()),
+        ));
+        observer.on_tool(ConversationTurnToolEvent::failed(
+            "call-2",
+            "web.fetch",
+            "missing network egress capability",
+        ));
+
+        let reply = capture.render_reply("final reply".to_owned());
+
+        assert!(reply.contains("final reply"));
+        assert!(reply.contains("execution trace:"));
+        assert!(reply.contains("- tool.search completed: returned 0 results"));
+        assert!(reply.contains("- web.fetch failed: missing network egress capability"));
+        assert!(
+            !reply.contains("tool.search running"),
+            "the capture should keep only the latest event per tool call"
+        );
+    }
+
+    #[test]
+    fn channel_turn_feedback_capture_skips_trace_when_policy_is_disabled() {
+        let capture = ChannelTurnFeedbackCapture::new(ChannelTurnFeedbackPolicy::disabled());
+        let reply = capture.render_reply("{\"status\":\"ok\"}".to_owned());
+
+        assert_eq!(reply, "{\"status\":\"ok\"}");
+        assert!(capture.observer_handle().is_none());
+    }
+
+    #[test]
+    fn channel_turn_feedback_capture_ignores_non_significant_completed_tools() {
+        let capture =
+            ChannelTurnFeedbackCapture::new(ChannelTurnFeedbackPolicy::final_trace_significant());
+        let observer = capture
+            .observer_handle()
+            .expect("significant trace policy should attach an observer");
+
+        observer.on_tool(ConversationTurnToolEvent::completed(
+            "call-1",
+            "shell.exec",
+            None,
+        ));
+
+        let reply = capture.render_reply("final reply".to_owned());
+
+        assert_eq!(reply, "final reply");
+    }
+}

--- a/crates/app/src/channel/wecom.rs
+++ b/crates/app/src/channel/wecom.rs
@@ -15,8 +15,8 @@ use crate::config::{
 use super::{
     CHANNEL_OPERATION_SERVE_ID, ChannelDelivery, ChannelDeliveryResource, ChannelInboundMessage,
     ChannelOperationRuntimeTracker, ChannelOutboundTarget, ChannelOutboundTargetKind,
-    ChannelPlatform, ChannelServeStopHandle, ChannelSession, process_inbound_with_provider,
-    runtime_state,
+    ChannelPlatform, ChannelServeStopHandle, ChannelSession, ChannelTurnFeedbackPolicy,
+    process_inbound_with_provider, runtime_state,
 };
 
 const WECOM_SUBSCRIBE_CMD: &str = "aibot_subscribe";
@@ -422,7 +422,8 @@ async fn run_wecom_serve_session(
                 config,
                 Some(resolved_path),
                 &parsed.message,
-                Some(provider_ctx.as_ref()),
+                provider_ctx.as_ref(),
+                ChannelTurnFeedbackPolicy::final_trace_significant(),
             )
             .await;
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -39,7 +39,7 @@ use super::analytics::{
     TurnCheckpointRecoveryAction, TurnCheckpointRepairManualReason, TurnCheckpointRepairPlan,
     TurnCheckpointSessionState, build_turn_checkpoint_repair_plan, summarize_safe_lane_history,
 };
-use super::context_engine::AssembledConversationContext;
+use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
 use super::ingress::ConversationIngressContext;
 use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
 use super::persistence::{
@@ -1783,6 +1783,32 @@ impl ConversationTurnCoordinator {
         .await
     }
 
+    pub async fn handle_turn_with_address_and_acp_options_and_ingress_and_observer(
+        &self,
+        config: &LoongClawConfig,
+        address: &ConversationSessionAddress,
+        user_input: &str,
+        error_mode: ProviderErrorMode,
+        acp_options: &AcpConversationTurnOptions<'_>,
+        binding: ConversationRuntimeBinding<'_>,
+        ingress: Option<&ConversationIngressContext>,
+        observer: Option<ConversationTurnObserverHandle>,
+    ) -> CliResult<String> {
+        let runtime = Self::build_default_runtime_or_observe_failure(config, observer.as_ref())?;
+        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+            config,
+            address,
+            user_input,
+            error_mode,
+            &runtime,
+            acp_options,
+            binding,
+            ingress,
+            observer,
+        )
+        .await
+    }
+
     pub async fn handle_turn_with_address_and_acp_options_and_observer(
         &self,
         config: &LoongClawConfig,
@@ -1793,19 +1819,33 @@ impl ConversationTurnCoordinator {
         binding: ConversationRuntimeBinding<'_>,
         observer: Option<ConversationTurnObserverHandle>,
     ) -> CliResult<String> {
-        let runtime = DefaultConversationRuntime::from_config_or_env(config)?;
-        self.handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer(
+        self.handle_turn_with_address_and_acp_options_and_ingress_and_observer(
             config,
             address,
             user_input,
             error_mode,
-            &runtime,
             acp_options,
             binding,
             None,
             observer,
         )
         .await
+    }
+
+    fn build_default_runtime_or_observe_failure(
+        config: &LoongClawConfig,
+        observer: Option<&ConversationTurnObserverHandle>,
+    ) -> CliResult<DefaultConversationRuntime<Box<dyn ConversationContextEngine>>> {
+        let runtime_result = DefaultConversationRuntime::from_config_or_env(config);
+        let runtime = match runtime_result {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                let failed_event = ConversationTurnPhaseEvent::failed();
+                observe_turn_phase(observer, failed_event);
+                return Err(error);
+            }
+        };
+        Ok(runtime)
     }
 
     pub async fn handle_turn_with_runtime<R: ConversationRuntime + ?Sized>(
@@ -2107,7 +2147,7 @@ impl ConversationTurnCoordinator {
         .await
     }
 
-    async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer<
+    pub async fn handle_turn_with_runtime_and_address_and_acp_options_and_ingress_and_observer<
         R: ConversationRuntime + ?Sized,
     >(
         &self,
@@ -7706,6 +7746,77 @@ mod tests {
             .lock()
             .expect("streaming call lock should not be poisoned");
         assert_eq!(*streaming_calls, 0);
+    }
+
+    #[tokio::test]
+    async fn handle_turn_with_ingress_and_observer_marks_failed_when_runtime_bootstrap_fails() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.context_engine = Some("missing-observer-runtime-ingress".to_owned());
+
+        let coordinator = ConversationTurnCoordinator::new();
+        let observer = Arc::new(RecordingTurnObserver::default());
+        let observer_handle: ConversationTurnObserverHandle = observer.clone();
+        let acp_options = AcpConversationTurnOptions::automatic();
+        let address = ConversationSessionAddress::from_session_id("observer-session");
+
+        let result = coordinator
+            .handle_turn_with_address_and_acp_options_and_ingress_and_observer(
+                &config,
+                &address,
+                "say hello",
+                ProviderErrorMode::Propagate,
+                &acp_options,
+                ConversationRuntimeBinding::direct(),
+                None,
+                Some(observer_handle),
+            )
+            .await;
+        let _error = result.expect_err("missing runtime bootstrap should fail");
+
+        let phase_events = observer
+            .phase_events
+            .lock()
+            .expect("phase event lock should not be poisoned");
+        let phase_names = phase_events
+            .iter()
+            .map(|event| event.phase)
+            .collect::<Vec<_>>();
+        assert_eq!(phase_names, vec![ConversationTurnPhase::Failed]);
+    }
+
+    #[tokio::test]
+    async fn handle_turn_with_observer_marks_failed_when_runtime_bootstrap_fails() {
+        let mut config = LoongClawConfig::default();
+        config.conversation.context_engine = Some("missing-observer-runtime".to_owned());
+
+        let coordinator = ConversationTurnCoordinator::new();
+        let observer = Arc::new(RecordingTurnObserver::default());
+        let observer_handle: ConversationTurnObserverHandle = observer.clone();
+        let acp_options = AcpConversationTurnOptions::automatic();
+        let address = ConversationSessionAddress::from_session_id("observer-session");
+
+        let result = coordinator
+            .handle_turn_with_address_and_acp_options_and_observer(
+                &config,
+                &address,
+                "say hello",
+                ProviderErrorMode::Propagate,
+                &acp_options,
+                ConversationRuntimeBinding::direct(),
+                Some(observer_handle),
+            )
+            .await;
+        let _error = result.expect_err("missing runtime bootstrap should fail");
+
+        let phase_events = observer
+            .phase_events
+            .lock()
+            .expect("phase event lock should not be poisoned");
+        let phase_names = phase_events
+            .iter()
+            .map(|event| event.phase)
+            .collect::<Vec<_>>();
+        assert_eq!(phase_names, vec![ConversationTurnPhase::Failed]);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -862,12 +862,7 @@ fn build_tool_intent_completed_trace(
     outcome: &ToolCoreOutcome,
 ) -> ToolBatchExecutionIntentTrace {
     let tool_name = effective_result_tool_name(intent);
-    let normalized_status = outcome.status.trim();
-    let detail = if normalized_status.is_empty() || normalized_status == "ok" {
-        None
-    } else {
-        Some(normalized_status.to_owned())
-    };
+    let detail = summarize_completed_tool_trace_detail(tool_name.as_str(), outcome);
 
     ToolBatchExecutionIntentTrace {
         tool_call_id: intent.tool_call_id.clone(),
@@ -875,6 +870,27 @@ fn build_tool_intent_completed_trace(
         status: ToolBatchExecutionIntentStatus::Completed,
         detail,
     }
+}
+
+fn summarize_completed_tool_trace_detail(
+    tool_name: &str,
+    outcome: &ToolCoreOutcome,
+) -> Option<String> {
+    let normalized_status = outcome.status.trim();
+    if !normalized_status.is_empty() && normalized_status != "ok" {
+        return Some(normalized_status.to_owned());
+    }
+
+    match tool_name {
+        "tool.search" => summarize_tool_search_completed_trace_detail(&outcome.payload),
+        _ => None,
+    }
+}
+
+fn summarize_tool_search_completed_trace_detail(payload: &serde_json::Value) -> Option<String> {
+    let returned = payload.get("returned")?.as_u64()?;
+    let noun = if returned == 1 { "result" } else { "results" };
+    Some(format!("returned {returned} {noun}"))
 }
 
 fn build_tool_intent_failure_trace(


### PR DESCRIPTION
## Summary

- Problem:
  channel ingress still consumed only the final reply text, and the service-channel path still accepted an optional kernel binding. That left channel users without lifecycle visibility for tool attempts and let future channel SDK entrypoints silently fall back to direct runtime.
- Why it matters:
  issue #570 surfaced this as a user-visible gap, and it is also a broader channel SDK contract problem tracked by #404.
- What changed:
  added a transport-agnostic channel turn feedback layer that attaches `ConversationTurnObserver` to channel turns, appends a concise final `execution trace` when significant tool activity happened on final-message-only surfaces, routes channel ingress through observer-aware coordinator entrypoints, tightens service-channel inbound processing to require kernel binding, disables trace injection for structured Feishu callback replies, and teaches completed `tool.search` traces to report returned result counts so zero-hit discovery is visible in the fallback trace.
- What did not change (scope boundary):
  this PR does not add full live lifecycle rendering for every channel, does not rewrite multilingual `tool.search`, and does not add autonomous external skill installation flows.

## Linked Issues

- Closes #574
- Related #570
- Related #404

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  service-channel ingress now fails closed when no kernel context is available, and channels can append system-generated execution trace text when significant tool activity occurred.
- Rollout / guardrails:
  the trace behavior is explicit at the channel ingress call sites, and structured Feishu callback replies keep trace injection disabled so callback payload parsing stays stable.
- Rollback path:
  revert this PR, or temporarily set the affected channel call sites back to `ChannelTurnFeedbackPolicy::disabled()` if trace rendering must be suppressed quickly.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
- passed

git diff --check
- passed

cargo test -p loongclaw-app channel_turn_feedback -- --test-threads=1
- passed

cargo test -p loongclaw-app process_inbound_with_runtime_and_feedback -- --test-threads=1
- passed

cargo test -p loongclaw-app handle_turn_with_observer_uses_streaming_request_and_emits_live_events -- --test-threads=1
- passed

cargo test -p loongclaw-app --locked -- --test-threads=1
- passed

cargo test -p loongclaw-app --all-features --locked -- --test-threads=1
- passed

cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
- passed

cargo test --workspace --locked -- --test-threads=1
- passed

cargo test --workspace --all-features --locked -- --test-threads=1
- passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
- passed
```

## User-visible / Operator-visible Changes

- channels that only deliver a final message can now append a concise `execution trace` when tool discovery or tool execution activity materially affected the turn
- service-channel ingress no longer silently downgrades to direct runtime when a kernel binding is missing
- completed `tool.search` traces now report how many results were returned, which makes zero-hit discovery visible in channel fallback traces

## Failure Recovery

- Fast rollback or disable path:
  revert this PR, or temporarily return `ChannelTurnFeedbackPolicy::disabled()` at the affected channel ingress call sites.
- Observable failure symptoms reviewers should watch for:
  unexpected `execution trace:` suffixes on surfaces that should stay structured, or channel ingress failures at newly uncovered integration points that were previously relying on silent direct-runtime fallback.

## Reviewer Focus

- review `crates/app/src/channel/turn_feedback.rs` for the observer capture and significant-trace rendering policy
- review `crates/app/src/channel/mod.rs` for the new runtime-injectable channel helper and kernel-required ingress path
- review `crates/app/src/channel/feishu/webhook.rs` to confirm structured callback replies stay trace-free while normal inbound Feishu messages get the fallback trace
- review `crates/app/src/conversation/turn_engine.rs` for the `tool.search` completion detail that makes zero-result discovery visible in the channel trace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution trace capture to display conversation turn details on supported channels with configurable trace modes.
  * Enhanced tool event tracking to provide improved detail information and better visibility into tool execution outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->