### PR TITLE
fix(windows): handle PermissionDenied when pruning locked runtime state files

### DIFF
--- a/crates/app/src/channel/runtime_state.rs
+++ b/crates/app/src/channel/runtime_state.rs
@@ -561,6 +561,11 @@ fn prune_inactive_channel_operation_runtime_files_for_optional_account_from_dir(
         match fs::remove_file(path.as_path()) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            // On Windows, another process/task may hold the file open, causing
+            // ERROR_ACCESS_DENIED (PermissionDenied). Unlike Unix, Windows does not
+            // allow unlinking an open file. Silently skip; the next prune cycle will retry.
+            #[cfg(windows)]
+            Err(ref error) if error.kind() == std::io::ErrorKind::PermissionDenied => {}
             Err(error) => {
                 return Err(format!(
                     "remove inactive channel runtime state failed for {}: {error}",


### PR DESCRIPTION
## Summary

Fixes the last 3 of 56 Windows test failures tracked in #304. All in `channel::feishu::webhook::tests`.

**Root cause:** On Windows, `fs::remove_file()` fails with `ERROR_ACCESS_DENIED` (os error 5) when another handle holds the file open. Rust's `std::fs::write` opens files with `FILE_SHARE_READ | FILE_SHARE_WRITE` but **not** `FILE_SHARE_DELETE`, so a concurrent heartbeat write prevents deletion. On Unix, `unlink` succeeds regardless of open handles.

**Fix:** Add a `#[cfg(windows)]` match arm in the prune function that silently skips `PermissionDenied` errors. The file will be retried on the next prune cycle, matching the existing `NotFound` handling pattern.

## Test Results (Windows 11 Pro, Rust 1.93.1)

**Before:** 3 failures — all panic at `start runtime tracker` with "拒绝访问 (os error 5)".
**After:** All 3 pass. No regressions — 2085 total tests pass.

## Files Changed

| File | Change |
|------|--------|
| `crates/app/src/channel/runtime_state.rs` | 5 lines: `#[cfg(windows)]` arm for `PermissionDenied` in prune match |

## Checklist

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p loongclaw-app --lib` passes (2085/2085)
- [x] No new dependencies
- [x] Platform-specific code properly gated with `#[cfg(windows)]`

Part 3 of 3 for #304 (cross-platform CI). Together with the companion PRs for path separators (#585) and SQLite UNC paths (#586), all 56 Windows test failures are resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file cleanup robustness on Windows to gracefully handle cases where files are temporarily in use by other processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->