### PR TITLE
Refine product modes into an autonomy-policy kernel

### DIFF
--- a/docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
+++ b/docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
@@ -429,13 +429,17 @@ The live runtime should expose one deterministic decision contract.
 
 Suggested input shape:
 
-- resolved product mode
 - autonomy-policy snapshot
 - capability action class
 - governance profile
 - runtime binding
 - channel support facts
 - turn budget facts
+
+`AutonomyPolicySnapshot` should be the sole runtime decision authority.
+If product-mode context is still useful for telemetry or operator explanation,
+store the resolved product mode as snapshot metadata rather than as an
+independent decision input.
 
 Suggested output shape:
 

--- a/docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
+++ b/docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
@@ -105,14 +105,7 @@ profile enum. It must respect whether the current channel surface can support:
 The goal is not to copy external systems directly. The goal is to identify
 which design shapes are compatible with LoongClaw's current governed runtime.
 
-### Hermes Agent
-
-Primary sources:
-
-- https://github.com/NousResearch/hermes-agent
-- https://hermes-agent.nousresearch.com/docs/developer-guide/architecture/
-- https://hermes-agent.nousresearch.com/docs/user-guide/features/skills/
-- https://hermes-agent.nousresearch.com/docs/user-guide/features/memory/
+### External multi-surface agent reference
 
 Useful ideas to learn from:
 
@@ -138,12 +131,7 @@ What LoongClaw should not copy directly:
 - making hard runtime permissions depend on soft procedural learning
 - treating cross-surface consistency as a UI concern instead of a kernel concern
 
-### HyperAgents
-
-Primary sources:
-
-- https://arxiv.org/abs/2603.19461
-- https://github.com/facebookresearch/Hyperagents
+### External self-improving agent reference
 
 Useful ideas to learn from:
 
@@ -170,9 +158,10 @@ What LoongClaw should not copy directly into the live runtime path:
 
 The key lesson is structural:
 
-- Hermes suggests a strong artifact and runtime boundary discipline
-- HyperAgents suggests that the improvement process itself deserves explicit
-  modeling
+- the multi-surface agent reference suggests strong artifact and runtime
+  boundary discipline
+- the self-improving agent reference suggests that the improvement process
+  itself deserves explicit modeling
 
 Combined, those imply that LoongClaw should separate:
 
@@ -397,8 +386,8 @@ Suggested workflow:
 5. promote or reject
 6. preserve rollback path
 
-This is where HyperAgents-style meta-improvement ideas belong in LoongClaw.
-They do not belong in the live turn-time permission path.
+This is where explicit meta-improvement ideas belong in LoongClaw. They do not
+belong in the live turn-time permission path.
 
 ## Hard Constraints vs Learnable Behavior
 
@@ -509,7 +498,7 @@ Rejected because the abstraction becomes overloaded and hard to evolve.
 
 Rejected because governance and binding rules must stay deterministic.
 
-### Risk: copying HyperAgents-style self-modification into the live turn loop
+### Risk: copying external self-modification patterns into the live turn loop
 
 Rejected because LoongClaw needs explicit promotion, rollback, and operator
 trust.

--- a/docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
+++ b/docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
@@ -92,8 +92,8 @@ Evidence:
 - `crates/app/src/channel/registry.rs`
 - `crates/app/src/config/channels.rs`
 
-This matters because future autonomy policy cannot live only in one product
-profile enum. It must respect whether the current channel surface can support:
+This matters because future autonomy policy cannot live only in one `product
+mode` enum. It must respect whether the current channel surface can support:
 
 - background runtime control
 - approval round-trips
@@ -172,7 +172,7 @@ Combined, those imply that LoongClaw should separate:
 
 ## Design Goals
 
-1. Keep `product mode` as the external product/profile surface.
+1. Keep `product mode` as the external product-facing profile surface.
 2. Introduce an internal autonomy-policy kernel as the real runtime control
    plane.
 3. Preserve deterministic hard constraints for approval, binding, source
@@ -196,9 +196,14 @@ Combined, those imply that LoongClaw should separate:
 LoongClaw should use three different layers instead of one overloaded
 `product mode` abstraction.
 
-### 1. Product profile
+### 1. Product mode
 
 This is the operator-facing layer.
+
+`product mode` is the canonical external term in this document. If follow-up
+runtime code needs an explicit resolved type, it can represent that mode with a
+type such as `AutonomyProfile`, but the operator-facing contract should keep
+the `product mode` label.
 
 Examples:
 
