### PR TITLE
feat: add gateway localhost control surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,9 +484,18 @@ The current gateway slice now includes:
 - `loongclaw gateway run` for the owner lifecycle
 - `loongclaw gateway status` for cross-process owner inspection
 - `loongclaw gateway stop` for cooperative shutdown
+- a localhost-only authenticated control surface that publishes status,
+  channel inventory, runtime snapshot, and cooperative stop endpoints from the
+  same `gateway run` owner
 
 `gateway run` starts headless by default. Pass `--session` when you want the
 concurrent CLI host attached to the same runtime owner.
+
+When `gateway run` is active, it also binds a loopback-only control endpoint on
+an ephemeral localhost port and writes the actual `bind_address`, `port`, and
+`token_path` into `loongclaw gateway status --json`. Local clients such as the
+future Web UI can discover the running owner through that persisted state
+without introducing a second service lifecycle.
 
 ```bash
 loongclaw gateway run --config ~/.loongclaw/config.toml

--- a/README.md
+++ b/README.md
@@ -338,10 +338,11 @@ instability from true upstream unavailability.
    - dashboard
    - onboarding
 
-   The initial product mode stays same-origin and local by default.
+   The initial product mode stays same-origin and localhost-bound by default.
 
-   That local-first boundary is the current operating slice, not the long-term
-   architecture endpoint.
+   That default bind policy is a security boundary for the current operating
+   slice, not a statement that future gateway/service expansion is out of
+   scope or the long-term architecture endpoint.
 
    The long-term direction is to keep Web UI attached to the same daemon-owned
    gateway/service runtime rather than creating a second assistant runtime.

--- a/README.md
+++ b/README.md
@@ -485,8 +485,8 @@ The current gateway slice now includes:
 - `loongclaw gateway status` for cross-process owner inspection
 - `loongclaw gateway stop` for cooperative shutdown
 - a localhost-only authenticated control surface that publishes status,
-  channel inventory, runtime snapshot, and cooperative stop endpoints from the
-  same `gateway run` owner
+  channel inventory, runtime snapshot, operator summary, and cooperative stop
+  endpoints from the same `gateway run` owner
 
 `gateway run` starts headless by default. Pass `--session` when you want the
 concurrent CLI host attached to the same runtime owner.
@@ -496,6 +496,11 @@ an ephemeral localhost port and writes the actual `bind_address`, `port`, and
 `token_path` into `loongclaw gateway status --json`. Local clients such as the
 future Web UI can discover the running owner through that persisted state
 without introducing a second service lifecycle.
+
+The daemon now also carries a reusable localhost gateway client/discovery layer
+that centralizes loopback validation, bearer-token loading, and route helpers
+for `status`, `channels`, `runtime-snapshot`, `operator-summary`, and `stop`.
+That keeps dashboard and Web UI bootstrap logic out of ad-hoc file reads.
 
 ```bash
 loongclaw gateway run --config ~/.loongclaw/config.toml

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -49,6 +49,7 @@ libc = "0.2"
 
 
 [dependencies]
+axum.workspace = true
 clap.workspace = true
 clap_complete = "4.5"
 dialoguer.workspace = true
@@ -76,7 +77,6 @@ name = "loongclaw"
 path = "src/main.rs"
 
 [dev-dependencies]
