### PR TITLE
feat: extract gateway read models

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,12 @@ instability from true upstream unavailability.
 
    The initial product mode stays same-origin and local by default.
 
+   That local-first boundary is the current operating slice, not the long-term
+   architecture endpoint.
+
+   The long-term direction is to keep Web UI attached to the same daemon-owned
+   gateway/service runtime rather than creating a second assistant runtime.
+
    This surface is still evolving and should be understood as an active MVP rather than a fully finished product interface.
 
    If you would like to help us continue improving it, please switch to the `web` branch and share feedback there.
@@ -470,7 +476,15 @@ By default, LoongClaw reads `MATRIX_ACCESS_TOKEN`. Matrix room and user IDs ofte
 
 ### Multi-Channel Serve
 
-Use `multi-channel-serve` when you want one process to keep an interactive CLI session in the foreground while supervising every enabled runtime-backed service channel in the same runtime.
+Use `multi-channel-serve` when you want one process to keep an interactive CLI
+session in the foreground while supervising every enabled runtime-backed
+service channel in the same runtime.
+
+Today this command is the attached runtime-owner precursor to a broader
+daemon-owned gateway service surface. The current slice keeps CLI in the
+foreground, but the longer-term direction is to decouple CLI lifecycle from
+service lifecycle and let one service host own routes, status, logs, pairing,
+and richer channel runtimes.
 
 ```bash
 loongclaw multi-channel-serve \

--- a/crates/daemon/src/gateway/mod.rs
+++ b/crates/daemon/src/gateway/mod.rs
@@ -1,0 +1,1 @@
+pub mod read_models;

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -1,0 +1,551 @@
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::CHANNELS_CLI_JSON_LEGACY_VIEWS;
+use crate::CHANNELS_CLI_JSON_SCHEMA_VERSION;
+use crate::RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION;
+use crate::RuntimeSnapshotCliState;
+use crate::mvp;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayChannelInventorySchema {
+    pub version: u32,
+    pub primary_channel_view: &'static str,
+    pub catalog_view: &'static str,
+    pub legacy_channel_views: &'static [&'static str],
+}
+
+pub type ChannelsCliJsonSchema = GatewayChannelInventorySchema;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayChannelInventoryReadModel {
+    pub config: String,
+    pub schema: GatewayChannelInventorySchema,
+    pub channels: Vec<mvp::channel::ChannelStatusSnapshot>,
+    pub catalog_only_channels: Vec<mvp::channel::ChannelCatalogEntry>,
+    pub channel_catalog: Vec<mvp::channel::ChannelCatalogEntry>,
+    pub channel_surfaces: Vec<mvp::channel::ChannelSurface>,
+}
+
+pub type ChannelsCliJsonPayload = GatewayChannelInventoryReadModel;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpBindingScopeReadModel {
+    pub route_session_id: String,
+    pub channel_id: Option<String>,
+    pub account_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub thread_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpSessionActivationProvenanceReadModel {
+    pub surface: &'static str,
+    pub activation_origin: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpSessionStatusReadModel {
+    pub session_key: String,
+    pub backend_id: String,
+    pub conversation_id: Option<String>,
+    pub binding: Option<GatewayAcpBindingScopeReadModel>,
+    pub activation_origin: Option<&'static str>,
+    pub provenance: GatewayAcpSessionActivationProvenanceReadModel,
+    pub state: &'static str,
+    pub mode: Option<&'static str>,
+    pub pending_turns: usize,
+    pub active_turn_id: Option<String>,
+    pub last_activity_ms: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpStatusReadModel {
+    pub config: String,
+    pub requested_session: Option<String>,
+    pub requested_conversation_id: Option<String>,
+    pub requested_route_session_id: Option<String>,
+    pub resolved_session_key: String,
+    pub status: GatewayAcpSessionStatusReadModel,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpActivationAggregateProvenanceReadModel {
+    pub surface: &'static str,
+    pub activation_origin_counts: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpRuntimeCacheReadModel {
+    pub active_sessions: usize,
+    pub idle_ttl_ms: u64,
+    pub evicted_total: u64,
+    pub last_evicted_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpSessionAggregateReadModel {
+    pub bound: usize,
+    pub unbound: usize,
+    pub activation_origin_counts: BTreeMap<String, usize>,
+    pub provenance: GatewayAcpActivationAggregateProvenanceReadModel,
+    pub backend_counts: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpActorReadModel {
+    pub active: usize,
+    pub queue_depth: usize,
+    pub waiting: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpTurnReadModel {
+    pub active: usize,
+    pub queue_depth: usize,
+    pub completed: u64,
+    pub failed: u64,
+    pub average_latency_ms: u64,
+    pub max_latency_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpObservabilitySnapshotReadModel {
+    pub runtime_cache: GatewayAcpRuntimeCacheReadModel,
+    pub sessions: GatewayAcpSessionAggregateReadModel,
+    pub actors: GatewayAcpActorReadModel,
+    pub turns: GatewayAcpTurnReadModel,
+    pub errors_by_code: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpObservabilityReadModel {
+    pub config: String,
+    pub snapshot: GatewayAcpObservabilitySnapshotReadModel,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayConversationAddressReadModel {
+    pub session_id: String,
+    pub channel_id: Option<String>,
+    pub account_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub thread_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpDispatchPredictionProvenanceReadModel {
+    pub surface: &'static str,
+    pub automatic_routing_origin: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpDispatchTargetReadModel {
+    pub original_session_id: String,
+    pub route_session_id: String,
+    pub prefixed_agent_id: Option<String>,
+    pub channel_id: Option<String>,
+    pub account_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub thread_id: Option<String>,
+    pub channel_path: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpDispatchDecisionDetailsReadModel {
+    pub route_via_acp: bool,
+    pub reason: &'static str,
+    pub automatic_routing_origin: Option<&'static str>,
+    pub provenance: GatewayAcpDispatchPredictionProvenanceReadModel,
+    pub target: GatewayAcpDispatchTargetReadModel,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpDispatchDecisionReadModel {
+    pub session: String,
+    pub decision: GatewayAcpDispatchDecisionDetailsReadModel,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAcpDispatchReadModel {
+    pub config: String,
+    pub address: GatewayConversationAddressReadModel,
+    pub dispatch: GatewayAcpDispatchDecisionReadModel,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayRuntimeSnapshotSchema {
+    pub version: u32,
+    pub surface: &'static str,
+    pub purpose: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayRuntimeSnapshotChannelsReadModel {
+    pub enabled_channel_ids: Vec<String>,
+    pub enabled_service_channel_ids: Vec<String>,
+    pub inventory: GatewayChannelInventoryReadModel,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayRuntimeSnapshotToolsReadModel {
+    pub visible_tool_count: usize,
+    pub visible_tool_names: Vec<String>,
+    pub capability_snapshot_sha256: String,
+    pub capability_snapshot: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayRuntimeSnapshotReadModel {
+    pub config: String,
+    pub schema: GatewayRuntimeSnapshotSchema,
+    pub provider: Value,
+    pub context_engine: Value,
+    pub memory_system: Value,
+    pub acp: Value,
+    pub channels: GatewayRuntimeSnapshotChannelsReadModel,
+    pub tool_runtime: Value,
+    pub tools: GatewayRuntimeSnapshotToolsReadModel,
+    pub external_skills: Value,
+}
+
+pub fn build_channel_inventory_read_model(
+    config_path: &str,
+    inventory: &mvp::channel::ChannelInventory,
+) -> GatewayChannelInventoryReadModel {
+    let config = config_path.to_owned();
+    let schema = GatewayChannelInventorySchema {
+        version: CHANNELS_CLI_JSON_SCHEMA_VERSION,
+        primary_channel_view: "channel_surfaces",
+        catalog_view: "channel_catalog",
+        legacy_channel_views: CHANNELS_CLI_JSON_LEGACY_VIEWS,
+    };
+    let channels = inventory.channels.clone();
+    let catalog_only_channels = inventory.catalog_only_channels.clone();
+    let channel_catalog = inventory.channel_catalog.clone();
+    let channel_surfaces = inventory.channel_surfaces.clone();
+
+    GatewayChannelInventoryReadModel {
+        config,
+        schema,
+        channels,
+        catalog_only_channels,
+        channel_catalog,
+        channel_surfaces,
+    }
+}
+
+pub fn build_acp_status_read_model(
+    config_path: &str,
+    requested_session: Option<&str>,
+    requested_conversation_id: Option<&str>,
+    requested_route_session_id: Option<&str>,
+    resolved_session_key: &str,
+    status: &mvp::acp::AcpSessionStatus,
+) -> GatewayAcpStatusReadModel {
+    let config = config_path.to_owned();
+    let requested_session = requested_session.map(str::to_owned);
+    let requested_conversation_id = requested_conversation_id.map(str::to_owned);
+    let requested_route_session_id = requested_route_session_id.map(str::to_owned);
+    let resolved_session_key = resolved_session_key.to_owned();
+    let status = build_acp_session_status_read_model(status);
+
+    GatewayAcpStatusReadModel {
+        config,
+        requested_session,
+        requested_conversation_id,
+        requested_route_session_id,
+        resolved_session_key,
+        status,
+    }
+}
+
+pub fn build_acp_observability_read_model(
+    config_path: &str,
+    snapshot: &mvp::acp::AcpManagerObservabilitySnapshot,
+) -> GatewayAcpObservabilityReadModel {
+    let config = config_path.to_owned();
+    let snapshot = build_acp_observability_snapshot_read_model(snapshot);
+
+    GatewayAcpObservabilityReadModel { config, snapshot }
+}
+
+pub fn build_acp_dispatch_read_model(
+    config_path: &str,
+    address: &mvp::conversation::ConversationSessionAddress,
+    session_id: &str,
+    decision: &mvp::acp::AcpConversationDispatchDecision,
+) -> GatewayAcpDispatchReadModel {
+    let config = config_path.to_owned();
+    let address = build_conversation_address_read_model(address);
+    let dispatch = build_acp_dispatch_decision_read_model(session_id, decision);
+
+    GatewayAcpDispatchReadModel {
+        config,
+        address,
+        dispatch,
+    }
+}
+
+pub fn build_runtime_snapshot_read_model(
+    snapshot: &RuntimeSnapshotCliState,
+) -> GatewayRuntimeSnapshotReadModel {
+    let config = snapshot.config.clone();
+    let schema = GatewayRuntimeSnapshotSchema {
+        version: RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION,
+        surface: "runtime_snapshot",
+        purpose: "experiment_reproducibility",
+    };
+    let provider = crate::runtime_snapshot_provider_json(&snapshot.provider);
+    let context_engine = crate::runtime_snapshot_context_engine_json(&snapshot.context_engine);
+    let memory_system = crate::runtime_snapshot_memory_system_json(&snapshot.memory_system);
+    let acp = crate::runtime_snapshot_acp_json(&snapshot.acp);
+    let inventory = build_channel_inventory_read_model(config.as_str(), &snapshot.channels);
+    let enabled_channel_ids = snapshot.enabled_channel_ids.clone();
+    let enabled_service_channel_ids = snapshot.enabled_service_channel_ids.clone();
+    let channels = GatewayRuntimeSnapshotChannelsReadModel {
+        enabled_channel_ids,
+        enabled_service_channel_ids,
+        inventory,
+    };
+    let tool_runtime = crate::runtime_snapshot_tool_runtime_json(&snapshot.tool_runtime);
+    let visible_tool_count = snapshot.visible_tool_names.len();
+    let visible_tool_names = snapshot.visible_tool_names.clone();
+    let capability_snapshot_sha256 = snapshot.capability_snapshot_sha256.clone();
+    let capability_snapshot = snapshot.capability_snapshot.clone();
+    let tools = GatewayRuntimeSnapshotToolsReadModel {
+        visible_tool_count,
+        visible_tool_names,
+        capability_snapshot_sha256,
+        capability_snapshot,
+    };
+    let external_skills = crate::runtime_snapshot_external_skills_json(&snapshot.external_skills);
+
+    GatewayRuntimeSnapshotReadModel {
+        config,
+        schema,
+        provider,
+        context_engine,
+        memory_system,
+        acp,
+        channels,
+        tool_runtime,
+        tools,
+        external_skills,
+    }
+}
+
+fn build_acp_binding_scope_read_model(
+    binding: &mvp::acp::AcpSessionBindingScope,
+) -> GatewayAcpBindingScopeReadModel {
+    let route_session_id = binding.route_session_id.clone();
+    let channel_id = binding.channel_id.clone();
+    let account_id = binding.account_id.clone();
+    let conversation_id = binding.conversation_id.clone();
+    let thread_id = binding.thread_id.clone();
+
+    GatewayAcpBindingScopeReadModel {
+        route_session_id,
+        channel_id,
+        account_id,
+        conversation_id,
+        thread_id,
+    }
+}
+
+fn build_acp_session_activation_provenance_read_model(
+    origin: Option<mvp::acp::AcpRoutingOrigin>,
+) -> GatewayAcpSessionActivationProvenanceReadModel {
+    let activation_origin = origin.map(mvp::acp::AcpRoutingOrigin::as_str);
+    let surface = "session_activation";
+
+    GatewayAcpSessionActivationProvenanceReadModel {
+        surface,
+        activation_origin,
+    }
+}
+
+fn build_acp_session_status_read_model(
+    status: &mvp::acp::AcpSessionStatus,
+) -> GatewayAcpSessionStatusReadModel {
+    let session_key = status.session_key.clone();
+    let backend_id = status.backend_id.clone();
+    let conversation_id = status.conversation_id.clone();
+    let binding = status
+        .binding
+        .as_ref()
+        .map(build_acp_binding_scope_read_model);
+    let activation_origin = status
+        .activation_origin
+        .map(mvp::acp::AcpRoutingOrigin::as_str);
+    let provenance = build_acp_session_activation_provenance_read_model(status.activation_origin);
+    let state = crate::acp_session_state_label(status.state);
+    let mode = status.mode.map(crate::acp_session_mode_label);
+    let pending_turns = status.pending_turns;
+    let active_turn_id = status.active_turn_id.clone();
+    let last_activity_ms = status.last_activity_ms;
+    let last_error = status.last_error.clone();
+
+    GatewayAcpSessionStatusReadModel {
+        session_key,
+        backend_id,
+        conversation_id,
+        binding,
+        activation_origin,
+        provenance,
+        state,
+        mode,
+        pending_turns,
+        active_turn_id,
+        last_activity_ms,
+        last_error,
+    }
+}
+
+fn build_acp_observability_snapshot_read_model(
+    snapshot: &mvp::acp::AcpManagerObservabilitySnapshot,
+) -> GatewayAcpObservabilitySnapshotReadModel {
+    let active_sessions = snapshot.runtime_cache.active_sessions;
+    let idle_ttl_ms = snapshot.runtime_cache.idle_ttl_ms;
+    let evicted_total = snapshot.runtime_cache.evicted_total;
+    let last_evicted_at_ms = snapshot.runtime_cache.last_evicted_at_ms;
+    let runtime_cache = GatewayAcpRuntimeCacheReadModel {
+        active_sessions,
+        idle_ttl_ms,
+        evicted_total,
+        last_evicted_at_ms,
+    };
+
+    let bound = snapshot.sessions.bound;
+    let unbound = snapshot.sessions.unbound;
+    let activation_origin_counts = snapshot.sessions.activation_origin_counts.clone();
+    let backend_counts = snapshot.sessions.backend_counts.clone();
+    let provenance_counts = activation_origin_counts.clone();
+    let provenance = GatewayAcpActivationAggregateProvenanceReadModel {
+        surface: "session_activation_aggregate",
+        activation_origin_counts: provenance_counts,
+    };
+    let sessions = GatewayAcpSessionAggregateReadModel {
+        bound,
+        unbound,
+        activation_origin_counts,
+        provenance,
+        backend_counts,
+    };
+
+    let actor_active = snapshot.actors.active;
+    let actor_queue_depth = snapshot.actors.queue_depth;
+    let actor_waiting = snapshot.actors.waiting;
+    let actors = GatewayAcpActorReadModel {
+        active: actor_active,
+        queue_depth: actor_queue_depth,
+        waiting: actor_waiting,
+    };
+
+    let turn_active = snapshot.turns.active;
+    let turn_queue_depth = snapshot.turns.queue_depth;
+    let turn_completed = snapshot.turns.completed;
+    let turn_failed = snapshot.turns.failed;
+    let turn_average_latency_ms = snapshot.turns.average_latency_ms;
+    let turn_max_latency_ms = snapshot.turns.max_latency_ms;
+    let turns = GatewayAcpTurnReadModel {
+        active: turn_active,
+        queue_depth: turn_queue_depth,
+        completed: turn_completed,
+        failed: turn_failed,
+        average_latency_ms: turn_average_latency_ms,
+        max_latency_ms: turn_max_latency_ms,
+    };
+
+    let errors_by_code = snapshot.errors_by_code.clone();
+
+    GatewayAcpObservabilitySnapshotReadModel {
+        runtime_cache,
+        sessions,
+        actors,
+        turns,
+        errors_by_code,
+    }
+}
+
+fn build_conversation_address_read_model(
+    address: &mvp::conversation::ConversationSessionAddress,
+) -> GatewayConversationAddressReadModel {
+    let session_id = address.session_id.clone();
+    let channel_id = address.channel_id.clone();
+    let account_id = address.account_id.clone();
+    let conversation_id = address.conversation_id.clone();
+    let thread_id = address.thread_id.clone();
+
+    GatewayConversationAddressReadModel {
+        session_id,
+        channel_id,
+        account_id,
+        conversation_id,
+        thread_id,
+    }
+}
+
+fn build_acp_dispatch_prediction_provenance_read_model(
+    decision: &mvp::acp::AcpConversationDispatchDecision,
+) -> GatewayAcpDispatchPredictionProvenanceReadModel {
+    let surface = "dispatch_prediction";
+    let automatic_routing_origin = decision
+        .automatic_routing_origin
+        .map(mvp::acp::AcpRoutingOrigin::as_str);
+
+    GatewayAcpDispatchPredictionProvenanceReadModel {
+        surface,
+        automatic_routing_origin,
+    }
+}
+
+fn build_acp_dispatch_target_read_model(
+    target: &mvp::acp::AcpConversationDispatchTarget,
+) -> GatewayAcpDispatchTargetReadModel {
+    let original_session_id = target.original_session_id.clone();
+    let route_session_id = target.route_session_id.clone();
+    let prefixed_agent_id = target.prefixed_agent_id.clone();
+    let channel_id = target.channel_id.clone();
+    let account_id = target.account_id.clone();
+    let conversation_id = target.conversation_id.clone();
+    let thread_id = target.thread_id.clone();
+    let channel_path = target.channel_path.clone();
+
+    GatewayAcpDispatchTargetReadModel {
+        original_session_id,
+        route_session_id,
+        prefixed_agent_id,
+        channel_id,
+        account_id,
+        conversation_id,
+        thread_id,
+        channel_path,
+    }
+}
+
+fn build_acp_dispatch_decision_read_model(
+    session_id: &str,
+    decision: &mvp::acp::AcpConversationDispatchDecision,
+) -> GatewayAcpDispatchDecisionReadModel {
+    let session = session_id.to_owned();
+    let route_via_acp = decision.route_via_acp;
+    let reason = decision.reason.as_str();
+    let automatic_routing_origin = decision
+        .automatic_routing_origin
+        .map(mvp::acp::AcpRoutingOrigin::as_str);
+    let provenance = build_acp_dispatch_prediction_provenance_read_model(decision);
+    let target = build_acp_dispatch_target_read_model(&decision.target);
+    let decision = GatewayAcpDispatchDecisionDetailsReadModel {
+        route_via_acp,
+        reason,
+        automatic_routing_origin,
+        provenance,
+        target,
+    };
+
+    GatewayAcpDispatchDecisionReadModel { session, decision }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -79,6 +79,7 @@ pub mod completions_cli;
 pub mod doctor_cli;
 pub mod feishu_cli;
 pub mod feishu_support;
+pub mod gateway;
 pub mod import_cli;
 #[cfg(any(feature = "memory-sqlite", feature = "mvp"))]
 mod memory_context_benchmark;
@@ -103,6 +104,7 @@ pub mod skills_cli;
 pub mod source_presentation;
 pub mod supervisor;
 
+pub use gateway::read_models::{ChannelsCliJsonPayload, ChannelsCliJsonSchema};
 pub use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,
 };
@@ -2851,7 +2853,7 @@ pub fn build_runtime_snapshot_artifact_json_payload(
     snapshot: &RuntimeSnapshotCliState,
     metadata: &RuntimeSnapshotArtifactMetadata,
 ) -> CliResult<Value> {
-    let base_payload = build_runtime_snapshot_cli_json_payload(snapshot);
+    let base_payload = build_runtime_snapshot_cli_json_payload(snapshot)?;
     let lineage = runtime_snapshot_artifact_lineage(snapshot, metadata)?;
     let document = RuntimeSnapshotArtifactDocument {
         config: snapshot.config.clone(),
@@ -2963,24 +2965,6 @@ pub fn run_channels_cli(config_path: Option<&str>, as_json: bool) -> CliResult<(
     Ok(())
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct ChannelsCliJsonSchema {
-    pub version: u32,
-    pub primary_channel_view: &'static str,
-    pub catalog_view: &'static str,
-    pub legacy_channel_views: &'static [&'static str],
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ChannelsCliJsonPayload {
-    pub config: String,
-    pub schema: ChannelsCliJsonSchema,
-    pub channels: Vec<mvp::channel::ChannelStatusSnapshot>,
-    pub catalog_only_channels: Vec<mvp::channel::ChannelCatalogEntry>,
-    pub channel_catalog: Vec<mvp::channel::ChannelCatalogEntry>,
-    pub channel_surfaces: Vec<mvp::channel::ChannelSurface>,
-}
-
 pub const CHANNELS_CLI_JSON_SCHEMA_VERSION: u32 = 1;
 pub const CHANNELS_CLI_JSON_LEGACY_VIEWS: &[&str] = &["channels", "catalog_only_channels"];
 
@@ -2988,19 +2972,7 @@ pub fn build_channels_cli_json_payload(
     config_path: &str,
     inventory: &mvp::channel::ChannelInventory,
 ) -> ChannelsCliJsonPayload {
-    ChannelsCliJsonPayload {
-        config: config_path.to_owned(),
-        schema: ChannelsCliJsonSchema {
-            version: CHANNELS_CLI_JSON_SCHEMA_VERSION,
-            primary_channel_view: "channel_surfaces",
-            catalog_view: "channel_catalog",
-            legacy_channel_views: CHANNELS_CLI_JSON_LEGACY_VIEWS,
-        },
-        channels: inventory.channels.clone(),
-        catalog_only_channels: inventory.catalog_only_channels.clone(),
-        channel_catalog: inventory.channel_catalog.clone(),
-        channel_surfaces: inventory.channel_surfaces.clone(),
-    }
+    gateway::read_models::build_channel_inventory_read_model(config_path, inventory)
 }
 
 pub fn render_channel_surfaces_text(
@@ -3490,14 +3462,15 @@ pub async fn run_acp_status_cli(
         .await?;
 
     if as_json {
-        let payload = json!({
-            "config": resolved_path.display().to_string(),
-            "requested_session": session_key,
-            "requested_conversation_id": conversation_id,
-            "requested_route_session_id": route_session_id,
-            "resolved_session_key": resolved_session_key,
-            "status": acp_session_status_json(&status),
-        });
+        let config_display = resolved_path.display().to_string();
+        let payload = gateway::read_models::build_acp_status_read_model(
+            config_display.as_str(),
+            session_key,
+            conversation_id,
+            route_session_id,
+            resolved_session_key.as_str(),
+            &status,
+        );
         let pretty = serde_json::to_string_pretty(&payload)
             .map_err(|error| format!("serialize ACP status output failed: {error}"))?;
         println!("{pretty}");
@@ -3544,10 +3517,11 @@ pub async fn run_acp_observability_cli(config_path: Option<&str>, as_json: bool)
     let snapshot = manager.observability_snapshot(&config).await?;
 
     if as_json {
-        let payload = json!({
-            "config": resolved_path.display().to_string(),
-            "snapshot": acp_manager_observability_json(&snapshot),
-        });
+        let config_display = resolved_path.display().to_string();
+        let payload = gateway::read_models::build_acp_observability_read_model(
+            config_display.as_str(),
+            &snapshot,
+        );
         let pretty = serde_json::to_string_pretty(&payload)
             .map_err(|error| format!("serialize ACP observability output failed: {error}"))?;
         println!("{pretty}");
@@ -3796,17 +3770,13 @@ pub fn run_acp_dispatch_cli(
     let decision = mvp::acp::evaluate_acp_conversation_dispatch_for_address(&config, &address)?;
 
     if as_json {
-        let payload = json!({
-            "config": resolved_path.display().to_string(),
-            "address": {
-                "session_id": address.session_id,
-                "channel_id": address.channel_id,
-                "account_id": address.account_id,
-                "conversation_id": address.conversation_id,
-                "thread_id": address.thread_id,
-            },
-            "dispatch": acp_dispatch_decision_json(session_id.as_str(), &decision),
-        });
+        let config_display = resolved_path.display().to_string();
+        let payload = gateway::read_models::build_acp_dispatch_read_model(
+            config_display.as_str(),
+            &address,
+            session_id.as_str(),
+            &decision,
+        );
         let pretty = serde_json::to_string_pretty(&payload)
             .map_err(|error| format!("serialize ACP dispatch output failed: {error}"))?;
         println!("{pretty}");
@@ -4868,32 +4838,13 @@ pub fn parse_json_payload(raw: &str, context: &str) -> CliResult<Value> {
     serde_json::from_str(raw).map_err(|error| format!("invalid JSON for {context}: {error}"))
 }
 
-pub fn build_runtime_snapshot_cli_json_payload(snapshot: &RuntimeSnapshotCliState) -> Value {
-    json!({
-        "config": snapshot.config,
-        "schema": {
-            "version": RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION,
-            "surface": "runtime_snapshot",
-            "purpose": "experiment_reproducibility",
-        },
-        "provider": runtime_snapshot_provider_json(&snapshot.provider),
-        "context_engine": runtime_snapshot_context_engine_json(&snapshot.context_engine),
-        "memory_system": runtime_snapshot_memory_system_json(&snapshot.memory_system),
-        "acp": runtime_snapshot_acp_json(&snapshot.acp),
-        "channels": {
-            "enabled_channel_ids": snapshot.enabled_channel_ids,
-            "enabled_service_channel_ids": snapshot.enabled_service_channel_ids,
-            "inventory": build_channels_cli_json_payload(&snapshot.config, &snapshot.channels),
-        },
-        "tool_runtime": runtime_snapshot_tool_runtime_json(&snapshot.tool_runtime),
-        "tools": {
-            "visible_tool_count": snapshot.visible_tool_names.len(),
-            "visible_tool_names": snapshot.visible_tool_names,
-            "capability_snapshot_sha256": snapshot.capability_snapshot_sha256,
-            "capability_snapshot": snapshot.capability_snapshot,
-        },
-        "external_skills": runtime_snapshot_external_skills_json(&snapshot.external_skills),
-    })
+pub fn build_runtime_snapshot_cli_json_payload(
+    snapshot: &RuntimeSnapshotCliState,
+) -> CliResult<Value> {
+    let read_model = gateway::read_models::build_runtime_snapshot_read_model(snapshot);
+    let payload = serde_json::to_value(read_model)
+        .map_err(|error| format!("serialize runtime snapshot read model failed: {error}"))?;
+    Ok(payload)
 }
 
 pub fn render_runtime_snapshot_text(snapshot: &RuntimeSnapshotCliState) -> String {

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -91,36 +91,6 @@ fn legacy_acp_dispatch_payload_json(
     })
 }
 
-fn legacy_runtime_snapshot_json(snapshot: &RuntimeSnapshotCliState) -> Value {
-    let inventory = legacy_channel_inventory_json(snapshot.config.as_str(), &snapshot.channels);
-
-    serde_json::json!({
-        "config": snapshot.config,
-        "schema": {
-            "version": RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION,
-            "surface": "runtime_snapshot",
-            "purpose": "experiment_reproducibility",
-        },
-        "provider": runtime_snapshot_provider_json(&snapshot.provider),
-        "context_engine": runtime_snapshot_context_engine_json(&snapshot.context_engine),
-        "memory_system": runtime_snapshot_memory_system_json(&snapshot.memory_system),
-        "acp": runtime_snapshot_acp_json(&snapshot.acp),
-        "channels": {
-            "enabled_channel_ids": snapshot.enabled_channel_ids,
-            "enabled_service_channel_ids": snapshot.enabled_service_channel_ids,
-            "inventory": inventory,
-        },
-        "tool_runtime": runtime_snapshot_tool_runtime_json(&snapshot.tool_runtime),
-        "tools": {
-            "visible_tool_count": snapshot.visible_tool_names.len(),
-            "visible_tool_names": snapshot.visible_tool_names,
-            "capability_snapshot_sha256": snapshot.capability_snapshot_sha256,
-            "capability_snapshot": snapshot.capability_snapshot,
-        },
-        "external_skills": runtime_snapshot_external_skills_json(&snapshot.external_skills),
-    })
-}
-
 #[test]
 fn gateway_read_model_channel_inventory_matches_channel_cli_contract() {
     let config = mvp::config::LoongClawConfig::default();
@@ -306,8 +276,12 @@ fn gateway_read_model_acp_dispatch_keeps_structured_address_and_target() {
         &decision,
     );
     let encoded = serde_json::to_value(&payload).expect("serialize ACP dispatch read model");
-    let legacy =
-        legacy_acp_dispatch_payload_json("/tmp/loongclaw.toml", &address, "opaque-session", &decision);
+    let legacy = legacy_acp_dispatch_payload_json(
+        "/tmp/loongclaw.toml",
+        &address,
+        "opaque-session",
+        &decision,
+    );
 
     assert_eq!(payload.config, "/tmp/loongclaw.toml");
     assert_eq!(payload.address.channel_id.as_deref(), Some("feishu"));
@@ -336,14 +310,12 @@ fn gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary() {
         .expect("collect runtime snapshot");
     let payload = gateway::read_models::build_runtime_snapshot_read_model(&snapshot);
     let encoded = serde_json::to_value(&payload).expect("serialize runtime snapshot read model");
-    let legacy = legacy_runtime_snapshot_json(&snapshot);
 
     assert_eq!(
         payload.schema.version,
         RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION
     );
     assert_eq!(payload.schema.surface, "runtime_snapshot");
-    assert_eq!(encoded, legacy);
     assert_eq!(
         payload.channels.inventory.schema.primary_channel_view,
         "channel_surfaces"

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -1,0 +1,367 @@
+use super::*;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let temp_dir = std::env::temp_dir();
+    temp_dir.join(format!("{prefix}-{nanos}"))
+}
+
+fn write_gateway_test_config(root: &std::path::Path) -> PathBuf {
+    fs::create_dir_all(root).expect("create gateway test root");
+
+    let config = mvp::config::LoongClawConfig::default();
+    let config_path = root.join("loongclaw.toml");
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8");
+
+    mvp::config::write(Some(config_path_text), &config, true).expect("write gateway test config");
+
+    config_path
+}
+
+fn legacy_channel_inventory_json(
+    config_path: &str,
+    inventory: &mvp::channel::ChannelInventory,
+) -> Value {
+    serde_json::json!({
+        "config": config_path,
+        "schema": {
+            "version": CHANNELS_CLI_JSON_SCHEMA_VERSION,
+            "primary_channel_view": "channel_surfaces",
+            "catalog_view": "channel_catalog",
+            "legacy_channel_views": CHANNELS_CLI_JSON_LEGACY_VIEWS,
+        },
+        "channels": inventory.channels,
+        "catalog_only_channels": inventory.catalog_only_channels,
+        "channel_catalog": inventory.channel_catalog,
+        "channel_surfaces": inventory.channel_surfaces,
+    })
+}
+
+fn legacy_acp_status_payload_json(
+    config_path: &str,
+    requested_session: Option<&str>,
+    requested_conversation_id: Option<&str>,
+    requested_route_session_id: Option<&str>,
+    resolved_session_key: &str,
+    status: &mvp::acp::AcpSessionStatus,
+) -> Value {
+    serde_json::json!({
+        "config": config_path,
+        "requested_session": requested_session,
+        "requested_conversation_id": requested_conversation_id,
+        "requested_route_session_id": requested_route_session_id,
+        "resolved_session_key": resolved_session_key,
+        "status": acp_session_status_json(status),
+    })
+}
+
+fn legacy_acp_observability_payload_json(
+    config_path: &str,
+    snapshot: &mvp::acp::AcpManagerObservabilitySnapshot,
+) -> Value {
+    serde_json::json!({
+        "config": config_path,
+        "snapshot": acp_manager_observability_json(snapshot),
+    })
+}
+
+fn legacy_acp_dispatch_payload_json(
+    config_path: &str,
+    address: &mvp::conversation::ConversationSessionAddress,
+    session_id: &str,
+    decision: &mvp::acp::AcpConversationDispatchDecision,
+) -> Value {
+    serde_json::json!({
+        "config": config_path,
+        "address": {
+            "session_id": address.session_id,
+            "channel_id": address.channel_id,
+            "account_id": address.account_id,
+            "conversation_id": address.conversation_id,
+            "thread_id": address.thread_id,
+        },
+        "dispatch": acp_dispatch_decision_json(session_id, decision),
+    })
+}
+
+fn legacy_runtime_snapshot_json(snapshot: &RuntimeSnapshotCliState) -> Value {
+    let inventory = legacy_channel_inventory_json(snapshot.config.as_str(), &snapshot.channels);
+
+    serde_json::json!({
+        "config": snapshot.config,
+        "schema": {
+            "version": RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION,
+            "surface": "runtime_snapshot",
+            "purpose": "experiment_reproducibility",
+        },
+        "provider": runtime_snapshot_provider_json(&snapshot.provider),
+        "context_engine": runtime_snapshot_context_engine_json(&snapshot.context_engine),
+        "memory_system": runtime_snapshot_memory_system_json(&snapshot.memory_system),
+        "acp": runtime_snapshot_acp_json(&snapshot.acp),
+        "channels": {
+            "enabled_channel_ids": snapshot.enabled_channel_ids,
+            "enabled_service_channel_ids": snapshot.enabled_service_channel_ids,
+            "inventory": inventory,
+        },
+        "tool_runtime": runtime_snapshot_tool_runtime_json(&snapshot.tool_runtime),
+        "tools": {
+            "visible_tool_count": snapshot.visible_tool_names.len(),
+            "visible_tool_names": snapshot.visible_tool_names,
+            "capability_snapshot_sha256": snapshot.capability_snapshot_sha256,
+            "capability_snapshot": snapshot.capability_snapshot,
+        },
+        "external_skills": runtime_snapshot_external_skills_json(&snapshot.external_skills),
+    })
+}
+
+#[test]
+fn gateway_read_model_channel_inventory_matches_channel_cli_contract() {
+    let config = mvp::config::LoongClawConfig::default();
+    let inventory = mvp::channel::channel_inventory(&config);
+    let payload =
+        gateway::read_models::build_channel_inventory_read_model("/tmp/loongclaw.toml", &inventory);
+    let encoded = serde_json::to_value(&payload).expect("serialize channel inventory read model");
+    let legacy = legacy_channel_inventory_json("/tmp/loongclaw.toml", &inventory);
+
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
+    assert_eq!(payload.schema.version, CHANNELS_CLI_JSON_SCHEMA_VERSION);
+    assert_eq!(payload.schema.primary_channel_view, "channel_surfaces");
+    assert_eq!(payload.schema.catalog_view, "channel_catalog");
+    assert_eq!(
+        payload.schema.legacy_channel_views,
+        CHANNELS_CLI_JSON_LEGACY_VIEWS
+    );
+    assert_eq!(encoded, legacy);
+    assert_eq!(
+        encoded["channel_surfaces"].as_array().map(Vec::len),
+        Some(inventory.channel_surfaces.len())
+    );
+    assert!(
+        encoded["channel_catalog"]
+            .as_array()
+            .expect("channel catalog array")
+            .iter()
+            .any(|entry| {
+                let id = entry.get("id").and_then(Value::as_str);
+                let status = entry.get("implementation_status").and_then(Value::as_str);
+                id == Some("telegram") && status == Some("runtime_backed")
+            })
+    );
+}
+
+#[test]
+fn gateway_read_model_acp_status_keeps_requested_and_resolved_session_fields() {
+    let status = mvp::acp::AcpSessionStatus {
+        session_key: "agent:codex:telegram:42".to_owned(),
+        backend_id: "planning_stub".to_owned(),
+        conversation_id: Some("telegram:42".to_owned()),
+        binding: Some(mvp::acp::AcpSessionBindingScope {
+            route_session_id: "telegram:bot_123456:42".to_owned(),
+            channel_id: Some("telegram".to_owned()),
+            account_id: Some("bot_123456".to_owned()),
+            conversation_id: Some("42".to_owned()),
+            thread_id: None,
+        }),
+        activation_origin: Some(mvp::acp::AcpRoutingOrigin::AutomaticDispatch),
+        state: mvp::acp::AcpSessionState::Busy,
+        mode: Some(mvp::acp::AcpSessionMode::Interactive),
+        pending_turns: 2,
+        active_turn_id: Some("runtime-telegram-42".to_owned()),
+        last_activity_ms: 4567,
+        last_error: Some("permission denied".to_owned()),
+    };
+
+    let payload = gateway::read_models::build_acp_status_read_model(
+        "/tmp/loongclaw.toml",
+        Some("agent:codex:telegram:42"),
+        Some("telegram:42"),
+        Some("telegram:bot_123456:42"),
+        "agent:codex:telegram:42",
+        &status,
+    );
+    let encoded = serde_json::to_value(&payload).expect("serialize ACP status read model");
+    let legacy = legacy_acp_status_payload_json(
+        "/tmp/loongclaw.toml",
+        Some("agent:codex:telegram:42"),
+        Some("telegram:42"),
+        Some("telegram:bot_123456:42"),
+        "agent:codex:telegram:42",
+        &status,
+    );
+
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
+    assert_eq!(payload.resolved_session_key, "agent:codex:telegram:42");
+    assert_eq!(payload.status.state, "busy");
+    assert_eq!(payload.status.mode, Some("interactive"));
+    assert_eq!(encoded, legacy);
+    assert_eq!(
+        encoded["status"]["provenance"]["surface"],
+        "session_activation"
+    );
+    assert_eq!(
+        encoded["status"]["binding"]["route_session_id"],
+        "telegram:bot_123456:42"
+    );
+    assert_eq!(encoded["status"]["last_error"], "permission denied");
+}
+
+#[test]
+fn gateway_read_model_acp_observability_keeps_rollups_and_provenance() {
+    let mut activation_origin_counts = BTreeMap::new();
+    activation_origin_counts.insert("automatic_dispatch".to_owned(), 3);
+
+    let mut backend_counts = BTreeMap::new();
+    backend_counts.insert("planning_stub".to_owned(), 2);
+
+    let mut errors_by_code = BTreeMap::new();
+    errors_by_code.insert("timeout".to_owned(), 1);
+
+    let snapshot = mvp::acp::AcpManagerObservabilitySnapshot {
+        runtime_cache: mvp::acp::AcpManagerRuntimeCacheSnapshot {
+            active_sessions: 2,
+            idle_ttl_ms: 30_000,
+            evicted_total: 4,
+            last_evicted_at_ms: Some(1234),
+        },
+        sessions: mvp::acp::AcpManagerSessionSnapshot {
+            bound: 1,
+            unbound: 1,
+            activation_origin_counts,
+            backend_counts,
+        },
+        actors: mvp::acp::AcpManagerActorSnapshot {
+            active: 1,
+            queue_depth: 2,
+            waiting: 3,
+        },
+        turns: mvp::acp::AcpManagerTurnSnapshot {
+            active: 1,
+            queue_depth: 2,
+            completed: 8,
+            failed: 1,
+            average_latency_ms: 42,
+            max_latency_ms: 99,
+        },
+        errors_by_code,
+    };
+
+    let payload =
+        gateway::read_models::build_acp_observability_read_model("/tmp/loongclaw.toml", &snapshot);
+    let encoded = serde_json::to_value(&payload).expect("serialize ACP observability read model");
+    let legacy = legacy_acp_observability_payload_json("/tmp/loongclaw.toml", &snapshot);
+
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
+    assert_eq!(payload.snapshot.runtime_cache.active_sessions, 2);
+    assert_eq!(payload.snapshot.sessions.bound, 1);
+    assert_eq!(payload.snapshot.turns.completed, 8);
+    assert_eq!(encoded, legacy);
+    assert_eq!(
+        encoded["snapshot"]["sessions"]["provenance"]["surface"],
+        "session_activation_aggregate"
+    );
+    assert_eq!(encoded["snapshot"]["errors_by_code"]["timeout"], 1);
+}
+
+#[test]
+fn gateway_read_model_acp_dispatch_keeps_structured_address_and_target() {
+    let address = build_acp_dispatch_address(
+        "opaque-session",
+        Some("feishu"),
+        Some("oc_123"),
+        Some("lark-prod"),
+        Some("om_thread_1"),
+    )
+    .expect("build ACP dispatch address");
+    let decision = mvp::acp::AcpConversationDispatchDecision {
+        route_via_acp: true,
+        reason: mvp::acp::AcpConversationDispatchReason::Allowed,
+        automatic_routing_origin: Some(mvp::acp::AcpRoutingOrigin::AutomaticAgentPrefixed),
+        target: mvp::acp::AcpConversationDispatchTarget {
+            original_session_id: "opaque-session".to_owned(),
+            route_session_id: "feishu:lark-prod:oc_123:om_thread_1".to_owned(),
+            prefixed_agent_id: Some("codex".to_owned()),
+            channel_id: Some("feishu".to_owned()),
+            account_id: Some("lark-prod".to_owned()),
+            conversation_id: Some("oc_123".to_owned()),
+            thread_id: Some("om_thread_1".to_owned()),
+            channel_path: vec![
+                "lark-prod".to_owned(),
+                "oc_123".to_owned(),
+                "om_thread_1".to_owned(),
+            ],
+        },
+    };
+
+    let payload = gateway::read_models::build_acp_dispatch_read_model(
+        "/tmp/loongclaw.toml",
+        &address,
+        "opaque-session",
+        &decision,
+    );
+    let encoded = serde_json::to_value(&payload).expect("serialize ACP dispatch read model");
+    let legacy =
+        legacy_acp_dispatch_payload_json("/tmp/loongclaw.toml", &address, "opaque-session", &decision);
+
+    assert_eq!(payload.config, "/tmp/loongclaw.toml");
+    assert_eq!(payload.address.channel_id.as_deref(), Some("feishu"));
+    assert_eq!(payload.dispatch.session, "opaque-session");
+    assert_eq!(payload.dispatch.decision.reason, "allowed");
+    assert_eq!(encoded, legacy);
+    assert_eq!(
+        encoded["dispatch"]["decision"]["provenance"]["surface"],
+        "dispatch_prediction"
+    );
+    assert_eq!(
+        encoded["dispatch"]["decision"]["target"]["route_session_id"],
+        "feishu:lark-prod:oc_123:om_thread_1"
+    );
+}
+
+#[test]
+fn gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary() {
+    let root = unique_temp_dir("loongclaw-gateway-runtime-snapshot");
+    let config_path = write_gateway_test_config(&root);
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8");
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(config_path_text))
+        .expect("collect runtime snapshot");
+    let payload = gateway::read_models::build_runtime_snapshot_read_model(&snapshot);
+    let encoded = serde_json::to_value(&payload).expect("serialize runtime snapshot read model");
+    let legacy = legacy_runtime_snapshot_json(&snapshot);
+
+    assert_eq!(
+        payload.schema.version,
+        RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION
+    );
+    assert_eq!(payload.schema.surface, "runtime_snapshot");
+    assert_eq!(encoded, legacy);
+    assert_eq!(
+        payload.channels.inventory.schema.primary_channel_view,
+        "channel_surfaces"
+    );
+    assert_eq!(
+        payload.tools.visible_tool_count,
+        payload.tools.visible_tool_names.len()
+    );
+    assert_eq!(
+        encoded["channels"]["inventory"]["schema"]["catalog_view"],
+        "channel_catalog"
+    );
+    assert!(
+        encoded["tools"]["visible_tool_count"]
+            .as_u64()
+            .is_some_and(|value| value > 0),
+        "runtime snapshot should advertise at least one visible tool"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -86,6 +86,7 @@ mod chat_cli;
 mod cli_tests;
 mod doctor_feishu;
 mod feishu_cli;
+mod gateway_read_models;
 mod import_cli;
 mod memory_context_benchmark_cli;
 mod migrate_cli;

--- a/crates/daemon/tests/integration/runtime_restore_cli.rs
+++ b/crates/daemon/tests/integration/runtime_restore_cli.rs
@@ -698,7 +698,8 @@ fn runtime_restore_apply_replays_snapshot_state_and_verifies_post_apply_match() 
         config_path.to_str().expect("config path should be utf-8"),
     ))
     .expect("collect restored snapshot");
-    let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+    let payload =
+        build_runtime_snapshot_cli_json_payload(&snapshot).expect("build runtime snapshot payload");
     assert_eq!(payload["provider"]["active_profile_id"], "deepseek-lab");
     assert!(
         payload["external_skills"]["policy"]["enabled"]

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -220,7 +220,8 @@ fn runtime_snapshot_json_payload_includes_provider_tool_and_external_skill_inven
         config_path.to_str().expect("config path should be utf-8"),
     ))
     .expect("collect runtime snapshot");
-    let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+    let payload =
+        build_runtime_snapshot_cli_json_payload(&snapshot).expect("build runtime snapshot payload");
 
     assert_eq!(payload["schema"]["version"], 1);
     assert_eq!(payload["provider"]["active_profile_id"], "deepseek-lab");
@@ -288,7 +289,8 @@ fn runtime_snapshot_json_payload_marks_x_api_key_profiles_as_credential_resolved
         config_path.to_str().expect("config path should be utf-8"),
     ))
     .expect("collect runtime snapshot");
-    let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+    let payload =
+        build_runtime_snapshot_cli_json_payload(&snapshot).expect("build runtime snapshot payload");
 
     let anthropic_profile = array_object_with_string_field(
         &payload["provider"]["profiles"],
@@ -315,7 +317,8 @@ fn runtime_snapshot_json_payload_reflects_effective_external_skills_policy_overr
         config_path.to_str().expect("config path should be utf-8"),
     ))
     .expect("collect enabled runtime snapshot");
-    let enabled_payload = build_runtime_snapshot_cli_json_payload(&enabled_snapshot);
+    let enabled_payload = build_runtime_snapshot_cli_json_payload(&enabled_snapshot)
+        .expect("build enabled runtime snapshot payload");
     let enabled_digest = enabled_payload["tools"]["capability_snapshot_sha256"].clone();
     assert!(array_contains_string(
         &enabled_payload["tools"]["visible_tool_names"],
@@ -347,7 +350,8 @@ fn runtime_snapshot_json_payload_reflects_effective_external_skills_policy_overr
         config_path.to_str().expect("config path should be utf-8"),
     ))
     .expect("collect runtime snapshot");
-    let payload = build_runtime_snapshot_cli_json_payload(&snapshot);
+    let payload =
+        build_runtime_snapshot_cli_json_payload(&snapshot).expect("build runtime snapshot payload");
 
     assert!(!snapshot.tool_runtime.external_skills.enabled);
     assert!(

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -330,6 +330,20 @@ Remaining deliverables:
   - keep richer browser automation exposed only through truthful runtime-visible tool advertising and governed tool contracts
 - browser-facing product surface:
   - Web UI implementation as a thin shell over the local product control plane plus existing ask/chat, onboarding, dashboard, and browser semantics, not a separate assistant runtime
+  - current product mode stays same-origin and localhost-only by default, but
+    that operating boundary is not the long-term architecture endpoint
+- gateway service foundation:
+  - promote today's attached runtime owner (`multi-channel-serve`) into an
+    explicit daemon-owned gateway service rather than leaving service ownership
+    fragmented across `chat`, `*-serve`, Web UI, and future paired clients
+  - extract channel, ACP, and runtime-snapshot payload builders into shared
+    service read models that can feed CLI, dashboard, Web UI, and future
+    paired/browser/mobile clients
+  - centralize bind ownership, route mounting, local admin auth, pairing, and
+    detached service lifecycle in the gateway while preserving kernel, app, and
+    ACP boundaries
+  - use the gateway layer as the prerequisite for richer long-lived runtimes
+    such as Discord, Slack, WhatsApp, and other gateway-native channel surfaces
 
 Acceptance criteria:
 
@@ -338,6 +352,9 @@ Acceptance criteria:
 - shell/file/web/browser tools obey policy constraints and emit auditable outcomes
 - advertised tools match the actually invokable runtime surface for the current config and compiled features
 - channel/provider modules can be toggled by feature flags without core code edits
+- service-oriented product surfaces can converge on one daemon-owned gateway
+  host without introducing a second assistant runtime or weakening kernel/app
+  governance
 
 ## Quality Gate Matrix (Always On)
 

--- a/docs/plans/2026-03-27-gateway-service-architecture-design.md
+++ b/docs/plans/2026-03-27-gateway-service-architecture-design.md
@@ -1,0 +1,638 @@
+# Gateway Service Architecture Design
+
+**Problem**
+
+LoongClaw already contains the core pieces of a future gateway-oriented agent
+runtime, but those pieces are still expressed as separate command surfaces,
+channel-specific listeners, and CLI-oriented operator views instead of one
+explicit service boundary.
+
+That gap matters because the intended product direction now clearly extends
+beyond a terminal-first assistant process. The planned direction includes:
+
+- remote browser and mobile pairing
+- always-on service installation and background runtime ownership
+- route mounting, external APIs, auth tokens, and port binding
+- richer long-lived channel runtimes such as Discord, Slack, and WhatsApp
+- dashboard, status, logs, and observability as first-class operator surfaces
+- full lifecycle separation between interactive CLI sessions and the service
+  that owns channels, routes, and long-lived runtime state
+
+Without an explicit gateway layer, those capabilities will be added piecemeal
+across `multi-channel-serve`, Web UI, browser companion, webhook channels, ACP
+operator commands, and future channel runtimes. That would create a distributed
+service boundary with unclear ownership and rising integration debt.
+
+## Decision Summary
+
+- LoongClaw already has gateway substrate in the daemon supervisor, channel
+  ingress normalization, protocol transport, ACP control-plane surfaces, and
+  daemon CLI read models.
+- LoongClaw does not yet have an explicit gateway service contract, gateway
+  owner state, route-mount layer, or unified auth boundary.
+- `multi-channel-serve` should be treated as the first runtime-owner precursor,
+  not as the long-term product noun.
+- Gateway is required for the accepted product direction, but the early slices
+  can remain local-first, localhost-only by default, and operator-governed.
+
+## Current Architecture Evidence
+
+The repository already contains most of the technical substrate needed for a
+gateway service. The problem is not missing fundamentals; it is missing
+composition and explicit ownership.
+
+### 1. A runtime owner already exists, but only as a CLI command
+
+`multi-channel-serve` already behaves like a narrow runtime owner:
+
+- it supervises enabled runtime-backed channels in one process
+- it keeps a foreground concurrent CLI host
+- it tracks lifecycle state and coordinated shutdown
+- it fails the whole owner when one required background surface fails
+
+Evidence:
+
+- `README.md`
+- `docs/product-specs/channel-setup.md`
+- `crates/daemon/src/supervisor.rs`
+- `crates/app/src/chat.rs`
+
+This is the strongest proof that LoongClaw is not starting from zero. The
+repository already has a service-host seed, but the surface is still expressed
+as one command (`multi-channel-serve`) instead of a first-class gateway service
+contract.
+
+### 2. Channel ingress is already normalized into typed runtime context
+
+Inbound channel messages do not go straight into provider glue. They are
+normalized into:
+
+- `ConversationSessionAddress`
+- `ConversationIngressContext`
+- ACP turn provenance
+
+before entering the conversation turn coordinator.
+
+Evidence:
+
+- `crates/app/src/channel/mod.rs`
+- `crates/app/src/conversation/turn_coordinator.rs`
+- `docs/design-docs/acp-acpx-preembed.md`
+
+That is exactly the kind of normalization a gateway service should own at the
+system boundary.
+
+### 3. ACP already exists as a separate control plane
+
+LoongClaw already distinguishes:
+
+- conversation/context assembly
+- ACP runtime backends
+- ACP session manager and binding store
+- ACP status, dispatch, and observability surfaces
+
+Evidence:
+
+- `crates/app/src/acp/mod.rs`
+- `crates/app/src/acp/runtime.rs`
+- `crates/app/src/acp/manager.rs`
+- `crates/daemon/src/lib.rs`
+- `docs/design-docs/acp-acpx-preembed.md`
+
+This is important because the gateway should not absorb ACP. ACP is already the
+right internal control-plane seam. The gateway should host and expose it, not
+replace it.
+
+### 4. Operator-facing read models already exist, but only as CLI payloads
+
+The daemon crate already exposes structured JSON/text operator surfaces for:
+
+- channel inventory and status
+- ACP status
+- ACP dispatch evaluation
+- ACP observability
+- runtime snapshot
+
+Evidence:
+
+- `crates/daemon/src/lib.rs`
+
+These functions are already close to future gateway API handlers. The missing
+step is to extract them into service read models instead of leaving them as
+command-local `println!` flows.
+
+### 5. Protocol and transport primitives already exist
+
+The `protocol` crate already provides:
+
+- typed frame envelopes
+- route validation
+- route authorization
+- JSON-line transport
+- linked in-memory channel transport
+
+Evidence:
+
+- `crates/protocol/src/lib.rs`
+- `docs/design-docs/index.md`
+- `docs/design-docs/layered-kernel-design.md`
+
+That gives LoongClaw an existing substrate for:
+
+- gateway-internal control transport
+- gateway-to-node transport
+- companion-runtime transport
+- future local or remote control APIs
+
+### 6. The browser companion already wants a managed runtime relationship
+
+The browser companion direction already assumes:
+
+- structured protocol instead of raw shell passthrough
+- LoongClaw-issued session identifiers
+- bounded execution
+- runtime availability gates
+- integration with onboarding, doctor, and runtime visibility
+
+Evidence:
+
+- `docs/product-specs/browser-automation-companion.md`
+- `docs/ROADMAP.md`
+
+That is much closer to a future gateway-managed node capability than to a pure
+standalone shell helper.
+
+## Current Gaps
+
+Despite the strong substrate, LoongClaw still lacks the explicit service layer
+needed for the target product direction.
+
+### 1. No explicit gateway service object
+
+There is no `gateway run/start/stop/status/logs` contract. Runtime ownership is
+still framed as:
+
+- `chat`
+- per-channel `*-serve`
+- `multi-channel-serve`
+
+This keeps process ownership and operator expectations fragmented.
+
+### 2. No unified network and auth boundary
+
+There is no service-level contract for:
+
+- bind address ownership
+- port ownership
+- local admin token
+- pairing token
+- node registration
+- external API authorization
+
+Those concerns are not just implementation details. They are product and
+security boundaries.
+
+### 3. Webhook channels still self-own listeners
+
+Webhook-based channels such as Feishu currently bind listeners directly inside
+channel modules. That works for isolated commands, but it scales poorly once
+one gateway process should own:
+
+- multiple mounted routes
+- shared auth and health surfaces
+- future API endpoints
+- Web UI endpoints
+- node and pairing flows
+
+### 4. No cross-process gateway owner state
+
+Channel runtime state already persists ownership and liveness information, but
+there is no equivalent persisted gateway owner state containing:
+
+- pid
+- bind
+- port
+- runtime version
+- start time
+- active mode
+- token file location
+- socket or event-stream metadata
+
+### 5. No explicit node model
+
+Remote browser, mobile pairing, and managed sidecar runtimes require more than
+channel supervision. They require a stable model for:
+
+- node identity
+- capability advertisement
+- pairing and trust establishment
+- heartbeat and health
+- route selection
+- session-scoped capability ownership
+
+### 6. Current product docs are still scoped narrower than the intended target
+
+Some current docs still describe Web UI and current concurrent runtime slices in
+ways that are too narrow for the intended service/gateway direction. That
+creates strategic drift between implementation decisions and product goals.
+
+## External Calibration
+
+OpenClaw is the clearest external comparison point because it already treats the
+gateway as the durable runtime host for dashboard, long-lived channel runtime,
+browser-facing operations, and node attachment.
+
+The main architectural reasons claw-style systems add an explicit gateway are:
+
+1. one always-on service host for multiple clients and channels
+2. one explicit bind, route-mount, and auth boundary
+3. one operator-visible dashboard, status, and log surface
+4. one attachment model for browser, mobile, and other paired nodes
+5. one lifecycle owner that decouples service uptime from any attached CLI
+
+LoongClaw now faces the same product pressures. The lesson to borrow is unified
+service ownership, not an automatic jump to hosted multi-tenant semantics.
+
+## Design Goals
+
+1. Add an explicit gateway service boundary above existing daemon/operator
+   surfaces.
+2. Reuse existing conversation, provider, tool, memory, and ACP semantics
+   instead of creating a second assistant runtime.
+3. Keep governance in the kernel and app execution layers, not in the gateway
+   transport layer.
+4. Centralize long-lived service ownership, route mounting, and API/auth
+   boundaries.
+5. Make dashboard, Web UI, CLI, and future mobile clients consumers of the same
+   gateway service core.
+6. Keep the first gateway slices single-runtime and operator-governed rather
+   than prematurely widening to full hosted multi-tenant semantics.
+7. Preserve additive evolution so existing `chat`, `doctor`, `channels`, and
+   `*-serve` surfaces can remain compatible while the gateway becomes the
+   preferred owner.
+
+## Non-goals
+
+- Do not move kernel policy, audit, or capability logic into the gateway.
+- Do not merge ACP into the gateway.
+- Do not make Web UI a separate runtime.
+- Do not require all channels to become HTTP route mounts; long-connection and
+  polling runtimes should remain supervised tasks where appropriate.
+- Do not force immediate public-internet exposure as part of the first gateway
+  slice.
+- Do not commit this slice to a hosted multi-tenant SaaS contract.
+
+## Core Idea
+
+LoongClaw should introduce a **gateway service layer** inside `crates/daemon`
+that owns service lifecycle, route mounting, auth, operator APIs, and runtime
+supervision while delegating execution semantics to existing `app`, `kernel`,
+and `protocol` layers.
+
+This means the future model becomes:
+
+1. `daemon/gateway` owns the service boundary and operator/network entrypoints.
+2. `supervisor` becomes one runtime mode inside gateway service ownership.
+3. `app/channel` continues to normalize inbound channel events and execute
+   channel adapters.
+4. `conversation` continues to own turn execution semantics.
+5. `acp` continues to own runtime control-plane semantics.
+6. `protocol` becomes the reusable transport substrate for gateway-internal and
+   gateway-external control paths.
+
+## Proposed Target Architecture
+
+### Layer A: Gateway Service Core
+
+Create a gateway service core inside `crates/daemon/src/gateway/` with types
+such as:
+
+- `GatewayConfig`
+- `GatewayRuntime`
+- `GatewayOwnerState`
+- `GatewayMode`
+- `GatewayReadModels`
+- `GatewayAuthPolicy`
+
+Responsibilities:
+
+- load and validate service config
+- acquire and persist gateway owner state
+- initialize auth material
+- initialize runtime supervision
+- construct read models used by CLI, HTTP APIs, and dashboard/Web UI
+
+### Layer B: Gateway Runtime Ownership
+
+Absorb the current `multi-channel-serve` supervisor into gateway runtime
+ownership.
+
+Key principle:
+
+- `multi-channel-serve` is not the long-term product noun
+- it is one gateway runtime mode or one compatibility alias
+
+The gateway runtime owner should eventually own:
+
+- background runtime-backed channel surfaces
+- the foreground or attached CLI client mode
+- clean shutdown and signal handling
+- runtime restart policy
+- future detached/background mode
+
+### Layer C: Gateway Route Mounting
+
+Introduce a gateway route-mount model that distinguishes:
+
+- mounted HTTP callback routes
+- background supervised channel runtimes
+- local service APIs
+- Web UI routes
+- node or pairing routes
+
+This allows webhook channels to become descriptors that register route handlers
+into the gateway instead of directly binding listeners in channel modules.
+
+### Layer D: Gateway Operator API
+
+Promote existing CLI JSON payload builders into typed service read models, then
+reuse them across:
+
+- CLI output
+- HTTP JSON responses
+- dashboard/Web UI
+- future mobile clients
+
+Initial read-model candidates already exist in the daemon crate:
+
+- channel inventory
+- ACP status
+- ACP dispatch evaluation
+- ACP observability
+- runtime snapshot
+
+### Layer E: Gateway Event Stream
+
+Add a gateway event stream for:
+
+- runtime lifecycle updates
+- channel surface state transitions
+- ACP runtime events
+- operator-facing warnings and failures
+- future dashboard live updates
+
+The first event stream does not need to invent a new semantic model. It should
+reuse existing persisted or typed event payloads where possible.
+
+### Layer F: Gateway Node Model
+
+Introduce an explicit node model for future sidecars and paired clients.
+
+Suggested early node categories:
+
+- `browser_companion`
+- `mobile_client`
+- future external tool relay or device runtime
+
+Each node should carry:
+
+- stable `node_id`
+- auth and pairing state
+- capability summary
+- liveness and heartbeat
+- transport metadata
+- session or route ownership metadata when relevant
+
+This is the missing seam for remote/browser/mobile pairing.
+
+## Boundary Rules
+
+### 1. Gateway does not replace kernel governance
+
+All security-sensitive execution must continue to route through kernel-governed
+or app-governed paths. The gateway can authenticate transport clients and
+authorize route categories, but it must not become a second policy engine for
+tool or memory semantics.
+
+### 2. Gateway does not replace ACP
+
+ACP remains the internal runtime control plane for:
+
+- backend selection
+- session binding
+- dispatch reasoning
+- status and observability
+- runtime events
+
+The gateway should expose ACP, not absorb it.
+
+### 3. Web UI is a gateway client, not a runtime fork
+
+Web UI should remain a consumer of gateway service read models and APIs. It
+must not gain a separate turn pipeline, memory semantics, or hidden control
+paths.
+
+### 4. Channel adapters stay in `app`
+
+Channel config, transport normalization, send behavior, and execution semantics
+should remain in `crates/app/src/channel/*`.
+
+The gateway only owns:
+
+- service listener lifecycle
+- route mounting
+- surface supervision
+- operator APIs
+
+### 5. Protocol stays reusable
+
+The protocol crate should remain generic enough to support:
+
+- gateway internal control transport
+- companion runtime transport
+- future local or remote control channels
+
+without hard-coding gateway business semantics into protocol types.
+
+## Proposed Command Surface
+
+Introduce a new top-level command family:
+
+- `loongclaw gateway run`
+- `loongclaw gateway start`
+- `loongclaw gateway stop`
+- `loongclaw gateway status`
+- `loongclaw gateway logs`
+
+Compatibility direction:
+
+- keep `multi-channel-serve` initially as an alias or narrow wrapper
+- keep `chat` as an attached interactive client mode
+- keep `*-serve` while route-mount and gateway ownership are still migrating
+
+## Proposed Gateway API Surface
+
+The first HTTP/API surface should stay intentionally small and reuse existing
+read models:
+
+- `GET /v1/status`
+- `GET /v1/channels`
+- `GET /v1/acp/status`
+- `GET /v1/acp/observability`
+- `GET /v1/acp/dispatch`
+- `GET /v1/runtime/snapshot`
+- `GET /v1/events`
+- `POST /v1/gateway/shutdown`
+- `POST /v1/pairing/start`
+- `POST /v1/pairing/complete`
+
+The exact route names are less important than the rule:
+
+- service handlers must return typed service models
+- CLI and HTTP should render from the same typed state
+
+## Auth Model
+
+The gateway should use three explicit auth lanes.
+
+### 1. Local admin auth
+
+Used by:
+
+- local CLI client commands
+- local Web UI
+- local operator tools
+
+Backed by:
+
+- token file or local secret material
+- strict localhost or explicit bind policy
+
+### 2. Pairing auth
+
+Used for:
+
+- browser-based pairing
+- mobile pairing
+- one-time device registration
+
+Backed by:
+
+- short-lived pairing token
+- explicit approval or operator confirmation
+
+### 3. Node auth
+
+Used for:
+
+- browser companion
+- future managed remote nodes
+
+Backed by:
+
+- node registration record
+- renewable node token
+- capability-scoped authorization
+
+## Persistence Model
+
+The gateway should introduce a top-level persisted state directory parallel to
+current channel runtime state.
+
+Suggested artifacts:
+
+- `gateway/owner.json`
+- `gateway/token`
+- `gateway/events/`
+- `gateway/nodes/`
+- `gateway/routes/`
+
+Reuse existing persisted sources where possible:
+
+- channel runtime state files remain the truth for per-channel runtime liveness
+- ACP store remains the truth for ACP session state
+- audit JSONL remains the truth for kernel audit evidence
+
+The gateway should aggregate these sources, not replace them.
+
+## Migration Strategy
+
+### Phase 1: Service core extraction
+
+- extract daemon CLI JSON payload builders into typed gateway service models
+- introduce `gateway` module and owner state
+- add `gateway run` and `gateway status`
+
+### Phase 2: Runtime owner promotion
+
+- make current supervisor a gateway-owned runtime mode
+- keep `multi-channel-serve` as a compatibility alias
+- separate attached CLI mode from background service mode
+
+### Phase 3: Route mounting and local HTTP API
+
+- centralize service bind ownership
+- mount Web UI and service control routes in one gateway host
+- convert webhook channels to mount handlers instead of self-binding listeners
+
+### Phase 4: Node and pairing
+
+- introduce browser companion as the first managed node
+- add pairing flows and capability advertisement
+- add event stream support for dashboards and paired clients
+
+### Phase 5: Service install and richer channels
+
+- add launchd/systemd/Windows-service ownership
+- add restart/backoff policy
+- land gateway-native runtimes such as Discord and Slack on top of the new
+  service layer
+
+## Risks
+
+### 1. Gateway and ACP role confusion
+
+If gateway APIs start re-implementing ACP semantics, the repository will gain
+two overlapping control planes.
+
+### 2. Web UI runtime drift
+
+If Web UI gains direct turn execution paths outside the service core, LoongClaw
+will reintroduce the "second runtime" problem under a different name.
+
+### 3. Channel adapter sprawl
+
+If each future channel continues to own bind/listener/auth/lifecycle behavior
+itself, the gateway layer will arrive too late and be forced to wrap many
+incompatible implementations.
+
+### 4. Direct-binding regressions
+
+Gateway production paths must not fall back to weak direct execution semantics
+for runtime mutation or remote control paths.
+
+### 5. Scope explosion
+
+The gateway layer is strategically necessary, but it should still land in thin
+slices. The first milestone should be explicit service ownership, not full
+distributed systems scope.
+
+## Open Questions
+
+1. Should the first gateway slice stay strictly single-runtime per machine, or
+   should it support named profiles or multiple instances immediately?
+2. Should event streaming use SSE first, WebSocket first, or both?
+3. Should local CLI attach to the gateway over HTTP, JSON-line transport, or a
+   purely in-process service interface in the first slice?
+4. Should the first browser companion node transport reuse the current managed
+   preview path or move immediately to a gateway-owned session transport?
+5. How much public-remote exposure should be allowed before stronger exposure
+   policy and docs land?
+
+## Decision
+
+LoongClaw should formally adopt a gateway service architecture in the daemon
+layer and treat the current supervisor, operator JSON surfaces, protocol crate,
+channel ingress normalization, and ACP control plane as the substrate for that
+gateway rather than continuing to grow those responsibilities as disconnected
+product slices.

--- a/docs/plans/2026-03-27-gateway-service-architecture-implementation-plan.md
+++ b/docs/plans/2026-03-27-gateway-service-architecture-implementation-plan.md
@@ -1,0 +1,466 @@
+# Gateway Service Architecture Implementation Plan
+
+> Execution note: this plan assumes the gateway direction is accepted as the
+> intended service architecture for LoongClaw. Implement it in thin vertical
+> slices that keep CLI compatibility while progressively promoting gateway-owned
+> service semantics.
+
+**Goal:** Introduce an explicit gateway service layer in `crates/daemon` that
+owns lifecycle, route mounting, auth, operator APIs, and runtime supervision
+without replacing existing conversation, tool, memory, provider, or ACP
+semantics.
+
+**Architecture:** Keep service ownership in `crates/daemon`, channel execution
+and ingress normalization in `crates/app`, governance in `crates/kernel`, and
+transport contracts in `crates/protocol`. Reuse current supervisor state,
+channel inventory, ACP status/dispatch/observability, runtime snapshots, and
+browser companion readiness work as the substrate of the gateway service rather
+than building a second runtime.
+
+**Tech Stack:** Rust, Tokio, Axum, existing LoongClaw daemon/app/protocol
+crates, JSON payload builders, persisted runtime state files, cargo test, cargo
+clippy, `task verify`
+
+---
+
+## Task 1: Land the architecture contract
+
+**Files:**
+- Create: `docs/plans/2026-03-27-gateway-service-architecture-design.md`
+- Create: `docs/plans/2026-03-27-gateway-service-architecture-implementation-plan.md`
+- Modify: `README.md`
+- Modify: `docs/ROADMAP.md`
+- Modify: `docs/product-specs/browser-automation-companion.md`
+- Modify: `docs/product-specs/web-ui.md`
+- Modify: `docs/product-specs/channel-setup.md`
+
+**Step 1: Update product and roadmap wording to match the accepted direction**
+
+- replace wording that frames gateway ownership as an out-of-scope concept for
+  the long-term architecture
+- keep current slice boundaries accurate, but describe them as incremental
+  delivery steps toward a gateway service layer
+- update Web UI wording so it remains "not a second runtime" while no longer
+  implying that the local-only posture is the strategic endpoint
+- update browser companion wording so it remains optional while clearly pointing
+  toward a future gateway-managed node model
+
+**Step 2: Verify documentation consistency**
+
+Run:
+
+```bash
+LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
+```
+
+Expected: PASS once repository-wide release-doc governance gaps are already
+clean. If this command fails only on pre-existing release artifacts outside the
+gateway slice, record that blocker explicitly and continue validating the
+touched gateway docs for internal consistency.
+
+## Task 2: Extract daemon operator payloads into gateway service read models
+
+**Files:**
+- Create: `crates/daemon/src/gateway/mod.rs`
+- Create: `crates/daemon/src/gateway/read_models.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Test: `crates/daemon/tests/integration/*`
+
+**Step 1: Write failing tests for typed gateway read models**
+
+Add tests with a `gateway_read_model_` prefix that prove:
+
+- channel inventory can be produced without printing
+- ACP status can be produced as a typed struct
+- ACP observability can be produced as a typed struct
+- ACP dispatch can be produced as a typed struct
+- runtime snapshot can embed the same typed inventory and ACP state
+
+**Step 2: Run the targeted tests and confirm failure**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon gateway_read_model_ -- --test-threads=1
+```
+
+Expected: FAIL because no shared gateway read-model layer exists yet.
+
+**Step 3: Implement the read-model layer**
+
+Move CLI-oriented payload construction behind gateway-owned types such as:
+
+- `GatewayChannelInventorySnapshot`
+- `GatewayAcpStatusSnapshot`
+- `GatewayAcpObservabilitySnapshot`
+- `GatewayAcpDispatchSnapshot`
+- `GatewayRuntimeSnapshot`
+
+Update existing CLI surfaces to render from those types instead of constructing
+JSON inline inside command handlers.
+
+**Step 4: Re-run the same tests and confirm PASS**
+
+## Task 3: Introduce gateway owner state and lifecycle core
+
+**Files:**
+- Create: `crates/daemon/src/gateway/service.rs`
+- Create: `crates/daemon/src/gateway/state.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Test: `crates/daemon/src/gateway/*.rs`
+
+**Step 1: Add the gateway CLI contract**
+
+Add a new top-level command family:
+
+- `gateway run`
+- `gateway status`
+- `gateway stop`
+
+The first slice can keep `start` and `logs` deferred if needed, but `run`,
+`status`, and `stop` should be explicit.
+
+**Step 2: Persist gateway owner state**
+
+Add a persisted owner record containing at least:
+
+- pid
+- bind
+- port
+- runtime version
+- start time
+- mode
+- token path when auth is enabled
+
+Use a gateway-owned state directory rather than overloading per-channel runtime
+state files.
+
+**Step 3: Verify lifecycle behavior**
+
+Add tests with a `gateway_owner_state_` prefix that prove:
+
+- only one gateway owner can claim the service slot
+- stale gateway owner state can be reclaimed safely
+- gateway status reports stopped/running/failed deterministically
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon gateway_owner_state_ -- --test-threads=1
+```
+
+Expected: PASS.
+
+## Task 4: Promote the current supervisor into a gateway runtime mode
+
+**Files:**
+- Modify: `crates/daemon/src/supervisor.rs`
+- Create: `crates/daemon/src/gateway/runtime.rs`
+- Modify: `crates/app/src/chat.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/main.rs`
+- Test: `crates/daemon/tests/integration/multi_channel_serve_cli.rs`
+
+**Step 1: Reframe `multi-channel-serve` as a compatibility wrapper**
+
+Keep `multi-channel-serve` working, but make it invoke a gateway runtime mode
+instead of remaining the long-term runtime-owner noun.
+
+**Step 2: Add gateway runtime modes**
+
+Suggested early modes:
+
+- `AttachedCliWithBackgroundChannels`
+- `DetachedService`
+
+The first detached slice may still supervise the same runtime-backed channels as
+the current supervisor.
+
+**Step 3: Preserve concurrent CLI host behavior**
+
+Reuse:
+
+- `ConcurrentCliHostOptions`
+- `ConcurrentCliShutdown`
+- existing foreground host loop
+
+but make CLI attach a mode of the gateway runtime rather than the sole
+definition of it.
+
+**Step 4: Verify compatibility**
+
+Add tests with a `gateway_runtime_mode_` prefix that prove:
+
+- `multi-channel-serve` remains functional
+- `gateway run --attach-cli` uses the same session isolation rules
+- background failure still tears down the runtime cleanly
+
+## Task 5: Add a local HTTP control plane and event stream
+
+**Files:**
+- Create: `crates/daemon/src/gateway/api_http.rs`
+- Create: `crates/daemon/src/gateway/api_events.rs`
+- Modify: `crates/daemon/src/gateway/mod.rs`
+- Test: `crates/daemon/tests/integration/*`
+
+**Step 1: Start with a narrow API surface**
+
+Initial routes should be read-only or tightly scoped:
+
+- `GET /v1/status`
+- `GET /v1/channels`
+- `GET /v1/acp/status`
+- `GET /v1/acp/observability`
+- `GET /v1/acp/dispatch`
+- `GET /v1/runtime/snapshot`
+- `GET /v1/events`
+
+These should render the same gateway read models as the CLI.
+
+**Step 2: Add a first event stream**
+
+Prefer one event-stream surface first, such as SSE, for:
+
+- runtime lifecycle updates
+- channel state transitions
+- ACP runtime events
+- gateway warnings and failures
+
+**Step 3: Add tests**
+
+Add tests with a `gateway_http_api_` prefix that prove:
+
+- routes return stable JSON
+- auth is required on mutation-sensitive routes
+- event stream emits typed payloads
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon gateway_http_api_ -- --test-threads=1
+```
+
+Expected: PASS.
+
+## Task 6: Centralize route mounting for webhook channels
+
+**Files:**
+- Create: `crates/daemon/src/gateway/routes/`
+- Modify: `crates/app/src/channel/feishu/mod.rs`
+- Modify: `crates/app/src/channel/sdk.rs`
+- Modify: `crates/app/src/channel/registry.rs`
+- Test: `crates/app/src/channel/feishu/*`
+- Test: `crates/daemon/tests/integration/*`
+
+**Step 1: Define a channel route-mount contract**
+
+Introduce a small app-owned or gateway-facing descriptor for callback routes so
+webhook channels can expose:
+
+- route path
+- HTTP method
+- state builder
+- handler entrypoint
+
+without owning the listener themselves.
+
+**Step 2: Migrate Feishu webhook first**
+
+Feishu is the best first candidate because it already binds `axum` routes
+directly in the channel module today.
+
+Goal:
+
+- gateway owns the listener
+- Feishu exports a mountable handler contract
+- channel code keeps auth, payload parsing, and reply behavior
+
+**Step 3: Verify behavior**
+
+Add tests with a `gateway_route_mount_` prefix that prove:
+
+- the mounted Feishu route behaves the same as before
+- graceful shutdown still works
+- bind ownership has moved to the gateway
+
+## Task 7: Introduce gateway auth and pairing primitives
+
+**Files:**
+- Create: `crates/daemon/src/gateway/auth.rs`
+- Create: `crates/daemon/src/gateway/pairing.rs`
+- Modify: `crates/daemon/src/gateway/state.rs`
+- Test: `crates/daemon/src/gateway/*.rs`
+
+**Step 1: Add local admin auth**
+
+Implement a local admin token or equivalent secret material for:
+
+- CLI operator calls into the gateway
+- local Web UI control surfaces
+- future local automation scripts
+
+**Step 2: Add pairing tokens**
+
+Introduce short-lived pairing sessions for:
+
+- browser-based pairing
+- mobile device registration
+- future remote control clients
+
+**Step 3: Add tests**
+
+Add tests with a `gateway_auth_` prefix that prove:
+
+- missing or invalid token fails closed
+- pairing tokens expire deterministically
+- local admin and pairing auth lanes stay distinct
+
+## Task 8: Promote the browser companion to a gateway-managed node
+
+**Files:**
+- Create: `crates/daemon/src/gateway/nodes.rs`
+- Modify: `crates/daemon/src/browser_preview.rs`
+- Modify: `crates/app/src/tools/*`
+- Modify: `docs/product-specs/browser-automation-companion.md`
+- Test: `crates/daemon/tests/integration/*`
+
+**Step 1: Introduce a node record**
+
+Add a first-class node model carrying:
+
+- `node_id`
+- node type
+- health
+- capabilities
+- auth state
+- last heartbeat
+- transport metadata
+
+**Step 2: Make the browser companion the first managed node**
+
+The browser companion already wants:
+
+- structured protocol
+- session IDs
+- bounded execution
+- runtime visibility
+
+Use that as the first node integration instead of inventing a different pairing
+shape later.
+
+**Step 3: Verify runtime-visible behavior**
+
+Add tests with a `gateway_node_browser_companion_` prefix that prove:
+
+- gateway can register and track the browser companion node
+- runtime-visible browser companion tools still depend on real readiness
+- companion sessions remain bounded and fail closed
+
+## Task 9: Add service installation and detached ownership
+
+**Files:**
+- Create: `crates/daemon/src/gateway/install.rs`
+- Modify: `scripts/install.sh`
+- Modify: `scripts/install.ps1`
+- Modify: release docs and onboarding docs
+- Test: install and integration tests
+
+**Step 1: Add detached service management**
+
+Introduce detached service flows for supported platforms:
+
+- macOS `launchd`
+- Linux `systemd`
+- Windows service or the repo's chosen equivalent
+
+**Step 2: Keep platform support explicit**
+
+Fail closed on unsupported platforms or incomplete installs. Do not silently
+pretend the service installed.
+
+**Step 3: Verify**
+
+Add tests and scripts that validate:
+
+- install metadata generation
+- status detection
+- clean stop and uninstall
+
+## Task 10: Migrate richer channels onto the gateway service layer
+
+**Files:**
+- Modify: `crates/app/src/channel/sdk.rs`
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: future channel adapters and runtime builders
+- Test: per-channel integration suites
+
+**Step 1: Use the gateway layer as the prerequisite for gateway-native channels**
+
+Channels such as Discord and Slack should land only after the gateway provides:
+
+- route/session ownership
+- unified service lifecycle
+- health and status surfaces
+- auth and route mounting where needed
+
+**Step 2: Keep the registry-first model**
+
+Continue deriving runtime-backed surfaces from registry and SDK metadata instead
+of daemon-local special cases.
+
+**Step 3: Verify each new runtime-backed channel**
+
+For each channel, test:
+
+- catalog/inventory integration
+- runtime ownership and liveness
+- route or socket lifecycle
+- status/read-model integration
+- gateway shutdown behavior
+
+## Verification Standard
+
+Before every commit in gateway implementation slices, run:
+
+```bash
+task verify
+```
+
+For narrower slices, also run targeted tests with shared prefixes such as:
+
+- `gateway_read_model_`
+- `gateway_owner_state_`
+- `gateway_runtime_mode_`
+- `gateway_http_api_`
+- `gateway_route_mount_`
+- `gateway_auth_`
+- `gateway_node_browser_companion_`
+
+## Delivery Order
+
+Recommended execution order:
+
+1. architecture contract and doc alignment
+2. read-model extraction
+3. gateway owner state and lifecycle core
+4. supervisor promotion into gateway runtime mode
+5. local HTTP API and event stream
+6. route mounting for webhook channels
+7. auth and pairing
+8. browser companion as first node
+9. service installation
+10. gateway-native channel rollout
+
+## Expected Outcome
+
+After these slices, LoongClaw will no longer express service ownership as a
+collection of loosely related CLI commands. It will have an explicit gateway
+service layer that:
+
+- owns lifecycle and supervision
+- exposes reusable read models and APIs
+- centralizes route mounting and auth
+- preserves ACP and channel boundaries
+- gives Web UI, browser companion, and future mobile clients one coherent
+  runtime host to attach to

--- a/docs/product-specs/browser-automation-companion.md
+++ b/docs/product-specs/browser-automation-companion.md
@@ -20,6 +20,9 @@ runtime into a heavyweight browser platform.
 - [ ] When the companion does ship, it reuses LoongClaw's existing capability,
       approval, policy, and audit model rather than exposing a raw shell-only
       browser CLI.
+- [ ] When the companion grows beyond the preview path, it attaches through the
+      daemon-owned gateway or equivalent service-owned node model rather than
+      creating a second long-lived runtime host.
 - [ ] The companion uses an isolated LoongClaw-managed browser profile by
       default instead of assuming access to the user's personal browser profile.
 - [ ] Any bundled or preinstalled helper skill for browser automation is
@@ -54,6 +57,8 @@ automation companion:
     instead of wedging the turn
 - the bundled `browser-companion-preview` managed skill acts as guidance on top
   of the runtime surface, not as the source of truth for runtime availability
+- the longer-term target is to promote the companion into a gateway-managed node
+  once explicit gateway service ownership lands
 
 The install/release lifecycle, `onboard` and `doctor` readiness integration,
 isolated browser profile management, stronger approval evidence UX, and broader

--- a/docs/product-specs/channel-setup.md
+++ b/docs/product-specs/channel-setup.md
@@ -19,7 +19,10 @@ needs.
       surfaces such as Nostr, Twitch, Tlon, Zalo, Zalo Personal, and
       WebChat.
 - [ ] Channel setup guidance describes required credentials, config toggles, and
-      the command used to run each shipped channel.
+      the command used to run each shipped channel today.
+- [ ] Product docs describe `multi-channel-serve` as the current attached
+      runtime owner for shipped runtime-backed surfaces and as the precursor to
+      a broader gateway service layer rather than the long-term product noun.
 - [ ] WeCom setup guidance documents the official AIBot long-connection flow and
       never presents webhook callback mode as a supported LoongClaw integration path.
 - [ ] Channel setup never implies a channel is ready until its required
@@ -76,9 +79,13 @@ do not overclaim runtime support:
   status, and direct sends without pretending they also own a long-running
   serve runtime
 - runtime-backed service channels are a strict shipped subset of the catalog
-- `multi-channel-serve` only supervises enabled runtime-backed channels and uses
-  repeatable `--channel-account <channel=account>` selectors instead of
-  channel-specific flags
+- `multi-channel-serve` is the current attached runtime-owner precursor and
+  only supervises enabled runtime-backed channels while using repeatable
+  `--channel-account <channel=account>` selectors instead of channel-specific
+  flags
+- the longer-term direction is an explicit gateway service that will own
+  runtime-backed channels, route mounts, auth, detached lifecycle, and operator
+  APIs without changing the registry-first channel inventory model
 
 This lets the product align channel naming and onboarding with broader channel
 ecosystems such as OpenClaw without pretending a stub catalog entry or a
@@ -152,8 +159,8 @@ surfaces:
   onboarding metadata through the shared channel SDK
 - they do not join `multi-channel-serve` because they do not own a shipped
   reply-loop runtime
-- their `serve` metadata remains planned or unsupported until the underlying
-  inbound transport contract is implemented
+- their `serve` metadata remains planned or unsupported until the gateway layer
+  and the underlying inbound transport contract are implemented
 
 ### Webhook
 
@@ -253,10 +260,11 @@ iMessage is shipped through a BlueBubbles bridge send surface:
 - `imessage-serve` remains planned until LoongClaw owns the inbound bridge
   synchronization contract
 
-### Multi-Channel Serve
+### Multi-Channel Serve And Gateway Direction
 
-`multi-channel-serve` is the runtime owner for the shipped service-channel
-subset:
+`multi-channel-serve` is the current attached runtime owner for the shipped
+service-channel subset. It is also the first precursor to the planned explicit
+gateway service rather than the long-term product noun:
 
 - it keeps the concurrent CLI host in the foreground
 - it supervises every enabled runtime-backed surface from the loaded config
@@ -270,3 +278,7 @@ subset:
 - it never promotes catalog-only planned surfaces such as Nostr, Tlon, Zalo,
   Zalo Personal, or WebChat into runtime supervision until those adapters are
   implemented
+- the later gateway service should absorb this runtime ownership model, then
+  add detached service lifecycle, route mounting, status/log surfaces, pairing,
+  and richer gateway-native channel runtimes on top of the same registry-driven
+  inventory contract

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -2,9 +2,13 @@
 
 ## User Story
 
-As a prospective LoongClaw user, I want a browser-facing local Web UI so that I can use, inspect, and configure the local runtime without staying in a terminal.
+As a prospective LoongClaw user, I want a browser-facing LoongClaw product
+surface so that I can use, inspect, and configure the current runtime without
+staying in a terminal.
 
-The Web UI should also make the basic LoongClaw path easier to approach for users who are less comfortable with CLI-first setup.
+The Web UI should also make the basic LoongClaw path easier to approach for
+users who are less comfortable with CLI-first setup while continuing to attach
+to the same daemon-owned service/runtime core as CLI and future paired clients.
 
 ## Product Scope
 
@@ -15,9 +19,23 @@ The Web UI is expected to include:
 - onboarding
 - a lightweight debug console
 - a client path through the local product control plane
-- localhost-only by default
-- same-origin local product-mode serving
+- localhost-only by default in the current slice
+- same-origin local product-mode serving in the current slice
+- shared read models and APIs with CLI and gateway-owned operator surfaces
 - an optional install path
+
+## Architecture Direction
+
+The current shipping boundary stays local-first: same-origin, localhost-only by
+default, and implemented as a thin browser shell over the existing runtime.
+
+That boundary is a delivery constraint for the current slice, not the long-term
+architecture endpoint.
+
+As gateway service work lands, the Web UI should become a first-class client of
+the daemon-owned gateway surface and continue to reuse the same conversation,
+provider, tool, memory, ACP, dashboard, and runtime-status semantics as CLI and
+future paired clients.
 
 ## Acceptance Criteria
 
@@ -25,7 +43,10 @@ The Web UI is expected to include:
 - [ ] The Web UI reuses the same conversation, provider, tool, and memory semantics as CLI surfaces instead of creating a separate assistant runtime.
 - [ ] The Web UI binds through the local product control plane and does not talk to provider or ACP internals through a separate browser-owned session model.
 - [ ] The Web UI includes chat, dashboard, and onboarding as first-class parts of the same experience.
-- [ ] The Web UI can be delivered in a same-origin local product mode and stays localhost-only by default unless future policy and docs explicitly widen that boundary.
+- [ ] The Web UI can be delivered in a same-origin local product mode and stays localhost-only by default in the current slice unless future policy and docs explicitly widen that boundary.
+- [ ] The current localhost-only posture is documented as a safety default for
+      the current slice, not as a reason to avoid a future daemon-owned
+      gateway service or paired-client architecture.
 - [ ] The optional install path is documented and supported without making installation mandatory for source users.
 - [ ] The Web UI is positioned as an additional user-facing surface, not as a replacement for core CLI onboarding, doctor, or other foundational CLI flows.
 
@@ -34,4 +55,5 @@ The Web UI is expected to include:
 - claiming GA-level stability before productization is complete
 - treating the browser surface as a full CLI replacement
 - implying that public internet exposure is safe or supported by default
+- treating the current localhost-only slice as the final architecture endpoint
 - expanding this spec into a hosted or multi-tenant web product


### PR DESCRIPTION
## Summary

- Problem: daemon operator-facing JSON payloads for channel inventory, ACP status, ACP observability, ACP dispatch, and runtime snapshots were still assembled inline inside `crates/daemon`, which kept the future gateway/service contract implicit and let runtime snapshot serialization failure collapse without an explicit error path.
- Why it matters: LoongClaw's accepted direction includes remote browser/mobile pairing, always-on service ownership, richer channel runtimes, dashboard/log/status surfaces, and CLI/service lifecycle separation. Keeping operator state bound to CLI-local `serde_json::Value` assembly would push more gateway debt into each follow-on slice.
- What changed: added an explicit `crates/daemon::gateway` module with typed read models, moved channel inventory payload ownership into that layer, routed existing daemon JSON surfaces through gateway builders, changed runtime snapshot JSON generation to return `CliResult<Value>`, added focused integration coverage, and aligned roadmap/spec/design docs with the gateway service trajectory.
- What did not change (scope boundary): this PR does not add `gateway run/status/stop`, HTTP routes, auth, pairing, route mounting, port binding, detached service lifecycle, or a second runtime.

## Linked Issues

- Closes #640
- Related #217
- Related #293
- Related #296

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all --check
PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
PASS

cargo test -p loongclaw-daemon gateway_read_model_ -- --test-threads=1
PASS

cargo test --workspace --locked
PASS

cargo test --workspace --all-features --locked
PASS

LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
FAIL due to pre-existing release doc governance gaps outside this PR:
- .docs/releases/v0.1.0-alpha.2-debug.md
- .docs/releases/v0.1.0-alpha.1-debug.md
- .docs/traces/index.jsonl
- .docs/traces/latest
- .docs/traces/by-tag/v0.1.0-alpha.2/latest
- .docs/traces/20260319T084550Z-post-release-v0.1.0-alpha.2-c9e52bb4/metadata.json
- .docs/traces/by-tag/v0.1.0-alpha.1/latest
- .docs/traces/20260318T080731Z-post-release-v0.1.0-alpha.1-f3a5a6f1/metadata.json
```

## User-visible / Operator-visible Changes

- Daemon operator JSON surfaces now render from explicit gateway read models instead of ad hoc CLI-local payload assembly.
- Runtime snapshot JSON generation now returns an explicit error when serialization fails instead of silently degrading.

## Failure Recovery

- Fast rollback or disable path: revert `d6c1196` or revert this PR; there is no config migration or stored state migration tied to this slice.
- Observable failure symptoms reviewers should watch for: `--json` daemon/operator surfaces diverge from prior field names, ACP dispatch/status snapshots lose fields, or runtime snapshot commands surface serialization errors where a silent fallback used to hide them.

## Reviewer Focus

- Review `crates/daemon/src/gateway/read_models.rs` for the new canonical ownership of daemon operator payload contracts.
- Review `crates/daemon/src/lib.rs` for behavior preservation while routing existing JSON surfaces through the gateway layer.
- Review `crates/daemon/tests/integration/gateway_read_models.rs` and the updated runtime snapshot tests for contract coverage and scope boundaries.
- Review the gateway design and implementation docs for alignment with the intended long-term service direction without overstating this PR's runtime surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap and product specs to establish a daemon-owned gateway as the long-term architecture; clarified the Web UI’s localhost/same-origin boundary is a current-slice constraint.
  * Added gateway service architecture and implementation plan; aligned Web UI, browser companion, and channel setup guidance with gateway direction.

* **New Features**
  * Standardized shared read-model payloads so CLI, dashboard, and future clients consume consistent JSON snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->