### PR TITLE
Add capability action classes to the tool catalog

### DIFF
--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -34,6 +34,42 @@ impl ToolSchedulingClass {
     }
 }
 
+/// Semantic action families for the autonomy-policy kernel.
+///
+/// This taxonomy intentionally tracks policy-relevant boundary crossings
+/// instead of modeling every possible side effect as its own class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityActionClass {
+    Discover,
+    // Ordinary already-visible execution stays in this bucket unless it crosses
+    // a policy boundary such as acquisition, switching, or topology mutation.
+    ExecuteExisting,
+    CapabilityFetch,
+    CapabilityInstall,
+    CapabilityLoad,
+    RuntimeSwitch,
+    TopologyExpand,
+    PolicyMutation,
+    SessionMutation,
+}
+
+impl CapabilityActionClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Discover => "discover",
+            Self::ExecuteExisting => "execute_existing",
+            Self::CapabilityFetch => "capability_fetch",
+            Self::CapabilityInstall => "capability_install",
+            Self::CapabilityLoad => "capability_load",
+            Self::RuntimeSwitch => "runtime_switch",
+            Self::TopologyExpand => "topology_expand",
+            Self::PolicyMutation => "policy_mutation",
+            Self::SessionMutation => "session_mutation",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolGovernanceScope {
     Routine,
@@ -158,6 +194,18 @@ pub fn governance_profile_for_descriptor(descriptor: &ToolDescriptor) -> ToolGov
     descriptor.governance_profile()
 }
 
+pub fn capability_action_class_for_tool_name(tool_name: &str) -> Option<CapabilityActionClass> {
+    let catalog = tool_catalog();
+    let descriptor = catalog.resolve(tool_name)?;
+    Some(descriptor.capability_action_class())
+}
+
+pub fn capability_action_class_for_descriptor(
+    descriptor: &ToolDescriptor,
+) -> CapabilityActionClass {
+    descriptor.capability_action_class()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolExposureClass {
     ProviderCore,
@@ -189,6 +237,7 @@ pub struct ToolDescriptor {
     pub availability: ToolAvailability,
     pub exposure: ToolExposureClass,
     pub visibility_gate: ToolVisibilityGate,
+    capability_action_class: CapabilityActionClass,
     policy: ToolPolicyDescriptor,
     provider_definition_builder: fn(&ToolDescriptor) -> Value,
 }
@@ -226,6 +275,10 @@ impl ToolDescriptor {
         self.exposure == ToolExposureClass::Discoverable
     }
 
+    pub fn capability_action_class(&self) -> CapabilityActionClass {
+        self.capability_action_class
+    }
+
     pub fn scheduling_class(&self) -> ToolSchedulingClass {
         self.policy.scheduling_class
     }
@@ -247,6 +300,7 @@ pub struct ToolCatalogEntry {
     pub exposure: ToolExposureClass,
     pub execution_kind: ToolExecutionKind,
     pub availability: ToolAvailability,
+    pub capability_action_class: CapabilityActionClass,
     pub scheduling_class: ToolSchedulingClass,
 }
 
@@ -377,6 +431,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::ProviderCore,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::Discover,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: tool_search_definition,
         },
@@ -389,6 +444,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::ProviderCore,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: tool_invoke_definition,
         },
@@ -401,6 +457,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: claw_migrate_definition,
         },
@@ -413,6 +470,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
+            capability_action_class: CapabilityActionClass::CapabilityFetch,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: external_skills_fetch_definition,
         },
@@ -425,6 +483,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
+            capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: external_skills_inspect_definition,
         },
@@ -437,6 +496,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
+            capability_action_class: CapabilityActionClass::CapabilityInstall,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: external_skills_install_definition,
         },
@@ -449,6 +509,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
+            capability_action_class: CapabilityActionClass::CapabilityLoad,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: external_skills_invoke_definition,
         },
@@ -461,6 +522,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
+            capability_action_class: CapabilityActionClass::Discover,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: external_skills_list_definition,
         },
@@ -473,6 +535,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::PolicyMutation,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: external_skills_policy_definition,
         },
