### PR TITLE
fix(app): clarify provider auth env visibility failures

### DIFF
--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -1186,10 +1186,13 @@ impl ProviderConfig {
         if let Some(hint) = self.alternative_auth_configuration_hint() {
             configuration_paths.push(hint);
         }
-        let mut message = format!(
-            "provider credentials are missing; {}",
-            join_guidance_options(&configuration_paths)
-        );
+        let mut message = "provider credentials are missing".to_owned();
+        if let Some(detail) = self.missing_auth_runtime_detail() {
+            message.push_str("; ");
+            message.push_str(detail.as_str());
+        }
+        message.push_str("; ");
+        message.push_str(join_guidance_options(&configuration_paths).as_str());
         if let Some(hint) = self.auth_guidance_hint() {
             message.push(' ');
             message.push_str(hint.as_str());
@@ -1833,6 +1836,38 @@ impl ProviderConfig {
         Some(env_name)
     }
 
+    fn missing_auth_source_runtime_detail(
+        &self,
+        label: &str,
+        secret_ref: Option<&SecretRef>,
+        configured_env_name: Option<&str>,
+    ) -> Option<String> {
+        match resolve_secret_lookup(secret_ref) {
+            SecretLookup::Value(_) => return None,
+            SecretLookup::Missing => {
+                if let Some(env_name) = secret_ref_env_name(secret_ref) {
+                    return Some(format!(
+                        "configured provider {label} env `{env_name}` is unset, empty, or not visible to the current process"
+                    ));
+                }
+                if has_configured_secret_ref(secret_ref) {
+                    return Some(format!(
+                        "configured provider {label} secret reference could not be resolved at runtime"
+                    ));
+                }
+            }
+            SecretLookup::Absent => {}
+        }
+
+        let env_name = configured_env_name?;
+        match env::var(env_name) {
+            Ok(value) if !value.trim().is_empty() => None,
+            _ => Some(format!(
+                "configured provider {label} env `{env_name}` is unset, empty, or not visible to the current process"
+            )),
+        }
+    }
+
     pub fn configured_api_key_env_override(&self) -> Option<String> {
         let explicit_secret_env = secret_ref_env_name(self.api_key.as_ref());
         if let Some(explicit_secret_env) = explicit_secret_env {
@@ -1848,6 +1883,29 @@ impl ProviderConfig {
         }
         self.configured_oauth_access_token_env_name()
             .map(str::to_owned)
+    }
+
+    fn missing_auth_runtime_detail(&self) -> Option<String> {
+        match self.kind.auth_scheme() {
+            ProviderAuthScheme::Bearer => self
+                .missing_auth_source_runtime_detail(
+                    "oauth access token",
+                    self.oauth_access_token.as_ref(),
+                    self.configured_oauth_access_token_env_name(),
+                )
+                .or_else(|| {
+                    self.missing_auth_source_runtime_detail(
+                        "api key",
+                        self.api_key.as_ref(),
+                        self.configured_api_key_env_name(),
+                    )
+                }),
+            ProviderAuthScheme::XApiKey => self.missing_auth_source_runtime_detail(
+                "api key",
+                self.api_key.as_ref(),
+                self.configured_api_key_env_name(),
+            ),
+        }
     }
 
     pub fn normalized_for_persistence(&self) -> Self {

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -467,6 +467,26 @@ fn missing_auth_configuration_message_mentions_current_process_for_explicit_env_
 }
 
 #[test]
+fn missing_auth_configuration_message_mentions_current_process_for_explicit_oauth_env_secret_ref() {
+    let mut env = ScopedEnv::new();
+    env.remove("OPENAI_CODEX_OAUTH_TOKEN");
+    let provider = ProviderConfig {
+        kind: ProviderKind::Openai,
+        oauth_access_token: Some(SecretRef::Env {
+            env: "OPENAI_CODEX_OAUTH_TOKEN".to_owned(),
+        }),
+        ..ProviderConfig::default()
+    };
+
+    let message = provider.missing_auth_configuration_message();
+
+    assert!(message.contains("provider credentials are missing"));
+    assert!(message.contains("oauth access token"));
+    assert!(message.contains("OPENAI_CODEX_OAUTH_TOKEN"));
+    assert!(message.contains("current process"));
+}
+
+#[test]
 fn missing_auth_configuration_message_mentions_current_process_for_explicit_api_key_env_field() {
     let mut env = ScopedEnv::new();
     env.remove("DEEPSEEK_API_KEY");
@@ -482,6 +502,26 @@ api_key_env = "DEEPSEEK_API_KEY"
 
     assert!(message.contains("provider credentials are missing"));
     assert!(message.contains("DEEPSEEK_API_KEY"));
+    assert!(message.contains("current process"));
+}
+
+#[test]
+fn missing_auth_configuration_message_mentions_current_process_for_explicit_oauth_env_field() {
+    let mut env = ScopedEnv::new();
+    env.remove("OPENAI_CODEX_OAUTH_TOKEN");
+    let provider: ProviderConfig = toml::from_str(
+        r#"
+kind = "openai"
+oauth_access_token_env = "OPENAI_CODEX_OAUTH_TOKEN"
+"#,
+    )
+    .expect("deserialize provider config");
+
+    let message = provider.missing_auth_configuration_message();
+
+    assert!(message.contains("provider credentials are missing"));
+    assert!(message.contains("oauth access token"));
+    assert!(message.contains("OPENAI_CODEX_OAUTH_TOKEN"));
     assert!(message.contains("current process"));
 }
 

--- a/crates/app/src/provider/tests.rs
+++ b/crates/app/src/provider/tests.rs
@@ -447,6 +447,44 @@ fn bedrock_missing_auth_configuration_message_mentions_sigv4_fallback() {
     assert!(message.contains("AWS_REGION"));
 }
 
+#[test]
+fn missing_auth_configuration_message_mentions_current_process_for_explicit_env_secret_ref() {
+    let mut env = ScopedEnv::new();
+    env.remove("DEEPSEEK_API_KEY");
+    let provider = ProviderConfig {
+        kind: ProviderKind::Deepseek,
+        api_key: Some(SecretRef::Env {
+            env: "DEEPSEEK_API_KEY".to_owned(),
+        }),
+        ..ProviderConfig::default()
+    };
+
+    let message = provider.missing_auth_configuration_message();
+
+    assert!(message.contains("provider credentials are missing"));
+    assert!(message.contains("DEEPSEEK_API_KEY"));
+    assert!(message.contains("current process"));
+}
+
+#[test]
+fn missing_auth_configuration_message_mentions_current_process_for_explicit_api_key_env_field() {
+    let mut env = ScopedEnv::new();
+    env.remove("DEEPSEEK_API_KEY");
+    let provider: ProviderConfig = toml::from_str(
+        r#"
+kind = "deepseek"
+api_key_env = "DEEPSEEK_API_KEY"
+"#,
+    )
+    .expect("deserialize provider config");
+
+    let message = provider.missing_auth_configuration_message();
+
+    assert!(message.contains("provider credentials are missing"));
+    assert!(message.contains("DEEPSEEK_API_KEY"));
+    assert!(message.contains("current process"));
+}
+
 fn cleanup_sqlite_artifacts(path: &Path) {
     let _ = std::fs::remove_file(path);
     let wal = format!("{}-wal", path.display());


### PR DESCRIPTION
## Summary
- clarify missing-provider-auth errors when an explicitly configured env binding is not visible to the current process
- preserve existing remediation guidance for supported auth configuration paths
- add regression coverage for both `SecretRef::Env` and legacy `api_key_env` configuration

## Problem
Users can hit a confusing false-negative flow where `curl` works with `DEEPSEEK_API_KEY`, but LoongClaw still returns `[provider_error] provider credentials are missing` because the current runtime process cannot resolve the configured env binding.

## Validation
- `cargo fmt --all`
- `cargo test -p loongclaw-app missing_auth_configuration_message_mentions_current_process_for_explicit_env_secret_ref -- --nocapture`
- `cargo test -p loongclaw-app missing_auth_configuration_message_mentions_current_process_for_explicit_api_key_env_field -- --nocapture`
- `cargo test -p loongclaw-app custom_missing_auth_configuration_message_mentions_supported_headers -- --nocapture`
- `cargo test -p loongclaw-app bedrock_missing_auth_configuration_message_mentions_sigv4_fallback -- --nocapture`
- `cargo test -p loongclaw-app provider_auth_ready -- --nocapture`

Closes #624


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when provider credentials are missing, now providing runtime-specific details that guide users on which credentials are needed and where to configure them based on the authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->