### PR TITLE
Redesign tool.search for multilingual schema-derived discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,8 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
+ "unicode-normalization",
+ "unicode-segmentation",
  "wait-timeout",
  "which",
 ]
@@ -3676,6 +3678,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
 
 [[package]]
 name = "unicode-width"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -61,6 +61,8 @@ cbc = { version = "0.1", optional = true }
 wait-timeout = "0.2"
 tempfile = "3"
 which.workspace = true
+unicode-normalization = "0.1"
+unicode-segmentation = "1.12"
 # Kept unconditional because conversation/turn_shared.rs uses Regex to strip
 # leaked <think> tags even when tool-websearch is compiled out.
 regex.workspace = true

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -2607,10 +2607,6 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
     }
 }
 
-const EMPTY_REQUIRED_FIELD_GROUPS: &[&[&str]] = &[];
-const EXTERNAL_SKILLS_INSTALL_REQUIRED_FIELD_GROUPS: &[&[&str]] =
-    &[&["path"], &["bundled_skill_id"]];
-
 fn tool_required_fields(name: &str) -> &'static [&'static str] {
     match name {
         "tool.search" => &["query"],
@@ -2640,13 +2636,6 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "sessions_send" => &["session_id", "text"],
         "web.search" => &["query"],
         _ => &[],
-    }
-}
-
-pub(crate) fn tool_required_field_groups(name: &str) -> &'static [&'static [&'static str]] {
-    match name {
-        "external_skills.install" => EXTERNAL_SKILLS_INSTALL_REQUIRED_FIELD_GROUPS,
-        _ => EMPTY_REQUIRED_FIELD_GROUPS,
     }
 }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -14,6 +14,10 @@ use loongclaw_contracts::{Capability, ToolCoreOutcome, ToolCoreRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
+use tool_search::{
+    RankedSearchableToolEntry, SearchableToolEntry, rank_searchable_entries,
+    searchable_entry_from_descriptor, searchable_entry_from_provider_definition,
+};
 
 use crate::KernelContext;
 use crate::config::ToolConfig;
@@ -43,6 +47,7 @@ pub mod runtime_config;
 mod session;
 mod shell;
 pub mod shell_policy_ext;
+mod tool_search;
 // Browser reuses the shared SSRF and HTML helpers from web_fetch even when the
 // public web.fetch tool is compiled out.
 #[cfg(any(feature = "tool-webfetch", feature = "tool-browser"))]
@@ -864,16 +869,6 @@ pub struct ToolRegistryEntry {
     pub description: &'static str,
 }
 
-#[derive(Debug, Clone)]
-struct SearchableToolEntry {
-    canonical_name: String,
-    summary: String,
-    argument_hint: String,
-    required_fields: Vec<String>,
-    required_field_groups: Vec<Vec<String>>,
-    tags: Vec<String>,
-}
-
 /// Returns a sorted list of all registered tools, gated by feature flags.
 pub fn tool_registry() -> Vec<ToolRegistryEntry> {
     tool_registry_with_config(Some(runtime_config::get_tool_runtime_config()))
@@ -894,7 +889,7 @@ pub(crate) fn tool_registry_with_config(
     let mut entries: Vec<ToolRegistryEntry> = catalog::discoverable_tool_catalog()
         .into_iter()
         .filter(|entry| runtime_visible_tool_view.contains(entry.canonical_name))
-        .filter(|entry| tool_search_entry_is_runtime_usable(*entry, config))
+        .filter(|entry| tool_search_entry_is_runtime_usable(entry.canonical_name, config))
         .map(|entry| ToolRegistryEntry {
             name: entry.canonical_name,
             description: entry.summary,
@@ -972,107 +967,6 @@ fn provider_tool_definitions_for_view(_view: &ToolView) -> Vec<Value> {
     tools
 }
 
-fn search_argument_hint_from_provider_definition(parameters: &Value) -> String {
-    let Some(properties) = parameters.get("properties").and_then(Value::as_object) else {
-        return String::new();
-    };
-    let required = schema_required_fields(parameters)
-        .into_iter()
-        .collect::<BTreeSet<_>>();
-    let mut fields = properties
-        .iter()
-        .map(|(name, schema)| {
-            let schema_type = schema
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or("value");
-            let suffix = if required.contains(name.as_str()) {
-                ""
-            } else {
-                "?"
-            };
-            format!("{name}{suffix}:{schema_type}")
-        })
-        .collect::<Vec<_>>();
-    fields.sort();
-    fields.join(",")
-}
-
-fn schema_required_fields(parameters: &Value) -> Vec<String> {
-    parameters
-        .get("required")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
-        .map(str::to_owned)
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect()
-}
-
-fn schema_required_field_groups(parameters: &Value) -> Vec<Vec<String>> {
-    ["anyOf", "oneOf"]
-        .into_iter()
-        .filter_map(|key| parameters.get(key).and_then(Value::as_array))
-        .flatten()
-        .filter_map(|schema| {
-            let required = schema
-                .get("required")
-                .and_then(Value::as_array)?
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::to_owned)
-                .collect::<BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-            if required.is_empty() {
-                None
-            } else {
-                Some(required)
-            }
-        })
-        .collect()
-}
-
-fn default_required_field_groups(
-    required_fields: &[String],
-    mut required_field_groups: Vec<Vec<String>>,
-) -> Vec<Vec<String>> {
-    if required_field_groups.is_empty() && !required_fields.is_empty() {
-        required_field_groups.push(required_fields.to_vec());
-    }
-    required_field_groups
-}
-
-fn searchable_entry_from_catalog(entry: catalog::ToolCatalogEntry) -> SearchableToolEntry {
-    let required_fields = entry
-        .required_fields
-        .iter()
-        .map(|field| (*field).to_owned())
-        .collect::<Vec<_>>();
-    let required_field_groups = catalog::tool_required_field_groups(entry.canonical_name)
-        .iter()
-        .map(|group| {
-            group
-                .iter()
-                .map(|field| (*field).to_owned())
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-    let required_field_groups =
-        default_required_field_groups(&required_fields, required_field_groups);
-
-    SearchableToolEntry {
-        canonical_name: entry.canonical_name.to_owned(),
-        summary: entry.summary.to_owned(),
-        argument_hint: entry.argument_hint.to_owned(),
-        required_fields,
-        required_field_groups,
-        tags: entry.tags.iter().map(|tag| (*tag).to_owned()).collect(),
-    }
-}
-
 #[cfg(feature = "feishu-integration")]
 fn feishu_searchable_entries() -> Vec<SearchableToolEntry> {
     feishu::feishu_provider_tool_definitions()
@@ -1084,23 +978,23 @@ fn feishu_searchable_entries() -> Vec<SearchableToolEntry> {
                 .get("parameters")
                 .cloned()
                 .unwrap_or_else(|| json!({}));
-            let required_fields = schema_required_fields(&parameters);
-            let required_field_groups = default_required_field_groups(
-                &required_fields,
-                schema_required_field_groups(&parameters),
-            );
-            Some(SearchableToolEntry {
-                canonical_name: canonical_tool_name(provider_name).to_owned(),
-                summary: function
-                    .get("description")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_owned(),
-                argument_hint: search_argument_hint_from_provider_definition(&parameters),
-                required_field_groups,
-                required_fields,
-                tags: vec!["feishu".to_owned()],
-            })
+            let summary = function
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let tags = vec!["feishu".to_owned()];
+            let canonical_name = canonical_tool_name(provider_name).to_owned();
+            let preferred_parameter_order: &[(&str, &str)] = &[];
+            Some(searchable_entry_from_provider_definition(
+                canonical_name.as_str(),
+                provider_name,
+                &[],
+                summary,
+                &parameters,
+                preferred_parameter_order,
+                tags,
+            ))
         })
         .collect()
 }
@@ -1147,11 +1041,13 @@ fn runtime_discoverable_tool_entries(
         }
         None => &runtime_view,
     };
-    let mut entries = catalog::discoverable_tool_catalog()
-        .into_iter()
-        .filter(|entry| visible_tool_view.contains(entry.canonical_name))
-        .filter(|entry| tool_search_entry_is_runtime_usable(*entry, config))
-        .map(searchable_entry_from_catalog)
+    let mut entries = catalog::tool_catalog()
+        .descriptors()
+        .iter()
+        .filter(|descriptor| descriptor.is_discoverable())
+        .filter(|descriptor| visible_tool_view.contains(descriptor.name))
+        .filter(|descriptor| tool_search_entry_is_runtime_usable(descriptor.name, config))
+        .map(searchable_entry_from_descriptor)
         .collect::<Vec<_>>();
     #[cfg(feature = "feishu-integration")]
     if config.feishu.is_some() {
@@ -1215,36 +1111,22 @@ fn execute_tool_search_tool_with_config(
         .and_then(|value| serde_json::from_value::<BTreeSet<Capability>>(value).ok());
     let visible_tool_view = search_tool_view_from_payload(payload, config);
 
-    let query_normalized = query.to_ascii_lowercase();
-    let tokens = tokenize_search_query(query_normalized.as_str());
-    let mut ranked: Vec<(u32, Vec<String>, SearchableToolEntry)> =
-        runtime_discoverable_tool_entries(config, Some(&visible_tool_view))
-            .into_iter()
-            .filter(|entry| {
-                tool_search_entry_is_capability_usable(
-                    entry.canonical_name.as_str(),
-                    granted_capabilities.as_ref(),
-                )
-            })
-            .filter_map(|entry| {
-                let (score, why) = search_score(&entry, query_normalized.as_str(), &tokens);
-                if score == 0 {
-                    None
-                } else {
-                    Some((score, why, entry))
-                }
-            })
-            .collect();
-    ranked.sort_by(|(left_score, _, left), (right_score, _, right)| {
-        right_score
-            .cmp(left_score)
-            .then_with(|| left.canonical_name.cmp(&right.canonical_name))
-    });
-
-    let results: Vec<Value> = ranked
+    let searchable_entries = runtime_discoverable_tool_entries(config, Some(&visible_tool_view))
         .into_iter()
-        .take(limit)
-        .map(|(_score, why, entry)| {
+        .filter(|entry| {
+            tool_search_entry_is_capability_usable(
+                entry.canonical_name.as_str(),
+                granted_capabilities.as_ref(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let ranking = rank_searchable_entries(searchable_entries, query, limit);
+
+    let results: Vec<Value> = ranking
+        .results
+        .into_iter()
+        .map(|ranked_entry| {
+            let RankedSearchableToolEntry { entry, why } = ranked_entry;
             json!({
                 "tool_id": entry.canonical_name,
                 "summary": entry.summary,
@@ -1271,10 +1153,10 @@ fn execute_tool_search_tool_with_config(
 }
 
 fn tool_search_entry_is_runtime_usable(
-    entry: catalog::ToolCatalogEntry,
+    tool_name: &str,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> bool {
-    match entry.canonical_name {
+    match tool_name {
         "shell.exec" => {
             !config.shell_allow.is_empty()
                 || matches!(
@@ -1377,59 +1259,6 @@ fn execute_tool_invoke_tool_with_config(
             entry.canonical_name
         )),
     }
-}
-
-fn tokenize_search_query(query: &str) -> Vec<String> {
-    query
-        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-')
-        .map(str::trim)
-        .filter(|token| !token.is_empty())
-        .map(str::to_owned)
-        .collect()
-}
-
-fn search_score(entry: &SearchableToolEntry, query: &str, tokens: &[String]) -> (u32, Vec<String>) {
-    let name = entry.canonical_name.to_ascii_lowercase();
-    let summary = entry.summary.to_ascii_lowercase();
-    let argument_hint = entry.argument_hint.to_ascii_lowercase();
-    let tags = entry.tags.join(" ").to_ascii_lowercase();
-
-    let mut score = 0u32;
-    let mut why = Vec::new();
-
-    if name.contains(query) {
-        score += 50;
-        why.push("name_match".to_owned());
-    }
-    if summary.contains(query) {
-        score += 30;
-        why.push("summary_match".to_owned());
-    }
-    if argument_hint.contains(query) {
-        score += 20;
-        why.push("argument_match".to_owned());
-    }
-
-    for token in tokens {
-        if name.contains(token) {
-            score += 16;
-            why.push(format!("name:{token}"));
-        }
-        if summary.contains(token) {
-            score += 10;
-            why.push(format!("summary:{token}"));
-        }
-        if argument_hint.contains(token) {
-            score += 8;
-            why.push(format!("argument:{token}"));
-        }
-        if tags.contains(token) {
-            score += 12;
-            why.push(format!("tag:{token}"));
-        }
-    }
-
-    (score, why)
 }
 
 fn issue_tool_lease(tool_id: &str, payload: &serde_json::Map<String, Value>) -> String {
@@ -3423,6 +3252,127 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    #[cfg(all(feature = "tool-file", feature = "tool-webfetch"))]
+    #[test]
+    fn tool_search_uses_schema_derived_terms_for_web_fetch_modes() {
+        let root = unique_tool_temp_dir("loongclaw-tool-search-schema-derived");
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "raw_text",
+                    "limit": 6
+                }),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(
+            results.iter().any(|entry| entry["tool_id"] == "web.fetch"),
+            "schema-derived enum terms should make web.fetch discoverable: {results:?}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "tool-websearch"))]
+    #[test]
+    fn tool_search_matches_multilingual_queries_across_languages() {
+        let root = unique_tool_temp_dir("loongclaw-tool-search-multilingual");
+        let memory_dir = root.join("memory");
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(root.join("MEMORY.md"), "deploy freeze window\n")
+            .expect("write root memory");
+
+        let config = test_tool_runtime_config(root.clone());
+        let cases = vec![
+            ("编辑文件", "file.edit"),
+            ("ファイルを読む", "file.read"),
+            ("메모 검색", "memory_search"),
+            ("искать веб", "web.search"),
+            ("تثبيت مهارة", "external_skills.install"),
+            ("cambiar proveedor", "provider.switch"),
+            ("प्रदाता बदलें", "provider.switch"),
+        ];
+
+        for (query, expected_tool) in cases {
+            let payload = json!({
+                "query": query,
+                "limit": 8
+            });
+            let request = ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload,
+            };
+            let outcome = execute_tool_core_with_config(request, &config)
+                .expect("tool search should succeed");
+            let results = outcome.payload["results"].as_array().expect("results");
+            let expected_entry = results
+                .iter()
+                .find(|entry| entry["tool_id"] == expected_tool);
+
+            assert!(
+                expected_entry.is_some(),
+                "expected `{expected_tool}` for multilingual query `{query}`, got {results:?}"
+            );
+
+            let expected_entry = expected_entry.expect("expected tool entry");
+            let why = expected_entry["why"].as_array().expect("why");
+            let used_coarse_fallback = why
+                .iter()
+                .any(|reason| reason.as_str() == Some("coarse_fallback"));
+
+            assert!(
+                !used_coarse_fallback,
+                "expected semantic match for `{query}`, got coarse fallback: {expected_entry:?}"
+            );
+        }
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn tool_search_returns_coarse_fallback_for_zero_match_queries() {
+        let root = unique_tool_temp_dir("loongclaw-tool-search-coarse-fallback");
+        std::fs::create_dir_all(&root).expect("create fixture root");
+
+        let config = test_tool_runtime_config(root.clone());
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.search".to_owned(),
+                payload: json!({
+                    "query": "สวัสดีโลก",
+                    "limit": 4
+                }),
+            },
+            &config,
+        )
+        .expect("tool search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert!(
+            !results.is_empty(),
+            "coarse fallback should surface visible tools instead of an empty set"
+        );
+        assert!(
+            results
+                .iter()
+                .all(|entry| entry["why"].as_array().is_some_and(|why| why
+                    .iter()
+                    .any(|reason| reason.as_str() == Some("coarse_fallback")))),
+            "coarse fallback results should explain their fallback mode: {results:?}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
     #[cfg(feature = "tool-browser")]
     #[test]
     fn browser_companion_tool_search_returns_runtime_ready_companion_entries() {
@@ -3702,13 +3652,14 @@ mod tests {
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_search_reports_alternative_required_fields_for_bundled_skill_install() {
-        let entry = catalog::find_tool_catalog_entry("external_skills.install")
+        let descriptor = catalog::tool_catalog()
+            .descriptor("external_skills.install")
             .expect("external_skills.install should exist in the catalog");
-        let searchable = searchable_entry_from_catalog(entry);
+        let searchable = searchable_entry_from_descriptor(descriptor);
 
         assert!(
-            entry.required_fields.is_empty(),
-            "catalog required_fields should only list unconditional requirements"
+            descriptor.required_fields().is_empty(),
+            "schema-derived search should keep grouped requirements separate"
         );
         assert!(
             searchable.required_fields.is_empty(),

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -3963,7 +3963,10 @@ mod tests {
         assert_eq!(entry.required_fields, vec!["url".to_owned()]);
         assert_eq!(
             entry.required_field_groups,
-            vec![vec!["content".to_owned()], vec!["content_path".to_owned()]]
+            vec![
+                vec!["url".to_owned(), "content".to_owned()],
+                vec!["url".to_owned(), "content_path".to_owned()],
+            ]
         );
     }
 

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -1,0 +1,1938 @@
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
+
+use serde_json::Value;
+use unicode_normalization::UnicodeNormalization;
+use unicode_normalization::char::is_combining_mark;
+use unicode_segmentation::UnicodeSegmentation;
+
+use super::catalog::ToolDescriptor;
+
+const COARSE_FALLBACK_DISCOVERY_CONCEPTS: &[&str] =
+    &["fetch", "inspect", "list", "read", "search", "status"];
+const MAX_SEARCH_WHY_REASONS: usize = 4;
+
+#[derive(Debug, Clone)]
+pub(super) struct SearchableToolEntry {
+    pub(super) canonical_name: String,
+    pub(super) summary: String,
+    pub(super) argument_hint: String,
+    pub(super) required_fields: Vec<String>,
+    pub(super) required_field_groups: Vec<Vec<String>>,
+    pub(super) tags: Vec<String>,
+    search_document: SearchDocument,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RankedSearchableToolEntry {
+    pub(super) entry: SearchableToolEntry,
+    pub(super) why: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ToolSearchRanking {
+    pub(super) results: Vec<RankedSearchableToolEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct SearchSignalSet {
+    normalized_text: String,
+    tokens: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SearchDocument {
+    name: SearchSignalSet,
+    summary: SearchSignalSet,
+    arguments: SearchSignalSet,
+    schema: SearchSignalSet,
+    tags: SearchSignalSet,
+    concepts: BTreeSet<String>,
+    categories: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SearchQuery {
+    signal: SearchSignalSet,
+    concepts: BTreeSet<String>,
+    categories: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SearchScore {
+    score: u32,
+    why: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ScoredSearchableToolEntry {
+    entry: SearchableToolEntry,
+    score: u32,
+    why: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SchemaArgumentField {
+    name: String,
+    schema_type: String,
+    required: bool,
+    preferred_index: usize,
+}
+
+struct SearchConceptDefinition {
+    id: &'static str,
+    categories: &'static [&'static str],
+    forms: &'static [&'static str],
+}
+
+struct NormalizedSearchConcept {
+    id: &'static str,
+    categories: &'static [&'static str],
+    forms: Vec<String>,
+}
+
+impl SchemaArgumentField {
+    fn format(self) -> String {
+        let suffix = if self.required { "" } else { "?" };
+        format!("{}{}:{}", self.name, suffix, self.schema_type)
+    }
+}
+
+const SEARCH_CONCEPT_DEFINITIONS: &[SearchConceptDefinition] = &[
+    SearchConceptDefinition {
+        id: "search",
+        categories: &["discovery"],
+        forms: &[
+            "search",
+            "find",
+            "discover",
+            "lookup",
+            "query",
+            "buscar",
+            "busqueda",
+            "rechercher",
+            "recherche",
+            "suchen",
+            "suche",
+            "искать",
+            "поиск",
+            "найти",
+            "بحث",
+            "ابحث",
+            "खोज",
+            "तलाश",
+            "搜索",
+            "搜寻",
+            "查找",
+            "查询",
+            "检索",
+            "検索",
+            "探す",
+            "調べる",
+            "검색",
+            "찾기",
+            "조회",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "fetch",
+        categories: &["network", "retrieval"],
+        forms: &[
+            "fetch",
+            "download",
+            "retrieve",
+            "obtain",
+            "descargar",
+            "telecharger",
+            "скачать",
+            "получить",
+            "جلب",
+            "تنزيل",
+            "डाउनलोड",
+            "获取",
+            "抓取",
+            "拉取",
+            "取得",
+            "取得する",
+            "가져오기",
+            "다운로드",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "read",
+        categories: &["retrieval"],
+        forms: &[
+            "read",
+            "view",
+            "show",
+            "display",
+            "open",
+            "leer",
+            "lire",
+            "anzeigen",
+            "читать",
+            "открыть",
+            "قراءة",
+            "عرض",
+            "पढ़",
+            "देख",
+            "खोल",
+            "读取",
+            "阅读",
+            "查看",
+            "打开",
+            "読む",
+            "表示",
+            "開く",
+            "읽기",
+            "보기",
+            "열기",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "inspect",
+        categories: &["discovery", "retrieval"],
+        forms: &[
+            "inspect",
+            "detail",
+            "details",
+            "metadata",
+            "describe",
+            "detalle",
+            "detalles",
+            "details",
+            "metadonnees",
+            "метаданные",
+            "подробности",
+            "تفاصيل",
+            "بيانات وصفية",
+            "विवरण",
+            "मेटाडेटा",
+            "详情",
+            "元数据",
+            "详细",
+            "詳細",
+            "メタデータ",
+            "상세",
+            "메타데이터",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "list",
+        categories: &["discovery"],
+        forms: &[
+            "list",
+            "enumerate",
+            "browse",
+            "listar",
+            "liste",
+            "zeigen",
+            "список",
+            "показать",
+            "قائمة",
+            "اعرض",
+            "सूची",
+            "दिखा",
+            "列表",
+            "列出",
+            "浏览",
+            "一覧",
+            "参照",
+            "목록",
+            "나열",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "write",
+        categories: &["mutation"],
+        forms: &[
+            "write",
+            "create",
+            "save",
+            "append",
+            "record",
+            "escribir",
+            "crear",
+            "guardar",
+            "ecrire",
+            "creer",
+            "enregistrer",
+            "создать",
+            "записать",
+            "сохранить",
+            "كتابة",
+            "إنشاء",
+            "احفظ",
+            "लिख",
+            "बन",
+            "सहेज",
+            "写入",
+            "创建",
+            "保存",
+            "追加",
+            "作成",
+            "保存する",
+            "쓰기",
+            "저장",
+            "생성",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "edit",
+        categories: &["mutation"],
+        forms: &[
+            "edit",
+            "modify",
+            "update",
+            "replace",
+            "patch",
+            "editar",
+            "modifier",
+            "mettre a jour",
+            "изменить",
+            "обновить",
+            "заменить",
+            "تحرير",
+            "تعديل",
+            "تحديث",
+            "संपादित",
+            "बदल",
+            "अपडेट",
+            "编辑",
+            "修改",
+            "更新",
+            "替换",
+            "編集",
+            "修正",
+            "変更",
+            "편집",
+            "수정",
+            "업데이트",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "file",
+        categories: &["workspace"],
+        forms: &[
+            "file",
+            "files",
+            "filesystem",
+            "path",
+            "repo",
+            "repository",
+            "workspace",
+            "archivo",
+            "fichier",
+            "datei",
+            "файл",
+            "путь",
+            "репозиторий",
+            "ملف",
+            "مسار",
+            "مستودع",
+            "फ़ाइल",
+            "पथ",
+            "रिपॉजिटरी",
+            "वर्कस्पेस",
+            "文件",
+            "档案",
+            "路径",
+            "仓库",
+            "工作区",
+            "ファイル",
+            "パス",
+            "リポジトリ",
+            "ワークスペース",
+            "파일",
+            "경로",
+            "저장소",
+            "작업공간",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "memory",
+        categories: &["workspace"],
+        forms: &[
+            "memory",
+            "note",
+            "notes",
+            "memo",
+            "recall",
+            "durable",
+            "knowledge",
+            "memoria",
+            "memoire",
+            "заметки",
+            "память",
+            "ملاحظات",
+            "ذاكرة",
+            "नोट",
+            "स्मृति",
+            "याद",
+            "记忆",
+            "笔记",
+            "备忘",
+            "回忆",
+            "メモ",
+            "記憶",
+            "ノート",
+            "메모",
+            "기억",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "web",
+        categories: &["network"],
+        forms: &[
+            "web",
+            "website",
+            "site",
+            "url",
+            "http",
+            "https",
+            "internet",
+            "page",
+            "pagina web",
+            "site web",
+            "страница",
+            "веб",
+            "сайт",
+            "ويب",
+            "موقع",
+            "صفحة",
+            "वेब",
+            "साइट",
+            "पेज",
+            "网页",
+            "页面",
+            "网址",
+            "网络",
+            "ウェブ",
+            "サイト",
+            "ページ",
+            "웹",
+            "사이트",
+            "웹페이지",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "browser",
+        categories: &["interactive", "network"],
+        forms: &[
+            "browser",
+            "browse",
+            "navigate",
+            "click",
+            "type",
+            "selector",
+            "tab",
+            "navegador",
+            "naviguer",
+            "браузер",
+            "клик",
+            "переход",
+            "متصفح",
+            "انقر",
+            "اكتب",
+            "ब्राउज़र",
+            "क्लिक",
+            "टाइप",
+            "浏览器",
+            "导航",
+            "点击",
+            "输入",
+            "ブラウザ",
+            "クリック",
+            "入力",
+            "브라우저",
+            "클릭",
+            "입력",
+            "탐색",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "session",
+        categories: &["coordination"],
+        forms: &[
+            "session",
+            "thread",
+            "conversation",
+            "chat",
+            "history",
+            "event",
+            "status",
+            "queue",
+            "session_id",
+            "sesion",
+            "conversation",
+            "histoire",
+            "сессия",
+            "чат",
+            "история",
+            "событие",
+            "статус",
+            "جلسة",
+            "محادثة",
+            "سجل",
+            "حالة",
+            "सत्र",
+            "चैट",
+            "इतिहास",
+            "स्थिति",
+            "会话",
+            "对话",
+            "聊天",
+            "历史",
+            "事件",
+            "状态",
+            "セッション",
+            "会話",
+            "履歴",
+            "状態",
+            "세션",
+            "대화",
+            "이력",
+            "상태",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "message",
+        categories: &["communication"],
+        forms: &[
+            "message",
+            "messages",
+            "send",
+            "post",
+            "reply",
+            "mensaje",
+            "enviar",
+            "reponse",
+            "envoyer",
+            "сообщение",
+            "отправить",
+            "ответить",
+            "رسالة",
+            "إرسال",
+            "رد",
+            "संदेश",
+            "भेज",
+            "जवाब",
+            "消息",
+            "发送",
+            "回复",
+            "メッセージ",
+            "送信",
+            "返信",
+            "메시지",
+            "보내기",
+            "답장",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "delegate",
+        categories: &["coordination"],
+        forms: &[
+            "delegate",
+            "delegation",
+            "child",
+            "background",
+            "async",
+            "subtask",
+            "delegar",
+            "deleguer",
+            "делегировать",
+            "фоновый",
+            "تفويض",
+            "خلفية",
+            "उपकार्य",
+            "पृष्ठभूमि",
+            "委派",
+            "后台",
+            "子任务",
+            "委任",
+            "バックグラウンド",
+            "子タスク",
+            "비동기",
+            "위임",
+            "하위 작업",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "skill",
+        categories: &["extension"],
+        forms: &[
+            "skill",
+            "skills",
+            "plugin",
+            "extension",
+            "package",
+            "skillset",
+            "plugin",
+            "extension",
+            "плагин",
+            "расширение",
+            "مهارة",
+            "ملحق",
+            "إضافة",
+            "कौशल",
+            "प्लगइन",
+            "एक्सटेंशन",
+            "技能",
+            "插件",
+            "扩展",
+            "包",
+            "スキル",
+            "プラグイン",
+            "拡張",
+            "패키지",
+            "플러그인",
+            "확장",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "install",
+        categories: &["extension", "mutation"],
+        forms: &[
+            "install",
+            "setup",
+            "enable",
+            "configure",
+            "instalar",
+            "installer",
+            "einrichten",
+            "установить",
+            "настроить",
+            "включить",
+            "تثبيت",
+            "إعداد",
+            "تمكين",
+            "स्थापित",
+            "इंस्टॉल",
+            "सक्षम",
+            "सेटअप",
+            "安装",
+            "启用",
+            "配置",
+            "インストール",
+            "セットアップ",
+            "有効",
+            "설치",
+            "설정",
+            "활성화",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "remove",
+        categories: &["extension", "mutation"],
+        forms: &[
+            "remove",
+            "delete",
+            "uninstall",
+            "disable",
+            "erase",
+            "quitar",
+            "supprimer",
+            "удалить",
+            "деинсталлировать",
+            "выключить",
+            "إزالة",
+            "حذف",
+            "تعطيل",
+            "हट",
+            "मिटा",
+            "अनइंस्टॉल",
+            "删除",
+            "移除",
+            "卸载",
+            "禁用",
+            "削除",
+            "アンインストール",
+            "無効",
+            "제거",
+            "삭제",
+            "비활성화",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "provider",
+        categories: &["runtime"],
+        forms: &[
+            "provider",
+            "model",
+            "runtime",
+            "profile",
+            "engine",
+            "backend",
+            "proveedor",
+            "fournisseur",
+            "провайдер",
+            "модель",
+            "рантайм",
+            "مزود",
+            "نموذج",
+            "وقت التشغيل",
+            "प्रदाता",
+            "मॉडल",
+            "रनटाइम",
+            "प्रोफाइल",
+            "供应商",
+            "模型",
+            "运行时",
+            "配置档",
+            "プロバイダ",
+            "モデル",
+            "ランタイム",
+            "프로바이더",
+            "모델",
+            "런타임",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "switch",
+        categories: &["mutation", "runtime"],
+        forms: &[
+            "switch",
+            "change",
+            "select",
+            "swap",
+            "choose",
+            "toggle",
+            "cambiar",
+            "changer",
+            "wechseln",
+            "переключить",
+            "сменить",
+            "выбрать",
+            "تبديل",
+            "تغيير",
+            "اختر",
+            "बदल",
+            "बदलें",
+            "चुन",
+            "स्विच",
+            "切换",
+            "更换",
+            "选择",
+            "切り替え",
+            "変更",
+            "選択",
+            "전환",
+            "변경",
+            "선택",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "approval",
+        categories: &["governance"],
+        forms: &[
+            "approval",
+            "approve",
+            "permission",
+            "policy",
+            "security",
+            "allow",
+            "deny",
+            "aprobacion",
+            "autorisation",
+            "politique",
+            "одобрение",
+            "разрешение",
+            "политика",
+            "безопасность",
+            "موافقة",
+            "إذن",
+            "سياسة",
+            "أمان",
+            "अनुमति",
+            "स्वीकृति",
+            "नीति",
+            "सुरक्षा",
+            "审批",
+            "批准",
+            "权限",
+            "策略",
+            "安全",
+            "承認",
+            "許可",
+            "ポリシー",
+            "セキュリティ",
+            "승인",
+            "권한",
+            "정책",
+            "보안",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "wait",
+        categories: &["coordination"],
+        forms: &[
+            "wait",
+            "poll",
+            "watch",
+            "monitor",
+            "until",
+            "esperar",
+            "sonder",
+            "ждать",
+            "следить",
+            "انتظر",
+            "مراقبة",
+            "प्रतीक्षा",
+            "निगरानी",
+            "等待",
+            "轮询",
+            "监控",
+            "待つ",
+            "監視",
+            "대기",
+            "감시",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "cancel",
+        categories: &["coordination", "mutation"],
+        forms: &[
+            "cancel",
+            "stop",
+            "abort",
+            "kill",
+            "terminate",
+            "cancelar",
+            "arreter",
+            "остановить",
+            "отменить",
+            "прервать",
+            "إلغاء",
+            "إيقاف",
+            "إنهاء",
+            "रोक",
+            "रद्द",
+            "समाप्त",
+            "取消",
+            "停止",
+            "终止",
+            "キャンセル",
+            "停止する",
+            "취소",
+            "중지",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "archive",
+        categories: &["coordination"],
+        forms: &[
+            "archive",
+            "store",
+            "retain",
+            "archivar",
+            "archiver",
+            "архив",
+            "архивировать",
+            "أرشفة",
+            "حفظ",
+            "संग्रह",
+            "अभिलेख",
+            "归档",
+            "存档",
+            "アーカイブ",
+            "보관",
+        ],
+    },
+    SearchConceptDefinition {
+        id: "recover",
+        categories: &["coordination"],
+        forms: &[
+            "recover",
+            "restore",
+            "resume",
+            "repair",
+            "fix",
+            "recuperar",
+            "restaurer",
+            "восстановить",
+            "починить",
+            "استعادة",
+            "إصلاح",
+            "पुनर्प्राप्त",
+            "बहाल",
+            "मरम्मत",
+            "恢复",
+            "还原",
+            "復旧",
+            "復元",
+            "복구",
+        ],
+    },
+];
+
+impl SearchSignalSet {
+    fn from_fragment(fragment: &str) -> Self {
+        let fragments = vec![fragment.to_owned()];
+        Self::from_fragments(&fragments)
+    }
+
+    fn from_fragments(fragments: &[String]) -> Self {
+        let mut normalized_fragments = Vec::new();
+        let mut tokens = BTreeSet::new();
+
+        for fragment in fragments {
+            let normalized_fragment = normalize_search_text(fragment);
+            if normalized_fragment.is_empty() {
+                continue;
+            }
+
+            let fragment_tokens = tokenize_normalized_text(normalized_fragment.as_str());
+            tokens.extend(fragment_tokens);
+            normalized_fragments.push(normalized_fragment);
+        }
+
+        let normalized_text = normalized_fragments.join(" ");
+
+        Self {
+            normalized_text,
+            tokens,
+        }
+    }
+
+    fn contains_term(&self, normalized_term: &str) -> bool {
+        if normalized_term.is_empty() {
+            return false;
+        }
+
+        let ascii_token_only = normalized_term
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric());
+
+        if ascii_token_only {
+            return self.tokens.contains(normalized_term);
+        }
+
+        if self.tokens.contains(normalized_term) {
+            return true;
+        }
+
+        self.normalized_text.contains(normalized_term)
+    }
+}
+
+impl SearchDocument {
+    fn new(
+        name_fragments: Vec<String>,
+        summary_fragments: Vec<String>,
+        argument_fragments: Vec<String>,
+        schema_fragments: Vec<String>,
+        tag_fragments: Vec<String>,
+    ) -> Self {
+        let name = SearchSignalSet::from_fragments(&name_fragments);
+        let summary = SearchSignalSet::from_fragments(&summary_fragments);
+        let arguments = SearchSignalSet::from_fragments(&argument_fragments);
+        let schema = SearchSignalSet::from_fragments(&schema_fragments);
+        let tags = SearchSignalSet::from_fragments(&tag_fragments);
+
+        let mut all_fragments = Vec::new();
+        all_fragments.extend(name_fragments);
+        all_fragments.extend(summary_fragments);
+        all_fragments.extend(argument_fragments);
+        all_fragments.extend(schema_fragments);
+        all_fragments.extend(tag_fragments);
+
+        let all_signals = SearchSignalSet::from_fragments(&all_fragments);
+        let (concepts, categories) = extract_concepts_and_categories(&all_signals);
+
+        Self {
+            name,
+            summary,
+            arguments,
+            schema,
+            tags,
+            concepts,
+            categories,
+        }
+    }
+}
+
+impl SearchQuery {
+    fn new(raw_query: &str) -> Self {
+        let signal = SearchSignalSet::from_fragment(raw_query);
+        let (mut concepts, mut categories) = extract_concepts_and_categories(&signal);
+        apply_structural_query_hints(raw_query, &mut concepts, &mut categories);
+
+        Self {
+            signal,
+            concepts,
+            categories,
+        }
+    }
+}
+
+pub(super) fn searchable_entry_from_descriptor(descriptor: &ToolDescriptor) -> SearchableToolEntry {
+    let definition = descriptor.provider_definition();
+    let function = definition.get("function");
+
+    let summary_value = function.and_then(|value| value.get("description"));
+    let summary = summary_value
+        .and_then(Value::as_str)
+        .unwrap_or(descriptor.description)
+        .to_owned();
+
+    let parameters_value = function.and_then(|value| value.get("parameters"));
+    let parameters = parameters_value.unwrap_or(&Value::Null);
+    let tags = descriptor
+        .tags()
+        .iter()
+        .map(|tag| (*tag).to_owned())
+        .collect::<Vec<_>>();
+
+    searchable_entry_from_provider_definition(
+        descriptor.name,
+        descriptor.provider_name,
+        descriptor.aliases,
+        summary,
+        parameters,
+        descriptor.parameter_types(),
+        tags,
+    )
+}
+
+pub(super) fn searchable_entry_from_provider_definition(
+    canonical_name: &str,
+    provider_name: &str,
+    aliases: &[&str],
+    summary: String,
+    parameters: &Value,
+    preferred_parameter_order: &[(&str, &str)],
+    tags: Vec<String>,
+) -> SearchableToolEntry {
+    let required_fields = schema_required_fields(parameters);
+    let required_field_groups = schema_required_field_groups(parameters);
+    let required_field_groups =
+        default_required_field_groups(&required_fields, required_field_groups);
+    let argument_hint =
+        search_argument_hint_from_provider_definition(parameters, preferred_parameter_order);
+
+    let name_fragments = build_name_fragments(canonical_name, provider_name, aliases);
+    let summary_fragments = vec![summary.clone()];
+    let argument_fragments = build_argument_fragments(
+        argument_hint.as_str(),
+        &required_fields,
+        &required_field_groups,
+    );
+    let schema_fragments = collect_schema_search_terms(parameters);
+    let tag_fragments = tags.clone();
+    let search_document = SearchDocument::new(
+        name_fragments,
+        summary_fragments,
+        argument_fragments,
+        schema_fragments,
+        tag_fragments,
+    );
+
+    SearchableToolEntry {
+        canonical_name: canonical_name.to_owned(),
+        summary,
+        argument_hint,
+        required_fields,
+        required_field_groups,
+        tags,
+        search_document,
+    }
+}
+
+pub(super) fn search_argument_hint_from_provider_definition(
+    parameters: &Value,
+    preferred_parameter_order: &[(&str, &str)],
+) -> String {
+    let Some(properties) = parameters.get("properties").and_then(Value::as_object) else {
+        return String::new();
+    };
+
+    let required = schema_required_fields(parameters)
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+    let mut fields = Vec::new();
+    for (name, schema) in properties {
+        let schema_type = schema_argument_type(schema);
+        let is_required = required.contains(name.as_str());
+        let preferred_index = preferred_parameter_index(name.as_str(), preferred_parameter_order);
+        let field = SchemaArgumentField {
+            name: name.to_owned(),
+            schema_type,
+            required: is_required,
+            preferred_index,
+        };
+        fields.push(field);
+    }
+
+    fields.sort_by(|left, right| {
+        let left_required_rank = if left.required { 0usize } else { 1usize };
+        let right_required_rank = if right.required { 0usize } else { 1usize };
+
+        left_required_rank
+            .cmp(&right_required_rank)
+            .then_with(|| left.preferred_index.cmp(&right.preferred_index))
+            .then_with(|| left.name.cmp(&right.name))
+    });
+
+    let total_field_count = fields.len();
+    let compact_fields = compact_argument_hint_fields(fields);
+    let omitted_field_count = total_field_count.saturating_sub(compact_fields.len());
+    let mut fragments = compact_fields
+        .into_iter()
+        .map(|field| field.format())
+        .collect::<Vec<_>>();
+
+    if omitted_field_count > 0 {
+        fragments.push(format!("+{omitted_field_count} more"));
+    }
+
+    fragments.join(",")
+}
+
+pub(super) fn schema_required_fields(parameters: &Value) -> Vec<String> {
+    parameters
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+pub(super) fn schema_required_field_groups(parameters: &Value) -> Vec<Vec<String>> {
+    let mut groups = Vec::new();
+
+    for key in ["anyOf", "oneOf"] {
+        let Some(options) = parameters.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+
+        for schema in options {
+            let Some(required_array) = schema.get("required").and_then(Value::as_array) else {
+                continue;
+            };
+
+            let required = required_array
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+
+            if required.is_empty() {
+                continue;
+            }
+
+            groups.push(required);
+        }
+    }
+
+    groups
+}
+
+pub(super) fn default_required_field_groups(
+    required_fields: &[String],
+    mut required_field_groups: Vec<Vec<String>>,
+) -> Vec<Vec<String>> {
+    let missing_groups = required_field_groups.is_empty();
+    let has_required_fields = !required_fields.is_empty();
+
+    if missing_groups && has_required_fields {
+        required_field_groups.push(required_fields.to_vec());
+    }
+
+    required_field_groups
+}
+
+pub(super) fn rank_searchable_entries(
+    entries: Vec<SearchableToolEntry>,
+    query: &str,
+    limit: usize,
+) -> ToolSearchRanking {
+    if entries.is_empty() {
+        return ToolSearchRanking {
+            results: Vec::new(),
+        };
+    }
+
+    let search_query = SearchQuery::new(query);
+    let mut ranked = Vec::new();
+
+    for entry in &entries {
+        let score = score_entry(entry, &search_query);
+        let Some(score) = score else {
+            continue;
+        };
+
+        let ranked_entry = ScoredSearchableToolEntry {
+            entry: entry.clone(),
+            score: score.score,
+            why: score.why,
+        };
+        ranked.push(ranked_entry);
+    }
+
+    sort_scored_entries(&mut ranked);
+
+    if !ranked.is_empty() {
+        let results = ranked
+            .into_iter()
+            .take(limit)
+            .map(|entry| RankedSearchableToolEntry {
+                entry: entry.entry,
+                why: entry.why,
+            })
+            .collect();
+
+        return ToolSearchRanking { results };
+    }
+
+    coarse_fallback(entries, limit)
+}
+
+fn score_entry(entry: &SearchableToolEntry, query: &SearchQuery) -> Option<SearchScore> {
+    let mut score = 0u32;
+    let mut why = BTreeSet::new();
+
+    let normalized_query = query.signal.normalized_text.as_str();
+    let query_tokens = &query.signal.tokens;
+
+    let _name_phrase_hit = add_phrase_score(
+        "name",
+        64,
+        &entry.search_document.name,
+        normalized_query,
+        &mut score,
+        &mut why,
+    );
+
+    let _summary_phrase_hit = add_phrase_score(
+        "summary",
+        42,
+        &entry.search_document.summary,
+        normalized_query,
+        &mut score,
+        &mut why,
+    );
+
+    let _argument_phrase_hit = add_phrase_score(
+        "argument",
+        30,
+        &entry.search_document.arguments,
+        normalized_query,
+        &mut score,
+        &mut why,
+    );
+
+    let _schema_phrase_hit = add_phrase_score(
+        "schema",
+        28,
+        &entry.search_document.schema,
+        normalized_query,
+        &mut score,
+        &mut why,
+    );
+
+    let _tag_phrase_hit = add_phrase_score(
+        "tag",
+        24,
+        &entry.search_document.tags,
+        normalized_query,
+        &mut score,
+        &mut why,
+    );
+
+    let _name_token_hit = add_token_scores(
+        "name",
+        20,
+        &entry.search_document.name,
+        query_tokens,
+        &mut score,
+        &mut why,
+    );
+
+    let _summary_token_hit = add_token_scores(
+        "summary",
+        12,
+        &entry.search_document.summary,
+        query_tokens,
+        &mut score,
+        &mut why,
+    );
+
+    let _argument_token_hit = add_token_scores(
+        "argument",
+        10,
+        &entry.search_document.arguments,
+        query_tokens,
+        &mut score,
+        &mut why,
+    );
+
+    let _schema_token_hit = add_token_scores(
+        "schema",
+        9,
+        &entry.search_document.schema,
+        query_tokens,
+        &mut score,
+        &mut why,
+    );
+
+    let _tag_token_hit = add_token_scores(
+        "tag",
+        14,
+        &entry.search_document.tags,
+        query_tokens,
+        &mut score,
+        &mut why,
+    );
+
+    let concept_overlap = ordered_overlap(&query.concepts, &entry.search_document.concepts);
+    for concept in concept_overlap {
+        score += 26;
+        why.insert(format!("concept:{concept}"));
+    }
+
+    let category_overlap = ordered_overlap(&query.categories, &entry.search_document.categories);
+    for category in category_overlap {
+        score += 12;
+        why.insert(format!("category:{category}"));
+    }
+
+    if score == 0 {
+        return None;
+    }
+
+    let mut why = why.into_iter().collect::<Vec<_>>();
+    why.truncate(MAX_SEARCH_WHY_REASONS);
+
+    Some(SearchScore { score, why })
+}
+
+fn add_phrase_score(
+    label: &str,
+    weight: u32,
+    signal: &SearchSignalSet,
+    normalized_query: &str,
+    score: &mut u32,
+    why: &mut BTreeSet<String>,
+) -> bool {
+    let phrase_allowed = phrase_search_allowed(normalized_query);
+    if !phrase_allowed {
+        return false;
+    }
+
+    let contains_query = signal.normalized_text.contains(normalized_query);
+    if !contains_query {
+        return false;
+    }
+
+    *score += weight;
+    why.insert(format!("{label}_phrase"));
+    true
+}
+
+fn add_token_scores(
+    label: &str,
+    weight: u32,
+    signal: &SearchSignalSet,
+    query_tokens: &BTreeSet<String>,
+    score: &mut u32,
+    why: &mut BTreeSet<String>,
+) -> bool {
+    let overlaps = ordered_overlap(query_tokens, &signal.tokens);
+    if overlaps.is_empty() {
+        return false;
+    }
+
+    for token in overlaps {
+        *score += weight;
+        why.insert(format!("{label}:{token}"));
+    }
+
+    true
+}
+
+fn phrase_search_allowed(normalized_query: &str) -> bool {
+    if normalized_query.is_empty() {
+        return false;
+    }
+
+    let character_count = normalized_query.chars().count();
+    if normalized_query.is_ascii() {
+        return character_count >= 2;
+    }
+
+    character_count >= 1
+}
+
+fn coarse_fallback(entries: Vec<SearchableToolEntry>, limit: usize) -> ToolSearchRanking {
+    let mut ranked = Vec::new();
+
+    for entry in entries {
+        let (score, why) = coarse_fallback_score(&entry);
+        let ranked_entry = ScoredSearchableToolEntry { entry, score, why };
+        ranked.push(ranked_entry);
+    }
+
+    sort_scored_entries(&mut ranked);
+
+    let results = ranked
+        .into_iter()
+        .take(limit)
+        .map(|entry| RankedSearchableToolEntry {
+            entry: entry.entry,
+            why: entry.why,
+        })
+        .collect();
+
+    ToolSearchRanking { results }
+}
+
+fn coarse_fallback_score(entry: &SearchableToolEntry) -> (u32, Vec<String>) {
+    let mut score = 1u32;
+    let mut why = BTreeSet::new();
+
+    why.insert("coarse_fallback".to_owned());
+
+    let mut discovery_bonus = 0u32;
+    for concept in COARSE_FALLBACK_DISCOVERY_CONCEPTS {
+        let contains_concept = entry.search_document.concepts.contains(*concept);
+        if !contains_concept {
+            continue;
+        }
+
+        discovery_bonus += 1;
+    }
+
+    if discovery_bonus > 0 {
+        let discovery_score = 40u32 + discovery_bonus * 6u32;
+        score += discovery_score;
+        why.insert("coarse_discovery_tool".to_owned());
+    }
+
+    let category_score = entry.search_document.categories.len() as u32;
+    score += category_score;
+
+    let concept_score = entry.search_document.concepts.len() as u32;
+    score += concept_score;
+
+    let why = why.into_iter().collect::<Vec<_>>();
+
+    (score, why)
+}
+
+fn sort_scored_entries(entries: &mut [ScoredSearchableToolEntry]) {
+    entries.sort_by(|left, right| {
+        right
+            .score
+            .cmp(&left.score)
+            .then_with(|| left.entry.canonical_name.cmp(&right.entry.canonical_name))
+    });
+}
+
+fn build_name_fragments(
+    canonical_name: &str,
+    provider_name: &str,
+    aliases: &[&str],
+) -> Vec<String> {
+    let mut fragments = Vec::new();
+
+    fragments.push(canonical_name.to_owned());
+    fragments.push(identifier_phrase_variant(canonical_name));
+    fragments.push(provider_name.to_owned());
+    fragments.push(identifier_phrase_variant(provider_name));
+
+    for alias in aliases {
+        fragments.push((*alias).to_owned());
+        fragments.push(identifier_phrase_variant(alias));
+    }
+
+    fragments
+}
+
+fn build_argument_fragments(
+    argument_hint: &str,
+    required_fields: &[String],
+    required_field_groups: &[Vec<String>],
+) -> Vec<String> {
+    let mut fragments = Vec::new();
+
+    if !argument_hint.is_empty() {
+        fragments.push(argument_hint.to_owned());
+    }
+
+    if !required_fields.is_empty() {
+        let required_joined = required_fields.join(" ");
+        fragments.push(required_joined);
+    }
+
+    for group in required_field_groups {
+        let group_joined = group.join(" ");
+        fragments.push(group_joined);
+    }
+
+    fragments
+}
+
+fn collect_schema_search_terms(schema: &Value) -> Vec<String> {
+    let mut fragments = Vec::new();
+    collect_schema_search_terms_into(schema, &mut fragments);
+    fragments
+}
+
+fn collect_schema_search_terms_into(schema: &Value, fragments: &mut Vec<String>) {
+    let Value::Object(map) = schema else {
+        return;
+    };
+
+    for key in ["title", "description"] {
+        let value = map.get(key);
+        let Some(text) = value.and_then(Value::as_str) else {
+            continue;
+        };
+
+        fragments.push(text.to_owned());
+    }
+
+    let property_names = map.get("properties").and_then(Value::as_object);
+    if let Some(property_names) = property_names {
+        for (name, property_schema) in property_names {
+            fragments.push(name.to_owned());
+            collect_schema_search_terms_into(property_schema, fragments);
+        }
+    }
+
+    for key in [
+        "items",
+        "additionalProperties",
+        "contains",
+        "if",
+        "then",
+        "else",
+        "not",
+    ] {
+        let nested_schema = map.get(key);
+        let Some(nested_schema) = nested_schema else {
+            continue;
+        };
+
+        collect_schema_search_terms_into(nested_schema, fragments);
+    }
+
+    for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
+        let nested_schemas = map.get(key).and_then(Value::as_array);
+        let Some(nested_schemas) = nested_schemas else {
+            continue;
+        };
+
+        for nested_schema in nested_schemas {
+            collect_schema_search_terms_into(nested_schema, fragments);
+        }
+    }
+
+    let enum_values = map.get("enum").and_then(Value::as_array);
+    if let Some(enum_values) = enum_values {
+        for enum_value in enum_values {
+            let Some(text) = enum_value.as_str() else {
+                continue;
+            };
+
+            fragments.push(text.to_owned());
+        }
+    }
+
+    let example_values = map.get("examples").and_then(Value::as_array);
+    if let Some(example_values) = example_values {
+        for example_value in example_values {
+            let Some(text) = example_value.as_str() else {
+                continue;
+            };
+
+            fragments.push(text.to_owned());
+        }
+    }
+
+    let const_value = map.get("const").and_then(Value::as_str);
+    if let Some(const_value) = const_value {
+        fragments.push(const_value.to_owned());
+    }
+}
+
+fn identifier_phrase_variant(raw: &str) -> String {
+    let normalized = normalize_search_text(raw);
+    let mut characters = String::new();
+    let mut last_was_space = false;
+
+    for character in normalized.chars() {
+        let replacement = if is_identifier_separator(character) {
+            ' '
+        } else {
+            character
+        };
+
+        if replacement == ' ' {
+            if last_was_space {
+                continue;
+            }
+
+            last_was_space = true;
+            characters.push(' ');
+            continue;
+        }
+
+        last_was_space = false;
+        characters.push(replacement);
+    }
+
+    characters.trim().to_owned()
+}
+
+fn extract_concepts_and_categories(
+    signal: &SearchSignalSet,
+) -> (BTreeSet<String>, BTreeSet<String>) {
+    let mut concepts = BTreeSet::new();
+    let mut categories = BTreeSet::new();
+
+    for concept in normalized_search_concepts() {
+        let mut matched = false;
+
+        for form in &concept.forms {
+            let contains_form = signal.contains_term(form.as_str());
+            if !contains_form {
+                continue;
+            }
+
+            matched = true;
+            break;
+        }
+
+        if !matched {
+            continue;
+        }
+
+        concepts.insert(concept.id.to_owned());
+
+        for category in concept.categories {
+            categories.insert((*category).to_owned());
+        }
+    }
+
+    (concepts, categories)
+}
+
+fn normalized_search_concepts() -> &'static Vec<NormalizedSearchConcept> {
+    static SEARCH_CONCEPTS: OnceLock<Vec<NormalizedSearchConcept>> = OnceLock::new();
+
+    SEARCH_CONCEPTS.get_or_init(|| {
+        SEARCH_CONCEPT_DEFINITIONS
+            .iter()
+            .map(|concept| {
+                let forms = concept
+                    .forms
+                    .iter()
+                    .map(|form| normalize_search_text(form))
+                    .filter(|form| !form.is_empty())
+                    .collect::<Vec<_>>();
+
+                NormalizedSearchConcept {
+                    id: concept.id,
+                    categories: concept.categories,
+                    forms,
+                }
+            })
+            .collect()
+    })
+}
+
+fn apply_structural_query_hints(
+    raw_query: &str,
+    concepts: &mut BTreeSet<String>,
+    categories: &mut BTreeSet<String>,
+) {
+    let looks_like_url = query_looks_like_url(raw_query);
+    if looks_like_url {
+        insert_concept_and_categories("web", concepts, categories);
+    }
+
+    let looks_like_file_reference = query_looks_like_file_reference(raw_query);
+    if looks_like_file_reference {
+        insert_concept_and_categories("file", concepts, categories);
+    }
+}
+
+fn insert_concept_and_categories(
+    concept_id: &str,
+    concepts: &mut BTreeSet<String>,
+    categories: &mut BTreeSet<String>,
+) {
+    concepts.insert(concept_id.to_owned());
+
+    for concept in normalized_search_concepts() {
+        if concept.id != concept_id {
+            continue;
+        }
+
+        for category in concept.categories {
+            categories.insert((*category).to_owned());
+        }
+    }
+}
+
+fn query_looks_like_url(raw_query: &str) -> bool {
+    for token in raw_query.split_whitespace() {
+        let cleaned = trim_structural_token(token);
+        if cleaned.is_empty() {
+            continue;
+        }
+
+        let looks_like_url = token_looks_like_url(cleaned);
+        if looks_like_url {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn token_looks_like_url(token: &str) -> bool {
+    token.contains("://") || token.starts_with("www.")
+}
+
+fn query_looks_like_file_reference(raw_query: &str) -> bool {
+    for token in raw_query.split_whitespace() {
+        let cleaned = trim_structural_token(token);
+        if cleaned.is_empty() {
+            continue;
+        }
+
+        let looks_like_file_reference = token_looks_like_file_reference(cleaned);
+        if looks_like_file_reference {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn token_looks_like_file_reference(token: &str) -> bool {
+    if token_looks_like_url(token) {
+        return false;
+    }
+
+    let has_path_separator = token.contains('/') || token.contains('\\');
+    if has_path_separator {
+        return true;
+    }
+
+    let Some((stem, extension)) = token.rsplit_once('.') else {
+        return false;
+    };
+
+    let stem_valid = stem
+        .chars()
+        .any(|character| character.is_alphanumeric() || character == '_' || character == '-');
+    if !stem_valid {
+        return false;
+    }
+
+    let extension_length = extension.chars().count();
+    let extension_valid = extension_length >= 1
+        && extension_length <= 8
+        && extension
+            .chars()
+            .all(|character| character.is_alphanumeric());
+
+    extension_valid
+}
+
+fn trim_structural_token(token: &str) -> &str {
+    token.trim_matches(|character: char| {
+        character.is_whitespace()
+            || matches!(
+                character,
+                '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | '!' | '?'
+            )
+    })
+}
+
+fn schema_argument_type(schema: &Value) -> String {
+    let schema_type = schema
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("value");
+
+    if schema_type != "array" {
+        return schema_type.to_owned();
+    }
+
+    let item_type = schema
+        .get("items")
+        .and_then(|value| value.get("type"))
+        .and_then(Value::as_str);
+
+    let Some(item_type) = item_type else {
+        return "array".to_owned();
+    };
+
+    format!("{item_type}[]")
+}
+
+fn preferred_parameter_index(
+    parameter_name: &str,
+    preferred_parameter_order: &[(&str, &str)],
+) -> usize {
+    for (index, (preferred_name, _)) in preferred_parameter_order.iter().enumerate() {
+        if *preferred_name == parameter_name {
+            return index;
+        }
+    }
+
+    usize::MAX
+}
+
+fn compact_argument_hint_fields(fields: Vec<SchemaArgumentField>) -> Vec<SchemaArgumentField> {
+    if fields.len() <= 4 {
+        return fields;
+    }
+
+    let mut compacted = Vec::new();
+    let mut required_fields = 0usize;
+    let mut optional_fields = 0usize;
+
+    for field in fields {
+        if field.required {
+            if required_fields >= 2 {
+                continue;
+            }
+
+            required_fields += 1;
+            compacted.push(field);
+            continue;
+        }
+
+        if optional_fields >= 1 {
+            continue;
+        }
+
+        optional_fields += 1;
+        compacted.push(field);
+    }
+
+    if compacted.is_empty() {
+        return Vec::new();
+    }
+
+    compacted
+}
+
+fn normalize_search_text(raw: &str) -> String {
+    let compatibility = raw.nfkc().collect::<String>();
+    let lowercased = compatibility.to_lowercase();
+
+    let mut normalized = String::new();
+    let mut last_was_space = false;
+
+    for character in lowercased.nfd() {
+        if is_combining_mark(character) {
+            continue;
+        }
+
+        let normalized_character = if character.is_whitespace() {
+            ' '
+        } else {
+            character
+        };
+        if normalized_character == ' ' {
+            if last_was_space {
+                continue;
+            }
+
+            last_was_space = true;
+            normalized.push(' ');
+            continue;
+        }
+
+        last_was_space = false;
+        normalized.push(normalized_character);
+    }
+
+    normalized.trim().to_owned()
+}
+
+fn tokenize_normalized_text(normalized: &str) -> BTreeSet<String> {
+    let surface = identifier_phrase_variant(normalized);
+    let mut tokens = BTreeSet::new();
+
+    for word in UnicodeSegmentation::unicode_words(surface.as_str()) {
+        let token = word.trim();
+        let keep_token = should_keep_token(token);
+        if !keep_token {
+            continue;
+        }
+
+        tokens.insert(token.to_owned());
+    }
+
+    tokens
+}
+
+fn should_keep_token(token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+
+    let ascii_token = token
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric());
+
+    if ascii_token {
+        return token.len() >= 2;
+    }
+
+    true
+}
+
+fn is_identifier_separator(character: char) -> bool {
+    matches!(
+        character,
+        '.' | '_' | '-' | '/' | '\\' | ':' | ',' | ';' | '|' | '(' | ')' | '[' | ']'
+    )
+}
+
+fn ordered_overlap(left: &BTreeSet<String>, right: &BTreeSet<String>) -> Vec<String> {
+    left.intersection(right).cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_search_text_folds_diacritics_and_width_variants() {
+        let normalized = normalize_search_text("Ｂúsqueda　网页");
+        assert_eq!(normalized, "busqueda 网页");
+    }
+
+    #[test]
+    fn multilingual_concepts_extract_from_non_latin_queries() {
+        let signal = SearchSignalSet::from_fragment("تثبيت مهارة");
+        let (concepts, categories) = extract_concepts_and_categories(&signal);
+
+        assert!(concepts.contains("install"));
+        assert!(concepts.contains("skill"));
+        assert!(categories.contains("extension"));
+        assert!(categories.contains("mutation"));
+    }
+
+    #[test]
+    fn structural_query_hints_detect_file_references() {
+        let query = SearchQuery::new("read note.md");
+        assert!(query.concepts.contains("file"));
+        assert!(query.categories.contains("workspace"));
+    }
+}

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -1440,12 +1440,16 @@ fn build_name_fragments(
     provider_name: &str,
     aliases: &[&str],
 ) -> Vec<String> {
-    let mut fragments = Vec::new();
-
-    fragments.push(canonical_name.to_owned());
-    fragments.push(identifier_phrase_variant(canonical_name));
-    fragments.push(provider_name.to_owned());
-    fragments.push(identifier_phrase_variant(provider_name));
+    let canonical_name_fragment = canonical_name.to_owned();
+    let canonical_name_variant = identifier_phrase_variant(canonical_name);
+    let provider_name_fragment = provider_name.to_owned();
+    let provider_name_variant = identifier_phrase_variant(provider_name);
+    let mut fragments = Vec::from([
+        canonical_name_fragment,
+        canonical_name_variant,
+        provider_name_fragment,
+        provider_name_variant,
+    ]);
 
     for alias in aliases {
         fragments.push((*alias).to_owned());
@@ -1741,13 +1745,12 @@ fn token_looks_like_file_reference(token: &str) -> bool {
     }
 
     let extension_length = extension.chars().count();
-    let extension_valid = extension_length >= 1
-        && extension_length <= 8
-        && extension
-            .chars()
-            .all(|character| character.is_alphanumeric());
+    let extension_length_valid = (1..=8).contains(&extension_length);
+    let extension_characters_valid = extension
+        .chars()
+        .all(|character| character.is_alphanumeric());
 
-    extension_valid
+    extension_length_valid && extension_characters_valid
 }
 
 fn trim_structural_token(token: &str) -> &str {

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -866,11 +866,6 @@ const SEARCH_CONCEPT_DEFINITIONS: &[SearchConceptDefinition] = &[
 ];
 
 impl SearchSignalSet {
-    fn from_fragment(fragment: &str) -> Self {
-        let fragments = vec![fragment.to_owned()];
-        Self::from_fragments(&fragments)
-    }
-
     fn from_fragments(fragments: &[String]) -> Self {
         let mut normalized_fragments = Vec::new();
         let mut tokens = BTreeSet::new();
@@ -953,7 +948,7 @@ impl SearchDocument {
 
 impl SearchQuery {
     fn new(raw_query: &str) -> Self {
-        let signal = SearchSignalSet::from_fragment(raw_query);
+        let signal = search_query_signal_set(raw_query);
         let (mut concepts, mut categories) = extract_concepts_and_categories(&signal);
         apply_structural_query_hints(raw_query, &mut concepts, &mut categories);
 
@@ -963,6 +958,34 @@ impl SearchQuery {
             categories,
         }
     }
+}
+
+fn search_query_signal_set(raw_query: &str) -> SearchSignalSet {
+    let cleaned_tokens = raw_query
+        .split_whitespace()
+        .map(trim_structural_token)
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    let single_token_query = cleaned_tokens.len() == 1;
+    let mut fragments = Vec::new();
+
+    for token in cleaned_tokens {
+        let has_path_separator = token.contains('/') || token.contains('\\');
+        let ambiguous_single_dot_token = token_is_ambiguous_single_dot_token(token);
+        let host_like_path_token = has_path_separator && token_has_host_like_prefix(token);
+        let url_like_token = token_looks_like_url(token);
+        let skip_token = url_like_token
+            || host_like_path_token
+            || (single_token_query && ambiguous_single_dot_token);
+
+        if skip_token {
+            continue;
+        }
+
+        fragments.push(token.to_owned());
+    }
+
+    SearchSignalSet::from_fragments(&fragments)
 }
 
 pub(super) fn searchable_entry_from_descriptor(descriptor: &ToolDescriptor) -> SearchableToolEntry {
@@ -1103,6 +1126,7 @@ pub(super) fn schema_required_fields(parameters: &Value) -> Vec<String> {
 }
 
 pub(super) fn schema_required_field_groups(parameters: &Value) -> Vec<Vec<String>> {
+    let root_required_fields = schema_required_fields(parameters);
     let mut groups = Vec::new();
 
     for key in ["anyOf", "oneOf"] {
@@ -1111,27 +1135,43 @@ pub(super) fn schema_required_field_groups(parameters: &Value) -> Vec<Vec<String
         };
 
         for schema in options {
-            let Some(required_array) = schema.get("required").and_then(Value::as_array) else {
-                continue;
-            };
+            let branch_required_fields = schema_required_fields(schema);
+            let merged_required_fields = merge_required_field_group(
+                root_required_fields.as_slice(),
+                branch_required_fields.as_slice(),
+            );
+            let duplicate_group = groups.iter().any(|group| group == &merged_required_fields);
 
-            let required = required_array
-                .iter()
-                .filter_map(Value::as_str)
-                .map(str::to_owned)
-                .collect::<BTreeSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-
-            if required.is_empty() {
+            if duplicate_group {
                 continue;
             }
 
-            groups.push(required);
+            groups.push(merged_required_fields);
         }
     }
 
     groups
+}
+
+fn merge_required_field_group(
+    root_required_fields: &[String],
+    branch_required_fields: &[String],
+) -> Vec<String> {
+    let mut merged_required_fields = root_required_fields.to_vec();
+
+    for field_name in branch_required_fields {
+        let already_present = merged_required_fields
+            .iter()
+            .any(|existing_name| existing_name == field_name);
+
+        if already_present {
+            continue;
+        }
+
+        merged_required_fields.push(field_name.clone());
+    }
+
+    merged_required_fields
 }
 
 pub(super) fn default_required_field_groups(
@@ -1694,8 +1734,10 @@ fn query_looks_like_url(raw_query: &str) -> bool {
             continue;
         }
 
+        let has_path_separator = cleaned.contains('/') || cleaned.contains('\\');
+        let host_like_path = has_path_separator && token_has_host_like_prefix(cleaned);
         let looks_like_url = token_looks_like_url(cleaned);
-        if looks_like_url {
+        if looks_like_url || host_like_path {
             return true;
         }
     }
@@ -1708,13 +1750,21 @@ fn token_looks_like_url(token: &str) -> bool {
 }
 
 fn query_looks_like_file_reference(raw_query: &str) -> bool {
-    for token in raw_query.split_whitespace() {
-        let cleaned = trim_structural_token(token);
-        if cleaned.is_empty() {
+    let cleaned_tokens = raw_query
+        .split_whitespace()
+        .map(trim_structural_token)
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    let single_token_query = cleaned_tokens.len() == 1;
+
+    for token in cleaned_tokens {
+        let ambiguous_single_dot_token = token_is_ambiguous_single_dot_token(token);
+
+        if single_token_query && ambiguous_single_dot_token {
             continue;
         }
 
-        let looks_like_file_reference = token_looks_like_file_reference(cleaned);
+        let looks_like_file_reference = token_looks_like_file_reference(token);
         if looks_like_file_reference {
             return true;
         }
@@ -1730,12 +1780,31 @@ fn token_looks_like_file_reference(token: &str) -> bool {
 
     let has_path_separator = token.contains('/') || token.contains('\\');
     if has_path_separator {
+        let host_like_prefix = token_has_host_like_prefix(token);
+
+        if host_like_prefix {
+            return false;
+        }
+
         return true;
     }
 
     let Some((stem, extension)) = token.rsplit_once('.') else {
         return false;
     };
+
+    let single_dot_count = token.chars().filter(|character| *character == '.').count();
+    let has_single_dot = single_dot_count == 1;
+    if has_single_dot {
+        let stem_has_alpha = stem.chars().any(|character| character.is_alphabetic());
+        let extension_length = extension.chars().count();
+        let extension_length_valid = (2..=4).contains(&extension_length);
+        let extension_characters_valid = extension
+            .chars()
+            .all(|character| character.is_ascii_alphabetic());
+
+        return stem_has_alpha && extension_length_valid && extension_characters_valid;
+    }
 
     let stem_valid = stem
         .chars()
@@ -1751,6 +1820,56 @@ fn token_looks_like_file_reference(token: &str) -> bool {
         .all(|character| character.is_alphanumeric());
 
     extension_length_valid && extension_characters_valid
+}
+
+fn token_has_host_like_prefix(token: &str) -> bool {
+    let host_candidate = token.split(['/', '\\']).next().unwrap_or(token);
+    let normalized_candidate = host_candidate.to_ascii_lowercase();
+    let Some((stem, extension)) = normalized_candidate.rsplit_once('.') else {
+        return false;
+    };
+    let extension_length = extension.chars().count();
+    let extension_length_valid = (2..=4).contains(&extension_length);
+    let extension_characters_valid = extension
+        .chars()
+        .all(|character| character.is_ascii_lowercase());
+    let stem_has_alpha = stem
+        .chars()
+        .any(|character| character.is_ascii_alphabetic());
+    let stem_characters_valid = stem.chars().all(|character| {
+        character.is_ascii_lowercase()
+            || character.is_ascii_digit()
+            || character == '-'
+            || character == '.'
+    });
+
+    stem_has_alpha && extension_length_valid && extension_characters_valid && stem_characters_valid
+}
+
+fn token_is_ambiguous_single_dot_token(token: &str) -> bool {
+    let has_path_separator = token.contains('/') || token.contains('\\');
+    if has_path_separator {
+        return false;
+    }
+
+    let Some((stem, extension)) = token.rsplit_once('.') else {
+        return false;
+    };
+    let single_dot_count = token.chars().filter(|character| *character == '.').count();
+    let has_single_dot = single_dot_count == 1;
+
+    if !has_single_dot {
+        return false;
+    }
+
+    let stem_has_alpha = stem.chars().any(|character| character.is_alphabetic());
+    let extension_length = extension.chars().count();
+    let extension_length_valid = (2..=4).contains(&extension_length);
+    let extension_characters_valid = extension
+        .chars()
+        .all(|character| character.is_ascii_alphabetic());
+
+    stem_has_alpha && extension_length_valid && extension_characters_valid
 }
 
 fn trim_structural_token(token: &str) -> &str {
@@ -1923,7 +2042,8 @@ mod tests {
 
     #[test]
     fn multilingual_concepts_extract_from_non_latin_queries() {
-        let signal = SearchSignalSet::from_fragment("تثبيت مهارة");
+        let fragments = vec!["تثبيت مهارة".to_owned()];
+        let signal = SearchSignalSet::from_fragments(&fragments);
         let (concepts, categories) = extract_concepts_and_categories(&signal);
 
         assert!(concepts.contains("install"));
@@ -1937,5 +2057,56 @@ mod tests {
         let query = SearchQuery::new("read note.md");
         assert!(query.concepts.contains("file"));
         assert!(query.categories.contains("workspace"));
+    }
+
+    #[test]
+    fn schema_required_field_groups_merge_root_and_branch_requirements() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["url"],
+            "properties": {
+                "url": {"type": "string"},
+                "content": {"type": "string"},
+                "content_path": {"type": "string"}
+            },
+            "anyOf": [
+                {"required": ["content"]},
+                {}
+            ]
+        });
+        let required_field_groups = schema_required_field_groups(&schema);
+
+        assert_eq!(
+            required_field_groups,
+            vec![
+                vec!["url".to_owned(), "content".to_owned()],
+                vec!["url".to_owned()],
+            ]
+        );
+    }
+
+    #[test]
+    fn structural_query_hints_do_not_treat_lone_domains_as_files() {
+        let query = SearchQuery::new("example.com");
+
+        assert!(!query.concepts.contains("file"));
+        assert!(!query.categories.contains("workspace"));
+    }
+
+    #[test]
+    fn structural_query_hints_do_not_treat_domain_paths_as_files() {
+        let query = SearchQuery::new("example.com/path");
+
+        assert!(!query.concepts.contains("file"));
+        assert!(!query.categories.contains("workspace"));
+    }
+
+    #[test]
+    fn structural_query_hints_do_not_treat_version_tokens_as_files() {
+        let version_query = SearchQuery::new("gpt-4.1");
+        let numeric_query = SearchQuery::new("3.14");
+
+        assert!(!version_query.concepts.contains("file"));
+        assert!(!numeric_query.concepts.contains("file"));
     }
 }


### PR DESCRIPTION
Refs #570

## Summary

- redesign `tool.search` around schema-derived discovery metadata instead of the old hand-maintained search catalog
- make search matching Unicode-aware and language-agnostic with normalization, Unicode word segmentation, multilingual concept/synonym matching, category signals, and structural file/URL hints
- return a coarse fallback set for zero-hit queries instead of an empty result set
- compact schema-derived argument hints and bound search reasons so discovery follow-up payloads stay below truncation limits and keep provider lease bridging intact

## Root cause

Issue #570 exposed a broader degraded behavior around tool discovery and follow-up execution. For the `tool.search` slice, the main failures were structural:

1. search ranking depended on ASCII-only tokenization and a narrow hand-maintained metadata path, so discoverability drifted as tool schemas evolved and non-Latin queries lost signal
2. some tools had complete provider schemas but incomplete search metadata, which caused discovery mismatch for tools like `web.fetch`
3. zero-hit queries returned an empty set even when visible tools existed, which made recovery paths look dead-ended
4. large schema-derived search payloads could be truncated before the provider follow-up turn, which dropped the lease bridge context and caused follow-up calls to miss `tool.invoke`

This change addresses those structural failures without adding channel-specific search patches.

## Validation

- `cargo fmt --all --check`
- `cargo test -p loongclaw-app tool_search_`
- `cargo test -p loongclaw-app bridge_context_accepts_compacted_search_results`
- `cargo test -p loongclaw-app reduce_followup_payload_for_model_compacts_tool_search_summary`
- `cargo test -p loongclaw-app`

## Scope

This PR is intentionally scoped to the search/discovery slice of #570. It improves tool discoverability and follow-up stability, but it does not yet productize nanobot-style autonomous tool expansion or approval-visible policy switching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Major rewrite of tool search: improved multilingual semantic matching, schema-aware term extraction, richer argument hints and required-field group awareness, and more accurate ranking with a coarse fallback for zero-match queries.

* **Chores**
  * Added Unicode processing support to improve normalization and tokenization across languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->