@@ -231,7 +236,7 @@ Suggested core types:
 
 Responsibilities:
 
-- compile the selected product profile into deterministic policy fields
+- compile the selected product mode into deterministic policy fields
 - enforce hard constraints before mutation paths execute
 - produce explicit allow, approval-required, or deny outcomes
 
@@ -275,7 +280,7 @@ Input:
 
 Output:
 
-- selected product profile
+- selected product mode
 
 This is the human-facing abstraction, not the final execution contract.
 
@@ -283,7 +288,7 @@ This is the human-facing abstraction, not the final execution contract.
 
 Input:
 
-- selected product profile
+- selected product mode
 - runtime config
 - channel support
 - binding requirements
@@ -424,7 +429,7 @@ The live runtime should expose one deterministic decision contract.
 
 Suggested input shape:
 
-- resolved product profile
+- resolved product mode
 - autonomy-policy snapshot
 - capability action class
 - governance profile
@@ -442,14 +447,16 @@ Reason codes should stay explicit and operator-visible.
 
 Example families:
 
-- `product_mode_disallows_capability_acquisition`
+- `autonomy_policy_capability_acquisition_disallowed`
 - `autonomy_policy_binding_missing`
 - `autonomy_policy_channel_support_missing`
 - `autonomy_policy_source_policy_denied`
 - `autonomy_policy_budget_exceeded`
 
-`product mode` may still own the operator-facing vocabulary, but the internal
-reason model should not be limited to mode names alone.
+`product mode` may still own the operator-facing vocabulary and user-visible
+explanations, but once a mode is compiled into a policy snapshot, the internal
+reason model should stay rooted in autonomy-policy decisions rather than mixed
+layer names.
 
 ## Why Product Mode Still Matters
 
@@ -482,7 +489,7 @@ The refinement is internal:
 - add channel SDK support metadata
 - emit policy and outcome telemetry suitable for learning-time analysis
 
-### Long term
+### Long-term
 
 - add ranking models or learned strategy selection on top of the policy kernel
 - add a governed evolution plane with replay, shadow, and promotion workflows

