### PR TITLE
fix: render feishu serve replies as markdown cards when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,8 @@ loongclaw feishu-serve --config ~/.loongclaw/config.toml
 
 Webhook secrets are not required in websocket mode. If you are targeting Lark instead of Feishu, add `domain = "lark"`.
 
+Assistant replies sent through `loongclaw feishu-serve` use Feishu markdown cards when the reply fits the platform card payload limit, so Markdown renders natively in chat; oversized replies automatically fall back to plain text.
+
 Matrix channel example:
 
 ```bash

--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -10,6 +10,8 @@ use crate::feishu::FeishuClient;
 use crate::feishu::resources::messages::{self, FeishuOutboundMessageBody};
 use crate::feishu::{FeishuOperatorOutboundMessageInput, resolve_operator_outbound_message_body};
 
+const FEISHU_CARD_MESSAGE_CONTENT_LIMIT_BYTES: usize = 30 * 1024;
+
 pub(super) struct FeishuAdapter {
     client: FeishuClient,
     receive_id_type: String,
@@ -189,6 +191,30 @@ fn channel_outbound_message_from_body(body: FeishuOutboundMessageBody) -> Channe
         FeishuOutboundMessageBody::Image(image_key) => ChannelOutboundMessage::Image { image_key },
         FeishuOutboundMessageBody::File(file_key) => ChannelOutboundMessage::File { file_key },
     }
+}
+
+pub(super) fn outbound_reply_message_from_text(text: String) -> ChannelOutboundMessage {
+    let trimmed_text = text.trim();
+    if trimmed_text.is_empty() {
+        return ChannelOutboundMessage::Text(text);
+    }
+
+    let reply_fits_markdown_card = reply_text_fits_markdown_card(trimmed_text);
+    if reply_fits_markdown_card {
+        return ChannelOutboundMessage::MarkdownCard(text);
+    }
+
+    ChannelOutboundMessage::Text(text)
+}
+
+fn reply_text_fits_markdown_card(text: &str) -> bool {
+    let card = crate::feishu::resources::cards::build_markdown_card(text);
+    let encoded_card = match serde_json::to_string(&card) {
+        Ok(encoded_card) => encoded_card,
+        Err(_) => return false,
+    };
+    let encoded_card_len = encoded_card.len();
+    encoded_card_len <= FEISHU_CARD_MESSAGE_CONTENT_LIMIT_BYTES
 }
 
 #[async_trait]
@@ -614,5 +640,23 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    #[test]
+    fn outbound_reply_message_from_text_prefers_markdown_cards_within_limit() {
+        let reply_message = outbound_reply_message_from_text("## done\n\n- rendered".to_owned());
+
+        assert_eq!(
+            reply_message,
+            ChannelOutboundMessage::MarkdownCard("## done\n\n- rendered".to_owned())
+        );
+    }
+
+    #[test]
+    fn outbound_reply_message_from_text_falls_back_to_text_past_card_limit() {
+        let oversized_reply = "a".repeat(FEISHU_CARD_MESSAGE_CONTENT_LIMIT_BYTES);
+        let reply_message = outbound_reply_message_from_text(oversized_reply.clone());
+
+        assert_eq!(reply_message, ChannelOutboundMessage::Text(oversized_reply));
     }
 }

--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -201,7 +201,8 @@ pub(super) fn outbound_reply_message_from_text(text: String) -> ChannelOutboundM
 
     let reply_fits_markdown_card = reply_text_fits_markdown_card(trimmed_text);
     if reply_fits_markdown_card {
-        return ChannelOutboundMessage::MarkdownCard(text);
+        let markdown_card_text = trimmed_text.to_owned();
+        return ChannelOutboundMessage::MarkdownCard(markdown_card_text);
     }
 
     ChannelOutboundMessage::Text(text)
@@ -653,10 +654,40 @@ mod tests {
     }
 
     #[test]
-    fn outbound_reply_message_from_text_falls_back_to_text_past_card_limit() {
-        let oversized_reply = "a".repeat(FEISHU_CARD_MESSAGE_CONTENT_LIMIT_BYTES);
-        let reply_message = outbound_reply_message_from_text(oversized_reply.clone());
+    fn outbound_reply_message_from_text_trims_markdown_cards_before_returning() {
+        let reply_message =
+            outbound_reply_message_from_text("  ## done\n\n- rendered  ".to_owned());
 
-        assert_eq!(reply_message, ChannelOutboundMessage::Text(oversized_reply));
+        assert_eq!(
+            reply_message,
+            ChannelOutboundMessage::MarkdownCard("## done\n\n- rendered".to_owned())
+        );
+    }
+
+    #[test]
+    fn outbound_reply_message_from_text_respects_card_limit_boundary() {
+        let fitting_reply_len = max_reply_text_len_for_markdown_card();
+        let fitting_reply = "a".repeat(fitting_reply_len);
+        let overflowing_reply = format!("{fitting_reply}a");
+        let fitting_message = outbound_reply_message_from_text(fitting_reply.clone());
+        let overflowing_message = outbound_reply_message_from_text(overflowing_reply.clone());
+
+        assert_eq!(
+            fitting_message,
+            ChannelOutboundMessage::MarkdownCard(fitting_reply)
+        );
+        assert_eq!(
+            overflowing_message,
+            ChannelOutboundMessage::Text(overflowing_reply)
+        );
+    }
+
+    fn max_reply_text_len_for_markdown_card() -> usize {
+        let empty_card = crate::feishu::resources::cards::build_markdown_card("");
+        let encoded_empty_card =
+            serde_json::to_string(&empty_card).expect("encode empty markdown card");
+        let empty_card_len = encoded_empty_card.len();
+
+        FEISHU_CARD_MESSAGE_CONTENT_LIMIT_BYTES.saturating_sub(empty_card_len)
     }
 }

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -23,15 +23,14 @@ use tokio::sync::Mutex;
 use crate::CliResult;
 use crate::KernelContext;
 use crate::channel::{
-    ChannelAdapter, ChannelInboundMessage, ChannelOutboundMessage, ChannelOutboundTarget,
-    ChannelTurnFeedbackPolicy, process_inbound_with_provider,
-    runtime_state::ChannelOperationRuntimeTracker,
+    ChannelAdapter, ChannelInboundMessage, ChannelOutboundTarget, ChannelTurnFeedbackPolicy,
+    process_inbound_with_provider, runtime_state::ChannelOperationRuntimeTracker,
 };
 use crate::config::{LoongClawConfig, ResolvedFeishuChannelConfig};
 use crate::crypto::timing_safe_eq;
 use crate::feishu::{FeishuClient, resources::cards};
 
-use super::adapter::FeishuAdapter;
+use super::adapter::{FeishuAdapter, outbound_reply_message_from_text};
 use super::payload::{FeishuCardCallbackEvent, FeishuWebhookAction};
 
 const FEISHU_CALLBACK_RESPONSE_MARKER: &str = "[feishu_callback_response]";
@@ -615,7 +614,7 @@ async fn handle_feishu_inbound_event(
             )
         })?;
         let reply_target = channel_message.reply_target.clone();
-        let outbound = ChannelOutboundMessage::Text(reply);
+        let outbound = outbound_reply_message_from_text(reply);
 
         let mut adapter = state.adapter.lock().await;
         if let Err(first_error) = adapter.send_message(&reply_target, &outbound).await {
@@ -906,6 +905,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::sync::Mutex;
 
+    const MOCK_PROVIDER_MARKDOWN_REPLY: &str = "## structured inbound ack\n\n- rendered";
+
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct MockRequest {
         path: String,
@@ -1038,7 +1039,7 @@ mod tests {
                         Json(json!({
                             "choices": [{
                                 "message": {
-                                    "content": "structured inbound ack"
+                                    "content": MOCK_PROVIDER_MARKDOWN_REPLY
                                 }
                             }]
                         }))
@@ -1120,7 +1121,7 @@ mod tests {
                         Json(json!({
                             "choices": [{
                                 "message": {
-                                    "content": "structured inbound ack"
+                                    "content": MOCK_PROVIDER_MARKDOWN_REPLY
                                 }
                             }]
                         }))
@@ -1702,14 +1703,22 @@ mod tests {
             Some("Bearer t-token-webhook")
         );
         assert!(
-            feishu_requests[1].body.contains("\"msg_type\":\"text\""),
-            "webhook reply should still go out as text"
+            feishu_requests[1]
+                .body
+                .contains("\"msg_type\":\"interactive\""),
+            "webhook reply should send markdown-capable interactive cards"
         );
         assert!(
             feishu_requests[1]
                 .body
-                .contains("\\\"text\\\":\\\"structured inbound ack\\\""),
-            "reply body should include provider text"
+                .contains("\\\"tag\\\":\\\"markdown\\\""),
+            "reply body should wrap the provider reply in a markdown card"
+        );
+        assert!(
+            feishu_requests[1]
+                .body
+                .contains("\\\"content\\\":\\\"## structured inbound ack\\\\n\\\\n- rendered\\\""),
+            "reply body should preserve provider markdown content"
         );
 
         provider_server.abort();

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -458,6 +458,8 @@ mod tests {
 
     use super::*;
     use crate::channel::ChannelPlatform;
+
+    const MOCK_PROVIDER_MARKDOWN_REPLY: &str = "## structured inbound ack\n\n- rendered";
     use crate::config::{FeishuChannelServeMode, LoongClawConfig, ProviderConfig};
     use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_test_kernel_context};
 
@@ -527,7 +529,7 @@ mod tests {
                         Json(json!({
                             "choices": [{
                                 "message": {
-                                    "content": "structured inbound ack"
+                                    "content": MOCK_PROVIDER_MARKDOWN_REPLY
                                 }
                             }]
                         }))
@@ -1053,8 +1055,20 @@ mod tests {
         assert!(
             feishu_requests[1]
                 .body
-                .contains("\\\"text\\\":\\\"structured inbound ack\\\""),
-            "websocket flow should still send the provider reply back through Feishu"
+                .contains("\"msg_type\":\"interactive\""),
+            "websocket flow should send markdown-capable interactive cards"
+        );
+        assert!(
+            feishu_requests[1]
+                .body
+                .contains("\\\"tag\\\":\\\"markdown\\\""),
+            "websocket flow should wrap the provider reply in a markdown card"
+        );
+        assert!(
+            feishu_requests[1]
+                .body
+                .contains("\\\"content\\\":\\\"## structured inbound ack\\\\n\\\\n- rendered\\\""),
+            "websocket flow should preserve provider markdown content"
         );
 
         provider_server.abort();


### PR DESCRIPTION
## Summary

- Problem: `feishu-serve` always downgraded provider replies to Feishu `text` messages, so markdown syntax was delivered literally instead of rendering in chat.
- Why it matters: Feishu reply APIs support interactive markdown cards, but inbound assistant replies were losing headings, lists, and other markdown structure at the final outbound step.
- What changed: added a Feishu-only reply wrapper that promotes inbound assistant replies to markdown cards when the encoded card payload fits Feishu's card size limit, with a plain-text fallback for oversized replies. added webhook/websocket regressions, a card-size boundary test, and a short README note.
- What did not change (scope boundary): explicit `feishu-send` message type selection, callback update flows, and non-Feishu channels.

## Linked Issues

- Closes #643
- Related #643

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-app --lib feishu_webhook_file_event_reaches_provider_as_structured_text_and_replies
- failed before the fix after tightening the regression to require interactive markdown replies

cargo fmt --all -- --check
- passed

cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
- passed

cargo test -p loongclaw-app --lib channel::feishu -- --test-threads=1
- passed (70 tests)
```

