### PR TITLE
docs: formalize the local product control plane foundation

### DIFF
--- a/docs/PRODUCT_SENSE.md
+++ b/docs/PRODUCT_SENSE.md
@@ -16,7 +16,7 @@ LoongClaw is not only a runtime for developers. The current MVP is aimed at:
 2. **Safe by default** — visible capabilities must still honor policy, approval, and audit boundaries.
 3. **Assistant-first surfaces** — user-facing capability should feel like “my assistant can do this”, not only “the platform exposes an adapter”.
 4. **Progressive disclosure** — `onboard`, `ask`, `chat`, and `doctor` carry the common path; each surface should lead with the next user action before exposing runtime detail.
-5. **One runtime, many surfaces** — CLI ask, interactive chat, and future surfaces should share the same conversation, memory, tool, and provider semantics.
+5. **One runtime, one local control plane, many surfaces** — CLI ask, interactive chat, and future HTTP or browser surfaces should share the same conversation, memory, tool, provider, and session semantics.
 6. **Fail loud with a repair path** — when setup or runtime health breaks, LoongClaw must point users toward `doctor` instead of leaving them in silent failure.
 
 ## Current MVP Journey
@@ -39,6 +39,11 @@ This keeps the first-run journey legible while preserving the existing runtime a
 For the current MVP, that also means first-run surfaces should feel assistant-first in their copy:
 show the runnable handoff first, then keep config, memory, and runtime facts in secondary detail blocks.
 
+As browser and gateway surfaces arrive, they should layer on a localhost-only
+product control plane rather than reaching directly into provider or ACP internals.
+That keeps session continuity, approvals, and operator workflows aligned across
+CLI and future UI clients.
+
 ## Product Specifications
 
 See [Product Specs Index](product-specs/index.md) for detailed user-facing requirements:
@@ -50,6 +55,7 @@ See [Product Specs Index](product-specs/index.md) for detailed user-facing requi
 - [Browser Automation](product-specs/browser-automation.md) — bounded browser-style assistant actions
 - [Channel Setup](product-specs/channel-setup.md) — configuring shipped assistant surfaces
 - [Tool Surface](product-specs/tool-surface.md) — truthful runtime-visible tool advertising
+- [Local Product Control Plane](product-specs/local-product-control-plane.md) — shared localhost-only product substrate for future HTTP and Web UI surfaces
 - [Web UI](product-specs/web-ui.md) — expectations for the browser-facing product surface
 - [Memory Profiles](product-specs/memory-profiles.md) — memory access patterns
 - [Prompt And Personality](product-specs/prompt-and-personality.md) — prompt engineering constraints

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -293,7 +293,7 @@ Delivered in current baseline:
 - release-first install flow with checksum-verified prebuilt binaries and explicit source fallback (`scripts/install.sh`, `scripts/install.ps1`)
 - runtime-visible tool advertising so capability snapshots and provider tool schemas follow the actually enabled tool surface
 - Cargo feature flags for MVP packaging controls
-- product specs for installation, onboarding, one-shot ask, doctor, browser automation, tool surface, channel setup, runtime experiment, and Web UI expectations
+- product specs for installation, onboarding, one-shot ask, doctor, browser automation, tool surface, channel setup, runtime experiment, the local product control plane, and Web UI expectations
 - experiment-state operator surface foundation:
   - `runtime-snapshot` persists lineage-aware runtime checkpoint artifacts
   - `runtime-restore` replays a persisted checkpoint as a dry-run or apply plan
@@ -329,7 +329,7 @@ Remaining deliverables:
   - still add isolated browser profile lifecycle and release packaging around the companion runtime
   - keep richer browser automation exposed only through truthful runtime-visible tool advertising and governed tool contracts
 - browser-facing product surface:
-  - Web UI implementation as a thin shell over existing ask/chat, onboarding, dashboard, and browser semantics, not a separate assistant runtime
+  - Web UI implementation as a thin shell over the local product control plane plus existing ask/chat, onboarding, dashboard, and browser semantics, not a separate assistant runtime
 
 Acceptance criteria:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-20
+Last updated: 2026-03-27
 
 This roadmap is execution-focused. Every stage has:
 
@@ -439,7 +439,39 @@ adding more surface breadth.
 Trade-off: lowers merge risk and control-plane debt, but requires disciplined ownership extraction
 instead of feature-driven growth inside large files.
 