--- a/docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
+++ b/docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
@@ -1,0 +1,534 @@
+# Autonomy Policy Kernel Architecture
+
+> Related:
+> - issue `#596`
+> - product-facing baseline: `docs/plans/2026-03-26-product-mode-capability-acquisition-design.md`
+> - memory-pipeline self-evolution RFC: issue `#455`
+
+**Problem**
+
+`#581` and merged PR `#582` established an important boundary:
+
+- `discovery-first` selects tools on the current visible surface
+- `product mode` explains how capability acquisition should look to operators
+
+That is a strong product-facing contract, but it is still too coarse to serve
+as LoongClaw's long-term internal autonomy control plane.
+
+If the runtime keeps adding more behavior directly onto `product mode`, one
+product-facing enum will eventually become a catch-all for multiple orthogonal
+concerns:
+
+- capability-acquisition permissions
+- approval requirements
+- kernel-binding requirements
+- source-policy constraints
+- channel-surface constraints
+- budget enforcement
+- topology-expansion boundaries
+- future learning-time ranking
+- future governed evolution and promotion
+
+This becomes a structural problem as soon as LoongClaw wants to support:
+
+- more channels and SDK surfaces
+- more external-skill and provider mutation paths
+- learning systems that rank or select among allowed actions
+- governed self-improvement that proposes and validates new strategies
+
+The missing layer is an internal autonomy-policy kernel underneath
+`product mode`, so product modes stay simple and operator-facing while the
+runtime gets a more expressive, testable, and evolvable control plane.
+
+## Current Architecture Evidence
+
+The existing repository already has the main seams needed to support an
+autonomy-policy kernel.
+
+### Discovery-first already exists as a lower-layer substrate
+
+Evidence:
+
+- `crates/app/src/tools/catalog.rs`
+- `crates/app/src/tools/mod.rs`
+- `crates/app/src/tools/tool_search.rs`
+- `docs/plans/2026-03-15-tool-discovery-architecture.md`
+
+The runtime can already search the visible tool surface and bridge search
+results into follow-up invocation.
+
+### Governed mutation surfaces already exist
+
+Evidence:
+
+- `crates/app/src/tools/external_skills.rs`
+- `crates/app/src/tools/provider_switch.rs`
+- `crates/app/src/tools/approval.rs`
+- `crates/app/src/session/repository.rs`
+
+LoongClaw already has real mutation paths for:
+
+- fetching external skills
+- installing external skills
+- loading external skills into runtime context
+- switching provider state
+- requesting and resolving governed approvals
+
+### Runtime binding is explicit
+
+Evidence:
+
+- `crates/app/src/conversation/runtime_binding.rs`
+
+The runtime already distinguishes kernel-bound execution from direct execution.
+That makes it possible to encode hard autonomy requirements without falling back
+to prompt conventions.
+
+### Channel SDK surfaces already exist
+
+Evidence:
+
+- `crates/app/src/channel/sdk.rs`
+- `crates/app/src/channel/registry.rs`
+- `crates/app/src/config/channels.rs`
+
+This matters because future autonomy policy cannot live only in one product
+profile enum. It must respect whether the current channel surface can support:
+
+- background runtime control
+- approval round-trips
+- kernel-backed execution
+- session-level policy overrides
+
+## Research Calibration
+
+The goal is not to copy external systems directly. The goal is to identify
+which design shapes are compatible with LoongClaw's current governed runtime.
+
+### Hermes Agent
+
+Primary sources:
+
+- https://github.com/NousResearch/hermes-agent
+- https://hermes-agent.nousresearch.com/docs/developer-guide/architecture/
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/skills/
+- https://hermes-agent.nousresearch.com/docs/user-guide/features/memory/
+
+Useful ideas to learn from:
+
+- one core agent can serve multiple user surfaces without redefining the core
+  loop per surface
+- skills act as procedural memory rather than only static tool metadata
+- memory is persistent and useful, but still bounded and inspectable
+- RL and environment tooling live around the agent stack rather than replacing
+  hard execution boundaries
+- security is treated as layered runtime policy, not just prompt discipline
+
+What LoongClaw should borrow:
+
+- keep one autonomy-policy kernel across channels
+- treat learned procedures and reusable strategies as artifacts, not prompt fog
+- make memory and skill growth useful, but keep it bounded and inspectable
+- keep the learning stack adjacent to the agent core, not fused into hard
+  permission decisions
+
+What LoongClaw should not copy directly:
+
+- implicit policy mutation through accumulated skills or memory alone
+- making hard runtime permissions depend on soft procedural learning
+- treating cross-surface consistency as a UI concern instead of a kernel concern
+
+### HyperAgents
+
+Primary sources:
+
+- https://arxiv.org/abs/2603.19461
+- https://github.com/facebookresearch/Hyperagents
+
+Useful ideas to learn from:
+
+- the improvement process itself can be represented explicitly, not hidden in
+  ad hoc prompting
+- persistent memory and performance tracking are valuable for cross-task
+  improvement
+- a system improves faster when it can reason over both task execution and
+  meta-level improvement artifacts
+
+What LoongClaw should borrow:
+
+- model "how the agent improves" as a first-class plane, not an accidental
+  byproduct of tool use
+- persist evaluation artifacts and performance signals that can support later
+  policy promotion
+- keep meta-level proposals explicit enough to replay, compare, and audit
+
+What LoongClaw should not copy directly into the live runtime path:
+
+- unrestricted self-modification of the active control plane
+- ungoverned online mutation inside the same turn loop that serves users
+- blending experimental improvement logic with production permission decisions
+
+The key lesson is structural:
+
+- Hermes suggests a strong artifact and runtime boundary discipline
+- HyperAgents suggests that the improvement process itself deserves explicit
+  modeling
+
+Combined, those imply that LoongClaw should separate:
+
+- product-facing presets
+- hard autonomy policy
+- learning-time ranking
+- governed evolution and promotion
+
+## Design Goals
+
+1. Keep `product mode` as the external product/profile surface.
+2. Introduce an internal autonomy-policy kernel as the real runtime control
+   plane.
+3. Preserve deterministic hard constraints for approval, binding, source
+   policy, and channel support.
+4. Create a clean place for future learning systems to rank allowed actions.
+5. Create a separate governed evolution plane for proposing and promoting policy
+   changes.
+6. Keep the design compatible with the current discovery-first runtime.
+
+## Non-goals
+
+- Do not remove `product mode` from the operator-facing surface.
+- Do not implement the full learning or RL stack in the first slice.
+- Do not allow unrestricted online self-modification of live runtime policy.
+- Do not merge memory-pipeline evolution into this design; that remains related
+  but separate work under issue `#455`.
+- Do not turn channel SDK surfaces into autonomy-specific heuristic engines.
+
+## Core Thesis
+
+LoongClaw should use three different layers instead of one overloaded
+`product mode` abstraction.
+
+### 1. Product profile
+
+This is the operator-facing layer.
+
+Examples:
+
+- `discovery_only`
+- `guided_acquisition`
+- `bounded_autonomous`
+
+Responsibilities:
+
+- provide understandable presets
+- give channels and operators a small number of clear modes
+- communicate high-level behavior
+
+Non-responsibilities:
+
+- encoding every hard constraint directly
+- serving as the only internal runtime policy abstraction
+
+### 2. Autonomy-policy kernel
+
+This is the internal runtime control plane.
+
+Suggested core types:
+
+- `AutonomyProfile`
+- `AutonomyPolicySnapshot`
+- `PolicyDecisionInput`
+- `PolicyDecisionOutcome`
+- `CapabilityActionClass`
+
+Responsibilities:
+
+- compile the selected product profile into deterministic policy fields
+- enforce hard constraints before mutation paths execute
+- produce explicit allow, approval-required, or deny outcomes
+
+### 3. Learning and evolution planes
+
+These are higher layers that sit on top of the autonomy-policy kernel.
+
+Responsibilities:
+
+- learning plane:
+  - rank or choose among already-allowed actions
+  - learn from performance signals without mutating hard policy directly
+- evolution plane:
+  - propose changes to profiles, policies, or strategies
+  - evaluate them in replay, shadow, or experiments
+  - promote only through governed evidence-backed steps
+
+## Proposed Stack
+
+### Layer A: Discovery substrate
+
+Input:
+
+- current visible tools
+- current conversation context
+
+Output:
+
+- discovery candidates on the current surface
+
+This remains the home of multilingual search recall, synonym handling, and
+coarse fallback over the visible surface.
+
+### Layer B: Product profile
+
+Input:
+
+- session override
+- channel default
+- global runtime default
+
+Output:
+
+- selected product profile
+
+This is the human-facing abstraction, not the final execution contract.
+
+### Layer C: Autonomy-policy snapshot
+
+Input:
+
+- selected product profile
+- runtime config
+- channel support
+- binding requirements
+
+Output:
+
+- deterministic policy snapshot for the current turn
+
+Suggested policy fields:
+
+- allowed capability action classes
+- approval policy
+- kernel-binding policy
+- source policy
+- provider-switch policy
+- topology-expansion policy
+- budget limits
+- explanation policy
+
+### Layer D: Decision engine
+
+Input:
+
+- policy snapshot
+- capability action class
+- governance profile
+- binding strength
+- channel support facts
+- turn budget state
+
+Output:
+
+- `allow`
+- `approval_required`
+- `deny(reason_code)`
+
+This layer should be deterministic and directly testable.
+
+### Layer E: Capability graph
+
+The runtime should reason over capability families rather than raw tool names
+alone.
+
+Suggested node families:
+
+- visible tool
+- external skill package
+- loaded skill
+- provider profile
+- channel surface
+- delegate child runtime
+
+Suggested edge families:
+
+- discover
+- invoke
+- fetch
+- install
+- load
+- switch
+- delegate
+- mutate_policy
+- future experiment promotion
+
+This graph does not need to be a heavyweight database. It can start as typed
+runtime relationships derived from the tool catalog, runtime config, and channel
+surfaces.
+
+### Layer F: Learning plane
+
+This layer may optimize among permitted choices.
+
+Good candidates for learning:
+
+- search query reformulation
+- ranking of discovery candidates
+- ranking of provider-switch candidates
+- ranking of acquisition order
+- budget allocation hints
+- choosing whether to reuse an installed skill or search again
+
+This layer must not decide:
+
+- approval bypass
+- source allowlist changes
+- kernel-binding relaxation
+- topology-expansion rights
+- live policy mutation
+
+### Layer G: Governed evolution plane
+
+This layer proposes and validates changes to autonomy behavior over time.
+
+Suggested workflow:
+
+1. propose candidate profile, policy, or strategy change
+2. run static validation and invariants
+3. execute replay, shadow, or bounded experiment
+4. compare evidence against baseline
+5. promote or reject
+6. preserve rollback path
+
+This is where HyperAgents-style meta-improvement ideas belong in LoongClaw.
+They do not belong in the live turn-time permission path.
+
+## Hard Constraints vs Learnable Behavior
+
+The most important boundary in this design is not "manual vs autonomous". It is
+"hard constraint vs learnable behavior".
+
+### Hard constraints
+
+These must remain deterministic:
+
+- whether an action class is allowed at all
+- whether approval is required
+- whether the runtime binding is strong enough
+- whether the current channel surface supports the requested path
+- whether the source policy allows the acquisition source
+- whether topology expansion is permitted
+
+### Learnable behavior
+
+These may improve over time:
+
+- which allowed action to try first
+- how to reformulate a search query
+- which skill or provider candidate is most promising
+- how to allocate bounded budgets
+- which strategy performs better under a fixed policy envelope
+
+That separation is what keeps future RL or self-improvement compatible with
+governance.
+
+## Decision Contract
+
+The live runtime should expose one deterministic decision contract.
+
+Suggested input shape:
+
+- resolved product profile
+- autonomy-policy snapshot
+- capability action class
+- governance profile
+- runtime binding
+- channel support facts
+- turn budget facts
+
+Suggested output shape:
+
+- `allow`
+- `approval_required(reason_code)`
+- `deny(reason_code)`
+
+Reason codes should stay explicit and operator-visible.
+
+Example families:
+
+- `product_mode_disallows_capability_acquisition`
+- `autonomy_policy_binding_missing`
+- `autonomy_policy_channel_support_missing`
+- `autonomy_policy_source_policy_denied`
+- `autonomy_policy_budget_exceeded`
+
+`product mode` may still own the operator-facing vocabulary, but the internal
+reason model should not be limited to mode names alone.
+
+## Why Product Mode Still Matters
+
+This design does not replace `product mode`.
+
+`product mode` is still useful because it gives operators:
+
+- a simple way to choose a safety and autonomy posture
+- a clear surface for channel defaults
+- understandable explanations in user-facing interfaces
+
+The refinement is internal:
+
+- product mode stays
+- autonomy policy becomes the kernel
+
+## Integration Strategy
+
+### Near term
+
+- keep the existing product-mode design as the product-facing contract
+- introduce an autonomy-policy kernel underneath it
+- compile product-mode presets into policy snapshots
+- keep discovery-first intact
+
+### Medium term
+
+- add capability-action classification to the catalog
+- add decision evaluation and blocked-reason propagation
+- add channel SDK support metadata
+- emit policy and outcome telemetry suitable for learning-time analysis
+
+### Long term
+
+- add ranking models or learned strategy selection on top of the policy kernel
+- add a governed evolution plane with replay, shadow, and promotion workflows
+- connect, but do not merge, memory-pipeline evolution from issue `#455`
+
+## Risks
+
+### Risk: keeping all logic in `product mode`
+
+Rejected because the abstraction becomes overloaded and hard to evolve.
+
+### Risk: letting the learning layer own hard permissions
+
+Rejected because governance and binding rules must stay deterministic.
+
+### Risk: copying HyperAgents-style self-modification into the live turn loop
+
+Rejected because LoongClaw needs explicit promotion, rollback, and operator
+trust.
+
+### Risk: pushing autonomy decisions into channel-specific code
+
+Rejected because channels should declare capability facts, not local autonomy
+policy.
+
+## Recommended Direction
+
+Treat `product mode` as the external profile surface.
+
+Treat `AutonomyPolicy` as the internal runtime kernel.
+
+Treat learning as a ranking layer constrained by policy.
+
+Treat self-evolution as a separate governed promotion plane.
+
+That is the smallest structurally correct design that stays compatible with the
+current LoongClaw runtime while leaving room for future RL and self-improvement
+without collapsing governance into prompt behavior or soft heuristics.

