### PR TITLE
Align shipped service-channel ordering with registry metadata

### DIFF
--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -3451,6 +3451,11 @@ pub fn list_channel_catalog() -> Vec<ChannelCatalogEntry> {
         .collect()
 }
 
+pub(crate) fn resolve_channel_selection_order(raw: &str) -> Option<u16> {
+    let descriptor = find_channel_registry_descriptor(raw)?;
+    Some(descriptor.selection_order)
+}
+
 pub fn normalize_channel_catalog_id(raw: &str) -> Option<&'static str> {
     find_channel_registry_descriptor(raw).map(|descriptor| descriptor.id)
 }
@@ -7511,6 +7516,13 @@ mod tests {
         assert_eq!(normalize_channel_catalog_id("urbit"), Some("tlon"));
         assert_eq!(normalize_channel_catalog_id("web-ui"), Some("webchat"));
         assert_eq!(normalize_channel_catalog_id("unknown"), None);
+    }
+
+    #[test]
+    fn resolve_channel_selection_order_uses_registry_metadata() {
+        assert_eq!(resolve_channel_selection_order("telegram"), Some(10));
+        assert_eq!(resolve_channel_selection_order("discord-bot"), Some(40));
+        assert_eq!(resolve_channel_selection_order("unknown"), None);
     }
 
     #[test]

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -7522,6 +7522,7 @@ mod tests {
     fn resolve_channel_selection_order_uses_registry_metadata() {
         assert_eq!(resolve_channel_selection_order("telegram"), Some(10));
         assert_eq!(resolve_channel_selection_order("discord-bot"), Some(40));
+        assert_eq!(resolve_channel_selection_order(" DISCORD-BOT "), Some(40));
         assert_eq!(resolve_channel_selection_order("unknown"), None);
     }
 

--- a/crates/app/src/channel/sdk.rs
+++ b/crates/app/src/channel/sdk.rs
@@ -6,7 +6,7 @@ use crate::{
 use super::registry::{
     ChannelRuntimeCommandDescriptor, FEISHU_CATALOG_COMMAND_FAMILY_DESCRIPTOR,
     MATRIX_CATALOG_COMMAND_FAMILY_DESCRIPTOR, TELEGRAM_CATALOG_COMMAND_FAMILY_DESCRIPTOR,
-    WECOM_CATALOG_COMMAND_FAMILY_DESCRIPTOR,
+    WECOM_CATALOG_COMMAND_FAMILY_DESCRIPTOR, resolve_channel_selection_order,
 };
 
 #[cfg(feature = "channel-feishu")]
@@ -428,9 +428,27 @@ pub(crate) fn channel_descriptor(id: &str) -> Option<&'static ChannelDescriptor>
     Some(integration.descriptor)
 }
 
+fn ordered_channel_integrations() -> Vec<&'static ChannelIntegrationDescriptor> {
+    let mut integrations = CHANNEL_INTEGRATIONS.iter().collect::<Vec<_>>();
+    integrations.sort_by_key(|integration| channel_integration_order_key(integration));
+    integrations
+}
+
+fn channel_integration_order_key(
+    integration: &ChannelIntegrationDescriptor,
+) -> (u8, u16, &'static str) {
+    let runtime_group = match integration.descriptor.runtime_kind {
+        ChannelRuntimeKind::Interactive => 0_u8,
+        ChannelRuntimeKind::Service => 1_u8,
+    };
+    let selection_order =
+        resolve_channel_selection_order(integration.descriptor.id).unwrap_or(u16::MAX);
+    (runtime_group, selection_order, integration.descriptor.id)
+}
+
 pub(crate) fn service_channel_descriptors() -> Vec<&'static ChannelDescriptor> {
-    CHANNEL_INTEGRATIONS
-        .iter()
+    ordered_channel_integrations()
+        .into_iter()
         .map(|integration| integration.descriptor)
         .filter(|descriptor| descriptor.runtime_kind == ChannelRuntimeKind::Service)
         .collect()
