### PR TITLE
Add WeCom to shipped migration and onboarding surfaces

### DIFF
--- a/crates/daemon/src/migration/channels/mod.rs
+++ b/crates/daemon/src/migration/channels/mod.rs
@@ -10,6 +10,7 @@ use super::types::{
 mod feishu;
 mod matrix;
 mod telegram;
+mod wecom;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChannelPreview {
@@ -60,7 +61,7 @@ struct ChannelAdapter {
     apply_default_env_bindings: fn(&mut mvp::config::LoongClawConfig) -> Vec<String>,
 }
 
-const REGISTRY: [ChannelAdapter; 3] = [
+const REGISTRY: [ChannelAdapter; 4] = [
     ChannelAdapter {
         id: telegram::ID,
         collect_preview: telegram::collect_preview,
@@ -90,6 +91,16 @@ const REGISTRY: [ChannelAdapter; 3] = [
         collect_preflight_checks: matrix::collect_preflight_checks,
         collect_doctor_checks: matrix::collect_doctor_checks,
         apply_default_env_bindings: matrix::apply_default_env_bindings,
+    },
+    ChannelAdapter {
+        id: wecom::ID,
+        collect_preview: wecom::collect_preview,
+        apply: wecom::apply,
+        readiness_state: wecom::readiness_state,
+        apply_import_readiness: wecom::apply_import_readiness,
+        collect_preflight_checks: wecom::collect_preflight_checks,
+        collect_doctor_checks: wecom::collect_doctor_checks,
+        apply_default_env_bindings: wecom::apply_default_env_bindings,
     },
 ];
 

--- a/crates/daemon/src/migration/channels/wecom.rs
+++ b/crates/daemon/src/migration/channels/wecom.rs
@@ -230,9 +230,12 @@ fn merge_wecom_config(
             changed = true;
         }
     }
-    if target.websocket_url == default.websocket_url
-        && source.websocket_url != default.websocket_url
-    {
+    let default_websocket_url = default.resolved_websocket_url();
+    let target_websocket_url = target.resolved_websocket_url();
+    let source_websocket_url = source.resolved_websocket_url();
+    let target_uses_default_websocket = target_websocket_url == default_websocket_url;
+    let source_uses_default_websocket = source_websocket_url == default_websocket_url;
+    if target_uses_default_websocket && !source_uses_default_websocket {
         target.websocket_url = source.websocket_url.clone();
         changed = true;
     }
@@ -520,5 +523,41 @@ mod tests {
         assert_eq!(target.allowed_conversation_ids, vec!["group_ops"]);
         assert_eq!(target.acp.working_directory.as_deref(), Some("/tmp/wecom"));
         assert!(target.accounts.contains_key("ops"));
+    }
+
+    #[test]
+    fn merge_wecom_config_treats_explicit_default_websocket_url_as_default() {
+        let default_websocket_url =
+            mvp::config::WecomChannelConfig::default().resolved_websocket_url();
+        let mut target = mvp::config::WecomChannelConfig {
+            websocket_url: Some(default_websocket_url),
+            ..Default::default()
+        };
+        let source = mvp::config::WecomChannelConfig {
+            websocket_url: Some("wss://wecom.example.test".to_owned()),
+            ..Default::default()
+        };
+
+        let changed = merge_wecom_config(&mut target, &source);
+
+        assert!(changed);
+        assert_eq!(
+            target.websocket_url.as_deref(),
+            Some("wss://wecom.example.test")
+        );
+    }
+
+    #[test]
+    fn merge_wecom_config_ignores_blank_websocket_url_override() {
+        let mut target = mvp::config::WecomChannelConfig::default();
+        let source = mvp::config::WecomChannelConfig {
+            websocket_url: Some("   ".to_owned()),
+            ..Default::default()
+        };
+
+        let changed = merge_wecom_config(&mut target, &source);
+
+        assert!(!changed);
+        assert_eq!(target.websocket_url, None);
     }
 }

--- a/crates/daemon/src/migration/channels/wecom.rs
+++ b/crates/daemon/src/migration/channels/wecom.rs
@@ -1,0 +1,524 @@
+use loongclaw_app as mvp;
+
+use super::ChannelDoctorCheck;
+use super::ensure_default_env_binding;
+use super::{ChannelCheckLevel, ChannelPreflightCheck, ChannelPreview, build_channel_preview};
+use crate::migration::ChannelCredentialState;
+use crate::migration::{ChannelImportReadiness, ImportSurfaceLevel};
+
+pub(super) const ID: &str = "wecom";
+
+const FALLBACK_DESCRIPTOR: mvp::config::ChannelDescriptor = mvp::config::ChannelDescriptor {
+    id: ID,
+    label: "wecom",
+    surface_label: "wecom channel",
+    runtime_kind: mvp::config::ChannelRuntimeKind::Service,
+    serve_subcommand: Some("wecom-serve"),
+};
+
+#[derive(Debug, Clone)]
+struct EffectiveWecomConfig {
+    enabled: bool,
+    bot_id: Option<String>,
+    secret: Option<String>,
+    bot_id_env: Option<String>,
+    secret_env: Option<String>,
+    websocket_url: String,
+    allowed_conversation_ids: Vec<String>,
+}
+
+pub(super) fn collect_preview(
+    config: &mvp::config::LoongClawConfig,
+    readiness: &ChannelImportReadiness,
+    source: &str,
+) -> Option<ChannelPreview> {
+    let credential_state = readiness.state(ID);
+    let effective = effective_wecom_config(config);
+    let default_wecom = mvp::config::WecomChannelConfig::default();
+    let default_websocket_url = default_wecom.resolved_websocket_url();
+    let configured = effective.enabled
+        || credential_state != ChannelCredentialState::Missing
+        || effective.bot_id_env != default_wecom.bot_id_env
+        || effective.secret_env != default_wecom.secret_env
+        || effective.websocket_url != default_websocket_url
+        || !effective.allowed_conversation_ids.is_empty();
+    if !configured {
+        return None;
+    }
+
+    let level = if credential_state.is_ready() {
+        ImportSurfaceLevel::Ready
+    } else if effective.enabled {
+        ImportSurfaceLevel::Review
+    } else {
+        ImportSurfaceLevel::Blocked
+    };
+    let detail = match (effective.enabled, credential_state) {
+        (true, ChannelCredentialState::Ready) => {
+            let conversation_count = effective.allowed_conversation_ids.len();
+            format!(
+                "enabled · credentials resolved · {conversation_count} allowed conversation id(s)"
+            )
+        }
+        (false, ChannelCredentialState::Ready) => {
+            "credentials resolved · can enable during onboarding".to_owned()
+        }
+        (true, ChannelCredentialState::Partial) => "enabled · bot_id or secret missing".to_owned(),
+        (false, ChannelCredentialState::Partial) => {
+            "configured · bot_id or secret missing".to_owned()
+        }
+        (true, ChannelCredentialState::Missing) => "enabled · bot_id or secret missing".to_owned(),
+        (false, ChannelCredentialState::Missing) => "configured but disabled".to_owned(),
+    };
+
+    Some(build_channel_preview(
+        ID,
+        descriptor().label,
+        descriptor().surface_label,
+        source.to_owned(),
+        level,
+        detail,
+    ))
+}
+
+pub(super) fn apply(
+    target: &mut mvp::config::LoongClawConfig,
+    source: &mvp::config::LoongClawConfig,
+) -> bool {
+    merge_wecom_config(&mut target.wecom, &source.wecom)
+}
+
+pub(super) fn readiness_state(config: &mvp::config::LoongClawConfig) -> ChannelCredentialState {
+    let effective = effective_wecom_config(config);
+    let has_bot_id = effective.bot_id.is_some();
+    let has_secret = effective.secret.is_some();
+
+    match (has_bot_id, has_secret) {
+        (true, true) => ChannelCredentialState::Ready,
+        (true, false) | (false, true) => ChannelCredentialState::Partial,
+        (false, false) => ChannelCredentialState::Missing,
+    }
+}
+
+pub(super) fn apply_import_readiness(
+    target: &mut mvp::config::LoongClawConfig,
+    state: ChannelCredentialState,
+) {
+    if state.is_ready() {
+        target.wecom.enabled = true;
+    }
+}
+
+pub(super) fn collect_preflight_checks(
+    config: &mvp::config::LoongClawConfig,
+) -> Vec<ChannelPreflightCheck> {
+    let credential_state = readiness_state(config);
+    let (transport_level, transport_detail) = long_connection_check(config, false);
+
+    vec![
+        ChannelPreflightCheck {
+            name: descriptor().surface_label,
+            level: if credential_state.is_ready() {
+                ChannelCheckLevel::Pass
+            } else {
+                ChannelCheckLevel::Warn
+            },
+            detail: if credential_state.is_ready() {
+                "bot credentials resolved".to_owned()
+            } else {
+                "enabled but bot_id or secret is missing".to_owned()
+            },
+        },
+        ChannelPreflightCheck {
+            name: "wecom aibot long connection",
+            level: transport_level,
+            detail: transport_detail,
+        },
+    ]
+}
+
+pub(super) fn collect_doctor_checks(
+    config: &mvp::config::LoongClawConfig,
+) -> Vec<ChannelDoctorCheck> {
+    let credential_state = readiness_state(config);
+    let (transport_level, transport_detail) = long_connection_check(config, true);
+
+    vec![
+        ChannelDoctorCheck {
+            name: descriptor().surface_label,
+            level: if credential_state.is_ready() {
+                ChannelCheckLevel::Pass
+            } else {
+                ChannelCheckLevel::Fail
+            },
+            detail: if credential_state.is_ready() {
+                "bot credentials resolved".to_owned()
+            } else {
+                "enabled but bot_id or secret is missing".to_owned()
+            },
+        },
+        ChannelDoctorCheck {
+            name: "wecom aibot long connection",
+            level: transport_level,
+            detail: transport_detail,
+        },
+    ]
+}
+
+pub(super) fn apply_default_env_bindings(config: &mut mvp::config::LoongClawConfig) -> Vec<String> {
+    let mut fixes = Vec::new();
+    let default = mvp::config::WecomChannelConfig::default();
+
+    ensure_default_env_binding(
+        &mut config.wecom.bot_id_env,
+        default.bot_id_env.as_deref(),
+        "set wecom.bot_id_env",
+        &mut fixes,
+    );
+    ensure_default_env_binding(
+        &mut config.wecom.secret_env,
+        default.secret_env.as_deref(),
+        "set wecom.secret_env",
+        &mut fixes,
+    );
+
+    fixes
+}
+
+fn merge_wecom_config(
+    target: &mut mvp::config::WecomChannelConfig,
+    source: &mvp::config::WecomChannelConfig,
+) -> bool {
+    let default = mvp::config::WecomChannelConfig::default();
+    let mut changed = false;
+
+    if !target.enabled && source.enabled {
+        target.enabled = true;
+        changed = true;
+    }
+    if target.account_id.is_none() && source.account_id.is_some() {
+        target.account_id = source.account_id.clone();
+        changed = true;
+    }
+    if target.default_account.is_none() && source.default_account.is_some() {
+        target.default_account = source.default_account.clone();
+        changed = true;
+    }
+    if target.bot_id.is_none() && source.bot_id.is_some() {
+        target.bot_id = source.bot_id.clone();
+        changed = true;
+    }
+    if target.secret.is_none() && source.secret.is_some() {
+        target.secret = source.secret.clone();
+        changed = true;
+    }
+    if let Some(source_bot_id_env) = source.bot_id_env.as_ref() {
+        let target_uses_default_env =
+            target.bot_id_env.is_none() || target.bot_id_env == default.bot_id_env;
+        let target_matches_source = target.bot_id_env.as_ref() == Some(source_bot_id_env);
+        if target_uses_default_env && !target_matches_source {
+            target.bot_id_env = Some(source_bot_id_env.clone());
+            changed = true;
+        }
+    }
+    if let Some(source_secret_env) = source.secret_env.as_ref() {
+        let target_uses_default_env =
+            target.secret_env.is_none() || target.secret_env == default.secret_env;
+        let target_matches_source = target.secret_env.as_ref() == Some(source_secret_env);
+        if target_uses_default_env && !target_matches_source {
+            target.secret_env = Some(source_secret_env.clone());
+            changed = true;
+        }
+    }
+    if target.websocket_url == default.websocket_url
+        && source.websocket_url != default.websocket_url
+    {
+        target.websocket_url = source.websocket_url.clone();
+        changed = true;
+    }
+    if target.ping_interval_s == default.ping_interval_s
+        && source.ping_interval_s != default.ping_interval_s
+    {
+        target.ping_interval_s = source.ping_interval_s;
+        changed = true;
+    }
+    if target.reconnect_interval_s == default.reconnect_interval_s
+        && source.reconnect_interval_s != default.reconnect_interval_s
+    {
+        target.reconnect_interval_s = source.reconnect_interval_s;
+        changed = true;
+    }
+    for conversation_id in &source.allowed_conversation_ids {
+        changed |= merge_unique_string(&mut target.allowed_conversation_ids, conversation_id);
+    }
+    if target.acp == mvp::config::ChannelAcpConfig::default()
+        && source.acp != mvp::config::ChannelAcpConfig::default()
+    {
+        target.acp = source.acp.clone();
+        changed = true;
+    }
+    for (account_id, source_account) in &source.accounts {
+        match target.accounts.entry(account_id.clone()) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(source_account.clone());
+                changed = true;
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                changed |= merge_wecom_account_config(entry.get_mut(), source_account);
+            }
+        }
+    }
+
+    changed
+}
+
+fn effective_wecom_config(config: &mvp::config::LoongClawConfig) -> EffectiveWecomConfig {
+    if let Ok(resolved) = config.wecom.resolve_account(None) {
+        let bot_id = resolved.bot_id();
+        let secret = resolved.secret();
+        let websocket_url = resolved.resolved_websocket_url();
+
+        return EffectiveWecomConfig {
+            enabled: resolved.enabled,
+            bot_id,
+            secret,
+            bot_id_env: resolved.bot_id_env,
+            secret_env: resolved.secret_env,
+            websocket_url,
+            allowed_conversation_ids: resolved.allowed_conversation_ids,
+        };
+    }
+
+    let bot_id = config.wecom.bot_id();
+    let secret = config.wecom.secret();
+    let websocket_url = config.wecom.resolved_websocket_url();
+
+    EffectiveWecomConfig {
+        enabled: config.wecom.enabled,
+        bot_id,
+        secret,
+        bot_id_env: config.wecom.bot_id_env.clone(),
+        secret_env: config.wecom.secret_env.clone(),
+        websocket_url,
+        allowed_conversation_ids: config.wecom.allowed_conversation_ids.clone(),
+    }
+}
+
+fn merge_wecom_account_config(
+    target: &mut mvp::config::WecomAccountConfig,
+    source: &mvp::config::WecomAccountConfig,
+) -> bool {
+    let mut changed = false;
+
+    if target.enabled.is_none() && source.enabled.is_some() {
+        target.enabled = source.enabled;
+        changed = true;
+    }
+    if target.account_id.is_none() && source.account_id.is_some() {
+        target.account_id = source.account_id.clone();
+        changed = true;
+    }
+    if target.bot_id.is_none() && source.bot_id.is_some() {
+        target.bot_id = source.bot_id.clone();
+        changed = true;
+    }
+    if target.secret.is_none() && source.secret.is_some() {
+        target.secret = source.secret.clone();
+        changed = true;
+    }
+    if target.bot_id_env.is_none() && source.bot_id_env.is_some() {
+        target.bot_id_env = source.bot_id_env.clone();
+        changed = true;
+    }
+    if target.secret_env.is_none() && source.secret_env.is_some() {
+        target.secret_env = source.secret_env.clone();
+        changed = true;
+    }
+    if target.websocket_url.is_none() && source.websocket_url.is_some() {
+        target.websocket_url = source.websocket_url.clone();
+        changed = true;
+    }
+    if target.ping_interval_s.is_none() && source.ping_interval_s.is_some() {
+        target.ping_interval_s = source.ping_interval_s;
+        changed = true;
+    }
+    if target.reconnect_interval_s.is_none() && source.reconnect_interval_s.is_some() {
+        target.reconnect_interval_s = source.reconnect_interval_s;
+        changed = true;
+    }
+    match (
+        &mut target.allowed_conversation_ids,
+        &source.allowed_conversation_ids,
+    ) {
+        (None, Some(source_conversation_ids)) => {
+            target.allowed_conversation_ids = Some(source_conversation_ids.clone());
+            changed = true;
+        }
+        (Some(target_conversation_ids), Some(source_conversation_ids)) => {
+            for conversation_id in source_conversation_ids {
+                changed |= merge_unique_string(target_conversation_ids, conversation_id);
+            }
+        }
+        _ => {}
+    }
+    if target.acp.is_none() && source.acp.is_some() {
+        target.acp = source.acp.clone();
+        changed = true;
+    }
+
+    changed
+}
+
+fn merge_unique_string(target: &mut Vec<String>, value: &str) -> bool {
+    if target.iter().any(|existing| existing == value) {
+        return false;
+    }
+
+    target.push(value.to_owned());
+    true
+}
+
+fn descriptor() -> &'static mvp::config::ChannelDescriptor {
+    mvp::config::channel_descriptor(ID).unwrap_or(&FALLBACK_DESCRIPTOR)
+}
+
+fn long_connection_check(
+    config: &mvp::config::LoongClawConfig,
+    fail_on_error: bool,
+) -> (ChannelCheckLevel, String) {
+    let effective = effective_wecom_config(config);
+    let mut issues = Vec::new();
+
+    let websocket_url_issue = validate_wecom_websocket_url(effective.websocket_url.as_str());
+    if let Some(issue) = websocket_url_issue {
+        issues.push(issue);
+    }
+
+    let has_allowlist = effective
+        .allowed_conversation_ids
+        .iter()
+        .any(|value| !value.trim().is_empty());
+    if !has_allowlist {
+        issues.push("allowed_conversation_ids is empty".to_owned());
+    }
+
+    if issues.is_empty() {
+        return (
+            ChannelCheckLevel::Pass,
+            "websocket transport and conversation allowlist are configured".to_owned(),
+        );
+    }
+
+    let detail = issues.join("; ");
+    let level = if fail_on_error {
+        ChannelCheckLevel::Fail
+    } else {
+        ChannelCheckLevel::Warn
+    };
+
+    (level, detail)
+}
+
+fn validate_wecom_websocket_url(websocket_url: &str) -> Option<String> {
+    let parse_result = reqwest::Url::parse(websocket_url);
+    let parsed_url = match parse_result {
+        Ok(value) => value,
+        Err(error) => return Some(format!("websocket_url is invalid: {error}")),
+    };
+
+    let scheme = parsed_url.scheme();
+    let uses_websocket_scheme = scheme == "ws" || scheme == "wss";
+    if uses_websocket_scheme {
+        return None;
+    }
+
+    Some("websocket_url must use ws or wss".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_doctor_checks_uses_default_account_settings() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.wecom.enabled = true;
+        config.wecom.default_account = Some("ops".to_owned());
+        config.wecom.accounts.insert(
+            "ops".to_owned(),
+            mvp::config::WecomAccountConfig {
+                bot_id: Some(loongclaw_contracts::SecretRef::Inline(
+                    "wecom-bot".to_owned(),
+                )),
+                secret: Some(loongclaw_contracts::SecretRef::Inline(
+                    "wecom-secret".to_owned(),
+                )),
+                allowed_conversation_ids: Some(vec!["group_ops".to_owned()]),
+                ..Default::default()
+            },
+        );
+
+        let checks = collect_doctor_checks(&config);
+
+        assert_eq!(checks.len(), 2);
+        assert!(
+            checks
+                .iter()
+                .all(|check| check.level == ChannelCheckLevel::Pass)
+        );
+    }
+
+    #[test]
+    fn merge_wecom_config_copies_custom_defaults_and_account_overrides() {
+        let mut target = mvp::config::WecomChannelConfig::default();
+        let source_acp = mvp::config::ChannelAcpConfig {
+            bootstrap_mcp_servers: vec!["filesystem".to_owned()],
+            working_directory: Some("/tmp/wecom".to_owned()),
+        };
+        let source_account = mvp::config::WecomAccountConfig {
+            bot_id_env: Some("OPS_WECOM_BOT_ID".to_owned()),
+            secret_env: Some("OPS_WECOM_SECRET".to_owned()),
+            websocket_url: Some("wss://ops.example.test".to_owned()),
+            allowed_conversation_ids: Some(vec!["group_ops".to_owned()]),
+            ..Default::default()
+        };
+        let mut source_accounts = std::collections::BTreeMap::new();
+        source_accounts.insert("ops".to_owned(), source_account);
+        let source = mvp::config::WecomChannelConfig {
+            enabled: true,
+            default_account: Some("ops".to_owned()),
+            bot_id_env: Some("CUSTOM_TOP_LEVEL_WECOM_BOT_ID".to_owned()),
+            secret_env: Some("CUSTOM_TOP_LEVEL_WECOM_SECRET".to_owned()),
+            websocket_url: Some("wss://wecom.example.test".to_owned()),
+            ping_interval_s: 45,
+            reconnect_interval_s: 12,
+            allowed_conversation_ids: vec!["group_ops".to_owned()],
+            acp: source_acp,
+            accounts: source_accounts,
+            ..Default::default()
+        };
+
+        let changed = merge_wecom_config(&mut target, &source);
+
+        assert!(changed);
+        assert!(target.enabled);
+        assert_eq!(target.default_account.as_deref(), Some("ops"));
+        assert_eq!(
+            target.bot_id_env.as_deref(),
+            Some("CUSTOM_TOP_LEVEL_WECOM_BOT_ID")
+        );
+        assert_eq!(
+            target.secret_env.as_deref(),
+            Some("CUSTOM_TOP_LEVEL_WECOM_SECRET")
+        );
+        assert_eq!(
+            target.websocket_url.as_deref(),
+            Some("wss://wecom.example.test")
+        );
+        assert_eq!(target.ping_interval_s, 45);
+        assert_eq!(target.reconnect_interval_s, 12);
+        assert_eq!(target.allowed_conversation_ids, vec!["group_ops"]);
+        assert_eq!(target.acp.working_directory.as_deref(), Some("/tmp/wecom"));
+        assert!(target.accounts.contains_key("ops"));
+    }
+}

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -1091,6 +1091,8 @@ fn channel_registry_apply_selected_channels_merges_wecom_config() {
 
 #[test]
 fn resolve_channel_import_readiness_reports_partial_wecom_channel_credentials() {
+    let _env = MigrationEnvironmentGuard::set(&[("WECOM_BOT_ID", None), ("WECOM_SECRET", None)]);
+
     let mut config = mvp::config::LoongClawConfig::default();
     config.wecom.bot_id = Some(loongclaw_contracts::SecretRef::Inline(
         "wecom-bot".to_owned(),

--- a/crates/daemon/tests/integration/migration.rs
+++ b/crates/daemon/tests/integration/migration.rs
@@ -309,9 +309,29 @@ fn migration_channel_registry_includes_matrix_when_enabled() {
 }
 
 #[test]
-fn migration_channel_env_binding_applies_matrix_default() {
+fn migration_channel_registry_includes_wecom_when_enabled() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.wecom.enabled = true;
+    config.wecom.bot_id = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-bot".to_owned(),
+    ));
+    config.wecom.secret = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-secret".to_owned(),
+    ));
+    config.wecom.allowed_conversation_ids = vec!["group_demo".to_owned()];
+
+    let checks = loongclaw_daemon::migration::channels::collect_channel_doctor_checks(&config);
+    let names = checks.iter().map(|check| check.name).collect::<Vec<_>>();
+
+    assert_eq!(names, vec!["wecom channel", "wecom aibot long connection"]);
+}
+
+#[test]
+fn migration_channel_env_binding_applies_matrix_and_wecom_defaults() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.matrix.access_token_env = None;
+    config.wecom.bot_id_env = None;
+    config.wecom.secret_env = None;
 
     let fixes =
         loongclaw_daemon::migration::channels::apply_default_channel_env_bindings(&mut config);