--- a/docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md
+++ b/docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md
@@ -1,0 +1,312 @@
+# Autonomy Policy Kernel Implementation Plan
+
+> Execution note: implement this plan in follow-up slices after issue `#596`
+> is accepted.
+
+**Goal:** Keep `product mode` as the operator-facing profile surface, while
+moving the internal runtime control plane to an autonomy-policy kernel that can
+later support learning and governed evolution.
+
+**Architecture:** `product mode` resolves into an `AutonomyPolicySnapshot`.
+Discovery-first remains the lower-layer selection substrate. The autonomy-policy
+kernel decides whether capability-acquisition actions are allowed, approval
+bound, or denied. Future learning ranks among allowed actions. Future evolution
+proposes and validates policy or strategy changes outside the live turn path.
+
+**Tech Stack:** Rust, existing `loongclaw-app` tool and conversation runtime,
+channel SDK metadata, runtime config, approval and session persistence,
+docs-first delivery, GitHub issue-first workflow
+
+---
+
+## Execution Tasks
+
+Verification note: keep test prefixes slice-specific so every command can target
+one slice with a single positional filter.
+
+### Task 1: Land the docs contract
+
+**Files:**
+- Modify: `docs/plans/2026-03-26-product-mode-capability-acquisition-design.md`
+- Modify: `docs/plans/2026-03-26-product-mode-capability-acquisition-implementation-plan.md`
+- Create: `docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md`
+- Create: `docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md`
+
+**Step 1: Write the artifacts**
+
+- clarify that `product mode` remains the product-facing profile surface
+- define the internal autonomy-policy kernel
+- define the decision contract and hard-vs-learnable boundary
+- define the governed evolution plane and its relationship to issue `#455`
+- document what Hermes Agent and HyperAgents suggest, and what should remain
+  outside LoongClaw's live turn path
+
+**Step 2: Verify the artifacts exist**
+
+Run:
+
+```bash
+test -f docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
+test -f docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md
+git diff --check
+```
+
+Expected: success
+
+### Task 2: Introduce product profile and autonomy-policy types
+
+**Files:**
+- Modify: `crates/app/src/config/*.rs`
+- Modify: `crates/app/src/tools/runtime_config.rs`
+- Modify: `crates/app/src/runtime_env.rs`
+- Test: `crates/app/src/config/*`
+- Test: `crates/app/src/tools/runtime_config.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests with an `autonomy_profile_runtime_config_` prefix that prove:
+
+- product-facing profiles have a stable enum surface
+- runtime config resolves a default profile deterministically
+- a profile compiles into a policy snapshot
+- invalid profile or policy values fail closed
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app autonomy_profile_runtime_config_ -- --test-threads=1
+```
+
+Expected: FAIL because the runtime does not yet expose profile-to-policy
+compilation.
+
+**Step 3: Write minimal implementation**
+
+Introduce types such as:
+
+- `AutonomyProfile`
+- `AutonomyPolicySnapshot`
+- `AutonomyBudgetPolicy`
+
+Keep `product mode` as the product-facing vocabulary if that is already exposed
+elsewhere, but compile it into explicit policy fields instead of encoding every
+rule directly on the mode enum.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and expect PASS.
+
+### Task 3: Add capability-action classification to the tool catalog
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+- Test: `crates/app/src/tools/catalog.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests with an `autonomy_capability_action_` prefix that prove:
+
+- capability action classes exist independently of governance profile
+- known mutation tools classify correctly
+- new tools can be added without scattering raw-name checks across the runtime
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app autonomy_capability_action_ -- --test-threads=1
+```
+
+Expected: FAIL because the catalog does not yet expose typed action classes.
+
+**Step 3: Write minimal implementation**
+
+Add a stable action-class enum to the tool catalog and expose it through the
+descriptor or a derived catalog view.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and expect PASS.
+
+### Task 4: Add the autonomy decision engine
+
+**Files:**
+- Create: `crates/app/src/conversation/autonomy_policy.rs`
+- Modify: `crates/app/src/conversation/mod.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests with an `autonomy_policy_decision_` prefix that prove:
+
+- the decision engine consumes profile, policy snapshot, action class,
+  governance profile, binding facts, channel facts, and budget facts
+- the engine returns only `allow`, `approval_required`, or `deny`
+- the engine keeps hard constraints deterministic
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app autonomy_policy_decision_ -- --test-threads=1
+```
+
+Expected: FAIL because the decision engine does not yet exist.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- `PolicyDecisionInput`
+- `PolicyDecisionOutcome`
+- deterministic evaluation logic
+
+Keep learning and ranking out of this layer.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and expect PASS.
+
+### Task 5: Bind the autonomy kernel to runtime binding and channel SDK support
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime_binding.rs`
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/turn_loop.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/channel/sdk.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+- Test: `crates/app/src/channel/sdk.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests with an `autonomy_policy_surface_` prefix that prove:
+
+- weak bindings fail closed for mutation paths
+- explanation-only deny outcomes may still execute on weak bindings
+- channel SDK surfaces can declare whether kernel-backed mutation and approval
+  round-trips are supported
+- unsupported profile and surface combinations are rejected early
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app autonomy_policy_surface_ -- --test-threads=1
+```
+
+Expected: FAIL because the runtime and SDK are not yet autonomy-policy-aware.
+
+**Step 3: Write minimal implementation**
+
+Extend SDK metadata with the smallest set of fields needed to express:
+
+- supported product profiles
+- kernel-backed mutation support
+- approval round-trip support
+- session override support
+
+Keep channel SDK metadata declarative. Do not move autonomy heuristics into
+channel-specific code.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and expect PASS.
+
+### Task 6: Add explicit policy telemetry for later learning work
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+- Modify: `crates/app/src/conversation/turn_shared.rs`
+- Modify: `crates/app/src/tools/approval.rs`
+- Test: `crates/app/src/session/repository.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests with an `autonomy_policy_telemetry_` prefix that prove:
+
+- decision outcomes persist explicit reason codes
+- approval-required outcomes persist their policy source
+- blocked explanations preserve enough structure for later replay and analysis
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app autonomy_policy_telemetry_ -- --test-threads=1
+```
+
+Expected: FAIL because the runtime does not yet persist autonomy-policy outcome
+artifacts explicitly.
+
+**Step 3: Write minimal implementation**
+
+Add structured persistence for:
+
+- resolved profile
+- policy decision outcome
+- reason code
+- relevant action class
+
+This is the minimum foundation for later ranking or replay work.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command and expect PASS.
+
+### Task 7: Add a governed evolution lane outside the live turn path
+
+**Files:**
+- Create: future follow-up slice after Tasks 2-6 land
+
+**Step 1: Design first**
+
+Do not start by mutating the live autonomy policy online.
+
+The first governed evolution slice should define:
+
+- candidate policy artifact shape
+- replay or shadow evaluation contract
+- promotion decision rules
+- rollback path
+
+**Step 2: Implement later**
+
+Only after earlier tasks land, add bounded experiment and promotion support.
+
+## Recommended Slice Order
+
+1. docs refinement
+2. product profile and policy snapshot types
+3. capability-action classification
+4. decision engine
+5. binding and channel SDK support
+6. policy telemetry
+7. governed evolution plane
+
+## Full Verification
+
+After runtime slices land, run:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features -- --test-threads=1
+```
+
+Expected: PASS
+
+For the current docs-only slice, run:
+
+```bash
+git diff --check
+```
+
+Expected: PASS

