### PR TITLE
fix(windows): resolve 8.3 short names in sqlite path normalization

### DIFF
--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -811,6 +811,39 @@ fn lexical_normalize_runtime_db_path(path: &Path) -> PathBuf {
     }
 }
 
+/// Walk up the directory tree to find the deepest existing ancestor, canonicalize it
+/// via [`dunce::canonicalize`], and reattach the remaining path components.  This
+/// resolves Windows 8.3 short names (e.g. `RUNNER~1` -> `runneradmin`) even when
+/// the target file and its immediate parent directory do not yet exist.
+fn canonicalize_existing_ancestor(path: &Path) -> PathBuf {
+    let mut remaining = Vec::new();
+    let mut current = path.to_path_buf();
+
+    while !current.exists() {
+        let Some(name) = current.file_name().map(|n| n.to_os_string()) else {
+            return path.to_path_buf();
+        };
+        remaining.push(name);
+        let Some(parent) = current.parent().map(|p| p.to_path_buf()) else {
+            return path.to_path_buf();
+        };
+        if parent == current {
+            return path.to_path_buf();
+        }
+        current = parent;
+    }
+
+    match dunce::canonicalize(&current) {
+        Ok(mut canonical) => {
+            for component in remaining.into_iter().rev() {
+                canonical.push(component);
+            }
+            canonical
+        }
+        Err(_) => path.to_path_buf(),
+    }
+}
+
 fn normalize_runtime_db_path(path: &Path) -> Result<PathBuf, String> {
     let absolute = lexical_normalize_runtime_db_path(&absolutize_runtime_db_path(path)?);
     if let Some(normalized_path) = sqlite_runtime_path_alias_registry()
@@ -840,7 +873,7 @@ fn normalize_runtime_db_path(path: &Path) -> Result<PathBuf, String> {
 
         match dunce::canonicalize(parent) {
             Ok(canonical_parent) => canonical_parent.join(file_name),
-            Err(_) => absolute.clone(),
+            Err(_) => canonicalize_existing_ancestor(&absolute),
         }
     };
 


### PR DESCRIPTION
## Summary

Fixes #592 — two SQLite path normalization tests fail on `windows-latest` CI runner but pass locally.

**Root cause:** On GitHub Actions `windows-latest`, `std::env::temp_dir()` returns a path containing 8.3 short names (e.g. `C:\Users\RUNNER~1\...`). When `normalize_runtime_db_path` encounters a DB path whose parent directory does not yet exist, `dunce::canonicalize(parent)` fails and the code falls back to `absolute.clone()`, preserving the short name. Later lookups that canonicalize the same prefix resolve to the long name (`runneradmin`), causing `PathBuf::starts_with` mismatches.

This is also a latent production bug: if a user's working directory or config path contains 8.3 short names, the first DB access (before parent dirs exist) stores a short-name path, while subsequent accesses (after dirs exist) resolve to the long name — producing duplicate runtime instances.

**Fix:** Add `canonicalize_existing_ancestor()` which walks up the directory tree to find the deepest existing ancestor, canonicalizes it via `dunce::canonicalize`, and reattaches the remaining components. This is used as the final fallback in `normalize_runtime_db_path` when both the full path and its immediate parent are not yet on disk.

**Cross-platform impact:** The new function calls `dunce::canonicalize` which is designed to be cross-platform safe (on Unix it is equivalent to `std::fs::canonicalize`). The existing `normalize_runtime_db_path` already unconditionally calls `dunce::canonicalize` at lines 864/874 — this change extends the same pattern to the previously-unhandled fallback case. No `cfg` gate is needed because no platform-specific data transform is involved.

## Changes

- `crates/app/src/memory/sqlite.rs`: Add `canonicalize_existing_ancestor()` helper; replace `absolute.clone()` fallback with call to new helper

## Validation

Local Windows 11 test results:

```
cargo test -p loongclaw-app --lib -- memory::sqlite::tests::dot_dot_aliases memory::sqlite::tests::equivalent_relative_and_absolute
→ 2 passed; 0 failed

cargo test -p loongclaw-app --lib -- memory::sqlite::tests
→ 55 passed; 0 failed

cargo test -p loongclaw-app --lib
→ 2132 passed; 0 failed
```

## Reviewer Focus

- `canonicalize_existing_ancestor` (new function): verify the ancestor walk logic handles edge cases (root dir, empty path, no existing ancestor)
- The single-line change at the call site: `Err(_) => canonicalize_existing_ancestor(&absolute)` replaces `Err(_) => absolute.clone()`

## Related

- Part of #304 (Windows test compatibility)
- Unblocks #590 (cross-platform CI matrix) on `windows-latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database path normalization to better handle cases where target files or parent directories don't yet exist.
  * Enhanced path resolution on Windows by correctly processing aliased or short path components when parent directories are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->