@@ -485,6 +548,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::ExternalSkills,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: external_skills_remove_definition,
         },
@@ -497,6 +561,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::RuntimeSwitch,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: provider_switch_definition,
         },
@@ -509,6 +574,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: approval_request_resolve_definition,
         },
@@ -521,6 +587,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: approval_request_status_definition,
         },
@@ -533,6 +600,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: approval_requests_list_definition,
         },
@@ -545,6 +613,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Delegate,
+            capability_action_class: CapabilityActionClass::TopologyExpand,
             policy: TOPOLOGY_MUTATION_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: delegate_definition,
         },
@@ -557,6 +626,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Delegate,
+            capability_action_class: CapabilityActionClass::TopologyExpand,
             policy: TOPOLOGY_MUTATION_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: delegate_async_definition,
         },
@@ -569,6 +639,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::SessionMutation,
+            capability_action_class: CapabilityActionClass::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_archive_definition,
         },
@@ -581,6 +652,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::SessionMutation,
+            capability_action_class: CapabilityActionClass::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_cancel_definition,
         },
@@ -593,6 +665,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_events_definition,
         },
@@ -605,6 +678,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::SessionMutation,
+            capability_action_class: CapabilityActionClass::SessionMutation,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_recover_definition,
         },
@@ -617,6 +691,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_status_definition,
         },
@@ -629,6 +704,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_wait_definition,
         },
@@ -641,6 +717,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: sessions_history_definition,
         },
@@ -653,6 +730,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: sessions_list_definition,
         },
@@ -665,6 +743,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_messaging_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Messages,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: ELEVATED_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: sessions_send_definition,
         },
@@ -681,6 +760,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: file_read_definition,
         });
@@ -693,6 +773,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::MemoryFileRoot,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: memory_search_definition,
         });
@@ -705,6 +786,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::MemoryFileRoot,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: memory_get_definition,
         });
@@ -717,6 +799,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: file_write_definition,
         });
@@ -729,6 +812,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: file_edit_definition,
         });
@@ -745,6 +829,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Always,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: shell_exec_definition,
         });
@@ -761,6 +846,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Browser,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_click_definition,
         });
@@ -773,6 +859,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_companion_click_definition,
         });
@@ -785,6 +872,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_companion_navigate_definition,
         });
@@ -797,6 +885,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_companion_session_start_definition,
         });
@@ -809,6 +898,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_companion_session_stop_definition,
         });
@@ -821,6 +911,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_companion_snapshot_definition,
         });
@@ -833,6 +924,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_companion_type_definition,
         });
@@ -845,6 +937,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::BrowserCompanion,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_companion_wait_definition,
         });
@@ -857,6 +950,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Browser,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_extract_definition,
         });
@@ -870,6 +964,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Browser,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: browser_open_definition,
         });
@@ -886,6 +981,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::WebFetch,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: web_fetch_definition,
         });
@@ -903,6 +999,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::WebSearch,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: web_search_definition,
         });
@@ -1080,6 +1177,7 @@ fn descriptor_to_entry(descriptor: &ToolDescriptor) -> ToolCatalogEntry {
         exposure: descriptor.exposure,
         execution_kind: descriptor.execution_kind,
         availability: descriptor.availability,
+        capability_action_class: descriptor.capability_action_class(),
         scheduling_class: descriptor.scheduling_class(),
     }
 }