--- a/docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md
+++ b/docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md
@@ -38,8 +38,8 @@ one slice with a single positional filter.
 - define the internal autonomy-policy kernel
 - define the decision contract and hard-vs-learnable boundary
 - define the governed evolution plane and its relationship to issue `#455`
-- document what Hermes Agent and HyperAgents suggest, and what should remain
-  outside LoongClaw's live turn path
+- document what recent multi-surface agent systems and self-improving agent
+  research suggest, and what should remain outside LoongClaw's live turn path
 
 **Step 2: Verify the artifacts exist**
 

--- a/docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md
+++ b/docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md
@@ -53,7 +53,7 @@ git diff --check
 
 Expected: success
 
-### Task 2: Introduce product profile and autonomy-policy types
+### Task 2: Introduce product-mode and autonomy-policy types
 
 **Files:**
 - Modify: `crates/app/src/config/*.rs`
@@ -66,7 +66,7 @@ Expected: success
 
 Add tests with an `autonomy_profile_runtime_config_` prefix that prove:
 
-- product-facing profiles have a stable enum surface
+- `product mode` has a stable enum surface
 - runtime config resolves a default profile deterministically
 - a profile compiles into a policy snapshot
 - invalid profile or policy values fail closed
@@ -206,7 +206,7 @@ Expected: FAIL because the runtime and SDK are not yet autonomy-policy-aware.
 
 Extend SDK metadata with the smallest set of fields needed to express:
 