## User-visible / Operator-visible Changes

- `loongclaw feishu-serve` now sends inbound assistant replies as Feishu markdown cards when the payload fits the platform card size limit, so markdown renders in chat.
- oversized inbound replies automatically fall back to plain text instead of failing against the smaller card payload limit.

## Failure Recovery

- Fast rollback or disable path: revert commit `56f89e8`, or temporarily force Feishu inbound replies back to plain `text` by bypassing the new reply wrapper.
- Observable failure symptoms reviewers should watch for: unexpected card-style delivery for short plain-text replies, or Feishu card rejection on near-limit replies.

## Reviewer Focus

- check `crates/app/src/channel/feishu/adapter.rs` for the card-size boundary logic and the intentional plain-text fallback.
- check `crates/app/src/channel/feishu/webhook.rs` and `crates/app/src/channel/feishu/websocket.rs` for the shared inbound reply path and the updated regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feishu replies now use interactive markdown cards when the assistant reply fits size limits; oversized replies fall back to plain text.
* **Behavior Changes**
  * Trims outgoing reply text before deciding card vs. plain text and preserves provider markdown formatting when sent as a card.
* **Documentation**
  * Added note explaining Feishu rendering behavior.
* **Tests**
  * Updated tests to validate markdown-card rendering and boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->