### PR TITLE
refactor(tools): extract shared payload extraction helpers

### DIFF
--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -496,7 +496,8 @@ fn execute_approval_request_status(
     config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    let approval_request_id = required_payload_string(&payload, "approval_request_id", "approval tool")?;
+    let approval_request_id =
+        required_payload_string(&payload, "approval_request_id", "approval tool")?;
     let repo = SessionRepository::new(config)?;
     let request = repo
         .load_approval_request(&approval_request_id)?
@@ -806,8 +807,16 @@ fn parse_approval_request_resolve_request(
     payload: &Value,
 ) -> Result<ApprovalRequestResolveRequest, String> {
     Ok(ApprovalRequestResolveRequest {
-        approval_request_id: required_payload_string(payload, "approval_request_id", "approval tool")?,
-        decision: parse_approval_decision(&required_payload_string(payload, "decision", "approval tool")?)?,
+        approval_request_id: required_payload_string(
+            payload,
+            "approval_request_id",
+            "approval tool",
+        )?,
+        decision: parse_approval_decision(&required_payload_string(
+            payload,
+            "decision",
+            "approval tool",
+        )?)?,
     })
 }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -4,6 +4,8 @@ use serde_json::{Value, json};
 #[cfg(feature = "memory-sqlite")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use super::payload::{optional_payload_limit, optional_payload_string, required_payload_string};
+
 #[cfg(feature = "memory-sqlite")]
 use crate::config::SessionVisibility;
 use crate::config::ToolConfig;
@@ -494,7 +496,7 @@ fn execute_approval_request_status(
     config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    let approval_request_id = required_payload_string(&payload, "approval_request_id")?;
+    let approval_request_id = required_payload_string(&payload, "approval_request_id", "approval tool")?;
     let repo = SessionRepository::new(config)?;
     let request = repo
         .load_approval_request(&approval_request_id)?
@@ -804,8 +806,8 @@ fn parse_approval_request_resolve_request(
     payload: &Value,
 ) -> Result<ApprovalRequestResolveRequest, String> {
     Ok(ApprovalRequestResolveRequest {
-        approval_request_id: required_payload_string(payload, "approval_request_id")?,
-        decision: parse_approval_decision(&required_payload_string(payload, "decision")?)?,
+        approval_request_id: required_payload_string(payload, "approval_request_id", "approval tool")?,
+        decision: parse_approval_decision(&required_payload_string(payload, "decision", "approval tool")?)?,
     })
 }
 
@@ -845,33 +847,6 @@ fn ensure_visible(
     Err(format!(
         "visibility_denied: session `{target_session_id}` is not visible from `{current_session_id}`"
     ))
-}
-
-fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
-    payload
-        .get(field)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| format!("approval tool requires payload.{field}"))
-}
-
-fn optional_payload_string(payload: &Value, field: &str) -> Option<String> {
-    payload
-        .get(field)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-}
-
-fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usize) -> usize {
-    payload
-        .get(field)
-        .and_then(Value::as_u64)
-        .map(|value| value.clamp(1, max as u64) as usize)
-        .unwrap_or(default)
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{Value, json};
 
-use super::payload::required_payload_string;
+use super::payload::{optional_payload_string, required_payload_string};
 
 #[cfg(test)]
 pub const DEFAULT_TIMEOUT_SECONDS: u64 = 60;
@@ -26,12 +26,7 @@ pub(crate) fn parse_delegate_request_with_default_timeout(
     default_timeout_seconds: u64,
 ) -> Result<DelegateRequest, String> {
     let task = required_payload_string(payload, "task", "delegate tool")?;
-    let label = payload
-        .get("label")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|label| !label.is_empty())
-        .map(ToOwned::to_owned);
+    let label = optional_payload_string(payload, "label");
     let timeout_seconds = payload
         .get("timeout_seconds")
         .and_then(Value::as_u64)

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -4,6 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{Value, json};
 
+use super::payload::required_payload_string;
+
 #[cfg(test)]
 pub const DEFAULT_TIMEOUT_SECONDS: u64 = 60;
 
@@ -23,7 +25,7 @@ pub(crate) fn parse_delegate_request_with_default_timeout(
     payload: &Value,
     default_timeout_seconds: u64,
 ) -> Result<DelegateRequest, String> {
-    let task = required_payload_string(payload, "task")?;
+    let task = required_payload_string(payload, "task", "delegate tool")?;
     let label = payload
         .get("label")
         .and_then(Value::as_str)
@@ -120,16 +122,6 @@ pub(crate) fn delegate_error_outcome(
             "error": error,
         }),
     }