-- supported product profiles
+- supported product modes
 - kernel-backed mutation support
 - approval round-trip support
 - session override support
@@ -284,7 +284,7 @@ Only after earlier tasks land, add bounded experiment and promotion support.
 ## Recommended Slice Order
 
 1. docs refinement
-2. product profile and policy snapshot types
+2. product-mode and policy snapshot types
 3. capability-action classification
 4. decision engine
 5. binding and channel SDK support

--- a/docs/plans/2026-03-26-product-mode-capability-acquisition-design.md
+++ b/docs/plans/2026-03-26-product-mode-capability-acquisition-design.md
@@ -1,7 +1,8 @@
 # Product Mode Capability Acquisition Design
 
 > Follow-up refinement: issue `#596` keeps `product mode` as the external
-> product/profile surface, but generalizes the internal runtime control plane
+> external product-facing surface, but generalizes the internal runtime control
+> plane
 > into an autonomy-policy kernel. This document remains the product-facing
 > capability-acquisition contract. See
 > `docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md` for the

--- a/docs/plans/2026-03-26-product-mode-capability-acquisition-design.md
+++ b/docs/plans/2026-03-26-product-mode-capability-acquisition-design.md
@@ -1,5 +1,12 @@
 # Product Mode Capability Acquisition Design
 
