### PR TITLE
feat: add gateway local client and operator summary surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,8 +485,8 @@ The current gateway slice now includes:
 - `loongclaw gateway status` for cross-process owner inspection
 - `loongclaw gateway stop` for cooperative shutdown
 - a localhost-only authenticated control surface that publishes status,
-  channel inventory, runtime snapshot, and cooperative stop endpoints from the
-  same `gateway run` owner
+  channel inventory, runtime snapshot, operator summary, and cooperative stop
+  endpoints from the same `gateway run` owner
 
 `gateway run` starts headless by default. Pass `--session` when you want the
 concurrent CLI host attached to the same runtime owner.
@@ -496,6 +496,11 @@ an ephemeral localhost port and writes the actual `bind_address`, `port`, and
 `token_path` into `loongclaw gateway status --json`. Local clients such as the
 future Web UI can discover the running owner through that persisted state
 without introducing a second service lifecycle.
+
+The daemon now also carries a reusable localhost gateway client/discovery layer
+that centralizes loopback validation, bearer-token loading, and route helpers
+for `status`, `channels`, `runtime-snapshot`, `operator-summary`, and `stop`.
+That keeps dashboard and Web UI bootstrap logic out of ad-hoc file reads.
 
 ```bash
 loongclaw gateway run --config ~/.loongclaw/config.toml

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -92,7 +92,11 @@ impl GatewayLocalClient {
     }
 
     pub fn from_discovery(discovery: GatewayLocalDiscovery) -> Self {
-        let http_client = Client::new();
+        let http_client = Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_else(|_| Client::new());
 
         Self {
             discovery,

--- a/crates/daemon/src/gateway/client.rs
+++ b/crates/daemon/src/gateway/client.rs
@@ -1,0 +1,376 @@
+use std::{
+    fs,
+    net::{IpAddr, SocketAddr},
+    path::{Path, PathBuf},
+};
+
+use reqwest::{Client, Method, Response};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::Value;
+
+use crate::CliResult;
+
+use super::{
+    read_models::GatewayOperatorSummaryReadModel,
+    state::{GatewayOwnerStatus, default_gateway_runtime_state_dir, load_gateway_owner_status},
+};
+
+#[derive(Debug, Clone)]
+pub struct GatewayLocalDiscovery {
+    runtime_dir: PathBuf,
+    owner_status: GatewayOwnerStatus,
+    socket_address: SocketAddr,
+    base_url: String,
+    bearer_token: String,
+}
+
+impl GatewayLocalDiscovery {
+    pub fn discover_default() -> CliResult<Self> {
+        let runtime_dir = default_gateway_runtime_state_dir();
+        Self::discover(runtime_dir.as_path())
+    }
+
+    pub fn discover(runtime_dir: &Path) -> CliResult<Self> {
+        let owner_status = load_gateway_owner_status(runtime_dir);
+        let Some(owner_status) = owner_status else {
+            let runtime_dir_text = runtime_dir.display().to_string();
+            let error = format!("gateway owner status is unavailable in {runtime_dir_text}");
+            return Err(error);
+        };
+
+        let socket_address = validate_gateway_local_owner_status(&owner_status)?;
+        let token_path = gateway_token_path_from_status(&owner_status)?;
+        let bearer_token = load_gateway_bearer_token(token_path.as_path())?;
+        let base_url = format!("http://{socket_address}");
+        let runtime_dir = runtime_dir.to_path_buf();
+
+        Ok(Self {
+            runtime_dir,
+            owner_status,
+            socket_address,
+            base_url,
+            bearer_token,
+        })
+    }
+
+    pub fn runtime_dir(&self) -> &Path {
+        self.runtime_dir.as_path()
+    }
+
+    pub fn owner_status(&self) -> &GatewayOwnerStatus {
+        &self.owner_status
+    }
+
+    pub fn socket_address(&self) -> SocketAddr {
+        self.socket_address
+    }
+
+    pub fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+
+    fn bearer_token(&self) -> &str {
+        self.bearer_token.as_str()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GatewayLocalClient {
+    discovery: GatewayLocalDiscovery,
+    http_client: Client,
+}
+
+impl GatewayLocalClient {
+    pub fn discover_default() -> CliResult<Self> {
+        let discovery = GatewayLocalDiscovery::discover_default()?;
+        Ok(Self::from_discovery(discovery))
+    }
+
+    pub fn discover(runtime_dir: &Path) -> CliResult<Self> {
+        let discovery = GatewayLocalDiscovery::discover(runtime_dir)?;
+        Ok(Self::from_discovery(discovery))
+    }
+
+    pub fn from_discovery(discovery: GatewayLocalDiscovery) -> Self {
+        let http_client = Client::new();
+
+        Self {
+            discovery,
+            http_client,
+        }
+    }
+
+    pub fn discovery(&self) -> &GatewayLocalDiscovery {
+        &self.discovery
+    }
+
+    pub async fn status(&self) -> CliResult<GatewayOwnerStatus> {
+        let path = "/api/gateway/status";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn channels(&self) -> CliResult<Value> {
+        let path = "/api/gateway/channels";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn runtime_snapshot(&self) -> CliResult<Value> {
+        let path = "/api/gateway/runtime-snapshot";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn operator_summary(&self) -> CliResult<GatewayOperatorSummaryReadModel> {
+        let path = "/api/gateway/operator-summary";
+        self.request_json(Method::GET, path).await
+    }
+
+    pub async fn stop(&self) -> CliResult<GatewayStopResponse> {
+        let path = "/api/gateway/stop";
+        self.request_json(Method::POST, path).await
+    }
+
+    async fn request_json<T>(&self, method: Method, path: &str) -> CliResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let endpoint = self.endpoint_url(path)?;
+        let method_name = method.as_str().to_owned();
+        let request_builder = self.http_client.request(method, endpoint.as_str());
+        let request_builder = request_builder.bearer_auth(self.discovery.bearer_token());
+        let response = request_builder
+            .send()
+            .await
+            .map_err(|error| format!("send gateway request failed for {endpoint}: {error}"))?;
+        let status = response.status();
+
+        if !status.is_success() {
+            let error_message = decode_gateway_error_message(response).await;
+            let error = format!(
+                "gateway {method_name} {path} failed with status {status}: {error_message}"
+            );
+            return Err(error);
+        }
+
+        response
+            .json::<T>()
+            .await
+            .map_err(|error| format!("decode gateway response failed for {endpoint}: {error}"))
+    }
+
+    fn endpoint_url(&self, path: &str) -> CliResult<String> {
+        if !path.starts_with('/') {
+            let error = format!("gateway client path must start with `/`: {path}");
+            return Err(error);
+        }
+
+        let base_url = self.discovery.base_url();
+        let endpoint = format!("{base_url}{path}");
+        Ok(endpoint)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayStopResponseOutcome {
+    Requested,
+    AlreadyRequested,
+    AlreadyStopped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayStopResponse {
+    pub outcome: GatewayStopResponseOutcome,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatewayErrorEnvelope {
+    error: GatewayErrorBody,
+}
+
+#[derive(Debug, Deserialize)]
+struct GatewayErrorBody {
+    code: String,
+    message: String,
+}
+
+fn validate_gateway_local_owner_status(status: &GatewayOwnerStatus) -> CliResult<SocketAddr> {
+    if status.stale {
+        return Err("gateway owner status is stale".to_owned());
+    }
+    if !status.running {
+        return Err("gateway owner is not running".to_owned());
+    }
+
+    let bind_address = status
+        .bind_address
+        .as_deref()
+        .ok_or_else(|| "gateway owner status is missing bind_address".to_owned())?;
+    let port = status
+        .port
+        .ok_or_else(|| "gateway owner status is missing port".to_owned())?;
+    let ip_address = bind_address.parse::<IpAddr>().map_err(|error| {
+        format!("gateway owner bind_address is not a valid IP address: {error}")
+    })?;
+
+    if !ip_address.is_loopback() {
+        let error = format!("gateway control surface must use loopback bind, found {bind_address}");
+        return Err(error);
+    }
+
+    let socket_address = SocketAddr::new(ip_address, port);
+    Ok(socket_address)
+}
+
+fn gateway_token_path_from_status(status: &GatewayOwnerStatus) -> CliResult<PathBuf> {
+    let token_path = status
+        .token_path
+        .as_deref()
+        .ok_or_else(|| "gateway owner status is missing token_path".to_owned())?;
+    let token_path = PathBuf::from(token_path);
+    Ok(token_path)
+}
+
+fn load_gateway_bearer_token(path: &Path) -> CliResult<String> {
+    let token = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read gateway control token failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    let token = token.trim().to_owned();
+
+    if token.is_empty() {
+        let error = format!("gateway control token is empty at {}", path.display());
+        return Err(error);
+    }
+
+    Ok(token)
+}
+
+async fn decode_gateway_error_message(response: Response) -> String {
+    let response_text = response.text().await;
+    let response_text = match response_text {
+        Ok(response_text) => response_text,
+        Err(error) => {
+            return format!("unable to read gateway error response: {error}");
+        }
+    };
+
+    let parsed_error = serde_json::from_str::<GatewayErrorEnvelope>(response_text.as_str());
+    if let Ok(parsed_error) = parsed_error {
+        let code = parsed_error.error.code;
+        let message = parsed_error.error.message;
+        return format!("{code}: {message}");
+    }
+
+    let trimmed = response_text.trim();
+    if trimmed.is_empty() {
+        return "request failed without an error body".to_owned();
+    }
+
+    trimmed.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+
+    fn gateway_owner_status_fixture() -> GatewayOwnerStatus {
+        GatewayOwnerStatus {
+            runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
+            phase: "running".to_owned(),
+            running: true,
+            stale: false,
+            pid: Some(42),
+            mode: super::super::state::GatewayOwnerMode::GatewayHeadless,
+            version: "0.1.0".to_owned(),
+            config_path: "/tmp/loongclaw.toml".to_owned(),
+            attached_cli_session: None,
+            started_at_ms: 100,
+            last_heartbeat_at: 200,
+            stopped_at_ms: None,
+            shutdown_reason: None,
+            last_error: None,
+            configured_surface_count: 1,
+            running_surface_count: 1,
+            bind_address: Some("127.0.0.1".to_owned()),
+            port: Some(7777),
+            token_path: Some("/tmp/loongclaw-gateway-runtime/control-token".to_owned()),
+        }
+    }
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let temp_dir = std::env::temp_dir();
+        temp_dir.join(format!("loongclaw-gateway-client-{label}-{suffix}"))
+    }
+
+    #[test]
+    fn gateway_local_discovery_accepts_loopback_owner_status() {
+        let status = gateway_owner_status_fixture();
+
+        let socket_address =
+            validate_gateway_local_owner_status(&status).expect("validate loopback owner status");
+
+        assert_eq!(socket_address.to_string(), "127.0.0.1:7777");
+    }
+
+    #[test]
+    fn gateway_local_discovery_rejects_stale_owner_status() {
+        let mut status = gateway_owner_status_fixture();
+        status.stale = true;
+        status.running = false;
+
+        let error = validate_gateway_local_owner_status(&status)
+            .expect_err("stale gateway owner status should be rejected");
+
+        assert!(error.contains("stale"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn gateway_local_discovery_rejects_non_loopback_bind_address() {
+        let mut status = gateway_owner_status_fixture();
+        status.bind_address = Some("192.168.1.10".to_owned());
+
+        let error = validate_gateway_local_owner_status(&status)
+            .expect_err("non-loopback gateway bind should be rejected");
+
+        assert!(error.contains("loopback"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn gateway_local_discovery_loads_trimmed_bearer_token() {
+        let token_path = unique_temp_path("token-trimmed");
+        fs::write(token_path.as_path(), "abc123\n").expect("write token");
+
+        let token =
+            load_gateway_bearer_token(token_path.as_path()).expect("load gateway bearer token");
+
+        assert_eq!(token, "abc123");
+
+        fs::remove_file(token_path).ok();
+    }
+
+    #[test]
+    fn gateway_local_discovery_rejects_empty_bearer_token() {
+        let token_path = unique_temp_path("token-empty");
+        fs::write(token_path.as_path(), "\n").expect("write empty token");
+
+        let error = load_gateway_bearer_token(token_path.as_path())
+            .expect_err("empty gateway token should be rejected");
+
+        assert!(error.contains("empty"), "unexpected error: {error}");
+
+        fs::remove_file(token_path).ok();
+    }
+}

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -365,11 +365,22 @@ fn authorize_request(headers: &HeaderMap, expected_token: &str) -> CliResult<()>
         return Err("Authorization header must use Bearer auth".to_owned());
     };
 
-    if provided_token != expected_token {
+    if !constant_time_eq(provided_token.as_bytes(), expected_token.as_bytes()) {
         return Err("invalid gateway bearer token".to_owned());
     }
 
     Ok(())
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut result = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        result |= x ^ y;
+    }
+    result == 0
 }
 
 fn build_gateway_channel_inventory_read_model(

--- a/crates/daemon/src/gateway/control.rs
+++ b/crates/daemon/src/gateway/control.rs
@@ -23,10 +23,15 @@ use tokio::{
 };
 
 use crate::{
-    CliResult, build_channels_cli_json_payload, build_runtime_snapshot_cli_json_payload,
+    CliResult, build_channels_cli_json_payload,
     collect_runtime_snapshot_cli_state_from_loaded_config, mvp, supervisor::LoadedSupervisorConfig,
 };
 
+use super::read_models::{
+    GatewayChannelInventoryReadModel, GatewayOperatorSummaryReadModel,
+    GatewayRuntimeSnapshotReadModel, build_operator_summary_read_model,
+    build_runtime_snapshot_read_model,
+};
 use super::state::{
     GatewayControlSurfaceBinding, GatewayStopRequestOutcome, gateway_control_token_path,
     load_gateway_owner_status, request_gateway_stop,
@@ -41,8 +46,8 @@ type GatewayControlJsonResponse = (StatusCode, Json<Value>);
 struct GatewayControlAppState {
     runtime_dir: PathBuf,
     bearer_token: String,
-    channels_payload: Arc<Value>,
-    runtime_snapshot_payload: Arc<Value>,
+    channel_inventory: Arc<GatewayChannelInventoryReadModel>,
+    runtime_snapshot: Arc<GatewayRuntimeSnapshotReadModel>,
 }
 
 struct GatewayControlSurfaceRuntime {
@@ -119,8 +124,8 @@ pub async fn start_gateway_control_surface(
     runtime_dir: &Path,
     loaded_config: &LoadedSupervisorConfig,
 ) -> CliResult<GatewayControlSurface> {
-    let channels_payload = build_gateway_channels_payload(loaded_config)?;
-    let runtime_snapshot_payload = build_gateway_runtime_snapshot_payload(loaded_config)?;
+    let channel_inventory = build_gateway_channel_inventory_read_model(loaded_config)?;
+    let runtime_snapshot = build_gateway_runtime_snapshot_read_model(loaded_config)?;
     let bearer_token = new_gateway_control_bearer_token();
     let token_path = gateway_control_token_path(runtime_dir);
 
@@ -161,8 +166,8 @@ pub async fn start_gateway_control_surface(
     let app_state = GatewayControlAppState {
         runtime_dir: runtime_dir.to_path_buf(),
         bearer_token,
-        channels_payload: Arc::new(channels_payload),
-        runtime_snapshot_payload: Arc::new(runtime_snapshot_payload),
+        channel_inventory: Arc::new(channel_inventory),
+        runtime_snapshot: Arc::new(runtime_snapshot),
     };
     let app_state = Arc::new(app_state);
     let router = build_gateway_control_router(app_state);
@@ -202,6 +207,10 @@ fn build_gateway_control_router(app_state: Arc<GatewayControlAppState>) -> Route
         .route(
             "/api/gateway/runtime-snapshot",
             get(handle_gateway_runtime_snapshot),
+        )
+        .route(
+            "/api/gateway/operator-summary",
+            get(handle_gateway_operator_summary),
         )
         .route("/api/gateway/stop", post(handle_gateway_stop))
         .with_state(app_state)
@@ -243,8 +252,18 @@ async fn handle_gateway_channels(
         return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
     }
 
-    let payload = app_state.channels_payload.as_ref().clone();
-    json_response(StatusCode::OK, payload)
+    let payload = serialize_json_value(
+        app_state.channel_inventory.as_ref(),
+        "gateway channels payload",
+    );
+    match payload {
+        Ok(payload) => json_response(StatusCode::OK, payload),
+        Err(error) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "serialize_failed",
+            error.as_str(),
+        ),
+    }
 }
 
 async fn handle_gateway_runtime_snapshot(
@@ -255,8 +274,51 @@ async fn handle_gateway_runtime_snapshot(
         return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
     }
 
-    let payload = app_state.runtime_snapshot_payload.as_ref().clone();
-    json_response(StatusCode::OK, payload)
+    let payload = serialize_json_value(
+        app_state.runtime_snapshot.as_ref(),
+        "gateway runtime snapshot payload",
+    );
+    match payload {
+        Ok(payload) => json_response(StatusCode::OK, payload),
+        Err(error) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "serialize_failed",
+            error.as_str(),
+        ),
+    }
+}
+
+async fn handle_gateway_operator_summary(
+    headers: HeaderMap,
+    State(app_state): State<Arc<GatewayControlAppState>>,
+) -> GatewayControlJsonResponse {
+    if let Err(error) = authorize_request(&headers, app_state.bearer_token.as_str()) {
+        return json_error(StatusCode::UNAUTHORIZED, "unauthorized", error.as_str());
+    }
+
+    let status = load_gateway_owner_status(app_state.runtime_dir.as_path());
+    let Some(status) = status else {
+        return json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "status_unavailable",
+            "gateway owner status is unavailable",
+        );
+    };
+
+    let summary = build_gateway_operator_summary_read_model(
+        &status,
+        app_state.channel_inventory.as_ref(),
+        app_state.runtime_snapshot.as_ref(),
+    );
+    let payload = serialize_json_value(&summary, "gateway operator summary payload");
+    match payload {
+        Ok(payload) => json_response(StatusCode::OK, payload),
+        Err(error) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "serialize_failed",
+            error.as_str(),
+        ),
+    }
 }
 
 async fn handle_gateway_stop(
@@ -310,18 +372,29 @@ fn authorize_request(headers: &HeaderMap, expected_token: &str) -> CliResult<()>
     Ok(())
 }
 
-fn build_gateway_channels_payload(loaded_config: &LoadedSupervisorConfig) -> CliResult<Value> {
+fn build_gateway_channel_inventory_read_model(
+    loaded_config: &LoadedSupervisorConfig,
+) -> CliResult<GatewayChannelInventoryReadModel> {
     let config_path = loaded_config.resolved_path.display().to_string();
     let inventory = mvp::channel::channel_inventory(&loaded_config.config);
-    let payload = build_channels_cli_json_payload(config_path.as_str(), &inventory);
-    serialize_json_value(&payload, "gateway channels payload")
+    let read_model = build_channels_cli_json_payload(config_path.as_str(), &inventory);
+    Ok(read_model)
 }
 
-fn build_gateway_runtime_snapshot_payload(
+fn build_gateway_runtime_snapshot_read_model(
     loaded_config: &LoadedSupervisorConfig,
-) -> CliResult<Value> {
+) -> CliResult<GatewayRuntimeSnapshotReadModel> {
     let snapshot = collect_runtime_snapshot_cli_state_from_loaded_config(loaded_config)?;
-    build_runtime_snapshot_cli_json_payload(&snapshot)
+    let read_model = build_runtime_snapshot_read_model(&snapshot);
+    Ok(read_model)
+}
+
+fn build_gateway_operator_summary_read_model(
+    status: &super::state::GatewayOwnerStatus,
+    channel_inventory: &GatewayChannelInventoryReadModel,
+    runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorSummaryReadModel {
+    build_operator_summary_read_model(status, channel_inventory, runtime_snapshot)
 }
 
 fn serialize_json_value<T: Serialize>(value: &T, context: &str) -> CliResult<Value> {

--- a/crates/daemon/src/gateway/mod.rs
+++ b/crates/daemon/src/gateway/mod.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod control;
 pub mod read_models;
 pub mod service;

--- a/crates/daemon/src/gateway/read_models.rs
+++ b/crates/daemon/src/gateway/read_models.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
+use std::net::{IpAddr, SocketAddr};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::CHANNELS_CLI_JSON_LEGACY_VIEWS;
@@ -8,6 +9,8 @@ use crate::CHANNELS_CLI_JSON_SCHEMA_VERSION;
 use crate::RUNTIME_SNAPSHOT_CLI_JSON_SCHEMA_VERSION;
 use crate::RuntimeSnapshotCliState;
 use crate::mvp;
+
+use super::state::GatewayOwnerStatus;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct GatewayChannelInventorySchema {
@@ -212,6 +215,57 @@ pub struct GatewayRuntimeSnapshotReadModel {
     pub external_skills: Value,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorControlSurfaceReadModel {
+    pub base_url: Option<String>,
+    pub loopback_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorChannelSurfaceReadModel {
+    pub channel_id: String,
+    pub label: String,
+    pub configured_account_count: usize,
+    pub enabled_account_count: usize,
+    pub misconfigured_account_count: usize,
+    pub ready_send_account_count: usize,
+    pub ready_serve_account_count: usize,
+    pub default_configured_account_id: Option<String>,
+    pub service_enabled: bool,
+    pub service_ready: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorChannelsSummaryReadModel {
+    pub catalog_channel_count: usize,
+    pub configured_channel_count: usize,
+    pub configured_account_count: usize,
+    pub enabled_account_count: usize,
+    pub misconfigured_account_count: usize,
+    pub runtime_backed_channel_count: usize,
+    pub enabled_service_channel_count: usize,
+    pub ready_service_channel_count: usize,
+    pub surfaces: Vec<GatewayOperatorChannelSurfaceReadModel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorRuntimeSummaryReadModel {
+    pub enabled_channel_ids: Vec<String>,
+    pub enabled_service_channel_ids: Vec<String>,
+    pub visible_tool_count: usize,
+    pub capability_snapshot_sha256: String,
+    pub active_provider_profile_id: Option<String>,
+    pub active_provider_label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayOperatorSummaryReadModel {
+    pub owner: GatewayOwnerStatus,
+    pub control_surface: GatewayOperatorControlSurfaceReadModel,
+    pub channels: GatewayOperatorChannelsSummaryReadModel,
+    pub runtime: GatewayOperatorRuntimeSummaryReadModel,
+}
+
 pub fn build_channel_inventory_read_model(
     config_path: &str,
     inventory: &mvp::channel::ChannelInventory,
@@ -335,6 +389,24 @@ pub fn build_runtime_snapshot_read_model(
         tool_runtime,
         tools,
         external_skills,
+    }
+}
+
+pub fn build_operator_summary_read_model(
+    owner_status: &GatewayOwnerStatus,
+    channel_inventory: &GatewayChannelInventoryReadModel,
+    runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorSummaryReadModel {
+    let owner = owner_status.clone();
+    let control_surface = build_operator_control_surface_read_model(owner_status);
+    let channels = build_operator_channels_summary_read_model(channel_inventory, runtime_snapshot);
+    let runtime = build_operator_runtime_summary_read_model(runtime_snapshot);
+
+    GatewayOperatorSummaryReadModel {
+        owner,
+        control_surface,
+        channels,
+        runtime,
     }
 }
 
@@ -548,4 +620,206 @@ fn build_acp_dispatch_decision_read_model(
     };
 
     GatewayAcpDispatchDecisionReadModel { session, decision }
+}
+
+fn build_operator_control_surface_read_model(
+    owner_status: &GatewayOwnerStatus,
+) -> GatewayOperatorControlSurfaceReadModel {
+    let base_url = gateway_owner_base_url(owner_status);
+    let loopback_only = gateway_owner_control_is_loopback(owner_status);
+
+    GatewayOperatorControlSurfaceReadModel {
+        base_url,
+        loopback_only,
+    }
+}
+
+fn build_operator_channels_summary_read_model(
+    channel_inventory: &GatewayChannelInventoryReadModel,
+    runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorChannelsSummaryReadModel {
+    let catalog_channel_count = channel_inventory.channel_catalog.len();
+    let configured_channel_count = channel_inventory
+        .channel_surfaces
+        .iter()
+        .filter(|surface| !surface.configured_accounts.is_empty())
+        .count();
+    let configured_account_count = channel_inventory.channels.len();
+    let enabled_account_count = channel_inventory
+        .channels
+        .iter()
+        .filter(|account| account.enabled)
+        .count();
+    let misconfigured_account_count = channel_inventory
+        .channels
+        .iter()
+        .filter(|account| channel_account_is_misconfigured(account))
+        .count();
+    let runtime_backed_channel_count = channel_inventory
+        .channel_catalog
+        .iter()
+        .filter(|channel| {
+            channel.implementation_status
+                == mvp::channel::ChannelCatalogImplementationStatus::RuntimeBacked
+        })
+        .count();
+    let enabled_service_channel_ids = &runtime_snapshot.channels.enabled_service_channel_ids;
+    let enabled_service_channel_count = enabled_service_channel_ids.len();
+    let surfaces = build_operator_channel_surface_read_models(
+        &channel_inventory.channel_surfaces,
+        enabled_service_channel_ids,
+    );
+    let ready_service_channel_count = surfaces
+        .iter()
+        .filter(|surface| surface.service_ready)
+        .count();
+
+    GatewayOperatorChannelsSummaryReadModel {
+        catalog_channel_count,
+        configured_channel_count,
+        configured_account_count,
+        enabled_account_count,
+        misconfigured_account_count,
+        runtime_backed_channel_count,
+        enabled_service_channel_count,
+        ready_service_channel_count,
+        surfaces,
+    }
+}
+
+fn build_operator_channel_surface_read_models(
+    channel_surfaces: &[mvp::channel::ChannelSurface],
+    enabled_service_channel_ids: &[String],
+) -> Vec<GatewayOperatorChannelSurfaceReadModel> {
+    let mut surfaces = Vec::with_capacity(channel_surfaces.len());
+
+    for channel_surface in channel_surfaces {
+        let surface =
+            build_operator_channel_surface_read_model(channel_surface, enabled_service_channel_ids);
+        surfaces.push(surface);
+    }
+
+    surfaces
+}
+
+fn build_operator_channel_surface_read_model(
+    channel_surface: &mvp::channel::ChannelSurface,
+    enabled_service_channel_ids: &[String],
+) -> GatewayOperatorChannelSurfaceReadModel {
+    let channel_id = channel_surface.catalog.id.to_owned();
+    let label = channel_surface.catalog.label.to_owned();
+    let configured_account_count = channel_surface.configured_accounts.len();
+    let enabled_account_count = channel_surface
+        .configured_accounts
+        .iter()
+        .filter(|account| account.enabled)
+        .count();
+    let misconfigured_account_count = channel_surface
+        .configured_accounts
+        .iter()
+        .filter(|account| channel_account_is_misconfigured(account))
+        .count();
+    let ready_send_account_count = channel_surface
+        .configured_accounts
+        .iter()
+        .filter(|account| {
+            channel_account_operation_is_ready(account, mvp::channel::CHANNEL_OPERATION_SEND_ID)
+        })
+        .count();
+    let ready_serve_account_count = channel_surface
+        .configured_accounts
+        .iter()
+        .filter(|account| {
+            channel_account_operation_is_ready(account, mvp::channel::CHANNEL_OPERATION_SERVE_ID)
+        })
+        .count();
+    let default_configured_account_id = channel_surface.default_configured_account_id.clone();
+    let service_enabled = enabled_service_channel_ids.contains(&channel_id);
+    let service_ready = service_enabled && ready_serve_account_count > 0;
+
+    GatewayOperatorChannelSurfaceReadModel {
+        channel_id,
+        label,
+        configured_account_count,
+        enabled_account_count,
+        misconfigured_account_count,
+        ready_send_account_count,
+        ready_serve_account_count,
+        default_configured_account_id,
+        service_enabled,
+        service_ready,
+    }
+}
+
+fn build_operator_runtime_summary_read_model(
+    runtime_snapshot: &GatewayRuntimeSnapshotReadModel,
+) -> GatewayOperatorRuntimeSummaryReadModel {
+    let enabled_channel_ids = runtime_snapshot.channels.enabled_channel_ids.clone();
+    let enabled_service_channel_ids = runtime_snapshot
+        .channels
+        .enabled_service_channel_ids
+        .clone();
+    let visible_tool_count = runtime_snapshot.tools.visible_tool_count;
+    let capability_snapshot_sha256 = runtime_snapshot.tools.capability_snapshot_sha256.clone();
+    let active_provider_profile_id =
+        json_string_field(&runtime_snapshot.provider, "active_profile_id");
+    let active_provider_label = json_string_field(&runtime_snapshot.provider, "active_label");
+
+    GatewayOperatorRuntimeSummaryReadModel {
+        enabled_channel_ids,
+        enabled_service_channel_ids,
+        visible_tool_count,
+        capability_snapshot_sha256,
+        active_provider_profile_id,
+        active_provider_label,
+    }
+}
+
+fn channel_account_is_misconfigured(account: &mvp::channel::ChannelStatusSnapshot) -> bool {
+    account
+        .operations
+        .iter()
+        .any(|operation| operation.health == mvp::channel::ChannelOperationHealth::Misconfigured)
+}
+
+fn channel_account_operation_is_ready(
+    account: &mvp::channel::ChannelStatusSnapshot,
+    operation_id: &str,
+) -> bool {
+    let operation = account.operation(operation_id);
+    let Some(operation) = operation else {
+        return false;
+    };
+
+    operation.health == mvp::channel::ChannelOperationHealth::Ready
+}
+
+fn gateway_owner_base_url(owner_status: &GatewayOwnerStatus) -> Option<String> {
+    let bind_address = owner_status.bind_address.as_deref()?;
+    let port = owner_status.port?;
+    let ip_address = bind_address.parse::<IpAddr>().ok()?;
+    let socket_address = SocketAddr::new(ip_address, port);
+    let base_url = format!("http://{socket_address}");
+    Some(base_url)
+}
+
+fn gateway_owner_control_is_loopback(owner_status: &GatewayOwnerStatus) -> bool {
+    let bind_address = owner_status.bind_address.as_deref();
+    let Some(bind_address) = bind_address else {
+        return false;
+    };
+
+    let ip_address = bind_address.parse::<IpAddr>();
+    let Ok(ip_address) = ip_address else {
+        return false;
+    };
+
+    ip_address.is_loopback()
+}
+
+fn json_string_field(value: &Value, field: &str) -> Option<String> {
+    let object = value.as_object()?;
+    let value = object.get(field)?;
+    let text = value.as_str()?;
+    Some(text.to_owned())
 }

--- a/crates/daemon/src/gateway/state.rs
+++ b/crates/daemon/src/gateway/state.rs
@@ -40,7 +40,7 @@ impl GatewayOwnerMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GatewayOwnerStatus {
     pub runtime_dir: String,
     pub phase: String,

--- a/crates/daemon/tests/integration/gateway_owner_state.rs
+++ b/crates/daemon/tests/integration/gateway_owner_state.rs
@@ -12,6 +12,7 @@ use std::{
 
 use loongclaw_daemon::{
     gateway::{
+        client::{GatewayLocalClient, GatewayStopResponseOutcome},
         service::{
             run_gateway_run_with_hooks_for_test,
             run_multi_channel_serve_gateway_compat_with_hooks_for_test,
@@ -460,4 +461,101 @@ async fn gateway_owner_state_localhost_control_surface_requires_auth_and_stops_r
     assert_eq!(stopped_status.port, None);
     assert_eq!(stopped_status.token_path, None);
     assert!(!token_path.exists());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gateway_owner_state_local_client_discovers_owner_reads_summary_and_stops_runtime() {
+    let runtime_dir = unique_runtime_dir("local-client");
+    let hooks = SupervisorRuntimeHooks {
+        load_config: Arc::new(|_| Ok(headless_loaded_config_fixture())),
+        initialize_runtime_environment: Arc::new(|_| {}),
+        run_cli_host: Arc::new(|_| {
+            panic!("headless gateway run should not start the concurrent CLI host")
+        }),
+        background_channel_runners: BTreeMap::new(),
+        wait_for_shutdown: Arc::new(pending_shutdown_future),
+        observe_state: Arc::new(|_| Ok(())),
+    };
+
+    let runtime_dir_for_run = runtime_dir.clone();
+    let run = tokio::spawn(async move {
+        run_gateway_run_with_hooks_for_test(
+            None,
+            None,
+            Vec::new(),
+            runtime_dir_for_run.as_path(),
+            hooks,
+        )
+        .await
+    });
+
+    let running_status = wait_for_gateway_control_surface(runtime_dir.as_path()).await;
+    let expected_port = running_status
+        .port
+        .expect("gateway control surface port should be persisted");
+    let client =
+        GatewayLocalClient::discover(runtime_dir.as_path()).expect("discover gateway local client");
+
+    assert_eq!(client.discovery().socket_address().port(), expected_port);
+    assert_eq!(
+        client.discovery().base_url(),
+        format!("http://127.0.0.1:{expected_port}")
+    );
+
+    let status = client.status().await.expect("read gateway status");
+    assert_eq!(status.phase, "running");
+    assert_eq!(status.bind_address.as_deref(), Some("127.0.0.1"));
+
+    let channels = client.channels().await.expect("read gateway channels");
+    assert_eq!(
+        channels["schema"]["primary_channel_view"],
+        "channel_surfaces"
+    );
+    assert_eq!(channels["schema"]["catalog_view"], "channel_catalog");
+
+    let runtime_snapshot = client
+        .runtime_snapshot()
+        .await
+        .expect("read gateway runtime snapshot");
+    assert_eq!(runtime_snapshot["schema"]["surface"], "runtime_snapshot");
+
+    let operator_summary = client
+        .operator_summary()
+        .await
+        .expect("read gateway operator summary");
+    assert_eq!(operator_summary.owner.phase, "running");
+    assert_eq!(
+        operator_summary.control_surface.base_url.as_deref(),
+        Some(client.discovery().base_url())
+    );
+    assert!(operator_summary.control_surface.loopback_only);
+    assert_eq!(
+        operator_summary.channels.enabled_service_channel_count,
+        runtime_snapshot["channels"]["enabled_service_channel_ids"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default()
+    );
+    assert_eq!(
+        operator_summary.runtime.visible_tool_count,
+        runtime_snapshot["tools"]["visible_tool_count"]
+            .as_u64()
+            .map(|value| value as usize)
+            .unwrap_or_default()
+    );
+
+    let stop = client.stop().await.expect("request gateway stop");
+    assert_eq!(stop.outcome, GatewayStopResponseOutcome::Requested);
+
+    let supervisor = timeout(GATEWAY_OWNER_TEST_TIMEOUT, run)
+        .await
+        .expect("gateway run should stop after local client stop")
+        .expect("join gateway run after local client stop")
+        .expect("gateway run should return supervisor state");
+    assert!(supervisor.final_exit_result().is_ok());
+
+    let stopped_status = load_gateway_owner_status(runtime_dir.as_path())
+        .expect("stopped gateway status should be present");
+    assert_eq!(stopped_status.phase, "stopped");
+    assert!(!stopped_status.running);
 }

--- a/crates/daemon/tests/integration/gateway_read_models.rs
+++ b/crates/daemon/tests/integration/gateway_read_models.rs
@@ -251,3 +251,85 @@ fn gateway_read_model_runtime_snapshot_embeds_inventory_and_tool_summary() {
 
     fs::remove_dir_all(&root).ok();
 }
+
+#[test]
+fn gateway_read_model_operator_summary_keeps_owner_control_and_runtime_rollups() {
+    let root = unique_temp_dir("loongclaw-gateway-operator-summary");
+    let config_path = write_gateway_test_config(&root);
+    let config_path_text = config_path
+        .to_str()
+        .expect("config path should be valid utf-8");
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(config_path_text))
+        .expect("collect runtime snapshot");
+    let inventory = gateway::read_models::build_channel_inventory_read_model(
+        config_path_text,
+        &snapshot.channels,
+    );
+    let runtime_snapshot = gateway::read_models::build_runtime_snapshot_read_model(&snapshot);
+    let owner_status = gateway::state::GatewayOwnerStatus {
+        runtime_dir: "/tmp/loongclaw-gateway-runtime".to_owned(),
+        phase: "running".to_owned(),
+        running: true,
+        stale: false,
+        pid: Some(42),
+        mode: gateway::state::GatewayOwnerMode::GatewayHeadless,
+        version: env!("CARGO_PKG_VERSION").to_owned(),
+        config_path: config_path_text.to_owned(),
+        attached_cli_session: None,
+        started_at_ms: 100,
+        last_heartbeat_at: 200,
+        stopped_at_ms: None,
+        shutdown_reason: None,
+        last_error: None,
+        configured_surface_count: 0,
+        running_surface_count: 0,
+        bind_address: Some("127.0.0.1".to_owned()),
+        port: Some(7777),
+        token_path: Some("/tmp/loongclaw-gateway-runtime/control-token".to_owned()),
+    };
+
+    let summary = gateway::read_models::build_operator_summary_read_model(
+        &owner_status,
+        &inventory,
+        &runtime_snapshot,
+    );
+    let encoded = serde_json::to_value(&summary).expect("serialize operator summary read model");
+
+    assert_eq!(summary.owner.phase, "running");
+    assert_eq!(
+        summary.control_surface.base_url.as_deref(),
+        Some("http://127.0.0.1:7777")
+    );
+    assert!(summary.control_surface.loopback_only);
+    assert_eq!(
+        summary.channels.catalog_channel_count,
+        inventory.channel_catalog.len()
+    );
+    assert_eq!(
+        summary.channels.configured_account_count,
+        inventory.channels.len()
+    );
+    assert_eq!(
+        summary.channels.enabled_service_channel_count,
+        runtime_snapshot.channels.enabled_service_channel_ids.len()
+    );
+    assert_eq!(
+        summary.channels.surfaces.len(),
+        inventory.channel_surfaces.len()
+    );
+    assert_eq!(
+        summary.runtime.visible_tool_count,
+        runtime_snapshot.tools.visible_tool_count
+    );
+    assert_eq!(
+        summary.runtime.active_provider_profile_id.as_deref(),
+        runtime_snapshot.provider["active_profile_id"].as_str()
+    );
+    assert_eq!(
+        encoded["control_surface"]["base_url"],
+        "http://127.0.0.1:7777"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -38,8 +38,14 @@ future paired clients.
 
 The current gateway slice already provides a localhost-only authenticated
 control surface for gateway owner status, channel inventory, runtime snapshot,
-and cooperative stop. The Web UI should consume that control surface instead of
-inventing a second browser-only runtime contract.
+operator summary, and cooperative stop. The Web UI should consume that control
+surface instead of inventing a second browser-only runtime contract.
+
+The current daemon slice also includes a reusable localhost discovery/client
+contract that validates loopback binding, loads the local bearer token, and
+offers route-scoped helpers for the current gateway API. The Web UI dashboard
+path should build on that contract instead of reading `status.json` and the
+control token file independently.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

- Problem: localhost gateway consumers still had to reimplement owner discovery, loopback validation, token loading, and route usage, and there was no compact operator-facing summary surface for dashboard or Web UI bootstrap.
- Why it matters: duplicating discovery and auth bootstrap across local clients would create contract drift and slow the path to dashboard, status, and logs as first-class operator surfaces.
- What changed: added a daemon-owned localhost gateway client/discovery layer, added an authenticated `GET /api/gateway/operator-summary` route, introduced shared operator-summary read models, and covered the new contract with unit and integration tests.
- What did not change (scope boundary): no hosted or multi-tenant gateway API, no remote/browser/mobile pairing flow, no new service install flow, and no bind widening beyond loopback-only local access.

## Linked Issues

- Closes #650
- Related #649

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this changes localhost gateway attachment and authenticated control-surface behavior that future dashboard and Web UI flows will depend on.
- Rollout / guardrails: discovery fails closed on stale, incomplete, or non-loopback owner state; the route remains bearer-authenticated and loopback-only; lifecycle still stays with the existing `gateway run` owner.
- Rollback path: revert this stacked slice and fall back to the existing owner-state plus token-file contract from the prior localhost control-surface PR.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-daemon gateway_read_model_ -- --test-threads=1
cargo test -p loongclaw-daemon gateway_owner_state_ -- --test-threads=1
cargo test --workspace --all-features --locked
cargo test --workspace --locked

All commands completed successfully in this worktree. The new integration coverage exercises local discovery, authenticated route access, operator-summary rollups, and cooperative shutdown through the local client.
```

## User-visible / Operator-visible Changes

- Local localhost consumers now have one daemon-owned discovery and request path for `status`, `channels`, `runtime-snapshot`, `operator-summary`, and `stop`.
- The gateway control surface now exposes a compact authenticated operator summary payload for dashboard and Web UI bootstrap.
- README and Web UI product-spec docs now describe the localhost-only client/discovery contract and the new operator-summary surface.

## Failure Recovery

- Fast rollback or disable path: revert this PR and continue consuming the existing localhost control surface plus raw owner snapshot/token files from the prior slice.
- Observable failure symptoms reviewers should watch for: discovery should reject stale or non-loopback owner status, and `/api/gateway/operator-summary` should stay aligned with the persisted owner state and existing runtime/channel read models.

## Reviewer Focus

- Review `crates/daemon/src/gateway/client.rs` for fail-closed discovery, token loading, and typed route helpers.
- Review `crates/daemon/src/gateway/control.rs` and `crates/daemon/src/gateway/read_models.rs` for the new authenticated operator-summary route and the summary rollups built from shared read models.
- Review `crates/daemon/tests/integration/gateway_owner_state.rs` and `crates/daemon/tests/integration/gateway_read_models.rs` for the end-to-end local-client and read-model coverage.