-### D8: Shared execution security tiers
+### D8: Local product control plane foundation
+
+LoongClaw now has enough real runtime substrate that the next platform risk is
+surface drift rather than missing primitives.
+
+The repo already has:
+
+- a real ACP control plane
+- a durable session repository
+- operator-facing `onboard`, `doctor`, `acp-status`, and observability surfaces
+
+What it still lacks is one localhost-only product control plane contract that
+future HTTP and Web UI work can consume.
+
+Without that layer, `#217`, `#296`, and `#403` can drift into:
+
+- browser-only runtime semantics
+- a gateway-local session model
+- a giant product gateway that starts stealing authority from the kernel
+
+The preferred path is smaller:
+
+- keep the kernel as authority
+- keep ACP internal and real
+- use `SessionRepository` as the canonical product session plane
+- extract a shared local control plane for status, sessions, approvals, support
+  flows, and future turn submission
+
+Trade-off: this adds one explicit platform layer, but it prevents duplicated
+surface logic and keeps future gateway/UI work aligned with the kernel-first
+architecture.
+
+### D9: Shared execution security tiers
 
 The roadmap already names process sandbox profile tiers, but the wider runtime still needs one
 shared execution-tier vocabulary across process, browser, and WASM lanes. Without that, each lane
@@ -455,7 +487,7 @@ Current first-slice mapping:
   its runtime gate is open
 - `trusted` - reserved for future explicit high-trust runtime lanes rather than assumed by default
 
-### D9: First-party workflow packs on hardened primitives
+### D10: First-party workflow packs on hardened primitives
 
 Once the runtime base is harder, LoongClaw should turn that into a small set of first-party
 workflow packs that prove the kernel's value in operator-facing tasks such as release/review work,
@@ -469,8 +501,9 @@ instead of preceding it.
 1. Kernel-first runtime closure and direct-path retirement
 2. Persistent audit sink and query baseline
 3. ACP control-plane hardening and recovery
-4. Shared execution security tiers across process/browser/WASM lanes
-5. First-party workflow packs on hardened runtime primitives
+4. Local product control plane foundation
+5. Shared execution security tiers across process/browser/WASM lanes
+6. First-party workflow packs on hardened runtime primitives
 
 Execution package for this order:
 

--- a/docs/design-docs/acp-acpx-preembed.md
+++ b/docs/design-docs/acp-acpx-preembed.md
@@ -21,6 +21,9 @@ OpenClaw's latest ACP architecture makes the split explicit:
 If LoongClaw collapses these layers too early, future ACP/ACPX integration will require a large
 refactor across config, manager, channel routing, and daemon observability.
 
+For the outer localhost product surface that should consume ACP without
+replacing it, see [Local Product Control Plane](local-product-control-plane.md).
+
 ## OpenClaw design signals that matter
 
 The following patterns appear consistently in OpenClaw upstream:

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -7,6 +7,7 @@ Catalog of design documents and architectural decisions.
 | Document | Scope | Status |
 |----------|-------|--------|
 | [Core Beliefs](core-beliefs.md) | Engineering principles and taste enforcement | Living |
+| [Local Product Control Plane](local-product-control-plane.md) | Localhost-only platform layer above the runtime and below future HTTP/Web UI surfaces | Active |
 | [Discovery-First Tool Runtime Contract](discovery-first-tool-runtime-contract.md) | Provider-core tools, leases, parser rewrites, and follow-up turn contract | Active |
 | [Governance Simplification Classification](governance-simplification-classification.md) | Classifies governance surfaces as structural, transitional, cleanup-safe, or replacement-first | Active |
 | [Layered Kernel Design](layered-kernel-design.md) | L0-L9 kernel layer specification and boundary rules | Living |

--- a/docs/design-docs/local-product-control-plane.md
+++ b/docs/design-docs/local-product-control-plane.md
@@ -27,6 +27,11 @@ one of two bad outcomes:
 
 This document defines the smaller LoongClaw-native path.
 
+It intentionally keeps the public repository artifact scoped to the
+implementation-facing contract. The fuller comparative analysis, provenance
+trail, and extended references for this design are archived in
+`lc-knowledge-base`.
+
 ## Design Goals
 
 1. Keep the kernel as the authority for governance, policy, approvals, and

