### PR TITLE
fix(kernel): remove redundant local in verified_env_var_names_contain

### DIFF
--- a/crates/kernel/src/plugin_ir.rs
+++ b/crates/kernel/src/plugin_ir.rs
@@ -126,7 +126,6 @@ fn verified_env_var_names_contain(
 ) -> bool {
     #[cfg(windows)]
     {
-        let required_env_var = required_env_var;
         verified_env_vars
             .iter()
             .any(|verified_env_var| verified_env_var.eq_ignore_ascii_case(required_env_var))


### PR DESCRIPTION
## Summary

Remove a redundant `let required_env_var = required_env_var;` rebinding inside the `#[cfg(windows)]` block of `verified_env_var_names_contain`. This triggers `clippy::redundant_locals` (default since Rust 1.93) and will fail CI once the toolchain is updated.

Fixes #594

## Changes

- `crates/kernel/src/plugin_ir.rs`: delete one line (the redundant rebinding)

## Validation

```
cargo clippy -p loongclaw-kernel --lib -- -D warnings
→ 0 warnings, 0 errors
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor code cleanup on Windows builds affecting internal environment variable validation logic with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->