@@ -2960,6 +3058,95 @@ mod tests {
         assert_ne!(descriptor.provider_name, "shell");
         assert!(descriptor.aliases.contains(&"shell"));
         assert_eq!(alias_policy, expected_policy);
+    }
+
+    #[test]
+    fn autonomy_capability_action_is_independent_from_governance_profile() {
+        let catalog = tool_catalog();
+        let migrate = catalog
+            .descriptor("claw.migrate")
+            .expect("claw.migrate descriptor");
+        let provider_switch = catalog
+            .descriptor("provider.switch")
+            .expect("provider.switch descriptor");
+        let migrate_policy = governance_profile_for_descriptor(migrate);
+        let provider_switch_policy = governance_profile_for_descriptor(provider_switch);
+
+        assert_eq!(migrate_policy, provider_switch_policy);
+        assert_eq!(
+            migrate.scheduling_class(),
+            provider_switch.scheduling_class()
+        );
+        assert_eq!(
+            capability_action_class_for_descriptor(migrate),
+            CapabilityActionClass::ExecuteExisting
+        );
+        assert_eq!(
+            capability_action_class_for_descriptor(provider_switch),
+            CapabilityActionClass::RuntimeSwitch
+        );
+        assert_ne!(
+            migrate.capability_action_class(),
+            provider_switch.capability_action_class()
+        );
+    }
+
+    #[test]
+    fn autonomy_capability_action_classifies_representative_tool_families() {
+        let expectations = [
+            ("tool.search", CapabilityActionClass::Discover),
+            ("tool_search", CapabilityActionClass::Discover),
+            ("tool.invoke", CapabilityActionClass::ExecuteExisting),
+            (
+                "external_skills.fetch",
+                CapabilityActionClass::CapabilityFetch,
+            ),
+            (
+                "external_skills.install",
+                CapabilityActionClass::CapabilityInstall,
+            ),
+            (
+                "external_skills.invoke",
+                CapabilityActionClass::CapabilityLoad,
+            ),
+            ("provider.switch", CapabilityActionClass::RuntimeSwitch),
+            ("delegate", CapabilityActionClass::TopologyExpand),
+            ("delegate_async", CapabilityActionClass::TopologyExpand),
+            (
+                "external_skills.policy",
+                CapabilityActionClass::PolicyMutation,
+            ),
+            ("session_archive", CapabilityActionClass::SessionMutation),
+            ("session_cancel", CapabilityActionClass::SessionMutation),
+            ("session_recover", CapabilityActionClass::SessionMutation),
+        ];
+
+        for (tool_name, expected_action_class) in expectations {
+            let resolved_action_class = capability_action_class_for_tool_name(tool_name)
+                .unwrap_or_else(|| panic!("missing action class for `{tool_name}`"));
+
+            assert_eq!(resolved_action_class, expected_action_class);
+        }
+    }
+
+    #[test]
+    fn autonomy_capability_action_catalog_entries_expose_serializable_metadata() {
+        let entry =
+            find_tool_catalog_entry("delegate_async").expect("delegate_async catalog entry");
+        let value = serde_json::to_value(entry).expect("serialize catalog entry");
+
+        assert_eq!(
+            entry.capability_action_class,
+            CapabilityActionClass::TopologyExpand
+        );
+        assert_eq!(value["capability_action_class"], "topology_expand");
+    }
+
+    #[test]
+    fn autonomy_capability_action_returns_none_for_unknown_tools() {
+        let action_class = capability_action_class_for_tool_name("unknown.tool");
+
+        assert_eq!(action_class, None);
     }
 
     #[test]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -574,7 +574,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
-            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            capability_action_class: CapabilityActionClass::PolicyMutation,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: approval_request_resolve_definition,
         },
