### PR TITLE
feat(onboard): rank web search provider recommendations

### DIFF
--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -55,6 +55,14 @@ const ONBOARD_SINGLE_LINE_INPUT_HINT: &str = "- single-line input only";
 const ONBOARD_PASTE_DRAIN_WINDOW_ENV: &str = "LOONGCLAW_ONBOARD_PASTE_DRAIN_WINDOW_MS";
 const DEFAULT_ONBOARD_PASTE_DRAIN_WINDOW: Duration = Duration::from_millis(75);
 const ONBOARD_LINE_READER_BUFFER_SIZE: usize = 64;
+const ONBOARD_WEB_SEARCH_PROVIDER_PRIORITY: &[&str] = &[
+    mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
+    mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+    mvp::config::WEB_SEARCH_PROVIDER_BRAVE,
+    mvp::config::WEB_SEARCH_PROVIDER_PERPLEXITY,
+    mvp::config::WEB_SEARCH_PROVIDER_EXA,
+    mvp::config::WEB_SEARCH_PROVIDER_JINA,
+];
 
 #[derive(Debug, Clone)]
 pub struct OnboardCommandOptions {
@@ -1116,6 +1124,7 @@ struct StartingConfigSelection {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct WebSearchProviderRecommendation {
     provider: &'static str,
+    ordered_providers: Vec<&'static str>,
     reason: String,
     source: WebSearchProviderRecommendationSource,
 }
@@ -2269,7 +2278,9 @@ async fn resolve_web_search_provider_selection(
         return Ok(default_provider.to_owned());
     }
 
-    let screen_options = build_web_search_provider_screen_options(config, default_provider);
+    let ordered_providers = recommendation.ordered_providers.as_slice();
+    let screen_options =
+        build_web_search_provider_screen_options(config, ordered_providers, default_provider);
     let select_options = select_options_from_screen_options(&screen_options);
     let default_idx = screen_options.iter().position(|option| option.recommended);
 
@@ -2277,8 +2288,7 @@ async fn resolve_web_search_provider_selection(
         ui,
         render_web_search_provider_selection_screen_lines_with_style(
             config,
-            default_provider,
-            recommendation.reason.as_str(),
+            &recommendation,
             guided_prompt_path,
             context.render_width,
             true,
@@ -2421,6 +2431,20 @@ fn resolve_effective_web_search_default_provider(
     mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO
 }
 
+fn build_web_search_provider_recommendation(
+    provider: &'static str,
+    reason: String,
+    source: WebSearchProviderRecommendationSource,
+) -> WebSearchProviderRecommendation {
+    let ordered_providers = build_ranked_web_search_provider_list(provider);
+    WebSearchProviderRecommendation {
+        provider,
+        ordered_providers,
+        reason,
+        source,
+    }
+}
+
 async fn resolve_web_search_provider_recommendation(
     options: &OnboardCommandOptions,
     config: &mvp::config::LoongClawConfig,
@@ -2434,12 +2458,12 @@ async fn resolve_web_search_provider_recommendation(
             config.tools.web_search.default_provider.as_str(),
         )
     {
-        return Ok(WebSearchProviderRecommendation {
-            provider: configured_provider,
-            reason: "reusing the configured web search provider from the current starting point"
-                .to_owned(),
-            source: WebSearchProviderRecommendationSource::Configured,
-        });
+        let reason =
+            "reusing the configured web search provider from the current starting point".to_owned();
+        let source = WebSearchProviderRecommendationSource::Configured;
+        let recommendation =
+            build_web_search_provider_recommendation(configured_provider, reason, source);
+        return Ok(recommendation);
     }
 
     if let Some(credential_recommendation) =
@@ -2469,11 +2493,8 @@ fn explicit_web_search_provider_override(
             normalize_selected_web_search_provider("web-search-provider", trimmed_provider)?;
         let reason = "set by --web-search-provider".to_owned();
         let source = WebSearchProviderRecommendationSource::ExplicitCli;
-        let recommendation = WebSearchProviderRecommendation {
-            provider: normalized_provider,
-            reason,
-            source,
-        };
+        let recommendation =
+            build_web_search_provider_recommendation(normalized_provider, reason, source);
         return Ok(Some(recommendation));
     }
 
@@ -2490,11 +2511,8 @@ fn explicit_web_search_provider_override(
         normalize_selected_web_search_provider("LOONGCLAW_WEB_SEARCH_PROVIDER", trimmed_provider)?;
     let reason = "set by LOONGCLAW_WEB_SEARCH_PROVIDER".to_owned();
     let source = WebSearchProviderRecommendationSource::ExplicitEnv;
-    let recommendation = WebSearchProviderRecommendation {
-        provider: normalized_provider,
-        reason,
-        source,
-    };
+    let recommendation =
+        build_web_search_provider_recommendation(normalized_provider, reason, source);
     Ok(Some(recommendation))
 }
 
@@ -2537,61 +2555,70 @@ fn recommend_web_search_provider_from_available_credentials(
             descriptor.display_name
         )
     };
-    Some(WebSearchProviderRecommendation {
-        provider: descriptor.id,
-        reason,
-        source: WebSearchProviderRecommendationSource::DetectedCredential,
-    })
+    let source = WebSearchProviderRecommendationSource::DetectedCredential;
+    let recommendation = build_web_search_provider_recommendation(descriptor.id, reason, source);
+    Some(recommendation)
 }
 
 fn recommend_web_search_provider_from_signals(
     signals: WebSearchEnvironmentSignals,
 ) -> WebSearchProviderRecommendation {
-    if signals.domestic_locale_hint && (signals.tavily_reachable || !signals.duckduckgo_reachable) {
-        return WebSearchProviderRecommendation {
-            provider: mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
-            reason: if signals.tavily_reachable {
-                "domestic locale or timezone was detected and Tavily looked reachable from this host"
-                    .to_owned()
-            } else {
-                "domestic locale or timezone was detected and DuckDuckGo did not look reachable from this host"
-                    .to_owned()
-            },
-            source: WebSearchProviderRecommendationSource::DetectedSignals,
+    let source = WebSearchProviderRecommendationSource::DetectedSignals;
+
+    if signals.domestic_locale_hint {
+        let reason = if signals.tavily_reachable {
+            "domestic locale or timezone was detected and Tavily looked reachable from this host"
+                .to_owned()
+        } else {
+            "domestic locale or timezone was detected, so Tavily moves ahead of DuckDuckGo in the default recommendation order"
+                .to_owned()
         };
+        return build_web_search_provider_recommendation(
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            reason,
+            source,
+        );
+    }
+
+    if !signals.duckduckgo_reachable && signals.tavily_reachable {
+        let reason =
+            "DuckDuckGo did not look reachable, but Tavily's API route responded from this host"
+                .to_owned();
+        return build_web_search_provider_recommendation(
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            reason,
+            source,
+        );
     }
 
     if signals.duckduckgo_reachable {
-        return WebSearchProviderRecommendation {
-            provider: mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
-            reason: "DuckDuckGo looked reachable from this host, so the key-free fallback stays the default".to_owned(),
-            source: WebSearchProviderRecommendationSource::DetectedSignals,
-        };
+        let reason =
+            "DuckDuckGo looked reachable from this host, so the key-free fallback stays at the top of the recommendation order"
+                .to_owned();
+        return build_web_search_provider_recommendation(
+            mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
+            reason,
+            source,
+        );
     }
 
     if signals.tavily_reachable {
-        return WebSearchProviderRecommendation {
-            provider: mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
-            reason:
-                "DuckDuckGo did not look reachable, but Tavily's API route responded from this host"
-                    .to_owned(),
-            source: WebSearchProviderRecommendationSource::DetectedSignals,
-        };
+        let reason =
+            "DuckDuckGo did not look reachable, but Tavily's API route responded from this host"
+                .to_owned();
+        return build_web_search_provider_recommendation(
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            reason,
+            source,
+        );
     }
 
-    if signals.domestic_locale_hint {
-        return WebSearchProviderRecommendation {
-            provider: mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
-            reason: "domestic locale or timezone was detected, so Tavily is the safer API-first recommendation".to_owned(),
-            source: WebSearchProviderRecommendationSource::DetectedSignals,
-        };
-    }
-
-    WebSearchProviderRecommendation {
-        provider: mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
-        reason: "falling back to DuckDuckGo as the key-free default".to_owned(),
-        source: WebSearchProviderRecommendationSource::DetectedSignals,
-    }
+    let reason = "falling back to DuckDuckGo as the key-free default recommendation".to_owned();
+    build_web_search_provider_recommendation(
+        mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
+        reason,
+        source,
+    )
 }
 
 async fn detect_web_search_environment_signals() -> WebSearchEnvironmentSignals {
@@ -2665,44 +2692,123 @@ fn build_onboard_probe_client() -> reqwest::Client {
         .unwrap_or_else(|_| reqwest::Client::new())
 }
 
+fn push_ranked_web_search_provider(
+    ranked_providers: &mut Vec<&'static str>,
+    provider: &'static str,
+) {
+    let is_known_provider = mvp::config::web_search_provider_descriptor(provider).is_some();
+    if !is_known_provider {
+        return;
+    }
+
+    let already_present = ranked_providers.contains(&provider);
+    if already_present {
+        return;
+    }
+
+    ranked_providers.push(provider);
+}
+
+fn build_ranked_web_search_provider_list(preferred_provider: &'static str) -> Vec<&'static str> {
+    let mut ranked_providers = Vec::new();
+
+    push_ranked_web_search_provider(&mut ranked_providers, preferred_provider);
+
+    for provider in ONBOARD_WEB_SEARCH_PROVIDER_PRIORITY {
+        push_ranked_web_search_provider(&mut ranked_providers, provider);
+    }
+
+    for descriptor in mvp::config::web_search_provider_descriptors() {
+        push_ranked_web_search_provider(&mut ranked_providers, descriptor.id);
+    }
+
+    ranked_providers
+}
+
+fn render_web_search_provider_recommendation_order(ordered_providers: &[&'static str]) -> String {
+    let provider_labels: Vec<String> = ordered_providers
+        .iter()
+        .filter_map(|provider| mvp::config::web_search_provider_descriptor(provider))
+        .map(|descriptor| descriptor.display_name.to_owned())
+        .collect();
+    provider_labels.join(" -> ")
+}
+
+fn build_web_search_provider_screen_option(
+    config: &mvp::config::LoongClawConfig,
+    descriptor: &mvp::config::WebSearchProviderDescriptor,
+    recommended_provider: &str,
+) -> OnboardScreenOption {
+    let mut detail_lines = vec![descriptor.description.to_owned()];
+    let credential_summary = summarize_web_search_provider_credential(config, descriptor.id);
+    if let Some(credential) = credential_summary {
+        let label = credential.label;
+        let value = credential.value;
+        detail_lines.push(format!("{label}: {value}"));
+    }
+
+    OnboardScreenOption {
+        key: descriptor.id.to_owned(),
+        label: descriptor.display_name.to_owned(),
+        detail_lines,
+        recommended: descriptor.id == recommended_provider,
+    }
+}
+
 fn build_web_search_provider_screen_options(
     config: &mvp::config::LoongClawConfig,
+    ordered_providers: &[&'static str],
     recommended_provider: &str,
 ) -> Vec<OnboardScreenOption> {
-    mvp::config::web_search_provider_descriptors()
-        .iter()
-        .map(|descriptor| {
-            let mut detail_lines = vec![descriptor.description.to_owned()];
-            if let Some(credential) =
-                summarize_web_search_provider_credential(config, descriptor.id)
-            {
-                detail_lines.push(format!("{}: {}", credential.label, credential.value));
-            }
-            OnboardScreenOption {
-                key: descriptor.id.to_owned(),
-                label: descriptor.display_name.to_owned(),
-                detail_lines,
-                recommended: descriptor.id == recommended_provider,
-            }
-        })
-        .collect()
+    let mut options = Vec::new();
+
+    for provider in ordered_providers {
+        let descriptor = mvp::config::web_search_provider_descriptor(provider);
+        let Some(descriptor) = descriptor else {
+            continue;
+        };
+        let option =
+            build_web_search_provider_screen_option(config, descriptor, recommended_provider);
+        options.push(option);
+    }
+
+    for descriptor in mvp::config::web_search_provider_descriptors() {
+        let already_listed = options.iter().any(|option| option.key == descriptor.id);
+        if already_listed {
+            continue;
+        }
+
+        let option =
+            build_web_search_provider_screen_option(config, descriptor, recommended_provider);
+        options.push(option);
+    }
+
+    options
 }
 
 fn render_web_search_provider_selection_screen_lines_with_style(
     config: &mvp::config::LoongClawConfig,
-    recommended_provider: &str,
-    recommendation_reason: &str,
+    recommendation: &WebSearchProviderRecommendation,
     guided_prompt_path: GuidedPromptPath,
     width: usize,
     color_enabled: bool,
 ) -> Vec<String> {
+    let recommended_provider = recommendation.provider;
+    let recommendation_reason = recommendation.reason.as_str();
+    let recommendation_order = render_web_search_provider_recommendation_order(
+        recommendation.ordered_providers.as_slice(),
+    );
     let current_provider = mvp::config::normalize_web_search_provider(
         config.tools.web_search.default_provider.as_str(),
     )
     .unwrap_or(mvp::config::DEFAULT_WEB_SEARCH_PROVIDER);
     let current_provider_label = web_search_provider_display_name(current_provider);
     let recommended_provider_label = web_search_provider_display_name(recommended_provider);
-    let options = build_web_search_provider_screen_options(config, recommended_provider);
+    let options = build_web_search_provider_screen_options(
+        config,
+        recommendation.ordered_providers.as_slice(),
+        recommended_provider,
+    );
 
     render_onboard_choice_screen(
         OnboardHeaderStyle::Compact,
@@ -2714,6 +2820,8 @@ fn render_web_search_provider_selection_screen_lines_with_style(
             format!("- current provider: {current_provider_label}"),
             format!("- recommended provider: {recommended_provider_label}"),
             format!("- why this is recommended: {recommendation_reason}"),
+            format!("- recommendation order: {recommendation_order}"),
+            "- this is a recommendation only; you can still choose any provider below".to_owned(),
         ],
         options,
         vec![render_default_choice_footer_line(
@@ -7480,6 +7588,10 @@ mod tests {
             recommendation.source,
             WebSearchProviderRecommendationSource::DetectedCredential
         );
+        assert_eq!(
+            recommendation.ordered_providers.first().copied(),
+            Some(mvp::config::WEB_SEARCH_PROVIDER_PERPLEXITY)
+        );
         assert!(
             recommendation.reason.contains("Perplexity Search"),
             "recommendation reason should identify the provider that already has a ready credential: {recommendation:?}"
@@ -7536,6 +7648,10 @@ mod tests {
             recommendation.source,
             WebSearchProviderRecommendationSource::ExplicitCli
         );
+        assert_eq!(
+            recommendation.ordered_providers.first().copied(),
+            Some(mvp::config::WEB_SEARCH_PROVIDER_EXA)
+        );
     }
 
     #[test]
@@ -7556,11 +7672,11 @@ mod tests {
             skip_model_probe: false,
         };
         let config = mvp::config::LoongClawConfig::default();
-        let recommendation = WebSearchProviderRecommendation {
-            provider: mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
-            reason: "set by --web-search-provider".to_owned(),
-            source: WebSearchProviderRecommendationSource::ExplicitCli,
-        };
+        let recommendation = build_web_search_provider_recommendation(
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            "set by --web-search-provider".to_owned(),
+            WebSearchProviderRecommendationSource::ExplicitCli,
+        );
 
         let selected =
             resolve_effective_web_search_default_provider(&options, &config, &recommendation);
@@ -7591,11 +7707,11 @@ mod tests {
             skip_model_probe: false,
         };
         let config = mvp::config::LoongClawConfig::default();
-        let recommendation = WebSearchProviderRecommendation {
-            provider: mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
-            reason: "domestic locale or timezone was detected".to_owned(),
-            source: WebSearchProviderRecommendationSource::DetectedSignals,
-        };
+        let recommendation = build_web_search_provider_recommendation(
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            "domestic locale or timezone was detected".to_owned(),
+            WebSearchProviderRecommendationSource::DetectedSignals,
+        );
 
         let selected =
             resolve_effective_web_search_default_provider(&options, &config, &recommendation);
@@ -7604,6 +7720,154 @@ mod tests {
             selected,
             mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
             "detected Tavily recommendations should still fall back to the key-free provider in non-interactive mode when no Tavily credential is ready"
+        );
+    }
+
+    #[test]
+    fn build_ranked_web_search_provider_list_moves_preferred_provider_to_front() {
+        let ranked_providers =
+            build_ranked_web_search_provider_list(mvp::config::WEB_SEARCH_PROVIDER_TAVILY);
+
+        assert_eq!(
+            ranked_providers,
+            vec![
+                mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+                mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
+                mvp::config::WEB_SEARCH_PROVIDER_BRAVE,
+                mvp::config::WEB_SEARCH_PROVIDER_PERPLEXITY,
+                mvp::config::WEB_SEARCH_PROVIDER_EXA,
+                mvp::config::WEB_SEARCH_PROVIDER_JINA,
+            ]
+        );
+    }
+
+    #[test]
+    fn recommend_web_search_provider_from_signals_prefers_tavily_for_domestic_hosts() {
+        let signals = WebSearchEnvironmentSignals {
+            domestic_locale_hint: true,
+            duckduckgo_reachable: true,
+            tavily_reachable: false,
+        };
+
+        let recommendation = recommend_web_search_provider_from_signals(signals);
+
+        assert_eq!(
+            recommendation.provider,
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY
+        );
+        assert_eq!(
+            recommendation.ordered_providers.first().copied(),
+            Some(mvp::config::WEB_SEARCH_PROVIDER_TAVILY)
+        );
+        assert!(
+            recommendation
+                .reason
+                .contains("domestic locale or timezone"),
+            "domestic recommendation should explain why Tavily was moved to the top: {recommendation:?}"
+        );
+    }
+
+    #[test]
+    fn recommend_web_search_provider_from_signals_prefers_tavily_when_duckduckgo_unreachable() {
+        let signals = WebSearchEnvironmentSignals {
+            domestic_locale_hint: false,
+            duckduckgo_reachable: false,
+            tavily_reachable: true,
+        };
+
+        let recommendation = recommend_web_search_provider_from_signals(signals);
+
+        assert_eq!(
+            recommendation.provider,
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY
+        );
+        assert_eq!(
+            recommendation.ordered_providers.first().copied(),
+            Some(mvp::config::WEB_SEARCH_PROVIDER_TAVILY)
+        );
+        assert!(
+            recommendation
+                .reason
+                .contains("DuckDuckGo did not look reachable"),
+            "unreachable DuckDuckGo should move Tavily to the top of the recommendation list: {recommendation:?}"
+        );
+    }
+
+    #[test]
+    fn recommend_web_search_provider_from_signals_keeps_duckduckgo_first_without_positive_tavily_signal()
+     {
+        let signals = WebSearchEnvironmentSignals {
+            domestic_locale_hint: false,
+            duckduckgo_reachable: false,
+            tavily_reachable: false,
+        };
+
+        let recommendation = recommend_web_search_provider_from_signals(signals);
+
+        assert_eq!(
+            recommendation.provider,
+            mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO
+        );
+        assert_eq!(
+            recommendation.ordered_providers.first().copied(),
+            Some(mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO)
+        );
+        assert!(
+            recommendation.reason.contains("falling back to DuckDuckGo"),
+            "ambiguous offline environments should stay on the key-free recommendation instead of inventing a Tavily preference: {recommendation:?}"
+        );
+    }
+
+    #[test]
+    fn build_web_search_provider_screen_options_follow_ranked_recommendation_order() {
+        let config = mvp::config::LoongClawConfig::default();
+        let ordered_providers =
+            build_ranked_web_search_provider_list(mvp::config::WEB_SEARCH_PROVIDER_TAVILY);
+        let options = build_web_search_provider_screen_options(
+            &config,
+            ordered_providers.as_slice(),
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+        );
+
+        assert_eq!(
+            options.first().map(|option| option.key.as_str()),
+            Some("tavily")
+        );
+        assert_eq!(
+            options.get(1).map(|option| option.key.as_str()),
+            Some("duckduckgo")
+        );
+        assert!(options.first().is_some_and(|option| option.recommended));
+    }
+
+    #[test]
+    fn render_web_search_provider_selection_screen_mentions_recommendation_order() {
+        let config = mvp::config::LoongClawConfig::default();
+        let recommendation = build_web_search_provider_recommendation(
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            "domestic locale or timezone was detected".to_owned(),
+            WebSearchProviderRecommendationSource::DetectedSignals,
+        );
+
+        let lines = render_web_search_provider_selection_screen_lines_with_style(
+            &config,
+            &recommendation,
+            GuidedPromptPath::NativePromptPack,
+            80,
+            false,
+        );
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("recommendation order: Tavily -> DuckDuckGo")),
+            "the onboarding screen should surface the ranking order instead of only a single recommended provider: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| {
+                line.contains("recommendation only") && line.contains("choose any provider")
+            }),
+            "the onboarding screen should make it explicit that the recommendation does not remove user choice: {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2824,10 +2824,9 @@ fn render_web_search_provider_selection_screen_lines_with_style(
             "- this is a recommendation only; you can still choose any provider below".to_owned(),
         ],
         options,
-        vec![render_default_choice_footer_line(
-            "Enter",
-            format!("use {recommended_provider_label}").as_str(),
-        )],
+        vec![render_default_enter_choice_footer_line(format!(
+            "use {recommended_provider_label}"
+        ))],
         true,
         color_enabled,
     )
@@ -4280,6 +4279,10 @@ pub(crate) fn render_onboard_option_lines(
 
 pub(crate) fn render_default_choice_footer_line(key: &str, description: &str) -> String {
     format!("press Enter to use default {key}, {description}")
+}
+
+fn render_default_enter_choice_footer_line(description: impl AsRef<str>) -> String {
+    format!("press Enter to {}", description.as_ref())
 }
 
 fn render_prompt_with_default_text(label: &str, default: &str) -> String {
@@ -7868,6 +7871,14 @@ mod tests {
                 line.contains("recommendation only") && line.contains("choose any provider")
             }),
             "the onboarding screen should make it explicit that the recommendation does not remove user choice: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|line| line == "press Enter to use Tavily"),
+            "the web search selection footer should describe the Enter behavior directly instead of rendering an awkward default token: {lines:#?}"
+        );
+        assert!(
+            lines.iter().all(|line| !line.contains("default Enter")),
+            "the web search selection footer should not render the literal phrase 'default Enter': {lines:#?}"
         );
     }
 

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2271,6 +2271,7 @@ async fn resolve_web_search_provider_selection(
     context: &OnboardRuntimeContext,
 ) -> CliResult<String> {
     let recommendation = resolve_web_search_provider_recommendation(options, config).await?;
+    let recommended_provider = recommendation.provider;
     let default_provider =
         resolve_effective_web_search_default_provider(options, config, &recommendation);
 
@@ -2280,15 +2281,18 @@ async fn resolve_web_search_provider_selection(
 
     let ordered_providers = recommendation.ordered_providers.as_slice();
     let screen_options =
-        build_web_search_provider_screen_options(config, ordered_providers, default_provider);
+        build_web_search_provider_screen_options(config, ordered_providers, recommended_provider);
     let select_options = select_options_from_screen_options(&screen_options);
-    let default_idx = screen_options.iter().position(|option| option.recommended);
+    let default_idx = screen_options
+        .iter()
+        .position(|option| option.key == default_provider);
 
     print_lines(
         ui,
         render_web_search_provider_selection_screen_lines_with_style(
             config,
             &recommendation,
+            default_provider,
             guided_prompt_path,
             context.render_width,
             true,
@@ -2401,7 +2405,24 @@ fn resolve_effective_web_search_default_provider(
     recommendation: &WebSearchProviderRecommendation,
 ) -> &'static str {
     if !options.non_interactive {
-        return recommendation.provider;
+        let current_provider = current_web_search_provider(config);
+        match recommendation.source {
+            WebSearchProviderRecommendationSource::ExplicitCli => {
+                return recommendation.provider;
+            }
+            WebSearchProviderRecommendationSource::ExplicitEnv => {
+                return recommendation.provider;
+            }
+            WebSearchProviderRecommendationSource::Configured => {
+                return current_provider;
+            }
+            WebSearchProviderRecommendationSource::DetectedCredential => {
+                return current_provider;
+            }
+            WebSearchProviderRecommendationSource::DetectedSignals => {
+                return current_provider;
+            }
+        }
     }
 
     match recommendation.source {
@@ -2431,6 +2452,23 @@ fn resolve_effective_web_search_default_provider(
     mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO
 }
 
+fn configured_default_web_search_provider(
+    config: &mvp::config::LoongClawConfig,
+) -> Option<&'static str> {
+    let configured_provider = config.tools.web_search.default_provider.as_str();
+    if configured_provider == mvp::config::DEFAULT_WEB_SEARCH_PROVIDER {
+        return None;
+    }
+
+    mvp::config::normalize_web_search_provider(configured_provider)
+}
+
+fn current_web_search_provider(config: &mvp::config::LoongClawConfig) -> &'static str {
+    let configured_provider = config.tools.web_search.default_provider.as_str();
+    let normalized_provider = mvp::config::normalize_web_search_provider(configured_provider);
+    normalized_provider.unwrap_or(mvp::config::DEFAULT_WEB_SEARCH_PROVIDER)
+}
+
 fn build_web_search_provider_recommendation(
     provider: &'static str,
     reason: String,
@@ -2453,11 +2491,7 @@ async fn resolve_web_search_provider_recommendation(
         return Ok(explicit_recommendation);
     }
 
-    if onboard_web_search_is_user_configured(config)
-        && let Some(configured_provider) = mvp::config::normalize_web_search_provider(
-            config.tools.web_search.default_provider.as_str(),
-        )
-    {
+    if let Some(configured_provider) = configured_default_web_search_provider(config) {
         let reason =
             "reusing the configured web search provider from the current starting point".to_owned();
         let source = WebSearchProviderRecommendationSource::Configured;
@@ -2474,10 +2508,6 @@ async fn resolve_web_search_provider_recommendation(
 
     let signals = detect_web_search_environment_signals().await;
     Ok(recommend_web_search_provider_from_signals(signals))
-}
-
-fn onboard_web_search_is_user_configured(config: &mvp::config::LoongClawConfig) -> bool {
-    config.tools.web_search != mvp::config::WebSearchToolConfig::default()
 }
 
 fn explicit_web_search_provider_override(
@@ -2789,6 +2819,7 @@ fn build_web_search_provider_screen_options(
 fn render_web_search_provider_selection_screen_lines_with_style(
     config: &mvp::config::LoongClawConfig,
     recommendation: &WebSearchProviderRecommendation,
+    default_provider: &str,
     guided_prompt_path: GuidedPromptPath,
     width: usize,
     color_enabled: bool,
@@ -2798,17 +2829,20 @@ fn render_web_search_provider_selection_screen_lines_with_style(
     let recommendation_order = render_web_search_provider_recommendation_order(
         recommendation.ordered_providers.as_slice(),
     );
-    let current_provider = mvp::config::normalize_web_search_provider(
-        config.tools.web_search.default_provider.as_str(),
-    )
-    .unwrap_or(mvp::config::DEFAULT_WEB_SEARCH_PROVIDER);
+    let current_provider = current_web_search_provider(config);
     let current_provider_label = web_search_provider_display_name(current_provider);
     let recommended_provider_label = web_search_provider_display_name(recommended_provider);
+    let default_provider_label = web_search_provider_display_name(default_provider);
     let options = build_web_search_provider_screen_options(
         config,
         recommendation.ordered_providers.as_slice(),
         recommended_provider,
     );
+    let default_footer_description = if default_provider == current_provider {
+        format!("keep {current_provider_label}")
+    } else {
+        format!("use {default_provider_label}")
+    };
 
     render_onboard_choice_screen(
         OnboardHeaderStyle::Compact,
@@ -2824,9 +2858,9 @@ fn render_web_search_provider_selection_screen_lines_with_style(
             "- this is a recommendation only; you can still choose any provider below".to_owned(),
         ],
         options,
-        vec![render_default_enter_choice_footer_line(format!(
-            "use {recommended_provider_label}"
-        ))],
+        vec![render_default_enter_choice_footer_line(
+            default_footer_description.as_str(),
+        )],
         true,
         color_enabled,
     )
@@ -7601,6 +7635,88 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn resolve_web_search_provider_recommendation_detects_unique_ready_credential_without_explicit_default_provider()
+     {
+        let options = OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            web_search_provider: None,
+            web_search_api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        };
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.web_search.tavily_api_key = Some("${TAVILY_API_KEY}".to_owned());
+
+        let mut env = ScopedEnv::new();
+        env.set("TAVILY_API_KEY", "tavily-test-token");
+
+        let recommendation = resolve_web_search_provider_recommendation(&options, &config)
+            .await
+            .expect("resolve recommendation");
+
+        assert_eq!(
+            recommendation.provider,
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY
+        );
+        assert_eq!(
+            recommendation.source,
+            WebSearchProviderRecommendationSource::DetectedCredential
+        );
+        assert_eq!(
+            recommendation.ordered_providers.first().copied(),
+            Some(mvp::config::WEB_SEARCH_PROVIDER_TAVILY)
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resolve_web_search_provider_recommendation_keeps_explicitly_configured_default_provider()
+     {
+        let options = OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            web_search_provider: None,
+            web_search_api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        };
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.web_search.default_provider =
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY.to_owned();
+
+        let recommendation = resolve_web_search_provider_recommendation(&options, &config)
+            .await
+            .expect("resolve recommendation");
+
+        assert_eq!(
+            recommendation.provider,
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY
+        );
+        assert_eq!(
+            recommendation.source,
+            WebSearchProviderRecommendationSource::Configured
+        );
+        assert_eq!(
+            recommendation.ordered_providers.first().copied(),
+            Some(mvp::config::WEB_SEARCH_PROVIDER_TAVILY)
+        );
+    }
+
     #[test]
     fn recommend_web_search_provider_from_available_credentials_returns_none_when_multiple_ready() {
         let mut config = mvp::config::LoongClawConfig::default();
@@ -7657,6 +7773,51 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn resolve_web_search_provider_selection_keeps_current_provider_on_blank_interactive_input_when_recommendation_differs()
+     {
+        let options = OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            web_search_provider: None,
+            web_search_api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        };
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.web_search.tavily_api_key = Some("${TAVILY_API_KEY}".to_owned());
+
+        let mut env = ScopedEnv::new();
+        env.set("TAVILY_API_KEY", "tavily-test-token");
+
+        let mut ui = TestOnboardUi::with_inputs([""]);
+        let render_width = 80;
+        let temp_dirs = std::iter::empty::<PathBuf>();
+        let context = OnboardRuntimeContext::new_for_tests(render_width, None, temp_dirs);
+        let selected = resolve_web_search_provider_selection(
+            &options,
+            &config,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .await
+        .expect("blank interactive input should keep the current web search provider");
+
+        assert_eq!(
+            selected,
+            mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
+            "interactive enter should preserve the current provider even when another provider is recommended"
+        );
+    }
+
     #[test]
     fn resolve_effective_web_search_default_provider_keeps_explicit_non_interactive_provider() {
         let options = OnboardCommandOptions {
@@ -7688,6 +7849,41 @@ mod tests {
             selected,
             mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
             "non-interactive onboarding should keep an explicit web-search provider choice instead of silently falling back"
+        );
+    }
+
+    #[test]
+    fn resolve_effective_web_search_default_provider_keeps_current_interactive_provider_for_detected_recommendations()
+     {
+        let options = OnboardCommandOptions {
+            output: None,
+            force: false,
+            non_interactive: false,
+            accept_risk: true,
+            provider: None,
+            model: None,
+            api_key_env: None,
+            web_search_provider: None,
+            web_search_api_key_env: None,
+            personality: None,
+            memory_profile: None,
+            system_prompt: None,
+            skip_model_probe: false,
+        };
+        let config = mvp::config::LoongClawConfig::default();
+        let recommendation = build_web_search_provider_recommendation(
+            mvp::config::WEB_SEARCH_PROVIDER_TAVILY,
+            "domestic locale or timezone was detected".to_owned(),
+            WebSearchProviderRecommendationSource::DetectedSignals,
+        );
+
+        let selected =
+            resolve_effective_web_search_default_provider(&options, &config, &recommendation);
+
+        assert_eq!(
+            selected,
+            mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
+            "interactive onboarding should keep the current draft provider on enter even when a different provider is recommended"
         );
     }
 
@@ -7855,6 +8051,7 @@ mod tests {
         let lines = render_web_search_provider_selection_screen_lines_with_style(
             &config,
             &recommendation,
+            mvp::config::WEB_SEARCH_PROVIDER_DUCKDUCKGO,
             GuidedPromptPath::NativePromptPack,
             80,
             false,
@@ -7873,8 +8070,10 @@ mod tests {
             "the onboarding screen should make it explicit that the recommendation does not remove user choice: {lines:#?}"
         );
         assert!(
-            lines.iter().any(|line| line == "press Enter to use Tavily"),
-            "the web search selection footer should describe the Enter behavior directly instead of rendering an awkward default token: {lines:#?}"
+            lines
+                .iter()
+                .any(|line| line == "press Enter to keep DuckDuckGo"),
+            "the web search selection footer should describe the actual Enter default instead of the recommendation: {lines:#?}"
         );
         assert!(
             lines.iter().all(|line| !line.contains("default Enter")),

--- a/docs/product-specs/onboarding.md
+++ b/docs/product-specs/onboarding.md
@@ -27,9 +27,10 @@ next.
 - [ ] The credential-source step asks for an environment variable name,
       rejects pasted secret literals or shell assignment syntax, and never
       echoes rejected secret-like input in review or success output.
-- [ ] Interactive onboarding lets the user choose a default web search provider
-      and asks for a web-search credential env source immediately when that
-      provider requires a key.
+- [ ] Interactive onboarding lets the user choose a default web search provider,
+      shows a ranked recommendation order with an explicit reason, and asks for
+      a web-search credential env source immediately when the chosen provider
+      requires a key.
 - [ ] Non-interactive onboarding supports `--web-search-provider` and
       `--web-search-api-key`, and explicit web-search choices are not silently
       replaced by heuristic fallbacks.


### PR DESCRIPTION
## Summary

- Problem:
  Onboarding currently computes a single recommended web search provider, but the selection screen still follows the static catalog order. That makes the recommendation feel arbitrary as the provider set grows and makes it hard to express "recommend first" without silently forcing a provider choice.
- Why it matters:
  LoongClaw needs a scalable onboarding policy for a broader web search ecosystem. Operators should see a ranked recommendation order that reflects current signals such as domestic locale hints, network reachability, existing config, and available credentials, while keeping the final choice explicit.
- What changed:
  Added an onboarding-specific web search ranking policy, extended the recommendation contract to carry an ordered provider list, reordered the interactive selection screen to follow that ranking, surfaced the recommendation order plus rationale in the UI, and kept explicit CLI/env overrides plus configured-provider reuse authoritative. Also tightened the signal heuristic so generic offline environments still keep DuckDuckGo first unless Tavily has a positive signal or a domestic locale hint applies.
- What did not change (scope boundary):
  No runtime web search dispatch changes, no provider auto-selection beyond the existing non-interactive safety rules, no provider-specific setup hacks, and no installer / doctor rewrite in this slice.

## Linked Issues

- Closes #575
- Related #551
- Depends on #562

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo test -p loongclaw-daemon onboard_cli -- --nocapture
cargo fmt --all -- --check
git diff --check
cargo test --workspace --locked
cargo test --workspace --all-features --locked
cargo clippy --workspace --all-targets --all-features -- -D warnings

All commands passed.

Before:
- Onboarding returned one recommended provider but still displayed the provider list in the static catalog order.
- The UI explained only the single recommended provider, so "recommended" and "default choice order" were effectively the same thing.
- Generic offline environments could not distinguish between a ranked recommendation policy and a silent provider switch because the catalog order did not move.

After:
- Onboarding computes a ranked provider order and reorders the interactive selection screen to match it.
- The screen now explains both the reason for the top recommendation and the full recommendation order.
- Explicit CLI/env overrides and existing configured providers still win.
- Domestic locale hints move Tavily to the top of the ranking.
- General environments keep DuckDuckGo first unless Tavily has a positive reachability signal and DuckDuckGo does not.
- Ambiguous offline environments still keep DuckDuckGo first instead of inventing a Tavily preference.

Regression coverage:
- Unit tests cover ranked ordering, domestic Tavily preference, positive Tavily-on-DDG-failure preference, and the conservative DuckDuckGo fallback when Tavily has no positive signal.
- Integration onboarding coverage still passes end to end, including non-interactive explicit web-search provider safety.
- The onboarding product spec now reflects the ranked-recommendation behavior.

Env restoration / serialization notes:
- Onboarding tests that mutate process-global env continue to use `ScopedEnv`, `DetectedEnvironmentGuard`, and `EnvVarGuard` to restore state after each test.
```

## User-visible / Operator-visible Changes

- Interactive onboarding now shows web search providers in recommendation order instead of the static catalog order.
- The web search step explicitly says the ranking is a recommendation only and that the operator can still choose any supported provider.
- Domestic users see Tavily promoted in the recommendation order, while general environments still keep DuckDuckGo as the conservative top recommendation unless Tavily has a positive signal.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to restore the previous single-provider recommendation plus static provider-list order.
- Observable failure symptoms reviewers should watch for:
  Explicit provider overrides no longer staying first, interactive onboarding unexpectedly defaulting to a credentialed provider in generic offline environments, or the web search selection screen falling out of sync with the stated recommendation order.

## Reviewer Focus

- `crates/daemon/src/onboard_cli.rs`: ranking-policy boundaries, conservative offline fallback, and the separation between recommendation order and final user choice
- `crates/daemon/src/onboard_cli.rs`: screen rendering order plus the recommendation-only copy in the interactive web search step
- `docs/product-specs/onboarding.md`: acceptance criteria wording for ranked web search recommendations
