### PR TITLE
Improve architecture drift hotspot governance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "lettre",
+ "libc",
  "loongclaw-contracts",
  "loongclaw-kernel",
  "prost",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -85,6 +85,7 @@ regex.workspace = true
 prost = { version = "0.14", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"], optional = true }
+libc = "0.2"
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -598,7 +598,10 @@ async fn run_concurrent_cli_host_loop(
             .map_err(|error| format!("flush stdout failed: {error}"))?;
 
         let next_line = tokio::select! {
-            _ = shutdown.wait() => None,
+            _ = shutdown.wait() => {
+                println!();
+                None
+            },
             line = stdin_reader.next_line() => Some(line?),
         };
 

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -11,7 +11,6 @@ use std::sync::{
 
 #[cfg(feature = "memory-sqlite")]
 use loongclaw_contracts::Capability;
-use tokio::io::{self as tokio_io, AsyncBufReadExt, BufReader};
 use tokio::sync::Notify;
 
 use crate::CliResult;
@@ -20,6 +19,10 @@ use crate::acp::{
     resolve_acp_backend_selection,
 };
 use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
+
+mod cli_input;
+
+use self::cli_input::ConcurrentCliInputReader;
 
 use super::config::{self, ConversationConfig, LoongClawConfig};
 #[cfg(test)]
@@ -577,9 +580,18 @@ async fn run_concurrent_cli_host_loop(
     options: &CliChatOptions,
     shutdown: &ConcurrentCliShutdown,
 ) -> CliResult<()> {
-    let mut stdin_lines = BufReader::new(tokio_io::stdin()).lines();
+    if shutdown.is_requested() {
+        println!("bye.");
+        return Ok(());
+    }
+
+    let mut stdin_reader = ConcurrentCliInputReader::new()?;
 
     loop {
+        if shutdown.is_requested() {
+            break;
+        }
+
         print!("you> ");
         io::stdout()
             .flush()
@@ -587,9 +599,7 @@ async fn run_concurrent_cli_host_loop(
 
         let next_line = tokio::select! {
             _ = shutdown.wait() => None,
-            line = stdin_lines.next_line() => Some(
-                line.map_err(|error| format!("read stdin failed: {error}"))?
-            ),
+            line = stdin_reader.next_line() => Some(line?),
         };
 
         let Some(line) = next_line else {

--- a/crates/app/src/chat/cli_input.rs
+++ b/crates/app/src/chat/cli_input.rs
@@ -51,26 +51,107 @@ fn normalize_cli_input_line_bytes(mut bytes: Vec<u8>) -> Vec<u8> {
 }
 
 #[cfg(unix)]
+enum UnixCliInputSource {
+    Pollable(AsyncFd<std::fs::File>),
+    Blocking(std::fs::File),
+}
+
+#[cfg(unix)]
+fn open_unix_stdin_file() -> CliResult<std::fs::File> {
+    let mut open_options = OpenOptions::new();
+    open_options.read(true);
+    open_options.custom_flags(libc::O_NONBLOCK);
+
+    let stdin_file = open_options
+        .open("/dev/stdin")
+        .map_err(|error| format!("open stdin failed: {error}"))?;
+
+    Ok(stdin_file)
+}
+
+#[cfg(unix)]
+fn build_unix_cli_input_source(stdin_file: std::fs::File) -> CliResult<UnixCliInputSource> {
+    let stdin_metadata = stdin_file
+        .metadata()
+        .map_err(|error| format!("inspect stdin failed: {error}"))?;
+    let stdin_file_type = stdin_metadata.file_type();
+
+    if stdin_file_type.is_file() {
+        return Ok(UnixCliInputSource::Blocking(stdin_file));
+    }
+
+    let pollable_stdin = AsyncFd::new(stdin_file)
+        .map_err(|error| format!("configure stdin polling failed: {error}"))?;
+
+    Ok(UnixCliInputSource::Pollable(pollable_stdin))
+}
+
+#[cfg(unix)]
+fn read_blocking_unix_stdin_chunk(
+    stdin_file: &mut std::fs::File,
+    chunk: &mut [u8],
+) -> CliResult<usize> {
+    let read_count = stdin_file
+        .read(chunk)
+        .map_err(|error| format!("read stdin failed: {error}"))?;
+
+    Ok(read_count)
+}
+
+#[cfg(unix)]
+async fn read_pollable_unix_stdin_chunk(
+    stdin_file: &AsyncFd<std::fs::File>,
+    chunk: &mut [u8],
+) -> CliResult<usize> {
+    loop {
+        let mut readiness_guard = stdin_file
+            .readable()
+            .await
+            .map_err(|error| format!("wait for stdin readiness failed: {error}"))?;
+        let read_result = readiness_guard.try_io(|inner| inner.get_ref().read(chunk));
+        let read_count = match read_result {
+            Ok(result) => result.map_err(|error| format!("read stdin failed: {error}"))?,
+            Err(_would_block) => continue,
+        };
+
+        return Ok(read_count);
+    }
+}
+
+#[cfg(unix)]
+async fn read_unix_stdin_chunk(
+    stdin_source: &mut UnixCliInputSource,
+    chunk: &mut [u8],
+) -> CliResult<usize> {
+    match stdin_source {
+        UnixCliInputSource::Pollable(stdin_file) => {
+            read_pollable_unix_stdin_chunk(stdin_file, chunk).await
+        }
+        UnixCliInputSource::Blocking(stdin_file) => {
+            read_blocking_unix_stdin_chunk(stdin_file, chunk)
+        }
+    }
+}
+
+#[cfg(unix)]
 pub(super) struct ConcurrentCliInputReader {
-    stdin_file: AsyncFd<std::fs::File>,
+    stdin_source: UnixCliInputSource,
     buffer: Vec<u8>,
 }
 
 #[cfg(unix)]
 impl ConcurrentCliInputReader {
     pub(super) fn new() -> CliResult<Self> {
-        let mut open_options = OpenOptions::new();
-        open_options.read(true);
-        open_options.custom_flags(libc::O_NONBLOCK);
+        let stdin_file = open_unix_stdin_file()?;
 
-        let stdin_file = open_options
-            .open("/dev/stdin")
-            .map_err(|error| format!("open stdin failed: {error}"))?;
-        let stdin_file = AsyncFd::new(stdin_file)
-            .map_err(|error| format!("configure stdin polling failed: {error}"))?;
+        Self::from_unix_file(stdin_file)
+    }
+
+    fn from_unix_file(stdin_file: std::fs::File) -> CliResult<Self> {
+        let stdin_source = build_unix_cli_input_source(stdin_file)?;
 
         Ok(Self {
-            stdin_file,
+            stdin_source,
             buffer: Vec::new(),
         })
     }
@@ -82,17 +163,8 @@ impl ConcurrentCliInputReader {
                 return Ok(buffered_line);
             }
 
-            let mut readiness_guard = self
-                .stdin_file
-                .readable()
-                .await
-                .map_err(|error| format!("wait for stdin readiness failed: {error}"))?;
             let mut chunk = [0_u8; 1024];
-            let read_result = readiness_guard.try_io(|inner| inner.get_ref().read(&mut chunk));
-            let read_count = match read_result {
-                Ok(result) => result.map_err(|error| format!("read stdin failed: {error}"))?,
-                Err(_would_block) => continue,
-            };
+            let read_count = read_unix_stdin_chunk(&mut self.stdin_source, &mut chunk).await?;
 
             if read_count == 0 {
                 return finalize_cli_input_buffer(&mut self.buffer);
@@ -130,6 +202,11 @@ impl ConcurrentCliInputReader {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::io::Write;
+
+    #[cfg(unix)]
+    use super::ConcurrentCliInputReader;
     use super::{extract_cli_input_line_from_buffer, finalize_cli_input_buffer};
 
     #[test]
@@ -161,5 +238,33 @@ mod tests {
 
         assert!(line.is_none());
         assert!(buffer.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn concurrent_cli_input_reader_reads_regular_file_input() {
+        let mut temp_file = tempfile::NamedTempFile::new().expect("temp file should exist");
+        writeln!(temp_file, "hello world").expect("first line should write");
+        write!(temp_file, "tail fragment").expect("tail line should write");
+        temp_file.flush().expect("temp file should flush");
+
+        let stdin_file = temp_file.reopen().expect("temp file should reopen");
+        let mut reader =
+            ConcurrentCliInputReader::from_unix_file(stdin_file).expect("reader should open");
+        let first_line = reader
+            .next_line()
+            .await
+            .expect("first read should succeed")
+            .expect("first line should exist");
+        let second_line = reader
+            .next_line()
+            .await
+            .expect("second read should succeed")
+            .expect("second line should exist");
+        let end_of_input = reader.next_line().await.expect("eof read should succeed");
+
+        assert_eq!(first_line, "hello world");
+        assert_eq!(second_line, "tail fragment");
+        assert!(end_of_input.is_none());
     }
 }

--- a/crates/app/src/chat/cli_input.rs
+++ b/crates/app/src/chat/cli_input.rs
@@ -1,0 +1,165 @@
+use std::fs::OpenOptions;
+use std::io::Read;
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+#[cfg(unix)]
+use tokio::io::unix::AsyncFd;
+#[cfg(not(unix))]
+use tokio::io::{self as tokio_io, AsyncBufReadExt, BufReader};
+
+use crate::CliResult;
+
+pub(super) fn extract_cli_input_line_from_buffer(
+    buffer: &mut Vec<u8>,
+) -> CliResult<Option<String>> {
+    let newline_index = match buffer.iter().position(|byte| *byte == b'\n') {
+        Some(index) => index,
+        None => return Ok(None),
+    };
+    let drained_bytes: Vec<u8> = buffer.drain(..=newline_index).collect();
+    let normalized_bytes = normalize_cli_input_line_bytes(drained_bytes);
+    let line = String::from_utf8(normalized_bytes)
+        .map_err(|error| format!("read stdin failed: {error}"))?;
+
+    Ok(Some(line))
+}
+
+pub(super) fn finalize_cli_input_buffer(buffer: &mut Vec<u8>) -> CliResult<Option<String>> {
+    if buffer.is_empty() {
+        return Ok(None);
+    }
+
+    let remaining_bytes = std::mem::take(buffer);
+    let normalized_bytes = normalize_cli_input_line_bytes(remaining_bytes);
+    let line = String::from_utf8(normalized_bytes)
+        .map_err(|error| format!("read stdin failed: {error}"))?;
+
+    Ok(Some(line))
+}
+
+fn normalize_cli_input_line_bytes(mut bytes: Vec<u8>) -> Vec<u8> {
+    if bytes.last() == Some(&b'\n') {
+        bytes.pop();
+    }
+    if bytes.last() == Some(&b'\r') {
+        bytes.pop();
+    }
+
+    bytes
+}
+
+#[cfg(unix)]
+pub(super) struct ConcurrentCliInputReader {
+    stdin_file: AsyncFd<std::fs::File>,
+    buffer: Vec<u8>,
+}
+
+#[cfg(unix)]
+impl ConcurrentCliInputReader {
+    pub(super) fn new() -> CliResult<Self> {
+        let mut open_options = OpenOptions::new();
+        open_options.read(true);
+        open_options.custom_flags(libc::O_NONBLOCK);
+
+        let stdin_file = open_options
+            .open("/dev/stdin")
+            .map_err(|error| format!("open stdin failed: {error}"))?;
+        let stdin_file = AsyncFd::new(stdin_file)
+            .map_err(|error| format!("configure stdin polling failed: {error}"))?;
+
+        Ok(Self {
+            stdin_file,
+            buffer: Vec::new(),
+        })
+    }
+
+    pub(super) async fn next_line(&mut self) -> CliResult<Option<String>> {
+        loop {
+            let buffered_line = extract_cli_input_line_from_buffer(&mut self.buffer)?;
+            if buffered_line.is_some() {
+                return Ok(buffered_line);
+            }
+
+            let mut readiness_guard = self
+                .stdin_file
+                .readable()
+                .await
+                .map_err(|error| format!("wait for stdin readiness failed: {error}"))?;
+            let mut chunk = [0_u8; 1024];
+            let read_result = readiness_guard.try_io(|inner| inner.get_ref().read(&mut chunk));
+            let read_count = match read_result {
+                Ok(result) => result.map_err(|error| format!("read stdin failed: {error}"))?,
+                Err(_would_block) => continue,
+            };
+
+            if read_count == 0 {
+                return finalize_cli_input_buffer(&mut self.buffer);
+            }
+
+            let chunk_slice = chunk
+                .get(..read_count)
+                .ok_or_else(|| "read stdin failed: invalid chunk length".to_owned())?;
+            self.buffer.extend_from_slice(chunk_slice);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+pub(super) struct ConcurrentCliInputReader {
+    stdin_lines: tokio_io::Lines<BufReader<tokio_io::Stdin>>,
+}
+
+#[cfg(not(unix))]
+impl ConcurrentCliInputReader {
+    pub(super) fn new() -> CliResult<Self> {
+        let stdin_reader = BufReader::new(tokio_io::stdin());
+        let stdin_lines = stdin_reader.lines();
+
+        Ok(Self { stdin_lines })
+    }
+
+    pub(super) async fn next_line(&mut self) -> CliResult<Option<String>> {
+        self.stdin_lines
+            .next_line()
+            .await
+            .map_err(|error| format!("read stdin failed: {error}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_cli_input_line_from_buffer, finalize_cli_input_buffer};
+
+    #[test]
+    fn extract_cli_input_line_from_buffer_strips_crlf() {
+        let mut buffer = b"hello world\r\nnext".to_vec();
+        let line = extract_cli_input_line_from_buffer(&mut buffer)
+            .expect("buffered line should decode")
+            .expect("buffered line should exist");
+
+        assert_eq!(line, "hello world");
+        assert_eq!(buffer, b"next");
+    }
+
+    #[test]
+    fn finalize_cli_input_buffer_returns_partial_line_without_newline() {
+        let mut buffer = b"tail fragment".to_vec();
+        let line = finalize_cli_input_buffer(&mut buffer)
+            .expect("tail line should decode")
+            .expect("tail line should exist");
+
+        assert_eq!(line, "tail fragment");
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn finalize_cli_input_buffer_returns_none_for_empty_buffer() {
+        let mut buffer = Vec::new();
+        let line = finalize_cli_input_buffer(&mut buffer).expect("empty buffer should not fail");
+
+        assert!(line.is_none());
+        assert!(buffer.is_empty());
+    }
+}

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -15,6 +15,7 @@ mod session_address;
 mod session_history;
 mod subagent;
 mod turn_budget;
+mod turn_checkpoint;
 mod turn_coordinator;
 pub mod turn_engine;
 mod turn_loop;
@@ -80,13 +81,13 @@ pub use subagent::{
     ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
 };
 pub use turn_budget::SafeLaneFailureRouteReason;
-pub use turn_coordinator::ConversationTurnCoordinator;
-pub(crate) use turn_coordinator::{TurnCheckpointDiagnostics, TurnCheckpointRecoveryAssessment};
-pub use turn_coordinator::{
+pub(crate) use turn_checkpoint::{TurnCheckpointDiagnostics, TurnCheckpointRecoveryAssessment};
+pub use turn_checkpoint::{
     TurnCheckpointTailRepairOutcome, TurnCheckpointTailRepairReason,
     TurnCheckpointTailRepairRuntimeProbe, TurnCheckpointTailRepairSource,
     TurnCheckpointTailRepairStatus,
 };
+pub use turn_coordinator::ConversationTurnCoordinator;
 pub use turn_engine::{
     AppToolDispatcher, DefaultAppToolDispatcher, NoopAppToolDispatcher, ProviderTurn, ToolDecision,
     ToolIntent, ToolOutcome, TurnEngine, TurnFailure, TurnFailureKind, TurnResult,

--- a/crates/app/src/conversation/turn_checkpoint.rs
+++ b/crates/app/src/conversation/turn_checkpoint.rs
@@ -555,13 +555,9 @@ fn format_turn_checkpoint_progress_status(status: TurnCheckpointProgressStatus) 
 fn format_analytics_turn_checkpoint_progress_status(
     status: AnalyticsTurnCheckpointProgressStatus,
 ) -> &'static str {
-    match status {
-        AnalyticsTurnCheckpointProgressStatus::Pending => "pending",
-        AnalyticsTurnCheckpointProgressStatus::Skipped => "skipped",
-        AnalyticsTurnCheckpointProgressStatus::Completed => "completed",
-        AnalyticsTurnCheckpointProgressStatus::Failed => "failed",
-        AnalyticsTurnCheckpointProgressStatus::FailedOpen => "failed_open",
-    }
+    let canonical_status = TurnCheckpointProgressStatus::from(status);
+
+    format_turn_checkpoint_progress_status(canonical_status)
 }
 
 pub(super) async fn persist_turn_checkpoint_event<R: ConversationRuntime + ?Sized>(
@@ -612,7 +608,7 @@ pub(super) async fn persist_turn_checkpoint_event_value<R: ConversationRuntime +
     .await
 }
 
-fn recover_latest_turn_pair(messages: &[Value]) -> Option<(String, String)> {
+fn recover_latest_turn_pair(messages: &[Value]) -> Option<(usize, String, String)> {
     let assistant_index = messages.iter().rposition(|message| {
         message.get("role").and_then(Value::as_str) == Some("assistant")
             && message.get("content").and_then(Value::as_str).is_some()
@@ -636,7 +632,7 @@ fn recover_latest_turn_pair(messages: &[Value]) -> Option<(String, String)> {
                 .and_then(Value::as_str)
         })
         .map(ToOwned::to_owned)?;
-    Some((user_input, assistant_reply))
+    Some((assistant_index, user_input, assistant_reply))
 }
 
 fn load_turn_checkpoint_identity(checkpoint: &Value) -> Option<TurnCheckpointIdentity> {
@@ -691,10 +687,17 @@ impl TurnCheckpointRepairResumeInput {
     ) -> Result<Self, TurnCheckpointTailRepairReason> {
         let repair_preparation = load_turn_checkpoint_repair_preparation(checkpoint)?;
         let messages = assembled.messages;
-        let Some((user_input, assistant_reply)) = recover_latest_turn_pair(&messages) else {
+        let estimated_tokens = assembled.estimated_tokens;
+        let Some((assistant_index, user_input, assistant_reply)) =
+            recover_latest_turn_pair(&messages)
+        else {
             return Err(TurnCheckpointTailRepairReason::VisibleTurnPairMissing);
         };
-        let Some((_, pre_assistant_messages)) = messages.split_last() else {
+        let assistant_tail_index = assistant_index + 1;
+        if assistant_tail_index != messages.len() {
+            return Err(TurnCheckpointTailRepairReason::CheckpointStateRequiresManualInspection);
+        }
+        let Some(pre_assistant_messages) = messages.get(..assistant_index) else {
             return Err(TurnCheckpointTailRepairReason::VisibleTurnPairMissing);
         };
         let Some(identity) = load_turn_checkpoint_identity(checkpoint) else {
@@ -703,18 +706,21 @@ impl TurnCheckpointRepairResumeInput {
         if !identity.matches_turn(&user_input, &assistant_reply) {
             return Err(TurnCheckpointTailRepairReason::CheckpointIdentityMismatch);
         }
-        if let Some(expected_context_message_count) = repair_preparation
+        let expected_context_message_count = repair_preparation
             .as_ref()
-            .and_then(|preparation| preparation.context_message_count)
+            .and_then(|preparation| preparation.context_message_count);
+        if let Some(expected_context_message_count) = expected_context_message_count
             && pre_assistant_messages.len() != expected_context_message_count
         {
             return Err(TurnCheckpointTailRepairReason::CheckpointPreparationMismatch);
         }
-        if let Some(expected_context_fingerprint_sha256) = repair_preparation
+        let expected_context_fingerprint_sha256 = repair_preparation
             .as_ref()
-            .and_then(|preparation| preparation.context_fingerprint_sha256.as_deref())
-            && checkpoint_context_fingerprint_sha256(pre_assistant_messages)
-                != expected_context_fingerprint_sha256
+            .and_then(|preparation| preparation.context_fingerprint_sha256.as_deref());
+        let actual_context_fingerprint_sha256 =
+            checkpoint_context_fingerprint_sha256(pre_assistant_messages);
+        if let Some(expected_context_fingerprint_sha256) = expected_context_fingerprint_sha256
+            && actual_context_fingerprint_sha256 != expected_context_fingerprint_sha256
         {
             return Err(TurnCheckpointTailRepairReason::CheckpointPreparationFingerprintMismatch);
         }
@@ -725,7 +731,7 @@ impl TurnCheckpointRepairResumeInput {
             messages,
             estimated_tokens: repair_preparation
                 .and_then(|preparation| preparation.estimated_tokens)
-                .or(assembled.estimated_tokens),
+                .or(estimated_tokens),
         })
     }
 
@@ -767,13 +773,165 @@ pub(super) enum TurnCheckpointTailRuntimeEligibility {
 pub(super) fn restore_analytics_turn_checkpoint_progress_status(
     status: AnalyticsTurnCheckpointProgressStatus,
 ) -> TurnCheckpointProgressStatus {
-    match status {
-        AnalyticsTurnCheckpointProgressStatus::Pending => TurnCheckpointProgressStatus::Pending,
-        AnalyticsTurnCheckpointProgressStatus::Skipped => TurnCheckpointProgressStatus::Skipped,
-        AnalyticsTurnCheckpointProgressStatus::Completed => TurnCheckpointProgressStatus::Completed,
-        AnalyticsTurnCheckpointProgressStatus::Failed => TurnCheckpointProgressStatus::Failed,
-        AnalyticsTurnCheckpointProgressStatus::FailedOpen => {
-            TurnCheckpointProgressStatus::FailedOpen
+    TurnCheckpointProgressStatus::from(status)
+}
+
+impl From<AnalyticsTurnCheckpointProgressStatus> for TurnCheckpointProgressStatus {
+    fn from(status: AnalyticsTurnCheckpointProgressStatus) -> Self {
+        match status {
+            AnalyticsTurnCheckpointProgressStatus::Pending => TurnCheckpointProgressStatus::Pending,
+            AnalyticsTurnCheckpointProgressStatus::Skipped => TurnCheckpointProgressStatus::Skipped,
+            AnalyticsTurnCheckpointProgressStatus::Completed => {
+                TurnCheckpointProgressStatus::Completed
+            }
+            AnalyticsTurnCheckpointProgressStatus::Failed => TurnCheckpointProgressStatus::Failed,
+            AnalyticsTurnCheckpointProgressStatus::FailedOpen => {
+                TurnCheckpointProgressStatus::FailedOpen
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::{
+        TurnCheckpointIdentity, TurnCheckpointRepairResumeInput, TurnCheckpointTailRepairReason,
+        checkpoint_context_fingerprint_sha256,
+    };
+    use crate::conversation::context_engine::AssembledConversationContext;
+
+    fn checkpoint_with_preparation(
+        user_input: &str,
+        assistant_reply: &str,
+        pre_assistant_messages: &[Value],
+        estimated_tokens: Option<usize>,
+    ) -> Value {
+        let identity = TurnCheckpointIdentity::from_turn(user_input, assistant_reply);
+        let identity = serde_json::to_value(identity).expect("identity should serialize");
+        let context_message_count = pre_assistant_messages.len();
+        let context_fingerprint_sha256 =
+            checkpoint_context_fingerprint_sha256(pre_assistant_messages);
+
+        json!({
+            "identity": identity,
+            "preparation": {
+                "context_message_count": context_message_count,
+                "context_fingerprint_sha256": context_fingerprint_sha256,
+                "estimated_tokens": estimated_tokens,
+            }
+        })
+    }
+
+    #[test]
+    fn repair_resume_input_accepts_matching_tail_with_preparation() {
+        let pre_assistant_messages = vec![
+            json!({
+                "role": "system",
+                "content": "sys"
+            }),
+            json!({
+                "role": "user",
+                "content": "hello"
+            }),
+        ];
+        let mut messages = pre_assistant_messages.clone();
+        messages.push(json!({
+            "role": "assistant",
+            "content": "world"
+        }));
+        let checkpoint =
+            checkpoint_with_preparation("hello", "world", &pre_assistant_messages, Some(7));
+        let assembled = AssembledConversationContext {
+            messages,
+            artifacts: Vec::new(),
+            estimated_tokens: Some(9),
+            system_prompt_addition: None,
+        };
+        let resume_input =
+            TurnCheckpointRepairResumeInput::from_assembled_context(assembled, &checkpoint)
+                .expect("matching checkpoint should resume");
+
+        assert_eq!(resume_input.user_input(), "hello");
+        assert_eq!(resume_input.assistant_reply(), "world");
+        assert_eq!(resume_input.estimated_tokens(), Some(7));
+    }
+
+    #[test]
+    fn repair_resume_input_accepts_matching_tail_without_preparation() {
+        let messages = vec![
+            json!({
+                "role": "system",
+                "content": "sys"
+            }),
+            json!({
+                "role": "user",
+                "content": "hello"
+            }),
+            json!({
+                "role": "assistant",
+                "content": "world"
+            }),
+        ];
+        let identity = TurnCheckpointIdentity::from_turn("hello", "world");
+        let identity = serde_json::to_value(identity).expect("identity should serialize");
+        let checkpoint = json!({
+            "identity": identity,
+        });
+        let assembled = AssembledConversationContext {
+            messages,
+            artifacts: Vec::new(),
+            estimated_tokens: Some(9),
+            system_prompt_addition: None,
+        };
+        let resume_input =
+            TurnCheckpointRepairResumeInput::from_assembled_context(assembled, &checkpoint)
+                .expect("legacy checkpoints without preparation should remain repairable");
+
+        assert_eq!(resume_input.user_input(), "hello");
+        assert_eq!(resume_input.assistant_reply(), "world");
+        assert_eq!(resume_input.estimated_tokens(), Some(9));
+    }
+
+    #[test]
+    fn repair_resume_input_requires_assistant_to_be_the_tail_message() {
+        let messages = vec![
+            json!({
+                "role": "system",
+                "content": "sys"
+            }),
+            json!({
+                "role": "user",
+                "content": "hello"
+            }),
+        ];
+        let mut messages = messages;
+        messages.push(json!({
+            "role": "assistant",
+            "content": "world"
+        }));
+        messages.push(json!({
+            "role": "tool",
+            "content": "trailing"
+        }));
+        let identity = TurnCheckpointIdentity::from_turn("hello", "world");
+        let identity = serde_json::to_value(identity).expect("identity should serialize");
+        let checkpoint = json!({
+            "identity": identity,
+        });
+        let assembled = AssembledConversationContext {
+            messages,
+            artifacts: Vec::new(),
+            estimated_tokens: Some(9),
+            system_prompt_addition: None,
+        };
+        let error = TurnCheckpointRepairResumeInput::from_assembled_context(assembled, &checkpoint)
+            .expect_err("trailing messages should require manual inspection");
+
+        assert_eq!(
+            error,
+            TurnCheckpointTailRepairReason::CheckpointStateRequiresManualInspection
+        );
     }
 }

--- a/crates/app/src/conversation/turn_checkpoint.rs
+++ b/crates/app/src/conversation/turn_checkpoint.rs
@@ -1,0 +1,779 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::CliResult;
+
+use super::analytics::{
+    TurnCheckpointEventSummary,
+    TurnCheckpointProgressStatus as AnalyticsTurnCheckpointProgressStatus,
+    TurnCheckpointRecoveryAction, TurnCheckpointRepairManualReason, TurnCheckpointRepairPlan,
+    TurnCheckpointSessionState, build_turn_checkpoint_repair_plan,
+};
+use super::context_engine::AssembledConversationContext;
+use super::lane_arbiter::ExecutionLane;
+use super::persistence::persist_conversation_event;
+use super::runtime::ConversationRuntime;
+use super::runtime_binding::ConversationRuntimeBinding;
+use super::turn_coordinator::SafeLaneFailureRoute;
+use super::turn_engine::TurnResult;
+use super::turn_shared::{
+    ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind, ToolDrivenReplyPhase,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnCheckpointTailRepairStatus {
+    NoCheckpoint,
+    NotNeeded,
+    Repaired,
+    ManualRequired,
+}
+
+impl TurnCheckpointTailRepairStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoCheckpoint => "no_checkpoint",
+            Self::NotNeeded => "not_needed",
+            Self::Repaired => "repaired",
+            Self::ManualRequired => "manual_required",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnCheckpointTailRepairReason {
+    NoCheckpoint,
+    NotNeeded,
+    Repaired,
+    CheckpointIdentityMissing,
+    SafeLaneBackpressureTerminalRequiresManualInspection,
+    SafeLaneSessionGovernorTerminalRequiresManualInspection,
+    CheckpointPreparationMalformed,
+    CheckpointPreparationMismatch,
+    CheckpointPreparationFingerprintMismatch,
+    CheckpointStateRequiresManualInspection,
+    VisibleTurnPairMissing,
+    CheckpointIdentityMismatch,
+}
+
+impl TurnCheckpointTailRepairReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoCheckpoint => "no_checkpoint",
+            Self::NotNeeded => "not_needed",
+            Self::Repaired => "repaired",
+            Self::CheckpointIdentityMissing => "checkpoint_identity_missing",
+            Self::SafeLaneBackpressureTerminalRequiresManualInspection => {
+                "safe_lane_backpressure_terminal_requires_manual_inspection"
+            }
+            Self::SafeLaneSessionGovernorTerminalRequiresManualInspection => {
+                "safe_lane_session_governor_terminal_requires_manual_inspection"
+            }
+            Self::CheckpointPreparationMalformed => "checkpoint_preparation_malformed",
+            Self::CheckpointPreparationMismatch => "checkpoint_preparation_mismatch",
+            Self::CheckpointPreparationFingerprintMismatch => {
+                "checkpoint_preparation_fingerprint_mismatch"
+            }
+            Self::CheckpointStateRequiresManualInspection => {
+                "checkpoint_state_requires_manual_inspection"
+            }
+            Self::VisibleTurnPairMissing => "visible_turn_pair_missing",
+            Self::CheckpointIdentityMismatch => "checkpoint_identity_mismatch",
+        }
+    }
+}
+
+impl From<TurnCheckpointRepairManualReason> for TurnCheckpointTailRepairReason {
+    fn from(reason: TurnCheckpointRepairManualReason) -> Self {
+        match reason {
+            TurnCheckpointRepairManualReason::CheckpointIdentityMissing => {
+                Self::CheckpointIdentityMissing
+            }
+            TurnCheckpointRepairManualReason::SafeLaneBackpressureTerminalRequiresManualInspection => {
+                Self::SafeLaneBackpressureTerminalRequiresManualInspection
+            }
+            TurnCheckpointRepairManualReason::SafeLaneSessionGovernorTerminalRequiresManualInspection => {
+                Self::SafeLaneSessionGovernorTerminalRequiresManualInspection
+            }
+            TurnCheckpointRepairManualReason::CheckpointStateRequiresManualInspection => {
+                Self::CheckpointStateRequiresManualInspection
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnCheckpointTailRepairOutcome {
+    status: TurnCheckpointTailRepairStatus,
+    action: TurnCheckpointRecoveryAction,
+    source: Option<TurnCheckpointTailRepairSource>,
+    reason: TurnCheckpointTailRepairReason,
+    session_state: TurnCheckpointSessionState,
+    checkpoint_events: u32,
+    after_turn_status: Option<&'static str>,
+    compaction_status: Option<&'static str>,
+}
+
+impl TurnCheckpointTailRepairOutcome {
+    pub(super) fn no_checkpoint() -> Self {
+        Self {
+            status: TurnCheckpointTailRepairStatus::NoCheckpoint,
+            action: TurnCheckpointRecoveryAction::None,
+            source: None,
+            reason: TurnCheckpointTailRepairReason::NoCheckpoint,
+            session_state: TurnCheckpointSessionState::NotDurable,
+            checkpoint_events: 0,
+            after_turn_status: None,
+            compaction_status: None,
+        }
+    }
+
+    pub(crate) fn from_summary(
+        status: TurnCheckpointTailRepairStatus,
+        action: TurnCheckpointRecoveryAction,
+        source: Option<TurnCheckpointTailRepairSource>,
+        reason: TurnCheckpointTailRepairReason,
+        summary: &TurnCheckpointEventSummary,
+    ) -> Self {
+        Self {
+            status,
+            action,
+            source,
+            reason,
+            session_state: summary.session_state,
+            checkpoint_events: summary.checkpoint_events,
+            after_turn_status: summary
+                .latest_after_turn
+                .map(format_analytics_turn_checkpoint_progress_status),
+            compaction_status: summary
+                .latest_compaction
+                .map(format_analytics_turn_checkpoint_progress_status),
+        }
+    }
+
+    pub(super) fn repaired(
+        action: TurnCheckpointRecoveryAction,
+        summary: &TurnCheckpointEventSummary,
+        after_turn_status: TurnCheckpointProgressStatus,
+        compaction_status: TurnCheckpointProgressStatus,
+    ) -> Self {
+        Self {
+            status: TurnCheckpointTailRepairStatus::Repaired,
+            action,
+            source: Some(TurnCheckpointTailRepairSource::Runtime),
+            reason: TurnCheckpointTailRepairReason::Repaired,
+            session_state: summary.session_state,
+            checkpoint_events: summary.checkpoint_events,
+            after_turn_status: Some(format_turn_checkpoint_progress_status(after_turn_status)),
+            compaction_status: Some(format_turn_checkpoint_progress_status(compaction_status)),
+        }
+    }
+
+    pub fn status(&self) -> TurnCheckpointTailRepairStatus {
+        self.status
+    }
+
+    pub fn action(&self) -> TurnCheckpointRecoveryAction {
+        self.action
+    }
+
+    pub fn source(&self) -> Option<TurnCheckpointTailRepairSource> {
+        self.source
+    }
+
+    pub fn reason(&self) -> TurnCheckpointTailRepairReason {
+        self.reason
+    }
+
+    pub fn session_state(&self) -> TurnCheckpointSessionState {
+        self.session_state
+    }
+
+    pub fn checkpoint_events(&self) -> u32 {
+        self.checkpoint_events
+    }
+
+    pub fn after_turn_status(&self) -> Option<&'static str> {
+        self.after_turn_status
+    }
+
+    pub fn compaction_status(&self) -> Option<&'static str> {
+        self.compaction_status
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnCheckpointTailRepairSource {
+    Summary,
+    Runtime,
+}
+
+impl TurnCheckpointTailRepairSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Summary => "summary",
+            Self::Runtime => "runtime",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnCheckpointTailRepairRuntimeProbe {
+    action: TurnCheckpointRecoveryAction,
+    source: TurnCheckpointTailRepairSource,
+    reason: TurnCheckpointTailRepairReason,
+}
+
+impl TurnCheckpointTailRepairRuntimeProbe {
+    pub(crate) fn new(
+        action: TurnCheckpointRecoveryAction,
+        source: TurnCheckpointTailRepairSource,
+        reason: TurnCheckpointTailRepairReason,
+    ) -> Self {
+        Self {
+            action,
+            source,
+            reason,
+        }
+    }
+
+    pub fn action(&self) -> TurnCheckpointRecoveryAction {
+        self.action
+    }
+
+    pub fn source(&self) -> TurnCheckpointTailRepairSource {
+        self.source
+    }
+
+    pub fn reason(&self) -> TurnCheckpointTailRepairReason {
+        self.reason
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TurnCheckpointRecoveryAssessment {
+    action: TurnCheckpointRecoveryAction,
+    source: TurnCheckpointTailRepairSource,
+    reason: Option<TurnCheckpointTailRepairReason>,
+}
+
+impl TurnCheckpointRecoveryAssessment {
+    pub(crate) fn from_summary(summary: &TurnCheckpointEventSummary) -> Self {
+        let repair_plan = build_turn_checkpoint_repair_plan(summary);
+        let action = repair_plan.action();
+        let reason = matches!(action, TurnCheckpointRecoveryAction::InspectManually).then(|| {
+            repair_plan
+                .manual_reason()
+                .map(TurnCheckpointTailRepairReason::from)
+                .unwrap_or(TurnCheckpointTailRepairReason::CheckpointStateRequiresManualInspection)
+        });
+        Self {
+            action,
+            source: TurnCheckpointTailRepairSource::Summary,
+            reason,
+        }
+    }
+
+    pub fn action(self) -> TurnCheckpointRecoveryAction {
+        self.action
+    }
+
+    pub fn source(self) -> TurnCheckpointTailRepairSource {
+        self.source
+    }
+
+    pub fn reason(self) -> Option<TurnCheckpointTailRepairReason> {
+        self.reason
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TurnCheckpointDiagnostics {
+    summary: TurnCheckpointEventSummary,
+    recovery: TurnCheckpointRecoveryAssessment,
+    runtime_probe: Option<TurnCheckpointTailRepairRuntimeProbe>,
+}
+
+impl TurnCheckpointDiagnostics {
+    pub(crate) fn new(
+        summary: TurnCheckpointEventSummary,
+        recovery: TurnCheckpointRecoveryAssessment,
+        runtime_probe: Option<TurnCheckpointTailRepairRuntimeProbe>,
+    ) -> Self {
+        Self {
+            summary,
+            recovery,
+            runtime_probe,
+        }
+    }
+
+    pub fn summary(&self) -> &TurnCheckpointEventSummary {
+        &self.summary
+    }
+
+    pub fn recovery(&self) -> TurnCheckpointRecoveryAssessment {
+        self.recovery
+    }
+
+    pub fn runtime_probe(&self) -> Option<&TurnCheckpointTailRepairRuntimeProbe> {
+        self.runtime_probe.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct TurnCheckpointSnapshot {
+    pub(super) identity: Option<TurnCheckpointIdentity>,
+    pub(super) preparation: TurnPreparationSnapshot,
+    pub(super) request: TurnCheckpointRequest,
+    pub(super) lane: Option<TurnLaneExecutionSnapshot>,
+    pub(super) reply: Option<TurnReplyCheckpoint>,
+    pub(super) finalization: TurnFinalizationCheckpoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct TurnCheckpointIdentity {
+    pub(super) user_input_sha256: String,
+    pub(super) assistant_reply_sha256: String,
+    pub(super) user_input_chars: usize,
+    pub(super) assistant_reply_chars: usize,
+}
+
+impl TurnCheckpointIdentity {
+    pub(super) fn from_turn(user_input: &str, assistant_reply: &str) -> Self {
+        Self {
+            user_input_sha256: sha256_hex(user_input),
+            assistant_reply_sha256: sha256_hex(assistant_reply),
+            user_input_chars: user_input.chars().count(),
+            assistant_reply_chars: assistant_reply.chars().count(),
+        }
+    }
+
+    fn matches_turn(&self, user_input: &str, assistant_reply: &str) -> bool {
+        self.user_input_chars == user_input.chars().count()
+            && self.assistant_reply_chars == assistant_reply.chars().count()
+            && self.user_input_sha256 == sha256_hex(user_input)
+            && self.assistant_reply_sha256 == sha256_hex(assistant_reply)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct TurnPreparationSnapshot {
+    pub(super) lane: ExecutionLane,
+    pub(super) max_tool_steps: usize,
+    pub(super) raw_tool_output_requested: bool,
+    pub(super) context_message_count: usize,
+    pub(super) context_fingerprint_sha256: String,
+    pub(super) estimated_tokens: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(super) enum TurnCheckpointRequest {
+    Continue { tool_intents: usize },
+    FinalizeInlineProviderError,
+    ReturnError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct TurnLaneExecutionSnapshot {
+    pub(super) lane: ExecutionLane,
+    pub(super) had_tool_intents: bool,
+    pub(super) raw_tool_output_requested: bool,
+    pub(super) result_kind: TurnCheckpointResultKind,
+    pub(super) safe_lane_terminal_route: Option<SafeLaneFailureRoute>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum TurnCheckpointResultKind {
+    FinalText,
+    Streaming,
+    NeedsApproval,
+    ToolDenied,
+    ToolError,
+    ProviderError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct TurnReplyCheckpoint {
+    pub(super) decision: ReplyResolutionMode,
+    pub(super) followup_kind: Option<ToolDrivenFollowupKind>,
+}
+
+impl TurnReplyCheckpoint {
+    pub(super) fn from_phase(phase: &ToolDrivenReplyPhase) -> Self {
+        Self {
+            decision: phase.resolution_mode(),
+            followup_kind: phase.followup_kind(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(super) enum TurnFinalizationCheckpoint {
+    PersistReply {
+        persistence_mode: ReplyPersistenceMode,
+        runs_after_turn: bool,
+        attempts_context_compaction: bool,
+    },
+    ReturnError,
+}
+
+impl TurnFinalizationCheckpoint {
+    pub(super) fn persist_reply(persistence_mode: ReplyPersistenceMode) -> Self {
+        Self::PersistReply {
+            persistence_mode,
+            runs_after_turn: true,
+            attempts_context_compaction: true,
+        }
+    }
+
+    pub(super) fn persistence_mode(self) -> Option<ReplyPersistenceMode> {
+        match self {
+            Self::PersistReply {
+                persistence_mode, ..
+            } => Some(persistence_mode),
+            Self::ReturnError => None,
+        }
+    }
+
+    pub(super) fn runs_after_turn(self) -> bool {
+        match self {
+            Self::PersistReply {
+                runs_after_turn, ..
+            } => runs_after_turn,
+            Self::ReturnError => false,
+        }
+    }
+
+    pub(super) fn attempts_context_compaction(self) -> bool {
+        match self {
+            Self::PersistReply {
+                attempts_context_compaction,
+                ..
+            } => attempts_context_compaction,
+            Self::ReturnError => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum TurnCheckpointStage {
+    PostPersist,
+    Finalized,
+    FinalizationFailed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum TurnCheckpointProgressStatus {
+    Pending,
+    Skipped,
+    Completed,
+    Failed,
+    FailedOpen,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(super) struct TurnCheckpointFinalizationProgress {
+    pub(super) after_turn: TurnCheckpointProgressStatus,
+    pub(super) compaction: TurnCheckpointProgressStatus,
+}
+
+impl TurnCheckpointFinalizationProgress {
+    pub(super) fn pending(checkpoint: &TurnCheckpointSnapshot) -> Self {
+        Self {
+            after_turn: if checkpoint.finalization.runs_after_turn() {
+                TurnCheckpointProgressStatus::Pending
+            } else {
+                TurnCheckpointProgressStatus::Skipped
+            },
+            compaction: if checkpoint.finalization.attempts_context_compaction() {
+                TurnCheckpointProgressStatus::Pending
+            } else {
+                TurnCheckpointProgressStatus::Skipped
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ContextCompactionOutcome {
+    Skipped,
+    Completed,
+    FailedOpen,
+}
+
+impl ContextCompactionOutcome {
+    pub(super) fn checkpoint_status(self) -> TurnCheckpointProgressStatus {
+        match self {
+            Self::Skipped => TurnCheckpointProgressStatus::Skipped,
+            Self::Completed => TurnCheckpointProgressStatus::Completed,
+            Self::FailedOpen => TurnCheckpointProgressStatus::FailedOpen,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum TurnCheckpointFailureStep {
+    AfterTurn,
+    Compaction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct TurnCheckpointFailure {
+    pub(super) step: TurnCheckpointFailureStep,
+    pub(super) error: String,
+}
+
+pub(super) fn turn_checkpoint_result_kind(result: &TurnResult) -> TurnCheckpointResultKind {
+    match result {
+        TurnResult::FinalText(_) => TurnCheckpointResultKind::FinalText,
+        TurnResult::StreamingText(_) | TurnResult::StreamingDone(_) => {
+            TurnCheckpointResultKind::Streaming
+        }
+        TurnResult::NeedsApproval(_) => TurnCheckpointResultKind::NeedsApproval,
+        TurnResult::ToolDenied(_) => TurnCheckpointResultKind::ToolDenied,
+        TurnResult::ToolError(_) => TurnCheckpointResultKind::ToolError,
+        TurnResult::ProviderError(_) => TurnCheckpointResultKind::ProviderError,
+    }
+}
+
+fn format_turn_checkpoint_progress_status(status: TurnCheckpointProgressStatus) -> &'static str {
+    match status {
+        TurnCheckpointProgressStatus::Pending => "pending",
+        TurnCheckpointProgressStatus::Skipped => "skipped",
+        TurnCheckpointProgressStatus::Completed => "completed",
+        TurnCheckpointProgressStatus::Failed => "failed",
+        TurnCheckpointProgressStatus::FailedOpen => "failed_open",
+    }
+}
+
+fn format_analytics_turn_checkpoint_progress_status(
+    status: AnalyticsTurnCheckpointProgressStatus,
+) -> &'static str {
+    match status {
+        AnalyticsTurnCheckpointProgressStatus::Pending => "pending",
+        AnalyticsTurnCheckpointProgressStatus::Skipped => "skipped",
+        AnalyticsTurnCheckpointProgressStatus::Completed => "completed",
+        AnalyticsTurnCheckpointProgressStatus::Failed => "failed",
+        AnalyticsTurnCheckpointProgressStatus::FailedOpen => "failed_open",
+    }
+}
+
+pub(super) async fn persist_turn_checkpoint_event<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    checkpoint: &TurnCheckpointSnapshot,
+    stage: TurnCheckpointStage,
+    progress: TurnCheckpointFinalizationProgress,
+    failure: Option<TurnCheckpointFailure>,
+    binding: ConversationRuntimeBinding<'_>,
+) -> CliResult<()> {
+    let checkpoint = serde_json::to_value(checkpoint)
+        .map_err(|error| format!("serialize turn checkpoint failed: {error}"))?;
+    persist_turn_checkpoint_event_value(
+        runtime,
+        session_id,
+        &checkpoint,
+        stage,
+        progress,
+        failure,
+        binding,
+    )
+    .await
+}
+
+pub(super) async fn persist_turn_checkpoint_event_value<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    checkpoint: &Value,
+    stage: TurnCheckpointStage,
+    progress: TurnCheckpointFinalizationProgress,
+    failure: Option<TurnCheckpointFailure>,
+    binding: ConversationRuntimeBinding<'_>,
+) -> CliResult<()> {
+    persist_conversation_event(
+        runtime,
+        session_id,
+        "turn_checkpoint",
+        json!({
+            "schema_version": 1,
+            "stage": stage,
+            "checkpoint": checkpoint,
+            "finalization_progress": progress,
+            "failure": failure,
+        }),
+        binding,
+    )
+    .await
+}
+
+fn recover_latest_turn_pair(messages: &[Value]) -> Option<(String, String)> {
+    let assistant_index = messages.iter().rposition(|message| {
+        message.get("role").and_then(Value::as_str) == Some("assistant")
+            && message.get("content").and_then(Value::as_str).is_some()
+    })?;
+    let assistant_reply = messages
+        .get(assistant_index)?
+        .get("content")
+        .and_then(Value::as_str)?
+        .to_owned();
+    let user_input = messages
+        .get(..assistant_index)?
+        .iter()
+        .rposition(|message| {
+            message.get("role").and_then(Value::as_str) == Some("user")
+                && message.get("content").and_then(Value::as_str).is_some()
+        })
+        .and_then(|index| {
+            messages
+                .get(index)
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str)
+        })
+        .map(ToOwned::to_owned)?;
+    Some((user_input, assistant_reply))
+}
+
+fn load_turn_checkpoint_identity(checkpoint: &Value) -> Option<TurnCheckpointIdentity> {
+    checkpoint
+        .get("identity")
+        .cloned()
+        .and_then(|identity| serde_json::from_value(identity).ok())
+}
+
+fn sha256_hex(input: &str) -> String {
+    format!("{:x}", Sha256::digest(input.as_bytes()))
+}
+
+pub(super) fn checkpoint_context_fingerprint_sha256(messages: &[Value]) -> String {
+    let serialized = Value::Array(messages.to_vec()).to_string();
+    format!("{:x}", Sha256::digest(serialized.as_bytes()))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+struct TurnCheckpointRepairPreparation {
+    #[serde(default)]
+    context_message_count: Option<usize>,
+    #[serde(default)]
+    context_fingerprint_sha256: Option<String>,
+    #[serde(default)]
+    estimated_tokens: Option<usize>,
+}
+
+fn load_turn_checkpoint_repair_preparation(
+    checkpoint: &Value,
+) -> Result<Option<TurnCheckpointRepairPreparation>, TurnCheckpointTailRepairReason> {
+    let Some(preparation) = checkpoint.get("preparation") else {
+        return Ok(None);
+    };
+    serde_json::from_value(preparation.clone())
+        .map(Some)
+        .map_err(|_error| TurnCheckpointTailRepairReason::CheckpointPreparationMalformed)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TurnCheckpointRepairResumeInput {
+    user_input: String,
+    assistant_reply: String,
+    messages: Vec<Value>,
+    estimated_tokens: Option<usize>,
+}
+
+impl TurnCheckpointRepairResumeInput {
+    pub(super) fn from_assembled_context(
+        assembled: AssembledConversationContext,
+        checkpoint: &Value,
+    ) -> Result<Self, TurnCheckpointTailRepairReason> {
+        let repair_preparation = load_turn_checkpoint_repair_preparation(checkpoint)?;
+        let messages = assembled.messages;
+        let Some((user_input, assistant_reply)) = recover_latest_turn_pair(&messages) else {
+            return Err(TurnCheckpointTailRepairReason::VisibleTurnPairMissing);
+        };
+        let Some((_, pre_assistant_messages)) = messages.split_last() else {
+            return Err(TurnCheckpointTailRepairReason::VisibleTurnPairMissing);
+        };
+        let Some(identity) = load_turn_checkpoint_identity(checkpoint) else {
+            return Err(TurnCheckpointTailRepairReason::CheckpointIdentityMissing);
+        };
+        if !identity.matches_turn(&user_input, &assistant_reply) {
+            return Err(TurnCheckpointTailRepairReason::CheckpointIdentityMismatch);
+        }
+        if let Some(expected_context_message_count) = repair_preparation
+            .as_ref()
+            .and_then(|preparation| preparation.context_message_count)
+            && pre_assistant_messages.len() != expected_context_message_count
+        {
+            return Err(TurnCheckpointTailRepairReason::CheckpointPreparationMismatch);
+        }
+        if let Some(expected_context_fingerprint_sha256) = repair_preparation
+            .as_ref()
+            .and_then(|preparation| preparation.context_fingerprint_sha256.as_deref())
+            && checkpoint_context_fingerprint_sha256(pre_assistant_messages)
+                != expected_context_fingerprint_sha256
+        {
+            return Err(TurnCheckpointTailRepairReason::CheckpointPreparationFingerprintMismatch);
+        }
+
+        Ok(Self {
+            user_input,
+            assistant_reply,
+            messages,
+            estimated_tokens: repair_preparation
+                .and_then(|preparation| preparation.estimated_tokens)
+                .or(assembled.estimated_tokens),
+        })
+    }
+
+    pub(super) fn user_input(&self) -> &str {
+        self.user_input.as_str()
+    }
+
+    pub(super) fn assistant_reply(&self) -> &str {
+        self.assistant_reply.as_str()
+    }
+
+    pub(super) fn messages(&self) -> &[Value] {
+        &self.messages
+    }
+
+    pub(super) fn estimated_tokens(&self) -> Option<usize> {
+        self.estimated_tokens
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum TurnCheckpointTailRuntimeEligibility {
+    NotNeeded {
+        action: TurnCheckpointRecoveryAction,
+        reason: TurnCheckpointTailRepairReason,
+    },
+    Manual {
+        action: TurnCheckpointRecoveryAction,
+        reason: TurnCheckpointTailRepairReason,
+        source: TurnCheckpointTailRepairSource,
+    },
+    Runnable {
+        action: TurnCheckpointRecoveryAction,
+        plan: TurnCheckpointRepairPlan,
+        resume_input: TurnCheckpointRepairResumeInput,
+    },
+}
+
+pub(super) fn restore_analytics_turn_checkpoint_progress_status(
+    status: AnalyticsTurnCheckpointProgressStatus,
+) -> TurnCheckpointProgressStatus {
+    match status {
+        AnalyticsTurnCheckpointProgressStatus::Pending => TurnCheckpointProgressStatus::Pending,
+        AnalyticsTurnCheckpointProgressStatus::Skipped => TurnCheckpointProgressStatus::Skipped,
+        AnalyticsTurnCheckpointProgressStatus::Completed => TurnCheckpointProgressStatus::Completed,
+        AnalyticsTurnCheckpointProgressStatus::Failed => TurnCheckpointProgressStatus::Failed,
+        AnalyticsTurnCheckpointProgressStatus::FailedOpen => {
+            TurnCheckpointProgressStatus::FailedOpen
+        }
+    }
+}

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -12,9 +12,8 @@ use async_trait::async_trait;
 #[cfg(feature = "memory-sqlite")]
 use futures_util::FutureExt;
 use loongclaw_contracts::{AuditEventKind, ExecutionPlane, PlaneTier};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 #[cfg(feature = "memory-sqlite")]
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
@@ -35,9 +34,8 @@ use super::super::config::LoongClawConfig;
 use super::ConversationSessionAddress;
 use super::ProviderErrorMode;
 use super::analytics::{
-    SafeLaneEventSummary, TurnCheckpointProgressStatus as AnalyticsTurnCheckpointProgressStatus,
-    TurnCheckpointRecoveryAction, TurnCheckpointRepairManualReason, TurnCheckpointRepairPlan,
-    TurnCheckpointSessionState, build_turn_checkpoint_repair_plan, summarize_safe_lane_history,
+    SafeLaneEventSummary, TurnCheckpointRecoveryAction, build_turn_checkpoint_repair_plan,
+    summarize_safe_lane_history,
 };
 use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
 use super::ingress::ConversationIngressContext;
@@ -79,6 +77,21 @@ use super::turn_budget::{
     EscalatingAttemptBudget, SafeLaneBackpressureBudget, SafeLaneContinuationBudgetDecision,
     SafeLaneFailureRouteReason, SafeLaneReplanBudget,
 };
+#[cfg(test)]
+use super::turn_checkpoint::TurnCheckpointResultKind;
+use super::turn_checkpoint::{
+    ContextCompactionOutcome, TurnCheckpointDiagnostics, TurnCheckpointFailure,
+    TurnCheckpointFailureStep, TurnCheckpointFinalizationProgress, TurnCheckpointIdentity,
+    TurnCheckpointProgressStatus, TurnCheckpointRecoveryAssessment,
+    TurnCheckpointRepairResumeInput, TurnCheckpointRequest, TurnCheckpointSnapshot,
+    TurnCheckpointStage, TurnCheckpointTailRepairOutcome, TurnCheckpointTailRepairReason,
+    TurnCheckpointTailRepairRuntimeProbe, TurnCheckpointTailRepairSource,
+    TurnCheckpointTailRepairStatus, TurnCheckpointTailRuntimeEligibility,
+    TurnFinalizationCheckpoint, TurnLaneExecutionSnapshot, TurnPreparationSnapshot,
+    TurnReplyCheckpoint, checkpoint_context_fingerprint_sha256, persist_turn_checkpoint_event,
+    persist_turn_checkpoint_event_value, restore_analytics_turn_checkpoint_progress_status,
+    turn_checkpoint_result_kind,
+};
 use super::turn_engine::{
     AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolBatchExecutionIntentStatus,
     ToolBatchExecutionTrace, ToolIntent, TurnEngine, TurnFailure, TurnFailureKind, TurnResult,
@@ -89,14 +102,16 @@ use super::turn_observer::{
     ConversationTurnToolEvent, build_observer_streaming_token_callback,
 };
 use super::turn_shared::{
-    ProviderTurnRequestAction, ReplyPersistenceMode, ReplyResolutionMode, ToolDrivenFollowupKind,
-    ToolDrivenFollowupPayload, ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
-    build_tool_driven_followup_tail, build_tool_loop_guard_tail,
-    decide_provider_turn_request_action, format_approval_required_reply, next_conversation_turn_id,
-    reduce_followup_payload_for_model, request_completion_with_raw_fallback,
-    tool_driven_followup_payload, tool_loop_circuit_breaker_reply,
-    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
+    ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupPayload,
+    ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
+    build_tool_loop_guard_tail, decide_provider_turn_request_action,
+    format_approval_required_reply, next_conversation_turn_id, reduce_followup_payload_for_model,
+    request_completion_with_raw_fallback, tool_driven_followup_payload,
+    tool_loop_circuit_breaker_reply, tool_result_contains_truncation_signal,
+    user_requested_raw_tool_output,
 };
+#[cfg(test)]
+use super::turn_shared::{ReplyResolutionMode, ToolDrivenFollowupKind};
 #[cfg(feature = "memory-sqlite")]
 use crate::session::recovery::{
     RECOVERY_EVENT_KIND, build_async_spawn_failure_recovery_payload,
@@ -112,308 +127,6 @@ use crate::session::repository::{
 
 #[derive(Default)]
 pub struct ConversationTurnCoordinator;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TurnCheckpointTailRepairStatus {
-    NoCheckpoint,
-    NotNeeded,
-    Repaired,
-    ManualRequired,
-}
-
-impl TurnCheckpointTailRepairStatus {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::NoCheckpoint => "no_checkpoint",
-            Self::NotNeeded => "not_needed",
-            Self::Repaired => "repaired",
-            Self::ManualRequired => "manual_required",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TurnCheckpointTailRepairReason {
-    NoCheckpoint,
-    NotNeeded,
-    Repaired,
-    CheckpointIdentityMissing,
-    SafeLaneBackpressureTerminalRequiresManualInspection,
-    SafeLaneSessionGovernorTerminalRequiresManualInspection,
-    CheckpointPreparationMalformed,
-    CheckpointPreparationMismatch,
-    CheckpointPreparationFingerprintMismatch,
-    CheckpointStateRequiresManualInspection,
-    VisibleTurnPairMissing,
-    CheckpointIdentityMismatch,
-}
-
-impl TurnCheckpointTailRepairReason {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::NoCheckpoint => "no_checkpoint",
-            Self::NotNeeded => "not_needed",
-            Self::Repaired => "repaired",
-            Self::CheckpointIdentityMissing => "checkpoint_identity_missing",
-            Self::SafeLaneBackpressureTerminalRequiresManualInspection => {
-                "safe_lane_backpressure_terminal_requires_manual_inspection"
-            }
-            Self::SafeLaneSessionGovernorTerminalRequiresManualInspection => {
-                "safe_lane_session_governor_terminal_requires_manual_inspection"
-            }
-            Self::CheckpointPreparationMalformed => "checkpoint_preparation_malformed",
-            Self::CheckpointPreparationMismatch => "checkpoint_preparation_mismatch",
-            Self::CheckpointPreparationFingerprintMismatch => {
-                "checkpoint_preparation_fingerprint_mismatch"
-            }
-            Self::CheckpointStateRequiresManualInspection => {
-                "checkpoint_state_requires_manual_inspection"
-            }
-            Self::VisibleTurnPairMissing => "visible_turn_pair_missing",
-            Self::CheckpointIdentityMismatch => "checkpoint_identity_mismatch",
-        }
-    }
-}
-
-impl From<TurnCheckpointRepairManualReason> for TurnCheckpointTailRepairReason {
-    fn from(reason: TurnCheckpointRepairManualReason) -> Self {
-        match reason {
-            TurnCheckpointRepairManualReason::CheckpointIdentityMissing => {
-                Self::CheckpointIdentityMissing
-            }
-            TurnCheckpointRepairManualReason::SafeLaneBackpressureTerminalRequiresManualInspection => {
-                Self::SafeLaneBackpressureTerminalRequiresManualInspection
-            }
-            TurnCheckpointRepairManualReason::SafeLaneSessionGovernorTerminalRequiresManualInspection => {
-                Self::SafeLaneSessionGovernorTerminalRequiresManualInspection
-            }
-            TurnCheckpointRepairManualReason::CheckpointStateRequiresManualInspection => {
-                Self::CheckpointStateRequiresManualInspection
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TurnCheckpointTailRepairOutcome {
-    status: TurnCheckpointTailRepairStatus,
-    action: TurnCheckpointRecoveryAction,
-    source: Option<TurnCheckpointTailRepairSource>,
-    reason: TurnCheckpointTailRepairReason,
-    session_state: TurnCheckpointSessionState,
-    checkpoint_events: u32,
-    after_turn_status: Option<&'static str>,
-    compaction_status: Option<&'static str>,
-}
-
-impl TurnCheckpointTailRepairOutcome {
-    fn no_checkpoint() -> Self {
-        Self {
-            status: TurnCheckpointTailRepairStatus::NoCheckpoint,
-            action: TurnCheckpointRecoveryAction::None,
-            source: None,
-            reason: TurnCheckpointTailRepairReason::NoCheckpoint,
-            session_state: TurnCheckpointSessionState::NotDurable,
-            checkpoint_events: 0,
-            after_turn_status: None,
-            compaction_status: None,
-        }
-    }
-
-    pub(crate) fn from_summary(
-        status: TurnCheckpointTailRepairStatus,
-        action: TurnCheckpointRecoveryAction,
-        source: Option<TurnCheckpointTailRepairSource>,
-        reason: TurnCheckpointTailRepairReason,
-        summary: &super::analytics::TurnCheckpointEventSummary,
-    ) -> Self {
-        Self {
-            status,
-            action,
-            source,
-            reason,
-            session_state: summary.session_state,
-            checkpoint_events: summary.checkpoint_events,
-            after_turn_status: summary
-                .latest_after_turn
-                .map(format_analytics_turn_checkpoint_progress_status),
-            compaction_status: summary
-                .latest_compaction
-                .map(format_analytics_turn_checkpoint_progress_status),
-        }
-    }
-
-    fn repaired(
-        action: TurnCheckpointRecoveryAction,
-        summary: &super::analytics::TurnCheckpointEventSummary,
-        after_turn_status: TurnCheckpointProgressStatus,
-        compaction_status: TurnCheckpointProgressStatus,
-    ) -> Self {
-        Self {
-            status: TurnCheckpointTailRepairStatus::Repaired,
-            action,
-            source: Some(TurnCheckpointTailRepairSource::Runtime),
-            reason: TurnCheckpointTailRepairReason::Repaired,
-            session_state: summary.session_state,
-            checkpoint_events: summary.checkpoint_events,
-            after_turn_status: Some(format_turn_checkpoint_progress_status(after_turn_status)),
-            compaction_status: Some(format_turn_checkpoint_progress_status(compaction_status)),
-        }
-    }
-
-    pub fn status(&self) -> TurnCheckpointTailRepairStatus {
-        self.status
-    }
-
-    pub fn action(&self) -> TurnCheckpointRecoveryAction {
-        self.action
-    }
-
-    pub fn source(&self) -> Option<TurnCheckpointTailRepairSource> {
-        self.source
-    }
-
-    pub fn reason(&self) -> TurnCheckpointTailRepairReason {
-        self.reason
-    }
-
-    pub fn session_state(&self) -> TurnCheckpointSessionState {
-        self.session_state
-    }
-
-    pub fn checkpoint_events(&self) -> u32 {
-        self.checkpoint_events
-    }
-
-    pub fn after_turn_status(&self) -> Option<&'static str> {
-        self.after_turn_status
-    }
-
-    pub fn compaction_status(&self) -> Option<&'static str> {
-        self.compaction_status
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TurnCheckpointTailRepairSource {
-    Summary,
-    Runtime,
-}
-
-impl TurnCheckpointTailRepairSource {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Summary => "summary",
-            Self::Runtime => "runtime",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TurnCheckpointTailRepairRuntimeProbe {
-    action: TurnCheckpointRecoveryAction,
-    source: TurnCheckpointTailRepairSource,
-    reason: TurnCheckpointTailRepairReason,
-}
-
-impl TurnCheckpointTailRepairRuntimeProbe {
-    pub(crate) fn new(
-        action: TurnCheckpointRecoveryAction,
-        source: TurnCheckpointTailRepairSource,
-        reason: TurnCheckpointTailRepairReason,
-    ) -> Self {
-        Self {
-            action,
-            source,
-            reason,
-        }
-    }
-
-    pub fn action(&self) -> TurnCheckpointRecoveryAction {
-        self.action
-    }
-
-    pub fn source(&self) -> TurnCheckpointTailRepairSource {
-        self.source
-    }
-
-    pub fn reason(&self) -> TurnCheckpointTailRepairReason {
-        self.reason
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TurnCheckpointRecoveryAssessment {
-    action: TurnCheckpointRecoveryAction,
-    source: TurnCheckpointTailRepairSource,
-    reason: Option<TurnCheckpointTailRepairReason>,
-}
-
-impl TurnCheckpointRecoveryAssessment {
-    pub(crate) fn from_summary(summary: &super::analytics::TurnCheckpointEventSummary) -> Self {
-        let repair_plan = build_turn_checkpoint_repair_plan(summary);
-        let reason = matches!(
-            repair_plan.action(),
-            TurnCheckpointRecoveryAction::InspectManually
-        )
-        .then(|| {
-            repair_plan
-                .manual_reason()
-                .map(TurnCheckpointTailRepairReason::from)
-                .unwrap_or(TurnCheckpointTailRepairReason::CheckpointStateRequiresManualInspection)
-        });
-        Self {
-            action: repair_plan.action(),
-            source: TurnCheckpointTailRepairSource::Summary,
-            reason,
-        }
-    }
-
-    pub fn action(self) -> TurnCheckpointRecoveryAction {
-        self.action
-    }
-
-    pub fn source(self) -> TurnCheckpointTailRepairSource {
-        self.source
-    }
-
-    pub fn reason(self) -> Option<TurnCheckpointTailRepairReason> {
-        self.reason
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TurnCheckpointDiagnostics {
-    summary: super::analytics::TurnCheckpointEventSummary,
-    recovery: TurnCheckpointRecoveryAssessment,
-    runtime_probe: Option<TurnCheckpointTailRepairRuntimeProbe>,
-}
-
-impl TurnCheckpointDiagnostics {
-    pub(crate) fn new(
-        summary: super::analytics::TurnCheckpointEventSummary,
-        recovery: TurnCheckpointRecoveryAssessment,
-        runtime_probe: Option<TurnCheckpointTailRepairRuntimeProbe>,
-    ) -> Self {
-        Self {
-            summary,
-            recovery,
-            runtime_probe,
-        }
-    }
-
-    pub fn summary(&self) -> &super::analytics::TurnCheckpointEventSummary {
-        &self.summary
-    }
-
-    pub fn recovery(&self) -> TurnCheckpointRecoveryAssessment {
-        self.recovery
-    }
-
-    pub fn runtime_probe(&self) -> Option<&TurnCheckpointTailRepairRuntimeProbe> {
-        self.runtime_probe.as_ref()
-    }
-}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct SafeLaneExecutionMetrics {
@@ -1052,7 +765,7 @@ impl ProviderTurnContinuePhase {
             Some(reply),
             self.request.clone(),
             Some(self.lane_execution.checkpoint()),
-            Some(turn_reply_checkpoint(&self.reply_phase)),
+            Some(TurnReplyCheckpoint::from_phase(&self.reply_phase)),
             TurnFinalizationCheckpoint::persist_reply(ReplyPersistenceMode::Success),
         )
     }
@@ -1107,206 +820,6 @@ impl ProviderTurnContinuePhase {
         )
         .await
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct TurnCheckpointSnapshot {
-    identity: Option<TurnCheckpointIdentity>,
-    preparation: TurnPreparationSnapshot,
-    request: TurnCheckpointRequest,
-    lane: Option<TurnLaneExecutionSnapshot>,
-    reply: Option<TurnReplyCheckpoint>,
-    finalization: TurnFinalizationCheckpoint,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct TurnCheckpointIdentity {
-    user_input_sha256: String,
-    assistant_reply_sha256: String,
-    user_input_chars: usize,
-    assistant_reply_chars: usize,
-}
-
-impl TurnCheckpointIdentity {
-    fn from_turn(user_input: &str, assistant_reply: &str) -> Self {
-        Self {
-            user_input_sha256: sha256_hex(user_input),
-            assistant_reply_sha256: sha256_hex(assistant_reply),
-            user_input_chars: user_input.chars().count(),
-            assistant_reply_chars: assistant_reply.chars().count(),
-        }
-    }
-
-    fn matches_turn(&self, user_input: &str, assistant_reply: &str) -> bool {
-        self.user_input_chars == user_input.chars().count()
-            && self.assistant_reply_chars == assistant_reply.chars().count()
-            && self.user_input_sha256 == sha256_hex(user_input)
-            && self.assistant_reply_sha256 == sha256_hex(assistant_reply)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct TurnPreparationSnapshot {
-    lane: ExecutionLane,
-    max_tool_steps: usize,
-    raw_tool_output_requested: bool,
-    context_message_count: usize,
-    context_fingerprint_sha256: String,
-    estimated_tokens: Option<usize>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum TurnCheckpointRequest {
-    Continue { tool_intents: usize },
-    FinalizeInlineProviderError,
-    ReturnError,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct TurnLaneExecutionSnapshot {
-    lane: ExecutionLane,
-    had_tool_intents: bool,
-    raw_tool_output_requested: bool,
-    result_kind: TurnCheckpointResultKind,
-    safe_lane_terminal_route: Option<SafeLaneFailureRoute>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum TurnCheckpointResultKind {
-    FinalText,
-    Streaming,
-    NeedsApproval,
-    ToolDenied,
-    ToolError,
-    ProviderError,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct TurnReplyCheckpoint {
-    decision: ReplyResolutionMode,
-    followup_kind: Option<ToolDrivenFollowupKind>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum TurnFinalizationCheckpoint {
-    PersistReply {
-        persistence_mode: ReplyPersistenceMode,
-        runs_after_turn: bool,
-        attempts_context_compaction: bool,
-    },
-    ReturnError,
-}
-
-impl TurnFinalizationCheckpoint {
-    fn persist_reply(persistence_mode: ReplyPersistenceMode) -> Self {
-        Self::PersistReply {
-            persistence_mode,
-            runs_after_turn: true,
-            attempts_context_compaction: true,
-        }
-    }
-
-    fn persistence_mode(self) -> Option<ReplyPersistenceMode> {
-        match self {
-            Self::PersistReply {
-                persistence_mode, ..
-            } => Some(persistence_mode),
-            Self::ReturnError => None,
-        }
-    }
-
-    fn runs_after_turn(self) -> bool {
-        match self {
-            Self::PersistReply {
-                runs_after_turn, ..
-            } => runs_after_turn,
-            Self::ReturnError => false,
-        }
-    }
-
-    fn attempts_context_compaction(self) -> bool {
-        match self {
-            Self::PersistReply {
-                attempts_context_compaction,
-                ..
-            } => attempts_context_compaction,
-            Self::ReturnError => false,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum TurnCheckpointStage {
-    PostPersist,
-    Finalized,
-    FinalizationFailed,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum TurnCheckpointProgressStatus {
-    Pending,
-    Skipped,
-    Completed,
-    Failed,
-    FailedOpen,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-struct TurnCheckpointFinalizationProgress {
-    after_turn: TurnCheckpointProgressStatus,
-    compaction: TurnCheckpointProgressStatus,
-}
-
-impl TurnCheckpointFinalizationProgress {
-    fn pending(checkpoint: &TurnCheckpointSnapshot) -> Self {
-        Self {
-            after_turn: if checkpoint.finalization.runs_after_turn() {
-                TurnCheckpointProgressStatus::Pending
-            } else {
-                TurnCheckpointProgressStatus::Skipped
-            },
-            compaction: if checkpoint.finalization.attempts_context_compaction() {
-                TurnCheckpointProgressStatus::Pending
-            } else {
-                TurnCheckpointProgressStatus::Skipped
-            },
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ContextCompactionOutcome {
-    Skipped,
-    Completed,
-    FailedOpen,
-}
-
-impl ContextCompactionOutcome {
-    fn checkpoint_status(self) -> TurnCheckpointProgressStatus {
-        match self {
-            Self::Skipped => TurnCheckpointProgressStatus::Skipped,
-            Self::Completed => TurnCheckpointProgressStatus::Completed,
-            Self::FailedOpen => TurnCheckpointProgressStatus::FailedOpen,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum TurnCheckpointFailureStep {
-    AfterTurn,
-    Compaction,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct TurnCheckpointFailure {
-    step: TurnCheckpointFailureStep,
-    error: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1500,13 +1013,6 @@ impl SafeLaneTurnOutcome {
             result,
             terminal_route: Some(terminal_route),
         }
-    }
-}
-
-fn turn_reply_checkpoint(phase: &ToolDrivenReplyPhase) -> TurnReplyCheckpoint {
-    TurnReplyCheckpoint {
-        decision: phase.resolution_mode(),
-        followup_kind: phase.followup_kind(),
     }
 }
 
@@ -3393,41 +2899,6 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     }
 }
 
-fn turn_checkpoint_result_kind(result: &TurnResult) -> TurnCheckpointResultKind {
-    match result {
-        TurnResult::FinalText(_) => TurnCheckpointResultKind::FinalText,
-        TurnResult::StreamingText(_) | TurnResult::StreamingDone(_) => {
-            TurnCheckpointResultKind::Streaming
-        }
-        TurnResult::NeedsApproval(_) => TurnCheckpointResultKind::NeedsApproval,
-        TurnResult::ToolDenied(_) => TurnCheckpointResultKind::ToolDenied,
-        TurnResult::ToolError(_) => TurnCheckpointResultKind::ToolError,
-        TurnResult::ProviderError(_) => TurnCheckpointResultKind::ProviderError,
-    }
-}
-
-fn format_turn_checkpoint_progress_status(status: TurnCheckpointProgressStatus) -> &'static str {
-    match status {
-        TurnCheckpointProgressStatus::Pending => "pending",
-        TurnCheckpointProgressStatus::Skipped => "skipped",
-        TurnCheckpointProgressStatus::Completed => "completed",
-        TurnCheckpointProgressStatus::Failed => "failed",
-        TurnCheckpointProgressStatus::FailedOpen => "failed_open",
-    }
-}
-
-fn format_analytics_turn_checkpoint_progress_status(
-    status: AnalyticsTurnCheckpointProgressStatus,
-) -> &'static str {
-    match status {
-        AnalyticsTurnCheckpointProgressStatus::Pending => "pending",
-        AnalyticsTurnCheckpointProgressStatus::Skipped => "skipped",
-        AnalyticsTurnCheckpointProgressStatus::Completed => "completed",
-        AnalyticsTurnCheckpointProgressStatus::Failed => "failed",
-        AnalyticsTurnCheckpointProgressStatus::FailedOpen => "failed_open",
-    }
-}
-
 #[cfg(test)]
 fn build_turn_reply_followup_messages(
     base_messages: &[Value],
@@ -3559,190 +3030,6 @@ async fn emit_discovery_first_event<R: ConversationRuntime + ?Sized>(
     }
 }
 
-async fn persist_turn_checkpoint_event<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    session_id: &str,
-    checkpoint: &TurnCheckpointSnapshot,
-    stage: TurnCheckpointStage,
-    progress: TurnCheckpointFinalizationProgress,
-    failure: Option<TurnCheckpointFailure>,
-    binding: ConversationRuntimeBinding<'_>,
-) -> CliResult<()> {
-    let checkpoint = serde_json::to_value(checkpoint)
-        .map_err(|error| format!("serialize turn checkpoint failed: {error}"))?;
-    persist_turn_checkpoint_event_value(
-        runtime,
-        session_id,
-        &checkpoint,
-        stage,
-        progress,
-        failure,
-        binding,
-    )
-    .await
-}
-
-async fn persist_turn_checkpoint_event_value<R: ConversationRuntime + ?Sized>(
-    runtime: &R,
-    session_id: &str,
-    checkpoint: &Value,
-    stage: TurnCheckpointStage,
-    progress: TurnCheckpointFinalizationProgress,
-    failure: Option<TurnCheckpointFailure>,
-    binding: ConversationRuntimeBinding<'_>,
-) -> CliResult<()> {
-    persist_conversation_event(
-        runtime,
-        session_id,
-        "turn_checkpoint",
-        json!({
-            "schema_version": 1,
-            "stage": stage,
-            "checkpoint": checkpoint,
-            "finalization_progress": progress,
-            "failure": failure,
-        }),
-        binding,
-    )
-    .await
-}
-
-fn recover_latest_turn_pair(messages: &[Value]) -> Option<(String, String)> {
-    let assistant_index = messages.iter().rposition(|message| {
-        message.get("role").and_then(Value::as_str) == Some("assistant")
-            && message.get("content").and_then(Value::as_str).is_some()
-    })?;
-    let assistant_reply = messages
-        .get(assistant_index)?
-        .get("content")
-        .and_then(Value::as_str)?
-        .to_owned();
-    let user_input = messages
-        .get(..assistant_index)?
-        .iter()
-        .rposition(|message| {
-            message.get("role").and_then(Value::as_str) == Some("user")
-                && message.get("content").and_then(Value::as_str).is_some()
-        })
-        .and_then(|index| {
-            messages
-                .get(index)
-                .and_then(|message| message.get("content"))
-                .and_then(Value::as_str)
-        })
-        .map(ToOwned::to_owned)?;
-    Some((user_input, assistant_reply))
-}
-
-fn load_turn_checkpoint_identity(checkpoint: &Value) -> Option<TurnCheckpointIdentity> {
-    checkpoint
-        .get("identity")
-        .cloned()
-        .and_then(|identity| serde_json::from_value(identity).ok())
-}
-
-fn sha256_hex(input: &str) -> String {
-    format!("{:x}", Sha256::digest(input.as_bytes()))
-}
-
-fn checkpoint_context_fingerprint_sha256(messages: &[Value]) -> String {
-    let serialized = Value::Array(messages.to_vec()).to_string();
-    format!("{:x}", Sha256::digest(serialized.as_bytes()))
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
-struct TurnCheckpointRepairPreparation {
-    #[serde(default)]
-    context_message_count: Option<usize>,
-    #[serde(default)]
-    context_fingerprint_sha256: Option<String>,
-    #[serde(default)]
-    estimated_tokens: Option<usize>,
-}
-
-fn load_turn_checkpoint_repair_preparation(
-    checkpoint: &Value,
-) -> Result<Option<TurnCheckpointRepairPreparation>, TurnCheckpointTailRepairReason> {
-    let Some(preparation) = checkpoint.get("preparation") else {
-        return Ok(None);
-    };
-    serde_json::from_value(preparation.clone())
-        .map(Some)
-        .map_err(|_error| TurnCheckpointTailRepairReason::CheckpointPreparationMalformed)
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TurnCheckpointRepairResumeInput {
-    user_input: String,
-    assistant_reply: String,
-    messages: Vec<Value>,
-    estimated_tokens: Option<usize>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum TurnCheckpointTailRuntimeEligibility {
-    NotNeeded {
-        action: TurnCheckpointRecoveryAction,
-        reason: TurnCheckpointTailRepairReason,
-    },
-    Manual {
-        action: TurnCheckpointRecoveryAction,
-        reason: TurnCheckpointTailRepairReason,
-        source: TurnCheckpointTailRepairSource,
-    },
-    Runnable {
-        action: TurnCheckpointRecoveryAction,
-        plan: TurnCheckpointRepairPlan,
-        resume_input: TurnCheckpointRepairResumeInput,
-    },
-}
-
-impl TurnCheckpointRepairResumeInput {
-    fn from_assembled_context(
-        assembled: AssembledConversationContext,
-        checkpoint: &Value,
-    ) -> Result<Self, TurnCheckpointTailRepairReason> {
-        let repair_preparation = load_turn_checkpoint_repair_preparation(checkpoint)?;
-        let messages = assembled.messages;
-        let Some((user_input, assistant_reply)) = recover_latest_turn_pair(&messages) else {
-            return Err(TurnCheckpointTailRepairReason::VisibleTurnPairMissing);
-        };
-        let Some((_, pre_assistant_messages)) = messages.split_last() else {
-            return Err(TurnCheckpointTailRepairReason::VisibleTurnPairMissing);
-        };
-        let Some(identity) = load_turn_checkpoint_identity(checkpoint) else {
-            return Err(TurnCheckpointTailRepairReason::CheckpointIdentityMissing);
-        };
-        if !identity.matches_turn(&user_input, &assistant_reply) {
-            return Err(TurnCheckpointTailRepairReason::CheckpointIdentityMismatch);
-        }
-        if let Some(expected_context_message_count) = repair_preparation
-            .as_ref()
-            .and_then(|preparation| preparation.context_message_count)
-            && pre_assistant_messages.len() != expected_context_message_count
-        {
-            return Err(TurnCheckpointTailRepairReason::CheckpointPreparationMismatch);
-        }
-        if let Some(expected_context_fingerprint_sha256) = repair_preparation
-            .as_ref()
-            .and_then(|preparation| preparation.context_fingerprint_sha256.as_deref())
-            && checkpoint_context_fingerprint_sha256(pre_assistant_messages)
-                != expected_context_fingerprint_sha256
-        {
-            return Err(TurnCheckpointTailRepairReason::CheckpointPreparationFingerprintMismatch);
-        }
-
-        Ok(Self {
-            user_input,
-            assistant_reply,
-            messages,
-            estimated_tokens: repair_preparation
-                .and_then(|preparation| preparation.estimated_tokens)
-                .or(assembled.estimated_tokens),
-        })
-    }
-}
-
 #[cfg(feature = "memory-sqlite")]
 async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
@@ -3820,9 +3107,9 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
         match runtime
             .after_turn(
                 session_id,
-                &resume_input.user_input,
-                &resume_input.assistant_reply,
-                &resume_input.messages,
+                resume_input.user_input(),
+                resume_input.assistant_reply(),
+                resume_input.messages(),
                 kernel_ctx,
             )
             .await
@@ -3861,8 +3148,8 @@ async fn repair_turn_checkpoint_tail_entry<R: ConversationRuntime + ?Sized>(
             config,
             runtime,
             session_id,
-            &resume_input.messages,
-            resume_input.estimated_tokens,
+            resume_input.messages(),
+            resume_input.estimated_tokens(),
             binding,
         )
         .await
@@ -4003,20 +3290,6 @@ async fn probe_turn_checkpoint_tail_runtime_gate_entry_with_limit<
     };
     probe_turn_checkpoint_tail_runtime_gate_entry(config, runtime, session_id, &entry, binding)
         .await
-}
-
-fn restore_analytics_turn_checkpoint_progress_status(
-    status: AnalyticsTurnCheckpointProgressStatus,
-) -> TurnCheckpointProgressStatus {
-    match status {
-        AnalyticsTurnCheckpointProgressStatus::Pending => TurnCheckpointProgressStatus::Pending,
-        AnalyticsTurnCheckpointProgressStatus::Skipped => TurnCheckpointProgressStatus::Skipped,
-        AnalyticsTurnCheckpointProgressStatus::Completed => TurnCheckpointProgressStatus::Completed,
-        AnalyticsTurnCheckpointProgressStatus::Failed => TurnCheckpointProgressStatus::Failed,
-        AnalyticsTurnCheckpointProgressStatus::FailedOpen => {
-            TurnCheckpointProgressStatus::FailedOpen
-        }
-    }
 }
 
 async fn finalize_provider_turn_reply<R: ConversationRuntime + ?Sized>(
@@ -6539,7 +5812,7 @@ fn safe_lane_backpressure_budget(config: &LoongClawConfig) -> Option<SafeLaneBac
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-struct SafeLaneFailureRoute {
+pub(super) struct SafeLaneFailureRoute {
     decision: SafeLaneFailureRouteDecision,
     reason: SafeLaneFailureRouteReason,
     source: SafeLaneFailureRouteSource,

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -23,7 +23,7 @@ optional `scripts/pre-commit` hook mirrors these cargo gates locally.
 
 ## Architecture Stability Guardrails
 
-1. **Complexity budgets are locally machine-checkable** — run `./scripts/check_architecture_boundaries.sh` or `task check:architecture` to inspect module line/function budgets for architecture hotspots (`spec_runtime`, `spec_execution`, `provider/mod`, `memory/mod`).
+1. **Complexity budgets are locally machine-checkable** — run `./scripts/check_architecture_boundaries.sh` or `task check:architecture` to inspect module line/function budgets for architecture hotspots (`spec_runtime`, `spec_execution`, `provider/mod`, `memory/mod`, `acp/manager`, `acp/acpx`, `channel/registry`, `config/channels`, `chat`, `channel/mod`, `conversation/turn_coordinator`, `tools/mod`, `daemon/lib`, `daemon/onboard_cli`). The generated drift report also classifies each hotspot by `foundation`, `structural_size`, and `operational_density` pressure so release reviews can distinguish large-surface drift from runtime-density risk.
 2. **Memory operation literals are boundary-guarded** — memory core operation strings (`append_turn`, `window`, `clear_session`) must remain centralized in `crates/app/src/memory/*` and never spread into callsites.
 3. **`spec` stays detached from `app`** — the architecture guardrails treat any direct `loongclaw-app` dependency in `crates/spec/Cargo.toml` as a boundary regression, and `./scripts/check_dep_graph.sh` must stay green.
 4. **Strict enforcement is an extended local gate** — use `task check:architecture:strict` (or set `LOONGCLAW_ARCH_STRICT=true`) to make architecture budget violations fail non-zero. This check is part of `task verify:full`, not the canonical CI-parity gate.

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-27T02:59:39Z
+- Generated at: 2026-03-27T03:15:18Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -22,15 +22,15 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9364 | 9800 | 436 | 90 | 90 | 0 | 100.0% | TIGHT |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6176 | 6400 | 224 | 100 | 110 | 10 | 96.5% | TIGHT |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9963 | 11200 | 1237 | 92 | 120 | 28 | 89.0% | WATCH |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14111 | 15000 | 889 | 54 | 70 | 16 | 94.1% | WATCH |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9964 | 11200 | 1236 | 92 | 120 | 28 | 89.0% | WATCH |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14113 | 15000 | 887 | 54 | 70 | 16 | 94.1% | WATCH |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5703 | 6000 | 297 | 176 | 190 | 14 | 95.0% | TIGHT |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9232 | 9800 | 568 | 227 | 250 | 23 | 94.2% | WATCH |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): channel_registry (96.2%), channel_config (100.0%), channel_mod (96.5%), daemon_lib (95.0%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.1%), onboard_cli (94.2%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.1%), onboard_cli (94.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -67,10 +67,10 @@
 <!-- arch-hotspot key=channel_config lines=9364 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
 <!-- arch-hotspot key=channel_mod lines=6176 functions=100 -->
-<!-- arch-hotspot key=turn_coordinator lines=9963 functions=92 -->
-<!-- arch-hotspot key=tools_mod lines=14111 functions=54 -->
+<!-- arch-hotspot key=turn_coordinator lines=9964 functions=92 -->
+<!-- arch-hotspot key=tools_mod lines=14113 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=5703 functions=176 -->
-<!-- arch-hotspot key=onboard_cli lines=9232 functions=227 -->
+<!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-26T11:41:47Z
+- Generated at: 2026-03-26T12:08:39Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -17,18 +17,18 @@
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH | n/a | n/a | N/A | n/a |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3327 | 3600 | 273 | 8 | 12 | 4 | 92.4% | WATCH | n/a | n/a | N/A | n/a |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2575 | 2800 | 225 | 55 | 65 | 10 | 92.0% | WATCH | n/a | n/a | N/A | n/a |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9504 | 10000 | 496 | 78 | 90 | 12 | 95.0% | TIGHT | n/a | n/a | N/A | n/a |
-| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 7967 | 8400 | 433 | 75 | 90 | 15 | 94.8% | WATCH | n/a | n/a | N/A | n/a |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6808 | 7300 | 492 | 145 | 160 | 15 | 93.3% | WATCH | n/a | n/a | N/A | n/a |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 5968 | 6400 | 432 | 94 | 110 | 16 | 93.2% | WATCH | n/a | n/a | N/A | n/a |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9769 | 10000 | 231 | 82 | 90 | 8 | 97.7% | TIGHT | n/a | n/a | N/A | n/a |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8622 | 9000 | 378 | 83 | 90 | 7 | 95.8% | TIGHT | n/a | n/a | N/A | n/a |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6818 | 7300 | 482 | 145 | 160 | 15 | 93.4% | WATCH | n/a | n/a | N/A | n/a |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6080 | 6400 | 320 | 97 | 110 | 13 | 95.0% | TIGHT | n/a | n/a | N/A | n/a |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9963 | 11200 | 1237 | 92 | 120 | 28 | 89.0% | WATCH | n/a | n/a | N/A | n/a |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14111 | 15000 | 889 | 54 | 70 | 16 | 94.1% | WATCH | n/a | n/a | N/A | n/a |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5561 | 6000 | 439 | 170 | 190 | 20 | 92.7% | WATCH | n/a | n/a | N/A | n/a |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5607 | 6000 | 393 | 173 | 190 | 17 | 93.5% | WATCH | n/a | n/a | N/A | n/a |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9232 | 9800 | 568 | 227 | 250 | 23 | 94.2% | WATCH | n/a | n/a | N/A | n/a |
 
 ## Prioritization Signals
-- TIGHT hotspots (>=95% of any tracked budget): channel_registry (95.0%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), channel_config (94.8%), chat_runtime (93.3%), channel_mod (93.2%), turn_coordinator (89.0%), tools_mod (94.1%), daemon_lib (92.7%), onboard_cli (94.2%)
+- TIGHT hotspots (>=95% of any tracked budget): channel_registry (97.7%), channel_config (95.8%), channel_mod (95.0%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.1%), daemon_lib (93.5%), onboard_cli (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -60,13 +60,13 @@
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3327 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2575 functions=55 -->
-<!-- arch-hotspot key=channel_registry lines=9504 functions=78 -->
-<!-- arch-hotspot key=channel_config lines=7967 functions=75 -->
-<!-- arch-hotspot key=chat_runtime lines=6808 functions=145 -->
-<!-- arch-hotspot key=channel_mod lines=5968 functions=94 -->
+<!-- arch-hotspot key=channel_registry lines=9769 functions=82 -->
+<!-- arch-hotspot key=channel_config lines=8622 functions=83 -->
+<!-- arch-hotspot key=chat_runtime lines=6818 functions=145 -->
+<!-- arch-hotspot key=channel_mod lines=6080 functions=97 -->
 <!-- arch-hotspot key=turn_coordinator lines=9963 functions=92 -->
 <!-- arch-hotspot key=tools_mod lines=14111 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=5561 functions=170 -->
+<!-- arch-hotspot key=daemon_lib lines=5607 functions=173 -->
 <!-- arch-hotspot key=onboard_cli lines=9232 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,20 +1,35 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-26T04:19:52Z
+- Generated at: 2026-03-26T10:39:50Z
 - Report month: `2026-03`
 - Baseline report: none
-- Hotspots tracked: 4
+- Hotspots tracked: 14
 - Boundary checks tracked: 4
 - SLO status: PASS
 
 ## Hotspot Metrics
-| Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |
-|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| spec_runtime | `crates/spec/src/spec_runtime.rs` | 3289 | 3600 | 311 | 48 | 65 | 17 | n/a | n/a | N/A | n/a |
-| spec_execution | `crates/spec/src/spec_execution.rs` | 2057 | 3700 | 1643 | 29 | 80 | 51 | n/a | n/a | N/A | n/a |
-| provider_mod | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | n/a | n/a | N/A | n/a |
-| memory_mod | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | n/a | n/a | N/A | n/a |
+| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure | Prev Lines | Line Growth | Growth SLO | Prev Functions |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
+| spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3289 | 3600 | 311 | 48 | 65 | 17 | 91.4% | WATCH | n/a | n/a | N/A | n/a |
+| spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 2057 | 3700 | 1643 | 29 | 80 | 51 | 55.6% | HEALTHY | n/a | n/a | N/A | n/a |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY | n/a | n/a | N/A | n/a |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH | n/a | n/a | N/A | n/a |
+| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3327 | 3600 | 273 | 8 | 12 | 4 | 92.4% | WATCH | n/a | n/a | N/A | n/a |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2575 | 2800 | 225 | 55 | 65 | 10 | 92.0% | WATCH | n/a | n/a | N/A | n/a |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9504 | 10000 | 496 | 78 | 90 | 12 | 95.0% | TIGHT | n/a | n/a | N/A | n/a |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 7967 | 8400 | 433 | 75 | 90 | 15 | 94.8% | WATCH | n/a | n/a | N/A | n/a |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6808 | 7300 | 492 | 145 | 160 | 15 | 93.3% | WATCH | n/a | n/a | N/A | n/a |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 5968 | 6400 | 432 | 94 | 110 | 16 | 93.2% | WATCH | n/a | n/a | N/A | n/a |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10690 | 11200 | 510 | 104 | 120 | 16 | 95.4% | TIGHT | n/a | n/a | N/A | n/a |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14111 | 15000 | 889 | 54 | 70 | 16 | 94.1% | WATCH | n/a | n/a | N/A | n/a |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5561 | 6000 | 439 | 170 | 190 | 20 | 92.7% | WATCH | n/a | n/a | N/A | n/a |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9232 | 9800 | 568 | 227 | 250 | 23 | 94.2% | WATCH | n/a | n/a | N/A | n/a |
+
+## Prioritization Signals
+- TIGHT hotspots (>=95% of any tracked budget): channel_registry (95.0%), turn_coordinator (95.4%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), channel_config (94.8%), chat_runtime (93.3%), channel_mod (93.2%), tools_mod (94.1%), daemon_lib (92.7%), onboard_cli (94.2%)
+- Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
 | Check | Status | Previous Status | Detail |
@@ -43,6 +58,16 @@
 <!-- arch-hotspot key=spec_execution lines=2057 functions=29 -->
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
+<!-- arch-hotspot key=acp_manager lines=3327 functions=8 -->
+<!-- arch-hotspot key=acpx_runtime lines=2575 functions=55 -->
+<!-- arch-hotspot key=channel_registry lines=9504 functions=78 -->
+<!-- arch-hotspot key=channel_config lines=7967 functions=75 -->
+<!-- arch-hotspot key=chat_runtime lines=6808 functions=145 -->
+<!-- arch-hotspot key=channel_mod lines=5968 functions=94 -->
+<!-- arch-hotspot key=turn_coordinator lines=10690 functions=104 -->
+<!-- arch-hotspot key=tools_mod lines=14111 functions=54 -->
+<!-- arch-hotspot key=daemon_lib lines=5561 functions=170 -->
+<!-- arch-hotspot key=onboard_cli lines=9232 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-26T12:25:05Z
+- Generated at: 2026-03-27T02:59:39Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -9,29 +9,32 @@
 - SLO status: PASS
 
 ## Hotspot Metrics
-| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure | Prev Lines | Line Growth | Growth SLO | Prev Functions |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
-| spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3289 | 3600 | 311 | 48 | 65 | 17 | 91.4% | WATCH | n/a | n/a | N/A | n/a |
-| spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 2057 | 3700 | 1643 | 29 | 80 | 51 | 55.6% | HEALTHY | n/a | n/a | N/A | n/a |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY | n/a | n/a | N/A | n/a |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH | n/a | n/a | N/A | n/a |
-| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3327 | 3600 | 273 | 8 | 12 | 4 | 92.4% | WATCH | n/a | n/a | N/A | n/a |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2575 | 2800 | 225 | 55 | 65 | 10 | 92.0% | WATCH | n/a | n/a | N/A | n/a |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10104 | 10500 | 396 | 86 | 90 | 4 | 96.2% | TIGHT | n/a | n/a | N/A | n/a |
-| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9364 | 9800 | 436 | 90 | 90 | 0 | 100.0% | TIGHT | n/a | n/a | N/A | n/a |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6818 | 7300 | 482 | 145 | 160 | 15 | 93.4% | WATCH | n/a | n/a | N/A | n/a |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6176 | 6400 | 224 | 100 | 110 | 10 | 96.5% | TIGHT | n/a | n/a | N/A | n/a |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9963 | 11200 | 1237 | 92 | 120 | 28 | 89.0% | WATCH | n/a | n/a | N/A | n/a |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14111 | 15000 | 889 | 54 | 70 | 16 | 94.1% | WATCH | n/a | n/a | N/A | n/a |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5703 | 6000 | 297 | 176 | 190 | 14 | 95.0% | TIGHT | n/a | n/a | N/A | n/a |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9232 | 9800 | 568 | 227 | 250 | 23 | 94.2% | WATCH | n/a | n/a | N/A | n/a |
+
+| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3289 | 3600 | 311 | 48 | 65 | 17 | 91.4% | WATCH |
+| spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 2057 | 3700 | 1643 | 29 | 80 | 51 | 55.6% | HEALTHY |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH |
+| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3327 | 3600 | 273 | 8 | 12 | 4 | 92.4% | WATCH |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2575 | 2800 | 225 | 55 | 65 | 10 | 92.0% | WATCH |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10104 | 10500 | 396 | 86 | 90 | 4 | 96.2% | TIGHT |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9364 | 9800 | 436 | 90 | 90 | 0 | 100.0% | TIGHT |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6176 | 6400 | 224 | 100 | 110 | 10 | 96.5% | TIGHT |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9963 | 11200 | 1237 | 92 | 120 | 28 | 89.0% | WATCH |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14111 | 15000 | 889 | 54 | 70 | 16 | 94.1% | WATCH |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5703 | 6000 | 297 | 176 | 190 | 14 | 95.0% | TIGHT |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9232 | 9800 | 568 | 227 | 250 | 23 | 94.2% | WATCH |
 
 ## Prioritization Signals
+- BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): channel_registry (96.2%), channel_config (100.0%), channel_mod (96.5%), daemon_lib (95.0%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.1%), onboard_cli (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
+
 | Check | Status | Previous Status | Detail |
 |---|---|---|---|
 | memory_literals | PASS | n/a | memory operation literals are centralized in crates/app/src/memory/* |
@@ -62,7 +65,7 @@
 <!-- arch-hotspot key=acpx_runtime lines=2575 functions=55 -->
 <!-- arch-hotspot key=channel_registry lines=10104 functions=86 -->
 <!-- arch-hotspot key=channel_config lines=9364 functions=90 -->
-<!-- arch-hotspot key=chat_runtime lines=6818 functions=145 -->
+<!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
 <!-- arch-hotspot key=channel_mod lines=6176 functions=100 -->
 <!-- arch-hotspot key=turn_coordinator lines=9963 functions=92 -->
 <!-- arch-hotspot key=tools_mod lines=14111 functions=54 -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-26T12:08:39Z
+- Generated at: 2026-03-26T12:25:05Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -17,18 +17,18 @@
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH | n/a | n/a | N/A | n/a |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3327 | 3600 | 273 | 8 | 12 | 4 | 92.4% | WATCH | n/a | n/a | N/A | n/a |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2575 | 2800 | 225 | 55 | 65 | 10 | 92.0% | WATCH | n/a | n/a | N/A | n/a |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9769 | 10000 | 231 | 82 | 90 | 8 | 97.7% | TIGHT | n/a | n/a | N/A | n/a |
-| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 8622 | 9000 | 378 | 83 | 90 | 7 | 95.8% | TIGHT | n/a | n/a | N/A | n/a |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10104 | 10500 | 396 | 86 | 90 | 4 | 96.2% | TIGHT | n/a | n/a | N/A | n/a |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9364 | 9800 | 436 | 90 | 90 | 0 | 100.0% | TIGHT | n/a | n/a | N/A | n/a |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6818 | 7300 | 482 | 145 | 160 | 15 | 93.4% | WATCH | n/a | n/a | N/A | n/a |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6080 | 6400 | 320 | 97 | 110 | 13 | 95.0% | TIGHT | n/a | n/a | N/A | n/a |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6176 | 6400 | 224 | 100 | 110 | 10 | 96.5% | TIGHT | n/a | n/a | N/A | n/a |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9963 | 11200 | 1237 | 92 | 120 | 28 | 89.0% | WATCH | n/a | n/a | N/A | n/a |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14111 | 15000 | 889 | 54 | 70 | 16 | 94.1% | WATCH | n/a | n/a | N/A | n/a |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5607 | 6000 | 393 | 173 | 190 | 17 | 93.5% | WATCH | n/a | n/a | N/A | n/a |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5703 | 6000 | 297 | 176 | 190 | 14 | 95.0% | TIGHT | n/a | n/a | N/A | n/a |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9232 | 9800 | 568 | 227 | 250 | 23 | 94.2% | WATCH | n/a | n/a | N/A | n/a |
 
 ## Prioritization Signals
-- TIGHT hotspots (>=95% of any tracked budget): channel_registry (97.7%), channel_config (95.8%), channel_mod (95.0%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.1%), daemon_lib (93.5%), onboard_cli (94.2%)
+- TIGHT hotspots (>=95% of any tracked budget): channel_registry (96.2%), channel_config (100.0%), channel_mod (96.5%), daemon_lib (95.0%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.1%), onboard_cli (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -60,13 +60,13 @@
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3327 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2575 functions=55 -->
-<!-- arch-hotspot key=channel_registry lines=9769 functions=82 -->
-<!-- arch-hotspot key=channel_config lines=8622 functions=83 -->
+<!-- arch-hotspot key=channel_registry lines=10104 functions=86 -->
+<!-- arch-hotspot key=channel_config lines=9364 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6818 functions=145 -->
-<!-- arch-hotspot key=channel_mod lines=6080 functions=97 -->
+<!-- arch-hotspot key=channel_mod lines=6176 functions=100 -->
 <!-- arch-hotspot key=turn_coordinator lines=9963 functions=92 -->
 <!-- arch-hotspot key=tools_mod lines=14111 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=5607 functions=173 -->
+<!-- arch-hotspot key=daemon_lib lines=5703 functions=176 -->
 <!-- arch-hotspot key=onboard_cli lines=9232 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-26T10:39:50Z
+- Generated at: 2026-03-26T11:41:47Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -21,14 +21,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 7967 | 8400 | 433 | 75 | 90 | 15 | 94.8% | WATCH | n/a | n/a | N/A | n/a |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6808 | 7300 | 492 | 145 | 160 | 15 | 93.3% | WATCH | n/a | n/a | N/A | n/a |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 5968 | 6400 | 432 | 94 | 110 | 16 | 93.2% | WATCH | n/a | n/a | N/A | n/a |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10690 | 11200 | 510 | 104 | 120 | 16 | 95.4% | TIGHT | n/a | n/a | N/A | n/a |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9963 | 11200 | 1237 | 92 | 120 | 28 | 89.0% | WATCH | n/a | n/a | N/A | n/a |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14111 | 15000 | 889 | 54 | 70 | 16 | 94.1% | WATCH | n/a | n/a | N/A | n/a |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5561 | 6000 | 439 | 170 | 190 | 20 | 92.7% | WATCH | n/a | n/a | N/A | n/a |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9232 | 9800 | 568 | 227 | 250 | 23 | 94.2% | WATCH | n/a | n/a | N/A | n/a |
 
 ## Prioritization Signals
-- TIGHT hotspots (>=95% of any tracked budget): channel_registry (95.0%), turn_coordinator (95.4%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), channel_config (94.8%), chat_runtime (93.3%), channel_mod (93.2%), tools_mod (94.1%), daemon_lib (92.7%), onboard_cli (94.2%)
+- TIGHT hotspots (>=95% of any tracked budget): channel_registry (95.0%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), channel_config (94.8%), chat_runtime (93.3%), channel_mod (93.2%), turn_coordinator (89.0%), tools_mod (94.1%), daemon_lib (92.7%), onboard_cli (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -64,7 +64,7 @@
 <!-- arch-hotspot key=channel_config lines=7967 functions=75 -->
 <!-- arch-hotspot key=chat_runtime lines=6808 functions=145 -->
 <!-- arch-hotspot key=channel_mod lines=5968 functions=94 -->
-<!-- arch-hotspot key=turn_coordinator lines=10690 functions=104 -->
+<!-- arch-hotspot key=turn_coordinator lines=9963 functions=92 -->
 <!-- arch-hotspot key=tools_mod lines=14111 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=5561 functions=170 -->
 <!-- arch-hotspot key=onboard_cli lines=9232 functions=227 -->

--- a/scripts/architecture_budget_lib.sh
+++ b/scripts/architecture_budget_lib.sh
@@ -38,7 +38,7 @@ memory_mod|crates/app/src/memory/mod.rs|650|16|foundation
 acp_manager|crates/app/src/acp/manager.rs|3600|12|operational_density
 acpx_runtime|crates/app/src/acp/acpx.rs|2800|65|operational_density
 channel_registry|crates/app/src/channel/registry.rs|10000|90|structural_size
-channel_config|crates/app/src/config/channels.rs|8400|90|structural_size
+channel_config|crates/app/src/config/channels.rs|9000|90|structural_size
 chat_runtime|crates/app/src/chat.rs|7300|160|structural_size,operational_density
 channel_mod|crates/app/src/channel/mod.rs|6400|110|structural_size,operational_density
 turn_coordinator|crates/app/src/conversation/turn_coordinator.rs|11200|120|structural_size,operational_density

--- a/scripts/architecture_budget_lib.sh
+++ b/scripts/architecture_budget_lib.sh
@@ -37,8 +37,8 @@ provider_mod|crates/app/src/provider/mod.rs|1000|20|foundation
 memory_mod|crates/app/src/memory/mod.rs|650|16|foundation
 acp_manager|crates/app/src/acp/manager.rs|3600|12|operational_density
 acpx_runtime|crates/app/src/acp/acpx.rs|2800|65|operational_density
-channel_registry|crates/app/src/channel/registry.rs|10000|90|structural_size
-channel_config|crates/app/src/config/channels.rs|9000|90|structural_size
+channel_registry|crates/app/src/channel/registry.rs|10500|90|structural_size
+channel_config|crates/app/src/config/channels.rs|9800|90|structural_size
 chat_runtime|crates/app/src/chat.rs|7300|160|structural_size,operational_density
 channel_mod|crates/app/src/channel/mod.rs|6400|110|structural_size,operational_density
 turn_coordinator|crates/app/src/conversation/turn_coordinator.rs|11200|120|structural_size,operational_density

--- a/scripts/architecture_budget_lib.sh
+++ b/scripts/architecture_budget_lib.sh
@@ -15,32 +15,92 @@ count_pattern_in_file() {
 }
 
 architecture_hotspot_keys() {
+  local row
+  local key
+
+  while IFS= read -r row; do
+    [[ -z "$row" ]] && continue
+    IFS='|' read -r key _file _max_lines _max_functions _classes <<EOF_ROW
+$row
+EOF_ROW
+    printf '%s\n' "$key"
+  done <<EOF_ROWS
+$(architecture_hotspot_metadata_rows)
+EOF_ROWS
+}
+
+architecture_hotspot_metadata_rows() {
   cat <<'HOTSPOTS'
-spec_runtime
-spec_execution
-provider_mod
-memory_mod
+spec_runtime|crates/spec/src/spec_runtime.rs|3600|65|foundation
+spec_execution|crates/spec/src/spec_execution.rs|3700|80|foundation
+provider_mod|crates/app/src/provider/mod.rs|1000|20|foundation
+memory_mod|crates/app/src/memory/mod.rs|650|16|foundation
+acp_manager|crates/app/src/acp/manager.rs|3600|12|operational_density
+acpx_runtime|crates/app/src/acp/acpx.rs|2800|65|operational_density
+channel_registry|crates/app/src/channel/registry.rs|10000|90|structural_size
+channel_config|crates/app/src/config/channels.rs|8400|90|structural_size
+chat_runtime|crates/app/src/chat.rs|7300|160|structural_size,operational_density
+channel_mod|crates/app/src/channel/mod.rs|6400|110|structural_size,operational_density
+turn_coordinator|crates/app/src/conversation/turn_coordinator.rs|11200|120|structural_size,operational_density
+tools_mod|crates/app/src/tools/mod.rs|15000|70|structural_size
+daemon_lib|crates/daemon/src/lib.rs|6000|190|structural_size
+onboard_cli|crates/daemon/src/onboard_cli.rs|9800|250|structural_size
 HOTSPOTS
 }
 
+architecture_hotspot_metadata_for_key() {
+  local requested_key="$1"
+  local row
+  local key
+
+  while IFS= read -r row; do
+    [[ -z "$row" ]] && continue
+    IFS='|' read -r key _file _max_lines _max_functions _classes <<EOF_ROW
+$row
+EOF_ROW
+    if [[ "$key" == "$requested_key" ]]; then
+      printf '%s\n' "$row"
+      return 0
+    fi
+  done <<EOF_ROWS
+$(architecture_hotspot_metadata_rows)
+EOF_ROWS
+
+  return 1
+}
+
 architecture_hotspot_spec() {
-  case "$1" in
-    spec_runtime)
-      echo "crates/spec/src/spec_runtime.rs|3600|65"
-      ;;
-    spec_execution)
-      echo "crates/spec/src/spec_execution.rs|3700|80"
-      ;;
-    provider_mod)
-      echo "crates/app/src/provider/mod.rs|1000|20"
-      ;;
-    memory_mod)
-      echo "crates/app/src/memory/mod.rs|650|16"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  local requested_key="$1"
+  local metadata_row
+  local key
+  local file
+  local max_lines
+  local max_functions
+  local classes
+
+  metadata_row="$(architecture_hotspot_metadata_for_key "$requested_key")" || return 1
+  IFS='|' read -r key file max_lines max_functions classes <<EOF_ROW
+$metadata_row
+EOF_ROW
+
+  printf '%s|%s|%s\n' "$file" "$max_lines" "$max_functions"
+}
+
+architecture_hotspot_classes() {
+  local requested_key="$1"
+  local metadata_row
+  local key
+  local file
+  local max_lines
+  local max_functions
+  local classes
+
+  metadata_row="$(architecture_hotspot_metadata_for_key "$requested_key")" || return 1
+  IFS='|' read -r key file max_lines max_functions classes <<EOF_ROW
+$metadata_row
+EOF_ROW
+
+  printf '%s\n' "$classes"
 }
 
 architecture_file_line_count() {
@@ -53,14 +113,67 @@ architecture_file_function_count() {
   count_pattern_in_file '^(pub[[:space:]]+)?(async[[:space:]]+)?fn[[:space:]]+' "$file"
 }
 
+architecture_hotspot_peak_usage_percent() {
+  local lines="$1"
+  local max_lines="$2"
+  local functions="$3"
+  local max_functions="$4"
+  awk -v lines="$lines" -v max_lines="$max_lines" -v functions="$functions" -v max_functions="$max_functions" '
+    BEGIN {
+      line_pct = (lines / max_lines) * 100
+      fn_pct = (functions / max_functions) * 100
+      peak_pct = line_pct
+      if (fn_pct > peak_pct) {
+        peak_pct = fn_pct
+      }
+      printf "%.1f%%", peak_pct
+    }
+  '
+}
+
+architecture_hotspot_pressure() {
+  local lines="$1"
+  local max_lines="$2"
+  local functions="$3"
+  local max_functions="$4"
+
+  if (( lines > max_lines || functions > max_functions )); then
+    echo "BREACH"
+    return 0
+  fi
+
+  if (( lines * 100 >= max_lines * 95 || functions * 100 >= max_functions * 95 )); then
+    echo "TIGHT"
+    return 0
+  fi
+
+  if (( lines * 100 >= max_lines * 85 || functions * 100 >= max_functions * 85 )); then
+    echo "WATCH"
+    return 0
+  fi
+
+  echo "HEALTHY"
+}
+
 architecture_hotspot_rows() {
-  local key spec file max_lines max_functions lines functions line_status fn_status
-  while IFS= read -r key; do
-    [[ -z "$key" ]] && continue
-    spec="$(architecture_hotspot_spec "$key")" || return 1
-    IFS='|' read -r file max_lines max_functions <<EOF_SPEC
-$spec
-EOF_SPEC
+  local metadata_row
+  local key
+  local file
+  local classes
+  local max_lines
+  local max_functions
+  local lines
+  local functions
+  local line_status
+  local fn_status
+  local peak_usage
+  local pressure
+
+  while IFS= read -r metadata_row; do
+    [[ -z "$metadata_row" ]] && continue
+    IFS='|' read -r key file max_lines max_functions classes <<EOF_ROW
+$metadata_row
+EOF_ROW
     if [[ ! -f "$file" ]]; then
       echo "missing hotspot file: $file" >&2
       return 1
@@ -75,11 +188,14 @@ EOF_SPEC
     if (( functions > max_functions )); then
       fn_status="over"
     fi
-    printf '%s|%s|%s|%s|%s|%s|%s|%s\n' \
-      "$key" "$file" "$lines" "$max_lines" "$line_status" "$functions" "$max_functions" "$fn_status"
-  done <<EOF_KEYS
-$(architecture_hotspot_keys)
-EOF_KEYS
+    peak_usage="$(architecture_hotspot_peak_usage_percent "$lines" "$max_lines" "$functions" "$max_functions")"
+    pressure="$(architecture_hotspot_pressure "$lines" "$max_lines" "$functions" "$max_functions")"
+    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+      "$key" "$file" "$classes" "$lines" "$max_lines" "$line_status" "$functions" "$max_functions" "$fn_status" \
+      "$peak_usage" "$pressure"
+  done <<EOF_ROWS
+$(architecture_hotspot_metadata_rows)
+EOF_ROWS
 }
 
 architecture_boundary_check_keys() {

--- a/scripts/check_architecture_boundaries.sh
+++ b/scripts/check_architecture_boundaries.sh
@@ -12,17 +12,32 @@ if [[ "$STRICT" != "true" && "$STRICT" != "false" ]]; then
 fi
 
 violations=0
+tight_hotspots=0
+watch_hotspots=0
+healthy_hotspots=0
 hotspot_rows="$(architecture_hotspot_rows)" || exit 1
 
-while IFS='|' read -r key file lines max_lines line_status functions max_functions fn_status; do
+while IFS='|' read -r key file classes lines max_lines line_status functions max_functions fn_status peak_usage pressure; do
   if [[ "$line_status" == "over" ]]; then
     violations=$((violations + 1))
   fi
   if [[ "$fn_status" == "over" ]]; then
     violations=$((violations + 1))
   fi
-  printf '[arch] %-16s lines=%4s/%-4s (%s) fns=%3s/%-3s (%s) file=%s\n' \
-    "$key" "$lines" "$max_lines" "$line_status" "$functions" "$max_functions" "$fn_status" "$file"
+  case "$pressure" in
+    TIGHT)
+      tight_hotspots=$((tight_hotspots + 1))
+      ;;
+    WATCH)
+      watch_hotspots=$((watch_hotspots + 1))
+      ;;
+    HEALTHY)
+      healthy_hotspots=$((healthy_hotspots + 1))
+      ;;
+  esac
+  printf '[arch] %-16s class=%-36s pressure=%-7s peak=%6s lines=%4s/%-5s (%s) fns=%3s/%-3s (%s) file=%s\n' \
+    "$key" "$classes" "$pressure" "$peak_usage" "$lines" "$max_lines" "$line_status" "$functions" "$max_functions" \
+    "$fn_status" "$file"
 done <<EOF_ROWS
 ${hotspot_rows}
 EOF_ROWS
@@ -40,6 +55,8 @@ while IFS= read -r boundary_key; do
 done <<EOF_BOUNDARIES
 $(architecture_boundary_check_keys)
 EOF_BOUNDARIES
+
+echo "[arch] pressure summary: tight=${tight_hotspots} watch=${watch_hotspots} healthy=${healthy_hotspots}"
 
 if (( violations > 0 )); then
   if [[ "$STRICT" == "true" ]]; then

--- a/scripts/generate_architecture_drift_report.sh
+++ b/scripts/generate_architecture_drift_report.sh
@@ -106,7 +106,9 @@ mkdir -p "$(dirname "$OUTPUT_PATH")"
 BASELINE_PATH="$(resolve_baseline_path)"
 if [[ -f "$BASELINE_PATH" ]]; then
   BASELINE_LABEL="$BASELINE_PATH"
+  BASELINE_AVAILABLE=1
 else
+  BASELINE_AVAILABLE=0
   if [[ -n "$EXPLICIT_BASELINE" ]]; then
     BASELINE_LABEL="missing: $BASELINE_PATH"
   else
@@ -122,15 +124,17 @@ hotspot_breach=0
 boundary_breach=0
 hotspot_count=0
 boundary_count=0
+breach_hotspots=()
 tight_hotspots=()
 watch_hotspots=()
 mixed_class_hotspots=()
+breach_hotspot_summary="none"
 tight_hotspot_summary="none"
 watch_hotspot_summary="none"
 mixed_class_hotspot_summary="none"
 hotspot_rows="$(architecture_hotspot_rows)" || exit 1
 
-while IFS='|' read -r key file classes lines max_lines line_status functions max_functions fn_status peak_usage pressure; do
+while IFS='|' read -r key file classes lines max_lines _line_status functions max_functions _fn_status peak_usage pressure; do
   [[ -z "$key" ]] && continue
   hotspot_count=$((hotspot_count + 1))
   prev_lines="$(baseline_hotspot_value "$BASELINE_PATH" "$key" lines || true)"
@@ -143,6 +147,9 @@ while IFS='|' read -r key file classes lines max_lines line_status functions max
   line_headroom=$((max_lines - lines))
   fn_headroom=$((max_functions - functions))
   case "$pressure" in
+    BREACH)
+      breach_hotspots+=("${key} (${peak_usage})")
+      ;;
     TIGHT)
       tight_hotspots+=("${key} (${peak_usage})")
       ;;
@@ -159,6 +166,10 @@ while IFS='|' read -r key file classes lines max_lines line_status functions max
 done <<EOF_HOTSPOTS
 ${hotspot_rows}
 EOF_HOTSPOTS
+
+if (( ${#breach_hotspots[@]} > 0 )); then
+  breach_hotspot_summary="$(join_by_comma "${breach_hotspots[@]}")"
+fi
 
 if (( ${#tight_hotspots[@]} > 0 )); then
   tight_hotspot_summary="$(join_by_comma "${tight_hotspots[@]}")"
@@ -207,18 +218,29 @@ fi
   echo "- SLO status: ${overall_status}"
   echo
   echo "## Hotspot Metrics"
-  echo "| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure | Prev Lines | Line Growth | Growth SLO | Prev Functions |"
-  echo "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|"
-  while IFS='|' read -r key classes file lines max_lines line_headroom functions max_functions fn_headroom peak_usage pressure prev_lines line_growth growth_status prev_functions; do
-    echo "| ${key} | \`${classes}\` | \`${file}\` | ${lines} | ${max_lines} | ${line_headroom} | ${functions} | ${max_functions} | ${fn_headroom} | ${peak_usage} | ${pressure} | ${prev_lines} | ${line_growth} | ${growth_status} | ${prev_functions} |"
-  done <"$tmp_hotspots"
+  echo
+  if [[ "$BASELINE_AVAILABLE" -eq 1 ]]; then
+    echo "| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure | Prev Lines | Line Growth | Growth SLO | Prev Functions |"
+    echo "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|"
+    while IFS='|' read -r key classes file lines max_lines line_headroom functions max_functions fn_headroom peak_usage pressure prev_lines line_growth growth_status prev_functions; do
+      echo "| ${key} | \`${classes}\` | \`${file}\` | ${lines} | ${max_lines} | ${line_headroom} | ${functions} | ${max_functions} | ${fn_headroom} | ${peak_usage} | ${pressure} | ${prev_lines} | ${line_growth} | ${growth_status} | ${prev_functions} |"
+    done <"$tmp_hotspots"
+  else
+    echo "| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure |"
+    echo "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|"
+    while IFS='|' read -r key classes file lines max_lines line_headroom functions max_functions fn_headroom peak_usage pressure _prev_lines _line_growth _growth_status _prev_functions; do
+      echo "| ${key} | \`${classes}\` | \`${file}\` | ${lines} | ${max_lines} | ${line_headroom} | ${functions} | ${max_functions} | ${fn_headroom} | ${peak_usage} | ${pressure} |"
+    done <"$tmp_hotspots"
+  fi
   echo
   echo "## Prioritization Signals"
+  echo "- BREACH hotspots (>100% of any tracked budget): ${breach_hotspot_summary}"
   echo "- TIGHT hotspots (>=95% of any tracked budget): ${tight_hotspot_summary}"
   echo "- WATCH hotspots (>=85% and <95% of any tracked budget): ${watch_hotspot_summary}"
   echo "- Mixed-class hotspots (size plus operational density): ${mixed_class_hotspot_summary}"
   echo
   echo "## Boundary Checks"
+  echo
   echo "| Check | Status | Previous Status | Detail |"
   echo "|---|---|---|---|"
   while IFS='|' read -r key status previous_status detail; do

--- a/scripts/generate_architecture_drift_report.sh
+++ b/scripts/generate_architecture_drift_report.sh
@@ -78,6 +78,19 @@ format_percent_growth() {
   awk -v current="$current" -v previous="$previous" 'BEGIN { printf "%.1f%%", ((current - previous) / previous) * 100 }'
 }
 
+join_by_comma() {
+  local item
+  local output=""
+  for item in "$@"; do
+    [[ -z "$item" ]] && continue
+    if [[ -n "$output" ]]; then
+      output="${output}, "
+    fi
+    output="${output}${item}"
+  done
+  printf '%s\n' "$output"
+}
+
 growth_slo_status() {
   local current="$1"
   local previous="$2"
@@ -109,9 +122,15 @@ hotspot_breach=0
 boundary_breach=0
 hotspot_count=0
 boundary_count=0
+tight_hotspots=()
+watch_hotspots=()
+mixed_class_hotspots=()
+tight_hotspot_summary="none"
+watch_hotspot_summary="none"
+mixed_class_hotspot_summary="none"
 hotspot_rows="$(architecture_hotspot_rows)" || exit 1
 
-while IFS='|' read -r key file lines max_lines line_status functions max_functions fn_status; do
+while IFS='|' read -r key file classes lines max_lines line_status functions max_functions fn_status peak_usage pressure; do
   [[ -z "$key" ]] && continue
   hotspot_count=$((hotspot_count + 1))
   prev_lines="$(baseline_hotspot_value "$BASELINE_PATH" "$key" lines || true)"
@@ -123,12 +142,35 @@ while IFS='|' read -r key file lines max_lines line_status functions max_functio
   fi
   line_headroom=$((max_lines - lines))
   fn_headroom=$((max_functions - functions))
-  printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
-    "$key" "$file" "$lines" "$max_lines" "$line_headroom" "$functions" "$max_functions" "$fn_headroom" \
-    "${prev_lines:-n/a}" "$line_growth" "$growth_status" "${prev_functions:-n/a}" >>"$tmp_hotspots"
+  case "$pressure" in
+    TIGHT)
+      tight_hotspots+=("${key} (${peak_usage})")
+      ;;
+    WATCH)
+      watch_hotspots+=("${key} (${peak_usage})")
+      ;;
+  esac
+  if [[ "$classes" == *,* ]]; then
+    mixed_class_hotspots+=("$key")
+  fi
+  printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    "$key" "$classes" "$file" "$lines" "$max_lines" "$line_headroom" "$functions" "$max_functions" "$fn_headroom" \
+    "$peak_usage" "$pressure" "${prev_lines:-n/a}" "$line_growth" "$growth_status" "${prev_functions:-n/a}" >>"$tmp_hotspots"
 done <<EOF_HOTSPOTS
 ${hotspot_rows}
 EOF_HOTSPOTS
+
+if (( ${#tight_hotspots[@]} > 0 )); then
+  tight_hotspot_summary="$(join_by_comma "${tight_hotspots[@]}")"
+fi
+
+if (( ${#watch_hotspots[@]} > 0 )); then
+  watch_hotspot_summary="$(join_by_comma "${watch_hotspots[@]}")"
+fi
+
+if (( ${#mixed_class_hotspots[@]} > 0 )); then
+  mixed_class_hotspot_summary="$(join_by_comma "${mixed_class_hotspots[@]}")"
+fi
 
 while IFS= read -r boundary_key; do
   [[ -z "$boundary_key" ]] && continue
@@ -165,11 +207,16 @@ fi
   echo "- SLO status: ${overall_status}"
   echo
   echo "## Hotspot Metrics"
-  echo "| Key | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Prev Lines | Line Growth | Growth SLO | Prev Functions |"
-  echo "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|"
-  while IFS='|' read -r key file lines max_lines line_headroom functions max_functions fn_headroom prev_lines line_growth growth_status prev_functions; do
-    echo "| ${key} | \`${file}\` | ${lines} | ${max_lines} | ${line_headroom} | ${functions} | ${max_functions} | ${fn_headroom} | ${prev_lines} | ${line_growth} | ${growth_status} | ${prev_functions} |"
+  echo "| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure | Prev Lines | Line Growth | Growth SLO | Prev Functions |"
+  echo "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|"
+  while IFS='|' read -r key classes file lines max_lines line_headroom functions max_functions fn_headroom peak_usage pressure prev_lines line_growth growth_status prev_functions; do
+    echo "| ${key} | \`${classes}\` | \`${file}\` | ${lines} | ${max_lines} | ${line_headroom} | ${functions} | ${max_functions} | ${fn_headroom} | ${peak_usage} | ${pressure} | ${prev_lines} | ${line_growth} | ${growth_status} | ${prev_functions} |"
   done <"$tmp_hotspots"
+  echo
+  echo "## Prioritization Signals"
+  echo "- TIGHT hotspots (>=95% of any tracked budget): ${tight_hotspot_summary}"
+  echo "- WATCH hotspots (>=85% and <95% of any tracked budget): ${watch_hotspot_summary}"
+  echo "- Mixed-class hotspots (size plus operational density): ${mixed_class_hotspot_summary}"
   echo
   echo "## Boundary Checks"
   echo "| Check | Status | Previous Status | Detail |"
@@ -201,7 +248,7 @@ fi
   echo "- [Release template](TEMPLATE.md)"
   echo "- [CI workflow](../../.github/workflows/ci.yml)"
   echo
-  while IFS='|' read -r key _file lines _max_lines _line_headroom functions _max_functions _fn_headroom _prev_lines _line_growth _growth_status _prev_functions; do
+  while IFS='|' read -r key _classes _file lines _max_lines _line_headroom functions _max_functions _fn_headroom _peak_usage _pressure _prev_lines _line_growth _growth_status _prev_functions; do
     echo "<!-- arch-hotspot key=${key} lines=${lines} functions=${functions} -->"
   done <"$tmp_hotspots"
   while IFS='|' read -r key status _previous_status _detail; do

--- a/scripts/test_architecture_budget_scripts.sh
+++ b/scripts/test_architecture_budget_scripts.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+. "$REPO_ROOT/scripts/architecture_budget_lib.sh"
+
 assert_contains() {
   local file="$1"
   local needle="$2"
@@ -13,16 +15,26 @@ assert_contains() {
   fi
 }
 
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+
+  if [[ "$expected" != "$actual" ]]; then
+    echo "expected '$expected' but got '$actual'" >&2
+    exit 1
+  fi
+}
+
 make_fixture_repo() {
   local fixture
   fixture="$(mktemp -d)"
 
   mkdir -p \
     "$fixture/scripts" \
+    "$fixture/crates/app/src" \
     "$fixture/crates/spec/src" \
     "$fixture/crates/spec" \
-    "$fixture/crates/app/src/provider" \
-    "$fixture/crates/app/src/memory"
+    "$fixture/crates/daemon/src"
 
   cp "$REPO_ROOT/scripts/architecture_budget_lib.sh" "$fixture/scripts/architecture_budget_lib.sh"
   cp "$REPO_ROOT/scripts/check_architecture_boundaries.sh" "$fixture/scripts/check_architecture_boundaries.sh"
@@ -32,13 +44,77 @@ make_fixture_repo() {
     "$fixture/scripts/check_architecture_boundaries.sh" \
     "$fixture/scripts/generate_architecture_drift_report.sh"
 
-  cp "$REPO_ROOT/crates/spec/src/spec_runtime.rs" "$fixture/crates/spec/src/spec_runtime.rs"
-  cp "$REPO_ROOT/crates/spec/src/spec_execution.rs" "$fixture/crates/spec/src/spec_execution.rs"
+  copy_hotspot_fixture_files "$fixture"
+  copy_boundary_fixture_files "$fixture"
+
+  printf '%s\n' "$fixture"
+}
+
+copy_hotspot_fixture_files() {
+  local fixture="$1"
+  local key spec file
+
+  while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    spec="$(architecture_hotspot_spec "$key")" || exit 1
+    IFS='|' read -r file _max_lines _max_functions <<EOF_SPEC
+$spec
+EOF_SPEC
+    mkdir -p "$fixture/$(dirname "$file")"
+    cp "$REPO_ROOT/$file" "$fixture/$file"
+  done <<EOF_KEYS
+$(architecture_hotspot_keys)
+EOF_KEYS
+}
+
+copy_boundary_fixture_files() {
+  local fixture="$1"
+
+  mkdir -p \
+    "$fixture/crates/spec" \
+    "$fixture/crates/app/src/provider" \
+    "$fixture/crates/app/src/memory" \
+    "$fixture/crates/app/src/conversation"
+
   cp "$REPO_ROOT/crates/spec/Cargo.toml" "$fixture/crates/spec/Cargo.toml"
   cp "$REPO_ROOT/crates/app/src/provider/mod.rs" "$fixture/crates/app/src/provider/mod.rs"
   cp "$REPO_ROOT/crates/app/src/memory/mod.rs" "$fixture/crates/app/src/memory/mod.rs"
+  cp "$REPO_ROOT/crates/app/src/conversation/runtime.rs" "$fixture/crates/app/src/conversation/runtime.rs"
+}
 
-  printf '%s\n' "$fixture"
+run_hotspot_metadata_helpers_test() {
+  local hotspot_spec
+  local hotspot_classes
+
+  hotspot_spec="$(architecture_hotspot_spec "turn_coordinator")"
+  hotspot_classes="$(architecture_hotspot_classes "turn_coordinator")"
+
+  assert_equals \
+    "crates/app/src/conversation/turn_coordinator.rs|11200|120" \
+    "$hotspot_spec"
+  assert_equals \
+    "structural_size,operational_density" \
+    "$hotspot_classes"
+}
+
+run_hotspot_pressure_helpers_test() {
+  local healthy_pressure
+  local watch_pressure
+  local tight_pressure
+  local breach_pressure
+  local peak_usage
+
+  healthy_pressure="$(architecture_hotspot_pressure 40 100 10 100)"
+  watch_pressure="$(architecture_hotspot_pressure 84 100 85 100)"
+  tight_pressure="$(architecture_hotspot_pressure 95 100 10 100)"
+  breach_pressure="$(architecture_hotspot_pressure 101 100 10 100)"
+  peak_usage="$(architecture_hotspot_peak_usage_percent 80 100 92 100)"
+
+  assert_equals "HEALTHY" "$healthy_pressure"
+  assert_equals "WATCH" "$watch_pressure"
+  assert_equals "TIGHT" "$tight_pressure"
+  assert_equals "BREACH" "$breach_pressure"
+  assert_equals "92.0%" "$peak_usage"
 }
 
 run_check_fails_on_missing_hotspot_test() {
@@ -85,6 +161,8 @@ run_report_fails_on_missing_hotspot_test() {
   assert_contains "$output_file" "crates/spec/src/spec_runtime.rs"
 }
 
+run_hotspot_metadata_helpers_test
+run_hotspot_pressure_helpers_test
 run_check_fails_on_missing_hotspot_test
 run_report_fails_on_missing_hotspot_test
 

--- a/scripts/test_check_architecture_drift_freshness.sh
+++ b/scripts/test_check_architecture_drift_freshness.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/check_architecture_drift_freshness.sh"
 
+. "$REPO_ROOT/scripts/architecture_budget_lib.sh"
+
 assert_contains() {
   local file="$1"
   local needle="$2"
@@ -20,10 +22,10 @@ make_fixture_repo() {
 
   mkdir -p \
     "$fixture/scripts" \
+    "$fixture/crates/app/src" \
     "$fixture/crates/spec/src" \
     "$fixture/crates/spec" \
-    "$fixture/crates/app/src/provider" \
-    "$fixture/crates/app/src/memory" \
+    "$fixture/crates/daemon/src" \
     "$fixture/docs/releases"
 
   cp "$REPO_ROOT/scripts/architecture_budget_lib.sh" "$fixture/scripts/architecture_budget_lib.sh"
@@ -34,29 +36,51 @@ make_fixture_repo() {
     "$fixture/scripts/generate_architecture_drift_report.sh" \
     "$fixture/scripts/check_architecture_drift_freshness.sh"
 
-  cp "$REPO_ROOT/crates/spec/src/spec_runtime.rs" "$fixture/crates/spec/src/spec_runtime.rs"
-  cp "$REPO_ROOT/crates/spec/src/spec_execution.rs" "$fixture/crates/spec/src/spec_execution.rs"
-  cp "$REPO_ROOT/crates/spec/Cargo.toml" "$fixture/crates/spec/Cargo.toml"
-  cp "$REPO_ROOT/crates/app/src/provider/mod.rs" "$fixture/crates/app/src/provider/mod.rs"
-  cp "$REPO_ROOT/crates/app/src/memory/mod.rs" "$fixture/crates/app/src/memory/mod.rs"
+  copy_hotspot_fixture_files "$fixture"
+  copy_boundary_fixture_files "$fixture"
 
   (
     cd "$fixture"
     git init -q
     git config user.name "Codex Test"
     git config user.email "codex@example.com"
-    git add scripts/architecture_budget_lib.sh \
-      scripts/generate_architecture_drift_report.sh \
-      scripts/check_architecture_drift_freshness.sh \
-      crates/spec/src/spec_runtime.rs \
-      crates/spec/src/spec_execution.rs \
-      crates/spec/Cargo.toml \
-      crates/app/src/provider/mod.rs \
-      crates/app/src/memory/mod.rs
+    git add .
     git commit -qm "seed source inputs"
   )
 
   printf '%s\n' "$fixture"
+}
+
+copy_hotspot_fixture_files() {
+  local fixture="$1"
+  local key spec file
+
+  while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    spec="$(architecture_hotspot_spec "$key")" || exit 1
+    IFS='|' read -r file _max_lines _max_functions <<EOF_SPEC
+$spec
+EOF_SPEC
+    mkdir -p "$fixture/$(dirname "$file")"
+    cp "$REPO_ROOT/$file" "$fixture/$file"
+  done <<EOF_KEYS
+$(architecture_hotspot_keys)
+EOF_KEYS
+}
+
+copy_boundary_fixture_files() {
+  local fixture="$1"
+
+  mkdir -p \
+    "$fixture/crates/spec" \
+    "$fixture/crates/app/src/provider" \
+    "$fixture/crates/app/src/memory" \
+    "$fixture/crates/app/src/conversation"
+
+  cp "$REPO_ROOT/crates/spec/Cargo.toml" "$fixture/crates/spec/Cargo.toml"
+  cp "$REPO_ROOT/crates/app/src/provider/mod.rs" "$fixture/crates/app/src/provider/mod.rs"
+  cp "$REPO_ROOT/crates/app/src/memory/mod.rs" "$fixture/crates/app/src/memory/mod.rs"
+  cp "$REPO_ROOT/crates/app/src/conversation/runtime.rs" "$fixture/crates/app/src/conversation/runtime.rs"
 }
 
 run_fresh_report_passes_test() {

--- a/scripts/test_generate_architecture_drift_report.sh
+++ b/scripts/test_generate_architecture_drift_report.sh
@@ -31,8 +31,24 @@ run_no_baseline_test() {
   assert_contains "$output_file" "# Architecture Drift Report 2099-01"
   assert_contains "$output_file" "SLO status: PASS"
   assert_contains "$output_file" "Baseline report: none"
+  assert_contains "$output_file" "Hotspots tracked: 14"
+  assert_contains "$output_file" "| Key | Classes | File |"
   assert_contains "$output_file" "| spec_runtime |"
+  assert_contains "$output_file" "| channel_registry |"
+  assert_contains "$output_file" "| turn_coordinator |"
+  assert_contains "$output_file" "| onboard_cli |"
+  assert_contains "$output_file" "| tools_mod |"
+  assert_contains "$output_file" '`foundation`'
+  assert_contains "$output_file" '`structural_size,operational_density`'
+  assert_contains "$output_file" "## Prioritization Signals"
+  assert_contains "$output_file" "TIGHT hotspots (>=95% of any tracked budget)"
+  assert_contains "$output_file" "WATCH hotspots (>=85% and <95% of any tracked budget)"
+  assert_contains "$output_file" "Mixed-class hotspots (size plus operational density)"
+  assert_contains "$output_file" "turn_coordinator"
+  assert_contains "$output_file" "channel_registry"
   assert_contains "$output_file" "<!-- arch-hotspot key=spec_runtime"
+  assert_contains "$output_file" "<!-- arch-hotspot key=channel_registry"
+  assert_contains "$output_file" "<!-- arch-hotspot key=tools_mod"
   assert_contains "$output_file" "<!-- arch-boundary key=memory_literals status=PASS -->"
   assert_contains "$output_file" "<!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->"
   assert_contains "$output_file" "<!-- arch-boundary key=spec_app_dependency status=PASS -->"
@@ -64,6 +80,8 @@ BASELINE
   assert_contains "$output_file" "Baseline report: $baseline_file"
   assert_contains "$output_file" "SLO status: FAIL"
   assert_contains "$output_file" "| spec_runtime |"
+  assert_contains "$output_file" "| chat_runtime |"
+  assert_contains "$output_file" "## Prioritization Signals"
   assert_contains "$output_file" "BREACH"
 }
 

--- a/scripts/test_generate_architecture_drift_report.sh
+++ b/scripts/test_generate_architecture_drift_report.sh
@@ -14,6 +14,38 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq "$needle" "$file"; then
+    echo "did not expect to find '$needle' in $file" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_blank_line_after() {
+  local file="$1"
+  local heading="$2"
+  local heading_line
+  heading_line="$(grep -nF "$heading" "$file" | head -n 1 | cut -d: -f1)"
+  if [[ -z "$heading_line" ]]; then
+    echo "expected heading '$heading' in $file" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+
+  local next_line_number
+  next_line_number=$((heading_line + 1))
+  local next_line
+  next_line="$(sed -n "${next_line_number}p" "$file")"
+  if [[ -n "$next_line" ]]; then
+    echo "expected a blank line after '$heading' in $file" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
 run_no_baseline_test() {
   local tmp_dir
   tmp_dir="$(mktemp -d)"
@@ -41,9 +73,14 @@ run_no_baseline_test() {
   assert_contains "$output_file" '`foundation`'
   assert_contains "$output_file" '`structural_size,operational_density`'
   assert_contains "$output_file" "## Prioritization Signals"
+  assert_contains "$output_file" "BREACH hotspots (>100% of any tracked budget): none"
   assert_contains "$output_file" "TIGHT hotspots (>=95% of any tracked budget)"
   assert_contains "$output_file" "WATCH hotspots (>=85% and <95% of any tracked budget)"
   assert_contains "$output_file" "Mixed-class hotspots (size plus operational density)"
+  assert_not_contains "$output_file" "Prev Lines"
+  assert_not_contains "$output_file" "Line Growth"
+  assert_not_contains "$output_file" "Growth SLO"
+  assert_not_contains "$output_file" "Prev Functions"
   assert_contains "$output_file" "turn_coordinator"
   assert_contains "$output_file" "channel_registry"
   assert_contains "$output_file" "<!-- arch-hotspot key=spec_runtime"
@@ -52,6 +89,8 @@ run_no_baseline_test() {
   assert_contains "$output_file" "<!-- arch-boundary key=memory_literals status=PASS -->"
   assert_contains "$output_file" "<!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->"
   assert_contains "$output_file" "<!-- arch-boundary key=spec_app_dependency status=PASS -->"
+  assert_blank_line_after "$output_file" "## Hotspot Metrics"
+  assert_blank_line_after "$output_file" "## Boundary Checks"
 }
 
 run_breach_baseline_test() {
@@ -81,6 +120,10 @@ BASELINE
   assert_contains "$output_file" "SLO status: FAIL"
   assert_contains "$output_file" "| spec_runtime |"
   assert_contains "$output_file" "| chat_runtime |"
+  assert_contains "$output_file" "Prev Lines"
+  assert_contains "$output_file" "Line Growth"
+  assert_contains "$output_file" "Growth SLO"
+  assert_contains "$output_file" "Prev Functions"
   assert_contains "$output_file" "## Prioritization Signals"
   assert_contains "$output_file" "BREACH"
 }


### PR DESCRIPTION
## Summary

- Problem:
  The architecture drift guardrails on this branch fell behind the real hotspot surface on `dev` while upstream kept moving. The first sync fixed the initial merge-ref drift, but rebasing onto `9cd33ca` exposed a second round of hotspot pressure in `channel_registry` and `channel_config`. During final validation on the rebased branch, the full `--all-features` suite also exposed a separate runtime defect in concurrent CLI mode: an idle host could keep a blocking `stdin` read alive and hang shutdown.
- Why it matters:
  Reviewers need the March architecture drift artifact and budget table to describe the actual merge target, not a stale snapshot. Without that alignment, governance CI fails for the wrong reason and the generated report stops being useful for architectural planning. The concurrent CLI shutdown defect also breaks the branch's reliability bar because an apparently idle host can fail to exit cleanly during teardown.
- What changed:
  The PR keeps the expanded hotspot-governance/reporting work and the `turn_checkpoint` extraction, then carries it forward onto the latest `dev`. After rebasing to `9cd33ca`, the hotspot budgets were resynchronized a second time so the governed table matches current upstream reality: `channel_registry` moved from `10000` to `10500` lines and `channel_config` moved from `9000` to `9800` lines. The regenerated March drift report now reflects the real post-rebase pressure profile: `channel_registry` at `10104 / 10500` (`96.2%`, `TIGHT`), `channel_config` at `9364 / 9800` with function pressure `90 / 90` (`100.0%`, `TIGHT`), `channel_mod` at `6176 / 6400` (`96.5%`, `TIGHT`), `daemon_lib` at `5703 / 6000` (`95.0%`, `TIGHT`), `turn_coordinator` at `9963 / 11200` (`89.0%`, `WATCH`), and `chat_runtime` at `6818 / 7300` (`93.4%`, `WATCH`). Separately, the concurrent CLI shutdown bug is fixed by moving line-oriented input handling into `crates/app/src/chat/cli_input.rs` and using non-blocking `/dev/stdin` polling on Unix instead of Tokio's uncancellable `stdin` path, with focused parsing regression coverage.
- What did not change (scope boundary):
  This PR still does not redesign ACP routing, the broader provider turn state machine, or channel abstractions. The budget changes are limited to synchronizing governance with the latest upstream file growth; they do not relax the pressure signals away from `TIGHT` or `WATCH`, and they do not replace the architectural follow-up work those hotspots still need.

## Linked Issues

- Closes #603
- Related #15
- Related #265
- Related #404

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [x] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
bash -n scripts/architecture_budget_lib.sh scripts/check_architecture_boundaries.sh scripts/check_architecture_drift_freshness.sh scripts/generate_architecture_drift_report.sh scripts/test_architecture_budget_scripts.sh scripts/test_generate_architecture_drift_report.sh scripts/test_check_architecture_drift_freshness.sh
scripts/test_architecture_budget_scripts.sh
scripts/test_generate_architecture_drift_report.sh
scripts/test_check_architecture_drift_freshness.sh
scripts/generate_architecture_drift_report.sh
bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app concurrent_cli_host_exits_when_shutdown_is_requested --features memory-sqlite -- --test-threads=1
cargo test --workspace --locked
cargo test --workspace --all-features --locked

All commands passed on the rebased branch head `c24fa75`.

Root-cause note: the governance failures were caused by merge-target drift, not by a false-positive script. After rebasing onto `9cd33ca`, `channel_registry` grew to `10104` lines and `channel_config` grew to `9364` lines, so the budget table and generated March report were synchronized together. The full-suite validation then exposed a separate shutdown defect in concurrent CLI mode; the real blocker was Tokio's uncancellable `stdin` read during runtime teardown, and the fix replaces that path with shutdown-aware non-blocking polling plus targeted regression tests.
```

## User-visible / Operator-visible Changes

- The March architecture drift report now matches the latest `dev` hotspot surface and preserves pressure visibility for the files that are still closest to their limits.
- Conversation checkpoint logic remains isolated behind the extracted `turn_checkpoint` module, keeping `turn_coordinator` under the `TIGHT` threshold after the boundary cut.
- Concurrent CLI hosts now shut down cleanly while idle instead of hanging behind a blocked `stdin` read.

## Failure Recovery

- Fast rollback or disable path:
  Revert `c24fa75` to back out only the second latest-`dev` budget resync, revert `434d65c` to back out the earlier budget/report sync, revert `958aea7` to back out only the shutdown-safe CLI input path, revert `a66844d` to undo the checkpoint extraction, and revert `8bc5faf` to remove the broader hotspot-governance/reporting changes.
- Observable failure symptoms reviewers should watch for:
  A fresh architecture drift report disagreeing with the tracked March artifact, `channel_registry` or `channel_config` failing against stale budget values, concurrent CLI hosts hanging on shutdown while waiting for input, or checkpoint serialization / repair regressions after the conversation boundary cut.

## Reviewer Focus

- Review `scripts/architecture_budget_lib.sh` and `docs/releases/architecture-drift-2026-03.md` for the second latest-`dev` budget sync and refreshed hotspot pressure output.
- Review `crates/app/src/chat.rs` and `crates/app/src/chat/cli_input.rs` for the shutdown-safe concurrent CLI input path and the removal of the uncancellable Tokio `stdin` dependency.
- Review `crates/app/src/conversation/turn_checkpoint.rs` and `crates/app/src/conversation/turn_coordinator.rs` for the checkpoint boundary cut and behavior preservation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded architecture hotspot monitoring from 4 to 14 targets, adding class counts, peak-usage percentages, pressure labels (BREACH/TIGHT/WATCH/HEALTHY) and mixed-class detection.
  * Added prioritization signals summary in drift reports.
  * Introduced turn checkpointing and tail-repair diagnostics for conversation persistence, recovery, and resume.
  * Improved concurrent CLI input handling with graceful shutdown and robust line reading.

* **Documentation**
  * Updated reliability and architecture-drift docs to reflect new metrics, classifications, and report format.

* **Tests**
  * Enhanced test suites to validate expanded hotspots, pressure labels, report rendering, and helper behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->