### PR TITLE
feat(session): add persisted session tool policy controls

### DIFF
--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -880,6 +880,7 @@ impl DelegateChildRuntimeConfig {
         crate::tools::runtime_config::ToolRuntimeNarrowing {
             web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
                 allow_private_hosts: self.web.allow_private_hosts,
+                enforce_allowed_domains: !self.web.normalized_allowed_domains().is_empty(),
                 allowed_domains: self.web.normalized_allowed_domains().into_iter().collect(),
                 blocked_domains: self.web.normalized_blocked_domains().into_iter().collect(),
                 timeout_seconds: self.web.timeout_seconds,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -178,6 +178,127 @@ fn load_session_runtime_self_continuity(
     runtime_self_continuity::load_persisted_runtime_self_continuity(repo, session_id)
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[derive(Clone)]
+struct PersistedSessionSnapshot {
+    session_id: String,
+    parent_session_id: Option<String>,
+    is_delegate_child: bool,
+    session_tool_policy: Option<SessionToolPolicyRecord>,
+    delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+    runtime_self_continuity: Option<RuntimeSelfContinuity>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn open_session_repository(config: &LoongClawConfig) -> CliResult<SessionRepository> {
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    SessionRepository::new(&memory_config)
+        .map_err(|error| format!("open session repository failed: {error}"))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_persisted_session_snapshot(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> CliResult<Option<PersistedSessionSnapshot>> {
+    let session_tool_policy = load_session_tool_policy(repo, session_id)?;
+    let session = repo
+        .load_session(session_id)
+        .map_err(|error| format!("load session context failed: {error}"))?;
+
+    if let Some(session) = session {
+        let parent_session_id = session.parent_session_id;
+        let is_delegate_child = parent_session_id.is_some();
+        let delegate_runtime_narrowing = if is_delegate_child {
+            load_delegate_runtime_narrowing(repo, session_id)?
+        } else {
+            None
+        };
+        let runtime_self_continuity = load_session_runtime_self_continuity(repo, session_id)?;
+        let snapshot = PersistedSessionSnapshot {
+            session_id: session.session_id,
+            parent_session_id,
+            is_delegate_child,
+            session_tool_policy,
+            delegate_runtime_narrowing,
+            runtime_self_continuity,
+        };
+        return Ok(Some(snapshot));
+    }
+
+    let summary = repo
+        .load_session_summary_with_legacy_fallback(session_id)
+        .map_err(|error| format!("load legacy session context failed: {error}"))?;
+
+    let Some(summary) = summary else {
+        return Ok(None);
+    };
+
+    let is_delegate_child = summary.kind == SessionKind::DelegateChild;
+    let delegate_runtime_narrowing = if is_delegate_child {
+        load_delegate_runtime_narrowing(repo, session_id)?
+    } else {
+        None
+    };
+    let runtime_self_continuity = load_session_runtime_self_continuity(repo, session_id)?;
+    let snapshot = PersistedSessionSnapshot {
+        session_id: summary.session_id,
+        parent_session_id: summary.parent_session_id,
+        is_delegate_child,
+        session_tool_policy,
+        delegate_runtime_narrowing,
+        runtime_self_continuity,
+    };
+    Ok(Some(snapshot))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_base_tool_view_from_snapshot(
+    config: &LoongClawConfig,
+    repo: &SessionRepository,
+    session_id: &str,
+    snapshot: Option<&PersistedSessionSnapshot>,
+) -> CliResult<ToolView> {
+    let Some(snapshot) = snapshot else {
+        return Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
+            config,
+        ));
+    };
+
+    if snapshot.parent_session_id.is_some() {
+        let depth = match repo.session_lineage_depth(session_id) {
+            Ok(depth) => depth,
+            Err(error)
+                if error.starts_with("session_lineage_broken:")
+                    || error.starts_with("session_lineage_cycle_detected:") =>
+            {
+                return Ok(delegate_child_tool_view_for_config_with_delegate(
+                    &config.tools,
+                    false,
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "compute session lineage depth for tool view failed: {error}"
+                ));
+            }
+        };
+        let allow_nested_delegate = depth < config.tools.delegate.max_depth;
+        return Ok(delegate_child_tool_view_for_config_with_delegate(
+            &config.tools,
+            allow_nested_delegate,
+        ));
+    }
+
+    if snapshot.is_delegate_child {
+        return Ok(delegate_child_tool_view_for_config(&config.tools));
+    }
+
+    Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
+        config,
+    ))
+}
+
 #[derive(Clone)]
 pub struct AsyncDelegateSpawnRequest {
     pub child_session_id: String,
@@ -474,56 +595,6 @@ impl<E> DefaultConversationRuntime<E>
 where
     E: ConversationContextEngine,
 {
-    fn base_tool_view(&self, config: &LoongClawConfig, session_id: &str) -> CliResult<ToolView> {
-        #[cfg(feature = "memory-sqlite")]
-        {
-            let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-            if let Ok(repo) = SessionRepository::new(&memory_config) {
-                if let Some(session) = repo
-                    .load_session(session_id)
-                    .map_err(|error| format!("load session tool-view context failed: {error}"))?
-                {
-                    if session.parent_session_id.is_some() {
-                        let depth = match repo.session_lineage_depth(session_id) {
-                            Ok(depth) => depth,
-                            Err(error)
-                                if error.starts_with("session_lineage_broken:")
-                                    || error.starts_with("session_lineage_cycle_detected:") =>
-                            {
-                                return Ok(delegate_child_tool_view_for_config_with_delegate(
-                                    &config.tools,
-                                    false,
-                                ));
-                            }
-                            Err(error) => {
-                                return Err(format!(
-                                    "compute session lineage depth for tool view failed: {error}"
-                                ));
-                            }
-                        };
-                        let allow_nested_delegate = depth < config.tools.delegate.max_depth;
-                        return Ok(delegate_child_tool_view_for_config_with_delegate(
-                            &config.tools,
-                            allow_nested_delegate,
-                        ));
-                    }
-                } else if repo
-                    .load_session_summary_with_legacy_fallback(session_id)
-                    .map_err(|error| {
-                        format!("load legacy session tool-view context failed: {error}")
-                    })?
-                    .is_some_and(|session| session.kind == SessionKind::DelegateChild)
-                {
-                    return Ok(delegate_child_tool_view_for_config(&config.tools));
-                }
-            }
-        }
-
-        Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
-            config,
-        ))
-    }
-
     async fn build_context_for_tool_view(
         &self,
         config: &LoongClawConfig,
@@ -877,118 +948,48 @@ where
         &self,
         config: &LoongClawConfig,
         session_id: &str,
-        binding: ConversationRuntimeBinding<'_>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<SessionContext> {
-        let tool_view = self.tool_view(config, session_id, binding)?;
-
         #[cfg(feature = "memory-sqlite")]
         {
-            let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-            if let Ok(repo) = SessionRepository::new(&memory_config) {
-                let session_tool_policy = load_session_tool_policy(&repo, session_id)?;
-                if let Some(session) = repo
-                    .load_session(session_id)
-                    .map_err(|error| format!("load session context failed: {error}"))?
-                {
-                    if let Some(parent_session_id) = session.parent_session_id {
-                        let delegate_runtime_narrowing =
-                            load_delegate_runtime_narrowing(&repo, session_id)?;
-                        let runtime_narrowing = merge_effective_runtime_narrowing(
-                            delegate_runtime_narrowing,
-                            session_tool_policy.as_ref(),
-                        );
-                        let runtime_self_continuity =
-                            load_session_runtime_self_continuity(&repo, session_id)?;
-                        let session_context =
-                            SessionContext::child(session.session_id, parent_session_id, tool_view);
-                        let session_context = match runtime_narrowing {
-                            Some(runtime_narrowing) => {
-                                session_context.with_runtime_narrowing(runtime_narrowing)
-                            }
-                            None => session_context,
-                        };
-                        let session_context = match runtime_self_continuity {
-                            Some(runtime_self_continuity) => session_context
-                                .with_runtime_self_continuity(runtime_self_continuity),
-                            None => session_context,
-                        };
-                        return Ok(session_context);
-                    }
+            let repo = open_session_repository(config)?;
+            let snapshot = load_persisted_session_snapshot(&repo, session_id)?;
+            let base_tool_view =
+                build_base_tool_view_from_snapshot(config, &repo, session_id, snapshot.as_ref())?;
+            let session_tool_policy = snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.session_tool_policy.as_ref());
+            let tool_view =
+                apply_session_tool_policy_to_tool_view(base_tool_view, session_tool_policy);
 
-                    let runtime_self_continuity =
-                        load_session_runtime_self_continuity(&repo, session_id)?;
-                    let runtime_narrowing =
-                        merge_effective_runtime_narrowing(None, session_tool_policy.as_ref());
-                    let session_context =
-                        SessionContext::root_with_tool_view(session.session_id, tool_view);
-                    let session_context = match runtime_narrowing {
-                        Some(runtime_narrowing) => {
-                            session_context.with_runtime_narrowing(runtime_narrowing)
-                        }
-                        None => session_context,
-                    };
-                    let session_context = match runtime_self_continuity {
-                        Some(runtime_self_continuity) => {
-                            session_context.with_runtime_self_continuity(runtime_self_continuity)
-                        }
-                        None => session_context,
-                    };
-                    return Ok(session_context);
-                } else if let Some(summary) = repo
-                    .load_session_summary_with_legacy_fallback(session_id)
-                    .map_err(|error| format!("load legacy session context failed: {error}"))?
-                    && let Some(parent_session_id) = summary.parent_session_id
-                {
-                    let delegate_runtime_narrowing =
-                        load_delegate_runtime_narrowing(&repo, session_id)?;
-                    let runtime_narrowing = merge_effective_runtime_narrowing(
-                        delegate_runtime_narrowing,
-                        session_tool_policy.as_ref(),
-                    );
-                    let runtime_self_continuity =
-                        load_session_runtime_self_continuity(&repo, session_id)?;
-                    let session_context =
-                        SessionContext::child(summary.session_id, parent_session_id, tool_view);
-                    let session_context = match runtime_narrowing {
-                        Some(runtime_narrowing) => {
-                            session_context.with_runtime_narrowing(runtime_narrowing)
-                        }
-                        None => session_context,
-                    };
-                    let session_context = match runtime_self_continuity {
-                        Some(runtime_self_continuity) => {
-                            session_context.with_runtime_self_continuity(runtime_self_continuity)
-                        }
-                        None => session_context,
-                    };
-                    return Ok(session_context);
-                } else if let Some(summary) = repo
-                    .load_session_summary_with_legacy_fallback(session_id)
-                    .map_err(|error| format!("load legacy session context failed: {error}"))?
-                {
-                    let runtime_self_continuity =
-                        load_session_runtime_self_continuity(&repo, session_id)?;
-                    let runtime_narrowing =
-                        merge_effective_runtime_narrowing(None, session_tool_policy.as_ref());
-                    let session_context =
-                        SessionContext::root_with_tool_view(summary.session_id, tool_view);
-                    let session_context = match runtime_narrowing {
-                        Some(runtime_narrowing) => {
-                            session_context.with_runtime_narrowing(runtime_narrowing)
-                        }
-                        None => session_context,
-                    };
-                    let session_context = match runtime_self_continuity {
-                        Some(runtime_self_continuity) => {
-                            session_context.with_runtime_self_continuity(runtime_self_continuity)
-                        }
-                        None => session_context,
-                    };
-                    return Ok(session_context);
+            if let Some(snapshot) = snapshot {
+                let runtime_narrowing = merge_effective_runtime_narrowing(
+                    snapshot.delegate_runtime_narrowing.clone(),
+                    snapshot.session_tool_policy.as_ref(),
+                );
+                let mut session_context = match snapshot.parent_session_id {
+                    Some(parent_session_id) => {
+                        SessionContext::child(snapshot.session_id, parent_session_id, tool_view)
+                    }
+                    None => SessionContext::root_with_tool_view(snapshot.session_id, tool_view),
+                };
+                if let Some(runtime_narrowing) = runtime_narrowing {
+                    session_context = session_context.with_runtime_narrowing(runtime_narrowing);
                 }
+                if let Some(runtime_self_continuity) = snapshot.runtime_self_continuity {
+                    session_context =
+                        session_context.with_runtime_self_continuity(runtime_self_continuity);
+                }
+                return Ok(session_context);
             }
+
+            Ok(SessionContext::root_with_tool_view(session_id, tool_view))
         }
 
+        #[cfg(not(feature = "memory-sqlite"))]
+        let tool_view = self.tool_view(config, session_id, _binding)?;
+
+        #[cfg(not(feature = "memory-sqlite"))]
         Ok(SessionContext::root_with_tool_view(session_id, tool_view))
     }
 
@@ -998,23 +999,25 @@ where
         session_id: &str,
         _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ToolView> {
-        let base_tool_view = self.base_tool_view(config, session_id)?;
-
         #[cfg(feature = "memory-sqlite")]
         {
-            let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-            if let Ok(repo) = SessionRepository::new(&memory_config) {
-                let session_tool_policy = load_session_tool_policy(&repo, session_id)?;
-                if session_tool_policy.is_some() {
-                    return Ok(apply_session_tool_policy_to_tool_view(
-                        base_tool_view,
-                        session_tool_policy.as_ref(),
-                    ));
-                }
-            }
+            let repo = open_session_repository(config)?;
+            let snapshot = load_persisted_session_snapshot(&repo, session_id)?;
+            let base_tool_view =
+                build_base_tool_view_from_snapshot(config, &repo, session_id, snapshot.as_ref())?;
+            let session_tool_policy = snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.session_tool_policy.as_ref());
+            Ok(apply_session_tool_policy_to_tool_view(
+                base_tool_view,
+                session_tool_policy,
+            ))
         }
 
-        Ok(base_tool_view)
+        #[cfg(not(feature = "memory-sqlite"))]
+        Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
+            config,
+        ))
     }
 
     async fn bootstrap(

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -39,7 +39,8 @@ use super::turn_middleware_registry::{
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    SessionKind, SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
+    SessionKind, SessionRepository, SessionState, SessionToolPolicyRecord,
+    TransitionSessionWithEventIfCurrentRequest,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -124,6 +125,49 @@ fn load_delegate_runtime_narrowing(
     Ok(execution.and_then(|execution| {
         (!execution.runtime_narrowing.is_empty()).then_some(execution.runtime_narrowing)
     }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_session_tool_policy(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<SessionToolPolicyRecord>, String> {
+    repo.load_session_tool_policy(session_id)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn apply_session_tool_policy_to_tool_view(
+    base_tool_view: ToolView,
+    session_tool_policy: Option<&SessionToolPolicyRecord>,
+) -> ToolView {
+    let Some(session_tool_policy) = session_tool_policy else {
+        return base_tool_view;
+    };
+    if session_tool_policy.requested_tool_ids.is_empty() {
+        return base_tool_view;
+    }
+
+    let policy_tool_view = ToolView::from_tool_names(session_tool_policy.requested_tool_ids.iter());
+    base_tool_view.intersect(&policy_tool_view)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn merge_effective_runtime_narrowing(
+    delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+    session_tool_policy: Option<&SessionToolPolicyRecord>,
+) -> Option<ToolRuntimeNarrowing> {
+    let policy_runtime_narrowing = session_tool_policy.and_then(|policy| {
+        (!policy.runtime_narrowing.is_empty()).then_some(policy.runtime_narrowing.clone())
+    });
+
+    match (delegate_runtime_narrowing, policy_runtime_narrowing) {
+        (Some(delegate_runtime_narrowing), Some(policy_runtime_narrowing)) => {
+            Some(delegate_runtime_narrowing.intersect(&policy_runtime_narrowing))
+        }
+        (Some(delegate_runtime_narrowing), None) => Some(delegate_runtime_narrowing),
+        (None, Some(policy_runtime_narrowing)) => Some(policy_runtime_narrowing),
+        (None, None) => None,
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -430,6 +474,56 @@ impl<E> DefaultConversationRuntime<E>
 where
     E: ConversationContextEngine,
 {
+    fn base_tool_view(&self, config: &LoongClawConfig, session_id: &str) -> CliResult<ToolView> {
+        #[cfg(feature = "memory-sqlite")]
+        {
+            let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+            if let Ok(repo) = SessionRepository::new(&memory_config) {
+                if let Some(session) = repo
+                    .load_session(session_id)
+                    .map_err(|error| format!("load session tool-view context failed: {error}"))?
+                {
+                    if session.parent_session_id.is_some() {
+                        let depth = match repo.session_lineage_depth(session_id) {
+                            Ok(depth) => depth,
+                            Err(error)
+                                if error.starts_with("session_lineage_broken:")
+                                    || error.starts_with("session_lineage_cycle_detected:") =>
+                            {
+                                return Ok(delegate_child_tool_view_for_config_with_delegate(
+                                    &config.tools,
+                                    false,
+                                ));
+                            }
+                            Err(error) => {
+                                return Err(format!(
+                                    "compute session lineage depth for tool view failed: {error}"
+                                ));
+                            }
+                        };
+                        let allow_nested_delegate = depth < config.tools.delegate.max_depth;
+                        return Ok(delegate_child_tool_view_for_config_with_delegate(
+                            &config.tools,
+                            allow_nested_delegate,
+                        ));
+                    }
+                } else if repo
+                    .load_session_summary_with_legacy_fallback(session_id)
+                    .map_err(|error| {
+                        format!("load legacy session tool-view context failed: {error}")
+                    })?
+                    .is_some_and(|session| session.kind == SessionKind::DelegateChild)
+                {
+                    return Ok(delegate_child_tool_view_for_config(&config.tools));
+                }
+            }
+        }
+
+        Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
+            config,
+        ))
+    }
+
     async fn build_context_for_tool_view(
         &self,
         config: &LoongClawConfig,
@@ -791,17 +885,28 @@ where
         {
             let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
             if let Ok(repo) = SessionRepository::new(&memory_config) {
+                let session_tool_policy = load_session_tool_policy(&repo, session_id)?;
                 if let Some(session) = repo
                     .load_session(session_id)
                     .map_err(|error| format!("load session context failed: {error}"))?
                 {
                     if let Some(parent_session_id) = session.parent_session_id {
-                        let runtime_narrowing = load_delegate_runtime_narrowing(&repo, session_id)?;
+                        let delegate_runtime_narrowing =
+                            load_delegate_runtime_narrowing(&repo, session_id)?;
+                        let runtime_narrowing = merge_effective_runtime_narrowing(
+                            delegate_runtime_narrowing,
+                            session_tool_policy.as_ref(),
+                        );
                         let runtime_self_continuity =
                             load_session_runtime_self_continuity(&repo, session_id)?;
                         let session_context =
-                            SessionContext::child(session.session_id, parent_session_id, tool_view)
-                                .with_runtime_narrowing(runtime_narrowing.unwrap_or_default());
+                            SessionContext::child(session.session_id, parent_session_id, tool_view);
+                        let session_context = match runtime_narrowing {
+                            Some(runtime_narrowing) => {
+                                session_context.with_runtime_narrowing(runtime_narrowing)
+                            }
+                            None => session_context,
+                        };
                         let session_context = match runtime_self_continuity {
                             Some(runtime_self_continuity) => session_context
                                 .with_runtime_self_continuity(runtime_self_continuity),
@@ -812,8 +917,16 @@ where
 
                     let runtime_self_continuity =
                         load_session_runtime_self_continuity(&repo, session_id)?;
+                    let runtime_narrowing =
+                        merge_effective_runtime_narrowing(None, session_tool_policy.as_ref());
                     let session_context =
                         SessionContext::root_with_tool_view(session.session_id, tool_view);
+                    let session_context = match runtime_narrowing {
+                        Some(runtime_narrowing) => {
+                            session_context.with_runtime_narrowing(runtime_narrowing)
+                        }
+                        None => session_context,
+                    };
                     let session_context = match runtime_self_continuity {
                         Some(runtime_self_continuity) => {
                             session_context.with_runtime_self_continuity(runtime_self_continuity)
@@ -826,12 +939,22 @@ where
                     .map_err(|error| format!("load legacy session context failed: {error}"))?
                     && let Some(parent_session_id) = summary.parent_session_id
                 {
-                    let runtime_narrowing = load_delegate_runtime_narrowing(&repo, session_id)?;
+                    let delegate_runtime_narrowing =
+                        load_delegate_runtime_narrowing(&repo, session_id)?;
+                    let runtime_narrowing = merge_effective_runtime_narrowing(
+                        delegate_runtime_narrowing,
+                        session_tool_policy.as_ref(),
+                    );
                     let runtime_self_continuity =
                         load_session_runtime_self_continuity(&repo, session_id)?;
                     let session_context =
-                        SessionContext::child(summary.session_id, parent_session_id, tool_view)
-                            .with_runtime_narrowing(runtime_narrowing.unwrap_or_default());
+                        SessionContext::child(summary.session_id, parent_session_id, tool_view);
+                    let session_context = match runtime_narrowing {
+                        Some(runtime_narrowing) => {
+                            session_context.with_runtime_narrowing(runtime_narrowing)
+                        }
+                        None => session_context,
+                    };
                     let session_context = match runtime_self_continuity {
                         Some(runtime_self_continuity) => {
                             session_context.with_runtime_self_continuity(runtime_self_continuity)
@@ -845,8 +968,16 @@ where
                 {
                     let runtime_self_continuity =
                         load_session_runtime_self_continuity(&repo, session_id)?;
+                    let runtime_narrowing =
+                        merge_effective_runtime_narrowing(None, session_tool_policy.as_ref());
                     let session_context =
                         SessionContext::root_with_tool_view(summary.session_id, tool_view);
+                    let session_context = match runtime_narrowing {
+                        Some(runtime_narrowing) => {
+                            session_context.with_runtime_narrowing(runtime_narrowing)
+                        }
+                        None => session_context,
+                    };
                     let session_context = match runtime_self_continuity {
                         Some(runtime_self_continuity) => {
                             session_context.with_runtime_self_continuity(runtime_self_continuity)
@@ -867,53 +998,23 @@ where
         session_id: &str,
         _binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<ToolView> {
+        let base_tool_view = self.base_tool_view(config, session_id)?;
+
         #[cfg(feature = "memory-sqlite")]
         {
             let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
             if let Ok(repo) = SessionRepository::new(&memory_config) {
-                if let Some(session) = repo
-                    .load_session(session_id)
-                    .map_err(|error| format!("load session tool-view context failed: {error}"))?
-                {
-                    if session.parent_session_id.is_some() {
-                        let depth = match repo.session_lineage_depth(session_id) {
-                            Ok(depth) => depth,
-                            Err(error)
-                                if error.starts_with("session_lineage_broken:")
-                                    || error.starts_with("session_lineage_cycle_detected:") =>
-                            {
-                                return Ok(delegate_child_tool_view_for_config_with_delegate(
-                                    &config.tools,
-                                    false,
-                                ));
-                            }
-                            Err(error) => {
-                                return Err(format!(
-                                    "compute session lineage depth for tool view failed: {error}"
-                                ));
-                            }
-                        };
-                        let allow_nested_delegate = depth < config.tools.delegate.max_depth;
-                        return Ok(delegate_child_tool_view_for_config_with_delegate(
-                            &config.tools,
-                            allow_nested_delegate,
-                        ));
-                    }
-                } else if repo
-                    .load_session_summary_with_legacy_fallback(session_id)
-                    .map_err(|error| {
-                        format!("load legacy session tool-view context failed: {error}")
-                    })?
-                    .is_some_and(|session| session.kind == SessionKind::DelegateChild)
-                {
-                    return Ok(delegate_child_tool_view_for_config(&config.tools));
+                let session_tool_policy = load_session_tool_policy(&repo, session_id)?;
+                if session_tool_policy.is_some() {
+                    return Ok(apply_session_tool_policy_to_tool_view(
+                        base_tool_view,
+                        session_tool_policy.as_ref(),
+                    ));
                 }
             }
         }
 
-        Ok(crate::tools::runtime_tool_view_from_loongclaw_config(
-            config,
-        ))
+        Ok(base_tool_view)
     }
 
     async fn bootstrap(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2151,6 +2151,36 @@ fn default_runtime_tool_view_intersects_root_session_with_persisted_tool_policy(
 
 #[cfg(feature = "memory-sqlite")]
 #[test]
+fn default_runtime_tool_view_errors_when_session_repository_is_unavailable() {
+    let db_path = std::env::temp_dir().join(unique_acp_test_id(
+        "conversation-tool-view",
+        "repo-unavailable",
+    ));
+    let _ = std::fs::remove_dir_all(&db_path);
+    std::fs::create_dir_all(&db_path).expect("create invalid sqlite directory");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+
+    let runtime = DefaultConversationRuntime::default();
+    let error = runtime
+        .tool_view(
+            &config,
+            "root-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect_err("tool view should fail closed when the session repository is unavailable");
+
+    assert!(
+        error.contains("open session repository failed"),
+        "error={error}"
+    );
+
+    std::fs::remove_dir_all(&db_path).ok();
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
 fn default_runtime_tool_view_denies_delegate_for_broken_lineage_child() {
     let mut config = test_config();
     config.tools.delegate.allow_shell_in_child = false;
@@ -2234,6 +2264,38 @@ fn default_runtime_session_context_uses_persisted_parent_session_id() {
         session_context.parent_session_id.as_deref(),
         Some("root-session")
     );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn default_runtime_session_context_errors_when_session_repository_is_unavailable() {
+    let db_path = std::env::temp_dir().join(unique_acp_test_id(
+        "conversation-session-context",
+        "repo-unavailable",
+    ));
+    let _ = std::fs::remove_dir_all(&db_path);
+    std::fs::create_dir_all(&db_path).expect("create invalid sqlite directory");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+
+    let runtime = DefaultConversationRuntime::default();
+    let error = runtime
+        .session_context(
+            &config,
+            "root-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect_err(
+            "session context should fail closed when the session repository is unavailable",
+        );
+
+    assert!(
+        error.contains("open session repository failed"),
+        "error={error}"
+    );
+
+    std::fs::remove_dir_all(&db_path).ok();
 }
 
 #[tokio::test]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -37,7 +37,8 @@ use crate::memory::{
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    NewSessionEvent, NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    NewSessionEvent, NewSessionRecord, NewSessionToolPolicyRecord, SessionKind, SessionRepository,
+    SessionState,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -1559,6 +1560,7 @@ fn sample_delegate_runtime_narrowing() -> crate::tools::runtime_config::ToolRunt
         },
         web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
             allow_private_hosts: Some(false),
+            enforce_allowed_domains: false,
             allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
             blocked_domains: BTreeSet::from(["deny.example.com".to_owned()]),
             timeout_seconds: Some(5),
@@ -2097,6 +2099,54 @@ fn default_runtime_tool_view_uses_persisted_delegate_child_restrictions() {
     assert!(child_view.contains("file.read"));
     assert!(child_view.contains("file.write"));
     assert!(!child_view.contains("shell.exec"));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn default_runtime_tool_view_intersects_root_session_with_persisted_tool_policy() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-tool-view", "session-policy")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.upsert_session_tool_policy(NewSessionToolPolicyRecord {
+        session_id: "root-session".to_owned(),
+        requested_tool_ids: vec![
+            "tool.search".to_owned(),
+            "tool.invoke".to_owned(),
+            "session_status".to_owned(),
+        ],
+        runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
+    })
+    .expect("upsert session tool policy");
+
+    let runtime = DefaultConversationRuntime::default();
+    let root_view = runtime
+        .tool_view(
+            &config,
+            "root-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("root tool view");
+
+    assert!(root_view.contains("tool.search"));
+    assert!(root_view.contains("tool.invoke"));
+    assert!(root_view.contains("session_status"));
+    assert!(!root_view.contains("web.fetch"));
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -14901,6 +14951,66 @@ async fn session_context_preserves_child_runtime_narrowing_after_many_later_even
         BTreeSet::from(["docs.example.com".to_owned()])
     );
     assert_eq!(runtime_narrowing.browser.max_sessions, Some(1));
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn session_context_merges_persisted_session_policy_runtime_narrowing() {
+    let mut config = test_config();
+    let child_session_id = seed_delegate_child_session_with_runtime_narrowing(
+        &mut config,
+        "session-policy-merge",
+        sample_delegate_runtime_narrowing(),
+    );
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.upsert_session_tool_policy(NewSessionToolPolicyRecord {
+        session_id: child_session_id.clone(),
+        requested_tool_ids: Vec::new(),
+        runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing {
+            browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+                max_sessions: Some(3),
+                ..crate::tools::runtime_config::BrowserRuntimeNarrowing::default()
+            },
+            web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
+                allow_private_hosts: None,
+                enforce_allowed_domains: false,
+                allowed_domains: BTreeSet::from(["api.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["extra-block.example.com".to_owned()]),
+                timeout_seconds: None,
+                max_bytes: None,
+                max_redirects: None,
+            },
+        },
+    })
+    .expect("upsert child session tool policy");
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_context = runtime
+        .session_context(
+            &config,
+            &child_session_id,
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("load child session context");
+
+    let runtime_narrowing = session_context
+        .runtime_narrowing
+        .expect("effective runtime narrowing");
+    assert_eq!(runtime_narrowing.browser.max_sessions, Some(1));
+    assert!(runtime_narrowing.web_fetch.enforce_allowed_domains);
+    assert!(
+        runtime_narrowing.web_fetch.allowed_domains.is_empty(),
+        "disjoint allowlists should fail closed"
+    );
+    assert_eq!(
+        runtime_narrowing.web_fetch.blocked_domains,
+        BTreeSet::from([
+            "deny.example.com".to_owned(),
+            "extra-block.example.com".to_owned(),
+        ])
+    );
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -684,6 +684,8 @@ fn augment_tool_payload_for_kernel(
     session_context: &SessionContext,
 ) -> serde_json::Value {
     let payload = inject_runtime_narrowing_context(payload, session_context);
+    let payload =
+        inject_tool_search_visibility_context(canonical_tool_name, payload, session_context);
 
     // Direct browser tool calls: inject scope at the top level.
     if browser_scope_injection_required(canonical_tool_name) {
@@ -708,6 +710,47 @@ fn augment_tool_payload_for_kernel(
     }
 
     payload
+}
+
+fn inject_tool_search_visibility_context(
+    canonical_tool_name: &str,
+    payload: serde_json::Value,
+    session_context: &SessionContext,
+) -> serde_json::Value {
+    if canonical_tool_name != "tool.search" {
+        return payload;
+    }
+
+    let serde_json::Value::Object(mut object) = payload else {
+        return payload;
+    };
+
+    let mut internal = object
+        .remove(crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY)
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    let mut tool_search_context = internal
+        .remove(crate::tools::LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY)
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    let visible_tool_ids = session_context
+        .tool_view
+        .tool_names()
+        .map(|tool_name| serde_json::Value::String(tool_name.to_owned()))
+        .collect::<Vec<_>>();
+    tool_search_context.insert(
+        crate::tools::LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY.to_owned(),
+        serde_json::Value::Array(visible_tool_ids),
+    );
+    internal.insert(
+        crate::tools::LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY.to_owned(),
+        serde_json::Value::Object(tool_search_context),
+    );
+    object.insert(
+        crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+        serde_json::Value::Object(internal),
+    );
+    serde_json::Value::Object(object)
 }
 
 fn inject_runtime_narrowing_context(
@@ -1730,11 +1773,15 @@ impl TurnEngine {
             intent.args_json.clone(),
             ingress,
         );
+        let injected_payload_uses_reserved_internal_context =
+            crate::tools::payload_uses_reserved_internal_tool_context(&injected.payload);
         let augmented_payload = augment_tool_payload_for_kernel(
             resolved_tool.canonical_name,
             injected.payload,
             session_context,
         );
+        let augmented_payload_uses_reserved_internal_context =
+            crate::tools::payload_uses_reserved_internal_tool_context(&augmented_payload);
         let request = ToolCoreRequest {
             tool_name: resolved_tool.canonical_name.to_owned(),
             payload: augmented_payload,
@@ -1809,7 +1856,9 @@ impl TurnEngine {
             request: effective_request,
             execution_kind: effective_execution_kind,
             scheduling_class,
-            trusted_internal_context: injected.trusted_internal_context,
+            trusted_internal_context: injected.trusted_internal_context
+                || (!injected_payload_uses_reserved_internal_context
+                    && augmented_payload_uses_reserved_internal_context),
         })
     }
 
@@ -2911,6 +2960,39 @@ mod tests {
         assert_eq!(
             augmented["arguments"][crate::tools::BROWSER_SESSION_SCOPE_FIELD],
             "root-session"
+        );
+    }
+
+    #[test]
+    fn augment_tool_payload_injects_visible_tool_ids_for_tool_search() {
+        let session_context = SessionContext::root_with_tool_view(
+            "root-session",
+            crate::tools::ToolView::from_tool_names(["tool.search", "tool.invoke", "file.read"]),
+        )
+        .with_runtime_narrowing(crate::tools::runtime_config::ToolRuntimeNarrowing {
+            browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+                max_sessions: Some(1),
+                ..crate::tools::runtime_config::BrowserRuntimeNarrowing::default()
+            },
+            ..crate::tools::runtime_config::ToolRuntimeNarrowing::default()
+        });
+        let payload = json!({
+            "query": "read note.md",
+            "limit": 3,
+        });
+
+        let augmented = augment_tool_payload_for_kernel("tool.search", payload, &session_context);
+
+        assert_eq!(
+            augmented[crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY]
+                [crate::tools::LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY]
+                [crate::tools::LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY],
+            json!(["file.read", "tool.invoke", "tool.search"])
+        );
+        assert_eq!(
+            augmented[crate::tools::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY]
+                [crate::tools::LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY]["browser"]["max_sessions"],
+            1
         );
     }
 }

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -102,8 +102,8 @@ impl PromptWindowQueryDiagnostics {
 }
 
 const SUMMARY_FORMAT_VERSION: i64 = 1;
-const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 4;
-const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 9;
+const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 5;
+const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 10;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const SQLITE_PREPARED_STATEMENT_CACHE_CAPACITY: usize = 16;
 const SQL_INSERT_TURN: &str = "INSERT INTO turns(session_id, session_turn_index, role, content, ts) VALUES (?1, ?2, ?3, ?4, ?5)";
@@ -147,7 +147,8 @@ const SQL_COUNT_CURRENT_SCHEMA_OBJECTS: &str = "SELECT COUNT(*)
                         'memory_summary_checkpoints',
                         'memory_summary_checkpoint_bodies',
                         'approval_requests',
-                        'approval_grants'
+                        'approval_grants',
+                        'session_tool_policies'
                     ))
                 OR (type = 'index' AND name IN (
                         'idx_turns_session_id',
@@ -1317,6 +1318,12 @@ fn open_sqlite_connection_with_diagnostics(
               updated_at INTEGER NOT NULL,
               PRIMARY KEY(scope_session_id, approval_key)
             );
+            CREATE TABLE IF NOT EXISTS session_tool_policies(
+              session_id TEXT PRIMARY KEY,
+              requested_tool_ids_json TEXT NOT NULL,
+              runtime_narrowing_json TEXT NOT NULL,
+              updated_at INTEGER NOT NULL
+            );
             CREATE INDEX IF NOT EXISTS idx_approval_requests_session_status_requested_at
               ON approval_requests(session_id, status, requested_at DESC, approval_request_id);
             ",
@@ -1328,6 +1335,7 @@ fn open_sqlite_connection_with_diagnostics(
     if user_version < SQLITE_MEMORY_SCHEMA_VERSION {
         ensure_turn_session_index_and_state_metadata(&conn)?;
         ensure_approval_lifecycle_tables(&conn)?;
+        ensure_session_tool_policy_storage(&conn)?;
         ensure_summary_checkpoint_storage_layout(&conn)?;
         write_sqlite_user_version(&conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
     }
@@ -1499,6 +1507,25 @@ fn ensure_approval_lifecycle_tables(conn: &Connection) -> Result<(), String> {
         ",
     )
     .map_err(|error| format!("ensure approval lifecycle storage failed: {error}"))?;
+
+    Ok(())
+}
+
+fn ensure_session_tool_policy_storage(conn: &Connection) -> Result<(), String> {
+    #[cfg(test)]
+    test_support::record_sqlite_schema_repair("session_tool_policy");
+
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS session_tool_policies(
+          session_id TEXT PRIMARY KEY,
+          requested_tool_ids_json TEXT NOT NULL,
+          runtime_narrowing_json TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        ",
+    )
+    .map_err(|error| format!("ensure session tool policy storage failed: {error}"))?;
 
     Ok(())
 }

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
+use crate::tools::runtime_config::ToolRuntimeNarrowing;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionKind {
@@ -212,6 +213,21 @@ pub struct NewApprovalGrantRecord {
     pub scope_session_id: String,
     pub approval_key: String,
     pub created_by_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionToolPolicyRecord {
+    pub session_id: String,
+    pub requested_tool_ids: Vec<String>,
+    pub runtime_narrowing: ToolRuntimeNarrowing,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewSessionToolPolicyRecord {
+    pub session_id: String,
+    pub requested_tool_ids: Vec<String>,
+    pub runtime_narrowing: ToolRuntimeNarrowing,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1238,6 +1254,97 @@ impl SessionRepository {
         raw.map(ApprovalGrantRecord::try_from_raw).transpose()
     }
 
+    pub fn upsert_session_tool_policy(
+        &self,
+        record: NewSessionToolPolicyRecord,
+    ) -> Result<SessionToolPolicyRecord, String> {
+        let session_id = normalize_required_text(&record.session_id, "session_id")?;
+        let session_exists = self
+            .load_session_summary_with_legacy_fallback(&session_id)?
+            .is_some();
+        if !session_exists {
+            return Err(format!("session `{session_id}` not found"));
+        }
+
+        let requested_tool_ids = normalize_tool_id_list(record.requested_tool_ids);
+        let encoded_requested_tool_ids = serde_json::to_string(&requested_tool_ids)
+            .map_err(|error| format!("encode session tool policy tool ids failed: {error}"))?;
+        let encoded_runtime_narrowing = serde_json::to_string(&record.runtime_narrowing)
+            .map_err(|error| format!("encode session tool policy narrowing failed: {error}"))?;
+        let updated_at = unix_ts_now();
+        let conn = self.open_connection()?;
+        conn.execute(
+            "INSERT INTO session_tool_policies(
+                session_id,
+                requested_tool_ids_json,
+                runtime_narrowing_json,
+                updated_at
+             ) VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(session_id) DO UPDATE SET
+                requested_tool_ids_json = excluded.requested_tool_ids_json,
+                runtime_narrowing_json = excluded.runtime_narrowing_json,
+                updated_at = excluded.updated_at",
+            params![
+                session_id,
+                encoded_requested_tool_ids,
+                encoded_runtime_narrowing,
+                updated_at,
+            ],
+        )
+        .map_err(|error| format!("upsert session tool policy failed: {error}"))?;
+
+        self.load_session_tool_policy(&record.session_id)?
+            .ok_or_else(|| {
+                format!(
+                    "session tool policy `{}` disappeared after upsert",
+                    record.session_id
+                )
+            })
+    }
+
+    pub fn load_session_tool_policy(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionToolPolicyRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        let raw = conn
+            .query_row(
+                "SELECT
+                    session_id,
+                    requested_tool_ids_json,
+                    runtime_narrowing_json,
+                    updated_at
+                 FROM session_tool_policies
+                 WHERE session_id = ?1",
+                params![session_id],
+                |row| {
+                    Ok(RawSessionToolPolicyRecord {
+                        session_id: row.get(0)?,
+                        requested_tool_ids_json: row.get(1)?,
+                        runtime_narrowing_json: row.get(2)?,
+                        updated_at: row.get(3)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| format!("load session tool policy failed: {error}"))?;
+        raw.map(SessionToolPolicyRecord::try_from_raw).transpose()
+    }
+
+    pub fn delete_session_tool_policy(&self, session_id: &str) -> Result<bool, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let conn = self.open_connection()?;
+        let affected = conn
+            .execute(
+                "DELETE FROM session_tool_policies
+                 WHERE session_id = ?1",
+                params![session_id],
+            )
+            .map_err(|error| format!("delete session tool policy failed: {error}"))?;
+        Ok(affected > 0)
+    }
+
     pub fn upsert_terminal_outcome(
         &self,
         session_id: &str,
@@ -1958,6 +2065,14 @@ struct RawApprovalGrantRecord {
     updated_at: i64,
 }
 
+#[derive(Debug)]
+struct RawSessionToolPolicyRecord {
+    session_id: String,
+    requested_tool_ids_json: String,
+    runtime_narrowing_json: String,
+    updated_at: i64,
+}
+
 impl SessionRecord {
     fn try_from_raw(raw: RawSessionRecord) -> Result<Self, String> {
         Ok(Self {
@@ -2058,6 +2173,22 @@ impl ApprovalGrantRecord {
     }
 }
 
+impl SessionToolPolicyRecord {
+    fn try_from_raw(raw: RawSessionToolPolicyRecord) -> Result<Self, String> {
+        let requested_tool_ids: Vec<String> = serde_json::from_str(&raw.requested_tool_ids_json)
+            .map_err(|error| format!("decode session tool policy tool ids failed: {error}"))?;
+        let runtime_narrowing: ToolRuntimeNarrowing =
+            serde_json::from_str(&raw.runtime_narrowing_json)
+                .map_err(|error| format!("decode session tool policy narrowing failed: {error}"))?;
+        Ok(Self {
+            session_id: raw.session_id,
+            requested_tool_ids: normalize_tool_id_list(requested_tool_ids),
+            runtime_narrowing,
+            updated_at: raw.updated_at,
+        })
+    }
+}
+
 fn normalize_required_text(value: &str, field_name: &str) -> Result<String, String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -2071,6 +2202,18 @@ fn normalize_optional_text(value: Option<String>) -> Option<String> {
         let trimmed = raw.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_owned())
     })
+}
+
+fn normalize_tool_id_list(tool_ids: Vec<String>) -> Vec<String> {
+    let mut normalized = BTreeSet::new();
+    for tool_id in tool_ids {
+        let trimmed = tool_id.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        normalized.insert(trimmed.to_owned());
+    }
+    normalized.into_iter().collect()
 }
 
 fn unix_ts_now() -> i64 {
@@ -2099,6 +2242,7 @@ fn sort_session_summaries(sessions: &mut [SessionSummaryRecord]) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::fs;
     use std::sync::Arc;
     use std::thread;
@@ -2108,6 +2252,7 @@ mod tests {
 
     use crate::memory::append_turn_direct;
     use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::tools::runtime_config::ToolRuntimeNarrowing;
 
     use super::*;
 
@@ -3380,6 +3525,73 @@ mod tests {
             .expect("load approval grant")
             .expect("approval grant row");
         assert_eq!(loaded, created);
+    }
+
+    #[test]
+    fn session_tool_policy_repository_round_trips_and_deletes_policy() {
+        let config = isolated_memory_config("session-tool-policy");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+
+        let created = repo
+            .upsert_session_tool_policy(NewSessionToolPolicyRecord {
+                session_id: "root-session".to_owned(),
+                requested_tool_ids: vec![
+                    "tool.search".to_owned(),
+                    "file.read".to_owned(),
+                    "tool.search".to_owned(),
+                ],
+                runtime_narrowing: ToolRuntimeNarrowing {
+                    browser: crate::tools::runtime_config::BrowserRuntimeNarrowing {
+                        max_sessions: Some(1),
+                        ..crate::tools::runtime_config::BrowserRuntimeNarrowing::default()
+                    },
+                    web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
+                        allow_private_hosts: Some(false),
+                        enforce_allowed_domains: false,
+                        allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                        blocked_domains: BTreeSet::from(["deny.example.com".to_owned()]),
+                        timeout_seconds: Some(5),
+                        max_bytes: Some(4_096),
+                        max_redirects: Some(2),
+                    },
+                },
+            })
+            .expect("upsert session tool policy");
+
+        assert_eq!(created.session_id, "root-session");
+        assert_eq!(
+            created.requested_tool_ids,
+            vec!["file.read".to_owned(), "tool.search".to_owned()]
+        );
+        assert_eq!(created.runtime_narrowing.browser.max_sessions, Some(1));
+        assert_eq!(
+            created.runtime_narrowing.web_fetch.allowed_domains,
+            BTreeSet::from(["docs.example.com".to_owned()])
+        );
+
+        let loaded = repo
+            .load_session_tool_policy("root-session")
+            .expect("load session tool policy")
+            .expect("session tool policy");
+        assert_eq!(loaded, created);
+
+        let deleted = repo
+            .delete_session_tool_policy("root-session")
+            .expect("delete session tool policy");
+        assert!(deleted);
+        assert!(
+            repo.load_session_tool_policy("root-session")
+                .expect("load session tool policy after delete")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -678,6 +678,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_tool_policy_status_definition,
         },
@@ -690,6 +691,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::SessionMutation,
+            capability_action_class: CapabilityActionClass::PolicyMutation,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_tool_policy_set_definition,
         },
@@ -702,6 +704,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::SessionMutation,
+            capability_action_class: CapabilityActionClass::PolicyMutation,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: session_tool_policy_clear_definition,
         },
@@ -3320,6 +3323,18 @@ mod tests {
             ("session_archive", CapabilityActionClass::SessionMutation),
             ("session_cancel", CapabilityActionClass::SessionMutation),
             ("session_events", CapabilityActionClass::ExecuteExisting),
+            (
+                "session_tool_policy_status",
+                CapabilityActionClass::ExecuteExisting,
+            ),
+            (
+                "session_tool_policy_set",
+                CapabilityActionClass::PolicyMutation,
+            ),
+            (
+                "session_tool_policy_clear",
+                CapabilityActionClass::PolicyMutation,
+            ),
             ("session_recover", CapabilityActionClass::SessionMutation),
         ];
 

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -670,6 +670,42 @@ fn build_tool_catalog() -> ToolCatalog {
             provider_definition_builder: session_events_definition,
         },
         ToolDescriptor {
+            name: "session_tool_policy_status",
+            provider_name: "session_tool_policy_status",
+            aliases: &[],
+            description: "Inspect the session-scoped tool policy for a visible session",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
+            policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
+            provider_definition_builder: session_tool_policy_status_definition,
+        },
+        ToolDescriptor {
+            name: "session_tool_policy_set",
+            provider_name: "session_tool_policy_set",
+            aliases: &[],
+            description: "Update the session-scoped tool policy for a visible session",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::SessionMutation,
+            policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            provider_definition_builder: session_tool_policy_set_definition,
+        },
+        ToolDescriptor {
+            name: "session_tool_policy_clear",
+            provider_name: "session_tool_policy_clear",
+            aliases: &[],
+            description: "Clear the session-scoped tool policy for a visible session",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::SessionMutation,
+            policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
+            provider_definition_builder: session_tool_policy_clear_definition,
+        },
+        ToolDescriptor {
             name: "session_recover",
             provider_name: "session_recover",
             aliases: &[],
@@ -2333,6 +2369,151 @@ fn session_status_definition(descriptor: &ToolDescriptor) -> Value {
     })
 }
 
+fn session_tool_runtime_narrowing_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "browser": {
+                "type": "object",
+                "properties": {
+                    "max_sessions": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional upper bound for browser session count."
+                    },
+                    "max_links": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional upper bound for extracted browser links."
+                    },
+                    "max_text_chars": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional upper bound for extracted browser text characters."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "web_fetch": {
+                "type": "object",
+                "properties": {
+                    "allow_private_hosts": {
+                        "type": "boolean",
+                        "description": "Optional narrowing for private-host access. Use false to deny private hosts."
+                    },
+                    "enforce_allowed_domains": {
+                        "type": "boolean",
+                        "description": "When true, enforce the provided allowed_domains list even when it is empty."
+                    },
+                    "allowed_domains": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Optional allowlist intersection for web.fetch."
+                    },
+                    "blocked_domains": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Optional additional blocked domains for web.fetch."
+                    },
+                    "timeout_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional maximum web.fetch timeout."
+                    },
+                    "max_bytes": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional maximum web.fetch response size in bytes."
+                    },
+                    "max_redirects": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional maximum web.fetch redirect count."
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+fn session_tool_policy_status_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional visible session identifier to inspect. Defaults to the current session."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_tool_policy_set_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional visible session identifier to update. Defaults to the current session."
+                    },
+                    "tool_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Optional replacement visible tool id set. Use an empty array to clear the session-specific tool surface restriction."
+                    },
+                    "runtime_narrowing": session_tool_runtime_narrowing_schema()
+                },
+                "anyOf": [
+                    { "required": ["tool_ids"] },
+                    { "required": ["runtime_narrowing"] }
+                ],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn session_tool_policy_clear_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional visible session identifier to clear. Defaults to the current session."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
 fn session_recover_definition(descriptor: &ToolDescriptor) -> Value {
     json!({
         "type": "function",
@@ -2603,6 +2784,10 @@ fn tool_argument_hint(name: &str) -> &'static str {
         "shell.exec" => "command:string,args?:string[],timeout_ms?:integer,cwd?:string",
         "provider.switch" => "selector?:string",
         "delegate" | "delegate_async" => "task:string,label?:string,timeout_seconds?:integer",
+        "session_tool_policy_status" | "session_tool_policy_clear" => "session_id?:string",
+        "session_tool_policy_set" => {
+            "session_id?:string,tool_ids?:string[],runtime_narrowing?:object"
+        }
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => "session_id:string",
         "sessions_list" => "limit?:integer,state?:string",
@@ -2692,6 +2877,12 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
             ("label", "string"),
             ("timeout_seconds", "integer"),
         ],
+        "session_tool_policy_status" | "session_tool_policy_clear" => &[("session_id", "string")],
+        "session_tool_policy_set" => &[
+            ("session_id", "string"),
+            ("tool_ids", "array"),
+            ("runtime_narrowing", "object"),
+        ],
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => &[("session_id", "string")],
         "sessions_list" => &[("limit", "integer"), ("state", "string")],
@@ -2729,6 +2920,8 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "file.edit" => &["path", "old_string", "new_string"],
         "shell.exec" => &["command"],
         "delegate" | "delegate_async" => &["task"],
+        "session_tool_policy_status" | "session_tool_policy_clear" => &[],
+        "session_tool_policy_set" => &[],
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => &["session_id"],
         "sessions_send" => &["session_id", "text"],
@@ -2765,6 +2958,9 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
         "shell.exec" => &["shell", "command", "process", "exec"],
         "provider.switch" => &["provider", "switch", "model", "runtime"],
         "delegate" | "delegate_async" => &["session", "delegate", "child"],
+        "session_tool_policy_status" | "session_tool_policy_set" | "session_tool_policy_clear" => {
+            &["session", "policy", "tools", "security"]
+        }
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" | "sessions_list" => {
             &["session", "history", "runtime"]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -181,6 +181,23 @@ pub(crate) fn payload_uses_reserved_internal_tool_context(payload: &Value) -> bo
         .as_object()
         .is_some_and(|body| body.contains_key(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY))
 }
+
+fn ensure_untrusted_payload_does_not_use_reserved_internal_tool_context(
+    tool_name: &str,
+    payload: &Value,
+    payload_path: &str,
+) -> Result<(), String> {
+    if trusted_internal_tool_payload_enabled() {
+        return Ok(());
+    }
+    if !payload_uses_reserved_internal_tool_context(payload) {
+        return Ok(());
+    }
+
+    Err(format!(
+        "tool `{tool_name}` {payload_path}.{LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY} is reserved for trusted internal tool context; retry without that field"
+    ))
+}
 /// Execute a tool request, routing through the kernel for
 /// policy enforcement and audit recording.
 ///
@@ -654,14 +671,11 @@ pub fn execute_tool_core_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    if !trusted_internal_tool_payload_enabled()
-        && payload_uses_reserved_internal_tool_context(&request.payload)
-    {
-        return Err(format!(
-            "tool `{}` payload.{LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY} is reserved for trusted internal tool context; retry without that field",
-            request.tool_name
-        ));
-    }
+    ensure_untrusted_payload_does_not_use_reserved_internal_tool_context(
+        request.tool_name.as_str(),
+        &request.payload,
+        "payload",
+    )?;
     let canonical_name = canonical_tool_name(request.tool_name.as_str());
     let request = ToolCoreRequest {
         tool_name: canonical_name.to_owned(),
@@ -1258,6 +1272,12 @@ fn execute_tool_invoke_tool_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let inner_arguments = request.payload.get("arguments").unwrap_or(&Value::Null);
+    ensure_untrusted_payload_does_not_use_reserved_internal_tool_context(
+        request.tool_name.as_str(),
+        inner_arguments,
+        "payload.arguments",
+    )?;
     let (entry, effective_request) = resolve_tool_invoke_request(&request)?;
     match entry.execution_kind {
         ToolExecutionKind::Core => {
@@ -4227,6 +4247,53 @@ mod tests {
         assert!(
             error.contains("not in allowed_domains"),
             "expected inner web.fetch denial after narrowing, got: {error}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn tool_invoke_rejects_forged_reserved_internal_context_inside_arguments() {
+        let root = std::env::temp_dir().join(format!(
+            "loongclaw-tool-invoke-inner-context-forged-{}",
+            std::process::id()
+        ));
+        let fixture_path = root.join("README.md");
+
+        std::fs::create_dir_all(&root).expect("create fixture root");
+        std::fs::write(&fixture_path, "tool invoke fixture").expect("write fixture file");
+
+        let config = test_tool_runtime_config(root.clone());
+        let (tool_name, mut payload) = bridge_provider_tool_call_with_scope(
+            "file.read",
+            json!({
+                "path": fixture_path.display().to_string()
+            }),
+            None,
+            None,
+        );
+        let payload_object = payload.as_object_mut().expect("tool.invoke payload object");
+        let arguments = payload_object
+            .get_mut("arguments")
+            .and_then(Value::as_object_mut)
+            .expect("tool.invoke arguments object");
+        arguments.insert(
+            LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY.to_owned(),
+            json!({
+                LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: {
+                    LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: ["file.read"]
+                }
+            }),
+        );
+
+        let error = execute_tool_core_with_config(ToolCoreRequest { tool_name, payload }, &config)
+            .expect_err("untrusted tool.invoke should reject forged inner reserved context");
+
+        assert!(
+            error.contains(
+                "payload.arguments._loongclaw is reserved for trusted internal tool context"
+            ),
+            "error={error}"
         );
 
         std::fs::remove_dir_all(&root).ok();

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -91,8 +91,8 @@ const WEB_FETCH_TOOL_NAME: &str = "web.fetch";
 const WEB_SEARCH_TOOL_NAME: &str = "web.search";
 
 pub(crate) const LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY: &str = "_loongclaw";
-const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
-const LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: &str = "visible_tool_ids";
+pub(crate) const LOONGCLAW_INTERNAL_TOOL_SEARCH_KEY: &str = "tool_search";
+pub(crate) const LOONGCLAW_INTERNAL_TOOL_SEARCH_VISIBLE_TOOL_IDS_KEY: &str = "visible_tool_ids";
 pub(crate) const LOONGCLAW_INTERNAL_RUNTIME_NARROWING_KEY: &str = "runtime_narrowing";
 
 pub fn normalize_external_skills_domain_rule(raw: &str) -> Result<String, String> {
@@ -176,7 +176,7 @@ fn trusted_internal_tool_payload_enabled() -> bool {
             .unwrap_or(false)
 }
 
-fn payload_uses_reserved_internal_tool_context(payload: &Value) -> bool {
+pub(crate) fn payload_uses_reserved_internal_tool_context(payload: &Value) -> bool {
     payload
         .as_object()
         .is_some_and(|body| body.contains_key(LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY))
@@ -281,15 +281,21 @@ fn execute_app_tool_with_browser_companion_readiness(
                 tool_config,
             )
         }
-        "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" => {
-            session::execute_session_tool_with_policies(
-                request,
-                current_session_id,
-                memory_config,
-                tool_config,
-            )
-        }
+        "sessions_list"
+        | "sessions_history"
+        | "session_tool_policy_status"
+        | "session_tool_policy_set"
+        | "session_tool_policy_clear"
+        | "session_status"
+        | "session_events"
+        | "session_archive"
+        | "session_cancel"
+        | "session_recover" => session::execute_session_tool_with_policies(
+            request,
+            current_session_id,
+            memory_config,
+            tool_config,
+        ),
         #[cfg(feature = "tool-browser")]
         "browser.companion.click" | "browser.companion.type" => {
             if assume_browser_companion_ready {
@@ -1756,6 +1762,7 @@ mod tests {
             "file.write",
             "provider.switch",
             "session_events",
+            "session_tool_policy_status",
             "session_status",
             "session_wait",
             "sessions_history",
@@ -1797,6 +1804,7 @@ mod tests {
             "file.write",
             "provider.switch",
             "session_events",
+            "session_tool_policy_status",
             "session_status",
             "session_wait",
             "sessions_history",
@@ -1822,6 +1830,8 @@ mod tests {
         assert!(names.contains(&"session_archive"));
         assert!(names.contains(&"session_cancel"));
         assert!(names.contains(&"session_recover"));
+        assert!(names.contains(&"session_tool_policy_set"));
+        assert!(names.contains(&"session_tool_policy_clear"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
@@ -1864,6 +1874,7 @@ mod tests {
             "delegate",
             "delegate_async",
             "session_events",
+            "session_tool_policy_status",
             "session_status",
             "session_wait",
             "sessions_history",
@@ -1878,7 +1889,13 @@ mod tests {
             );
         }
 
-        for tool_name in ["session_archive", "session_cancel", "session_recover"] {
+        for tool_name in [
+            "session_archive",
+            "session_cancel",
+            "session_recover",
+            "session_tool_policy_set",
+            "session_tool_policy_clear",
+        ] {
             assert!(
                 !view.contains(tool_name),
                 "expected runtime view to hide `{tool_name}` by default"
@@ -1905,6 +1922,8 @@ mod tests {
         assert!(view.contains("session_archive"));
         assert!(view.contains("session_cancel"));
         assert!(view.contains("session_recover"));
+        assert!(view.contains("session_tool_policy_set"));
+        assert!(view.contains("session_tool_policy_clear"));
     }
 
     #[test]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -14,6 +14,10 @@ use crate::config::{FeishuChannelConfig, FeishuIntegrationConfig};
 use crate::secrets::has_configured_secret_ref;
 use crate::secrets::{SecretLookup, resolve_secret_lookup};
 
+fn bool_is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BrowserRuntimeNarrowing {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -35,6 +39,8 @@ impl BrowserRuntimeNarrowing {
 pub struct WebFetchRuntimeNarrowing {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_private_hosts: Option<bool>,
+    #[serde(default, skip_serializing_if = "bool_is_false")]
+    pub enforce_allowed_domains: bool,
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub allowed_domains: BTreeSet<String>,
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
@@ -51,11 +57,17 @@ impl WebFetchRuntimeNarrowing {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.allow_private_hosts.is_none()
+            && !self.enforces_allowed_domains()
             && self.allowed_domains.is_empty()
             && self.blocked_domains.is_empty()
             && self.timeout_seconds.is_none()
             && self.max_bytes.is_none()
             && self.max_redirects.is_none()
+    }
+
+    #[must_use]
+    pub fn enforces_allowed_domains(&self) -> bool {
+        self.enforce_allowed_domains || !self.allowed_domains.is_empty()
     }
 }
 
@@ -72,6 +84,99 @@ impl ToolRuntimeNarrowing {
     pub fn is_empty(&self) -> bool {
         self.browser.is_empty() && self.web_fetch.is_empty()
     }
+
+    #[must_use]
+    pub fn intersect(&self, other: &Self) -> Self {
+        if self.is_empty() {
+            return other.clone();
+        }
+        if other.is_empty() {
+            return self.clone();
+        }
+
+        let browser = BrowserRuntimeNarrowing {
+            max_sessions: min_optional_limit(self.browser.max_sessions, other.browser.max_sessions),
+            max_links: min_optional_limit(self.browser.max_links, other.browser.max_links),
+            max_text_chars: min_optional_limit(
+                self.browser.max_text_chars,
+                other.browser.max_text_chars,
+            ),
+        };
+
+        let left_enforces_allowed_domains = self.web_fetch.enforces_allowed_domains();
+        let right_enforces_allowed_domains = other.web_fetch.enforces_allowed_domains();
+        let mut allowed_domains = BTreeSet::new();
+        let mut enforce_allowed_domains = false;
+
+        if left_enforces_allowed_domains && right_enforces_allowed_domains {
+            enforce_allowed_domains = true;
+            let left_is_deny_all = self.web_fetch.allowed_domains.is_empty();
+            let right_is_deny_all = other.web_fetch.allowed_domains.is_empty();
+            if !left_is_deny_all && !right_is_deny_all {
+                allowed_domains = self
+                    .web_fetch
+                    .allowed_domains
+                    .intersection(&other.web_fetch.allowed_domains)
+                    .cloned()
+                    .collect();
+            }
+        } else if left_enforces_allowed_domains {
+            enforce_allowed_domains = true;
+            allowed_domains = self.web_fetch.allowed_domains.clone();
+        } else if right_enforces_allowed_domains {
+            enforce_allowed_domains = true;
+            allowed_domains = other.web_fetch.allowed_domains.clone();
+        }
+
+        let allow_private_hosts = intersect_private_host_setting(
+            self.web_fetch.allow_private_hosts,
+            other.web_fetch.allow_private_hosts,
+        );
+
+        let blocked_domains = self
+            .web_fetch
+            .blocked_domains
+            .union(&other.web_fetch.blocked_domains)
+            .cloned()
+            .collect();
+
+        let web_fetch = WebFetchRuntimeNarrowing {
+            allow_private_hosts,
+            enforce_allowed_domains,
+            allowed_domains,
+            blocked_domains,
+            timeout_seconds: min_optional_limit(
+                self.web_fetch.timeout_seconds,
+                other.web_fetch.timeout_seconds,
+            ),
+            max_bytes: min_optional_limit(self.web_fetch.max_bytes, other.web_fetch.max_bytes),
+            max_redirects: min_optional_limit(
+                self.web_fetch.max_redirects,
+                other.web_fetch.max_redirects,
+            ),
+        };
+
+        Self { browser, web_fetch }
+    }
+}
+
+fn min_optional_limit<T>(left: Option<T>, right: Option<T>) -> Option<T>
+where
+    T: Ord + Copy,
+{
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn intersect_private_host_setting(left: Option<bool>, right: Option<bool>) -> Option<bool> {
+    if left == Some(false) || right == Some(false) {
+        return Some(false);
+    }
+    None
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -773,11 +878,13 @@ impl ToolRuntimeConfig {
 
         let preserve_deny_all = narrowed.web_fetch.enforce_allowed_domains
             && narrowed.web_fetch.allowed_domains.is_empty();
-        if !narrowing.web_fetch.allowed_domains.is_empty() {
+        if narrowing.web_fetch.enforces_allowed_domains() {
             narrowed.web_fetch.enforce_allowed_domains = true;
             if !preserve_deny_all {
                 narrowed.web_fetch.allowed_domains =
-                    if narrowed.web_fetch.allowed_domains.is_empty() {
+                    if narrowing.web_fetch.allowed_domains.is_empty() {
+                        BTreeSet::new()
+                    } else if narrowed.web_fetch.allowed_domains.is_empty() {
                         narrowing.web_fetch.allowed_domains.clone()
                     } else {
                         narrowed
@@ -838,7 +945,7 @@ impl ToolRuntimeConfig {
                     }
                 ));
             }
-            if !narrowing.web_fetch.allowed_domains.is_empty() {
+            if narrowing.web_fetch.enforces_allowed_domains() {
                 rendered_any = true;
                 if effective.web_fetch.enforce_allowed_domains
                     && effective.web_fetch.allowed_domains.is_empty()
@@ -2011,6 +2118,7 @@ mod tests {
             },
             web_fetch: WebFetchRuntimeNarrowing {
                 allow_private_hosts: Some(false),
+                enforce_allowed_domains: false,
                 allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
                 blocked_domains: BTreeSet::from(["deny.example.com".to_owned()]),
                 timeout_seconds: Some(5),
@@ -2060,6 +2168,7 @@ mod tests {
         let narrowing = ToolRuntimeNarrowing {
             web_fetch: WebFetchRuntimeNarrowing {
                 allow_private_hosts: None,
+                enforce_allowed_domains: false,
                 allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
                 blocked_domains: BTreeSet::new(),
                 timeout_seconds: None,
@@ -2143,6 +2252,60 @@ mod tests {
     }
 
     #[test]
+    fn tool_runtime_narrowing_intersect_fail_closes_disjoint_allowlists() {
+        let left = ToolRuntimeNarrowing {
+            browser: BrowserRuntimeNarrowing {
+                max_sessions: Some(1),
+                ..BrowserRuntimeNarrowing::default()
+            },
+            web_fetch: WebFetchRuntimeNarrowing {
+                allow_private_hosts: Some(false),
+                enforce_allowed_domains: false,
+                allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["deny-left.example.com".to_owned()]),
+                timeout_seconds: Some(5),
+                max_bytes: Some(4_096),
+                max_redirects: Some(2),
+            },
+        };
+        let right = ToolRuntimeNarrowing {
+            browser: BrowserRuntimeNarrowing {
+                max_sessions: Some(3),
+                ..BrowserRuntimeNarrowing::default()
+            },
+            web_fetch: WebFetchRuntimeNarrowing {
+                allow_private_hosts: None,
+                enforce_allowed_domains: false,
+                allowed_domains: BTreeSet::from(["api.example.com".to_owned()]),
+                blocked_domains: BTreeSet::from(["deny-right.example.com".to_owned()]),
+                timeout_seconds: Some(9),
+                max_bytes: Some(8_192),
+                max_redirects: Some(4),
+            },
+        };
+
+        let effective = left.intersect(&right);
+
+        assert_eq!(effective.browser.max_sessions, Some(1));
+        assert_eq!(effective.web_fetch.allow_private_hosts, Some(false));
+        assert!(effective.web_fetch.enforce_allowed_domains);
+        assert!(
+            effective.web_fetch.allowed_domains.is_empty(),
+            "disjoint allowlists should collapse to an enforced empty intersection"
+        );
+        assert_eq!(
+            effective.web_fetch.blocked_domains,
+            BTreeSet::from([
+                "deny-left.example.com".to_owned(),
+                "deny-right.example.com".to_owned(),
+            ])
+        );
+        assert_eq!(effective.web_fetch.timeout_seconds, Some(5));
+        assert_eq!(effective.web_fetch.max_bytes, Some(4_096));
+        assert_eq!(effective.web_fetch.max_redirects, Some(2));
+    }
+
+    #[test]
     fn delegate_child_prompt_summary_returns_none_when_narrowing_is_empty() {
         assert_eq!(
             ToolRuntimeConfig::default()
@@ -2180,6 +2343,7 @@ mod tests {
             },
             web_fetch: WebFetchRuntimeNarrowing {
                 allow_private_hosts: Some(true),
+                enforce_allowed_domains: false,
                 allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
                 blocked_domains: BTreeSet::from(["deny.example.com".to_owned()]),
                 timeout_seconds: Some(5),

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -2379,6 +2379,14 @@ fn ensure_policy_target_session_exists(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn session_tool_policy_root_tool_view(
+    tool_config: &ToolConfig,
+    runtime_config: &crate::tools::runtime_config::ToolRuntimeConfig,
+) -> ToolView {
+    crate::tools::runtime_tool_view_with_runtime_config(tool_config, runtime_config)
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn session_tool_policy_base_tool_view(
     repo: &SessionRepository,
     session_id: &str,
@@ -2417,9 +2425,8 @@ fn session_tool_policy_base_tool_view(
     }
 
     let runtime_config = crate::tools::runtime_config::get_tool_runtime_config();
-    Ok(crate::tools::runtime_tool_view_for_runtime_config(
-        runtime_config,
-    ))
+    let root_tool_view = session_tool_policy_root_tool_view(tool_config, runtime_config);
+    Ok(root_tool_view)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -3854,6 +3861,32 @@ mod tests {
             policy.requested_tool_ids,
             vec!["session_status".to_owned(), "tool.search".to_owned()]
         );
+    }
+
+    #[cfg(feature = "feishu-integration")]
+    #[test]
+    fn session_tool_policy_root_tool_view_includes_runtime_discovered_feishu_tools() {
+        let runtime_config = crate::tools::runtime_config::ToolRuntimeConfig {
+            feishu: Some(crate::tools::runtime_config::FeishuToolRuntimeConfig {
+                channel: crate::config::FeishuChannelConfig {
+                    enabled: true,
+                    app_id: Some(loongclaw_contracts::SecretRef::Inline(
+                        "test-feishu-app-id".to_owned(),
+                    )),
+                    app_secret: Some(loongclaw_contracts::SecretRef::Inline(
+                        "test-feishu-app-secret".to_owned(),
+                    )),
+                    ..crate::config::FeishuChannelConfig::default()
+                },
+                integration: crate::config::FeishuIntegrationConfig::default(),
+            }),
+            ..crate::tools::runtime_config::ToolRuntimeConfig::default()
+        };
+        let tool_config = ToolConfig::default();
+        let tool_view = super::session_tool_policy_root_tool_view(&tool_config, &runtime_config);
+
+        assert!(tool_view.contains("feishu.whoami"));
+        assert!(tool_view.contains("feishu.messages.send"));
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -2561,6 +2561,7 @@ fn resolve_session_tool_policy_tool_ids(
 fn normalize_session_tool_runtime_narrowing(
     mut runtime_narrowing: ToolRuntimeNarrowing,
 ) -> ToolRuntimeNarrowing {
+    // Persisted session policies are only allowed to tighten fetch access, never widen it.
     if runtime_narrowing.web_fetch.allow_private_hosts == Some(true) {
         runtime_narrowing.web_fetch.allow_private_hosts = None;
     }

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -28,11 +28,16 @@ use crate::session::{
     DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED, DELEGATE_CANCEL_REQUESTED_EVENT_KIND,
     DELEGATE_CANCELLED_EVENT_KIND, delegate_cancelled_error,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::tools::ToolView;
+#[cfg(feature = "memory-sqlite")]
+use crate::tools::runtime_config::ToolRuntimeNarrowing;
 
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    SessionEventRecord, SessionKind, SessionObservationRecord, SessionRepository, SessionState,
-    SessionSummaryRecord, SessionTerminalOutcomeRecord,
+    NewSessionRecord, NewSessionToolPolicyRecord, SessionEventRecord, SessionKind,
+    SessionObservationRecord, SessionRepository, SessionState, SessionSummaryRecord,
+    SessionTerminalOutcomeRecord, SessionToolPolicyRecord,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -168,6 +173,14 @@ struct SessionArchivePlan {
 }
 
 #[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionToolPolicySetRequest {
+    session_id: String,
+    tool_ids: Option<Vec<String>>,
+    runtime_narrowing: Option<ToolRuntimeNarrowing>,
+}
+
+#[cfg(feature = "memory-sqlite")]
 #[derive(Debug, Clone, PartialEq)]
 struct SessionToolActionOutcome {
     inspection: Value,
@@ -280,6 +293,15 @@ pub fn execute_session_tool_with_policies(
             }
             "sessions_history" => {
                 execute_sessions_history(payload, current_session_id, config, tool_config)
+            }
+            "session_tool_policy_status" => {
+                execute_session_tool_policy_status(payload, current_session_id, config, tool_config)
+            }
+            "session_tool_policy_set" => {
+                execute_session_tool_policy_set(payload, current_session_id, config, tool_config)
+            }
+            "session_tool_policy_clear" => {
+                execute_session_tool_policy_clear(payload, current_session_id, config, tool_config)
             }
             "session_status" => {
                 execute_session_status(payload, current_session_id, config, tool_config)
@@ -490,6 +512,149 @@ fn execute_sessions_history(
             "session_id": target_session_id,
             "limit": limit,
             "turns": turns,
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_tool_policy_status(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let repo = SessionRepository::new(config)?;
+    let target_session_id =
+        resolve_session_tool_policy_target_session_id(&payload, current_session_id)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &target_session_id,
+        tool_config.sessions.visibility,
+    )?;
+    let policy = build_session_tool_policy_status_payload(&repo, &target_session_id, tool_config)?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "tool": "session_tool_policy_status",
+            "current_session_id": current_session_id,
+            "target_session_id": target_session_id,
+            "policy": policy,
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_tool_policy_set(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let repo = SessionRepository::new(config)?;
+    let request = parse_session_tool_policy_set_request(&payload, current_session_id)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &request.session_id,
+        tool_config.sessions.visibility,
+    )?;
+    ensure_policy_target_session_exists(&repo, &request.session_id, current_session_id)?;
+
+    let existing_policy = repo.load_session_tool_policy(&request.session_id)?;
+    let existing_tool_ids = existing_policy
+        .as_ref()
+        .map(|policy| policy.requested_tool_ids.clone())
+        .unwrap_or_default();
+    let existing_runtime_narrowing = existing_policy
+        .as_ref()
+        .map(|policy| policy.runtime_narrowing.clone())
+        .unwrap_or_default();
+
+    let next_tool_ids = match request.tool_ids {
+        Some(tool_ids) => {
+            resolve_session_tool_policy_tool_ids(&repo, &request.session_id, tool_config, tool_ids)?
+        }
+        None => existing_tool_ids,
+    };
+    let next_runtime_narrowing = request
+        .runtime_narrowing
+        .unwrap_or(existing_runtime_narrowing);
+    let clears_policy = next_tool_ids.is_empty() && next_runtime_narrowing.is_empty();
+
+    let action = if clears_policy {
+        if existing_policy.is_some() {
+            repo.delete_session_tool_policy(&request.session_id)?;
+            "cleared"
+        } else {
+            "unchanged"
+        }
+    } else {
+        let next_policy = NewSessionToolPolicyRecord {
+            session_id: request.session_id.clone(),
+            requested_tool_ids: next_tool_ids.clone(),
+            runtime_narrowing: next_runtime_narrowing.clone(),
+        };
+        let unchanged = existing_policy
+            .as_ref()
+            .is_some_and(|policy| policy.requested_tool_ids == next_tool_ids)
+            && existing_policy
+                .as_ref()
+                .is_some_and(|policy| policy.runtime_narrowing == next_runtime_narrowing);
+        if unchanged {
+            "unchanged"
+        } else {
+            repo.upsert_session_tool_policy(next_policy)?;
+            if existing_policy.is_some() {
+                "updated"
+            } else {
+                "created"
+            }
+        }
+    };
+    let policy = build_session_tool_policy_status_payload(&repo, &request.session_id, tool_config)?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "tool": "session_tool_policy_set",
+            "action": action,
+            "current_session_id": current_session_id,
+            "target_session_id": request.session_id,
+            "policy": policy,
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_session_tool_policy_clear(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let repo = SessionRepository::new(config)?;
+    let target_session_id =
+        resolve_session_tool_policy_target_session_id(&payload, current_session_id)?;
+    ensure_visible(
+        &repo,
+        current_session_id,
+        &target_session_id,
+        tool_config.sessions.visibility,
+    )?;
+
+    let cleared = repo.delete_session_tool_policy(&target_session_id)?;
+    let policy = build_session_tool_policy_status_payload(&repo, &target_session_id, tool_config)?;
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "tool": "session_tool_policy_clear",
+            "action": if cleared { "cleared" } else { "unchanged" },
+            "current_session_id": current_session_id,
+            "target_session_id": target_session_id,
+            "policy": policy,
         }),
     })
 }
@@ -2181,6 +2346,271 @@ fn ensure_visible(
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn resolve_session_tool_policy_target_session_id(
+    payload: &Value,
+    current_session_id: &str,
+) -> Result<String, String> {
+    Ok(optional_payload_string(payload, "session_id")
+        .unwrap_or_else(|| current_session_id.to_owned()))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn ensure_policy_target_session_exists(
+    repo: &SessionRepository,
+    target_session_id: &str,
+    current_session_id: &str,
+) -> Result<(), String> {
+    let existing_summary = repo.load_session_summary_with_legacy_fallback(target_session_id)?;
+    if existing_summary.is_some() {
+        return Ok(());
+    }
+    if target_session_id != current_session_id {
+        return Err(format!("session_not_found: `{target_session_id}`"));
+    }
+
+    repo.ensure_session(NewSessionRecord {
+        session_id: target_session_id.to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: None,
+        state: SessionState::Ready,
+    })?;
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_tool_policy_base_tool_view(
+    repo: &SessionRepository,
+    session_id: &str,
+    tool_config: &ToolConfig,
+) -> Result<ToolView, String> {
+    if let Some(session) = repo.load_session(session_id)? {
+        if session.parent_session_id.is_some() {
+            let depth = match repo.session_lineage_depth(session_id) {
+                Ok(depth) => depth,
+                Err(error)
+                    if error.starts_with("session_lineage_broken:")
+                        || error.starts_with("session_lineage_cycle_detected:") =>
+                {
+                    return Ok(super::delegate_child_tool_view_for_config_with_delegate(
+                        tool_config,
+                        false,
+                    ));
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "compute session lineage depth for session tool policy failed: {error}"
+                    ));
+                }
+            };
+            let allow_nested_delegate = depth < tool_config.delegate.max_depth;
+            return Ok(super::delegate_child_tool_view_for_config_with_delegate(
+                tool_config,
+                allow_nested_delegate,
+            ));
+        }
+    } else if repo
+        .load_session_summary_with_legacy_fallback(session_id)?
+        .is_some_and(|session| session.kind == SessionKind::DelegateChild)
+    {
+        return Ok(super::delegate_child_tool_view_for_config(tool_config));
+    }
+
+    let runtime_config = crate::tools::runtime_config::get_tool_runtime_config();
+    Ok(crate::tools::runtime_tool_view_for_runtime_config(
+        runtime_config,
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn apply_session_tool_policy_to_tool_view(
+    base_tool_view: &ToolView,
+    session_tool_policy: Option<&SessionToolPolicyRecord>,
+) -> ToolView {
+    let Some(session_tool_policy) = session_tool_policy else {
+        return base_tool_view.clone();
+    };
+    if session_tool_policy.requested_tool_ids.is_empty() {
+        return base_tool_view.clone();
+    }
+
+    let requested_tool_view =
+        ToolView::from_tool_names(session_tool_policy.requested_tool_ids.iter());
+    base_tool_view.intersect(&requested_tool_view)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_session_delegate_runtime_narrowing(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<ToolRuntimeNarrowing>, String> {
+    let events = repo.list_delegate_lifecycle_events(session_id)?;
+    let execution = events.into_iter().rev().find_map(|event| {
+        matches!(
+            event.event_kind.as_str(),
+            "delegate_queued" | "delegate_started"
+        )
+        .then(|| ConstrainedSubagentExecution::from_event_payload(&event.payload_json))
+        .flatten()
+    });
+    Ok(execution.and_then(|execution| {
+        (!execution.runtime_narrowing.is_empty()).then_some(execution.runtime_narrowing)
+    }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn merge_session_tool_policy_runtime_narrowing(
+    delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
+    session_tool_policy: Option<&SessionToolPolicyRecord>,
+) -> Option<ToolRuntimeNarrowing> {
+    let policy_runtime_narrowing = session_tool_policy.and_then(|policy| {
+        (!policy.runtime_narrowing.is_empty()).then_some(policy.runtime_narrowing.clone())
+    });
+
+    match (delegate_runtime_narrowing, policy_runtime_narrowing) {
+        (Some(delegate_runtime_narrowing), Some(policy_runtime_narrowing)) => {
+            Some(delegate_runtime_narrowing.intersect(&policy_runtime_narrowing))
+        }
+        (Some(delegate_runtime_narrowing), None) => Some(delegate_runtime_narrowing),
+        (None, Some(policy_runtime_narrowing)) => Some(policy_runtime_narrowing),
+        (None, None) => None,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn tool_view_names(tool_view: &ToolView) -> Vec<String> {
+    tool_view.tool_names().map(str::to_owned).collect()
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn runtime_narrowing_json(runtime_narrowing: Option<ToolRuntimeNarrowing>) -> Value {
+    match runtime_narrowing {
+        Some(runtime_narrowing) => serde_json::to_value(runtime_narrowing).unwrap_or(Value::Null),
+        None => Value::Null,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_session_tool_policy_status_payload(
+    repo: &SessionRepository,
+    target_session_id: &str,
+    tool_config: &ToolConfig,
+) -> Result<Value, String> {
+    let session_tool_policy = repo.load_session_tool_policy(target_session_id)?;
+    let base_tool_view = session_tool_policy_base_tool_view(repo, target_session_id, tool_config)?;
+    let effective_tool_view =
+        apply_session_tool_policy_to_tool_view(&base_tool_view, session_tool_policy.as_ref());
+    let delegate_runtime_narrowing =
+        load_session_delegate_runtime_narrowing(repo, target_session_id)?;
+    let effective_runtime_narrowing = merge_session_tool_policy_runtime_narrowing(
+        delegate_runtime_narrowing.clone(),
+        session_tool_policy.as_ref(),
+    );
+    let requested_tool_ids = session_tool_policy
+        .as_ref()
+        .map(|policy| policy.requested_tool_ids.clone())
+        .unwrap_or_default();
+    let requested_runtime_narrowing = session_tool_policy.as_ref().and_then(|policy| {
+        (!policy.runtime_narrowing.is_empty()).then_some(policy.runtime_narrowing.clone())
+    });
+    let updated_at = session_tool_policy.as_ref().map(|policy| policy.updated_at);
+
+    Ok(json!({
+        "has_policy": session_tool_policy.is_some(),
+        "updated_at": updated_at,
+        "requested_tool_ids": requested_tool_ids,
+        "base_tool_ids": tool_view_names(&base_tool_view),
+        "effective_tool_ids": tool_view_names(&effective_tool_view),
+        "requested_runtime_narrowing": runtime_narrowing_json(requested_runtime_narrowing),
+        "delegate_runtime_narrowing": runtime_narrowing_json(delegate_runtime_narrowing),
+        "effective_runtime_narrowing": runtime_narrowing_json(effective_runtime_narrowing),
+    }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_session_tool_policy_tool_ids(
+    repo: &SessionRepository,
+    session_id: &str,
+    tool_config: &ToolConfig,
+    raw_tool_ids: Vec<String>,
+) -> Result<Vec<String>, String> {
+    let base_tool_view = session_tool_policy_base_tool_view(repo, session_id, tool_config)?;
+    let mut normalized_tool_ids = BTreeMap::new();
+
+    for raw_tool_id in raw_tool_ids {
+        let canonical_tool_id = crate::tools::canonical_tool_name(&raw_tool_id).to_owned();
+        if !base_tool_view.contains(&canonical_tool_id) {
+            return Err(format!(
+                "session_tool_policy_set_invalid_tool_id: `{raw_tool_id}` is not available in session `{session_id}`"
+            ));
+        }
+        normalized_tool_ids.insert(canonical_tool_id.clone(), canonical_tool_id);
+    }
+
+    Ok(normalized_tool_ids.into_values().collect())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn normalize_session_tool_runtime_narrowing(
+    mut runtime_narrowing: ToolRuntimeNarrowing,
+) -> ToolRuntimeNarrowing {
+    if runtime_narrowing.web_fetch.allow_private_hosts == Some(true) {
+        runtime_narrowing.web_fetch.allow_private_hosts = None;
+    }
+    runtime_narrowing.browser.max_sessions = runtime_narrowing
+        .browser
+        .max_sessions
+        .map(|value| value.max(1));
+    runtime_narrowing.browser.max_links = runtime_narrowing
+        .browser
+        .max_links
+        .map(|value| value.max(1));
+    runtime_narrowing.browser.max_text_chars = runtime_narrowing
+        .browser
+        .max_text_chars
+        .map(|value| value.max(1));
+    runtime_narrowing.web_fetch.timeout_seconds = runtime_narrowing
+        .web_fetch
+        .timeout_seconds
+        .map(|value| value.max(1));
+    runtime_narrowing.web_fetch.max_bytes = runtime_narrowing
+        .web_fetch
+        .max_bytes
+        .map(|value| value.max(1));
+    runtime_narrowing.web_fetch.max_redirects = runtime_narrowing
+        .web_fetch
+        .max_redirects
+        .map(|value| value.max(1));
+    if !runtime_narrowing.web_fetch.allowed_domains.is_empty() {
+        runtime_narrowing.web_fetch.enforce_allowed_domains = true;
+    }
+    runtime_narrowing
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_session_tool_policy_set_request(
+    payload: &Value,
+    current_session_id: &str,
+) -> Result<SessionToolPolicySetRequest, String> {
+    let session_id = resolve_session_tool_policy_target_session_id(payload, current_session_id)?;
+    let tool_ids = optional_payload_session_tool_policy_tool_ids(payload, "tool_ids")?;
+    let runtime_narrowing =
+        optional_payload_session_tool_runtime_narrowing(payload, "runtime_narrowing")?;
+    if tool_ids.is_none() && runtime_narrowing.is_none() {
+        return Err(
+            "session_tool_policy_set requires payload.tool_ids or payload.runtime_narrowing"
+                .to_owned(),
+        );
+    }
+
+    Ok(SessionToolPolicySetRequest {
+        session_id,
+        tool_ids,
+        runtime_narrowing,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn normalize_required_session_id(session_id: &str) -> Result<String, String> {
     let trimmed = session_id.trim();
     if trimmed.is_empty() {
@@ -2328,6 +2758,50 @@ fn optional_payload_string_array(
         session_ids.push(trimmed.to_owned());
     }
     Ok(Some(session_ids))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_session_tool_policy_tool_ids(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<Vec<String>>, String> {
+    let Some(value) = payload.get(field) else {
+        return Ok(None);
+    };
+    let values = value.as_array().ok_or_else(|| {
+        format!("session tool requires payload.{field} to be an array of strings")
+    })?;
+
+    let mut tool_ids = Vec::with_capacity(values.len());
+    for value in values {
+        let Some(tool_id) = value.as_str() else {
+            return Err(format!(
+                "session tool requires payload.{field} to be an array of strings"
+            ));
+        };
+        let trimmed = tool_id.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "session tool requires payload.{field} to be an array of strings"
+            ));
+        }
+        tool_ids.push(trimmed.to_owned());
+    }
+    Ok(Some(tool_ids))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn optional_payload_session_tool_runtime_narrowing(
+    payload: &Value,
+    field: &str,
+) -> Result<Option<ToolRuntimeNarrowing>, String> {
+    let Some(value) = payload.get(field) else {
+        return Ok(None);
+    };
+    let runtime_narrowing: ToolRuntimeNarrowing = serde_json::from_value(value.clone())
+        .map_err(|error| format!("invalid session tool payload.{field}: {error}"))?;
+    let runtime_narrowing = normalize_session_tool_runtime_narrowing(runtime_narrowing);
+    Ok(Some(runtime_narrowing))
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -3249,6 +3723,137 @@ mod tests {
             .expect("recent_events array");
         assert_eq!(recent_events.len(), 1);
         assert_eq!(recent_events[0]["event_kind"], "delegate_failed");
+    }
+
+    #[test]
+    fn session_tool_policy_tools_round_trip_and_clear_policy() {
+        let config = isolated_memory_config("session-tool-policy-tools");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+
+        let set = execute_session_mutation_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_tool_policy_set".to_owned(),
+                payload: json!({
+                    "tool_ids": ["tool.search", "session_status"],
+                    "runtime_narrowing": {
+                        "browser": {
+                            "max_sessions": 2,
+                        },
+                        "web_fetch": {
+                            "allowed_domains": ["docs.example.com"],
+                            "blocked_domains": ["deny.example.com"],
+                            "allow_private_hosts": false,
+                        }
+                    }
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("set session tool policy");
+
+        assert_eq!(set.payload["action"], "created");
+        assert_eq!(set.payload["policy"]["has_policy"], true);
+        assert_eq!(
+            set.payload["policy"]["requested_tool_ids"],
+            json!(["session_status", "tool.search"])
+        );
+        assert_eq!(
+            set.payload["policy"]["effective_tool_ids"],
+            json!(["session_status", "tool.search"])
+        );
+        assert_eq!(
+            set.payload["policy"]["requested_runtime_narrowing"]["browser"]["max_sessions"],
+            2
+        );
+        assert_eq!(
+            set.payload["policy"]["effective_runtime_narrowing"]["web_fetch"]["allowed_domains"],
+            json!(["docs.example.com"])
+        );
+
+        let status = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_tool_policy_status".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session tool policy status");
+
+        assert_eq!(status.payload["policy"]["has_policy"], true);
+        assert_eq!(
+            status.payload["policy"]["requested_tool_ids"],
+            json!(["session_status", "tool.search"])
+        );
+        assert_eq!(
+            status.payload["policy"]["requested_runtime_narrowing"]["web_fetch"]["blocked_domains"],
+            json!(["deny.example.com"])
+        );
+
+        let clear = execute_session_mutation_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_tool_policy_clear".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("clear session tool policy");
+
+        assert_eq!(clear.payload["action"], "cleared");
+        assert_eq!(clear.payload["policy"]["has_policy"], false);
+        assert_eq!(clear.payload["policy"]["requested_tool_ids"], json!([]));
+        assert!(
+            clear.payload["policy"]["effective_tool_ids"]
+                .as_array()
+                .expect("effective tool ids")
+                .iter()
+                .any(|value| value == "session_status")
+        );
+    }
+
+    #[test]
+    fn session_tool_policy_set_bootstraps_current_root_session_when_missing() {
+        let config = isolated_memory_config("session-tool-policy-bootstrap");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        let set = execute_session_mutation_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_tool_policy_set".to_owned(),
+                payload: json!({
+                    "tool_ids": ["tool.search", "session_status"]
+                }),
+            },
+            "fresh-root-session",
+            &config,
+        )
+        .expect("set session tool policy");
+
+        assert_eq!(set.payload["action"], "created");
+        let session = repo
+            .load_session("fresh-root-session")
+            .expect("load bootstrapped root session")
+            .expect("bootstrapped root session");
+        assert_eq!(session.kind, SessionKind::Root);
+        assert_eq!(session.state, SessionState::Ready);
+
+        let policy = repo
+            .load_session_tool_policy("fresh-root-session")
+            .expect("load bootstrapped session tool policy")
+            .expect("bootstrapped session tool policy");
+        assert_eq!(
+            policy.requested_tool_ids,
+            vec!["session_status".to_owned(), "tool.search".to_owned()]
+        );
     }
 
     #[test]

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-27T09:30:15Z
+- Generated at: 2026-03-27T09:54:37Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -23,14 +23,14 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6294 | 6400 | 106 | 103 | 110 | 7 | 98.3% | TIGHT |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9964 | 11200 | 1236 | 92 | 120 | 28 | 89.0% | WATCH |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14132 | 15000 | 868 | 53 | 70 | 17 | 94.2% | WATCH |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14199 | 15000 | 801 | 54 | 70 | 16 | 94.7% | WATCH |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5792 | 6000 | 208 | 179 | 190 | 11 | 96.5% | TIGHT |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): channel_registry (100.0%), channel_config (100.0%), channel_mod (98.3%), daemon_lib (96.5%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.2%), onboard_cli (94.4%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.7%), onboard_cli (94.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
 <!-- arch-hotspot key=channel_mod lines=6294 functions=103 -->
 <!-- arch-hotspot key=turn_coordinator lines=9964 functions=92 -->
-<!-- arch-hotspot key=tools_mod lines=14132 functions=53 -->
+<!-- arch-hotspot key=tools_mod lines=14199 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=5792 functions=179 -->
 <!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-27T09:12:18Z
+- Generated at: 2026-03-27T09:30:15Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -23,14 +23,14 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6294 | 6400 | 106 | 103 | 110 | 7 | 98.3% | TIGHT |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9964 | 11200 | 1236 | 92 | 120 | 28 | 89.0% | WATCH |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14113 | 15000 | 887 | 54 | 70 | 16 | 94.1% | WATCH |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14132 | 15000 | 868 | 53 | 70 | 17 | 94.2% | WATCH |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5792 | 6000 | 208 | 179 | 190 | 11 | 96.5% | TIGHT |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): channel_registry (100.0%), channel_config (100.0%), channel_mod (98.3%), daemon_lib (96.5%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.1%), onboard_cli (94.4%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (91.4%), memory_mod (87.5%), acp_manager (92.4%), acpx_runtime (92.0%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.2%), onboard_cli (94.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
 <!-- arch-hotspot key=channel_mod lines=6294 functions=103 -->
 <!-- arch-hotspot key=turn_coordinator lines=9964 functions=92 -->
-<!-- arch-hotspot key=tools_mod lines=14113 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14132 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=5792 functions=179 -->
 <!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  Session-scoped governance stopped at hiding session mutation tools by default. There was no first-class persisted policy for narrowing a session's visible tool surface or runtime narrowing, `tool.search` could drift from the effective session surface, and trusted internal tool-search context needed an explicit provenance boundary.
- Why it matters:
  Operators need a per-session way to narrow visible tools and network scope without mutating global config, and policy-sensitive discovery must fail closed instead of surfacing tools outside the effective runtime envelope.
- What changed:
  Added persisted `session_tool_policy` storage and repository APIs, introduced `session_tool_policy_status` / `session_tool_policy_set` / `session_tool_policy_clear`, merged persisted session policy into effective runtime tool-view and runtime narrowing, injected runtime-visible tool ids into `tool.search` through trusted engine-owned internal context only, fail-closed disjoint web allowlists during narrowing intersection, and guarded concurrent CLI host shutdown so all-features validation no longer hangs on an uncancellable stdin reader.
- What did not change (scope boundary):
  No new GUI/TUI toolbar surface, no broad approval-system redesign for every core tool, and no attempt to change unrelated global tool defaults beyond the session-scoped policy path.

## Linked Issues

- Closes #635
- Related #411

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes session-effective tool discovery and runtime narrowing behavior, including trusted internal context handling for `tool.search` and fail-closed web allowlist intersections.
- Rollout / guardrails:
  The change is confined to session-scoped policy storage plus three explicit session tools. Coverage now exercises repository persistence, runtime/tool-view merge behavior, trusted internal context injection, and session policy lifecycle flows.
- Rollback path:
  Revert this commit or remove the `session_tool_policy_*` registrations and ignore persisted `session_tool_policies` rows to fall back to the prior runtime tool surface.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app chat::tests::concurrent_cli_host_exits_when_shutdown_is_requested --all-features -- --exact --nocapture
cargo test --workspace --locked
cargo test --workspace --all-features --locked

All commands passed.

Key regression coverage exercised in this branch:
- session::repository::tests::session_tool_policy_repository_round_trips_and_deletes_policy
- tools::session::tests::session_tool_policy_tools_round_trip_and_clear_policy
- tools::session::tests::session_tool_policy_set_bootstraps_current_root_session_when_missing
- conversation::tests::default_runtime_tool_view_intersects_root_session_with_persisted_tool_policy
- conversation::tests::session_context_merges_persisted_session_policy_runtime_narrowing
- conversation::turn_engine::tests::augment_tool_payload_injects_visible_tool_ids_for_tool_search
- tools::runtime_config::tests::tool_runtime_narrowing_intersect_fail_closes_disjoint_allowlists
- chat::tests::concurrent_cli_host_exits_when_shutdown_is_requested
```

## User-visible / Operator-visible Changes

- Added `session_tool_policy_status`, `session_tool_policy_set`, and `session_tool_policy_clear` so operators can inspect and persist a narrower session-visible tool surface plus runtime narrowing.
- `tool.search` now inherits the session-effective visible tool ids from trusted runtime context instead of discovering outside the active session policy envelope.
- Combining delegate-child narrowing with session policy narrowing now fails closed when web allowlists do not overlap.

## Failure Recovery

- Fast rollback or disable path:
  Revert `200cc9a0747fb30e7eece3f9d369fd2dc25a2150`, or remove the `session_tool_policy_*` tool registrations and ignore persisted `session_tool_policies` rows.
- Observable failure symptoms reviewers should watch for:
  `tool.search` surfacing tools that were excluded by session policy, `web.fetch` succeeding across disjoint allowlists, or concurrent CLI host shutdown hanging again under all-features tests.

## Reviewer Focus

- Check the trusted internal context promotion path in `crates/app/src/conversation/turn_engine.rs`.
- Check runtime narrowing intersection semantics in `crates/app/src/tools/runtime_config.rs`.
- Check session policy persistence and status/set/clear semantics in `crates/app/src/session/repository.rs`, `crates/app/src/conversation/runtime.rs`, and `crates/app/src/tools/session.rs`.
- Check the concurrent CLI host shutdown guard in `crates/app/src/chat.rs` that keeps all-features validation from hanging on uncancellable stdin reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-scoped tool policy management with three discoverable tools to view/set/clear per-session policies.
  * Persistent storage for session tool policies, including requested tool lists and runtime constraints.
  * Tool payload augmentation: search tool now receives the session’s visible tool IDs.

* **Bug Fixes / Behavior**
  * Merged session policies with delegate runtime constraints (fail-closed on disjoint allowlists; enforce allowed-domain semantics).

* **Tests**
  * Added end-to-end and unit tests for policy set/status/clear, persistence, and merging behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->