@@ -320,10 +340,22 @@ fn migration_channel_env_binding_applies_matrix_default() {
         config.matrix.access_token_env.as_deref(),
         Some("MATRIX_ACCESS_TOKEN")
     );
+    assert_eq!(config.wecom.bot_id_env.as_deref(), Some("WECOM_BOT_ID"));
+    assert_eq!(config.wecom.secret_env.as_deref(), Some("WECOM_SECRET"));
     assert!(
         fixes
             .iter()
             .any(|fix| fix == "set matrix.access_token_env=MATRIX_ACCESS_TOKEN")
+    );
+    assert!(
+        fixes
+            .iter()
+            .any(|fix| fix == "set wecom.bot_id_env=WECOM_BOT_ID")
+    );
+    assert!(
+        fixes
+            .iter()
+            .any(|fix| fix == "set wecom.secret_env=WECOM_SECRET")
     );
 }
 
@@ -721,7 +753,7 @@ fn migration_recommended_plan_supplements_cli_prompt_metadata_and_memory_profile
 fn channel_registry_lists_registered_channel_ids() {
     assert_eq!(
         loongclaw_daemon::migration::channels::registered_channel_ids(),
-        vec!["telegram", "feishu", "matrix"]
+        vec!["telegram", "feishu", "matrix", "wecom"]
     );
 }
 