@@ -440,8 +458,8 @@ pub(crate) fn enabled_channel_ids(
     config: &LoongClawConfig,
     runtime_kind: Option<ChannelRuntimeKind>,
 ) -> Vec<String> {
-    CHANNEL_INTEGRATIONS
-        .iter()
+    ordered_channel_integrations()
+        .into_iter()
         .filter(|integration| {
             let enabled = (integration.is_enabled)(config);
             let matches_runtime_kind =
@@ -455,15 +473,15 @@ pub(crate) fn enabled_channel_ids(
 pub(crate) fn collect_channel_validation_issues(
     config: &LoongClawConfig,
 ) -> Vec<ConfigValidationIssue> {
-    CHANNEL_INTEGRATIONS
-        .iter()
+    ordered_channel_integrations()
+        .into_iter()
         .flat_map(|integration| (integration.collect_validation_issues)(config))
         .collect()
 }
 
 pub fn background_channel_runtime_descriptors() -> Vec<ChannelRuntimeCommandDescriptor> {
-    CHANNEL_INTEGRATIONS
-        .iter()
+    ordered_channel_integrations()
+        .into_iter()
         .filter_map(|integration| integration.background_runtime)
         .collect()
 }
@@ -754,49 +772,68 @@ mod tests {
 
     use super::*;
 
+    fn expected_service_channel_ids() -> Vec<&'static str> {
+        let mut channel_ids = Vec::new();
+        let catalog = super::super::registry::list_channel_catalog();
+
+        for catalog_entry in catalog {
+            let Some(descriptor) = channel_descriptor(catalog_entry.id) else {
+                continue;
+            };
+            if descriptor.runtime_kind != ChannelRuntimeKind::Service {
+                continue;
+            }
+            channel_ids.push(descriptor.id);
+        }
+
+        channel_ids
+    }
+
+    fn expected_background_channel_ids() -> Vec<&'static str> {
+        let mut channel_ids = Vec::new();
+        let catalog = super::super::registry::list_channel_catalog();
+
+        for catalog_entry in catalog {
+            let runtime_descriptor =
+                super::super::registry::resolve_channel_runtime_command_descriptor(
+                    catalog_entry.id,
+                );
+            if runtime_descriptor.is_none() {
+                continue;
+            }
+            let Some(descriptor) = channel_descriptor(catalog_entry.id) else {
+                continue;
+            };
+            if descriptor.runtime_kind != ChannelRuntimeKind::Service {
+                continue;
+            }
+            channel_ids.push(descriptor.id);
+        }
+
+        channel_ids
+    }
+
     #[test]
-    fn service_channel_descriptors_follow_integration_order() {
+    fn service_channel_descriptors_follow_registry_selection_order() {
         let descriptors = service_channel_descriptors();
         let ids = descriptors
             .into_iter()
             .map(|descriptor| descriptor.id)
             .collect::<Vec<_>>();
-
-        assert_eq!(
-            ids,
-            vec![
-                "telegram",
-                "feishu",
-                "matrix",
-                "wecom",
-                "discord",
-                "slack",
-                "line",
-                "dingtalk",
-                "whatsapp",
-                "email",
-                "webhook",
-                "google-chat",
-                "signal",
-                "teams",
-                "mattermost",
-                "nextcloud-talk",
-                "synology-chat",
-                "irc",
-                "imessage",
-            ]
-        );
+        let expected_ids = expected_service_channel_ids();
+        assert_eq!(ids, expected_ids);
     }
 
     #[test]
-    fn background_channel_runtime_descriptors_follow_integration_order() {
+    fn background_channel_runtime_descriptors_follow_registry_selection_order() {
         let descriptors = background_channel_runtime_descriptors();
         let ids = descriptors
             .into_iter()
             .map(|descriptor| descriptor.channel_id)
             .collect::<Vec<_>>();
+        let expected_ids = expected_background_channel_ids();
 
-        assert_eq!(ids, vec!["telegram", "feishu", "matrix", "wecom"]);
+        assert_eq!(ids, expected_ids);
     }
 
     #[test]

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -124,27 +124,44 @@ mod tests {
     use std::collections::BTreeSet;
 
     fn expected_service_channel_ids() -> Vec<&'static str> {
-        vec![
-            "telegram",
-            "feishu",
-            "matrix",
-            "wecom",
-            "discord",
-            "slack",
-            "line",
-            "dingtalk",
-            "whatsapp",
-            "email",
-            "webhook",
-            "google-chat",
-            "signal",
-            "teams",
-            "mattermost",
-            "nextcloud-talk",
-            "synology-chat",
-            "irc",
-            "imessage",
-        ]
+        let mut service_ids = Vec::new();
+        let catalog = crate::channel::list_channel_catalog();
+
+        for catalog_entry in catalog {
+            let Some(descriptor) = channel_descriptor(catalog_entry.id) else {
+                continue;
+            };
+            if descriptor.runtime_kind != ChannelRuntimeKind::Service {
+                continue;
+            }
+            service_ids.push(descriptor.id);
+        }
+
+        service_ids
+    }
+
+    fn config_with_all_service_channels_enabled() -> LoongClawConfig {
+        let default_config = LoongClawConfig::default();
+        let mut config_value =
+            serde_json::to_value(default_config).expect("serialize default config");
+        let config_object = config_value
+            .as_object_mut()
+            .expect("config should serialize to an object");
+        let service_ids = expected_service_channel_ids();
+
+        for channel_id in service_ids {
+            let field_name = channel_id.replace('-', "_");
+            let channel_value = config_object
+                .get_mut(field_name.as_str())
+                .expect("service channel config field");
+            let channel_object = channel_value
+                .as_object_mut()
+                .expect("channel config should serialize to an object");
+            let enabled_value = serde_json::Value::Bool(true);
+            channel_object.insert("enabled".to_owned(), enabled_value);
+        }
+
+        serde_json::from_value(config_value).expect("deserialize enabled config")
     }
 
     #[test]
@@ -282,65 +299,29 @@ mod tests {
 
     #[test]
     fn enabled_channel_views_follow_shared_catalog_order() {
-        let mut config = LoongClawConfig::default();
-        assert_eq!(config.enabled_channel_ids(), vec!["cli"]);
-        assert!(config.enabled_service_channel_ids().is_empty());
+        let default_config = LoongClawConfig::default();
+        assert_eq!(default_config.enabled_channel_ids(), vec!["cli"]);
+        assert!(default_config.enabled_service_channel_ids().is_empty());
+        let config = config_with_all_service_channels_enabled();
+        let expected_service_ids = expected_service_channel_ids();
+        let expected_enabled_service_ids = expected_service_ids
+            .iter()
+            .map(|channel_id| (*channel_id).to_owned())
+            .collect::<Vec<_>>();
+        let mut expected_enabled_channel_ids = vec!["cli".to_owned()];
+        expected_enabled_channel_ids.extend(expected_enabled_service_ids.iter().cloned());
 
-        config.telegram.enabled = true;
-        config.feishu.enabled = true;
-        config.matrix.enabled = true;
-        config.wecom.enabled = true;
-        config.discord.enabled = true;
-        config.slack.enabled = true;
-        config.line.enabled = true;
-        config.dingtalk.enabled = true;
-        config.whatsapp.enabled = true;
-        config.email.enabled = true;
-        config.webhook.enabled = true;
-        config.google_chat.enabled = true;
-        config.signal.enabled = true;
-        config.teams.enabled = true;
-        config.mattermost.enabled = true;
-        config.nextcloud_talk.enabled = true;
-        config.synology_chat.enabled = true;
-        config.irc.enabled = true;
-        config.imessage.enabled = true;
-
-        assert_eq!(
-            config.enabled_channel_ids(),
-            vec![
-                "cli",
-                "telegram",
-                "feishu",
-                "matrix",
-                "wecom",
-                "discord",
-                "slack",
-                "line",
-                "dingtalk",
-                "whatsapp",
-                "email",
-                "webhook",
-                "google-chat",
-                "signal",
-                "teams",
-                "mattermost",
-                "nextcloud-talk",
-                "synology-chat",
-                "irc",
-                "imessage",
-            ]
-        );
+        assert_eq!(config.enabled_channel_ids(), expected_enabled_channel_ids);
         assert_eq!(
             config.enabled_service_channel_ids(),
-            expected_service_channel_ids()
+            expected_enabled_service_ids
         );
 
         let service_ids = service_channel_descriptors()
             .into_iter()
             .map(|descriptor| descriptor.id)
             .collect::<Vec<_>>();
-        assert_eq!(service_ids, expected_service_channel_ids());
+        assert_eq!(service_ids, expected_service_ids);
     }
 
     #[test]
@@ -353,7 +334,7 @@ mod tests {
     }
 
     #[test]
-    fn service_channel_descriptors_include_matrix_surface() {
+    fn service_channel_descriptors_follow_registry_selection_order() {
         let service_ids = service_channel_descriptors()
             .into_iter()
             .map(|descriptor| descriptor.id)

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-27T08:28:49Z
+- Generated at: 2026-03-27T08:56:02Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -18,7 +18,7 @@
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3327 | 3600 | 273 | 8 | 12 | 4 | 92.4% | WATCH |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2575 | 2800 | 225 | 55 | 65 | 10 | 92.0% | WATCH |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10448 | 10500 | 52 | 90 | 90 | 0 | 100.0% | TIGHT |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10461 | 10500 | 39 | 90 | 90 | 0 | 100.0% | TIGHT |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9446 | 9800 | 354 | 90 | 90 | 0 | 100.0% | TIGHT |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6325 | 6400 | 75 | 103 | 110 | 7 | 98.8% | TIGHT |
@@ -63,7 +63,7 @@
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3327 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2575 functions=55 -->
-<!-- arch-hotspot key=channel_registry lines=10448 functions=90 -->
+<!-- arch-hotspot key=channel_registry lines=10461 functions=90 -->
 <!-- arch-hotspot key=channel_config lines=9446 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
 <!-- arch-hotspot key=channel_mod lines=6325 functions=103 -->


### PR DESCRIPTION
## Summary

- Problem: `crates/app/src/channel/sdk.rs` still followed local `CHANNEL_INTEGRATIONS` order even though the channel registry already carried the canonical `selection_order` metadata.
- Why it matters: That left config-facing service-channel views vulnerable to drifting away from the shared catalog order used by channel inventory, migration flows, and background-runtime listings.
- What changed:
  - Added a crate-private registry helper to resolve channel `selection_order` from the canonical catalog metadata.
  - Sorted sdk-derived service-channel descriptors, enabled-channel views, background runtime descriptors, and channel validation traversal from registry metadata while keeping interactive channels ahead of service channels.
  - Reworked sdk and config tests to derive expected service ordering from the registry catalog instead of hardcoded order tables, and auto-enable shipped service configs in test coverage.
  - Rebased the branch onto the latest `dev` head and refreshed the tracked March 2026 architecture drift report so governance checks stay aligned with both the registry change and the latest `channel/mod.rs` baseline metrics.
- What did not change (scope boundary):
  - No new channel surfaces or runtime adapters were added.
  - No migration adapter registration set changed.
  - No config schema, env contract, or onboarding copy changed.

## Linked Issues

- Closes #626
- Related #622

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
cargo test --workspace --locked
cargo test --workspace --all-features --locked
cargo clippy --workspace --all-targets --all-features -- -D warnings
```

Results:
- Workspace tests passed on the rebased head under both default and all-features builds.
- Clippy passed with `-D warnings`.
- Architecture drift freshness passed after refreshing the tracked March 2026 report against the latest `dev` baseline.

## User-visible / Operator-visible Changes

- Shipped service-channel descriptors, enabled-channel views, and background-runtime listings now follow the registry's canonical `selection_order`, which keeps config-facing ordering aligned with catalog and migration surfaces.

## Failure Recovery

- Fast rollback or disable path: Revert commits `c8db4cc`, `6589519`, and `cc6a181` to restore the previous sdk-local iteration order, pre-refresh drift report snapshots, and pre-review test coverage wording.
- Observable failure symptoms reviewers should watch for: service-channel lists appearing in a different order between config views, channel catalog output, migration/onboarding previews, and background runtime listings.

## Reviewer Focus

- `crates/app/src/channel/sdk.rs`: registry-driven ordering, the interactive-vs-service ordering boundary, and the surfaces that now share one ordering path.
- `crates/app/src/channel/registry.rs`: the narrow crate-private `selection_order` helper.
- `crates/app/src/config/mod.rs`: registry-derived expectations replacing remaining hardcoded order lists in tests.
- `docs/releases/architecture-drift-2026-03.md`: the refreshed tracked drift metrics required by governance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Channel integrations are now ordered using a registry-driven system, ensuring consistent and predictable channel presentation across the application.

* **Tests**
  * Updated test suite to dynamically validate channel ordering against the runtime registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