-}
-
-fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
-    payload
-        .get(field)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| format!("delegate tool requires payload.{field}"))
 }
 
 #[cfg(test)]

--- a/crates/app/src/tools/messaging.rs
+++ b/crates/app/src/tools/messaging.rs
@@ -1,6 +1,8 @@
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{Value, json};
 
+use super::payload::required_payload_string;
+
 use crate::config::{LoongClawConfig, ToolConfig};
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 
@@ -39,7 +41,7 @@ pub(crate) async fn execute_sessions_send_with_config(
             return Err("app_tool_disabled: messaging tools are disabled by config".to_owned());
         }
 
-        let session_id = required_payload_string(&payload, "session_id")?;
+        let session_id = required_payload_string(&payload, "session_id", "sessions_send")?;
         let text = required_payload_text(&payload)?;
         let text_length = text.chars().count();
 
@@ -88,16 +90,6 @@ pub(crate) async fn execute_sessions_send_with_config(
             }),
         })
     }
-}
-
-fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
-    payload
-        .get(field)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| format!("sessions_send requires payload.{field}"))
 }
 
 fn required_payload_text(payload: &Value) -> Result<String, String> {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -38,6 +38,7 @@ mod kernel_adapter;
 #[cfg(feature = "tool-file")]
 mod memory_tools;
 pub(crate) mod messaging;
+mod payload;
 mod provider_switch;
 pub mod runtime_config;
 mod session;

--- a/crates/app/src/tools/payload.rs
+++ b/crates/app/src/tools/payload.rs
@@ -127,4 +127,10 @@ mod tests {
         let payload = json!({"limit": -3});
         assert_eq!(optional_payload_limit(&payload, "limit", 10, 20), 10);
     }
+
+    #[test]
+    fn optional_string_returns_none_for_non_string() {
+        let payload = json!({"tag": 42});
+        assert!(optional_payload_string(&payload, "tag").is_none());
+    }
 }

--- a/crates/app/src/tools/payload.rs
+++ b/crates/app/src/tools/payload.rs
@@ -115,4 +115,16 @@ mod tests {
         let payload = json!({"limit": 0});
         assert_eq!(optional_payload_limit(&payload, "limit", 10, 20), 1);
     }
+
+    #[test]
+    fn optional_limit_returns_value_in_normal_range() {
+        let payload = json!({"limit": 5});
+        assert_eq!(optional_payload_limit(&payload, "limit", 10, 20), 5);
+    }
+
+    #[test]
+    fn optional_limit_returns_default_for_negative() {
+        let payload = json!({"limit": -3});
+        assert_eq!(optional_payload_limit(&payload, "limit", 10, 20), 10);
+    }
 }