--- a/docs/design-docs/local-product-control-plane.md
+++ b/docs/design-docs/local-product-control-plane.md
@@ -1,0 +1,345 @@
+# Local Product Control Plane
+
+## Purpose
+
+LoongClaw already has the hard parts of a kernel-first system:
+
+- a governed execution boundary in the kernel
+- a real ACP control plane for backend session lifecycle and routing
+- a durable `SessionRepository` for session lineage, events, approvals, and outcomes
+- operator-facing CLI surfaces such as `onboard`, `doctor`, `acp-status`, and `list-acp-sessions`
+
+What it does not yet have is one written contract for how those pieces become a
+coherent local product platform.
+
+That gap is now risky because:
+
+- `#217` tracks an always-on operator/runtime surface
+- `#296` tracks a minimal HTTP gateway
+- `#403` tracks a browser-first launcher and Web UI path
+
+Without an explicit product control plane contract, those efforts can drift into
+one of two bad outcomes:
+
+- a giant gateway that becomes a second authority center above the kernel
+- separate browser, CLI, and runtime pathways that each invent their own
+  session and status semantics
+
+This document defines the smaller LoongClaw-native path.
+
+## Design Goals
+
+1. Keep the kernel as the authority for governance, policy, approvals, and
+   audit.
+2. Keep ACP as an internal runtime control plane rather than turning it into
+   the product-facing gateway by accident.
+3. Make the local product layer explicitly localhost-first and operator-owned.
+4. Reuse one canonical session plane across CLI, HTTP, and future Web UI
+   surfaces.
+5. Let `onboard`, `doctor`, `status`, approvals, and turn submission converge
+   through shared operations instead of surface-specific logic.
+
+## Non-Goals
+
+- replacing the kernel with a gateway-owned policy layer
+- making ACP the public product API by default
+- introducing a hosted or multi-tenant control plane
+- implying that public or remote exposure is safe by default
+- rewriting the existing CLI surfaces before the shared substrate exists
+
+## Current Foundation
+
+### Kernel
+
+The kernel remains the only place that can authoritatively decide whether a
+governed action is allowed, denied, or requires approval.
+
+The product layer may expose better status, routing, and operator workflows, but
+it must not become a shadow policy engine.
+
+### ACP
+
+ACP is already a real internal control plane. It owns:
+
+- backend selection
+- ACP session lifecycle
+- session binding and route reuse
+- active turn serialization
+- backend observability and doctor surfaces
+
+That role is valid and should continue. The mistake would be to treat ACP's
+backend/session cache as the same thing as the user-facing product session
+model.
+
+### Session Repository
+
+`SessionRepository` is already the closest thing LoongClaw has to a canonical
+product session plane. It persists:
+
+- root and delegate-child session lineage
+- session state and labels
+- session events
+- terminal outcomes
+- approval requests
+- approval grants
+- session observations
+
+That makes it the right source of truth for product-facing session identity,
+history, approval visibility, and cross-surface continuity.
+
+## Core Decisions
+
+### 1. Introduce a local product control plane above the runtime, not above the kernel
+
+LoongClaw should add a thin local product control plane that sits above the
+existing runtime and orchestration layers.
+
+Its job is to provide one shared operator and surface contract for:
+
+- runtime snapshot and health
+- session listing and observation
+- turn submission and streaming
+- approval visibility and decisions
+- onboarding and doctor workflows
+
+It is not a new execution authority.
+
+The control plane must consume existing runtime and kernel-backed semantics
+rather than replacing them.
+
+### 2. `SessionRepository` is the canonical product session plane
+
+All new product surfaces should converge on `SessionRepository` semantics for:
+
+- session identity
+- session state
+- session lineage
+- event history
+- terminal outcomes
+- approval state
+
+This means the first HTTP and Web UI slices should not invent a second
+gateway-local session store.
+
+If a surface needs to create or continue a session, it should do so through the
+same product session plane that already backs conversation continuity and
+approval visibility.
+
+### 3. `AcpSessionStore` remains ACP-local state, not the product source of truth
+
+`AcpSessionStore` is still necessary.
+
+It is the right place for ACP-local backend reuse and route bindings such as:
+
+- `session_key`
+- ACP backend session metadata
+- typed ACP binding scope
+- ACP-local last activity and backend error state
+
+But it should stay ACP-local.
+
+The product control plane must not treat `AcpSessionStore` as the primary
+operator-facing session database.
+
+When ACP state needs to be visible to product surfaces, the correct direction is
+projection:
+
+- ACP status and bindings project into product-readable snapshots
+- product session identity remains anchored in `SessionRepository`
+
+### 4. Surface binding must be explicit and shared
+
+Every user-facing surface should bind through one shared contract instead of
+inventing its own runtime model.
+
+The binding questions are simple:
+
+- does the surface create a new root session or attach to an existing one
+- does the surface use a local session id, a channel-bound conversation scope,
+  or an ACP route binding
+- does the surface need read-only observation, turn execution, approvals, or
+  support actions
+
+CLI, HTTP, and Web UI may present those flows differently, but they should bind
+through the same session and runtime substrate.
+
+### 5. The first platform layer is local-only by default
+
+LoongClaw's first product control plane should be localhost-only by default.
+
+That means:
+
+- loopback binding by default
+- explicit authentication even on local HTTP surfaces
+- no silent widening into LAN or public exposure
+- no multi-user or hosted assumptions in the first contract
+
+This keeps the platform layer aligned with LoongClaw's current trust model:
+private, operator-owned, and local-first.
+
+### 6. `onboard`, `doctor`, and `status` become reusable control-plane operations
+
+The product gap is not only chat transport.
+
+LoongClaw already has meaningful operator flows in CLI form:
+
+- onboarding
+- doctor and repair guidance
+- ACP status and observability
+- runtime experiment and capability review surfaces
+
+The local product control plane should treat these as reusable operations, not
+as terminal-only UX.
+
+That is what allows a future launcher or Web UI to remain a thin product surface
+instead of a second implementation.
+
+## Control Plane Resource Model
+
+The shared local product control plane should grow around a small set of stable
+resource groups.
+
+### Runtime
+
+The runtime resource group should answer:
+
+- is the local runtime healthy
+- which backend and runtime modes are active
+- what operator-visible warnings or repair states exist
+
+This should aggregate existing runtime and ACP visibility instead of creating a
+new runtime state machine.
+
+### Sessions
+
+The session resource group should expose:
+
+- create or continue root sessions
+- list sessions
+- inspect session observations
+- follow event streams
+- read terminal outcomes
+
+The canonical session identity comes from `SessionRepository`.
+
+### Approvals
+
+The approval resource group should expose:
+
+- pending approval requests
+- approval decisions
+- scoped approval grants
+- execution or failure outcomes tied to a session
+
+The product layer should present approval state, but approval authority still
+belongs to kernel-governed execution.
+
+### Support
+
+The support resource group should expose:
+
+- onboarding readiness and handoff
+- doctor diagnostics
+- repair suggestions
+- local migration or configuration guidance when relevant
+
+These are operator workflows, not browser-only features.
+
+### Turns
+
+The turn resource group should expose:
+
+- submit turn
+- stream turn events
+- fetch final turn result
+
+This is the minimal bridge needed for `#296`, but it should attach to the shared
+session plane rather than bypassing it.
+
+## Sequencing
+
+### Phase 1: Converge the local product substrate
+
+Before broad surface expansion, LoongClaw should tighten the shared substrate:
+
+- keep `#265` focused on ACP decomposition and observability hardening
+- make product-facing status and session observation reuse one consistent
+  session/runtime story
+- keep CLI as the first client of the shared contract while the substrate is
+  extracted
+
+This is the minimum work needed to stop future gateway and Web UI effort from
+forking the runtime model.
+
+### Phase 2: Land the minimal localhost gateway on top of the shared substrate
+
+`#296` should be implemented as a thin local HTTP layer over the product control
+plane.
+
+The first slice should stay narrow:
+
+- health
+- authenticated turn submission
+- SSE turn streaming
+- non-streaming turn result fetch
+
+That slice should reuse the canonical session plane and existing execution
+semantics instead of inventing HTTP-specific session ownership.
+
+### Phase 3: Add launcher and Web UI as clients, not as a second runtime
+
+`#403` should consume the local product control plane rather than reaching into
+provider or ACP internals directly.
+
+That means:
+
+- same session semantics
+- same onboarding and doctor semantics
+- same runtime and approval behavior
+- same localhost-only default boundary
+
+The browser surface becomes a client of the platform layer, not a competing
+runtime stack.
+
+## Why not copy the OpenClaw gateway shape
+
+OpenClaw's gateway-heavy platform is useful as a product signal:
+
+- cross-surface continuity matters
+- session routing matters
+- operator-friendly local surfaces matter
+
+But LoongClaw should not copy the whole control-center shape verbatim.
+
+LoongClaw's architectural advantage is the kernel membrane and its explicit
+governance model.
+
+A giant gateway that owns routing, permissions, and runtime truth would weaken
+that advantage and recreate policy drift one layer higher.
+
+The correct translation is smaller:
+
+- preserve kernel authority
+- keep ACP internal and real
+- add a localhost-only product control plane for shared surface semantics
+
+## Delivery Mapping
+
+| Issue | Role in this design |
+| --- | --- |
+| `#217` | umbrella for the always-on operator/runtime platform track |
+| `#265` | ACP hardening prerequisite so control-plane work does not keep growing inside large hotspots |
+| `#296` | first minimal localhost gateway slice on top of the shared substrate |
+| `#403` | launcher and Web UI follow-on that consumes the same control plane |
+| `#293` | channel and gateway sequencing context for broader protocol work |
+
+## Summary
+
+LoongClaw does not need a bigger kernel and it does not need a giant gateway.
+
+It needs a boring, explicit, localhost-only product control plane that:
+
+- keeps the kernel as authority
+- keeps ACP as an internal control plane
+- uses `SessionRepository` as the canonical product session plane
+- lets CLI, HTTP, and Web UI converge on one shared operator/runtime contract

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -18,6 +18,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - [Tool Surface](tool-surface.md)
 - [Runtime Experiment](runtime-experiment.md)
 - [Runtime Capability](runtime-capability.md)
