### PR TITLE
Add autonomy profile compilation and policy snapshots

### DIFF
--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -78,8 +78,9 @@ pub(crate) use shared::ConfigValidationIssue;
 pub use shared::{CLI_COMMAND_NAME, expand_path};
 #[allow(unused_imports)]
 pub use tools::{
-    BrowserCompanionToolConfig, BrowserToolConfig, DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS,
-    DEFAULT_BROWSER_MAX_LINKS, DEFAULT_BROWSER_MAX_SESSIONS, DEFAULT_BROWSER_MAX_TEXT_CHARS,
+    AUTONOMY_PROFILE_VALID_VALUES, AutonomyProfile, BrowserCompanionToolConfig, BrowserToolConfig,
+    DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS, DEFAULT_BROWSER_MAX_LINKS,
+    DEFAULT_BROWSER_MAX_SESSIONS, DEFAULT_BROWSER_MAX_TEXT_CHARS,
     DEFAULT_RUNTIME_SELF_MAX_SOURCE_CHARS, DEFAULT_RUNTIME_SELF_MAX_TOTAL_CHARS,
     DEFAULT_SHELL_ALLOW, DEFAULT_WEB_FETCH_MAX_BYTES, DEFAULT_WEB_FETCH_MAX_REDIRECTS,
     DEFAULT_WEB_FETCH_TIMEOUT_SECONDS, DEFAULT_WEB_SEARCH_MAX_RESULTS, DEFAULT_WEB_SEARCH_PROVIDER,
@@ -92,7 +93,7 @@ pub use tools::{
     WEB_SEARCH_PROVIDER_BRAVE, WEB_SEARCH_PROVIDER_DUCKDUCKGO, WEB_SEARCH_PROVIDER_EXA,
     WEB_SEARCH_PROVIDER_JINA, WEB_SEARCH_PROVIDER_PERPLEXITY, WEB_SEARCH_PROVIDER_TAVILY,
     WEB_SEARCH_PROVIDER_VALID_VALUES, WEB_SEARCH_TAVILY_API_KEY_ENV, WebSearchProviderDescriptor,
-    WebSearchToolConfig, WebToolConfig, normalize_web_search_provider,
+    WebSearchToolConfig, WebToolConfig, normalize_web_search_provider, parse_autonomy_profile,
     web_search_provider_api_key_env_names, web_search_provider_default_api_key_env,
     web_search_provider_descriptor, web_search_provider_descriptors,
 };

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -66,6 +66,8 @@ pub struct ToolConfig {
     pub web_search: WebSearchToolConfig,
     #[serde(default)]
     pub tool_execution: ToolExecutionToolConfig,
+    #[serde(default)]
+    pub autonomy_profile: AutonomyProfile,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -74,6 +76,28 @@ pub struct ToolExecutionToolConfig {
     pub default_timeout_seconds: Option<u64>,
     #[serde(default)]
     pub per_tool_timeout: BTreeMap<String, u64>,
+}
+
+pub const AUTONOMY_PROFILE_VALID_VALUES: &str =
+    "discovery_only, guided_acquisition, bounded_autonomous";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomyProfile {
+    #[default]
+    DiscoveryOnly,
+    GuidedAcquisition,
+    BoundedAutonomous,
+}
+
+impl AutonomyProfile {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DiscoveryOnly => "discovery_only",
+            Self::GuidedAcquisition => "guided_acquisition",
+            Self::BoundedAutonomous => "bounded_autonomous",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -420,6 +444,7 @@ impl Default for ToolConfig {
             web: WebToolConfig::default(),
             web_search: WebSearchToolConfig::default(),
             tool_execution: ToolExecutionToolConfig::default(),
+            autonomy_profile: AutonomyProfile::default(),
         }
     }
 }
@@ -787,6 +812,17 @@ pub fn web_search_provider_api_key_env_names(raw: &str) -> &'static [&'static st
         .unwrap_or(WEB_SEARCH_EMPTY_API_KEY_ENV_NAMES)
 }
 