--- a/crates/app/src/tools/payload.rs
+++ b/crates/app/src/tools/payload.rs
@@ -1,0 +1,118 @@
+use serde_json::Value;
+
+/// Extract a required string field from a JSON payload.
+///
+/// Returns a trimmed, non-empty owned string or an error naming the tool and field.
+pub(super) fn required_payload_string(
+    payload: &Value,
+    field: &str,
+    tool_name: &str,
+) -> Result<String, String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("{tool_name} requires payload.{field}"))
+}
+
+/// Extract an optional string field from a JSON payload.
+///
+/// Returns `Some(trimmed_value)` when the field exists and is a non-empty string,
+/// `None` otherwise.
+pub(super) fn optional_payload_string(payload: &Value, field: &str) -> Option<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// Extract an optional unsigned integer field, clamped to `[1, max]`.
+///
+/// Returns `default` when the field is absent or not a valid `u64`.
+pub(super) fn optional_payload_limit(
+    payload: &Value,
+    field: &str,
+    default: usize,
+    max: usize,
+) -> usize {
+    payload
+        .get(field)
+        .and_then(Value::as_u64)
+        .map(|value| value.clamp(1, max as u64) as usize)
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn required_string_returns_trimmed_value() {
+        let payload = json!({"name": "  hello  "});
+        let result = required_payload_string(&payload, "name", "test tool");
+        assert_eq!(result.unwrap(), "hello");
+    }
+
+    #[test]
+    fn required_string_rejects_missing_field() {
+        let payload = json!({});
+        let error = required_payload_string(&payload, "name", "test tool").unwrap_err();
+        assert!(error.contains("test tool"), "error: {error}");
+        assert!(error.contains("payload.name"), "error: {error}");
+    }
+
+    #[test]
+    fn required_string_rejects_empty_string() {
+        let payload = json!({"name": "   "});
+        let error = required_payload_string(&payload, "name", "test tool").unwrap_err();
+        assert!(error.contains("payload.name"), "error: {error}");
+    }
+
+    #[test]
+    fn required_string_rejects_non_string() {
+        let payload = json!({"name": 42});
+        let error = required_payload_string(&payload, "name", "test tool").unwrap_err();
+        assert!(error.contains("payload.name"), "error: {error}");
+    }
+
+    #[test]
+    fn optional_string_returns_trimmed_value() {
+        let payload = json!({"tag": "  rust  "});
+        assert_eq!(optional_payload_string(&payload, "tag").unwrap(), "rust");
+    }
+
+    #[test]
+    fn optional_string_returns_none_for_missing() {
+        let payload = json!({});
+        assert!(optional_payload_string(&payload, "tag").is_none());
+    }
+
+    #[test]
+    fn optional_string_returns_none_for_empty() {
+        let payload = json!({"tag": "  "});
+        assert!(optional_payload_string(&payload, "tag").is_none());
+    }
+
+    #[test]
+    fn optional_limit_returns_clamped_value() {
+        let payload = json!({"limit": 50});
+        assert_eq!(optional_payload_limit(&payload, "limit", 10, 20), 20);
+    }
+
+    #[test]
+    fn optional_limit_returns_default_for_missing() {
+        let payload = json!({});
+        assert_eq!(optional_payload_limit(&payload, "limit", 10, 20), 10);
+    }
+
+    #[test]
+    fn optional_limit_clamps_to_minimum_one() {
+        let payload = json!({"limit": 0});
+        assert_eq!(optional_payload_limit(&payload, "limit", 10, 20), 1);
+    }
+}

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -9,6 +9,8 @@ use tokio::time::{Duration, Instant, sleep};
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{Value, json};
 
+use super::payload::{optional_payload_limit, optional_payload_string, required_payload_string};
+
 use crate::config::{SessionVisibility, ToolConfig};
 #[cfg(feature = "memory-sqlite")]
 use crate::conversation::ConstrainedSubagentExecution;