+- [Local Product Control Plane](local-product-control-plane.md)
 - [Web UI](web-ui.md)
 - [Prompt And Personality](prompt-and-personality.md)
 - [Memory Profiles](memory-profiles.md)
@@ -28,6 +29,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - `Installation`, `Onboarding`, `One-Shot Ask`, `Doctor`, `Browser Automation`, `Tool Surface`, and `Channel Setup` define the shipped first-run and support journey for the current MVP.
 - `Runtime Experiment` defines the shipped local experiment-record surface layered on top of runtime snapshot and restore artifacts.
 - `Runtime Capability` defines the shipped local capability-candidate review surface layered on top of runtime experiment artifacts.
+- `Local Product Control Plane` defines the shared localhost-only product substrate that future HTTP and Web UI surfaces must consume instead of inventing a second runtime.
 - `Browser Automation Companion` and `Web UI` are expectation-setting specs for the next user-facing surfaces. They should not be documented as generally available before the implementation exists.
 
 Template for new specs:

--- a/docs/product-specs/local-product-control-plane.md
+++ b/docs/product-specs/local-product-control-plane.md
@@ -1,0 +1,47 @@
+# Local Product Control Plane
+
+## User Story
+
+As a LoongClaw operator, I want every local product surface to use one shared
+localhost-only control plane so that sessions, approvals, status, onboarding,
+and browser surfaces all behave like the same assistant runtime.
+
+## Product Scope
+
+The local product control plane is the shared surface contract for:
+
+- runtime health and status
+- session creation, continuation, and observation
+- turn submission and streaming
+- approval visibility and decisions
+- onboarding and doctor workflows
+
+It is a local product substrate.
+
+It is not a hosted control panel, a public admin API, or a second assistant
+runtime.
+
+## Acceptance Criteria
+
+- [ ] LoongClaw defines one localhost-only product control plane that future
+      HTTP and Web UI surfaces consume instead of inventing separate runtime
+      semantics.
+- [ ] The control plane reuses the same session model across CLI and future
+      browser surfaces instead of creating gateway-local session ids with
+      unrelated lifecycle rules.
+- [ ] Approval visibility and decisions stay consistent with the kernel-governed
+      execution path rather than being reimplemented in a browser-only layer.
+- [ ] `status`, `onboard`, and `doctor` can be exposed as reusable local control
+      plane operations instead of staying terminal-only behavior.
+- [ ] The first browser-facing surfaces remain localhost-only by default and do
+      not imply that public exposure is supported or safe.
+- [ ] The control plane remains a thin product layer above the runtime and does
+      not become a second policy authority above the kernel.
+
+## Out of Scope
+
+- public internet exposure by default
+- multi-user or hosted deployment semantics
+- replacing CLI onboarding or doctor as supported operator paths
+- treating ACP backend state as the canonical product session database
+- creating a browser-only config or conversation model

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -14,6 +14,7 @@ The Web UI is expected to include:
 - dashboard
 - onboarding
 - a lightweight debug console
