### PR TITLE
fix(windows): resolve 8.3 short names and UNC paths in daemon integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dialoguer",
+ "dunce",
  "ed25519-dalek",
  "libc",
  "loongclaw-app",

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -2501,13 +2501,12 @@ fn project_discovery_probe_roots(
     let Some(project_root) = project_discovery_root(config) else {
         return Vec::new();
     };
-    let project_root = project_root
-        .canonicalize()
-        .unwrap_or_else(|_| project_root.clone());
+    let project_root =
+        dunce::canonicalize(&project_root).unwrap_or_else(|_| project_root.clone());
 
     let mut roots = Vec::new();
     if let Ok(current_dir) = std::env::current_dir() {
-        let current_dir = current_dir.canonicalize().unwrap_or(current_dir);
+        let current_dir = dunce::canonicalize(&current_dir).unwrap_or(current_dir);
         if current_dir.starts_with(&project_root) {
             let mut next = Some(current_dir.as_path());
             while let Some(path) = next {
@@ -2635,7 +2634,7 @@ fn visit_discoverable_skill_roots(
     roots: &mut Vec<PathBuf>,
     visited: &mut BTreeSet<String>,
 ) {
-    let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let canonical = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     let key = canonical.display().to_string();
     if !visited.insert(key) {
         return;

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -2501,8 +2501,7 @@ fn project_discovery_probe_roots(
     let Some(project_root) = project_discovery_root(config) else {
         return Vec::new();
     };
-    let project_root =
-        dunce::canonicalize(&project_root).unwrap_or_else(|_| project_root.clone());
+    let project_root = dunce::canonicalize(&project_root).unwrap_or_else(|_| project_root.clone());
 
     let mut roots = Vec::new();
     if let Ok(current_dir) = std::env::current_dir() {

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -49,6 +49,7 @@ libc = "0.2"
 
 [dependencies]
 clap.workspace = true
+dunce = "1"
 clap_complete = "4.5"
 dialoguer.workspace = true
 kernel = { package = "loongclaw-kernel", path = "../kernel" }
@@ -75,6 +76,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 axum.workspace = true
+dunce = "1"
 loongclaw-spec = { path = "../spec", features = ["test-hooks"] }
 sha2.workspace = true
 wat = "1"

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1155,7 +1155,7 @@ fn persist_runtime_capability_artifact(
 }
 
 fn canonicalize_existing_path(path: &Path) -> CliResult<String> {
-    fs::canonicalize(path)
+    dunce::canonicalize(path)
         .map(|resolved| resolved.display().to_string())
         .map_err(|error| {
             format!(

--- a/crates/daemon/tests/integration/import_cli.rs
+++ b/crates/daemon/tests/integration/import_cli.rs
@@ -39,7 +39,8 @@ fn unique_temp_dir(label: &str) -> PathBuf {
         .expect("system time before unix epoch")
         .as_nanos();
     let counter = IMPORT_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
+    let base = dunce::canonicalize(std::env::temp_dir()).unwrap_or_else(|_| std::env::temp_dir());
+    base.join(format!(
         "loongclaw-import-{label}-{}-{nanos}-{counter}",
         std::process::id(),
     ))

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -17,7 +17,8 @@ fn unique_temp_dir(label: &str) -> PathBuf {
         .expect("system time before unix epoch")
         .as_nanos();
     let counter = MIGRATION_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
+    let base = dunce::canonicalize(std::env::temp_dir()).unwrap_or_else(|_| std::env::temp_dir());
+    base.join(format!(
         "loongclaw-migration-{label}-{}-{nanos}-{counter}",
         std::process::id(),
     ))

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -40,7 +40,8 @@ fn unique_temp_path(label: &str) -> PathBuf {
         .expect("system time before unix epoch")
         .as_nanos();
     let counter = TEMP_PATH_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
+    let base = dunce::canonicalize(std::env::temp_dir()).unwrap_or_else(|_| std::env::temp_dir());
+    base.join(format!(
         "loongclaw-onboard-{label}-{}-{nanos}-{counter}",
         std::process::id(),
     ))

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -17,7 +17,8 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("clock should be after epoch")
         .as_nanos();
-    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    let base = dunce::canonicalize(std::env::temp_dir()).unwrap_or_else(|_| std::env::temp_dir());
+    base.join(format!("{prefix}-{nanos}"))
 }
 
 fn write_runtime_capability_config(root: &Path) -> PathBuf {

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -19,7 +19,8 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("clock should be after epoch")
         .as_nanos();
-    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    let base = dunce::canonicalize(std::env::temp_dir()).unwrap_or_else(|_| std::env::temp_dir());
+    base.join(format!("{prefix}-{nanos}"))
 }
 
 fn write_file(root: &Path, relative: &str, content: &str) {


### PR DESCRIPTION
## Summary

Fix 7 daemon integration tests that fail on `windows-latest` CI runner due to 8.3 short names and UNC path prefixes. These are pre-existing Windows compatibility issues discovered by adding Windows to the CI matrix (#590).

Fixes #610

## Root Causes

1. **8.3 short names** (6 tests): `std::env::temp_dir()` returns `C:\Users\RUNNER~1\...` on CI. Test-constructed paths retain this short name, but OS APIs (`read_dir`, `canonicalize`) resolve to the long form (`runneradmin`), breaking string assertions.

2. **UNC prefix** (1 test): `std::fs::canonicalize` returns `\?\C:\...` on Windows. Production code in `external_skills.rs` used this for skill discovery paths, breaking `contains()` assertions that expect forward-slash substrings.

## Changes

**Test fixes** (5 files):
- `import_cli.rs`, `migration.rs`, `onboard_cli.rs`, `runtime_capability_cli.rs`, `skills_cli.rs`: canonicalize `temp_dir()` via `dunce::canonicalize` in `unique_temp_dir` / `unique_temp_path` helpers

**Production fixes** (2 files):
- `crates/app/src/tools/external_skills.rs`: replace `.canonicalize()` with `dunce::canonicalize()` in `project_discovery_probe_roots` (2 call sites) and `discover_skills_from_root` (1 call site)
- `crates/daemon/src/runtime_capability_cli.rs`: replace `fs::canonicalize` with `dunce::canonicalize` in `canonicalize_existing_path`

**Dependencies**:
- `crates/daemon/Cargo.toml`: add `dunce = "1"` to both `[dependencies]` and `[dev-dependencies]`

## Validation

```
cargo check -p loongclaw-daemon → passes
cargo test -p loongclaw-app --lib → 2177 passed, 0 failed
```

Windows CI verification requires #590 (CI matrix PR).

## Related

- Part of #304 (Windows test compatibility)
- Unblocks #590 (cross-platform CI matrix)
- Same root cause patterns as #586 (UNC) and #593 (8.3 short names), applied to daemon crate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal path canonicalization handling across the application to improve system compatibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->