@@ -420,7 +422,7 @@ fn execute_session_events(
     config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    let target_session_id = required_payload_string(&payload, "session_id")?;
+    let target_session_id = required_payload_string(&payload, "session_id", "session tool")?;
     let default_limit = tool_config.sessions.history_limit.min(50);
     let limit = optional_payload_limit(
         &payload,
@@ -464,7 +466,7 @@ fn execute_sessions_history(
     config: &MemoryRuntimeConfig,
     tool_config: &ToolConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    let target_session_id = required_payload_string(&payload, "session_id")?;
+    let target_session_id = required_payload_string(&payload, "session_id", "session tool")?;
     let default_limit = tool_config.sessions.history_limit.min(50);
     let limit = optional_payload_limit(
         &payload,
@@ -2178,16 +2180,6 @@ fn ensure_visible(
     ))
 }
 
-fn required_payload_string(payload: &Value, field: &str) -> Result<String, String> {
-    payload
-        .get(field)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| format!("session tool requires payload.{field}"))
-}
-
 #[cfg(feature = "memory-sqlite")]
 fn normalize_required_session_id(session_id: &str) -> Result<String, String> {
     let trimmed = session_id.trim();
@@ -2238,14 +2230,6 @@ fn legacy_single_session_id(session_ids: &[String]) -> Result<&str, String> {
     session_ids.first().map(String::as_str).ok_or_else(|| {
         "session_tool_internal_error: legacy single request missing session id".to_owned()
     })
-}
-
-fn optional_payload_limit(payload: &Value, field: &str, default: usize, max: usize) -> usize {
-    payload
-        .get(field)
-        .and_then(Value::as_u64)
-        .map(|value| value.clamp(1, max as u64) as usize)
-        .unwrap_or(default)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -2309,15 +2293,6 @@ fn optional_payload_session_kind(
         "delegate_child" => Ok(Some(SessionKind::DelegateChild)),
         _ => Err(format!("invalid session tool payload.{field}: `{raw}`")),
     }
-}
-
-fn optional_payload_string(payload: &Value, field: &str) -> Option<String> {
-    payload
-        .get(field)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
 }
 
 #[cfg(feature = "memory-sqlite")]


### PR DESCRIPTION
## Summary

- Problem: Three payload extraction helpers duplicated across 4–5 tool files with identical logic
- Why it matters: Any change to extraction behavior must be replicated in all copies independently
- What changed: Extract into shared `tools/payload.rs` module, replace 9 local definitions and 1 inline pattern with imports
- What did not change (scope boundary): Error messages, public API, `browser_companion.rs`

## Linked Issues

- Closes #583

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Tools

## Risk Track

- [x] Track A (routine / low-risk)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: N/A
- [ ] If tests mutate process-global env: N/A

Commands and evidence:

```text
$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)
# zero warnings, zero errors

$ cargo test -p loongclaw-app --all-features -- tools::payload tools::delegate
test tools::payload::tests::required_string_returns_trimmed_value ... ok
test tools::payload::tests::required_string_rejects_missing_field ... ok
test tools::payload::tests::required_string_rejects_empty_string ... ok
test tools::payload::tests::required_string_rejects_non_string ... ok
test tools::payload::tests::optional_string_returns_trimmed_value ... ok
test tools::payload::tests::optional_string_returns_none_for_missing ... ok
test tools::payload::tests::optional_string_returns_none_for_empty ... ok
test tools::payload::tests::optional_string_returns_none_for_non_string ... ok
test tools::payload::tests::optional_limit_returns_clamped_value ... ok
test tools::payload::tests::optional_limit_returns_default_for_missing ... ok
test tools::payload::tests::optional_limit_clamps_to_minimum_one ... ok
test tools::payload::tests::optional_limit_returns_value_in_normal_range ... ok
test tools::payload::tests::optional_limit_returns_default_for_negative ... ok
test tools::delegate::tests::parse_delegate_request_requires_task ... ok
test tools::delegate::tests::parse_delegate_request_uses_defaults ... ok
test tools::delegate::tests::delegate_session_ids_use_expected_prefix ... ok
test result: ok. 16 passed; 0 failed
```

## User-visible / Operator-visible Changes

- None — internal refactor only, no public API or behavior change

## Failure Recovery

- Fast rollback or disable path: Single-commit revert, no migration needed
- Observable failure symptoms reviewers should watch for: N/A

## Reviewer Focus

- `payload.rs` — verify the three helpers match original behavior exactly
- Call sites in `approval.rs` and `session.rs` — verify `tool_name` parameter matches the original hard-coded string in each file's former local definition
- `delegate.rs` — inline `optional_payload_string` pattern was also replaced with the shared helper (same semantics: get → as_str → trim → filter(!empty) → to_owned)
- `browser_companion.rs` intentionally not touched — its variant takes `&Map<String, Value>` instead of `&Value`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and standardized validation error messages for approval, delegation, messaging, and session actions so missing or invalid fields report clearer context.
  * Consistent trimming of string inputs and handling of optional fields to avoid empty values.
  * Numeric limits now default and clamp sensibly, preventing out-of-range values and ensuring reliable defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->