### PR TITLE
ci: add Windows to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,12 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   rust-test-default:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     permissions:
       contents: read
     steps:
@@ -163,8 +167,12 @@ jobs:
           channel-cli,channel-telegram,channel-feishu,channel-matrix,config-toml,memory-sqlite,feishu-integration,tool-shell,tool-file,tool-browser,provider-openai,provider-anthropic,provider-bedrock,provider-volcengine
 
   rust-test-all-features:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     permissions:
       contents: read
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dialoguer",
+ "dunce",
  "ed25519-dalek",
  "libc",
  "loongclaw-app",

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4832,19 +4832,20 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     let repo = SessionRepository::new(&MemoryRuntimeConfig::from_memory_config(&config.memory))?;
     let start = Instant::now();
-    let child_result = timeout(Duration::from_secs(timeout_seconds), async {
-        AssertUnwindSafe(ConversationTurnCoordinator::new().handle_turn_with_runtime(
-            config,
-            child_session_id,
-            user_input,
-            ProviderErrorMode::Propagate,
-            runtime,
-            binding,
-        ))
-        .catch_unwind()
-        .await
-    })
-    .await;
+    let child_coordinator = ConversationTurnCoordinator::new();
+    let child_turn_future = child_coordinator.handle_turn_with_runtime(
+        config,
+        child_session_id,
+        user_input,
+        ProviderErrorMode::Propagate,
+        runtime,
+        binding,
+    );
+    // Heap-allocate nested delegate turn futures so each child turn does not inline the next
+    // delegate layer into the parent future on small-stack platforms like Windows.
+    let child_turn_future = Box::pin(AssertUnwindSafe(child_turn_future).catch_unwind());
+    let child_timeout = Duration::from_secs(timeout_seconds);
+    let child_result = timeout(child_timeout, child_turn_future).await;
     let duration_ms = start.elapsed().as_millis() as u64;
 
     match child_result {

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -3639,7 +3639,7 @@ mod tests {
 
         let thread_b_barrier = start_barrier.clone();
         let thread_b_path = db_path.clone();
-        let thread_b_config = config.clone();
+        let thread_b_config = config;
         let thread_b = std::thread::spawn(move || {
             thread_b_barrier.wait();
             ensure_memory_db_ready(Some(thread_b_path), &thread_b_config)

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -1144,7 +1144,45 @@ fn acquire_sqlite_runtime_with_diagnostics(
         // Lock drops here — cold bootstrap runs without blocking other paths.
     }
 
-    // Slow path: bootstrap outside the lock, then re-acquire to insert.
+    #[cfg(test)]
+    test_support::wait_for_sqlite_runtime_cache_miss(&normalized_path);
+
+    let bootstrap_lock = {
+        let mut bootstrap_registry =
+            sqlite_runtime_bootstrap_lock_registry()
+                .lock()
+                .map_err(|poisoned| {
+                    format!("lock sqlite runtime bootstrap registry failed: {poisoned}")
+                })?;
+        let bootstrap_entry = bootstrap_registry
+            .entry(normalized_path.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())));
+        bootstrap_entry.clone()
+    };
+    let _bootstrap_guard = bootstrap_lock
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    {
+        let registry_lock_started_at = StdInstant::now();
+        let registry = sqlite_runtime_registry()
+            .lock()
+            .map_err(|poisoned| format!("lock sqlite runtime registry failed: {poisoned}"))?;
+        diagnostics.registry_lock_ms += elapsed_ms(registry_lock_started_at);
+
+        let registry_lookup_started_at = StdInstant::now();
+        if let Some(runtime) = registry.get(&normalized_path) {
+            diagnostics.registry_lookup_ms += elapsed_ms(registry_lookup_started_at);
+            diagnostics.cache_hit = true;
+            diagnostics.total_ms = elapsed_ms(total_started_at);
+            return Ok((runtime.clone(), diagnostics));
+        }
+        diagnostics.registry_lookup_ms += elapsed_ms(registry_lookup_started_at);
+    }
+
+    // Slow path: bootstrap outside the global registry lock, but serialize cold
+    // starts for the same normalized path so concurrent callers do not race
+    // each other through connection configuration.
     let runtime_create_started_at = StdInstant::now();
     let (runtime, connection_diagnostics) =
         SqliteRuntime::new_with_diagnostics(normalized_path.clone())?;
@@ -1178,6 +1216,13 @@ fn sqlite_runtime_registry() -> &'static Mutex<HashMap<PathBuf, Arc<SqliteRuntim
     static SQLITE_RUNTIME_REGISTRY: OnceLock<Mutex<HashMap<PathBuf, Arc<SqliteRuntime>>>> =
         OnceLock::new();
     SQLITE_RUNTIME_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn sqlite_runtime_bootstrap_lock_registry() -> &'static Mutex<HashMap<PathBuf, Arc<Mutex<()>>>> {
+    static SQLITE_RUNTIME_BOOTSTRAP_LOCK_REGISTRY: OnceLock<
+        Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>,
+    > = OnceLock::new();
+    SQLITE_RUNTIME_BOOTSTRAP_LOCK_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 fn sqlite_runtime_path_alias_registry() -> &'static Mutex<HashMap<PathBuf, PathBuf>> {
@@ -1743,9 +1788,22 @@ fn summary_normalization_count_for_tests() -> usize {
 }
 
 #[cfg(test)]
+fn configure_sqlite_runtime_cache_miss_for_tests(path: &Path, target_waiters: usize) {
+    test_support::configure_sqlite_runtime_cache_miss(path, target_waiters);
+}
+
+#[cfg(test)]
+fn clear_sqlite_runtime_cache_miss_for_tests() {
+    test_support::clear_sqlite_runtime_cache_miss();
+}
+
+#[cfg(test)]
 fn reset_sqlite_runtime_test_state() {
     if let Ok(mut registry) = sqlite_runtime_registry().lock() {
         registry.clear();
+    }
+    if let Ok(mut bootstrap_registry) = sqlite_runtime_bootstrap_lock_registry().lock() {
+        bootstrap_registry.clear();
     }
     if let Ok(mut alias_registry) = sqlite_runtime_path_alias_registry().lock() {
         alias_registry.clear();
@@ -1761,6 +1819,9 @@ pub(super) fn drop_cached_sqlite_runtime(path: &Path) -> Result<bool, String> {
     let removed = registry.remove(&normalized_path).is_some();
     if removed && let Ok(mut alias_registry) = sqlite_runtime_path_alias_registry().lock() {
         alias_registry.retain(|_key, value| *value != normalized_path);
+    }
+    if removed && let Ok(mut bootstrap_registry) = sqlite_runtime_bootstrap_lock_registry().lock() {
+        bootstrap_registry.remove(&normalized_path);
     }
     Ok(removed)
 }
@@ -3537,6 +3598,71 @@ mod tests {
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir(&tmp);
+    }
+
+    #[test]
+    fn concurrent_same_path_bootstrap_reuses_one_cold_runtime() {
+        use crate::config::{MemoryMode, MemoryProfile};
+
+        let _guard = sqlite_runtime_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_sqlite_runtime_test_state();
+
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-sqlite-runtime-concurrent-bootstrap-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("runtime-concurrent.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowOnly,
+            mode: MemoryMode::WindowOnly,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 2,
+            ..MemoryRuntimeConfig::default()
+        };
+
+        configure_sqlite_runtime_cache_miss_for_tests(&db_path, 2);
+
+        let start_barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let thread_a_barrier = start_barrier.clone();
+        let thread_a_path = db_path.clone();
+        let thread_a_config = config.clone();
+        let thread_a = std::thread::spawn(move || {
+            thread_a_barrier.wait();
+            ensure_memory_db_ready(Some(thread_a_path), &thread_a_config)
+        });
+
+        let thread_b_barrier = start_barrier.clone();
+        let thread_b_path = db_path.clone();
+        let thread_b_config = config.clone();
+        let thread_b = std::thread::spawn(move || {
+            thread_b_barrier.wait();
+            ensure_memory_db_ready(Some(thread_b_path), &thread_b_config)
+        });
+
+        start_barrier.wait();
+
+        let thread_a_result = thread_a.join().expect("join bootstrap thread a");
+        let thread_b_result = thread_b.join().expect("join bootstrap thread b");
+
+        clear_sqlite_runtime_cache_miss_for_tests();
+
+        thread_a_result.expect("bootstrap thread a should succeed");
+        thread_b_result.expect("bootstrap thread b should succeed");
+
+        assert_eq!(
+            sqlite_bootstrap_count_for_tests(&db_path),
+            1,
+            "expected concurrent cold access to serialize same-path bootstrap work"
+        );
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
     }
 
     #[test]
@@ -7171,6 +7297,7 @@ mod tests {
 #[cfg(test)]
 mod test_support {
     use super::*;
+    use std::sync::Condvar;
 
     #[derive(Default)]
     struct SqliteMetricCapture {
@@ -7178,6 +7305,14 @@ mod test_support {
         cached_prepare_counts: HashMap<&'static str, usize>,
         summary_materialization_counts: HashMap<&'static str, usize>,
         runtime_path_normalization_counts: HashMap<&'static str, usize>,
+    }
+
+    #[derive(Default)]
+    struct SqliteRuntimeCacheMissGate {
+        path: Option<PathBuf>,
+        target_waiters: usize,
+        waiting_threads: usize,
+        released: bool,
     }
 
     fn bootstrap_counts() -> &'static Mutex<HashMap<PathBuf, usize>> {
@@ -7199,6 +7334,19 @@ mod test_support {
     fn sqlite_metric_capture() -> &'static Mutex<SqliteMetricCapture> {
         static SQLITE_METRIC_CAPTURE: OnceLock<Mutex<SqliteMetricCapture>> = OnceLock::new();
         SQLITE_METRIC_CAPTURE.get_or_init(|| Mutex::new(SqliteMetricCapture::default()))
+    }
+
+    fn sqlite_runtime_cache_miss_gate() -> &'static (Mutex<SqliteRuntimeCacheMissGate>, Condvar) {
+        static SQLITE_RUNTIME_CACHE_MISS_GATE: OnceLock<(
+            Mutex<SqliteRuntimeCacheMissGate>,
+            Condvar,
+        )> = OnceLock::new();
+        SQLITE_RUNTIME_CACHE_MISS_GATE.get_or_init(|| {
+            (
+                Mutex::new(SqliteRuntimeCacheMissGate::default()),
+                Condvar::new(),
+            )
+        })
     }
 
     fn lock_sqlite_metric_capture() -> std::sync::MutexGuard<'static, SqliteMetricCapture> {
@@ -7332,6 +7480,61 @@ mod test_support {
             .get("alias_hit")
             .copied()
             .unwrap_or_default()
+    }
+
+    pub(super) fn configure_sqlite_runtime_cache_miss(path: &Path, target_waiters: usize) {
+        let normalized_path = normalize_runtime_db_path_best_effort(path);
+        let (gate_lock, gate_condvar) = sqlite_runtime_cache_miss_gate();
+        let mut gate = gate_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        gate.path = Some(normalized_path);
+        gate.target_waiters = target_waiters;
+        gate.waiting_threads = 0;
+        gate.released = false;
+        gate_condvar.notify_all();
+    }
+
+    pub(super) fn wait_for_sqlite_runtime_cache_miss(path: &Path) {
+        let normalized_path = normalize_runtime_db_path_best_effort(path);
+        let (gate_lock, gate_condvar) = sqlite_runtime_cache_miss_gate();
+        let mut gate = gate_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(configured_path) = gate.path.as_ref() else {
+            return;
+        };
+        if *configured_path != normalized_path {
+            return;
+        }
+        if gate.released {
+            return;
+        }
+
+        gate.waiting_threads += 1;
+        if gate.waiting_threads >= gate.target_waiters {
+            gate.released = true;
+            gate_condvar.notify_all();
+            return;
+        }
+
+        while !gate.released {
+            gate = gate_condvar
+                .wait(gate)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+    }
+
+    pub(super) fn clear_sqlite_runtime_cache_miss() {
+        let (gate_lock, gate_condvar) = sqlite_runtime_cache_miss_gate();
+        let mut gate = gate_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        gate.path = None;
+        gate.target_waiters = 0;
+        gate.waiting_threads = 0;
+        gate.released = false;
+        gate_condvar.notify_all();
     }
 
     pub(super) fn record_summary_streaming_query(kind: &'static str) {
@@ -7510,5 +7713,6 @@ mod test_support {
         end_sqlite_metric_capture();
         reset_cached_prepare_metrics();
         reset_summary_materialization_metrics();
+        clear_sqlite_runtime_cache_miss();
     }
 }

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -2501,13 +2501,11 @@ fn project_discovery_probe_roots(
     let Some(project_root) = project_discovery_root(config) else {
         return Vec::new();
     };
-    let project_root = project_root
-        .canonicalize()
-        .unwrap_or_else(|_| project_root.clone());
+    let project_root = dunce::canonicalize(&project_root).unwrap_or(project_root);
 
     let mut roots = Vec::new();
     if let Ok(current_dir) = std::env::current_dir() {
-        let current_dir = current_dir.canonicalize().unwrap_or(current_dir);
+        let current_dir = dunce::canonicalize(&current_dir).unwrap_or(current_dir);
         if current_dir.starts_with(&project_root) {
             let mut next = Some(current_dir.as_path());
             while let Some(path) = next {
@@ -2635,7 +2633,7 @@ fn visit_discoverable_skill_roots(
     roots: &mut Vec<PathBuf>,
     visited: &mut BTreeSet<String>,
 ) {
-    let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let canonical = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     let key = canonical.display().to_string();
     if !visited.insert(key) {
         return;

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -68,6 +68,7 @@ base64.workspace = true
 rand.workspace = true
 sha2.workspace = true
 ed25519-dalek.workspace = true
+dunce = "1"
 
 [[bin]]
 name = "loongclaw"

--- a/crates/daemon/src/import_cli.rs
+++ b/crates/daemon/src/import_cli.rs
@@ -253,7 +253,13 @@ fn candidate_matches_source_path(
     requested_source_path: &Path,
 ) -> bool {
     crate::source_presentation::source_path(Some(candidate.source_kind), &candidate.source)
-        .is_some_and(|candidate_path| candidate_path == requested_source_path)
+        .is_some_and(|candidate_path| {
+            let resolved_candidate_path =
+                dunce::canonicalize(&candidate_path).unwrap_or(candidate_path);
+            let resolved_requested_path = dunce::canonicalize(requested_source_path)
+                .unwrap_or_else(|_| requested_source_path.to_path_buf());
+            resolved_candidate_path == resolved_requested_path
+        })
 }
 
 pub fn render_import_preview_lines_for_width(

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -6060,19 +6060,51 @@ mod tests {
         format!("{first}-{second}-{third}-{fourth}-{fifth}")
     }
 
-    fn write_browser_companion_script(script_path: &Path, body: &str) {
-        let mut file = std::fs::File::create(script_path).expect("create browser companion script");
-        file.write_all(body.as_bytes())
-            .expect("write browser companion script");
+    fn browser_companion_script_path(temp_dir: &Path) -> PathBuf {
+        #[cfg(windows)]
+        {
+            temp_dir.join("browser-companion.cmd")
+        }
+        #[cfg(not(windows))]
+        {
+            temp_dir.join("browser-companion")
+        }
+    }
+
+    fn write_browser_companion_version_script(temp_dir: &Path, version: &str) -> PathBuf {
+        let script_path = browser_companion_script_path(temp_dir);
+
+        #[cfg(windows)]
+        {
+            let script_body = format!(
+                "@echo off\r\nif \"%~1\"==\"--version\" (\r\n  echo loongclaw-browser-companion {version}\r\n  exit /b 0\r\n)\r\necho unexpected arguments 1>&2\r\nexit /b 1\r\n"
+            );
+            std::fs::write(&script_path, script_body).expect("write browser companion script");
+        }
+
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
 
-            let mut permissions = file.metadata().expect("script metadata").permissions();
+            let script_body = format!(
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'loongclaw-browser-companion {version}'\n  exit 0\nfi\necho 'unexpected arguments' >&2\nexit 1\n"
+            );
+            let mut file =
+                std::fs::File::create(&script_path).expect("create browser companion script");
+            file.write_all(script_body.as_bytes())
+                .expect("write browser companion script");
+            file.sync_all()
+                .expect("sync browser companion script to disk");
+            drop(file);
+
+            let metadata = std::fs::metadata(&script_path).expect("script metadata");
+            let mut permissions = metadata.permissions();
             permissions.set_mode(0o755);
-            std::fs::set_permissions(script_path, permissions)
+            std::fs::set_permissions(&script_path, permissions)
                 .expect("chmod browser companion script");
         }
+
+        script_path
     }
 
     impl OnboardUi for TestOnboardUi {
@@ -6469,11 +6501,7 @@ mod tests {
     async fn browser_companion_onboard_preflight_warns_when_runtime_gate_is_closed() {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
         let temp_dir = browser_companion_temp_dir("runtime-gate");
-        let script_path = temp_dir.join("browser-companion");
-        write_browser_companion_script(
-            &script_path,
-            "#!/bin/sh\necho 'loongclaw-browser-companion 1.5.0'\n",
-        );
+        let script_path = write_browser_companion_version_script(&temp_dir, "1.5.0");
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.api_key = Some(SecretRef::Inline("inline-openai-key".to_owned()));
@@ -6497,11 +6525,7 @@ mod tests {
     async fn browser_companion_onboard_preflight_passes_when_runtime_gate_is_open() {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_open();
         let temp_dir = browser_companion_temp_dir("runtime-ready");
-        let script_path = temp_dir.join("browser-companion");
-        write_browser_companion_script(
-            &script_path,
-            "#!/bin/sh\necho 'loongclaw-browser-companion 1.5.0'\n",
-        );
+        let script_path = write_browser_companion_version_script(&temp_dir, "1.5.0");
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.api_key = Some(SecretRef::Inline("inline-openai-key".to_owned()));

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1155,7 +1155,7 @@ fn persist_runtime_capability_artifact(
 }
 
 fn canonicalize_existing_path(path: &Path) -> CliResult<String> {
-    fs::canonicalize(path)
+    dunce::canonicalize(path)
         .map(|resolved| resolved.display().to_string())
         .map_err(|error| {
             format!(

--- a/crates/daemon/src/source_presentation.rs
+++ b/crates/daemon/src/source_presentation.rs
@@ -11,6 +11,13 @@ const SUGGESTED_STARTING_POINT_LABEL: &str = "suggested starting point";
 const EXISTING_CONFIG_SOURCE_PREFIX: &str = "existing config at ";
 const CODEX_CONFIG_SOURCE_PREFIX: &str = "Codex config at ";
 
+fn display_path(path: &Path) -> String {
+    dunce::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string()
+}
+
 pub const fn recommended_plan_source_label() -> &'static str {
     RECOMMENDED_PLAN_SOURCE_LABEL
 }
@@ -36,11 +43,13 @@ pub const fn suggested_starting_point_label() -> &'static str {
 }
 
 pub fn existing_loongclaw_config_source_label(path: &Path) -> String {
-    format!("{EXISTING_CONFIG_SOURCE_PREFIX}{}", path.display())
+    let rendered_path = display_path(path);
+    format!("{EXISTING_CONFIG_SOURCE_PREFIX}{rendered_path}")
 }
 
 pub fn codex_config_source_label(path: &Path) -> String {
-    format!("{CODEX_CONFIG_SOURCE_PREFIX}{}", path.display())
+    let rendered_path = display_path(path);
+    format!("{CODEX_CONFIG_SOURCE_PREFIX}{rendered_path}")
 }
 
 pub fn source_path(source_kind: Option<ImportSourceKind>, source: &str) -> Option<PathBuf> {

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -17,6 +17,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 static IMPORT_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+fn normalized_path_text(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
 fn assert_compact_loongclaw_header(lines: &[String], context: &str) {
     assert!(
         lines
@@ -1251,11 +1255,11 @@ model = "deepseek-chat"
         "runtime import should explain that the Codex source filter still matched multiple configs: {error}"
     );
     assert!(
-        error.contains(".codex/config.toml"),
+        normalized_path_text(&error).contains(".codex/config.toml"),
         "runtime import should surface the base Codex config path: {error}"
     );
     assert!(
-        error.contains(".codex/agents/loongclaw/config.toml"),
+        normalized_path_text(&error).contains(".codex/agents/loongclaw/config.toml"),
         "runtime import should surface the agent-scoped Codex config path: {error}"
     );
 }

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -43,7 +43,9 @@ fn unique_temp_dir(label: &str) -> PathBuf {
         .expect("system time before unix epoch")
         .as_nanos();
     let counter = IMPORT_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
+    let temp_dir = std::env::temp_dir();
+    let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
+    canonical_temp_dir.join(format!(
         "loongclaw-import-{label}-{}-{nanos}-{counter}",
         std::process::id(),
     ))

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -23,6 +23,10 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     ))
 }
 
+fn normalized_path_text(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
 #[test]
 fn source_presentation_canonical_labels_are_stable() {
     assert_eq!(
@@ -419,18 +423,21 @@ model = "deepseek-chat"
         })
         .map(|candidate| candidate.source.as_str())
         .collect::<Vec<_>>();
+    let normalized_codex_sources = codex_sources
+        .iter()
+        .map(|source| normalized_path_text(source))
+        .collect::<Vec<_>>();
 
     assert!(
-        codex_sources.contains(&"Codex config at /home/.codex/config.toml")
-            || codex_sources
-                .iter()
-                .any(|source: &&str| source.ends_with("/.codex/config.toml")),
+        normalized_codex_sources
+            .iter()
+            .any(|source| source.ends_with("/.codex/config.toml")),
         "detected candidates should include the base Codex config path: {codex_sources:#?}"
     );
     assert!(
-        codex_sources
+        normalized_codex_sources
             .iter()
-            .any(|source: &&str| source.ends_with(&format!(
+            .any(|source| source.ends_with(&format!(
                 "/.codex/agents/{}/config.toml",
                 mvp::config::CLI_COMMAND_NAME
             ))),

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -17,7 +17,9 @@ fn unique_temp_dir(label: &str) -> PathBuf {
         .expect("system time before unix epoch")
         .as_nanos();
     let counter = MIGRATION_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
+    let temp_dir = std::env::temp_dir();
+    let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
+    canonical_temp_dir.join(format!(
         "loongclaw-migration-{label}-{}-{nanos}-{counter}",
         std::process::id(),
     ))

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -5919,19 +5919,33 @@ requires_openai_auth = true
     .expect("run scripted detected-setup onboarding with explicit starting-point selection");
 
     let joined = transcript.join("\n");
+    let (_, written_config) = mvp::config::load(Some(output_path.to_string_lossy().as_ref()))
+        .expect("load written config");
     assert!(
         joined.contains("choose detected starting point")
             && joined.contains("SELECT Starting point"),
         "the interactive flow should still show the starting-point selection stage before applying the chosen path: {transcript:#?}"
     );
     assert!(
-        joined.contains("starting point: Codex config at")
-            && joined.contains("selection-order-codex.toml"),
+        joined.contains("starting point: Codex config at"),
         "after choosing [2], the rest of onboarding should carry the displayed Codex option forward, not some internal candidate order: {transcript:#?}"
     );
     assert!(
         !joined.contains("starting point: your current environment"),
         "selection should stay aligned with the on-screen numbering when candidates are reordered for UX: {transcript:#?}"
+    );
+    assert_eq!(
+        written_config.provider.kind,
+        mvp::config::ProviderKind::Openai,
+        "choosing the second starting-point entry should apply the displayed Codex provider candidate"
+    );
+    assert_eq!(
+        written_config.provider.model, "openai/gpt-5.1-codex",
+        "choosing the second starting-point entry should keep the Codex model from the displayed candidate"
+    );
+    assert_eq!(
+        written_config.provider.base_url, "https://codex.example.com/v1",
+        "choosing the second starting-point entry should keep the Codex-compatible base url from the displayed candidate"
     );
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -40,7 +40,9 @@ fn unique_temp_path(label: &str) -> PathBuf {
         .expect("system time before unix epoch")
         .as_nanos();
     let counter = TEMP_PATH_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
+    let temp_dir = std::env::temp_dir();
+    let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
+    canonical_temp_dir.join(format!(
         "loongclaw-onboard-{label}-{}-{nanos}-{counter}",
         std::process::id(),
     ))

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -20,6 +20,17 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
     std::env::temp_dir().join(format!("{prefix}-{nanos}"))
 }
 
+fn normalized_path_text(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
+fn artifact_path_suffix(path: &Path) -> String {
+    let normalized_path = normalized_path_text(&path.display().to_string());
+    let suffix_parts = normalized_path.rsplit('/').take(2).collect::<Vec<_>>();
+    let ordered_suffix_parts = suffix_parts.into_iter().rev().collect::<Vec<_>>();
+    ordered_suffix_parts.join("/")
+}
+
 fn write_runtime_capability_config(root: &Path) -> PathBuf {
     fs::create_dir_all(root).expect("create fixture root");
 
@@ -1583,7 +1594,7 @@ fn runtime_capability_index_rejects_malformed_supported_artifact_during_scan() {
         "error should surface the invalid review state: {error}"
     );
     assert!(
-        error.contains(&invalid_candidate_path.display().to_string()),
+        normalized_path_text(&error).contains(&artifact_path_suffix(&invalid_candidate_path)),
         "error should identify the malformed artifact path: {error}"
     );
 
@@ -1643,7 +1654,7 @@ fn runtime_capability_index_rejects_wrong_schema_purpose_during_scan() {
         "error should surface the invalid purpose value: {error}"
     );
     assert!(
-        error.contains(&invalid_candidate_path.display().to_string()),
+        normalized_path_text(&error).contains(&artifact_path_suffix(&invalid_candidate_path)),
         "error should identify the malformed artifact path: {error}"
     );
 
@@ -1936,7 +1947,7 @@ fn runtime_capability_plan_rejects_malformed_supported_artifact_during_scan() {
         "error should surface the invalid review state: {error}"
     );
     assert!(
-        error.contains(&invalid_candidate_path.display().to_string()),
+        normalized_path_text(&error).contains(&artifact_path_suffix(&invalid_candidate_path)),
         "error should identify the malformed artifact path: {error}"
     );
 

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -17,11 +17,18 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("clock should be after epoch")
         .as_nanos();
-    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    let temp_dir = std::env::temp_dir();
+    let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
+    canonical_temp_dir.join(format!("{prefix}-{nanos}"))
 }
 
 fn normalized_path_text(value: &str) -> String {
     value.replace('\\', "/")
+}
+
+fn canonicalized_path_text(path: &Path) -> String {
+    let canonical_path = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    canonical_path.display().to_string()
 }
 
 fn artifact_path_suffix(path: &Path) -> String {
@@ -1776,20 +1783,14 @@ fn runtime_capability_plan_builds_promotable_managed_skill_plan() {
     assert_eq!(plan.provenance.candidate_ids.len(), 2);
     assert_eq!(plan.provenance.source_run_ids.len(), 2);
     assert!(
-        plan.provenance.source_run_artifact_paths.contains(
-            &fs::canonicalize(&run_a_path)
-                .expect("canonicalize run a path")
-                .display()
-                .to_string()
-        )
+        plan.provenance
+            .source_run_artifact_paths
+            .contains(&canonicalized_path_text(&run_a_path))
     );
     assert!(
-        plan.provenance.source_run_artifact_paths.contains(
-            &fs::canonicalize(&run_b_path)
-                .expect("canonicalize run b path")
-                .display()
-                .to_string()
-        )
+        plan.provenance
+            .source_run_artifact_paths
+            .contains(&canonicalized_path_text(&run_b_path))
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -22,6 +22,10 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
     std::env::temp_dir().join(format!("{prefix}-{nanos}"))
 }
 
+fn normalized_path_text(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
 fn write_file(root: &Path, relative: &str, content: &str) {
     let path = root.join(relative);
     if let Some(parent) = path.parent() {
@@ -1096,10 +1100,12 @@ fn execute_skills_command_list_prefers_nearest_project_ancestor_for_duplicate_sk
     assert_eq!(list.outcome.payload["skills"][0]["skill_id"], "demo-skill");
     assert_eq!(list.outcome.payload["skills"][0]["scope"], "project");
     assert!(
-        list.outcome.payload["skills"][0]["source_path"]
-            .as_str()
-            .expect("source path should be text")
-            .contains("workspace/.agents/skills/demo-skill"),
+        normalized_path_text(
+            list.outcome.payload["skills"][0]["source_path"]
+                .as_str()
+                .expect("source path should be text"),
+        )
+        .contains("workspace/.agents/skills/demo-skill"),
         "nearest project ancestor should win within the project scope: {}",
         list.outcome.payload["skills"][0]
     );
@@ -1110,12 +1116,12 @@ fn execute_skills_command_list_prefers_nearest_project_ancestor_for_duplicate_sk
             .iter()
             .any(|skill| {
                 skill["skill_id"] == "demo-skill"
-                    && skill["source_path"]
-                        .as_str()
-                        .is_some_and(|path| path.ends_with(".agents/skills/demo-skill"))
-                    && !skill["source_path"]
-                        .as_str()
-                        .is_some_and(|path| path.contains("workspace/.agents/skills/demo-skill"))
+                    && skill["source_path"].as_str().is_some_and(|path| {
+                        normalized_path_text(path).ends_with(".agents/skills/demo-skill")
+                    })
+                    && !skill["source_path"].as_str().is_some_and(|path| {
+                        normalized_path_text(path).contains("workspace/.agents/skills/demo-skill")
+                    })
             }),
         "project ancestor duplicates should remain inspectable as shadowed skills"
     );

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -19,7 +19,9 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("clock should be after epoch")
         .as_nanos();
-    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    let temp_dir = std::env::temp_dir();
+    let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
+    canonical_temp_dir.join(format!("{prefix}-{nanos}"))
 }
 
 fn normalized_path_text(value: &str) -> String {


### PR DESCRIPTION
## Summary

Add `windows-latest` to the `rust-test-default` and `rust-test-all-features` CI matrix, with `fail-fast: false` so each platform reports independently.

## CI Status

| Platform | rust-test-default | rust-test-all-features |
|----------|-------------------|------------------------|
| Ubuntu | ✅ pass | ✅ pass |
| Windows | ❌ 7 daemon integration test failures (#610) | ❌ same 7 failures |

The 7 failures are **pre-existing Windows compatibility issues** (8.3 short names + UNC paths in daemon integration tests), not caused by this CI config change. They are tracked in #610.

The original 2 sqlite path normalization failures (#592) were fixed in #593 (merged). These 7 are new discoveries in the daemon crate — the exact reason we need Windows CI.

## Changes

- `.github/workflows/ci.yml`: add `strategy.matrix.os: [ubuntu-latest, windows-latest]` with `fail-fast: false` to `rust-test-default` and `rust-test-all-features`
- Linux-only jobs unchanged: `governance`, `rust-quality`, `docs-build`, `android-termux-build`

## macOS

Deferred to a separate PR pending #591 (pre-existing flaky SQLite WAL locking test).

## Related

- Tracked in #304
- Windows daemon test failures: #610
- macOS flaky test: #591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded test coverage to run on both Ubuntu and Windows operating systems, improving cross-platform validation of the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->