@@ -780,6 +812,14 @@ fn channel_registry_collects_ready_channel_candidates() {
     config.feishu.app_secret = Some(loongclaw_contracts::SecretRef::Inline(
         "feishu-secret".to_owned(),
     ));
+    config.wecom.enabled = true;
+    config.wecom.bot_id = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-bot".to_owned(),
+    ));
+    config.wecom.secret = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-secret".to_owned(),
+    ));
+    config.wecom.allowed_conversation_ids = vec!["group_demo".to_owned()];
 
     let previews = loongclaw_daemon::migration::channels::collect_channel_previews(
         &config,
@@ -793,7 +833,7 @@ fn channel_registry_collects_ready_channel_candidates() {
         .map(|preview| preview.candidate.id)
         .collect::<Vec<_>>();
 
-    assert_eq!(ids, vec!["telegram", "feishu"]);
+    assert_eq!(ids, vec!["telegram", "feishu", "wecom"]);
     assert!(
         previews.iter().all(|preview| {
             preview.candidate.status == loongclaw_daemon::migration::types::PreviewStatus::Ready
@@ -816,6 +856,14 @@ fn channel_preview_order_follows_shared_service_channel_catalog_order() {
     config.feishu.app_secret = Some(loongclaw_contracts::SecretRef::Inline(
         "feishu-secret".to_owned(),
     ));
+    config.wecom.enabled = true;
+    config.wecom.bot_id = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-bot".to_owned(),
+    ));
+    config.wecom.secret = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-secret".to_owned(),
+    ));
+    config.wecom.allowed_conversation_ids = vec!["group_demo".to_owned()];
 
     let previews = loongclaw_daemon::migration::channels::collect_channel_previews(
         &config,
@@ -866,10 +914,11 @@ fn channel_registry_lists_enabled_channel_ids() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.telegram.enabled = true;
     config.feishu.enabled = true;
+    config.wecom.enabled = true;
 
     assert_eq!(
         loongclaw_daemon::migration::channels::registered_enabled_channel_ids(&config),
-        vec!["telegram", "feishu"]
+        vec!["telegram", "feishu", "wecom"]
     );
 }
 
@@ -878,14 +927,19 @@ fn channel_registry_enabled_ids_follow_app_service_channel_catalog() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.telegram.enabled = true;
     config.feishu.enabled = true;
+    config.wecom.enabled = true;
 
     assert_eq!(
         config.enabled_service_channel_ids(),
-        vec!["telegram".to_owned(), "feishu".to_owned()]
+        vec![
+            "telegram".to_owned(),
+            "feishu".to_owned(),
+            "wecom".to_owned()
+        ]
     );
     assert_eq!(
         loongclaw_daemon::migration::channels::registered_enabled_channel_ids(&config),
-        vec!["telegram", "feishu"]
+        vec!["telegram", "feishu", "wecom"]
     );
 }
 
@@ -906,6 +960,14 @@ fn channel_registry_collects_preflight_checks_for_enabled_channels() {
     config.feishu.verification_token = Some(loongclaw_contracts::SecretRef::Inline(
         "verify-token".to_owned(),
     ));
+    config.wecom.enabled = true;
+    config.wecom.bot_id = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-bot".to_owned(),
+    ));
+    config.wecom.secret = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-secret".to_owned(),
+    ));
+    config.wecom.allowed_conversation_ids = vec!["group_demo".to_owned()];
 
     let checks = loongclaw_daemon::migration::channels::collect_channel_preflight_checks(&config);
 