+- a client path through the local product control plane
 - localhost-only by default
 - same-origin local product-mode serving
 - an optional install path
@@ -22,6 +23,7 @@ The Web UI is expected to include:
 
 - [ ] The Web UI is treated as one coherent product surface rather than a chat-only browser shell.
 - [ ] The Web UI reuses the same conversation, provider, tool, and memory semantics as CLI surfaces instead of creating a separate assistant runtime.
+- [ ] The Web UI binds through the local product control plane and does not talk to provider or ACP internals through a separate browser-owned session model.
 - [ ] The Web UI includes chat, dashboard, and onboarding as first-class parts of the same experience.
 - [ ] The Web UI can be delivered in a same-origin local product mode and stays localhost-only by default unless future policy and docs explicitly widen that boundary.
 - [ ] The optional install path is documented and supported without making installation mandatory for source users.


### PR DESCRIPTION
## Summary

- Problem:
  The repo already tracks the always-on runtime surface, ACP hardening, the minimal HTTP gateway, and the future launcher/Web UI path, but it did not yet document one shared contract for how a localhost-only product control plane should sit above ACP and the runtime without replacing kernel authority.
- Why it matters:
  Without that contract, future gateway and browser work can drift into duplicated session models, browser-only runtime semantics, or a giant gateway that starts stealing authority from the kernel.