+> Follow-up refinement: issue `#596` keeps `product mode` as the external
+> product/profile surface, but generalizes the internal runtime control plane
+> into an autonomy-policy kernel. This document remains the product-facing
+> capability-acquisition contract. See
+> `docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md` for the
+> internal architecture refinement.
+
 **Problem**
 
 LoongClaw now has a materially better `discovery-first` substrate, but it still

--- a/docs/plans/2026-03-26-product-mode-capability-acquisition-implementation-plan.md
+++ b/docs/plans/2026-03-26-product-mode-capability-acquisition-implementation-plan.md
@@ -1,5 +1,11 @@
 # Product Mode Capability Acquisition Implementation Plan
 
+> Follow-up refinement: issue `#596` keeps the product-facing `product mode`
+> surface, but updates the internal implementation target to an autonomy-policy
+> kernel. The slice order below still applies, but new runtime types should
+> compile product-mode presets into policy snapshots rather than hard-coding all
+> behavior directly on the mode enum.
+
 > Execution note: implement this plan in follow-up slices after the contract in
 > issue `#581` is accepted.
 


### PR DESCRIPTION
## Summary

- Problem:
  The merged product-mode RFC from `#582` is a strong product-facing contract,
  but it is still too coarse to be LoongClaw's long-term internal autonomy
  control plane once learning, governed self-improvement, and more channel SDK
  surfaces arrive.