+pub fn parse_autonomy_profile(raw: &str) -> Option<AutonomyProfile> {
+    let normalized = raw.trim().to_ascii_lowercase();
+
+    match normalized.as_str() {
+        "discovery_only" => Some(AutonomyProfile::DiscoveryOnly),
+        "guided_acquisition" => Some(AutonomyProfile::GuidedAcquisition),
+        "bounded_autonomous" => Some(AutonomyProfile::BoundedAutonomous),
+        _ => None,
+    }
+}
+
 #[cfg(feature = "tool-websearch")]
 pub(crate) fn web_search_provider_parameter_description() -> String {
     format!(
@@ -945,6 +981,7 @@ mod tests {
         assert!(config.shell_allow.is_empty());
         assert!(config.shell_deny.is_empty());
         assert_eq!(config.shell_default_mode, "deny");
+        assert_eq!(config.autonomy_profile, AutonomyProfile::DiscoveryOnly);
         assert_eq!(config.approval.mode, GovernedToolApprovalMode::Disabled);
         assert!(config.approval.approved_calls.is_empty());
         assert!(config.approval.denied_calls.is_empty());
@@ -1012,6 +1049,23 @@ mod tests {
         assert!(config.web_search.perplexity_api_key.is_none());
         assert!(config.web_search.exa_api_key.is_none());
         assert!(config.web_search.jina_api_key.is_none());
+    }
+
+    #[test]
+    fn parse_autonomy_profile_accepts_known_values() {
+        assert_eq!(
+            parse_autonomy_profile("discovery_only"),
+            Some(AutonomyProfile::DiscoveryOnly)
+        );
+        assert_eq!(
+            parse_autonomy_profile(" guided_acquisition "),
+            Some(AutonomyProfile::GuidedAcquisition)
+        );
+        assert_eq!(
+            parse_autonomy_profile("BOUNDED_AUTONOMOUS"),
+            Some(AutonomyProfile::BoundedAutonomous)
+        );
+        assert_eq!(parse_autonomy_profile("unknown"), None);
     }
 
     #[test]
@@ -1215,6 +1269,22 @@ per_tool_timeout = { "file.read" = 3, "web.search" = 9 }
                 .per_tool_timeout
                 .get("web.search"),
             Some(&9)
+        );
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    fn tool_config_parses_autonomy_profile_from_toml() {
+        let raw = r#"
+[tools]
+autonomy_profile = "guided_acquisition"
+"#;
+        let parsed =
+            toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
+
+        assert_eq!(
+            parsed.tools.autonomy_profile,
+            AutonomyProfile::GuidedAcquisition
         );
     }
 

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -78,9 +78,13 @@ pub struct ToolExecutionToolConfig {
     pub per_tool_timeout: BTreeMap<String, u64>,
 }
 
+const AUTONOMY_PROFILE_IDS: [&str; 3] =
+    ["discovery_only", "guided_acquisition", "bounded_autonomous"];
+
 pub const AUTONOMY_PROFILE_VALID_VALUES: &str =
     "discovery_only, guided_acquisition, bounded_autonomous";
 
+#[repr(usize)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AutonomyProfile {
@@ -91,11 +95,20 @@ pub enum AutonomyProfile {
 }
 
 impl AutonomyProfile {
+    const fn from_index(index: usize) -> Option<Self> {
+        match index {
+            0 => Some(Self::DiscoveryOnly),
+            1 => Some(Self::GuidedAcquisition),
+            2 => Some(Self::BoundedAutonomous),
+            _ => None,
+        }
+    }
+
     pub const fn as_str(self) -> &'static str {
         match self {
-            Self::DiscoveryOnly => "discovery_only",
-            Self::GuidedAcquisition => "guided_acquisition",
-            Self::BoundedAutonomous => "bounded_autonomous",
+            Self::DiscoveryOnly => AUTONOMY_PROFILE_IDS[0],
+            Self::GuidedAcquisition => AUTONOMY_PROFILE_IDS[1],
+            Self::BoundedAutonomous => AUTONOMY_PROFILE_IDS[2],
         }
     }
 }
@@ -814,13 +827,11 @@ pub fn web_search_provider_api_key_env_names(raw: &str) -> &'static [&'static st
 
 pub fn parse_autonomy_profile(raw: &str) -> Option<AutonomyProfile> {
     let normalized = raw.trim().to_ascii_lowercase();
+    let matched_index = AUTONOMY_PROFILE_IDS
+        .iter()
+        .position(|value| *value == normalized)?;
 
-    match normalized.as_str() {
-        "discovery_only" => Some(AutonomyProfile::DiscoveryOnly),
-        "guided_acquisition" => Some(AutonomyProfile::GuidedAcquisition),
-        "bounded_autonomous" => Some(AutonomyProfile::BoundedAutonomous),
-        _ => None,
-    }
+    AutonomyProfile::from_index(matched_index)
 }
 
 #[cfg(feature = "tool-websearch")]
@@ -1066,6 +1077,18 @@ mod tests {
             Some(AutonomyProfile::BoundedAutonomous)
         );
         assert_eq!(parse_autonomy_profile("unknown"), None);
+    }
+
+    #[test]
+    fn autonomy_profile_valid_values_stays_in_sync_with_profile_ids() {
+        let valid_values = [
+            AutonomyProfile::DiscoveryOnly.as_str(),
+            AutonomyProfile::GuidedAcquisition.as_str(),
+            AutonomyProfile::BoundedAutonomous.as_str(),
+        ]
+        .join(", ");
+
+        assert_eq!(AUTONOMY_PROFILE_VALID_VALUES, valid_values);
     }
 
     #[test]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -651,10 +651,7 @@ impl ToolRuntimeConfig {
         let web_search_max_results = parse_env_usize("LOONGCLAW_WEB_SEARCH_MAX_RESULTS")
             .map(|count| count.clamp(1, 10))
             .unwrap_or(crate::config::DEFAULT_WEB_SEARCH_MAX_RESULTS);
