### PR TITLE
feat: add gateway owner lifecycle core

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,15 +476,35 @@ By default, LoongClaw reads `MATRIX_ACCESS_TOKEN`. Matrix room and user IDs ofte
 
 ### Multi-Channel Serve
 
-Use `multi-channel-serve` when you want one process to keep an interactive CLI
-session in the foreground while supervising every enabled runtime-backed
-service channel in the same runtime.
+Use `gateway run` when you want LoongClaw to claim the explicit gateway owner
+slot and supervise the enabled runtime-backed service-channel subset.
 
-Today this command is the attached runtime-owner precursor to a broader
-daemon-owned gateway service surface. The current slice keeps CLI in the
-foreground, but the longer-term direction is to decouple CLI lifecycle from
-service lifecycle and let one service host own routes, status, logs, pairing,
-and richer channel runtimes.
+The current gateway slice now includes:
+
+- `loongclaw gateway run` for the owner lifecycle
+- `loongclaw gateway status` for cross-process owner inspection
+- `loongclaw gateway stop` for cooperative shutdown
+
+`gateway run` starts headless by default. Pass `--session` when you want the
+concurrent CLI host attached to the same runtime owner.
+
+```bash
+loongclaw gateway run --config ~/.loongclaw/config.toml
+```
+
+```bash
+loongclaw gateway status --json
+```
+
+```bash
+loongclaw gateway stop
+```
+
+`multi-channel-serve` still works as the attached compatibility wrapper when
+you want one process to keep an interactive CLI session in the foreground while
+supervising every enabled runtime-backed service channel in the same runtime.
+It now rides on the same gateway owner contract rather than remaining the
+long-term product noun.
 
 ```bash
 loongclaw multi-channel-serve \
@@ -497,6 +517,10 @@ loongclaw multi-channel-serve \
 ```
 
 `--session` is required. Repeat `--channel-account <CHANNEL=ACCOUNT>` to pin specific channel accounts. LoongClaw normalizes runtime-backed aliases such as `lark` to canonical channel ids and only supervises runtime-backed channels that are enabled in the loaded config.
+
+The longer-term direction remains to let one gateway-owned service host
+decouple CLI lifecycle from service lifecycle and own routes, status, logs,
+pairing, and richer channel runtimes.
 
 `loongclaw channels --json` exposes the broader channel catalog separately from shipped runtime-backed surfaces. Planned surfaces already modeled in the catalog include Discord, Slack, LINE, DingTalk, WhatsApp, Google Chat, Signal, Synology Chat, Tlon, iMessage / BlueBubbles, Nostr, Twitch, Zalo, and WebChat, but they do not claim runtime support until an adapter is actually shipped.
 

--- a/crates/daemon/src/gateway/mod.rs
+++ b/crates/daemon/src/gateway/mod.rs
@@ -1,1 +1,3 @@
 pub mod read_models;
+pub mod service;
+pub mod state;

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -110,6 +110,7 @@ async fn run_gateway_runtime_with_hooks_for_test(
         session,
         spec.surfaces.len(),
     )?);
+    let owner_token = tracker.owner_token().to_owned();
 
     let mut runtime_hooks = hooks.clone();
     let original_wait_for_shutdown = hooks.wait_for_shutdown.clone();