- What changed:
  Added a new design doc and product spec for the local product control plane, documented `SessionRepository` as the canonical product session plane, clarified that `AcpSessionStore` stays ACP-local, linked the ACP doc to the new outer control-plane layer, updated roadmap/product-sense/Web UI docs so `#217`, `#265`, `#296`, `#403`, and `#293` share one sequencing anchor, and now explicitly points the public design doc at `lc-knowledge-base` for the fuller internal archive.
- What did not change (scope boundary):
  This PR does not implement the HTTP gateway, Web UI, daemon lifecycle commands, or ACP runtime behavior changes. It is a docs-first boundary and sequencing package only.

## Linked Issues

- Closes #639
- Related #217
- Related #265
- Related #296
- Related #403
- Related #293

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --check
rg -n "local-product-control-plane|Local Product Control Plane" docs
ls docs/design-docs/local-product-control-plane.md docs/product-specs/local-product-control-plane.md
cargo fmt --all -- --check
cargo test --workspace --locked
cargo test --workspace --all-features --locked
cargo clippy --workspace --all-targets --all-features -- -D warnings
```

Results:
- diff and docs path checks passed
- default workspace tests passed
- all-features workspace tests passed
- clippy passed with `-D warnings`

## User-visible / Operator-visible Changes

- Docs now define a localhost-only local product control plane as the shared platform layer for future HTTP and Web UI work.
- The Web UI spec now explicitly requires a client path through that control plane instead of a separate browser-owned runtime.
- The public design doc now explicitly points readers at `lc-knowledge-base` for the fuller internal research archive behind this contract.
- Roadmap and product-sense docs now make the sequencing and architectural boundary explicit.

## Failure Recovery

- Fast rollback or disable path:
  Revert commits `61c3f047` and `b42df985`.
- Observable failure symptoms reviewers should watch for:
  Reviewers should watch for any wording that accidentally implies the gateway or Web UI already exists, or that repositions ACP or the gateway as a second authority above the kernel.

## Reviewer Focus

- Check whether the new design doc keeps the kernel / ACP / product-control-plane split crisp.
- Check whether the sequencing across `#217`, `#265`, `#296`, `#403`, and `#293` is accurate and non-duplicative.
- Check whether the Web UI and product-sense updates stay consistent with the existing localhost-only product direction.
- Check whether the public repo and `lc-knowledge-base` split now feels explicit rather than implicit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for a new "Local Product Control Plane" — a localhost-only control surface for CLI, HTTP, and future Web UI.
  * Updated roadmap and priorities to insert the local control plane foundation and adjust subsequent items.
  * Clarified session/approval conventions and updated Web UI acceptance criteria to require binding through the local control plane (not direct runtime/provider internals).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->