-        let autonomy_profile = parse_env_string("LOONGCLAW_AUTONOMY_PROFILE")
-            .as_deref()
-            .and_then(crate::config::parse_autonomy_profile)
-            .unwrap_or_default();
+        let autonomy_profile = resolve_autonomy_profile_from_env();
         let enabled = parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_ENABLED").unwrap_or(false);
         let require_download_approval =
             parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL").unwrap_or(true);
@@ -1066,6 +1063,30 @@ fn parse_env_domain_list(key: &str) -> BTreeSet<String> {
         .collect()
 }
 
+fn resolve_autonomy_profile_from_env() -> AutonomyProfile {
+    let raw_profile = parse_env_string("LOONGCLAW_AUTONOMY_PROFILE");
+    let Some(raw_profile) = raw_profile else {
+        return AutonomyProfile::default();
+    };
+
+    let parsed_profile = crate::config::parse_autonomy_profile(raw_profile.as_str());
+    let Some(profile) = parsed_profile else {
+        let default_profile = AutonomyProfile::default();
+        let default_profile_id = default_profile.as_str();
+        let valid_values = crate::config::AUTONOMY_PROFILE_VALID_VALUES;
+
+        #[allow(clippy::print_stderr)]
+        {
+            eprintln!(
+                "warning: invalid LOONGCLAW_AUTONOMY_PROFILE `{raw_profile}`; falling back to `{default_profile_id}`. supported values: {valid_values}"
+            );
+        }
+        return default_profile;
+    };
+
+    profile
+}
+
 #[cfg(feature = "feishu-integration")]
 fn has_enabled_feishu_runtime_credentials(config: &FeishuChannelConfig) -> bool {
     if !config.enabled {
@@ -1360,6 +1381,19 @@ mod tests {
 
         assert_eq!(runtime.autonomy_profile, AutonomyProfile::DiscoveryOnly);
         assert_eq!(snapshot.profile, AutonomyProfile::DiscoveryOnly);
+    }
+
+    #[test]
+    fn autonomy_profile_runtime_config_from_env_uses_valid_value() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONGCLAW_AUTONOMY_PROFILE", "guided_acquisition");
+
+        let runtime = ToolRuntimeConfig::from_env();
+        let snapshot = runtime.autonomy_policy_snapshot();
+
+        assert_eq!(runtime.autonomy_profile, AutonomyProfile::GuidedAcquisition);
+        assert_eq!(snapshot.profile, AutonomyProfile::GuidedAcquisition);
     }
 
     /// Deny starts empty so users are not forced to carry

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -215,21 +215,11 @@ impl AutonomyOperationMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AutonomyBudgetPolicy {
     pub max_capability_acquisitions_per_turn: usize,
     pub max_provider_switches_per_turn: usize,
     pub max_topology_mutations_per_turn: usize,
-}
-
-impl Default for AutonomyBudgetPolicy {
-    fn default() -> Self {
-        Self {
-            max_capability_acquisitions_per_turn: 0,
-            max_provider_switches_per_turn: 0,
-            max_topology_mutations_per_turn: 0,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1336,8 +1326,10 @@ mod tests {
 
     #[test]
     fn autonomy_profile_runtime_config_compiles_bounded_autonomous_snapshot() {
-        let mut config = ToolRuntimeConfig::default();
-        config.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+        let config = ToolRuntimeConfig {
+            autonomy_profile: AutonomyProfile::BoundedAutonomous,
+            ..ToolRuntimeConfig::default()
+        };
 
         let snapshot = config.autonomy_policy_snapshot();
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -7,7 +7,7 @@ use loongclaw_contracts::{ExecutionSecurityTier, SecretRef};
 use serde::{Deserialize, Serialize};
 
 use super::shell_policy_ext::ShellPolicyDefault;
-use crate::config::LoongClawConfig;
+use crate::config::{AutonomyProfile, LoongClawConfig};
 #[cfg(feature = "feishu-integration")]
 use crate::config::{FeishuChannelConfig, FeishuIntegrationConfig};
 #[cfg(feature = "feishu-integration")]
@@ -195,6 +195,93 @@ impl Default for RuntimeSelfRuntimePolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AutonomyOperationMode {
+    #[default]
+    Deny,
+    ApprovalRequired,
+    Allow,
+}
+
+impl AutonomyOperationMode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Deny => "deny",
+            Self::ApprovalRequired => "approval_required",
+            Self::Allow => "allow",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutonomyBudgetPolicy {
+    pub max_capability_acquisitions_per_turn: usize,
+    pub max_provider_switches_per_turn: usize,
+    pub max_topology_mutations_per_turn: usize,
+}
+
+impl Default for AutonomyBudgetPolicy {
+    fn default() -> Self {
+        Self {
+            max_capability_acquisitions_per_turn: 0,
+            max_provider_switches_per_turn: 0,
+            max_topology_mutations_per_turn: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutonomyPolicySnapshot {
+    pub profile: AutonomyProfile,
+    pub capability_acquisition_mode: AutonomyOperationMode,
+    pub provider_switch_mode: AutonomyOperationMode,
+    pub topology_mutation_mode: AutonomyOperationMode,
+    pub requires_kernel_binding: bool,
+    pub budget: AutonomyBudgetPolicy,
+}
+
+impl AutonomyPolicySnapshot {
+    #[must_use]
+    pub fn from_profile(profile: AutonomyProfile) -> Self {
+        match profile {
+            AutonomyProfile::DiscoveryOnly => Self {
+                profile,
+                capability_acquisition_mode: AutonomyOperationMode::Deny,
+                provider_switch_mode: AutonomyOperationMode::Deny,
+                topology_mutation_mode: AutonomyOperationMode::Deny,
+                requires_kernel_binding: false,
+                budget: AutonomyBudgetPolicy::default(),
+            },
+            AutonomyProfile::GuidedAcquisition => Self {
+                profile,
+                capability_acquisition_mode: AutonomyOperationMode::ApprovalRequired,
+                provider_switch_mode: AutonomyOperationMode::ApprovalRequired,
+                topology_mutation_mode: AutonomyOperationMode::Deny,
+                requires_kernel_binding: true,
+                budget: AutonomyBudgetPolicy {
+                    max_capability_acquisitions_per_turn: 1,
+                    max_provider_switches_per_turn: 1,
+                    max_topology_mutations_per_turn: 0,
+                },
+            },
+            AutonomyProfile::BoundedAutonomous => Self {
+                profile,
+                capability_acquisition_mode: AutonomyOperationMode::Allow,
+                provider_switch_mode: AutonomyOperationMode::ApprovalRequired,
+                topology_mutation_mode: AutonomyOperationMode::Deny,
+                requires_kernel_binding: true,
+                budget: AutonomyBudgetPolicy {
+                    max_capability_acquisitions_per_turn: 2,
+                    max_provider_switches_per_turn: 1,
+                    max_topology_mutations_per_turn: 0,
+                },
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebFetchRuntimePolicy {
     pub enabled: bool,
@@ -314,6 +401,7 @@ pub struct ToolRuntimeConfig {
     pub browser_companion: BrowserCompanionRuntimePolicy,
     pub web_fetch: WebFetchRuntimePolicy,
     pub web_search: WebSearchRuntimePolicy,
+    pub autonomy_profile: AutonomyProfile,
     pub external_skills: ExternalSkillsRuntimePolicy,
     pub tool_execution: ToolExecutionConfig,
     #[cfg(feature = "feishu-integration")]
@@ -340,6 +428,7 @@ impl Default for ToolRuntimeConfig {
             browser_companion: BrowserCompanionRuntimePolicy::default(),
             web_fetch: WebFetchRuntimePolicy::default(),
             web_search: WebSearchRuntimePolicy::default(),
+            autonomy_profile: AutonomyProfile::default(),
             external_skills: ExternalSkillsRuntimePolicy::default(),
             tool_execution: ToolExecutionConfig::default(),
             #[cfg(feature = "feishu-integration")]
@@ -444,6 +533,7 @@ impl ToolRuntimeConfig {
                 timeout_seconds: config.tools.web_search.timeout_seconds,
                 max_results: config.tools.web_search.max_results,
             },
+            autonomy_profile: config.tools.autonomy_profile,
             external_skills: ExternalSkillsRuntimePolicy {
                 enabled: config.external_skills.enabled,
                 require_download_approval: config.external_skills.require_download_approval,
@@ -571,6 +661,10 @@ impl ToolRuntimeConfig {
         let web_search_max_results = parse_env_usize("LOONGCLAW_WEB_SEARCH_MAX_RESULTS")
             .map(|count| count.clamp(1, 10))
             .unwrap_or(crate::config::DEFAULT_WEB_SEARCH_MAX_RESULTS);
+        let autonomy_profile = parse_env_string("LOONGCLAW_AUTONOMY_PROFILE")
+            .as_deref()
+            .and_then(crate::config::parse_autonomy_profile)
+            .unwrap_or_default();
         let enabled = parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_ENABLED").unwrap_or(false);
         let require_download_approval =
             parse_env_bool("LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL").unwrap_or(true);
@@ -642,6 +736,7 @@ impl ToolRuntimeConfig {
                 timeout_seconds: web_search_timeout_seconds,
                 max_results: web_search_max_results,
             },
+            autonomy_profile,
             tool_execution,
             ..Self::default()
         }
@@ -854,6 +949,11 @@ impl ToolRuntimeConfig {
     #[must_use]
     pub fn browser_companion_execution_security_tier(&self) -> ExecutionSecurityTier {
         self.browser_companion.execution_security_tier()
+    }
+
+    #[must_use]
+    pub fn autonomy_policy_snapshot(&self) -> AutonomyPolicySnapshot {
+        AutonomyPolicySnapshot::from_profile(self.autonomy_profile)
     }
 }
 
@@ -1100,6 +1200,7 @@ mod tests {
             "LOONGCLAW_WEB_SEARCH_PROVIDER",
             "LOONGCLAW_WEB_SEARCH_TIMEOUT_SECONDS",
             "LOONGCLAW_WEB_SEARCH_MAX_RESULTS",
+            "LOONGCLAW_AUTONOMY_PROFILE",
             "BRAVE_API_KEY",
             "TAVILY_API_KEY",
             "PERPLEXITY_API_KEY",
@@ -1179,6 +1280,94 @@ mod tests {
         assert!(config.external_skills.blocked_domains.is_empty());
         assert!(config.external_skills.install_root.is_none());
         assert!(!config.external_skills.auto_expose_installed);
+    }
+
+    #[test]
+    fn autonomy_profile_runtime_config_defaults_to_discovery_only() {
+        let config = ToolRuntimeConfig::default();
+        let snapshot = config.autonomy_policy_snapshot();
+
+        assert_eq!(config.autonomy_profile, AutonomyProfile::DiscoveryOnly);
+        assert_eq!(snapshot.profile, AutonomyProfile::DiscoveryOnly);
+        assert_eq!(
+            snapshot.capability_acquisition_mode,
+            AutonomyOperationMode::Deny
+        );
+        assert_eq!(snapshot.provider_switch_mode, AutonomyOperationMode::Deny);
+        assert_eq!(snapshot.topology_mutation_mode, AutonomyOperationMode::Deny);
+        assert!(!snapshot.requires_kernel_binding);
+        assert_eq!(snapshot.budget.max_capability_acquisitions_per_turn, 0);
+        assert_eq!(snapshot.budget.max_provider_switches_per_turn, 0);
+        assert_eq!(snapshot.budget.max_topology_mutations_per_turn, 0);
+        assert_eq!(AutonomyProfile::DiscoveryOnly.as_str(), "discovery_only");
+        assert_eq!(
+            AutonomyProfile::GuidedAcquisition.as_str(),
+            "guided_acquisition"
+        );
+        assert_eq!(
+            AutonomyProfile::BoundedAutonomous.as_str(),
+            "bounded_autonomous"
+        );
+    }
+
+    #[test]
+    fn autonomy_profile_runtime_config_from_loongclaw_config_uses_explicit_profile() {
+        let mut config = crate::config::LoongClawConfig::default();
+        config.tools.autonomy_profile = AutonomyProfile::GuidedAcquisition;
+
+        let runtime = ToolRuntimeConfig::from_loongclaw_config(&config, None);
+        let snapshot = runtime.autonomy_policy_snapshot();
+
+        assert_eq!(runtime.autonomy_profile, AutonomyProfile::GuidedAcquisition);
+        assert_eq!(
+            snapshot.capability_acquisition_mode,
+            AutonomyOperationMode::ApprovalRequired
+        );
+        assert_eq!(
+            snapshot.provider_switch_mode,
+            AutonomyOperationMode::ApprovalRequired
+        );
+        assert_eq!(snapshot.topology_mutation_mode, AutonomyOperationMode::Deny);
+        assert!(snapshot.requires_kernel_binding);
+        assert_eq!(snapshot.budget.max_capability_acquisitions_per_turn, 1);
+        assert_eq!(snapshot.budget.max_provider_switches_per_turn, 1);
+        assert_eq!(snapshot.budget.max_topology_mutations_per_turn, 0);
+    }
+
+    #[test]
+    fn autonomy_profile_runtime_config_compiles_bounded_autonomous_snapshot() {
+        let mut config = ToolRuntimeConfig::default();
+        config.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+
+        let snapshot = config.autonomy_policy_snapshot();
+
+        assert_eq!(snapshot.profile, AutonomyProfile::BoundedAutonomous);
+        assert_eq!(
+            snapshot.capability_acquisition_mode,
+            AutonomyOperationMode::Allow
+        );
+        assert_eq!(
+            snapshot.provider_switch_mode,
+            AutonomyOperationMode::ApprovalRequired
+        );
+        assert_eq!(snapshot.topology_mutation_mode, AutonomyOperationMode::Deny);
+        assert!(snapshot.requires_kernel_binding);
+        assert_eq!(snapshot.budget.max_capability_acquisitions_per_turn, 2);
+        assert_eq!(snapshot.budget.max_provider_switches_per_turn, 1);
+        assert_eq!(snapshot.budget.max_topology_mutations_per_turn, 0);
+    }
+
+    #[test]
+    fn autonomy_profile_runtime_config_from_env_invalid_value_fails_closed() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONGCLAW_AUTONOMY_PROFILE", "chaos");
+
+        let runtime = ToolRuntimeConfig::from_env();
+        let snapshot = runtime.autonomy_policy_snapshot();
+
+        assert_eq!(runtime.autonomy_profile, AutonomyProfile::DiscoveryOnly);
+        assert_eq!(snapshot.profile, AutonomyProfile::DiscoveryOnly);
     }
 
     /// Deny starts empty so users are not forced to carry


### PR DESCRIPTION
## Summary

- Problem:
  The autonomy-policy kernel defined in `#596` / `#597` still had no runtime entry point. `product mode` and future autonomy behavior had no typed profile-to-policy compilation boundary in code, which would force later slices back into scattered conditionals.
- Why it matters:
  Later work on capability action classes, deterministic policy evaluation, channel surface support, and policy telemetry needs one stable runtime artifact to depend on. Without it, the kernel stays docs-only.
- What changed:
  Added a user-facing `AutonomyProfile` config surface, runtime parsing helpers, and an `AutonomyPolicySnapshot` / `AutonomyBudgetPolicy` compilation path on `ToolRuntimeConfig`.
- What did not change (scope boundary):
  This PR does not implement the autonomy decision engine, channel SDK policy support, or any runtime behavior widening for tool execution.

## Linked Issues

- Closes #601
- Related #596
- Related #570

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This adds a new policy-facing config and snapshot surface. The main risk is accidentally implying behavior that the runtime does not enforce yet. The implementation keeps defaults conservative and limits this slice to typed compilation only.
- Rollout / guardrails:
  Default stays `discovery_only`. Invalid env input fails closed back to the default profile. No runtime tool-permission widening is introduced in this slice.
- Rollback path:
  Revert this PR to remove the config field and runtime snapshot types.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-app tool_search_returns_coarse_fallback_for_zero_match_queries -- --test-threads=1
cargo test -p loongclaw-app autonomy_profile_runtime_config_ -- --test-threads=1
cargo test -p loongclaw-app parse_autonomy_profile_accepts_known_values -- --test-threads=1
cargo test -p loongclaw-app tool_config_parses_autonomy_profile_from_toml -- --test-threads=1
cargo fmt --all
cargo fmt --all -- --check
git diff --check
cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings

Result:
- baseline app crate build and targeted search regression passed before the new slice
- autonomy profile runtime tests passed
- autonomy profile parsing tests passed for helper parsing and TOML config ingestion
- local clippy and fmt checks passed after the follow-up lint fix commit
- diff hygiene checks passed
```

## User-visible / Operator-visible Changes

- `tools.autonomy_profile` now exists as a typed config surface with:
  - `discovery_only`
  - `guided_acquisition`
  - `bounded_autonomous`
- runtime code can now compile that profile into an explicit `AutonomyPolicySnapshot`
- invalid `LOONGCLAW_AUTONOMY_PROFILE` values fail closed to `discovery_only`

## Failure Recovery

- Fast rollback or disable path:
  Revert the commit or stop setting `tools.autonomy_profile` / `LOONGCLAW_AUTONOMY_PROFILE`.
- Observable failure symptoms reviewers should watch for:
  Any future code that starts treating the new snapshot as if it already enforces turn-time policy would be a scope violation for this PR.

## Reviewer Focus

- Confirm the new config surface is conservative and backwards-compatible.
- Check that the snapshot shape is useful for the next slices without leaking premature behavior guarantees.
- Verify the fail-closed path for invalid env profile values and the TOML parsing path for explicit profile selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added autonomy profile configuration option for tools with three operation modes (deny, approval required, allow)
  * Added environment variable support for autonomy profile configuration
  * Added budget policies for autonomous operations to control per-turn resource limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->