@@ -932,6 +994,21 @@ fn channel_registry_collects_preflight_checks_for_enabled_channels() {
         }),
         "registry preflight should include feishu inbound transport readiness: {checks:#?}"
     );
+    assert!(
+        checks.iter().any(|check| {
+            check.name == "wecom channel"
+                && check.level == loongclaw_daemon::migration::channels::ChannelCheckLevel::Pass
+                && check.detail.contains("bot credentials resolved")
+        }),
+        "registry preflight should include wecom credential readiness: {checks:#?}"
+    );
+    assert!(
+        checks.iter().any(|check| {
+            check.name == "wecom aibot long connection"
+                && check.level == loongclaw_daemon::migration::channels::ChannelCheckLevel::Pass
+        }),
+        "registry preflight should include wecom long-connection readiness: {checks:#?}"
+    );
 }
 
 #[test]
@@ -939,13 +1016,14 @@ fn channel_registry_collects_serve_actions_for_enabled_channels() {
     let mut config = mvp::config::LoongClawConfig::default();
     config.telegram.enabled = true;
     config.feishu.enabled = true;
+    config.wecom.enabled = true;
 
     let actions = loongclaw_daemon::migration::channels::collect_channel_next_actions(
         &config,
         "/tmp/loongclaw-config.toml",
     );
 
-    assert_eq!(actions.len(), 2);
+    assert_eq!(actions.len(), 3);
     assert_eq!(actions[0].label, "Telegram");
     assert_eq!(
         actions[0].command,
@@ -955,6 +1033,77 @@ fn channel_registry_collects_serve_actions_for_enabled_channels() {
     assert_eq!(
         actions[1].command,
         "loongclaw feishu-serve --config '/tmp/loongclaw-config.toml'"
+    );
+    assert_eq!(actions[2].label, "WeCom");
+    assert_eq!(
+        actions[2].command,
+        "loongclaw wecom-serve --config '/tmp/loongclaw-config.toml'"
+    );
+}
+
+#[test]
+fn channel_registry_apply_selected_channels_merges_wecom_config() {
+    let mut target = mvp::config::LoongClawConfig::default();
+    target.wecom.secret_env = Some("TARGET_WECOM_SECRET".to_owned());
+
+    let mut source = mvp::config::LoongClawConfig::default();
+    source.wecom.enabled = true;
+    source.wecom.default_account = Some("ops".to_owned());
+    source.wecom.bot_id_env = Some("SOURCE_WECOM_BOT_ID".to_owned());
+    source.wecom.secret_env = Some("SOURCE_WECOM_SECRET".to_owned());
+    source.wecom.allowed_conversation_ids = vec!["group_alpha".to_owned()];
+    source.wecom.accounts.insert(
+        "ops".to_owned(),
+        mvp::config::WecomAccountConfig {
+            websocket_url: Some("wss://wecom.example.test".to_owned()),
+            allowed_conversation_ids: Some(vec!["group_ops".to_owned()]),
+            ..Default::default()
+        },
+    );
+
+    let changed = loongclaw_daemon::migration::channels::apply_selected_channels(
+        &mut target,
+        &source,
+        &["wecom"],
+    );
+
+    assert!(changed);
+    assert!(target.wecom.enabled);
+    assert_eq!(target.wecom.default_account.as_deref(), Some("ops"));
+    assert_eq!(
+        target.wecom.bot_id_env.as_deref(),
+        Some("SOURCE_WECOM_BOT_ID")
+    );
+    assert_eq!(
+        target.wecom.secret_env.as_deref(),
+        Some("TARGET_WECOM_SECRET")
+    );
+    assert_eq!(target.wecom.allowed_conversation_ids, vec!["group_alpha"]);
+    assert_eq!(
+        target
+            .wecom
+            .accounts
+            .get("ops")
+            .and_then(|account| account.websocket_url.as_deref()),
+        Some("wss://wecom.example.test")
+    );
+}
+
+#[test]
+fn resolve_channel_import_readiness_reports_partial_wecom_channel_credentials() {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.wecom.bot_id = Some(loongclaw_contracts::SecretRef::Inline(
+        "wecom-bot".to_owned(),
+    ));
+
+    let readiness =
+        loongclaw_daemon::migration::discovery::resolve_channel_import_readiness_from_config(
+            &config,
+        );
+
+    assert_eq!(
+        readiness.state("wecom"),
+        loongclaw_daemon::migration::ChannelCredentialState::Partial
     );
 }
 


### PR DESCRIPTION
## Summary

- Problem:
  The daemon migration/onboarding registry already exposed shipped service-channel surfaces for Telegram, Feishu, and Matrix, but WeCom runtime support was missing from the migration adapter layer. That left import previews, readiness checks, default env repair, and serve handoff actions out of sync with the shipped WeCom runtime.
- Why it matters:
  Operators could enable and run WeCom at runtime, but the guided onboarding and migration flow could not recognize or carry that support forward cleanly. That mismatch creates avoidable setup drift and weakens the shared channel-catalog contract.
- What changed:
  Added a dedicated WeCom migration adapter, registered it in the daemon migration channel registry, and expanded migration integration coverage for preview ordering, readiness, env defaults, doctor/preflight checks, serve actions, and config merge behavior.
- What did not change (scope boundary):
  This PR does not introduce a new channel abstraction, does not add new non-WeCom channel runtimes, and does not change the app-level channel catalog ordering beyond aligning the daemon migration surface with the existing shipped WeCom runtime.

## Linked Issues

- Closes #629
- Related #628

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo test -p loongclaw-daemon wecom -- --nocapture
cargo test -p loongclaw-daemon --test integration integration::migration:: -- --nocapture
cargo test -p loongclaw-daemon migration -- --nocapture
cargo fmt --all -- --check
cargo clippy -p loongclaw-daemon --all-targets --all-features -- -D warnings
cargo test -p loongclaw-daemon --locked

Results:
- Added unit coverage for WeCom default-account doctor checks and merge behavior.
- Added migration integration coverage for WeCom registration, preview ordering, readiness, env default repair, doctor/preflight checks, serve actions, and config merge semantics.
- Verified daemon package tests pass after the new adapter is registered.
```

## User-visible / Operator-visible Changes

- `loongclaw` migration and onboarding flows now treat WeCom as a shipped service channel alongside Telegram, Feishu, and Matrix.
- WeCom configs now participate in detected preview surfaces, readiness classification, doctor/preflight diagnostics, default env binding repair, and follow-up serve actions.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `62f20ca` or disable `wecom.enabled` if a downstream config unexpectedly surfaces in migration guidance.
- Observable failure symptoms reviewers should watch for:
  WeCom missing from migration previews, incorrect readiness state for partial credentials, or unexpected overwrite of existing WeCom env bindings/account overrides during import apply.

## Reviewer Focus

- Review `crates/daemon/src/migration/channels/wecom.rs` for merge semantics between top-level defaults and per-account overrides.
- Review `crates/daemon/tests/integration/migration.rs` for the new cross-surface assertions that keep daemon migration behavior aligned with the shared app channel catalog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WeCom channel integration with full configuration, credential readiness handling, and import preview/support for enabling/importing the channel.
  * Introduced default environment variable bindings for WeCom credentials (WECOM_BOT_ID, WECOM_SECRET).
  * Added connectivity/health checks (preflight and doctor) for WeCom, including websocket and credential validations.
* **Tests**
  * Added integration tests covering WeCom import, merging, readiness states, and health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->