@@ -117,10 +118,11 @@ async fn run_gateway_runtime_with_hooks_for_test(
     runtime_hooks.wait_for_shutdown = Arc::new(move || {
         let original_wait_for_shutdown = original_wait_for_shutdown.clone();
         let runtime_dir = runtime_dir_for_shutdown.clone();
+        let owner_token = owner_token.clone();
         Box::pin(async move {
             tokio::select! {
                 result = (original_wait_for_shutdown)() => result,
-                result = wait_for_gateway_stop_request(runtime_dir.as_path()) => {
+                result = wait_for_gateway_stop_request(runtime_dir.as_path(), owner_token.as_str()) => {
                     result?;
                     Ok("gateway stop requested".to_owned())
                 }

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -1,0 +1,343 @@
+use std::{path::Path, sync::Arc};
+
+use clap::Subcommand;
+
+use crate::{
+    CliResult, MultiChannelServeChannelAccount,
+    supervisor::{
+        LoadedSupervisorConfig, RuntimeOwnerMode, SupervisorRuntimeHooks, SupervisorSpec,
+        collect_loaded_background_surfaces, run_supervisor_with_loaded_config_for_test,
+    },
+};
+
+use super::state::{
+    GatewayOwnerMode, GatewayOwnerStatus, GatewayOwnerTracker, GatewayStopRequestOutcome,
+    default_gateway_runtime_state_dir, load_gateway_owner_status, request_gateway_stop,
+    wait_for_gateway_stop_request,
+};
+
+#[derive(Subcommand, Debug)]
+pub enum GatewayCommand {
+    /// Claim the gateway owner slot and run the gateway runtime
+    Run {
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long)]
+        session: Option<String>,
+        #[arg(long = "channel-account", value_name = "CHANNEL=ACCOUNT")]
+        channel_account: Vec<MultiChannelServeChannelAccount>,
+    },
+    /// Show the persisted gateway owner status
+    Status {
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Request cooperative shutdown for the active gateway owner
+    Stop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GatewayRuntimeEntryPoint {
+    GatewayRun,
+    MultiChannelServeCompatibility,
+}
+
+pub async fn run_gateway_cli(command: GatewayCommand) -> CliResult<()> {
+    match command {
+        GatewayCommand::Run {
+            config,
+            session,
+            channel_account,
+        } => run_gateway_run_cli(config.as_deref(), session.as_deref(), channel_account).await,
+        GatewayCommand::Status { json } => run_gateway_status_cli(json),
+        GatewayCommand::Stop => run_gateway_stop_cli(),
+    }
+}
+
+pub async fn run_gateway_run_cli(
+    config_path: Option<&str>,
+    session: Option<&str>,
+    channel_accounts: Vec<MultiChannelServeChannelAccount>,
+) -> CliResult<()> {
+    let runtime_dir = default_gateway_runtime_state_dir();
+    let supervisor = run_gateway_runtime_with_hooks_for_test(
+        config_path,
+        session,
+        channel_accounts,
+        runtime_dir.as_path(),
+        GatewayRuntimeEntryPoint::GatewayRun,
+        SupervisorRuntimeHooks::production(),
+    )
+    .await?;
+    supervisor.final_exit_result()
+}
+
+pub async fn run_multi_channel_serve_gateway_compat_cli(
+    config_path: Option<&str>,
+    session: &str,
+    channel_accounts: Vec<MultiChannelServeChannelAccount>,
+) -> CliResult<()> {
+    let runtime_dir = default_gateway_runtime_state_dir();
+    let supervisor = run_gateway_runtime_with_hooks_for_test(
+        config_path,
+        Some(session),
+        channel_accounts,
+        runtime_dir.as_path(),
+        GatewayRuntimeEntryPoint::MultiChannelServeCompatibility,
+        SupervisorRuntimeHooks::production(),
+    )
+    .await?;
+    supervisor.final_exit_result()
+}
+
+async fn run_gateway_runtime_with_hooks_for_test(
+    config_path: Option<&str>,
+    session: Option<&str>,
+    channel_accounts: Vec<MultiChannelServeChannelAccount>,
+    runtime_dir: &Path,
+    entry_point: GatewayRuntimeEntryPoint,
+    hooks: SupervisorRuntimeHooks,
+) -> CliResult<crate::supervisor::SupervisorState> {
+    let loaded_config = (hooks.load_config)(config_path)?;
+    (hooks.initialize_runtime_environment)(&loaded_config);
+    let spec =
+        build_gateway_supervisor_spec(&loaded_config, session, &channel_accounts, entry_point)?;
+    let owner_mode = gateway_owner_mode(entry_point, session);
+    let tracker = Arc::new(GatewayOwnerTracker::acquire(
+        runtime_dir,
+        owner_mode,
+        loaded_config.resolved_path.as_path(),
+        session,
+        spec.surfaces.len(),
+    )?);
+
+    let mut runtime_hooks = hooks.clone();
+    let original_wait_for_shutdown = hooks.wait_for_shutdown.clone();
+    let runtime_dir_for_shutdown = runtime_dir.to_path_buf();
+    runtime_hooks.wait_for_shutdown = Arc::new(move || {
+        let original_wait_for_shutdown = original_wait_for_shutdown.clone();
+        let runtime_dir = runtime_dir_for_shutdown.clone();
+        Box::pin(async move {
+            tokio::select! {
+                result = (original_wait_for_shutdown)() => result,
+                result = wait_for_gateway_stop_request(runtime_dir.as_path()) => {
+                    result?;
+                    Ok("gateway stop requested".to_owned())
+                }
+            }
+        })
+    });
+
+    let tracker_for_observer = tracker.clone();
+    runtime_hooks.observe_state =
+        Arc::new(move |supervisor| tracker_for_observer.sync_from_supervisor(supervisor));
+
+    let supervisor_result =
+        run_supervisor_with_loaded_config_for_test(loaded_config, spec, runtime_hooks).await;
+    match supervisor_result {
+        Ok(supervisor) => {
+            tracker.finalize_from_supervisor(&supervisor)?;
+            Ok(supervisor)
+        }
+        Err(error) => {
+            tracker.finalize_with_error(error.as_str())?;
+            Err(error)
+        }
+    }
+}
+
+#[doc(hidden)]
+pub async fn run_gateway_run_with_hooks_for_test(
+    config_path: Option<&str>,
+    session: Option<&str>,
+    channel_accounts: Vec<MultiChannelServeChannelAccount>,
+    runtime_dir: &Path,
+    hooks: SupervisorRuntimeHooks,
+) -> CliResult<crate::supervisor::SupervisorState> {
+    run_gateway_runtime_with_hooks_for_test(
+        config_path,
+        session,
+        channel_accounts,
+        runtime_dir,
+        GatewayRuntimeEntryPoint::GatewayRun,
+        hooks,
+    )
+    .await
+}
+
+#[doc(hidden)]
+pub async fn run_multi_channel_serve_gateway_compat_with_hooks_for_test(
+    config_path: Option<&str>,
+    session: &str,
+    channel_accounts: Vec<MultiChannelServeChannelAccount>,
+    runtime_dir: &Path,
+    hooks: SupervisorRuntimeHooks,
+) -> CliResult<crate::supervisor::SupervisorState> {
+    run_gateway_runtime_with_hooks_for_test(
+        config_path,
+        Some(session),
+        channel_accounts,
+        runtime_dir,
+        GatewayRuntimeEntryPoint::MultiChannelServeCompatibility,
+        hooks,
+    )
+    .await
+}
+
+pub fn run_gateway_status_cli(as_json: bool) -> CliResult<()> {
+    let runtime_dir = default_gateway_runtime_state_dir();
+    let status = load_gateway_owner_status(runtime_dir.as_path())
+        .unwrap_or_else(|| default_gateway_owner_status(runtime_dir.as_path()));
+
+    if as_json {
+        let pretty = serde_json::to_string_pretty(&status)
+            .map_err(|error| format!("serialize gateway status failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    let rendered = render_gateway_status_text(&status);
+    println!("{rendered}");
+    Ok(())
+}
+
+pub fn run_gateway_stop_cli() -> CliResult<()> {
+    let runtime_dir = default_gateway_runtime_state_dir();
+    let outcome = request_gateway_stop(runtime_dir.as_path())?;
+    match outcome {
+        GatewayStopRequestOutcome::Requested => {
+            println!("gateway stop requested");
+        }
+        GatewayStopRequestOutcome::AlreadyRequested => {
+            println!("gateway stop already requested");
+        }
+        GatewayStopRequestOutcome::AlreadyStopped => {
+            println!("gateway is not running");
+        }
+    }
+    Ok(())
+}
+
+fn build_gateway_supervisor_spec(
+    loaded_config: &LoadedSupervisorConfig,
+    session: Option<&str>,
+    channel_accounts: &[MultiChannelServeChannelAccount],
+    entry_point: GatewayRuntimeEntryPoint,
+) -> Result<SupervisorSpec, String> {
+    match entry_point {
+        GatewayRuntimeEntryPoint::GatewayRun => {
+            let surfaces =
+                collect_loaded_background_surfaces(&loaded_config.config, channel_accounts)?;
+            let mode = gateway_runtime_owner_mode(session)?;
+            SupervisorSpec::new(mode, surfaces)
+        }
+        GatewayRuntimeEntryPoint::MultiChannelServeCompatibility => {
+            let session = session.ok_or_else(|| {
+                "multi-channel gateway compatibility path requires a CLI session".to_owned()
+            })?;
+            SupervisorSpec::from_loaded_multi_channel_serve(
+                session,
+                &loaded_config.config,
+                channel_accounts,
+            )
+        }
+    }
+}
+
+fn gateway_runtime_owner_mode(session: Option<&str>) -> Result<RuntimeOwnerMode, String> {
+    match normalize_optional_text(session) {
+        Some(session) => Ok(RuntimeOwnerMode::GatewayAttachedCli {
+            cli_session: session,
+        }),
+        None => Ok(RuntimeOwnerMode::GatewayHeadless),
+    }
+}
+
+fn gateway_owner_mode(
+    entry_point: GatewayRuntimeEntryPoint,
+    session: Option<&str>,
+) -> GatewayOwnerMode {
+    match entry_point {
+        GatewayRuntimeEntryPoint::GatewayRun => match normalize_optional_text(session) {
+            Some(_) => GatewayOwnerMode::GatewayAttachedCli,
+            None => GatewayOwnerMode::GatewayHeadless,
+        },
+        GatewayRuntimeEntryPoint::MultiChannelServeCompatibility => {
+            GatewayOwnerMode::MultiChannelServe
+        }
+    }
+}
+
+fn default_gateway_owner_status(runtime_dir: &Path) -> GatewayOwnerStatus {
+    GatewayOwnerStatus {
+        runtime_dir: runtime_dir.display().to_string(),
+        phase: "stopped".to_owned(),
+        running: false,
+        stale: false,
+        pid: None,
+        mode: GatewayOwnerMode::GatewayHeadless,
+        version: env!("CARGO_PKG_VERSION").to_owned(),
+        config_path: "-".to_owned(),
+        attached_cli_session: None,
+        started_at_ms: 0,
+        last_heartbeat_at: 0,
+        stopped_at_ms: None,
+        shutdown_reason: None,
+        last_error: None,
+        configured_surface_count: 0,
+        running_surface_count: 0,
+        bind_address: None,
+        port: None,
+        token_path: None,
+    }
+}
+
+fn render_gateway_status_text(status: &GatewayOwnerStatus) -> String {
+    let pid = status
+        .pid
+        .map(|pid| pid.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let session = status.attached_cli_session.as_deref().unwrap_or("-");
+    let stopped_at = status
+        .stopped_at_ms
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let shutdown_reason = status.shutdown_reason.as_deref().unwrap_or("-");
+    let last_error = status.last_error.as_deref().unwrap_or("-");
+    let bind_address = status.bind_address.as_deref().unwrap_or("-");
+    let port = status
+        .port
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let token_path = status.token_path.as_deref().unwrap_or("-");
+
+    format!(
+        "runtime_dir={}\nphase={} running={} stale={} pid={} mode={} config={} session={} version={}\nstarted_at_ms={} last_heartbeat_at_ms={} stopped_at_ms={}\nsurfaces configured={} running={}\nshutdown_reason={}\nlast_error={}\nbind_address={} port={} token_path={}",
+        status.runtime_dir,
+        status.phase,
+        status.running,
+        status.stale,
+        pid,
+        status.mode.as_str(),
+        status.config_path,
+        session,
+        status.version,
+        status.started_at_ms,
+        status.last_heartbeat_at,
+        stopped_at,
+        status.configured_surface_count,
+        status.running_surface_count,
+        shutdown_reason,
+        last_error,
+        bind_address,
+        port,
+        token_path,
+    )
+}
+
+fn normalize_optional_text(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}

--- a/crates/daemon/src/gateway/state.rs
+++ b/crates/daemon/src/gateway/state.rs
@@ -96,6 +96,7 @@ struct PersistedGatewayOwnerState {
 struct PersistedGatewayStopRequest {
     requested_at_ms: u64,
     requested_by_pid: u32,
+    target_owner_token: String,
 }
 
 pub struct GatewayOwnerTracker {
@@ -120,7 +121,6 @@ impl GatewayOwnerTracker {
         let active_owner_path = active_gateway_owner_path(runtime_dir);
         let status_snapshot_path = gateway_status_snapshot_path(runtime_dir);
         let stop_request_path = gateway_stop_request_path(runtime_dir);
-        remove_stop_request_file(stop_request_path.as_path())?;
 
         let process_id = std::process::id();
         let owner_token = new_gateway_owner_token(process_id);
@@ -195,6 +195,10 @@ impl GatewayOwnerTracker {
             heartbeat_stopped,
             heartbeat_task: Mutex::new(Some(heartbeat_task)),
         })
+    }
+
+    pub fn owner_token(&self) -> &str {
+        self.owner_token.as_str()
     }
 
     pub fn sync_from_supervisor(&self, supervisor: &SupervisorState) -> CliResult<()> {
@@ -352,13 +356,19 @@ pub fn request_gateway_stop(runtime_dir: &Path) -> CliResult<GatewayStopRequestO
     if !active_owner_status.running || active_owner_status.stale {
         return Ok(GatewayStopRequestOutcome::AlreadyStopped);
     }
-    if stop_request_path.exists() {
+    let existing_stop_request = read_persisted_gateway_stop_request(stop_request_path.as_path());
+    let stop_request_already_targets_active_owner = existing_stop_request
+        .as_ref()
+        .map(|stop_request| stop_request.target_owner_token == active_owner.owner_token)
+        .unwrap_or(false);
+    if stop_request_already_targets_active_owner {
         return Ok(GatewayStopRequestOutcome::AlreadyRequested);
     }
 
     let stop_request = PersistedGatewayStopRequest {
         requested_at_ms: now_ms,
         requested_by_pid: std::process::id(),
+        target_owner_token: active_owner.owner_token,
     };
     write_json_path(
         stop_request_path.as_path(),
@@ -368,10 +378,15 @@ pub fn request_gateway_stop(runtime_dir: &Path) -> CliResult<GatewayStopRequestO
     Ok(GatewayStopRequestOutcome::Requested)
 }
 
-pub async fn wait_for_gateway_stop_request(runtime_dir: &Path) -> CliResult<()> {
+pub async fn wait_for_gateway_stop_request(runtime_dir: &Path, owner_token: &str) -> CliResult<()> {
     let stop_request_path = gateway_stop_request_path(runtime_dir);
     loop {
-        if stop_request_path.exists() {
+        let stop_request = read_persisted_gateway_stop_request(stop_request_path.as_path());
+        let stop_request_targets_owner = stop_request
+            .as_ref()
+            .map(|stop_request| stop_request.target_owner_token == owner_token)
+            .unwrap_or(false);
+        if stop_request_targets_owner {
             return Ok(());
         }
         sleep(Duration::from_millis(GATEWAY_STOP_REQUEST_POLL_MS)).await;
@@ -485,6 +500,11 @@ fn gateway_stop_request_path(runtime_dir: &Path) -> PathBuf {
 fn read_persisted_gateway_owner_state(path: &Path) -> Option<PersistedGatewayOwnerState> {
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str::<PersistedGatewayOwnerState>(&raw).ok()
+}
+
+fn read_persisted_gateway_stop_request(path: &Path) -> Option<PersistedGatewayStopRequest> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<PersistedGatewayStopRequest>(&raw).ok()
 }
 
 fn persisted_gateway_owner_is_stale(

--- a/crates/daemon/src/gateway/state.rs
+++ b/crates/daemon/src/gateway/state.rs
@@ -1,0 +1,889 @@
+use std::{
+    fs,
+    fs::OpenOptions,
+    io::{Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+use tokio::{task::JoinHandle, time::sleep};
+
+use crate::{
+    CliResult, mvp,
+    supervisor::{RuntimeOwnerPhase, SupervisorState, SurfacePhase},
+};
+
+const GATEWAY_RUNTIME_HEARTBEAT_MS: u64 = 5_000;
+const GATEWAY_RUNTIME_STALE_MS: u64 = 15_000;
+const GATEWAY_STOP_REQUEST_POLL_MS: u64 = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayOwnerMode {
+    GatewayHeadless,
+    GatewayAttachedCli,
+    MultiChannelServe,
+}
+
+impl GatewayOwnerMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::GatewayHeadless => "gateway_headless",
+            Self::GatewayAttachedCli => "gateway_attached_cli",
+            Self::MultiChannelServe => "multi_channel_serve",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GatewayOwnerStatus {
+    pub runtime_dir: String,
+    pub phase: String,
+    pub running: bool,
+    pub stale: bool,
+    pub pid: Option<u32>,
+    pub mode: GatewayOwnerMode,
+    pub version: String,
+    pub config_path: String,
+    pub attached_cli_session: Option<String>,
+    pub started_at_ms: u64,
+    pub last_heartbeat_at: u64,
+    pub stopped_at_ms: Option<u64>,
+    pub shutdown_reason: Option<String>,
+    pub last_error: Option<String>,
+    pub configured_surface_count: usize,
+    pub running_surface_count: usize,
+    pub bind_address: Option<String>,
+    pub port: Option<u16>,
+    pub token_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatewayStopRequestOutcome {
+    Requested,
+    AlreadyRequested,
+    AlreadyStopped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PersistedGatewayOwnerState {
+    phase: String,
+    running: bool,
+    pid: Option<u32>,
+    mode: GatewayOwnerMode,
+    version: String,
+    config_path: String,
+    attached_cli_session: Option<String>,
+    started_at_ms: u64,
+    last_heartbeat_at: u64,
+    stopped_at_ms: Option<u64>,
+    shutdown_reason: Option<String>,
+    last_error: Option<String>,
+    configured_surface_count: usize,
+    running_surface_count: usize,
+    bind_address: Option<String>,
+    port: Option<u16>,
+    token_path: Option<String>,
+    owner_token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PersistedGatewayStopRequest {
+    requested_at_ms: u64,
+    requested_by_pid: u32,
+}
+
+pub struct GatewayOwnerTracker {
+    active_owner_path: PathBuf,
+    status_snapshot_path: PathBuf,
+    stop_request_path: PathBuf,
+    owner_token: String,
+    owner_file: Arc<Mutex<fs::File>>,
+    state: Arc<Mutex<PersistedGatewayOwnerState>>,
+    heartbeat_stopped: Arc<AtomicBool>,
+    heartbeat_task: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl GatewayOwnerTracker {
+    pub fn acquire(
+        runtime_dir: &Path,
+        mode: GatewayOwnerMode,
+        config_path: &Path,
+        attached_cli_session: Option<&str>,
+        configured_surface_count: usize,
+    ) -> CliResult<Self> {
+        let active_owner_path = active_gateway_owner_path(runtime_dir);
+        let status_snapshot_path = gateway_status_snapshot_path(runtime_dir);
+        let stop_request_path = gateway_stop_request_path(runtime_dir);
+        remove_stop_request_file(stop_request_path.as_path())?;
+
+        let process_id = std::process::id();
+        let owner_token = new_gateway_owner_token(process_id);
+        let started_at_ms = now_ms();
+        let initial_state = PersistedGatewayOwnerState {
+            phase: runtime_owner_phase_text(RuntimeOwnerPhase::Starting).to_owned(),
+            running: true,
+            pid: Some(process_id),
+            mode,
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            config_path: config_path.display().to_string(),
+            attached_cli_session: normalize_optional_text(attached_cli_session),
+            started_at_ms,
+            last_heartbeat_at: started_at_ms,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count,
+            running_surface_count: 0,
+            bind_address: None,
+            port: None,
+            token_path: None,
+            owner_token: owner_token.clone(),
+        };
+        let owner_file = acquire_active_owner_file(active_owner_path.as_path(), &initial_state)?;
+        write_status_snapshot(status_snapshot_path.as_path(), &initial_state)?;
+
+        let owner_file = Arc::new(Mutex::new(owner_file));
+        let state = Arc::new(Mutex::new(initial_state));
+        let heartbeat_stopped = Arc::new(AtomicBool::new(false));
+        let heartbeat_owner_file = owner_file.clone();
+        let heartbeat_state = state.clone();
+        let heartbeat_stopped_flag = heartbeat_stopped.clone();
+        let heartbeat_status_path = status_snapshot_path.clone();
+        let heartbeat_task = tokio::spawn(async move {
+            while !heartbeat_stopped_flag.load(Ordering::SeqCst) {
+                sleep(Duration::from_millis(GATEWAY_RUNTIME_HEARTBEAT_MS)).await;
+                if heartbeat_stopped_flag.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                let persisted_state = {
+                    let state_guard = heartbeat_state.lock();
+                    let Ok(mut state_guard) = state_guard else {
+                        break;
+                    };
+                    state_guard.last_heartbeat_at = now_ms();
+                    state_guard.clone()
+                };
+
+                let write_owner_result =
+                    write_active_owner_state(heartbeat_owner_file.as_ref(), &persisted_state);
+                if write_owner_result.is_err() {
+                    break;
+                }
+
+                let write_status_result =
+                    write_status_snapshot(heartbeat_status_path.as_path(), &persisted_state);
+                if write_status_result.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(Self {
+            active_owner_path,
+            status_snapshot_path,
+            stop_request_path,
+            owner_token,
+            owner_file,
+            state,
+            heartbeat_stopped,
+            heartbeat_task: Mutex::new(Some(heartbeat_task)),
+        })
+    }
+
+    pub fn sync_from_supervisor(&self, supervisor: &SupervisorState) -> CliResult<()> {
+        let running_surface_count = count_running_surfaces(supervisor);
+        let shutdown_reason = supervisor.shutdown_reason().map(ToString::to_string);
+        let last_error = match supervisor.phase() {
+            RuntimeOwnerPhase::Failed => supervisor.failure_summary(),
+            RuntimeOwnerPhase::Starting
+            | RuntimeOwnerPhase::Running
+            | RuntimeOwnerPhase::Stopping
+            | RuntimeOwnerPhase::Stopped => None,
+        };
+        let runtime_phase = runtime_owner_phase_text(supervisor.phase());
+
+        self.update_state(
+            runtime_phase,
+            true,
+            None,
+            shutdown_reason,
+            last_error,
+            running_surface_count,
+        )
+    }
+
+    pub fn finalize_from_supervisor(&self, supervisor: &SupervisorState) -> CliResult<()> {
+        self.heartbeat_stopped.store(true, Ordering::SeqCst);
+        let heartbeat_task = self
+            .heartbeat_task
+            .lock()
+            .map_err(|error| format!("gateway owner heartbeat task lock poisoned: {error}"))?
+            .take();
+        if let Some(heartbeat_task) = heartbeat_task {
+            heartbeat_task.abort();
+        }
+
+        let running_surface_count = count_running_surfaces(supervisor);
+        let shutdown_reason = supervisor.shutdown_reason().map(ToString::to_string);
+        let last_error = match supervisor.phase() {
+            RuntimeOwnerPhase::Failed => supervisor.failure_summary(),
+            RuntimeOwnerPhase::Starting
+            | RuntimeOwnerPhase::Running
+            | RuntimeOwnerPhase::Stopping
+            | RuntimeOwnerPhase::Stopped => None,
+        };
+        let final_phase = runtime_owner_phase_text(supervisor.phase());
+
+        self.update_state(
+            final_phase,
+            false,
+            Some(now_ms()),
+            shutdown_reason,
+            last_error,
+            running_surface_count,
+        )?;
+        remove_stop_request_file(self.stop_request_path.as_path())?;
+        remove_active_owner_if_owned(self.active_owner_path.as_path(), self.owner_token.as_str())
+    }
+
+    pub fn finalize_with_error(&self, error: &str) -> CliResult<()> {
+        self.heartbeat_stopped.store(true, Ordering::SeqCst);
+        let heartbeat_task = self
+            .heartbeat_task
+            .lock()
+            .map_err(|lock_error| {
+                format!("gateway owner heartbeat task lock poisoned: {lock_error}")
+            })?
+            .take();
+        if let Some(heartbeat_task) = heartbeat_task {
+            heartbeat_task.abort();
+        }
+
+        self.update_state(
+            "failed",
+            false,
+            Some(now_ms()),
+            Some(error.to_owned()),
+            Some(error.to_owned()),
+            0,
+        )?;
+        remove_stop_request_file(self.stop_request_path.as_path())?;
+        remove_active_owner_if_owned(self.active_owner_path.as_path(), self.owner_token.as_str())
+    }
+
+    fn update_state(
+        &self,
+        phase: &str,
+        running: bool,
+        stopped_at_ms: Option<u64>,
+        shutdown_reason: Option<String>,
+        last_error: Option<String>,
+        running_surface_count: usize,
+    ) -> CliResult<()> {
+        let persisted_state = {
+            let state_guard = self.state.lock();
+            let mut state_guard = state_guard
+                .map_err(|error| format!("gateway owner state lock poisoned: {error}"))?;
+            state_guard.phase = phase.to_owned();
+            state_guard.running = running;
+            state_guard.running_surface_count = running_surface_count;
+            state_guard.shutdown_reason = shutdown_reason;
+            state_guard.last_error = last_error;
+            state_guard.last_heartbeat_at = now_ms();
+            if let Some(stopped_at_ms) = stopped_at_ms {
+                state_guard.stopped_at_ms = Some(stopped_at_ms);
+            }
+            state_guard.clone()
+        };
+
+        if running {
+            write_active_owner_state(self.owner_file.as_ref(), &persisted_state)?;
+        }
+        write_status_snapshot(self.status_snapshot_path.as_path(), &persisted_state)
+    }
+}
+
+impl Drop for GatewayOwnerTracker {
+    fn drop(&mut self) {
+        self.heartbeat_stopped.store(true, Ordering::SeqCst);
+        if let Ok(mut heartbeat_task) = self.heartbeat_task.lock() {
+            let heartbeat_task = heartbeat_task.take();
+            if let Some(heartbeat_task) = heartbeat_task {
+                heartbeat_task.abort();
+            }
+        }
+    }
+}
+
+pub fn default_gateway_runtime_state_dir() -> PathBuf {
+    mvp::config::default_loongclaw_home().join("gateway-runtime")
+}
+
+pub fn load_gateway_owner_status(runtime_dir: &Path) -> Option<GatewayOwnerStatus> {
+    let now_ms = now_ms();
+    let status_snapshot_path = gateway_status_snapshot_path(runtime_dir);
+    let active_owner_path = active_gateway_owner_path(runtime_dir);
+    let status_snapshot = read_persisted_gateway_owner_state(status_snapshot_path.as_path());
+    let active_owner_snapshot = read_persisted_gateway_owner_state(active_owner_path.as_path());
+    let persisted_state = select_preferred_snapshot(status_snapshot, active_owner_snapshot)?;
+    Some(build_gateway_owner_status(
+        runtime_dir,
+        &persisted_state,
+        now_ms,
+    ))
+}
+
+pub fn request_gateway_stop(runtime_dir: &Path) -> CliResult<GatewayStopRequestOutcome> {
+    let active_owner_path = active_gateway_owner_path(runtime_dir);
+    let stop_request_path = gateway_stop_request_path(runtime_dir);
+    let now_ms = now_ms();
+    let active_owner = read_persisted_gateway_owner_state(active_owner_path.as_path());
+    let Some(active_owner) = active_owner else {
+        return Ok(GatewayStopRequestOutcome::AlreadyStopped);
+    };
+    let active_owner_status = build_gateway_owner_status(runtime_dir, &active_owner, now_ms);
+    if !active_owner_status.running || active_owner_status.stale {
+        return Ok(GatewayStopRequestOutcome::AlreadyStopped);
+    }
+    if stop_request_path.exists() {
+        return Ok(GatewayStopRequestOutcome::AlreadyRequested);
+    }
+
+    let stop_request = PersistedGatewayStopRequest {
+        requested_at_ms: now_ms,
+        requested_by_pid: std::process::id(),
+    };
+    write_json_path(
+        stop_request_path.as_path(),
+        &stop_request,
+        "gateway stop request",
+    )?;
+    Ok(GatewayStopRequestOutcome::Requested)
+}
+
+pub async fn wait_for_gateway_stop_request(runtime_dir: &Path) -> CliResult<()> {
+    let stop_request_path = gateway_stop_request_path(runtime_dir);
+    loop {
+        if stop_request_path.exists() {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(GATEWAY_STOP_REQUEST_POLL_MS)).await;
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn write_gateway_owner_snapshot_for_test(
+    runtime_dir: &Path,
+    persisted_state: &GatewayOwnerStatus,
+) -> CliResult<()> {
+    let status_snapshot_path = gateway_status_snapshot_path(runtime_dir);
+    let owner_token = "test-owner".to_owned();
+    let raw_state = PersistedGatewayOwnerState {
+        phase: persisted_state.phase.clone(),
+        running: persisted_state.running,
+        pid: persisted_state.pid,
+        mode: persisted_state.mode,
+        version: persisted_state.version.clone(),
+        config_path: persisted_state.config_path.clone(),
+        attached_cli_session: persisted_state.attached_cli_session.clone(),
+        started_at_ms: persisted_state.started_at_ms,
+        last_heartbeat_at: persisted_state.last_heartbeat_at,
+        stopped_at_ms: persisted_state.stopped_at_ms,
+        shutdown_reason: persisted_state.shutdown_reason.clone(),
+        last_error: persisted_state.last_error.clone(),
+        configured_surface_count: persisted_state.configured_surface_count,
+        running_surface_count: persisted_state.running_surface_count,
+        bind_address: persisted_state.bind_address.clone(),
+        port: persisted_state.port,
+        token_path: persisted_state.token_path.clone(),
+        owner_token,
+    };
+    write_status_snapshot(status_snapshot_path.as_path(), &raw_state)
+}
+
+fn select_preferred_snapshot(
+    status_snapshot: Option<PersistedGatewayOwnerState>,
+    active_owner_snapshot: Option<PersistedGatewayOwnerState>,
+) -> Option<PersistedGatewayOwnerState> {
+    match (status_snapshot, active_owner_snapshot) {
+        (Some(status_snapshot), Some(active_owner_snapshot)) => {
+            if active_owner_snapshot.last_heartbeat_at >= status_snapshot.last_heartbeat_at {
+                return Some(active_owner_snapshot);
+            }
+            Some(status_snapshot)
+        }
+        (Some(status_snapshot), None) => Some(status_snapshot),
+        (None, Some(active_owner_snapshot)) => Some(active_owner_snapshot),
+        (None, None) => None,
+    }
+}
+
+fn build_gateway_owner_status(
+    runtime_dir: &Path,
+    persisted_state: &PersistedGatewayOwnerState,
+    now_ms: u64,
+) -> GatewayOwnerStatus {
+    let stale = persisted_gateway_owner_is_stale(persisted_state, now_ms);
+    let running = persisted_state.running && !stale;
+
+    GatewayOwnerStatus {
+        runtime_dir: runtime_dir.display().to_string(),
+        phase: persisted_state.phase.clone(),
+        running,
+        stale,
+        pid: persisted_state.pid,
+        mode: persisted_state.mode,
+        version: persisted_state.version.clone(),
+        config_path: persisted_state.config_path.clone(),
+        attached_cli_session: persisted_state.attached_cli_session.clone(),
+        started_at_ms: persisted_state.started_at_ms,
+        last_heartbeat_at: persisted_state.last_heartbeat_at,
+        stopped_at_ms: persisted_state.stopped_at_ms,
+        shutdown_reason: persisted_state.shutdown_reason.clone(),
+        last_error: persisted_state.last_error.clone(),
+        configured_surface_count: persisted_state.configured_surface_count,
+        running_surface_count: persisted_state.running_surface_count,
+        bind_address: persisted_state.bind_address.clone(),
+        port: persisted_state.port,
+        token_path: persisted_state.token_path.clone(),
+    }
+}
+
+fn count_running_surfaces(supervisor: &SupervisorState) -> usize {
+    let mut count = 0_usize;
+    for surface in &supervisor.spec().surfaces {
+        let surface_state = supervisor.surface_state(surface);
+        let Some(surface_state) = surface_state else {
+            continue;
+        };
+        if surface_state.phase == SurfacePhase::Running {
+            count = count.saturating_add(1);
+        }
+    }
+    count
+}
+
+fn active_gateway_owner_path(runtime_dir: &Path) -> PathBuf {
+    runtime_dir.join("owner-active.json")
+}
+
+fn gateway_status_snapshot_path(runtime_dir: &Path) -> PathBuf {
+    runtime_dir.join("status.json")
+}
+
+fn gateway_stop_request_path(runtime_dir: &Path) -> PathBuf {
+    runtime_dir.join("stop-request.json")
+}
+
+fn read_persisted_gateway_owner_state(path: &Path) -> Option<PersistedGatewayOwnerState> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<PersistedGatewayOwnerState>(&raw).ok()
+}
+
+fn persisted_gateway_owner_is_stale(
+    persisted_state: &PersistedGatewayOwnerState,
+    now_ms: u64,
+) -> bool {
+    if !persisted_state.running {
+        return false;
+    }
+
+    now_ms.saturating_sub(persisted_state.last_heartbeat_at) > GATEWAY_RUNTIME_STALE_MS
+}
+
+fn persisted_gateway_owner_is_inactive(
+    persisted_state: &PersistedGatewayOwnerState,
+    now_ms: u64,
+) -> bool {
+    if !persisted_state.running {
+        return true;
+    }
+
+    persisted_gateway_owner_is_stale(persisted_state, now_ms)
+}
+
+fn acquire_active_owner_file(
+    path: &Path,
+    persisted_state: &PersistedGatewayOwnerState,
+) -> CliResult<fs::File> {
+    ensure_parent_dir(path, "gateway runtime state directory")?;
+    let encoded = serialize_json_pretty(persisted_state, "gateway owner state")?;
+
+    let mut attempts = 0_u8;
+    loop {
+        attempts = attempts.saturating_add(1);
+        let open_result = OpenOptions::new().write(true).create_new(true).open(path);
+        let mut file = match open_result {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let now_ms = now_ms();
+                let existing_state = read_persisted_gateway_owner_state(path);
+                let existing_is_inactive = existing_state
+                    .as_ref()
+                    .map(|existing_state| {
+                        persisted_gateway_owner_is_inactive(existing_state, now_ms)
+                    })
+                    .unwrap_or(false);
+                if existing_is_inactive && attempts < 3 {
+                    match fs::remove_file(path) {
+                        Ok(()) => {}
+                        Err(remove_error)
+                            if remove_error.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(remove_error) => {
+                            return Err(format!(
+                                "remove inactive gateway owner slot failed for {}: {remove_error}",
+                                path.display()
+                            ));
+                        }
+                    }
+                    continue;
+                }
+
+                let existing_pid = existing_state
+                    .as_ref()
+                    .and_then(|existing_state| existing_state.pid)
+                    .map(|process_id| process_id.to_string())
+                    .unwrap_or_else(|| "unknown".to_owned());
+                return Err(format!(
+                    "gateway owner already active at {} (pid={existing_pid})",
+                    path.display()
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "create gateway owner slot failed for {}: {error}",
+                    path.display()
+                ));
+            }
+        };
+
+        let write_result = file.write_all(encoded.as_bytes());
+        if let Err(write_error) = write_result {
+            let _ = fs::remove_file(path);
+            return Err(format!(
+                "write gateway owner slot failed for {}: {write_error}",
+                path.display()
+            ));
+        }
+
+        let sync_result = file.sync_all();
+        if let Err(sync_error) = sync_result {
+            let _ = fs::remove_file(path);
+            return Err(format!(
+                "sync gateway owner slot failed for {}: {sync_error}",
+                path.display()
+            ));
+        }
+
+        return Ok(file);
+    }
+}
+
+fn write_active_owner_state(
+    owner_file: &Mutex<fs::File>,
+    persisted_state: &PersistedGatewayOwnerState,
+) -> CliResult<()> {
+    let encoded = serialize_json_pretty(persisted_state, "gateway owner state")?;
+    let owner_file_guard = owner_file.lock();
+    let mut owner_file_guard =
+        owner_file_guard.map_err(|error| format!("gateway owner file lock poisoned: {error}"))?;
+    owner_file_guard
+        .set_len(0)
+        .map_err(|error| format!("truncate gateway owner slot failed: {error}"))?;
+    owner_file_guard
+        .seek(SeekFrom::Start(0))
+        .map_err(|error| format!("seek gateway owner slot failed: {error}"))?;
+    owner_file_guard
+        .write_all(encoded.as_bytes())
+        .map_err(|error| format!("write gateway owner slot failed: {error}"))?;
+    owner_file_guard
+        .sync_all()
+        .map_err(|error| format!("sync gateway owner slot failed: {error}"))
+}
+
+fn write_status_snapshot(
+    path: &Path,
+    persisted_state: &PersistedGatewayOwnerState,
+) -> CliResult<()> {
+    write_json_path(path, persisted_state, "gateway status snapshot")
+}
+
+fn write_json_path<T: Serialize>(path: &Path, value: &T, context: &str) -> CliResult<()> {
+    ensure_parent_dir(path, context)?;
+    let encoded = serialize_json_pretty(value, context)?;
+    let open_result = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path);
+    let mut file = open_result
+        .map_err(|error| format!("open {context} failed for {}: {error}", path.display()))?;
+    file.write_all(encoded.as_bytes())
+        .map_err(|error| format!("write {context} failed for {}: {error}", path.display()))?;
+    file.sync_all()
+        .map_err(|error| format!("sync {context} failed for {}: {error}", path.display()))
+}
+
+fn serialize_json_pretty<T: Serialize>(value: &T, context: &str) -> CliResult<String> {
+    serde_json::to_string_pretty(value)
+        .map_err(|error| format!("serialize {context} failed: {error}"))
+}
+
+fn ensure_parent_dir(path: &Path, context: &str) -> CliResult<()> {
+    let parent = path.parent();
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("create {context} parent directory failed: {error}"))
+}
+
+fn remove_active_owner_if_owned(path: &Path, owner_token: &str) -> CliResult<()> {
+    let current_owner_token =
+        read_persisted_gateway_owner_state(path).map(|persisted_state| persisted_state.owner_token);
+    if current_owner_token.as_deref() != Some(owner_token) {
+        return Ok(());
+    }
+
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "remove gateway owner slot failed for {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn remove_stop_request_file(path: &Path) -> CliResult<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "remove gateway stop request failed for {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn normalize_optional_text(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn runtime_owner_phase_text(phase: RuntimeOwnerPhase) -> &'static str {
+    match phase {
+        RuntimeOwnerPhase::Starting => "starting",
+        RuntimeOwnerPhase::Running => "running",
+        RuntimeOwnerPhase::Stopping => "stopping",
+        RuntimeOwnerPhase::Stopped => "stopped",
+        RuntimeOwnerPhase::Failed => "failed",
+    }
+}
+
+fn new_gateway_owner_token(process_id: u32) -> String {
+    let now_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{process_id}-{now_nanos}")
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_gateway_runtime_dir(label: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let runtime_dir =
+            std::env::temp_dir().join(format!("loongclaw-gateway-runtime-{label}-{suffix}"));
+        fs::create_dir_all(&runtime_dir).expect("create gateway runtime dir");
+        runtime_dir
+    }
+
+    fn sample_status(running: bool, last_heartbeat_at: u64) -> GatewayOwnerStatus {
+        GatewayOwnerStatus {
+            runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
+            phase: if running {
+                "running".to_owned()
+            } else {
+                "stopped".to_owned()
+            },
+            running,
+            stale: false,
+            pid: Some(4242),
+            mode: GatewayOwnerMode::GatewayHeadless,
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            config_path: "/tmp/loongclaw.toml".to_owned(),
+            attached_cli_session: None,
+            started_at_ms: 1_710_000_000_000,
+            last_heartbeat_at,
+            stopped_at_ms: if running {
+                None
+            } else {
+                Some(1_710_000_001_000)
+            },
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count: 2,
+            running_surface_count: if running { 2 } else { 0 },
+            bind_address: None,
+            port: None,
+            token_path: None,
+        }
+    }
+
+    #[test]
+    fn gateway_owner_state_status_marks_running_snapshot_stale_after_heartbeat_budget() {
+        let runtime_dir = temp_gateway_runtime_dir("stale-status");
+        let stale_heartbeat_at = now_ms().saturating_sub(GATEWAY_RUNTIME_STALE_MS + 1);
+        let status = sample_status(true, stale_heartbeat_at);
+        write_gateway_owner_snapshot_for_test(runtime_dir.as_path(), &status)
+            .expect("write gateway status");
+
+        let loaded_status =
+            load_gateway_owner_status(runtime_dir.as_path()).expect("load gateway status");
+
+        assert!(loaded_status.stale);
+        assert!(!loaded_status.running);
+        assert_eq!(loaded_status.phase, "running");
+    }
+
+    #[tokio::test]
+    async fn gateway_owner_state_acquire_and_finalize_preserve_last_stopped_snapshot() {
+        let runtime_dir = temp_gateway_runtime_dir("finalize");
+        let tracker = GatewayOwnerTracker::acquire(
+            runtime_dir.as_path(),
+            GatewayOwnerMode::GatewayHeadless,
+            Path::new("/tmp/loongclaw.toml"),
+            None,
+            0,
+        )
+        .expect("acquire gateway owner");
+
+        let spec = crate::supervisor::SupervisorSpec::new(
+            crate::supervisor::RuntimeOwnerMode::GatewayHeadless,
+            Vec::new(),
+        )
+        .expect("build supervisor spec");
+        let mut supervisor = crate::supervisor::SupervisorState::new(spec);
+        supervisor
+            .request_shutdown("gateway stop requested".to_owned())
+            .expect("request shutdown");
+        supervisor.finalize_after_runtime_exit();
+
+        tracker
+            .finalize_from_supervisor(&supervisor)
+            .expect("finalize owner state");
+
+        let active_owner_path = active_gateway_owner_path(runtime_dir.as_path());
+        assert!(!active_owner_path.exists());
+
+        let loaded_status =
+            load_gateway_owner_status(runtime_dir.as_path()).expect("load final gateway status");
+        assert_eq!(loaded_status.phase, "stopped");
+        assert!(!loaded_status.running);
+        assert_eq!(
+            loaded_status.shutdown_reason.as_deref(),
+            Some("shutdown requested: gateway stop requested")
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_owner_state_reclaims_stale_owner_slot() {
+        let runtime_dir = temp_gateway_runtime_dir("reclaim-stale");
+        let active_owner_path = active_gateway_owner_path(runtime_dir.as_path());
+        let stale_owner_state = PersistedGatewayOwnerState {
+            phase: "running".to_owned(),
+            running: true,
+            pid: Some(7001),
+            mode: GatewayOwnerMode::GatewayHeadless,
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            config_path: "/tmp/stale.toml".to_owned(),
+            attached_cli_session: None,
+            started_at_ms: 1_710_000_000_000,
+            last_heartbeat_at: now_ms().saturating_sub(GATEWAY_RUNTIME_STALE_MS + 1),
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count: 1,
+            running_surface_count: 1,
+            bind_address: None,
+            port: None,
+            token_path: None,
+            owner_token: "stale-owner".to_owned(),
+        };
+        write_json_path(
+            active_owner_path.as_path(),
+            &stale_owner_state,
+            "stale gateway owner slot",
+        )
+        .expect("write stale owner slot");
+
+        let tracker = GatewayOwnerTracker::acquire(
+            runtime_dir.as_path(),
+            GatewayOwnerMode::GatewayHeadless,
+            Path::new("/tmp/fresh.toml"),
+            None,
+            0,
+        )
+        .expect("reclaim stale owner slot");
+        drop(tracker);
+
+        let active_owner = read_persisted_gateway_owner_state(active_owner_path.as_path())
+            .expect("active owner should be replaced");
+        assert_eq!(active_owner.config_path, "/tmp/fresh.toml");
+    }
+
+    #[test]
+    fn gateway_owner_state_stop_request_returns_already_stopped_without_active_owner() {
+        let runtime_dir = temp_gateway_runtime_dir("stop-idempotent");
+
+        let outcome =
+            request_gateway_stop(runtime_dir.as_path()).expect("request stop without active owner");
+
+        assert_eq!(outcome, GatewayStopRequestOutcome::AlreadyStopped);
+    }
+
+    #[tokio::test]
+    async fn gateway_owner_state_stop_request_writes_request_for_running_owner() {
+        let runtime_dir = temp_gateway_runtime_dir("stop-request");
+        let tracker = GatewayOwnerTracker::acquire(
+            runtime_dir.as_path(),
+            GatewayOwnerMode::GatewayHeadless,
+            Path::new("/tmp/loongclaw.toml"),
+            None,
+            0,
+        )
+        .expect("acquire gateway owner");
+
+        let outcome = request_gateway_stop(runtime_dir.as_path()).expect("request stop");
+
+        assert_eq!(outcome, GatewayStopRequestOutcome::Requested);
+        let stop_request_path = gateway_stop_request_path(runtime_dir.as_path());
+        assert!(stop_request_path.exists());
+        drop(tracker);
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1038,6 +1038,11 @@ pub enum Commands {
         #[arg(long = "channel-account", value_name = "CHANNEL=ACCOUNT")]
         channel_account: Vec<MultiChannelServeChannelAccount>,
     },
+    /// Run the gateway lifecycle namespace
+    Gateway {
+        #[command(subcommand)]
+        command: gateway::service::GatewayCommand,
+    },
     /// Run the Feishu integration namespace
     Feishu {
         #[command(subcommand)]
@@ -3984,12 +3989,12 @@ where
 {
     tokio::select! {
         result = serve_future => result,
-        result = wait_for_shutdown_signal() => result,
+        result = wait_for_shutdown_reason() => result.map(|_| ()),
     }
 }
 
 #[cfg(unix)]
-pub async fn wait_for_shutdown_signal() -> CliResult<()> {
+pub async fn wait_for_shutdown_reason() -> CliResult<String> {
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .map_err(|error| format!("failed to register SIGTERM handler: {error}"))?;
 
@@ -3997,22 +4002,26 @@ pub async fn wait_for_shutdown_signal() -> CliResult<()> {
         result = tokio::signal::ctrl_c() => {
             result.map_err(|error| format!("failed to register Ctrl-C handler: {error}"))?;
             eprintln!("\nReceived Ctrl-C, shutting down gracefully...");
-            Ok(())
+            Ok("ctrl-c received".to_owned())
         }
         _ = sigterm.recv() => {
             eprintln!("\nReceived SIGTERM, shutting down gracefully...");
-            Ok(())
+            Ok("sigterm received".to_owned())
         }
     }
 }
 
 #[cfg(not(unix))]
-pub async fn wait_for_shutdown_signal() -> CliResult<()> {
+pub async fn wait_for_shutdown_reason() -> CliResult<String> {
     tokio::signal::ctrl_c()
         .await
         .map_err(|error| format!("failed to register Ctrl-C handler: {error}"))?;
     eprintln!("\nReceived Ctrl-C, shutting down gracefully...");
-    Ok(())
+    Ok("ctrl-c received".to_owned())
+}
+
+pub async fn wait_for_shutdown_signal() -> CliResult<()> {
+    wait_for_shutdown_reason().await.map(|_| ())
 }
 
 pub const TELEGRAM_SEND_CLI_SPEC: ChannelSendCliSpec = ChannelSendCliSpec {
@@ -4742,7 +4751,12 @@ pub async fn run_multi_channel_serve_cli(
     session: &str,
     channel_accounts: Vec<MultiChannelServeChannelAccount>,
 ) -> CliResult<()> {
-    supervisor::run_multi_channel_serve(config_path, session, channel_accounts).await
+    gateway::service::run_multi_channel_serve_gateway_compat_cli(
+        config_path,
+        session,
+        channel_accounts,
+    )
+    .await
 }
 
 pub fn parse_json_payload(raw: &str, context: &str) -> CliResult<Value> {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -838,6 +838,7 @@ async fn main() {
             session,
             channel_account,
         } => run_multi_channel_serve_cli(config.as_deref(), &session, channel_account).await,
+        Commands::Gateway { command } => gateway::service::run_gateway_cli(command).await,
         Commands::Feishu { command } => feishu_cli::run_feishu_command(command).await,
         Commands::Completions { shell } => {
             completions_cli::run_completions_cli(completions_cli::CompletionsCommandOptions {

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -11,9 +11,10 @@ use std::{
 use loongclaw_spec::CliResult;
 use tokio::task::{Id, JoinSet};
 
-use crate::{MultiChannelServeChannelAccount, mvp, wait_for_shutdown_signal};
+use crate::{MultiChannelServeChannelAccount, mvp};
 
 type BoxedSupervisorFuture = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'static>>;
+type BoxedShutdownFuture = Pin<Box<dyn Future<Output = CliResult<String>> + Send + 'static>>;
 type BackgroundChannelRunner =
     Arc<dyn Fn(BackgroundChannelRunnerRequest) -> BoxedSupervisorFuture + Send + Sync + 'static>;
 type BackgroundChannelRunnerRegistry = BTreeMap<&'static str, BackgroundChannelRunner>;
@@ -79,6 +80,35 @@ fn collect_multi_channel_account_overrides(
     }
 
     Ok(collected_accounts)
+}
+
+pub fn collect_loaded_background_surfaces(
+    config: &mvp::config::LoongClawConfig,
+    channel_accounts: &[MultiChannelServeChannelAccount],
+) -> Result<Vec<BackgroundChannelSurface>, String> {
+    let account_overrides = collect_multi_channel_account_overrides(channel_accounts)?;
+    let mut surfaces = Vec::new();
+
+    let runtime_descriptors = mvp::channel::background_channel_runtime_descriptors();
+
+    for runtime_descriptor in runtime_descriptors {
+        let selected_account_id = account_overrides
+            .get(runtime_descriptor.channel_id)
+            .map(String::as_str);
+        let surface_is_enabled = mvp::channel::is_background_channel_surface_enabled(
+            runtime_descriptor.channel_id,
+            config,
+            selected_account_id,
+        )?;
+        if !surface_is_enabled {
+            continue;
+        }
+
+        let surface = BackgroundChannelSurface::new(runtime_descriptor, selected_account_id);
+        surfaces.push(surface);
+    }
+
+    Ok(surfaces)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -158,6 +188,8 @@ impl fmt::Display for SupervisorShutdownReason {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeOwnerMode {
     MultiChannelServe { cli_session: String },
+    GatewayAttachedCli { cli_session: String },
+    GatewayHeadless,
 }
 
 impl RuntimeOwnerMode {
@@ -169,6 +201,28 @@ impl RuntimeOwnerMode {
                 }
                 Ok(())
             }
+            Self::GatewayAttachedCli { cli_session } => {
+                if cli_session.trim().is_empty() {
+                    return Err("gateway attached mode requires a non-empty CLI session".into());
+                }
+                Ok(())
+            }
+            Self::GatewayHeadless => Ok(()),
+        }
+    }
+
+    fn attached_cli_session(&self) -> Option<&str> {
+        match self {
+            Self::MultiChannelServe { cli_session } => Some(cli_session.as_str()),
+            Self::GatewayAttachedCli { cli_session } => Some(cli_session.as_str()),
+            Self::GatewayHeadless => None,
+        }
+    }
+
+    fn owner_label(&self) -> &'static str {
+        match self {
+            Self::MultiChannelServe { .. } => "multi-channel supervisor",
+            Self::GatewayAttachedCli { .. } | Self::GatewayHeadless => "gateway service",
         }
     }
 }
@@ -185,9 +239,6 @@ impl SupervisorSpec {
         surfaces: Vec<BackgroundChannelSurface>,
     ) -> Result<Self, String> {
         mode.validate()?;
-        if surfaces.is_empty() {
-            return Err("supervisor requires at least one background surface".to_owned());
-        }
 
         let mut seen = BTreeSet::new();
         for surface in &surfaces {
@@ -206,26 +257,13 @@ impl SupervisorSpec {
         config: &mvp::config::LoongClawConfig,
         channel_accounts: &[MultiChannelServeChannelAccount],
     ) -> Result<Self, String> {
-        let account_overrides = collect_multi_channel_account_overrides(channel_accounts)?;
-        let mut surfaces = Vec::new();
+        let surfaces = collect_loaded_background_surfaces(config, channel_accounts)?;
 
-        let runtime_descriptors = mvp::channel::background_channel_runtime_descriptors();
-
-        for runtime_descriptor in runtime_descriptors {
-            let selected_account_id = account_overrides
-                .get(runtime_descriptor.channel_id)
-                .map(String::as_str);
-            let surface_is_enabled = mvp::channel::is_background_channel_surface_enabled(
-                runtime_descriptor.channel_id,
-                config,
-                selected_account_id,
-            )?;
-            if !surface_is_enabled {
-                continue;
-            }
-
-            let surface = BackgroundChannelSurface::new(runtime_descriptor, selected_account_id);
-            surfaces.push(surface);
+        if surfaces.is_empty() {
+            return Err(
+                "multi-channel supervisor requires at least one enabled runtime-backed service channel"
+                    .to_owned(),
+            );
         }
 
         Self::new(
@@ -257,9 +295,15 @@ impl SupervisorState {
             })
             .collect();
 
+        let initial_phase = if spec.surfaces.is_empty() {
+            RuntimeOwnerPhase::Running
+        } else {
+            RuntimeOwnerPhase::Starting
+        };
+
         Self {
             spec,
-            phase: RuntimeOwnerPhase::Starting,
+            phase: initial_phase,
             surfaces,
             shutdown_reason: None,
         }
@@ -450,9 +494,10 @@ impl SupervisorState {
     }
 
     pub fn failure_summary(&self) -> Option<String> {
+        let owner_label = self.spec.mode.owner_label();
         match self.shutdown_reason() {
             Some(SupervisorShutdownReason::SurfaceFailed { surface, error }) => Some(format!(
-                "multi-channel supervisor failed because {surface} exited unexpectedly: {error}"
+                "{owner_label} failed because {surface} exited unexpectedly: {error}"
             )),
             _ => self
                 .surfaces
@@ -464,14 +509,15 @@ impl SupervisorState {
                         .as_deref()
                         .unwrap_or("unknown background surface failure");
                     format!(
-                        "multi-channel supervisor failed because {} exited unexpectedly: {error}",
-                        state.surface
+                        "{owner_label} failed because {} exited unexpectedly: {error}",
+                        state.surface,
                     )
                 }),
         }
     }
 
     pub fn final_exit_summary(&self) -> String {
+        let owner_label = self.spec.mode.owner_label();
         if let Some(summary) = self.failure_summary() {
             return summary;
         }
@@ -485,7 +531,7 @@ impl SupervisorState {
                 .collect::<Vec<_>>()
                 .join(", ");
             return format!(
-                "multi-channel supervisor failed because surfaces stopped without a shutdown request: {surfaces}"
+                "{owner_label} failed because surfaces stopped without a shutdown request: {surfaces}"
             );
         }
 
@@ -497,10 +543,10 @@ impl SupervisorState {
             .collect::<Vec<_>>()
             .join(", ");
         match self.shutdown_reason() {
-            Some(reason) => format!(
-                "multi-channel supervisor exited cleanly after {reason}; surfaces: {surfaces}"
-            ),
-            None => format!("multi-channel supervisor is still active for surfaces: {surfaces}"),
+            Some(reason) => {
+                format!("{owner_label} exited cleanly after {reason}; surfaces: {surfaces}")
+            }
+            None => format!("{owner_label} is still active for surfaces: {surfaces}"),
         }
     }
 
@@ -517,6 +563,18 @@ impl SupervisorState {
         }
 
         Err(self.final_exit_summary())
+    }
+
+    pub fn finalize_after_runtime_exit(&mut self) {
+        if matches!(
+            self.phase,
+            RuntimeOwnerPhase::Failed | RuntimeOwnerPhase::Stopped
+        ) {
+            return;
+        }
+        if self.shutdown_reason.is_some() && self.all_surfaces_terminal() {
+            self.phase = RuntimeOwnerPhase::Stopped;
+        }
     }
 
     fn surface_state_mut(
@@ -567,7 +625,8 @@ pub struct SupervisorRuntimeHooks {
             + 'static,
     >,
     pub background_channel_runners: BackgroundChannelRunnerRegistry,
-    pub wait_for_shutdown: Arc<dyn Fn() -> BoxedSupervisorFuture + Send + Sync + 'static>,
+    pub wait_for_shutdown: Arc<dyn Fn() -> BoxedShutdownFuture + Send + Sync + 'static>,
+    pub observe_state: Arc<dyn Fn(&SupervisorState) -> CliResult<()> + Send + Sync + 'static>,
 }
 
 impl SupervisorRuntimeHooks {
@@ -599,7 +658,7 @@ impl SupervisorRuntimeHooks {
         runners
     }
 
-    fn production() -> Self {
+    pub fn production() -> Self {
         Self {
             load_config: Arc::new(|config_path| {
                 let (resolved_path, config) = mvp::config::load(config_path)?;
@@ -624,7 +683,10 @@ impl SupervisorRuntimeHooks {
                 })
             }),
             background_channel_runners: Self::production_background_channel_runners(),
-            wait_for_shutdown: Arc::new(|| Box::pin(async { wait_for_shutdown_signal().await })),
+            wait_for_shutdown: Arc::new(|| {
+                Box::pin(async { crate::wait_for_shutdown_reason().await })
+            }),
+            observe_state: Arc::new(|_| Ok(())),
         }
     }
 }
@@ -665,21 +727,17 @@ fn forward_root_shutdown(
 }
 
 #[doc(hidden)]
-pub async fn run_multi_channel_serve_with_hooks_for_test(
-    config_path: Option<&str>,
-    session: &str,
-    channel_accounts: Vec<MultiChannelServeChannelAccount>,
+pub async fn run_supervisor_with_loaded_config_for_test(
+    loaded_config: LoadedSupervisorConfig,
+    spec: SupervisorSpec,
     hooks: SupervisorRuntimeHooks,
 ) -> CliResult<SupervisorState> {
-    let loaded_config = (hooks.load_config)(config_path)?;
-    (hooks.initialize_runtime_environment)(&loaded_config);
     let LoadedSupervisorConfig {
         resolved_path,
         config,
     } = loaded_config;
-    let spec =
-        SupervisorSpec::from_loaded_multi_channel_serve(session, &config, &channel_accounts)?;
     let mut supervisor = SupervisorState::new(spec.clone());
+    (hooks.observe_state)(&supervisor)?;
 
     let cli_shutdown = mvp::chat::ConcurrentCliShutdown::new();
     let mut stop_handles = Vec::new();
@@ -723,24 +781,32 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
             .id();
         background_task_surfaces.insert(task_id, tracked_surface);
     }
+    (hooks.observe_state)(&supervisor)?;
 
-    let mut cli_host = Box::pin((hooks.run_cli_host)(mvp::chat::ConcurrentCliHostOptions {
-        resolved_path: resolved_path.clone(),
-        config: config.clone(),
-        session_id: session.to_owned(),
-        shutdown: cli_shutdown.clone(),
-        initialize_runtime_environment: false,
-    }));
-    let mut cli_active = true;
+    let mut cli_host = spec.mode.attached_cli_session().map(|session_id| {
+        Box::pin((hooks.run_cli_host)(mvp::chat::ConcurrentCliHostOptions {
+            resolved_path: resolved_path.clone(),
+            config: config.clone(),
+            session_id: session_id.to_owned(),
+            shutdown: cli_shutdown.clone(),
+            initialize_runtime_environment: false,
+        }))
+    });
+    let mut cli_active = cli_host.is_some();
 
     let mut shutdown_signal = Box::pin((hooks.wait_for_shutdown)());
     let mut signal_active = true;
 
     let mut foreground_failure: Option<String> = None;
 
-    while cli_active || !background_tasks.is_empty() {
+    while cli_active || signal_active || !background_tasks.is_empty() {
         tokio::select! {
-            cli_result = &mut cli_host, if cli_active => {
+            cli_result = async {
+                let cli_host = cli_host
+                    .as_mut()
+                    .expect("cli host future should exist");
+                cli_host.await
+            }, if cli_active => {
                 cli_active = false;
                 match cli_result {
                     Ok(()) => {
@@ -748,6 +814,7 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                             supervisor.request_shutdown("foreground CLI host exited".to_owned())?;
                         }
                         forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
+                        (hooks.observe_state)(&supervisor)?;
                     }
                     Err(error) => {
                         foreground_failure = Some(error.clone());
@@ -755,16 +822,18 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                             supervisor.request_shutdown(format!("foreground CLI host failed: {error}"))?;
                         }
                         forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
+                        (hooks.observe_state)(&supervisor)?;
                     }
                 }
             }
             signal_result = &mut shutdown_signal, if signal_active => {
                 signal_active = false;
-                signal_result?;
+                let shutdown_reason = signal_result?;
                 if !supervisor.shutdown_requested() {
-                    supervisor.request_shutdown("ctrl-c received".to_owned())?;
+                    supervisor.request_shutdown(shutdown_reason)?;
                 }
                 forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
+                (hooks.observe_state)(&supervisor)?;
             }
             Some(joined) = background_tasks.join_next_with_id(), if !background_tasks.is_empty() => {
                 match joined {
@@ -796,17 +865,39 @@ pub async fn run_multi_channel_serve_with_hooks_for_test(
                 if supervisor.shutdown_requested() {
                     forward_root_shutdown(&mut supervisor, &cli_shutdown, &stop_handles, &mut signal_active);
                 }
+                (hooks.observe_state)(&supervisor)?;
             }
         }
     }
 
+    supervisor.finalize_after_runtime_exit();
+    (hooks.observe_state)(&supervisor)?;
+
     if let Some(error) = foreground_failure {
+        let owner_label = spec.mode.owner_label();
         return Err(format!(
-            "multi-channel supervisor failed because foreground CLI host exited unexpectedly: {error}"
+            "{owner_label} failed because foreground CLI host exited unexpectedly: {error}"
         ));
     }
 
     Ok(supervisor)
+}
+
+#[doc(hidden)]
+pub async fn run_multi_channel_serve_with_hooks_for_test(
+    config_path: Option<&str>,
+    session: &str,
+    channel_accounts: Vec<MultiChannelServeChannelAccount>,
+    hooks: SupervisorRuntimeHooks,
+) -> CliResult<SupervisorState> {
+    let loaded_config = (hooks.load_config)(config_path)?;
+    (hooks.initialize_runtime_environment)(&loaded_config);
+    let spec = SupervisorSpec::from_loaded_multi_channel_serve(
+        session,
+        &loaded_config.config,
+        &channel_accounts,
+    )?;
+    run_supervisor_with_loaded_config_for_test(loaded_config, spec, hooks).await
 }
 
 pub async fn run_multi_channel_serve(

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -2053,6 +2053,97 @@ fn multi_channel_serve_cli_help_mentions_session_and_channel_account_flags() {
 }
 
 #[test]
+fn gateway_run_cli_accepts_optional_session_and_channel_account_flags() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "gateway",
+        "run",
+        "--session",
+        "cli-gateway",
+        "--channel-account",
+        "telegram=bot_123456",
+        "--channel-account",
+        "matrix=bridge-sync",
+    ])
+    .expect("gateway run should parse");
+
+    match cli.command {
+        Some(Commands::Gateway { command }) => match command {
+            loongclaw_daemon::gateway::service::GatewayCommand::Run {
+                session,
+                channel_account,
+                ..
+            } => {
+                assert_eq!(session.as_deref(), Some("cli-gateway"));
+                assert_eq!(channel_account.len(), 2);
+                assert_eq!(channel_account[0].channel_id, "telegram");
+                assert_eq!(channel_account[0].account_id, "bot_123456");
+                assert_eq!(channel_account[1].channel_id, "matrix");
+                assert_eq!(channel_account[1].account_id, "bridge-sync");
+            }
+            other @ loongclaw_daemon::gateway::service::GatewayCommand::Status { .. }
+            | other @ loongclaw_daemon::gateway::service::GatewayCommand::Stop => {
+                panic!("unexpected gateway subcommand: {other:?}")
+            }
+        },
+        other => panic!("unexpected parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn gateway_run_cli_allows_headless_mode_without_session() {
+    let cli = try_parse_cli(["loongclaw", "gateway", "run"])
+        .expect("gateway run should allow headless mode");
+
+    match cli.command {
+        Some(Commands::Gateway { command }) => match command {
+            loongclaw_daemon::gateway::service::GatewayCommand::Run { session, .. } => {
+                assert_eq!(session, None);
+            }
+            other @ loongclaw_daemon::gateway::service::GatewayCommand::Status { .. }
+            | other @ loongclaw_daemon::gateway::service::GatewayCommand::Stop => {
+                panic!("unexpected gateway subcommand: {other:?}")
+            }
+        },
+        other => panic!("unexpected parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn gateway_status_cli_parses_json_flag() {
+    let cli = try_parse_cli(["loongclaw", "gateway", "status", "--json"])
+        .expect("gateway status should parse");
+
+    match cli.command {
+        Some(Commands::Gateway { command }) => match command {
+            loongclaw_daemon::gateway::service::GatewayCommand::Status { json } => {
+                assert!(json);
+            }
+            other @ loongclaw_daemon::gateway::service::GatewayCommand::Run { .. }
+            | other @ loongclaw_daemon::gateway::service::GatewayCommand::Stop => {
+                panic!("unexpected gateway subcommand: {other:?}")
+            }
+        },
+        other => panic!("unexpected parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn gateway_cli_help_mentions_run_status_stop_and_optional_session() {
+    let help = render_cli_help(["gateway"]);
+    let run_help = render_cli_help(["gateway", "run"]);
+
+    assert!(help.contains("run"), "help: {help}");
+    assert!(help.contains("status"), "help: {help}");
+    assert!(help.contains("stop"), "help: {help}");
+    assert!(run_help.contains("--session <SESSION>"), "help: {run_help}");
+    assert!(
+        run_help.contains("--channel-account <CHANNEL=ACCOUNT>"),
+        "help: {run_help}"
+    );
+}
+
+#[test]
 fn default_channel_send_target_kind_uses_command_family_send_metadata() {
     assert_eq!(
         default_channel_send_target_kind(ChannelSendCliSpec {

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -1,0 +1,291 @@
+use super::*;
+
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use loongclaw_daemon::{
+    gateway::{
+        service::{
+            run_gateway_run_with_hooks_for_test,
+            run_multi_channel_serve_gateway_compat_with_hooks_for_test,
+        },
+        state::{
+            GatewayOwnerMode, GatewayStopRequestOutcome, load_gateway_owner_status,
+            request_gateway_stop,
+        },
+    },
+    supervisor::{BackgroundChannelRunnerRequest, LoadedSupervisorConfig, SupervisorRuntimeHooks},
+};
+use tokio::time::{sleep, timeout};
+
+type BoxedCliFuture = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'static>>;
+type BoxedShutdownFuture = Pin<Box<dyn Future<Output = CliResult<String>> + Send + 'static>>;
+type TestBackgroundChannelRunner =
+    Arc<dyn Fn(BackgroundChannelRunnerRequest) -> BoxedCliFuture + Send + Sync + 'static>;
+
+const GATEWAY_OWNER_TEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+fn boxed_cli_result(f: impl Future<Output = CliResult<()>> + Send + 'static) -> BoxedCliFuture {
+    Box::pin(f)
+}
+
+fn pending_shutdown_future() -> BoxedShutdownFuture {
+    Box::pin(async move {
+        std::future::pending::<()>().await;
+        Ok(String::new())
+    })
+}
+
+fn unique_runtime_dir(label: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let runtime_dir = std::env::temp_dir().join(format!(
+        "loongclaw-daemon-gateway-owner-state-{label}-{suffix}"
+    ));
+    std::fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+    runtime_dir
+}
+
+fn headless_loaded_config_fixture() -> LoadedSupervisorConfig {
+    LoadedSupervisorConfig {
+        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+        config: mvp::config::LoongClawConfig::default(),
+    }
+}
+
+fn telegram_loaded_config_fixture() -> LoadedSupervisorConfig {
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.telegram.enabled = true;
+    LoadedSupervisorConfig {
+        resolved_path: PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+    }
+}
+
+fn idle_background_channel_runner() -> TestBackgroundChannelRunner {
+    Arc::new(|request| {
+        boxed_cli_result(async move {
+            while !request.stop.is_requested() {
+                tokio::task::yield_now().await;
+            }
+            Ok(())
+        })
+    })
+}
+
+fn background_channel_runner_registry(
+    entries: Vec<(
+        mvp::channel::ChannelRuntimeCommandDescriptor,
+        TestBackgroundChannelRunner,
+    )>,
+) -> BTreeMap<&'static str, TestBackgroundChannelRunner> {
+    let mut runners = BTreeMap::new();
+    for (runtime, runner) in entries {
+        runners.insert(runtime.channel_id, runner);
+    }
+    runners
+}
+
+async fn wait_until(description: &str, predicate: impl Fn() -> bool) {
+    for _ in 0..200 {
+        if predicate() {
+            return;
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+
+    panic!("timed out waiting for {description}");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_headless_run_claims_slot_and_stops_via_stop_request() {
+    let runtime_dir = unique_runtime_dir("headless-stop");
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    wait_until("gateway headless status", || {
+        load_gateway_owner_status(runtime_dir.as_path())
+            .map(|status| status.running && status.phase == "running")
+            .unwrap_or(false)
+    })
+    .await;
+
+    let running_status =
+        load_gateway_owner_status(runtime_dir.as_path()).expect("gateway status should be present");
+    assert_eq!(running_status.phase, "running");
+    assert_eq!(running_status.mode, GatewayOwnerMode::GatewayHeadless);
+    assert_eq!(running_status.configured_surface_count, 0);
+    assert_eq!(running_status.running_surface_count, 0);
+
+    let stop_result = request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    assert_eq!(stop_result, GatewayStopRequestOutcome::Requested);
+
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop")
+        .expect("join gateway run")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+
+    let stopped_status = load_gateway_owner_status(runtime_dir.as_path())
+        .expect("stopped gateway status should be present");
+    assert_eq!(stopped_status.phase, "stopped");
+    assert!(!stopped_status.running);
+    assert_eq!(
+        stopped_status.shutdown_reason.as_deref(),
+        Some("shutdown requested: gateway stop requested")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_rejects_second_active_owner_slot() {
+    let runtime_dir = unique_runtime_dir("exclusive-slot");
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    wait_until("first gateway owner", || {
+        load_gateway_owner_status(runtime_dir.as_path())
+            .map(|status| status.running)
+            .unwrap_or(false)
+    })
+    .await;
+
+    let second_hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+    let second_result = run_gateway_run_with_hooks_for_test(
+        None,
+        None,
+        Vec::new(),
+        runtime_dir.as_path(),
+        second_hooks,
+    )
+    .await
+    .expect_err("second gateway owner should be rejected");
+    assert!(
+        second_result.contains("gateway owner already active"),
+        "unexpected duplicate-owner error: {second_result}"
+    );
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request gateway stop");
+    timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("first gateway run should stop")
+        .expect("join gateway run")
+        .expect("first gateway run should return supervisor state");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_multi_channel_compat_records_wrapper_mode_and_session() {
+    let runtime_dir = unique_runtime_dir("compat-wrapper");
+    let telegram_runner = idle_background_channel_runner();
+    let background_channel_runners = background_channel_runner_registry(vec![(
+        mvp::channel::TELEGRAM_RUNTIME_COMMAND_DESCRIPTOR,
+        telegram_runner,
+    )]);
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(telegram_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|options| {
+            boxed_cli_result(async move {
+                options.shutdown.wait().await;
+                Ok(())
+            })
+        }),
+        background_channel_runners,
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_multi_channel_serve_gateway_compat_with_hooks_for_test(
+            None,
+            "cli-supervisor",
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    wait_until("multi-channel compatibility status", || {
+        load_gateway_owner_status(runtime_dir.as_path())
+            .map(|status| status.running && status.running_surface_count == 1)
+            .unwrap_or(false)
+    })
+    .await;
+
+    let running_status =
+        load_gateway_owner_status(runtime_dir.as_path()).expect("compat status should be present");
+    assert_eq!(running_status.mode, GatewayOwnerMode::MultiChannelServe);
+    assert_eq!(
+        running_status.attached_cli_session.as_deref(),
+        Some("cli-supervisor")
+    );
+    assert_eq!(running_status.configured_surface_count, 1);
+    assert_eq!(running_status.running_surface_count, 1);
+
+    request_gateway_stop(runtime_dir.as_path()).expect("request compatibility stop");
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("compat run should stop")
+        .expect("join compat run")
+        .expect("compat run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+}

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -231,6 +231,74 @@ async fn gateway_owner_state_rejects_second_active_owner_slot() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_second_owner_attempt_preserves_pending_stop_request() {
+    let runtime_dir = unique_runtime_dir("duplicate-start-pending-stop");
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    wait_until("first gateway owner", || {
+        load_gateway_owner_status(runtime_dir.as_path())
+            .map(|status| status.running)
+            .unwrap_or(false)
+    })
+    .await;
+
+    let stop_result = request_gateway_stop(runtime_dir.as_path()).expect("request stop");
+    assert_eq!(stop_result, GatewayStopRequestOutcome::Requested);
+
+    let second_hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+    let second_result = run_gateway_run_with_hooks_for_test(
+        None,
+        None,
+        Vec::new(),
+        runtime_dir.as_path(),
+        second_hooks,
+    )
+    .await
+    .expect_err("second gateway owner should be rejected");
+    assert!(
+        second_result.contains("gateway owner already active"),
+        "unexpected duplicate-owner error: {second_result}"
+    );
+
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("first gateway run should still stop")
+        .expect("join gateway run")
+        .expect("first gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn gateway_owner_state_multi_channel_compat_records_wrapper_mode_and_session() {
     let runtime_dir = unique_runtime_dir("compat-wrapper");
     let telegram_runner = idle_background_channel_runner();

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -86,6 +86,7 @@ mod chat_cli;
 mod cli_tests;
 mod doctor_feishu;
 mod feishu_cli;
+mod gateway_owner_state;
 mod gateway_read_models;
 mod import_cli;
 mod memory_context_benchmark_cli;

--- a/crates/daemon/tests/integration/multi_channel_serve_cli.rs
+++ b/crates/daemon/tests/integration/multi_channel_serve_cli.rs
@@ -20,6 +20,7 @@ use loongclaw_daemon::supervisor::{
 use tokio::{sync::Notify, time::sleep};
 
 type BoxedCliFuture = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'static>>;
+type BoxedShutdownFuture = Pin<Box<dyn Future<Output = CliResult<String>> + Send + 'static>>;
 type TestBackgroundChannelRunner =
     Arc<dyn Fn(BackgroundChannelRunnerRequest) -> BoxedCliFuture + Send + Sync + 'static>;
 const MULTI_CHANNEL_TEST_TIMEOUT: Duration = Duration::from_secs(2);
@@ -46,10 +47,16 @@ fn boxed_cli_result(f: impl Future<Output = CliResult<()>> + Send + 'static) -> 
     Box::pin(f)
 }
 
-fn pending_shutdown_future() -> BoxedCliFuture {
+fn boxed_shutdown_result(
+    f: impl Future<Output = CliResult<String>> + Send + 'static,
+) -> BoxedShutdownFuture {
+    Box::pin(f)
+}
+
+fn pending_shutdown_future() -> BoxedShutdownFuture {
     Box::pin(async move {
         std::future::pending::<()>().await;
-        Ok(())
+        Ok(String::new())
     })
 }
 
@@ -106,7 +113,7 @@ fn hooks(
     run_cli_host: impl Fn(mvp::chat::ConcurrentCliHostOptions) -> BoxedCliFuture + Send + Sync + 'static,
     run_telegram: impl Fn(BackgroundChannelRunnerRequest) -> BoxedCliFuture + Send + Sync + 'static,
     run_feishu: impl Fn(BackgroundChannelRunnerRequest) -> BoxedCliFuture + Send + Sync + 'static,
-    wait_for_shutdown: impl Fn() -> BoxedCliFuture + Send + Sync + 'static,
+    wait_for_shutdown: impl Fn() -> BoxedShutdownFuture + Send + Sync + 'static,
 ) -> SupervisorRuntimeHooks {
     let telegram_runner = Arc::new(run_telegram);
     let feishu_runner = Arc::new(run_feishu);
@@ -134,6 +141,7 @@ fn hooks(
         run_cli_host: Arc::new(run_cli_host),
         background_channel_runners,
         wait_for_shutdown: Arc::new(wait_for_shutdown),
+        observe_state: Arc::new(|_| Ok(())),
     }
 }
 
@@ -333,6 +341,7 @@ async fn multi_channel_serve_starts_all_enabled_runtime_backed_service_channels(
             },
             background_channel_runners,
             wait_for_shutdown: Arc::new(pending_shutdown_future),
+            observe_state: Arc::new(|_| Ok(())),
         },
     )
     .await
@@ -1065,6 +1074,7 @@ async fn multi_channel_serve_initializes_runtime_environment_before_spawning_chi
             }),
             background_channel_runners,
             wait_for_shutdown: Arc::new(pending_shutdown_future),
+            observe_state: Arc::new(|_| Ok(())),
         },
     )
     .await
@@ -1137,10 +1147,10 @@ async fn multi_channel_serve_ctrl_c_waits_for_background_joins_and_reports_shutd
                         move || {
                             let ctrl_c = ctrl_c.clone();
                             let log = log.clone();
-                            boxed_cli_result(async move {
+                            boxed_shutdown_result(async move {
                                 ctrl_c.notified().await;
                                 log.push("ctrl-c");
-                                Ok(())
+                                Ok("ctrl-c received".to_owned())
                             })
                         },
                     ),
@@ -1231,9 +1241,9 @@ async fn multi_channel_serve_cooperative_stop_clears_channel_runtime_running_sta
                     },
                     move || {
                         let ctrl_c = ctrl_c.clone();
-                        boxed_cli_result(async move {
+                        boxed_shutdown_result(async move {
                             ctrl_c.notified().await;
-                            Ok(())
+                            Ok("ctrl-c received".to_owned())
                         })
                     },
                 ),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -334,9 +334,10 @@ Remaining deliverables:
   - current product mode stays same-origin and localhost-only by default, but
     that operating boundary is not the long-term architecture endpoint
 - gateway service foundation:
-  - promote today's attached runtime owner (`multi-channel-serve`) into an
-    explicit daemon-owned gateway service rather than leaving service ownership
-    fragmented across `chat`, `*-serve`, Web UI, and future paired clients
+  - land the first explicit daemon-owned gateway owner contract through
+    `gateway run`, `gateway status`, and `gateway stop`, while keeping
+    `multi-channel-serve` as the attached compatibility wrapper instead of the
+    long-term runtime-owner noun
   - extract channel, ACP, and runtime-snapshot payload builders into shared
     service read models that can feed CLI, dashboard, Web UI, and future
     paired/browser/mobile clients

--- a/docs/product-specs/channel-setup.md
+++ b/docs/product-specs/channel-setup.md
@@ -20,9 +20,10 @@ needs.
       WebChat.
 - [ ] Channel setup guidance describes required credentials, config toggles, and
       the command used to run each shipped channel today.
-- [ ] Product docs describe `multi-channel-serve` as the current attached
-      runtime owner for shipped runtime-backed surfaces and as the precursor to
-      a broader gateway service layer rather than the long-term product noun.
+- [ ] Product docs describe `gateway run/status/stop` as the current explicit
+      gateway owner contract and `multi-channel-serve` as the attached
+      compatibility wrapper for shipped runtime-backed surfaces rather than the
+      long-term product noun.
 - [ ] WeCom setup guidance documents the official AIBot long-connection flow and
       never presents webhook callback mode as a supported LoongClaw integration path.
 - [ ] Channel setup never implies a channel is ready until its required
@@ -78,8 +79,12 @@ do not overclaim runtime support:
   status, and direct sends without pretending they also own a long-running
   serve runtime
 - runtime-backed service channels are a strict shipped subset of the catalog
-- `multi-channel-serve` is the current attached runtime-owner precursor and
-  only supervises enabled runtime-backed channels while using repeatable
+- `gateway run` is the current explicit runtime-owner contract and can run
+  headless or with an attached CLI session
+- `gateway status` and `gateway stop` provide the first cross-process owner
+  inspection and cooperative shutdown surfaces
+- `multi-channel-serve` is the attached compatibility wrapper and only
+  supervises enabled runtime-backed channels while using repeatable
   `--channel-account <channel=account>` selectors instead of channel-specific
   flags
 - the longer-term direction is an explicit gateway service that will own
@@ -243,11 +248,19 @@ iMessage is shipped through a BlueBubbles bridge send surface:
 
 ### Multi-Channel Serve And Gateway Direction
 
-`multi-channel-serve` is the current attached runtime owner for the shipped
-service-channel subset. It is also the first precursor to the planned explicit
-gateway service rather than the long-term product noun:
+`gateway run/status/stop` is the current explicit owner contract for the
+shipped runtime-backed service-channel subset. `multi-channel-serve` remains
+the attached compatibility wrapper rather than the long-term product noun:
 
-- it keeps the concurrent CLI host in the foreground
+- `gateway run` can claim the persisted owner slot headless or attach a CLI
+  host when `--session` is provided
+- `gateway status` can inspect the persisted owner snapshot from another CLI
+  process
+- `gateway stop` can request cooperative shutdown from another CLI process
+- `multi-channel-serve` uses the same gateway owner contract while preserving
+  the attached CLI-first workflow for operators who want one foreground session
+
+- `multi-channel-serve` keeps the concurrent CLI host in the foreground
 - it supervises every enabled runtime-backed surface from the loaded config
 - it accepts repeatable `--channel-account <channel=account>` selectors to pin
   specific accounts such as `telegram=bot_123456`, `lark=alerts`, `matrix=bridge-sync`,


### PR DESCRIPTION
## Summary

- Problem:
  The repo had gateway read models, but the runtime still lacked an explicit owner lifecycle. Long-running service ownership was still anchored to `multi-channel-serve`, with no persisted owner slot, no cross-process status surface, and no cooperative stop contract.
- Why it matters:
  The next gateway work depends on one runtime owner contract that survives beyond a single foreground CLI loop and can be inspected or stopped from another process. Without that contract, remote/browser/mobile pairing, richer channel runtimes, status surfaces, and CLI/service lifecycle decoupling all stay blocked behind ad hoc process ownership.
- What changed:
  Added `gateway run`, `gateway status`, and `gateway stop`; introduced persisted gateway owner state plus stop-request files; refactored supervisor lifecycle hooks so gateway and `multi-channel-serve` share the same runtime core; fixed shutdown reason propagation so headless gateway mode and cross-process stop requests exit cleanly and report the correct reason; added regression coverage and docs for the new owner contract.
- What did not change (scope boundary):
  This slice does not add route mounting, external API/auth, hosted multi-tenant behavior, browser/mobile pairing UX, or a full dashboard/log viewer. `multi-channel-serve` remains as the attached compatibility wrapper, and the current product boundary stays local-first and localhost-only.

## Linked Issues

- Closes #644
- Related #640
- Related #217
- Related #293
- Related #296
- Related #642

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes long-running runtime ownership semantics, shutdown propagation, and the public daemon CLI surface for gateway control.
- Rollout / guardrails:
  The new gateway contract is additive, `multi-channel-serve` stays available as a compatibility wrapper, and coverage now exercises headless, attached, duplicate-owner, and cooperative-stop paths.
- Rollback path:
  Revert `d3a8983` to remove the gateway owner-state slice and fall back to the pre-existing `multi-channel-serve`-only ownership path.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all --check
  PASS

cargo clippy -p loongclaw-daemon --all-targets --all-features -- -D warnings
  PASS

cargo test -p loongclaw-daemon --locked
  PASS

cargo test -p loongclaw-daemon --all-features --locked
  PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS

cargo test --workspace --locked
  PASS

cargo test --workspace --all-features --locked
  PASS

LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
  FAIL due to pre-existing release-doc governance gaps unrelated to this slice:
  - missing .docs/releases/v0.1.0-alpha.2-debug.md
  - missing .docs/releases/v0.1.0-alpha.1-debug.md
  - missing .docs/traces/index.jsonl
  - missing .docs/traces/latest
  - missing .docs/traces/by-tag/v0.1.0-alpha.2/latest
  - missing .docs/traces/20260319T084550Z-post-release-v0.1.0-alpha.2-c9e52bb4/metadata.json
  - missing .docs/traces/by-tag/v0.1.0-alpha.1/latest
  - missing .docs/traces/20260318T080731Z-post-release-v0.1.0-alpha.1-f3a5a6f1/metadata.json
```

## User-visible / Operator-visible Changes

- Operators can now run `loongclaw gateway run`, inspect the active owner with `loongclaw gateway status`, and request cooperative shutdown with `loongclaw gateway stop`.
- `loongclaw multi-channel-serve` now rides on the same gateway owner contract instead of maintaining a separate lifecycle path.

## Failure Recovery

- Fast rollback or disable path:
  Revert `d3a8983`, or continue using `multi-channel-serve` while backing out the new gateway commands.
- Observable failure symptoms reviewers should watch for:
  Incorrect shutdown reason text, stale owner slot files that are not reclaimed, or headless gateway runs that never transition from `starting` to `running`/`stopped`.

## Reviewer Focus

- Review [`crates/daemon/src/gateway/service.rs`](crates/daemon/src/gateway/service.rs) and [`crates/daemon/src/gateway/state.rs`](crates/daemon/src/gateway/state.rs) for owner-slot persistence, stop-request semantics, and stale-owner reclamation.
- Review [`crates/daemon/src/supervisor.rs`](crates/daemon/src/supervisor.rs) for the generalized supervisor hooks, attached-vs-headless execution, and shutdown reason propagation.
- Review the new integration coverage in [`crates/daemon/tests/integration/gateway_owner_state.rs`](crates/daemon/tests/integration/gateway_owner_state.rs) for the core lifecycle scenarios this slice is locking down.