- Why it matters:
  Without a finer-grained kernel, autonomy behavior risks collapsing back into
  overloaded mode enums, channel-local heuristics, or future learned policies
  that blur hard governance boundaries.
- What changed:
  Added a follow-up autonomy-policy kernel architecture doc and implementation
  plan, and annotated the existing product-mode docs so they now explicitly act
  as the product-facing profile layer above the new kernel design.
- What did not change (scope boundary):
  No runtime code changed. This PR does not implement RL, online self-modifying
  policy, or the memory-pipeline evolution work tracked separately under `#455`.

## Linked Issues

- Closes #596
- Related #582
- Related #455

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  The risk is architectural drift, not runtime breakage. This PR re-centers the
  internal design from `product mode` alone to `product mode` plus an
  autonomy-policy kernel. Reviewers should verify that the new docs keep hard
  governance constraints deterministic and keep learning/evolution outside the
  live permission path.
- Rollout / guardrails:
  Docs-only slice. Future implementation should land incrementally behind typed
  policy snapshots, deterministic decision outputs, and fail-closed binding
  checks.
- Rollback path:
  Revert this docs PR. No runtime migration is required.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
test -f docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md
test -f docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md
git diff --check

Result:
- both new docs exist
- diff hygiene check passed
- content was cross-checked against the current dev branch structure, including
  crates/app/src/channel/sdk.rs, crates/app/src/tools/runtime_config.rs,
  crates/app/src/tools/catalog.rs, crates/app/src/tools/approval.rs, and
  crates/app/src/conversation/runtime_binding.rs
- external design calibration used recent multi-surface agent systems and recent
  self-improving agent research as architectural references, but the PR
  explicitly keeps governed evolution outside the live turn-time permission path
```

## User-visible / Operator-visible Changes

- No runtime behavior changes.
- Design docs now make a clearer distinction between:
  - product-facing autonomy presets
  - the internal autonomy-policy kernel
  - future learning and governed evolution layers

## Failure Recovery

- Fast rollback or disable path:
  Revert the docs commit or close the follow-up track before any runtime slice
  lands.
- Observable failure symptoms reviewers should watch for:
  Future implementers might misread the new docs as permission to add online
  self-modifying policy inside the live turn loop. The docs explicitly reject
  that path.

## Reviewer Focus

- Confirm the layered split is coherent:
  `product mode` as external profile, `AutonomyPolicy` as kernel, learning as
  ranking-only, and self-evolution as governed promotion.
- Check that the new docs align with the latest channel SDK surface instead of
  the older descriptor-only view.
- Check the external-reference calibration:
  external multi-surface agent references should inform artifact and runtime
  boundaries, while external self-improving agent research should inform the
  separate evolution plane, not live self-modifying permissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture and planning docs describing a layered autonomy-policy kernel beneath the product-facing surface.
  * Added an implementation roadmap with ordered slices, verification steps, and deterministic decision outcomes (allow / approval-required / deny).
  * Clarified product-mode docs to preserve the external profile while migrating internal runtime control to the new kernel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->