### PR TITLE
fix(windows): normalize path separators in display labels and test assertions

### DIFF
--- a/crates/app/src/config/audit.rs
+++ b/crates/app/src/config/audit.rs
@@ -75,7 +75,17 @@ mod tests {
 
         assert_eq!(config.mode, AuditMode::Fanout);
         assert!(config.retain_in_memory);
-        assert!(config.path.ends_with(".loongclaw/audit/events.jsonl"));
+        let expected_suffix = std::path::Path::new(".loongclaw")
+            .join("audit")
+            .join("events.jsonl");
+        assert!(
+            config
+                .path
+                .ends_with(&expected_suffix.display().to_string()),
+            "audit path {} should end with {}",
+            config.path,
+            expected_suffix.display(),
+        );
     }
 
     #[test]

--- a/crates/app/src/memory/workspace_files.rs
+++ b/crates/app/src/memory/workspace_files.rs
@@ -200,7 +200,7 @@ fn collect_document_if_present(
 pub(crate) fn workspace_memory_label(workspace_root: &Path, path: &Path) -> String {
     let relative_path = path.strip_prefix(workspace_root).ok();
     let display_path = relative_path.unwrap_or(path);
-    display_path.display().to_string()
+    display_path.display().to_string().replace('\\', "/")
 }
 
 fn parse_daily_log_date(path: &Path) -> Option<NaiveDate> {

--- a/crates/app/src/memory/workspace_files.rs
+++ b/crates/app/src/memory/workspace_files.rs
@@ -200,7 +200,14 @@ fn collect_document_if_present(
 pub(crate) fn workspace_memory_label(workspace_root: &Path, path: &Path) -> String {
     let relative_path = path.strip_prefix(workspace_root).ok();
     let display_path = relative_path.unwrap_or(path);
-    display_path.display().to_string().replace('\\', "/")
+    let raw_label = display_path.display().to_string();
+
+    if cfg!(windows) {
+        let normalized_label = raw_label.replace('\\', "/");
+        return normalized_label;
+    }
+
+    raw_label
 }
 
 fn parse_daily_log_date(path: &Path) -> Option<NaiveDate> {
@@ -290,6 +297,23 @@ mod tests {
 
         assert_eq!(documents.len(), 1);
         assert_eq!(documents[0].label, "workspace/MEMORY.md");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_memory_label_preserves_backslashes_in_unix_file_names() {
+        let temp_dir = tempdir().expect("tempdir");
+        let workspace_root = temp_dir.path();
+        let memory_dir = workspace_root.join("memory");
+        let file_name = "2026-03-26\\notes.md";
+        let daily_log_path = memory_dir.join(file_name);
+
+        std::fs::create_dir_all(&memory_dir).expect("create memory dir");
+        std::fs::write(&daily_log_path, "notes").expect("write daily log");
+
+        let label = workspace_memory_label(workspace_root, daily_log_path.as_path());
+
+        assert_eq!(label, format!("memory/{file_name}"));
     }
 
     #[cfg(unix)]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -7793,7 +7793,11 @@ mod tests {
         let saved_path = outcome.payload["path"]
             .as_str()
             .expect("resource output path");
-        assert!(saved_path.ends_with("/artifacts/images/incoming.png"));
+        assert!(
+            std::path::Path::new(saved_path)
+                .ends_with(std::path::Path::new("artifacts").join("images").join("incoming.png")),
+            "saved_path {saved_path} should end with artifacts/images/incoming.png",
+        );
         assert_eq!(
             fs::read(saved_path).expect("read downloaded image"),
             b"png-demo-bytes"
@@ -7967,7 +7971,11 @@ mod tests {
         let saved_path = outcome.payload["path"]
             .as_str()
             .expect("resource output path");
-        assert!(saved_path.ends_with("/artifacts/audio/voice.ogg"));
+        assert!(
+            std::path::Path::new(saved_path)
+                .ends_with(std::path::Path::new("artifacts").join("audio").join("voice.ogg")),
+            "saved_path {saved_path} should end with artifacts/audio/voice.ogg",
+        );
         assert_eq!(
             fs::read(saved_path).expect("read downloaded audio"),
             b"voice-demo-bytes"
@@ -8138,7 +8146,11 @@ mod tests {
         let saved_path = outcome.payload["path"]
             .as_str()
             .expect("resource output path");
-        assert!(saved_path.ends_with("/artifacts/media/preview.png"));
+        assert!(
+            std::path::Path::new(saved_path)
+                .ends_with(std::path::Path::new("artifacts").join("media").join("preview.png")),
+            "saved_path {saved_path} should end with artifacts/media/preview.png",
+        );
         assert_eq!(
             fs::read(saved_path).expect("read downloaded image"),
             b"png-media-preview"
@@ -8305,7 +8317,11 @@ mod tests {
         let saved_path = outcome.payload["path"]
             .as_str()
             .expect("resource output path");
-        assert!(saved_path.ends_with("/artifacts/post/image.jpg"));
+        assert!(
+            std::path::Path::new(saved_path)
+                .ends_with(std::path::Path::new("artifacts").join("post").join("image.jpg")),
+            "saved_path {saved_path} should end with artifacts/post/image.jpg",
+        );
         assert_eq!(
             fs::read(saved_path).expect("read downloaded image"),
             b"jpeg-post-image"

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -7794,8 +7794,11 @@ mod tests {
             .as_str()
             .expect("resource output path");
         assert!(
-            std::path::Path::new(saved_path)
-                .ends_with(std::path::Path::new("artifacts").join("images").join("incoming.png")),
+            std::path::Path::new(saved_path).ends_with(
+                std::path::Path::new("artifacts")
+                    .join("images")
+                    .join("incoming.png")
+            ),
             "saved_path {saved_path} should end with artifacts/images/incoming.png",
         );
         assert_eq!(
@@ -7972,8 +7975,11 @@ mod tests {
             .as_str()
             .expect("resource output path");
         assert!(
-            std::path::Path::new(saved_path)
-                .ends_with(std::path::Path::new("artifacts").join("audio").join("voice.ogg")),
+            std::path::Path::new(saved_path).ends_with(
+                std::path::Path::new("artifacts")
+                    .join("audio")
+                    .join("voice.ogg")
+            ),
             "saved_path {saved_path} should end with artifacts/audio/voice.ogg",
         );
         assert_eq!(
@@ -8147,8 +8153,11 @@ mod tests {
             .as_str()
             .expect("resource output path");
         assert!(
-            std::path::Path::new(saved_path)
-                .ends_with(std::path::Path::new("artifacts").join("media").join("preview.png")),
+            std::path::Path::new(saved_path).ends_with(
+                std::path::Path::new("artifacts")
+                    .join("media")
+                    .join("preview.png")
+            ),
             "saved_path {saved_path} should end with artifacts/media/preview.png",
         );
         assert_eq!(
@@ -8318,8 +8327,11 @@ mod tests {
             .as_str()
             .expect("resource output path");
         assert!(
-            std::path::Path::new(saved_path)
-                .ends_with(std::path::Path::new("artifacts").join("post").join("image.jpg")),
+            std::path::Path::new(saved_path).ends_with(
+                std::path::Path::new("artifacts")
+                    .join("post")
+                    .join("image.jpg")
+            ),
             "saved_path {saved_path} should end with artifacts/post/image.jpg",
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

Fixes 9 of 56 Windows test failures tracked in #304.

- **`workspace_memory_label`**: Normalize `\` → `/` in the returned label string. These are display labels shown to the LLM/user, not filesystem paths — forward slash is universally readable.
- **Audit config test**: Use `std::path::Path::join` for platform-agnostic suffix matching instead of hardcoded `/` string.
- **Feishu tool tests**: Use `std::path::Path::ends_with` instead of `str::ends_with` with hardcoded `/` paths.

## Test Results (Windows 11 Pro, Rust 1.93.1)

**Before:** 9 failures in `workspace_files`, `durable_recall`, `audit`, and `tools` modules.
**After:** All 9 pass. No regressions — 2085 total tests pass.

## Files Changed

| File | Change |
|------|--------|
| `crates/app/src/memory/workspace_files.rs` | 1 line: add `.replace('\', "/")` to label output |
| `crates/app/src/config/audit.rs` | Test-only: platform-agnostic path assertion |
| `crates/app/src/tools/mod.rs` | Test-only: 4 assertions use `Path::ends_with` |

## Checklist

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p loongclaw-app --lib` passes (2085/2085)
- [x] No new dependencies added

Part 1 of 3 for #304 (cross-platform CI). See also the companion PRs for SQLite UNC paths and Feishu runtime file locking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved audit configuration testing with platform-aware path comparisons.
  * Enhanced file location verification in Feishu message tests with OS-appropriate path assertions.

* **Bug Fixes**
  * Normalized path separators in workspace labels for consistent cross-platform formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->