@@ -3097,6 +3097,7 @@ mod tests {
             ("tool.search", CapabilityActionClass::Discover),
             ("tool_search", CapabilityActionClass::Discover),
             ("tool.invoke", CapabilityActionClass::ExecuteExisting),
+            ("claw.migrate", CapabilityActionClass::ExecuteExisting),
             (
                 "external_skills.fetch",
                 CapabilityActionClass::CapabilityFetch,
@@ -3113,11 +3114,16 @@ mod tests {
             ("delegate", CapabilityActionClass::TopologyExpand),
             ("delegate_async", CapabilityActionClass::TopologyExpand),
             (
+                "approval_request_resolve",
+                CapabilityActionClass::PolicyMutation,
+            ),
+            (
                 "external_skills.policy",
                 CapabilityActionClass::PolicyMutation,
             ),
             ("session_archive", CapabilityActionClass::SessionMutation),
             ("session_cancel", CapabilityActionClass::SessionMutation),
+            ("session_events", CapabilityActionClass::ExecuteExisting),
             ("session_recover", CapabilityActionClass::SessionMutation),
         ];
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -62,13 +62,15 @@ mod web_http;
 mod web_search;
 
 pub use catalog::{
-    ToolApprovalMode, ToolAvailability, ToolCatalog, ToolDescriptor, ToolExecutionKind,
-    ToolGovernanceProfile, ToolGovernanceScope, ToolRiskClass, ToolSchedulingClass, ToolView,
-    delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
-    governance_profile_for_descriptor, governance_profile_for_tool_name,
-    planned_delegate_child_tool_view, planned_root_tool_view, runtime_tool_view,
-    runtime_tool_view_for_config, runtime_tool_view_for_config_with_external_skills,
-    runtime_tool_view_for_runtime_config, tool_catalog,
+    CapabilityActionClass, ToolApprovalMode, ToolAvailability, ToolCatalog, ToolDescriptor,
+    ToolExecutionKind, ToolGovernanceProfile, ToolGovernanceScope, ToolRiskClass,
+    ToolSchedulingClass, ToolView, capability_action_class_for_descriptor,
+    capability_action_class_for_tool_name, delegate_child_tool_view_for_config,
+    delegate_child_tool_view_for_config_with_delegate, governance_profile_for_descriptor,
+    governance_profile_for_tool_name, planned_delegate_child_tool_view, planned_root_tool_view,
+    runtime_tool_view, runtime_tool_view_for_config,
+    runtime_tool_view_for_config_with_external_skills, runtime_tool_view_for_runtime_config,
+    tool_catalog,
 };
 #[cfg(feature = "feishu-integration")]
 pub(crate) use feishu::{DeferredFeishuCardUpdate, drain_deferred_feishu_card_updates};


### PR DESCRIPTION
## Summary

- Problem:
  The autonomy-policy rollout still lacked a typed semantic action layer in the
  tool catalog, so the next decision-engine slice would have had to infer policy
  meaning from raw tool-name checks.
- Why it matters:
  As tools, channels, and SDK surfaces grow, raw-name conditionals would drift
  back into runtime policy code and recreate the same architectural coupling this
  track is trying to remove.
- What changed:
  Added `CapabilityActionClass`, attached it to tool descriptors and catalog
  entries, exposed typed lookup helpers, classified the catalog centrally, and
  added regression tests for representative discovery, acquisition, switch,
  topology, and session-mutation paths.
- What did not change (scope boundary):
  This PR does not implement the autonomy decision engine, does not widen any
  runtime permission, and does not move channel-specific policy logic into the
  catalog.

## Linked Issues

- Closes #607
- Related #596, #601

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  The new action class metadata is intentionally internal and conservative, but
  later autonomy-policy slices will consume it directly, so taxonomy mistakes
  here would propagate into future policy evaluation.
- Rollout / guardrails:
  This slice only adds typed catalog metadata and regression coverage. Runtime
  behavior stays unchanged until the future decision engine consumes the new
  field.
- Rollback path:
  Revert this commit to remove the enum, helper surface, and catalog metadata.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
PASS

cargo test -p loongclaw-app autonomy_capability_action_ -- --test-threads=1
PASS

cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
PASS
```

## User-visible / Operator-visible Changes

- None. This is an internal catalog and policy-shaping metadata slice.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR. No config migration or runtime flag flip is required.
- Observable failure symptoms reviewers should watch for:
  Wrong action-class assignment would show up as future policy logic treating a
  tool as discovery, acquisition, or mutation when it should not.

## Reviewer Focus

- Check `crates/app/src/tools/catalog.rs` for the taxonomy shape and the per-tool
  classifications.
- Check the regression tests for the intended separation between governance
  profile and semantic action class.
- Check that `execute_existing` stays the catch-all for already-visible execution
  rather than becoming another raw-name special-case bucket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * All tools are now classified by a capability action class.
  * Tool catalog entries expose capability classification in serialized output for integration.
  * New public lookup functions let callers retrieve a tool's capability action class by tool name or by descriptor.
  * Classification is applied consistently across the tool catalog during build, and a public accessor returns a tool's class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->