### PR TITLE
fix(windows): use dunce::canonicalize to avoid UNC path mismatch in SQLite runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "cbc",
  "chrono",
  "console",
+ "dunce",
  "flate2",
  "futures-util",
  "hex",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -31,6 +31,7 @@ loongclaw-contracts = { path = "../contracts" }
 loongclaw-kernel = { path = "../kernel" }
 async-trait.workspace = true
 console.workspace = true
+dunce = "1"
 rand.workspace = true
 chrono.workspace = true
 serde.workspace = true

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -828,8 +828,7 @@ fn normalize_runtime_db_path(path: &Path) -> Result<PathBuf, String> {
     test_support::record_runtime_path_normalization_full();
 
     let normalized = if absolute.exists() {
-        absolute
-            .canonicalize()
+        dunce::canonicalize(&absolute)
             .map_err(|error| format!("canonicalize sqlite db path failed: {error}"))?
     } else {
         let Some(file_name) = absolute.file_name() else {
@@ -839,7 +838,7 @@ fn normalize_runtime_db_path(path: &Path) -> Result<PathBuf, String> {
             return Ok(absolute);
         };
 
-        match parent.canonicalize() {
+        match dunce::canonicalize(parent) {
             Ok(canonical_parent) => canonical_parent.join(file_name),
             Err(_) => absolute.clone(),
         }
@@ -3305,7 +3304,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3393,7 +3392,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3473,7 +3472,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3513,7 +3512,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3567,7 +3566,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3609,7 +3608,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3671,7 +3670,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3724,7 +3723,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3778,7 +3777,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3820,7 +3819,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3878,7 +3877,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3926,7 +3925,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -3973,7 +3972,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -4018,7 +4017,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4061,7 +4060,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4122,7 +4121,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4226,7 +4225,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4299,7 +4298,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4355,7 +4354,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4416,7 +4415,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -4519,7 +4518,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
 
@@ -4619,7 +4618,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4701,7 +4700,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4776,7 +4775,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4876,7 +4875,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -4969,7 +4968,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -5063,7 +5062,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -5166,7 +5165,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -5246,7 +5245,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -5501,7 +5500,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
 
@@ -5607,7 +5606,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -5680,7 +5679,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -5785,7 +5784,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -5903,7 +5902,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -5956,7 +5955,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -6062,7 +6061,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_summary_materialization_metrics_for_tests();
 
@@ -6165,7 +6164,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -6265,7 +6264,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -6354,7 +6353,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -6418,7 +6417,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -6492,7 +6491,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -6634,7 +6633,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
 
         let tmp = std::env::temp_dir().join(format!(
@@ -6846,7 +6845,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -6932,7 +6931,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();
@@ -7033,7 +7032,7 @@ mod tests {
 
         let _guard = sqlite_runtime_test_lock()
             .lock()
-            .expect("runtime test lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         reset_sqlite_runtime_test_state();
         reset_cached_prepare_metrics_for_tests();
         let _metrics = begin_sqlite_metric_capture_for_tests();


### PR DESCRIPTION
## Summary

Fixes ~43 of 56 Windows test failures tracked in #304. All in `memory::sqlite::tests`.

**Root cause:** `std::fs::canonicalize()` on Windows returns `\?\C:\...` UNC extended-length paths. When comparing these against non-UNC paths via `PathBuf::starts_with()`, the comparison always fails because `Component::Prefix` differs (`VerbatimDisk` vs `Disk`).

**Fix:** Replace `std::fs::canonicalize` with `dunce::canonicalize` in the SQLite runtime path normalization. `dunce` strips the `\?\` prefix when the path doesn't require it (< 260 chars, no special characters), which is the standard Rust solution for this Windows UNC issue.

**Bonus fix:** The shared test `Mutex` used `.expect("runtime test lock")`, which causes one test failure to cascade into ~42 `PoisonError` panics. Changed to `.unwrap_or_else(|poisoned| poisoned.into_inner())` so each test can proceed independently.

## Test Results (Windows 11 Pro, Rust 1.93.1)

**Before:** 43 failures in `memory::sqlite::tests` (1 real + 42 cascade from lock poisoning).
**After:** All 55 SQLite tests pass. No regressions — 2085 total tests pass.

## Files Changed

| File | Change |
|------|--------|
| `crates/app/Cargo.toml` | Add `dunce = "1"` dependency |
| `Cargo.lock` | Updated lockfile |
| `crates/app/src/memory/sqlite.rs` | Replace 2 `canonicalize()` calls with `dunce::canonicalize()`; replace 44 `.expect("runtime test lock")` with poison-resilient `.unwrap_or_else()` |

## Note on broader canonicalize usage

There are ~30 other `.canonicalize()` calls across `crates/app/src/` (in `migration/`, `tools/`, etc.). These were not changed in this PR because they don't cause test failures — the UNC mismatch specifically affects path comparison logic in the SQLite runtime cache. A follow-up PR could address the remaining calls for consistency.

## Checklist

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p loongclaw-app --lib` passes (2085/2085)
- [x] New dependency `dunce` is already in `Cargo.lock` as transitive dep; now direct

Part 2 of 3 for #304 (cross-platform CI). See also companion PRs for path separators and Feishu runtime file locking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new dependency to enhance file path handling capabilities across different operating systems.

* **Bug Fixes**
  * Improved database path normalization to more reliably handle edge cases in path canonicalization.
  * Enhanced test suite resilience by allowing test lock mechanisms to gracefully recover from poisoned states, reducing potential intermittent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->