-axum.workspace = true
 loongclaw-spec = { path = "../spec", features = ["test-hooks"] }
 sha2.workspace = true
 wat = "1"

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -1,0 +1,380 @@
+use std::{
+    fs,
+    net::{IpAddr, SocketAddr},
+    path::{Path, PathBuf},
+};
+
+use reqwest::{Client, Method, Response};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::Value;
+
+use crate::CliResult;
+
+use super::{
+    read_models::GatewayOperatorSummaryReadModel,
+    state::{GatewayOwnerStatus, default_gateway_runtime_state_dir, load_gateway_owner_status},
+};
+
+#[derive(Debug, Clone)]
+pub struct GatewayLocalDiscovery {
+    runtime_dir: PathBuf,
+    owner_status: GatewayOwnerStatus,
+    socket_address: SocketAddr,
+    base_url: String,
+    bearer_token: String,
+}
+
+impl GatewayLocalDiscovery {
+    pub fn discover_default() -> CliResult<Self> {
+        let runtime_dir = default_gateway_runtime_state_dir();
+        Self::discover(runtime_dir.as_path())
+    }
+
+    pub fn discover(runtime_dir: &Path) -> CliResult<Self> {
+        let owner_status = load_gateway_owner_status(runtime_dir);
+        let Some(owner_status) = owner_status else {
+            let runtime_dir_text = runtime_dir.display().to_string();
+            let error = format!("gateway owner status is unavailable in {runtime_dir_text}");
+            return Err(error);
+        };
+
+        let socket_address = validate_gateway_local_owner_status(&owner_status)?;
+        let token_path = gateway_token_path_from_status(&owner_status)?;
+        let bearer_token = load_gateway_bearer_token(token_path.as_path())?;
+        let base_url = format!("http://{socket_address}");
+        let runtime_dir = runtime_dir.to_path_buf();
+
+        Ok(Self {
+            runtime_dir,
+            owner_status,
+            socket_address,
+            base_url,
+            bearer_token,
+        })
+    }
+
+    pub fn runtime_dir(&self) -> &Path {
+        self.runtime_dir.as_path()
+    }
+
+    pub fn owner_status(&self) -> &GatewayOwnerStatus {
+        &self.owner_status
+    }
+
+    pub fn socket_address(&self) -> SocketAddr {
+        self.socket_address
+    }
+
+    pub fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+
+    fn bearer_token(&self) -> &str {
+        self.bearer_token.as_str()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GatewayLocalClient {
+    discovery: GatewayLocalDiscovery,
+    http_client: Client,
+}
+
+impl GatewayLocalClient {
+    pub fn discover_default() -> CliResult<Self> {
+        let discovery = GatewayLocalDiscovery::discover_default()?;
+        Ok(Self::from_discovery(discovery))
+    }
+
+    pub fn discover(runtime_dir: &Path) -> CliResult<Self> {
+        let discovery = GatewayLocalDiscovery::discover(runtime_dir)?;
+        Ok(Self::from_discovery(discovery))
+    }
+
+    pub fn from_discovery(discovery: GatewayLocalDiscovery) -> Self {
+        let http_client = Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_else(|_| Client::new());
+
+        Self {
+            discovery,
+            http_client,
+        }
+    }
+
+    pub fn discovery(&self) -> &GatewayLocalDiscovery {
+        &self.discovery
+    }
+
+    pub async fn status(&self) -> CliResult<GatewayOwnerStatus> {
+        let path = "/api/gateway/status";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn channels(&self) -> CliResult<Value> {
+        let path = "/api/gateway/channels";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn runtime_snapshot(&self) -> CliResult<Value> {
+        let path = "/api/gateway/runtime-snapshot";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn operator_summary(&self) -> CliResult<GatewayOperatorSummaryReadModel> {
+        let path = "/api/gateway/operator-summary";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn stop(&self) -> CliResult<GatewayStopResponse> {
+        let path = "/api/gateway/stop";
+        self.request_json(Method::POST, path).await
+    }
+
+    async fn request_json<T>(&self, method: Method, path: &str) -> CliResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let endpoint = self.endpoint_url(path)?;
+        let method_name = method.as_str().to_owned();
+        let request_builder = self.http_client.request(method, endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let response = request_builder
+            .send()
+            .await
+            .map_err(|error| format!("send gateway request failed for {endpoint}: {error}"))?;
+        let status = response.status();
+
+        if !status.is_success() {
+            let error_message = decode_gateway_error_message(response).await;
+            let error = format!(
+                "gateway {method_name} {path} failed with status {status}: {error_message}"
+            );
+            return Err(error);
+        }
+
+        response
+            .json::<T>()
+            .await
+            .map_err(|error| format!("decode gateway response failed for {endpoint}: {error}"))
+    }
+
+    fn endpoint_url(&self, path: &str) -> CliResult<String> {
+        if !path.starts_with('/') {
+            let error = format!("gateway client path must start with `/`: {path}");
+            return Err(error);
+        }
+
+        let base_url = self.discovery.base_url();
+        let endpoint = format!("{base_url}{path}");
+        Ok(endpoint)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayStopResponseOutcome {
+    Requested,
+    AlreadyRequested,
+    AlreadyStopped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayStopResponse {
+    pub outcome: GatewayStopResponseOutcome,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatewayErrorEnvelope {
+    error: GatewayErrorBody,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatewayErrorBody {
+    code: String,
+    message: String,
+}
+
+fn validate_gateway_local_owner_status(status: &GatewayOwnerStatus) -> CliResult<SocketAddr> {
+    if status.stale {
+        return Err("gateway owner status is stale".to_owned());
+    }
+    if !status.running {
+        return Err("gateway owner is not running".to_owned());
+    }
+
+    let bind_address = status
+        .bind_address
+        .as_deref()
+        .ok_or_else(|| "gateway owner status is missing bind_address".to_owned())?;
+    let port = status
+        .port
+        .ok_or_else(|| "gateway owner status is missing port".to_owned())?;
+    let ip_address = bind_address.parse::<IpAddr>().map_err(|error| {
+        format!("gateway owner bind_address is not a valid IP address: {error}")
+    })?;
+
+    if !ip_address.is_loopback() {
+        let error = format!("gateway control surface must use loopback bind, found {bind_address}");
+        return Err(error);
+    }
+
+    let socket_address = SocketAddr::new(ip_address, port);
+    Ok(socket_address)
+}
+
+fn gateway_token_path_from_status(status: &GatewayOwnerStatus) -> CliResult<PathBuf> {
+    let token_path = status
+        .token_path
+        .as_deref()
+        .ok_or_else(|| "gateway owner status is missing token_path".to_owned())?;
+    let token_path = PathBuf::from(token_path);
+    Ok(token_path)
+}
+
+fn load_gateway_bearer_token(path: &Path) -> CliResult<String> {
+    let token = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read gateway control token failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    let token = token.trim().to_owned();
+
+    if token.is_empty() {
+        let error = format!("gateway control token is empty at {}", path.display());
+        return Err(error);
+    }
+
+    Ok(token)
+}
+
+async fn decode_gateway_error_message(response: Response) -> String {
+    let response_text = response.text().await;
+    let response_text = match response_text {
+        Ok(response_text) => response_text,
+        Err(error) => {
+            return format!("unable to read gateway error response: {error}");
+        }
+    };
+
+    let parsed_error = serde_json::from_str::<GatewayErrorEnvelope>(response_text.as_str());
+    if let Ok(parsed_error) = parsed_error {
+        let code = parsed_error.error.code;
+        let message = parsed_error.error.message;
+        return format!("{code}: {message}");
+    }
+
+    let trimmed = response_text.trim();
+    if trimmed.is_empty() {
+        return "request failed without an error body".to_owned();
+    }
+
+    trimmed.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+
+    fn gateway_owner_status_fixture() -> GatewayOwnerStatus {
+        GatewayOwnerStatus {
+            runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
+            phase: "running".to_owned(),
+            running: true,
+            stale: false,
+            pid: Some(42),
+            mode: super::super::state::GatewayOwnerMode::GatewayHeadless,
+            version: "0.1.0".to_owned(),
+            config_path: "/tmp/loongclaw.toml".to_owned(),
+            attached_cli_session: None,
+            started_at_ms: 100,
+            last_heartbeat_at: 200,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count: 1,
+            running_surface_count: 1,
+            bind_address: Some("127.0.0.1".to_owned()),
+            port: Some(7777),
+            token_path: Some("/tmp/loongclaw-gateway-runtime/control-token".to_owned()),
+        }
+    }
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let temp_dir = std::env::temp_dir();
+        temp_dir.join(format!("loongclaw-gateway-client-{label}-{suffix}"))
+    }
+
+    #[test]
+    fn gateway_local_discovery_accepts_loopback_owner_status() {
+        let status = gateway_owner_status_fixture();
+
+        let socket_address =
+            validate_gateway_local_owner_status(&status).expect("validate loopback owner status");
+
+        assert_eq!(socket_address.to_string(), "127.0.0.1:7777");
+    }
+
+    #[test]
+    fn gateway_local_discovery_rejects_stale_owner_status() {
+        let mut status = gateway_owner_status_fixture();
+        status.stale = true;
+        status.running = false;
+
+        let error = validate_gateway_local_owner_status(&status)
+            .expect_err("stale gateway owner status should be rejected");
+
+        assert!(error.contains("stale"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn gateway_local_discovery_rejects_non_loopback_bind_address() {
+        let mut status = gateway_owner_status_fixture();
+        status.bind_address = Some("192.168.1.10".to_owned());
+
+        let error = validate_gateway_local_owner_status(&status)
+            .expect_err("non-loopback gateway bind should be rejected");
+
+        assert!(error.contains("loopback"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn gateway_local_discovery_loads_trimmed_bearer_token() {
+        let token_path = unique_temp_path("token-trimmed");
+        fs::write(token_path.as_path(), "abc123\n").expect("write token");
+
+        let token =
+            load_gateway_bearer_token(token_path.as_path()).expect("load gateway bearer token");
+
+        assert_eq!(token, "abc123");
+
+        fs::remove_file(token_path).ok();
+    }
+
+    #[test]
+    fn gateway_local_discovery_rejects_empty_bearer_token() {
+        let token_path = unique_temp_path("token-empty");
+        fs::write(token_path.as_path(), "\n").expect("write empty token");
+
+        let error = load_gateway_bearer_token(token_path.as_path())
+            .expect_err("empty gateway token should be rejected");
+
+        assert!(error.contains("empty"), "unexpected error: {error}");
+
+        fs::remove_file(token_path).ok();
+    }
+}

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -1,0 +1,521 @@
+use std::{
+    fs,
+    fs::OpenOptions,
+    io::Write,
+    net::{Ipv4Addr, SocketAddrV4},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::{HeaderMap, StatusCode, header::AUTHORIZATION},
+    routing::{get, post},
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::{
+    net::TcpListener,
+    sync::{oneshot, watch},
+    task::JoinHandle,
+};
+
+use crate::{
+    CliResult, build_channels_cli_json_payload, build_runtime_snapshot_cli_json_payload,
+    collect_runtime_snapshot_cli_state_from_loaded_config, mvp, supervisor::LoadedSupervisorConfig,
+};
+
+use super::state::{
+    GatewayControlSurfaceBinding, GatewayStopRequestOutcome, gateway_control_token_path,
+    load_gateway_owner_status, request_gateway_stop,
+};
+
+const GATEWAY_CONTROL_TOKEN_FILE_MODE: u32 = 0o600;
+const GATEWAY_CONTROL_RUNTIME_DIR_MODE: u32 = 0o700;
+
+type GatewayControlJsonResponse = (StatusCode, Json<Value>);
+
+#[derive(Clone)]
+struct GatewayControlAppState {
+    runtime_dir: PathBuf,
+    bearer_token: String,
+    channels_payload: Arc<Value>,
+    runtime_snapshot_payload: Arc<Value>,
+}
+
+struct GatewayControlSurfaceRuntime {
+    exit_sender: watch::Sender<Option<CliResult<()>>>,
+    shutdown_sender: Mutex<Option<oneshot::Sender<()>>>,
+    join_handle: Mutex<Option<JoinHandle<CliResult<()>>>>,
+}
+
+#[derive(Clone)]
+pub struct GatewayControlSurface {
+    binding: GatewayControlSurfaceBinding,
+    runtime: Arc<GatewayControlSurfaceRuntime>,
+}
+
+impl GatewayControlSurface {
+    pub fn binding(&self) -> &GatewayControlSurfaceBinding {
+        &self.binding
+    }
+
+    pub async fn wait_for_unexpected_exit(&self) -> CliResult<String> {
+        let exit_result = self.wait_for_exit_result().await?;
+        match exit_result {
+            Ok(()) => Err("gateway control surface exited unexpectedly".to_owned()),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub async fn shutdown(&self) -> CliResult<()> {
+        let shutdown_sender = {
+            let sender_guard = self.runtime.shutdown_sender.lock();
+            let mut sender_guard = sender_guard.map_err(|error| {
+                format!("gateway control surface shutdown lock poisoned: {error}")
+            })?;
+            sender_guard.take()
+        };
+        if let Some(shutdown_sender) = shutdown_sender {
+            let _ = shutdown_sender.send(());
+        }
+
+        let join_handle = {
+            let join_guard = self.runtime.join_handle.lock();
+            let mut join_guard = join_guard
+                .map_err(|error| format!("gateway control surface join lock poisoned: {error}"))?;
+            join_guard.take()
+        };
+        let Some(join_handle) = join_handle else {
+            return Ok(());
+        };
+
+        join_handle
+            .await
+            .map_err(|error| format!("gateway control surface task failed to join: {error}"))?
+    }
+
+    async fn wait_for_exit_result(&self) -> CliResult<CliResult<()>> {
+        let mut exit_receiver = self.runtime.exit_sender.subscribe();
+        let initial_result = exit_receiver.borrow().clone();
+        if let Some(initial_result) = initial_result {
+            return Ok(initial_result);
+        }
+
+        exit_receiver
+            .changed()
+            .await
+            .map_err(|error| format!("gateway control surface exit watch failed: {error}"))?;
+
+        let exit_result = exit_receiver.borrow().clone();
+        exit_result
+            .ok_or_else(|| "gateway control surface exited without reporting a result".to_owned())
+    }
+}
+
+pub async fn start_gateway_control_surface(
+    runtime_dir: &Path,
+    loaded_config: &LoadedSupervisorConfig,
+) -> CliResult<GatewayControlSurface> {
+    let channels_payload = build_gateway_channels_payload(loaded_config)?;
+    let runtime_snapshot_payload = build_gateway_runtime_snapshot_payload(loaded_config)?;
+    let bearer_token = new_gateway_control_bearer_token();
+    let token_path = gateway_control_token_path(runtime_dir);
+
+    write_gateway_control_token_file(token_path.as_path(), bearer_token.as_str())?;
+
+    let listener_address = gateway_control_listener_address();
+    let listener_result = TcpListener::bind(listener_address).await;
+    let listener = match listener_result {
+        Ok(listener) => listener,
+        Err(error) => {
+            let bind_error = format!("bind gateway control surface failed: {error}");
+            let cleanup_result = remove_gateway_control_token_file(token_path.as_path());
+            let final_error = merge_gateway_control_errors(bind_error, cleanup_result.err());
+            return Err(final_error);
+        }
+    };
+
+    let local_address_result = listener.local_addr();
+    let local_address = match local_address_result {
+        Ok(local_address) => local_address,
+        Err(error) => {
+            let address_error =
+                format!("read gateway control surface local address failed: {error}");
+            let cleanup_result = remove_gateway_control_token_file(token_path.as_path());
+            let final_error = merge_gateway_control_errors(address_error, cleanup_result.err());
+            return Err(final_error);
+        }
+    };
+
+    let bind_address = local_address.ip().to_string();
+    let port = local_address.port();
+    let binding = GatewayControlSurfaceBinding {
+        bind_address,
+        port,
+        token_path: token_path.clone(),
+    };
+
+    let app_state = GatewayControlAppState {
+        runtime_dir: runtime_dir.to_path_buf(),
+        bearer_token,
+        channels_payload: Arc::new(channels_payload),
+        runtime_snapshot_payload: Arc::new(runtime_snapshot_payload),
+    };
+    let app_state = Arc::new(app_state);
+    let router = build_gateway_control_router(app_state);
+
+    let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+    let (exit_sender, _) = watch::channel::<Option<CliResult<()>>>(None);
+    let exit_sender_for_task = exit_sender.clone();
+    let token_path_for_task = token_path;
+    let join_handle = tokio::spawn(async move {
+        let server = axum::serve(listener, router);
+        let server = server.with_graceful_shutdown(async move {
+            let _ = shutdown_receiver.await;
+        });
+        let server_result = server
+            .await
+            .map_err(|error| format!("gateway control surface server failed: {error}"));
+        let cleanup_result = remove_gateway_control_token_file(token_path_for_task.as_path());
+        let final_result = combine_gateway_control_task_results(server_result, cleanup_result);
+        let _ = exit_sender_for_task.send(Some(final_result.clone()));
+        final_result
+    });
+
+    let runtime = GatewayControlSurfaceRuntime {
+        exit_sender,
+        shutdown_sender: Mutex::new(Some(shutdown_sender)),
+        join_handle: Mutex::new(Some(join_handle)),
+    };
+    let runtime = Arc::new(runtime);
+
+    Ok(GatewayControlSurface { binding, runtime })
+}
+
+fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Router {
+    Router::new()
+        .route("/api/gateway/status", get(handle_gateway_status))
+        .route("/api/gateway/channels", get(handle_gateway_channels))
+        .route(
+            "/api/gateway/runtime-snapshot",
+            get(handle_gateway_runtime_snapshot),
+        )
+        .route("/api/gateway/stop", post(handle_gateway_stop))
+        .with_state(app_state)
+}
+
+async fn handle_gateway_status(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let status = load_gateway_owner_status(app_state.runtime_dir.as_path());
+    let Some(status) = status else {
+        return json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "status_unavailable",
+            "gateway owner status is unavailable",
+        );
+    };
+
+    let payload_result = serialize_json_value(&status, "gateway status payload");
+    match payload_result {
+        Ok(payload) => json_response(StatusCode::OK, payload),
+        Err(error) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "serialize_failed",
+            error.as_str(),
+        ),
+    }
+}
+
+async fn handle_gateway_channels(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let payload = app_state.channels_payload.as_ref().clone();
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_runtime_snapshot(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let payload = app_state.runtime_snapshot_payload.as_ref().clone();
+    json_response(StatusCode::OK, payload)
+}
+
+async fn handle_gateway_stop(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let stop_result = request_gateway_stop(app_state.runtime_dir.as_path());
+    let outcome = match stop_result {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "stop_failed",
+                error.as_str(),
+            );
+        }
+    };
+
+    let response_status = gateway_stop_outcome_status(outcome);
+    let response_message = gateway_stop_outcome_message(outcome);
+    let payload = json!({
+        "outcome": gateway_stop_outcome_code(outcome),
+        "message": response_message,
+    });
+    json_response(response_status, payload)
+}
+
+fn authorize_request(headers: &HeaderMap, expected_token: &str) -> CliResult<()> {
+    let authorization_header = headers.get(AUTHORIZATION);
+    let Some(authorization_header) = authorization_header else {
+        return Err("missing Authorization header".to_owned());
+    };
+
+    let authorization_text = authorization_header
+        .to_str()
+        .map_err(|error| format!("invalid Authorization header encoding: {error}"))?;
+    let bearer_prefix = "Bearer ";
+    let provided_token = authorization_text.strip_prefix(bearer_prefix);
+    let Some(provided_token) = provided_token else {
+        return Err("Authorization header must use Bearer auth".to_owned());
+    };
+
+    if provided_token != expected_token {
+        return Err("invalid gateway bearer token".to_owned());
+    }
+
+    Ok(())
+}
+
+fn build_gateway_channels_payload(loaded_config: &LoadedSupervisorConfig) -> CliResult<Value> {
+    let config_path = loaded_config.resolved_path.display().to_string();
+    let inventory = mvp::channel::channel_inventory(&loaded_config.config);
+    let payload = build_channels_cli_json_payload(config_path.as_str(), &inventory);
+    serialize_json_value(&payload, "gateway channels payload")
+}
+
+fn build_gateway_runtime_snapshot_payload(
+    loaded_config: &LoadedSupervisorConfig,
+) -> CliResult<Value> {
+    let snapshot = collect_runtime_snapshot_cli_state_from_loaded_config(loaded_config)?;
+    build_runtime_snapshot_cli_json_payload(&snapshot)
+}
+
+fn serialize_json_value<T: Serialize>(value: &T, context: &str) -> CliResult<Value> {
+    serde_json::to_value(value).map_err(|error| format!("serialize {context} failed: {error}"))
+}
+
+fn gateway_control_listener_address() -> SocketAddrV4 {
+    let bind_address = Ipv4Addr::LOCALHOST;
+    let bind_port = 0_u16;
+    SocketAddrV4::new(bind_address, bind_port)
+}
+
+fn new_gateway_control_bearer_token() -> String {
+    let random_bytes = rand::random::<[u8; 32]>();
+    URL_SAFE_NO_PAD.encode(random_bytes)
+}
+
+fn write_gateway_control_token_file(path: &Path, token: &str) -> CliResult<()> {
+    ensure_gateway_control_parent_dir(path)?;
+    harden_gateway_control_parent_dir(path)?;
+
+    let open_result = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path);
+    let mut file = open_result.map_err(|error| {
+        format!(
+            "open gateway control token file failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    file.write_all(token.as_bytes()).map_err(|error| {
+        format!(
+            "write gateway control token file failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    file.sync_all().map_err(|error| {
+        format!(
+            "sync gateway control token file failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    harden_gateway_control_token_file(path)
+}
+
+fn ensure_gateway_control_parent_dir(path: &Path) -> CliResult<()> {
+    let parent = path.parent();
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "create gateway control token parent directory failed for {}: {error}",
+            parent.display()
+        )
+    })
+}
+
+#[cfg(unix)]
+fn harden_gateway_control_parent_dir(path: &Path) -> CliResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let parent = path.parent();
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() || !parent.exists() {
+        return Ok(());
+    }
+
+    let metadata = fs::metadata(parent).map_err(|error| {
+        format!(
+            "read gateway control runtime directory metadata failed for {}: {error}",
+            parent.display()
+        )
+    })?;
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(GATEWAY_CONTROL_RUNTIME_DIR_MODE);
+    fs::set_permissions(parent, permissions).map_err(|error| {
+        format!(
+            "set gateway control runtime directory permissions failed for {}: {error}",
+            parent.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn harden_gateway_control_parent_dir(_path: &Path) -> CliResult<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn harden_gateway_control_token_file(path: &Path) -> CliResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let metadata = fs::metadata(path).map_err(|error| {
+        format!(
+            "read gateway control token metadata failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(GATEWAY_CONTROL_TOKEN_FILE_MODE);
+    fs::set_permissions(path, permissions).map_err(|error| {
+        format!(
+            "set gateway control token permissions failed for {}: {error}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn harden_gateway_control_token_file(_path: &Path) -> CliResult<()> {
+    Ok(())
+}
+
+fn remove_gateway_control_token_file(path: &Path) -> CliResult<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "remove gateway control token file failed for {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn combine_gateway_control_task_results(
+    server_result: CliResult<()>,
+    cleanup_result: CliResult<()>,
+) -> CliResult<()> {
+    match (server_result, cleanup_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(server_error), Ok(())) => Err(server_error),
+        (Ok(()), Err(cleanup_error)) => Err(cleanup_error),
+        (Err(server_error), Err(cleanup_error)) => {
+            let final_error = format!("{server_error}; {cleanup_error}");
+            Err(final_error)
+        }
+    }
+}
+
+fn merge_gateway_control_errors(primary_error: String, secondary_error: Option<String>) -> String {
+    let Some(secondary_error) = secondary_error else {
+        return primary_error;
+    };
+
+    format!("{primary_error}; {secondary_error}")
+}
+
+fn gateway_stop_outcome_status(outcome: GatewayStopRequestOutcome) -> StatusCode {
+    match outcome {
+        GatewayStopRequestOutcome::Requested => StatusCode::ACCEPTED,
+        GatewayStopRequestOutcome::AlreadyRequested => StatusCode::ACCEPTED,
+        GatewayStopRequestOutcome::AlreadyStopped => StatusCode::OK,
+    }
+}
+
+fn gateway_stop_outcome_message(outcome: GatewayStopRequestOutcome) -> &'static str {
+    match outcome {
+        GatewayStopRequestOutcome::Requested => "gateway stop requested",
+        GatewayStopRequestOutcome::AlreadyRequested => "gateway stop already requested",
+        GatewayStopRequestOutcome::AlreadyStopped => "gateway is not running",
+    }
+}
+
+fn gateway_stop_outcome_code(outcome: GatewayStopRequestOutcome) -> &'static str {
+    match outcome {
+        GatewayStopRequestOutcome::Requested => "requested",
+        GatewayStopRequestOutcome::AlreadyRequested => "already_requested",
+        GatewayStopRequestOutcome::AlreadyStopped => "already_stopped",
+    }
+}
+
+fn json_response(status_code: StatusCode, payload: Value) -> GatewayControlJsonResponse {
+    (status_code, Json(payload))
+}
+
+fn json_error(status_code: StatusCode, code: &str, message: &str) -> GatewayControlJsonResponse {
+    let payload = json!({
+        "error": {
+            "code": code,
+            "message": message,
+        }
+    });
+    json_response(status_code, payload)
+}

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -23,10 +23,15 @@ use tokio::{
 };
 
 use crate::{
-    CliResult, build_channels_cli_json_payload, build_runtime_snapshot_cli_json_payload,
+    CliResult, build_channels_cli_json_payload,
     collect_runtime_snapshot_cli_state_from_loaded_config, mvp, supervisor::LoadedSupervisorConfig,
 };
 
+use super::read_models::{
+    GatewayChannelInventoryReadModel, GatewayOperatorSummaryReadModel,
+    GatewayRuntimeSnapshotReadModel, build_operator_summary_read_model,
+    build_runtime_snapshot_read_model,
+};
 use super::state::{
     GatewayControlSurfaceBinding, GatewayStopRequestOutcome, gateway_control_token_path,
     load_gateway_owner_status, request_gateway_stop,
@@ -41,8 +46,8 @@ type GatewayControlJsonResponse = (StatusCode, Json<Value>);
 struct GatewayControlAppState {
     runtime_dir: PathBuf,
     bearer_token: String,
-    channels_payload: Arc<Value>,
-    runtime_snapshot_payload: Arc<Value>,
+    channel_inventory: Arc<GatewayChannelInventoryReadModel>,
+    runtime_snapshot: Arc<GatewayRuntimeSnapshotReadModel>,
 }
 
 struct GatewayControlSurfaceRuntime {
@@ -119,8 +124,8 @@ pub async fn start_gateway_control_surface(
     runtime_dir: &Path,
     loaded_config: &LoadedSupervisorConfig,
 ) -> CliResult<GatewayControlSurface> {
-    let channels_payload = build_gateway_channels_payload(loaded_config)?;
-    let runtime_snapshot_payload = build_gateway_runtime_snapshot_payload(loaded_config)?;
+    let channel_inventory = build_gateway_channel_inventory_read_model(loaded_config)?;
+    let runtime_snapshot = build_gateway_runtime_snapshot_read_model(loaded_config)?;
     let bearer_token = new_gateway_control_bearer_token();
     let token_path = gateway_control_token_path(runtime_dir);
 
@@ -161,8 +166,8 @@ pub async fn start_gateway_control_surface(
     let app_state = GatewayControlAppState {
         runtime_dir: runtime_dir.to_path_buf(),
         bearer_token,
-        channels_payload: Arc::new(channels_payload),
-        runtime_snapshot_payload: Arc::new(runtime_snapshot_payload),
+        channel_inventory: Arc::new(channel_inventory),
+        runtime_snapshot: Arc::new(runtime_snapshot),
     };
     let app_state = Arc::new(app_state);
     let router = build_gateway_control_router(app_state);
@@ -202,6 +207,10 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
         .route(
             "/api/gateway/runtime-snapshot",
             get(handle_gateway_runtime_snapshot),
+        )
+        .route(
+            "/api/gateway/operator-summary",
+            get(handle_gateway_operator_summary),
         )
         .route("/api/gateway/stop", post(handle_gateway_stop))
         .with_state(app_state)
@@ -243,8 +252,18 @@ async fn handle_gateway_channels(
         return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
     }
 
-    let payload = app_state.channels_payload.as_ref().clone();
-    json_response(StatusCode::OK, payload)
+    let payload = serialize_json_value(
+        app_state.channel_inventory.as_ref(),
+        "gateway channels payload",
+    );
+    match payload {
+        Ok(payload) => json_response(StatusCode::OK, payload),
+        Err(error) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "serialize_failed",
+            error.as_str(),
+        ),
+    }
 }
 
 async fn handle_gateway_runtime_snapshot(
@@ -255,8 +274,51 @@ async fn handle_gateway_runtime_snapshot(
         return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
     }
 
-    let payload = app_state.runtime_snapshot_payload.as_ref().clone();
-    json_response(StatusCode::OK, payload)
+    let payload = serialize_json_value(
+        app_state.runtime_snapshot.as_ref(),
+        "gateway runtime snapshot payload",
+    );
+    match payload {
+        Ok(payload) => json_response(StatusCode::OK, payload),
+        Err(error) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "serialize_failed",
+            error.as_str(),
+        ),
+    }
+}
+
+async fn handle_gateway_operator_summary(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let status = load_gateway_owner_status(app_state.runtime_dir.as_path());
+    let Some(status) = status else {
+        return json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "status_unavailable",
+            "gateway owner status is unavailable",
+        );
+    };
+
+    let summary = build_gateway_operator_summary_read_model(
+        &status,
+        app_state.channel_inventory.as_ref(),
+        app_state.runtime_snapshot.as_ref(),
+    );
+    let payload = serialize_json_value(&summary, "gateway operator summary payload");
+    match payload {
+        Ok(payload) => json_response(StatusCode::OK, payload),
+        Err(error) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "serialize_failed",
+            error.as_str(),
+        ),
+    }
 }
 
 async fn handle_gateway_stop(
@@ -321,18 +383,40 @@ fn authorize_request(headers: &HeaderMap, expected_token: &str) -> CliResult<()>
     Ok(())
 }
 
-fn build_gateway_channels_payload(loaded_config: &LoadedSupervisorConfig) -> CliResult<Value> {
-    let config_path = loaded_config.resolved_path.display().to_string();
-    let inventory = mvp::channel::channel_inventory(&loaded_config.config);
-    let payload = build_channels_cli_json_payload(config_path.as_str(), &inventory);
-    serialize_json_value(&payload, "gateway channels payload")
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut result = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        result |= x ^ y;
+    }
+    result == 0
 }
 
-fn build_gateway_runtime_snapshot_payload(
+fn build_gateway_channel_inventory_read_model(
     loaded_config: &LoadedSupervisorConfig,
-) -> CliResult<Value> {
+) -> CliResult<GatewayChannelInventoryReadModel> {
+    let config_path = loaded_config.resolved_path.display().to_string();
+    let inventory = mvp::channel::channel_inventory(&loaded_config.config);
+    let read_model = build_channels_cli_json_payload(config_path.as_str(), &inventory);
+    Ok(read_model)
+}
+
+fn build_gateway_runtime_snapshot_read_model(
+    loaded_config: &LoadedSupervisorConfig,
+) -> CliResult<GatewayRuntimeSnapshotReadModel> {
     let snapshot = collect_runtime_snapshot_cli_state_from_loaded_config(loaded_config)?;
-    build_runtime_snapshot_cli_json_payload(&snapshot)
+    let read_model = build_runtime_snapshot_read_model(&snapshot);
+    Ok(read_model)
+}
+
+fn build_gateway_operator_summary_read_model(
+    status: &super::state::GatewayOwnerStatus,
+    channel_inventory: &GatewayChannelInventoryReadModel,
+    runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorSummaryReadModel {
+    build_operator_summary_read_model(status, channel_inventory, runtime_snapshot)
 }
 
 fn serialize_json_value<T: Serialize>(value: &T, context: &str) -> CliResult<Value> {

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -288,6 +288,17 @@ async fn handle_gateway_stop(
     json_response(response_status, payload)
 }
 
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut result = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        result |= x ^ y;
+    }
+    result == 0
+}
+
 fn authorize_request(headers: &HeaderMap, expected_token: &str) -> CliResult<()> {
     let authorization_header = headers.get(AUTHORIZATION);
     let Some(authorization_header) = authorization_header else {
@@ -303,7 +314,7 @@ fn authorize_request(headers: &HeaderMap, expected_token: &str) -> CliResult<()>
         return Err("Authorization header must use Bearer auth".to_owned());
     };
 
-    if provided_token != expected_token {
+    if !constant_time_eq(provided_token.as_bytes(), expected_token.as_bytes()) {
         return Err("invalid gateway bearer token".to_owned());
     }
 
@@ -343,11 +354,14 @@ fn write_gateway_control_token_file(path: &Path, token: &str) -> CliResult<()> {
     ensure_gateway_control_parent_dir(path)?;
     harden_gateway_control_parent_dir(path)?;
 
-    let open_result = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path);
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(GATEWAY_CONTROL_TOKEN_FILE_MODE);
+    }
+    let open_result = options.open(path);
     let mut file = open_result.map_err(|error| {
         format!(
             "open gateway control token file failed for {}: {error}",

--- a/crates/daemon/src/gateway/mod.rs
+++ b/crates/daemon/src/gateway/mod.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod control;
 pub mod read_models;
 pub mod service;

--- a/crates/daemon/src/gateway/mod.rs
+++ b/crates/daemon/src/gateway/mod.rs
@@ -1,3 +1,4 @@
+pub mod control;
 pub mod read_models;
 pub mod service;
 pub mod state;

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
+use std::net::{IpAddr, SocketAddr};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::CHANNELS_CLI_JSON_LEGACY_VIEWS;
@@ -8,6 +9,8 @@ use crate::CHANNELS_CLI_JSON_SCHEMA_VERSION;
 use crate::RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION;
 use crate::RuntimeSnapshotCliState;
 use crate::mvp;
+
+use super::state::GatewayOwnerStatus;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct GatewayChannelInventorySchema {
@@ -212,6 +215,57 @@ pub struct GatewayRuntimeSnapshotReadModel {
     pub external_skills: Value,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorControlSurfaceReadModel {
+    pub base_url: Option<String>,
+    pub loopback_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorChannelSurfaceReadModel {
+    pub channel_id: String,
+    pub label: String,
+    pub configured_account_count: usize,
+    pub enabled_account_count: usize,
+    pub misconfigured_account_count: usize,
+    pub ready_send_account_count: usize,
+    pub ready_serve_account_count: usize,
+    pub default_configured_account_id: Option<String>,
+    pub service_enabled: bool,
+    pub service_ready: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorChannelsSummaryReadModel {
+    pub catalog_channel_count: usize,
+    pub configured_channel_count: usize,
+    pub configured_account_count: usize,
+    pub enabled_account_count: usize,
+    pub misconfigured_account_count: usize,
+    pub runtime_backed_channel_count: usize,
+    pub enabled_service_channel_count: usize,
+    pub ready_service_channel_count: usize,
+    pub surfaces: Vec<GatewayOperatorChannelSurfaceReadModel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorRuntimeSummaryReadModel {
+    pub enabled_channel_ids: Vec<String>,
+    pub enabled_service_channel_ids: Vec<String>,
+    pub visible_tool_count: usize,
+    pub capability_snapshot_sha256: String,
+    pub active_provider_profile_id: Option<String>,
+    pub active_provider_label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorSummaryReadModel {
+    pub owner: GatewayOwnerStatus,
+    pub control_surface: GatewayOperatorControlSurfaceReadModel,
+    pub channels: GatewayOperatorChannelsSummaryReadModel,
+    pub runtime: GatewayOperatorRuntimeSummaryReadModel,
+}
+
 pub fn build_channel_inventory_read_model(
     config_path: &str,
     inventory: &mvp::channel::ChannelInventory,
@@ -335,6 +389,24 @@ pub fn build_runtime_snapshot_read_model(
         tool_runtime,
         tools,
         external_skills,
+    }
+}
+
+pub fn build_operator_summary_read_model(
+    owner_status: &GatewayOwnerStatus,
+    channel_inventory: &GatewayChannelInventoryReadModel,
+    runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorSummaryReadModel {
+    let owner = owner_status.clone();
+    let control_surface = build_operator_control_surface_read_model(owner_status);
+    let channels = build_operator_channels_summary_read_model(channel_inventory, runtime_snapshot);
+    let runtime = build_operator_runtime_summary_read_model(runtime_snapshot);
+
+    GatewayOperatorSummaryReadModel {
+        owner,
+        control_surface,
+        channels,
+        runtime,
     }
 }
 
@@ -548,4 +620,206 @@ fn build_acp_dispatch_decision_read_model(
     };
 
     GatewayAcpDispatchDecisionReadModel { session, decision }
+}
+
+fn build_operator_control_surface_read_model(
+    owner_status: &GatewayOwnerStatus,
+) -> GatewayOperatorControlSurfaceReadModel {
+    let base_url = gateway_owner_base_url(owner_status);
+    let loopback_only = gateway_owner_control_is_loopback(owner_status);
+
+    GatewayOperatorControlSurfaceReadModel {
+        base_url,
+        loopback_only,
+    }
+}
+
+fn build_operator_channels_summary_read_model(
+    channel_inventory: &GatewayChannelInventoryReadModel,
+    runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorChannelsSummaryReadModel {
+    let catalog_channel_count = channel_inventory.channel_catalog.len();
+    let configured_channel_count = channel_inventory
+        .channel_surfaces
+        .iter()
+        .filter(|surface| !surface.configured_accounts.is_empty())
+        .count();
+    let configured_account_count = channel_inventory.channels.len();
+    let enabled_account_count = channel_inventory
+        .channels
+        .iter()
+        .filter(|account| account.enabled)
+        .count();
+    let misconfigured_account_count = channel_inventory
+        .channels
+        .iter()
+        .filter(|account| channel_account_is_misconfigured(account))
+        .count();
+    let runtime_backed_channel_count = channel_inventory
+        .channel_catalog
+        .iter()
+        .filter(|channel| {
+            channel.implementation_status
+                == mvp::channel::ChannelCatalogImplementationStatus::RuntimeBacked
+        })
+        .count();
+    let enabled_service_channel_ids = &runtime_snapshot.channels.enabled_service_channel_ids;
+    let enabled_service_channel_count = enabled_service_channel_ids.len();
+    let surfaces = build_operator_channel_surface_read_models(
+        &channel_inventory.channel_surfaces,
+        enabled_service_channel_ids,
+    );
+    let ready_service_channel_count = surfaces
+        .iter()
+        .filter(|surface| surface.service_ready)
+        .count();
+
+    GatewayOperatorChannelsSummaryReadModel {
+        catalog_channel_count,
+        configured_channel_count,
+        configured_account_count,
+        enabled_account_count,
+        misconfigured_account_count,
+        runtime_backed_channel_count,
+        enabled_service_channel_count,
+        ready_service_channel_count,
+        surfaces,
+    }
+}
+
+fn build_operator_channel_surface_read_models(
+    channel_surfaces: &[mvp::channel::ChannelSurface],
+    enabled_service_channel_ids: &[String],
+) -> Vec<GatewayOperatorChannelSurfaceReadModel> {
+    let mut surfaces = Vec::with_capacity(channel_surfaces.len());
+
+    for channel_surface in channel_surfaces {
+        let surface =
+            build_operator_channel_surface_read_model(channel_surface, enabled_service_channel_ids);
+        surfaces.push(surface);
+    }
+
+    surfaces
+}
+
+fn build_operator_channel_surface_read_model(
+    channel_surface: &mvp::channel::ChannelSurface,
+    enabled_service_channel_ids: &[String],
+) -> GatewayOperatorChannelSurfaceReadModel {
+    let channel_id = channel_surface.catalog.id.to_owned();
+    let label = channel_surface.catalog.label.to_owned();
+    let configured_account_count = channel_surface.configured_accounts.len();
+    let enabled_account_count = channel_surface
+        .configured_accounts
+        .iter()
+        .filter(|account| account.enabled)
+        .count();
+    let misconfigured_account_count = channel_surface
+        .configured_accounts
+        .iter()
+        .filter(|account| channel_account_is_misconfigured(account))
+        .count();
+    let ready_send_account_count = channel_surface
+        .configured_accounts
+        .iter()
+        .filter(|account| {
+            channel_account_operation_is_ready(account, mvp::channel::CHANNEL_OPERATION_SEND_ID)
+        })
+        .count();
+    let ready_serve_account_count = channel_surface
+        .configured_accounts
+        .iter()
+        .filter(|account| {
+            channel_account_operation_is_ready(account, mvp::channel::CHANNEL_OPERATION_SERVE_ID)
+        })
+        .count();
+    let default_configured_account_id = channel_surface.default_configured_account_id.clone();
+    let service_enabled = enabled_service_channel_ids.contains(&channel_id);
+    let service_ready = service_enabled && ready_serve_account_count > 0;
+
+    GatewayOperatorChannelSurfaceReadModel {
+        channel_id,
+        label,
+        configured_account_count,
+        enabled_account_count,
+        misconfigured_account_count,
+        ready_send_account_count,
+        ready_serve_account_count,
+        default_configured_account_id,
+        service_enabled,
+        service_ready,
+    }
+}
+
+fn build_operator_runtime_summary_read_model(
+    runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorRuntimeSummaryReadModel {
+    let enabled_channel_ids = runtime_snapshot.channels.enabled_channel_ids.clone();
+    let enabled_service_channel_ids = runtime_snapshot
+        .channels
+        .enabled_service_channel_ids
+        .clone();
+    let visible_tool_count = runtime_snapshot.tools.visible_tool_count;
+    let capability_snapshot_sha256 = runtime_snapshot.tools.capability_snapshot_sha256.clone();
+    let active_provider_profile_id =
+        json_string_field(&runtime_snapshot.provider, "active_profile_id");
+    let active_provider_label = json_string_field(&runtime_snapshot.provider, "active_label");
+
+    GatewayOperatorRuntimeSummaryReadModel {
+        enabled_channel_ids,
+        enabled_service_channel_ids,
+        visible_tool_count,
+        capability_snapshot_sha256,
+        active_provider_profile_id,
+        active_provider_label,
+    }
+}
+
+fn channel_account_is_misconfigured(account: &mvp::channel::ChannelStatusSnapshot) -> bool {
+    account
+        .operations
+        .iter()
+        .any(|operation| operation.health == mvp::channel::ChannelOperationHealth::Misconfigured)
+}
+
+fn channel_account_operation_is_ready(
+    account: &mvp::channel::ChannelStatusSnapshot,
+    operation_id: &str,
+) -> bool {
+    let operation = account.operation(operation_id);
+    let Some(operation) = operation else {
+        return false;
+    };
+
+    operation.health == mvp::channel::ChannelOperationHealth::Ready
+}
+
+fn gateway_owner_base_url(owner_status: &GatewayOwnerStatus) -> Option<String> {
+    let bind_address = owner_status.bind_address.as_deref()?;
+    let port = owner_status.port?;
+    let ip_address = bind_address.parse::<IpAddr>().ok()?;
+    let socket_address = SocketAddr::new(ip_address, port);
+    let base_url = format!("http://{socket_address}");
+    Some(base_url)
+}
+
+fn gateway_owner_control_is_loopback(owner_status: &GatewayOwnerStatus) -> bool {
+    let bind_address = owner_status.bind_address.as_deref();
+    let Some(bind_address) = bind_address else {
+        return false;
+    };
+
+    let ip_address = bind_address.parse::<IpAddr>();
+    let Ok(ip_address) = ip_address else {
+        return false;
+    };
+
+    ip_address.is_loopback()
+}
+
+fn json_string_field(value: &Value, field: &str) -> Option<String> {
+    let object = value.as_object()?;
+    let value = object.get(field)?;
+    let text = value.as_str()?;
+    Some(text.to_owned())
 }

--- a/crates/daemon/src/gateway/service.rs
+++ b/crates/daemon/src/gateway/service.rs
@@ -10,6 +10,7 @@ use crate::{
     },
 };
 
+use super::control::start_gateway_control_surface;
 use super::state::{
     GatewayOwnerMode, GatewayOwnerStatus, GatewayOwnerTracker, GatewayStopRequestOutcome,
     default_gateway_runtime_state_dir, load_gateway_owner_status, request_gateway_stop,
@@ -110,13 +111,30 @@ async fn run_gateway_runtime_with_hooks_for_test(
         session,
         spec.surfaces.len(),
     )?);
+    let control_surface_result = start_gateway_control_surface(runtime_dir, &loaded_config).await;
+    let control_surface = match control_surface_result {
+        Ok(control_surface) => control_surface,
+        Err(error) => {
+            tracker.finalize_with_error(error.as_str())?;
+            return Err(error);
+        }
+    };
+    let binding_result = tracker.set_control_surface_binding(control_surface.binding());
+    if let Err(error) = binding_result {
+        let shutdown_result = control_surface.shutdown().await;
+        let final_error = merge_gateway_runtime_errors(error, shutdown_result.err());
+        tracker.finalize_with_error(final_error.as_str())?;
+        return Err(final_error);
+    }
 
     let mut runtime_hooks = hooks.clone();
     let original_wait_for_shutdown = hooks.wait_for_shutdown.clone();
     let runtime_dir_for_shutdown = runtime_dir.to_path_buf();
+    let control_surface_for_shutdown = control_surface.clone();
     runtime_hooks.wait_for_shutdown = Arc::new(move || {
         let original_wait_for_shutdown = original_wait_for_shutdown.clone();
         let runtime_dir = runtime_dir_for_shutdown.clone();
+        let control_surface = control_surface_for_shutdown.clone();
         Box::pin(async move {
             tokio::select! {
                 result = (original_wait_for_shutdown)() => result,
@@ -124,6 +142,7 @@ async fn run_gateway_runtime_with_hooks_for_test(
                     result?;
                     Ok("gateway stop requested".to_owned())
                 }
+                result = control_surface.wait_for_unexpected_exit() => result,
             }
         })
     });
@@ -136,12 +155,19 @@ async fn run_gateway_runtime_with_hooks_for_test(
         run_supervisor_with_loaded_config_for_test(loaded_config, spec, runtime_hooks).await;
     match supervisor_result {
         Ok(supervisor) => {
+            let shutdown_result = control_surface.shutdown().await;
+            if let Err(error) = shutdown_result {
+                tracker.finalize_with_error(error.as_str())?;
+                return Err(error);
+            }
             tracker.finalize_from_supervisor(&supervisor)?;
             Ok(supervisor)
         }
         Err(error) => {
-            tracker.finalize_with_error(error.as_str())?;
-            Err(error)
+            let shutdown_result = control_surface.shutdown().await;
+            let final_error = merge_gateway_runtime_errors(error, shutdown_result.err());
+            tracker.finalize_with_error(final_error.as_str())?;
+            Err(final_error)
         }
     }
 }
@@ -340,4 +366,12 @@ fn normalize_optional_text(value: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
+}
+
+fn merge_gateway_runtime_errors(primary_error: String, secondary_error: Option<String>) -> String {
+    let Some(secondary_error) = secondary_error else {
+        return primary_error;
+    };
+
+    format!("{primary_error}; {secondary_error}")
 }

--- a/crates/daemon/src/gateway/state.rs
+++ b/crates/daemon/src/gateway/state.rs
@@ -63,6 +63,13 @@ pub struct GatewayOwnerStatus {
     pub token_path: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayControlSurfaceBinding {
+    pub bind_address: String,
+    pub port: u16,
+    pub token_path: PathBuf,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GatewayStopRequestOutcome {
     Requested,
@@ -219,6 +226,25 @@ impl GatewayOwnerTracker {
         )
     }
 
+    pub fn set_control_surface_binding(
+        &self,
+        binding: &GatewayControlSurfaceBinding,
+    ) -> CliResult<()> {
+        let persisted_state = {
+            let state_guard = self.state.lock();
+            let mut state_guard = state_guard
+                .map_err(|error| format!("gateway owner state lock poisoned: {error}"))?;
+            state_guard.bind_address = Some(binding.bind_address.clone());
+            state_guard.port = Some(binding.port);
+            state_guard.token_path = Some(binding.token_path.display().to_string());
+            state_guard.last_heartbeat_at = now_ms();
+            state_guard.clone()
+        };
+
+        write_active_owner_state(self.owner_file.as_ref(), &persisted_state)?;
+        write_status_snapshot(self.status_snapshot_path.as_path(), &persisted_state)
+    }
+
     pub fn finalize_from_supervisor(&self, supervisor: &SupervisorState) -> CliResult<()> {
         self.heartbeat_stopped.store(true, Ordering::SeqCst);
         let heartbeat_task = self
@@ -299,6 +325,11 @@ impl GatewayOwnerTracker {
             state_guard.last_heartbeat_at = now_ms();
             if let Some(stopped_at_ms) = stopped_at_ms {
                 state_guard.stopped_at_ms = Some(stopped_at_ms);
+            }
+            if !running {
+                state_guard.bind_address = None;
+                state_guard.port = None;
+                state_guard.token_path = None;
             }
             state_guard.clone()
         };
@@ -480,6 +511,10 @@ fn gateway_status_snapshot_path(runtime_dir: &Path) -> PathBuf {
 
 fn gateway_stop_request_path(runtime_dir: &Path) -> PathBuf {
     runtime_dir.join("stop-request.json")
+}
+
+pub fn gateway_control_token_path(runtime_dir: &Path) -> PathBuf {
+    runtime_dir.join("control-token")
 }
 
 fn read_persisted_gateway_owner_state(path: &Path) -> Option<PersistedGatewayOwnerState> {

--- a/crates/daemon/src/gateway/state.rs
+++ b/crates/daemon/src/gateway/state.rs
@@ -40,7 +40,7 @@ impl GatewayOwnerMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GatewayOwnerStatus {
     pub runtime_dir: String,
     pub phase: String,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1924,17 +1924,32 @@ pub fn collect_runtime_snapshot_cli_state(
     config_path: Option<&str>,
 ) -> CliResult<RuntimeSnapshotCliState> {
     let (resolved_path, config) = mvp::config::load(config_path)?;
+    collect_runtime_snapshot_cli_state_from_parts(resolved_path.as_path(), &config)
+}
+
+pub(crate) fn collect_runtime_snapshot_cli_state_from_loaded_config(
+    loaded_config: &supervisor::LoadedSupervisorConfig,
+) -> CliResult<RuntimeSnapshotCliState> {
+    let resolved_path = loaded_config.resolved_path.as_path();
+    let config = &loaded_config.config;
+    collect_runtime_snapshot_cli_state_from_parts(resolved_path, config)
+}
+
+fn collect_runtime_snapshot_cli_state_from_parts(
+    resolved_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<RuntimeSnapshotCliState> {
     let config_display = resolved_path.display().to_string();
-    let provider = collect_runtime_snapshot_provider_state(&config);
-    let context_engine = mvp::conversation::collect_context_engine_runtime_snapshot(&config)?;
-    let memory_system = mvp::memory::collect_memory_system_runtime_snapshot(&config)?;
-    let acp = mvp::acp::collect_acp_runtime_snapshot(&config)?;
+    let provider = collect_runtime_snapshot_provider_state(config);
+    let context_engine = mvp::conversation::collect_context_engine_runtime_snapshot(config)?;
+    let memory_system = mvp::memory::collect_memory_system_runtime_snapshot(config)?;
+    let acp = mvp::acp::collect_acp_runtime_snapshot(config)?;
     let enabled_channel_ids = config.enabled_channel_ids();
     let enabled_service_channel_ids = config.enabled_service_channel_ids();
-    let channels = mvp::channel::channel_inventory(&config);
+    let channels = mvp::channel::channel_inventory(config);
     let tool_runtime = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
-        &config,
-        Some(resolved_path.as_path()),
+        config,
+        Some(resolved_path),
     );
     let (external_skills, snapshot_tool_runtime) =
         collect_runtime_snapshot_external_skills_state(&tool_runtime);
@@ -1946,7 +1961,7 @@ pub fn collect_runtime_snapshot_cli_state(
     let capability_snapshot = mvp::tools::capability_snapshot_with_config(&snapshot_tool_runtime);
     let capability_snapshot_sha256 =
         runtime_snapshot_tool_digest(&visible_tool_names, &capability_snapshot)?;
-    let restore_spec = build_runtime_snapshot_restore_spec(&config, &external_skills);
+    let restore_spec = build_runtime_snapshot_restore_spec(config, &external_skills);
 
     Ok(RuntimeSnapshotCliState {
         config: config_display,

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -12,6 +12,7 @@ use std::{
 
 use loongclaw_daemon::{
     gateway::{
+        client::{GatewayLocalClient, GatewayStopResponseOutcome},
         service::{
             run_gateway_run_with_hooks_for_test,
             run_multi_channel_serve_gateway_compat_with_hooks_for_test,
@@ -460,4 +461,101 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
     assert_eq!(stopped_status.port, None);
     assert_eq!(stopped_status.token_path, None);
     assert!(!token_path.exists());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_local_client_discovers_owner_reads_summary_and_stops_runtime() {
+    let runtime_dir = unique_runtime_dir("local-client");
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let expected_port = running_status
+        .port
+        .expect("gateway control surface port should be persisted");
+    let client =
+        GatewayLocalClient::discover(runtime_dir.as_path()).expect("discover gateway local client");
+
+    assert_eq!(client.discovery().socket_address().port(), expected_port);
+    assert_eq!(
+        client.discovery().base_url(),
+        format!("http://127.0.0.1:{expected_port}")
+    );
+
+    let status = client.status().await.expect("read gateway status");
+    assert_eq!(status.phase, "running");
+    assert_eq!(status.bind_address.as_deref(), Some("127.0.0.1"));
+
+    let channels = client.channels().await.expect("read gateway channels");
+    assert_eq!(
+        channels["schema"]["primary_channel_view"],
+        "channel_surfaces"
+    );
+    assert_eq!(channels["schema"]["catalog_view"], "channel_catalog");
+
+    let runtime_snapshot = client
+        .runtime_snapshot()
+        .await
+        .expect("read gateway runtime snapshot");
+    assert_eq!(runtime_snapshot["schema"]["surface"], "runtime_snapshot");
+
+    let operator_summary = client
+        .operator_summary()
+        .await
+        .expect("read gateway operator summary");
+    assert_eq!(operator_summary.owner.phase, "running");
+    assert_eq!(
+        operator_summary.control_surface.base_url.as_deref(),
+        Some(client.discovery().base_url())
+    );
+    assert!(operator_summary.control_surface.loopback_only);
+    assert_eq!(
+        operator_summary.channels.enabled_service_channel_count,
+        runtime_snapshot["channels"]["enabled_service_channel_ids"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default()
+    );
+    assert_eq!(
+        operator_summary.runtime.visible_tool_count,
+        runtime_snapshot["tools"]["visible_tool_count"]
+            .as_u64()
+            .map(|value| value as usize)
+            .unwrap_or_default()
+    );
+
+    let stop = client.stop().await.expect("request gateway stop");
+    assert_eq!(stop.outcome, GatewayStopResponseOutcome::Requested);
+
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop after local client stop")
+        .expect("join gateway run after local client stop")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+
+    let stopped_status = load_gateway_owner_status(runtime_dir.as_path())
+        .expect("stopped gateway status should be present");
+    assert_eq!(stopped_status.phase, "stopped");
+    assert!(!stopped_status.running);
 }

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use std::{
     collections::BTreeMap,
+    fs,
     future::Future,
     path::PathBuf,
     pin::Pin,
@@ -22,6 +23,7 @@ use loongclaw_daemon::{
     },
     supervisor::{BackgroundChannelRunnerRequest, LoadedSupervisorConfig, SupervisorRuntimeHooks},
 };
+use serde_json::Value;
 use tokio::time::{sleep, timeout};
 
 type BoxedCliFuture = Pin<Box<dyn Future<Output = CliResult<()>> + Send + 'static>>;
@@ -103,6 +105,26 @@ async fn wait_until(description: &str, predicate: impl Fn() -> bool) {
     }
 
     panic!("timed out waiting for {description}");
+}
+
+async fn wait_for_gateway_control_surface(
+    runtime_dir: &std::path::Path,
+) -> loongclaw_daemon::gateway::state::GatewayOwnerStatus {
+    wait_until("gateway control surface binding", || {
+        let status = load_gateway_owner_status(runtime_dir);
+        let Some(status) = status else {
+            return false;
+        };
+
+        status.running
+            && status.bind_address.is_some()
+            && status.port.is_some()
+            && status.token_path.is_some()
+    })
+    .await;
+
+    load_gateway_owner_status(runtime_dir)
+        .expect("gateway control surface status should be present")
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -288,4 +310,154 @@ async fn gateway_owner_state_multi_channel_compat_records_wrapper_mode_and_sessi
         .expect("join compat run")
         .expect("compat run should return supervisor state");
     assert!(supervisor.final_exit_result().is_ok());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_runtime() {
+    let runtime_dir = unique_runtime_dir("localhost-control");
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    assert_eq!(running_status.bind_address.as_deref(), Some("127.0.0.1"));
+    let port = running_status
+        .port
+        .expect("control surface port should be persisted");
+    let token_path = running_status
+        .token_path
+        .clone()
+        .expect("control surface token path should be persisted");
+    let token_path = PathBuf::from(token_path);
+    assert!(token_path.exists());
+
+    let token = fs::read_to_string(token_path.as_path()).expect("read gateway control token file");
+    let token = token.trim().to_owned();
+    assert!(!token.is_empty());
+
+    let base_url = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    let unauthorized_status_response = client
+        .get(format!("{base_url}/api/gateway/status"))
+        .send()
+        .await
+        .expect("send unauthorized gateway status request");
+    assert_eq!(
+        unauthorized_status_response.status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+    let unauthorized_status_json: Value = unauthorized_status_response
+        .json()
+        .await
+        .expect("decode unauthorized gateway status response");
+    assert_eq!(unauthorized_status_json["error"]["code"], "unauthorized");
+
+    let authorized_status_response = client
+        .get(format!("{base_url}/api/gateway/status"))
+        .bearer_auth(token.as_str())
+        .send()
+        .await
+        .expect("send authorized gateway status request");
+    assert_eq!(authorized_status_response.status(), reqwest::StatusCode::OK);
+    let authorized_status_json: Value = authorized_status_response
+        .json()
+        .await
+        .expect("decode authorized gateway status response");
+    assert_eq!(authorized_status_json["phase"], "running");
+    assert_eq!(authorized_status_json["bind_address"], "127.0.0.1");
+    assert_eq!(
+        authorized_status_json["port"].as_u64(),
+        Some(u64::from(port))
+    );
+
+    let channels_response = client
+        .get(format!("{base_url}/api/gateway/channels"))
+        .bearer_auth(token.as_str())
+        .send()
+        .await
+        .expect("send gateway channels request");
+    assert_eq!(channels_response.status(), reqwest::StatusCode::OK);
+    let channels_json: Value = channels_response
+        .json()
+        .await
+        .expect("decode gateway channels response");
+    assert_eq!(
+        channels_json["schema"]["primary_channel_view"],
+        "channel_surfaces"
+    );
+    assert_eq!(channels_json["schema"]["catalog_view"], "channel_catalog");
+
+    let runtime_snapshot_response = client
+        .get(format!("{base_url}/api/gateway/runtime-snapshot"))
+        .bearer_auth(token.as_str())
+        .send()
+        .await
+        .expect("send gateway runtime snapshot request");
+    assert_eq!(runtime_snapshot_response.status(), reqwest::StatusCode::OK);
+    let runtime_snapshot_json: Value = runtime_snapshot_response
+        .json()
+        .await
+        .expect("decode gateway runtime snapshot response");
+    assert_eq!(
+        runtime_snapshot_json["schema"]["surface"],
+        "runtime_snapshot"
+    );
+    assert_eq!(
+        runtime_snapshot_json["channels"]["inventory"]["schema"]["catalog_view"],
+        "channel_catalog"
+    );
+    assert!(
+        runtime_snapshot_json["tools"]["visible_tool_count"]
+            .as_u64()
+            .is_some()
+    );
+
+    let stop_response = client
+        .post(format!("{base_url}/api/gateway/stop"))
+        .bearer_auth(token.as_str())
+        .send()
+        .await
+        .expect("send gateway stop request");
+    assert_eq!(stop_response.status(), reqwest::StatusCode::ACCEPTED);
+    let stop_json: Value = stop_response
+        .json()
+        .await
+        .expect("decode gateway stop response");
+    assert_eq!(stop_json["outcome"], "requested");
+
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop after control stop")
+        .expect("join gateway run after control stop")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+
+    let stopped_status = load_gateway_owner_status(runtime_dir.as_path())
+        .expect("stopped gateway status should be present");
+    assert_eq!(stopped_status.phase, "stopped");
+    assert!(!stopped_status.running);
+    assert_eq!(stopped_status.bind_address, None);
+    assert_eq!(stopped_status.port, None);
+    assert_eq!(stopped_status.token_path, None);
+    assert!(!token_path.exists());
 }

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -251,3 +251,85 @@ fn gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary() {
 
     fs::remove_dir_all(&root).ok();
 }
+
+#[test]
+fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups() {
+    let root = unique_temp_dir("loongclaw-gateway-operator-summary");
+    let config_path = write_gateway_test_config(&root);
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8");
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(config_path_text))
+        .expect("collect runtime snapshot");
+    let inventory = gateway::read_models::build_channel_inventory_read_model(
+        config_path_text,
+        &snapshot.channels,
+    );
+    let runtime_snapshot = gateway::read_models::build_runtime_snapshot_read_model(&snapshot);
+    let owner_status = gateway::state::GatewayOwnerStatus {
+        runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
+        phase: "running".to_owned(),
+        running: true,
+        stale: false,
+        pid: Some(42),
+        mode: gateway::state::GatewayOwnerMode::GatewayHeadless,
+        version: env!("CARGO_PKG_VERSION").to_owned(),
+        config_path: config_path_text.to_owned(),
+        attached_cli_session: None,
+        started_at_ms: 100,
+        last_heartbeat_at: 200,
+        stopped_at_ms: None,
+        shutdown_reason: None,
+        last_error: None,
+        configured_surface_count: 0,
+        running_surface_count: 0,
+        bind_address: Some("127.0.0.1".to_owned()),
+        port: Some(7777),
+        token_path: Some("/tmp/loongclaw-gateway-runtime/control-token".to_owned()),
+    };
+
+    let summary = gateway::read_models::build_operator_summary_read_model(
+        &owner_status,
+        &inventory,
+        &runtime_snapshot,
+    );
+    let encoded = serde_json::to_value(&summary).expect("serialize operator summary read model");
+
+    assert_eq!(summary.owner.phase, "running");
+    assert_eq!(
+        summary.control_surface.base_url.as_deref(),
+        Some("http://127.0.0.1:7777")
+    );
+    assert!(summary.control_surface.loopback_only);
+    assert_eq!(
+        summary.channels.catalog_channel_count,
+        inventory.channel_catalog.len()
+    );
+    assert_eq!(
+        summary.channels.configured_account_count,
+        inventory.channels.len()
+    );
+    assert_eq!(
+        summary.channels.enabled_service_channel_count,
+        runtime_snapshot.channels.enabled_service_channel_ids.len()
+    );
+    assert_eq!(
+        summary.channels.surfaces.len(),
+        inventory.channel_surfaces.len()
+    );
+    assert_eq!(
+        summary.runtime.visible_tool_count,
+        runtime_snapshot.tools.visible_tool_count
+    );
+    assert_eq!(
+        summary.runtime.active_provider_profile_id.as_deref(),
+        runtime_snapshot.provider["active_profile_id"].as_str()
+    );
+    assert_eq!(
+        encoded["control_surface"]["base_url"],
+        "http://127.0.0.1:7777"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/docs/plans/2026-03-27-gateway-service-architecture-design.md
+++ b/docs/plans/2026-03-27-gateway-service-architecture-design.md
@@ -33,7 +33,8 @@ service boundary with unclear ownership and rising integration debt.
 - `multi-channel-serve` should be treated as the first runtime-owner precursor,
   not as the long-term product noun.
 - Gateway is required for the accepted product direction, but the early slices
-  can remain local-first, localhost-only by default, and operator-governed.
+  can remain localhost-only by default, security-governed, and
+  operator-governed while the broader service contract matures.
 
 ## Current Architecture Evidence
 
@@ -253,6 +254,29 @@ The main architectural reasons claw-style systems add an explicit gateway are:
 LoongClaw now faces the same product pressures. The lesson to borrow is unified
 service ownership, not an automatic jump to hosted multi-tenant semantics.
 
+## Security Default, Not Product Retreat
+
+The current localhost-only bind policy should be understood as a security
+default, not as a strategic refusal of broader gateway capability.
+
+More specifically, the current policy means:
+
+- the gateway should not be publicly exposed by default
+- widening bind scope requires an explicit auth, lifecycle, and observability
+  contract
+- current Web UI and operator flows should attach through the daemon-owned
+  gateway surface instead of inventing a second runtime
+
+It does not mean:
+
+- remote browser or mobile pairing is out of scope
+- always-on service ownership is out of scope
+- stable bind and port ownership are out of scope
+- richer long-lived channel runtimes are out of scope
+
+The architectural mistake to avoid is treating "localhost-only by default" as a
+product noun. It is a rollout and security posture for the current slice.
+
 ## Design Goals
 
 1. Add an explicit gateway service boundary above existing daemon/operator
@@ -280,6 +304,8 @@ service ownership, not an automatic jump to hosted multi-tenant semantics.
   polling runtimes should remain supervised tasks where appropriate.
 - Do not force immediate public-internet exposure as part of the first gateway
   slice.
+- Do not treat the current localhost-only default as evidence that future
+  service-mode or remote attachment work is undesired.
 - Do not commit this slice to a hosted multi-tenant SaaS contract.
 
 ## Core Idea
@@ -453,6 +479,18 @@ The protocol crate should remain generic enough to support:
 - future local or remote control channels
 
 without hard-coding gateway business semantics into protocol types.
+
+### 6. Default bind policy is a security boundary
+
+The gateway can remain localhost-only by default for the current slice without
+turning that posture into the long-term product boundary.
+
+That means:
+
+- current slices should prefer loopback-only bind by default
+- future service mode may introduce stable or configurable bind ownership
+- broader exposure must follow explicit auth, token, operator-control, and
+  observability work
 
 ## Proposed Command Surface
 

--- a/docs/plans/2026-03-27-gateway-service-architecture-implementation-plan.md
+++ b/docs/plans/2026-03-27-gateway-service-architecture-implementation-plan.md
@@ -40,10 +40,13 @@ clippy, `task verify`
   the long-term architecture
 - keep current slice boundaries accurate, but describe them as incremental
   delivery steps toward a gateway service layer
-- update Web UI wording so it remains "not a second runtime" while no longer
-  implying that the local-only posture is the strategic endpoint
+- update Web UI wording so it remains "not a second runtime" while clearly
+  stating that localhost-only default binding is a security posture for the
+  current slice rather than the strategic endpoint
 - update browser companion wording so it remains optional while clearly pointing
   toward a future gateway-managed node model
+- keep "not publicly exposed by default" explicit so future service-mode work
+  is framed as governed expansion rather than a reversal of product direction
 
 **Step 2: Verify documentation consistency**
 
@@ -214,6 +217,9 @@ Initial routes should be read-only or tightly scoped:
 - `GET /v1/events`
 
 These should render the same gateway read models as the CLI.
+
+The first bind policy should remain loopback-only by default unless explicit
+gateway auth, operator controls, and product docs are widened together.
 
 **Step 2: Add a first event stream**
 

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -36,6 +36,11 @@ the daemon-owned gateway surface and continue to reuse the same conversation,
 provider, tool, memory, ACP, dashboard, and runtime-status semantics as CLI and
 future paired clients.
 
+The current gateway slice already provides a localhost-only authenticated
+control surface for gateway owner status, channel inventory, runtime snapshot,
+and cooperative stop. The Web UI should consume that control surface instead of
+inventing a second browser-only runtime contract.
+
 ## Acceptance Criteria
 
 - [ ] The Web UI is treated as one coherent product surface rather than a chat-only browser shell.

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -18,18 +18,19 @@ The Web UI is expected to include:
 - dashboard
 - onboarding
 - a lightweight debug console
-- localhost-only by default in the current slice
+- localhost-only by default in the current slice for security
 - same-origin local product-mode serving in the current slice
 - shared read models and APIs with CLI and gateway-owned operator surfaces
 - an optional install path
 
 ## Architecture Direction
 
-The current shipping boundary stays local-first: same-origin, localhost-only by
-default, and implemented as a thin browser shell over the existing runtime.
+The current shipping boundary stays same-origin, localhost-only by default, and
+implemented as a thin browser shell over the existing runtime.
 
-That boundary is a delivery constraint for the current slice, not the long-term
-architecture endpoint.
+That default bind policy is a security and rollout constraint for the current
+slice, not the long-term architecture endpoint or a statement that future
+service-mode, paired-client, or broader gateway capabilities are out of scope.
 
 As gateway service work lands, the Web UI should become a first-class client of
 the daemon-owned gateway surface and continue to reuse the same conversation,
@@ -54,8 +55,8 @@ control token file independently.
 - [ ] The Web UI includes chat, dashboard, and onboarding as first-class parts of the same experience.
 - [ ] The Web UI can be delivered in a same-origin local product mode and stays localhost-only by default in the current slice unless future policy and docs explicitly widen that boundary.
 - [ ] The current localhost-only posture is documented as a safety default for
-      the current slice, not as a reason to avoid a future daemon-owned
-      gateway service or paired-client architecture.
+      the current slice, not as a product claim that future daemon-owned
+      gateway service, pairing, or remote-capable architecture is unwanted.
 - [ ] The optional install path is documented and supported without making installation mandatory for source users.
 - [ ] The Web UI is positioned as an additional user-facing surface, not as a replacement for core CLI onboarding, doctor, or other foundational CLI flows.
 
@@ -64,5 +65,7 @@ control token file independently.
 - claiming GA-level stability before productization is complete
 - treating the browser surface as a full CLI replacement
 - implying that public internet exposure is safe or supported by default
+- treating the default localhost-only posture as evidence that future
+  service-mode or pairing work is out of scope
 - treating the current localhost-only slice as the final architecture endpoint
 - expanding this spec into a hosted or multi-tenant web product

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -38,8 +38,14 @@ future paired clients.
 
 The current gateway slice already provides a localhost-only authenticated
 control surface for gateway owner status, channel inventory, runtime snapshot,
-and cooperative stop. The Web UI should consume that control surface instead of
-inventing a second browser-only runtime contract.
+operator summary, and cooperative stop. The Web UI should consume that control
+surface instead of inventing a second browser-only runtime contract.
+
+The current daemon slice also includes a reusable localhost discovery/client
+contract that validates loopback binding, loads the local bearer token, and
+offers route-scoped helpers for the current gateway API. The Web UI dashboard
+path should build on that contract instead of reading `status.json` and the
+control token file independently.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

- Problem:
  `gateway run` owned the gateway runtime lifecycle, but it still had no localhost control surface for local clients to discover a running owner, authenticate, and reuse shared read models.
- Why it matters:
  The local-first, CLI-first product path still needs a daemon-owned bind point so the Web UI, dashboard, and future paired local clients can attach to the same runtime instead of creating a second service lifecycle.
- What changed:
  Added a localhost-only authenticated control surface to `gateway run`; persisted the real `bind_address`, `port`, and `token_path` into gateway owner state; reused the existing gateway read models for channel inventory and runtime snapshot JSON routes; treated unexpected control-surface exit as a gateway runtime failure; added integration coverage and docs for the new localhost discovery model.
- What did not change (scope boundary):
  No hosted/public API, no remote/browser/mobile pairing flow, no dashboard frontend, no new standalone `gateway serve` command, and no widening beyond loopback-only local auth.

## Linked Issues

- Closes #646
- Related #644, #645

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes gateway owner lifecycle behavior by adding a loopback HTTP control surface, local bearer-token auth, and token-file cleanup semantics.
- Rollout / guardrails:
  The surface is loopback-only, uses an ephemeral port, persists discovery state only while the gateway is running, and clears `bind_address`, `port`, and `token_path` on stop or failure.
- Rollback path:
  Revert this PR to return `gateway run` to owner-state-only behavior with no localhost control surface.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-daemon gateway_owner_state -- --nocapture
cargo test -p loongclaw-daemon gateway_ -- --nocapture
cargo test --workspace --locked
cargo test --workspace --all-features --locked

Result: all commands completed successfully.
Behavior checks: verified unauthorized requests return 401, authorized localhost requests return gateway status/channel inventory/runtime snapshot payloads, `/api/gateway/stop` requests cooperative shutdown, and the owner snapshot clears bind/token discovery fields after exit.
```

## User-visible / Operator-visible Changes

- `gateway run` now starts a localhost-only authenticated control surface with:
  - `GET /api/gateway/status`
  - `GET /api/gateway/channels`
  - `GET /api/gateway/runtime-snapshot`
  - `POST /api/gateway/stop`
- `loongclaw gateway status --json` now exposes the live `bind_address`, `port`, and `token_path` while the gateway is running so local clients can discover the active control surface.

## Failure Recovery

- Fast rollback or disable path:
  Stop the running gateway and revert this PR if the local control surface causes lifecycle regressions.
- Observable failure symptoms reviewers should watch for:
  `gateway run` failing early because the localhost surface cannot bind or clean up its token file, stale discovery fields remaining after shutdown, or authenticated local requests failing against a running gateway.

## Reviewer Focus

- Focus on `crates/daemon/src/gateway/control.rs` for auth, loopback binding, and token-file lifecycle.
- Focus on `crates/daemon/src/gateway/service.rs` and `crates/daemon/src/gateway/state.rs` for lifecycle ownership, unexpected control-surface exit handling, and bind/token field cleanup on shutdown.
- Focus on `crates/daemon/tests/integration/gateway_owner_state.rs` for the end-to-end contract the Web UI and other local clients will rely on.
