### PR TITLE
Add doctor security exposure audit and config hygiene report

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ survive process restarts.
 ```bash
 loongclaw doctor --config ~/.loongclaw/config.toml
 loongclaw doctor --config ~/.loongclaw/config.toml --json
+loongclaw doctor security --config ~/.loongclaw/config.toml
+loongclaw doctor security --config ~/.loongclaw/config.toml --json
 loongclaw audit recent --config ~/.loongclaw/config.toml
 loongclaw audit recent --config ~/.loongclaw/config.toml --kind tool-search-evaluated --query-contains "trust:official" --trust-tier official
 loongclaw audit summary --config ~/.loongclaw/config.toml
@@ -379,6 +381,14 @@ now adds a provider route probe for the active request/models host. That probe
 surfaces the host and port, DNS resolution results, fake-ip-style addresses,
 and a short TCP reachability check so you can separate local proxy/TUN/fake-ip
 instability from true upstream unavailability.
+
+`doctor security` complements the general health check with a security exposure
+and config hygiene audit. It reports `covered`, `partial`, `exposed`, and
+`unknown` findings across durable audit retention, shell execution posture,
+tool file-root confinement, web-fetch egress, external-skills download posture,
+secret storage hygiene, and browser automation surfaces. Use the text output
+for operator review and `--json` when you want a stable machine-readable
+contract for automation or support tooling.
 
 ## We Are Currently Working On
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -4,6 +4,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use clap::Subcommand;
 use kernel::probe_jsonl_audit_journal_runtime_ready;
 use loongclaw_app as mvp;
 use loongclaw_contracts::SecretRef;
@@ -13,12 +14,19 @@ use serde_json::json;
 use crate::provider_credential_policy;
 use crate::provider_model_probe_policy;
 
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum DoctorCommands {
+    /// Report effective security exposure and config hygiene posture
+    Security,
+}
+
 #[derive(Debug, Clone)]
 pub struct DoctorCommandOptions {
     pub config: Option<String>,
     pub fix: bool,
     pub json: bool,
     pub skip_model_probe: bool,
+    pub command: Option<DoctorCommands>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,6 +51,22 @@ struct DoctorSummary {
 }
 
 pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
+    if let Some(command) = options.command.clone() {
+        return match command {
+            DoctorCommands::Security => {
+                crate::doctor_security_cli::run_doctor_security_cli(
+                    crate::doctor_security_cli::DoctorSecurityCommandOptions {
+                        config: options.config,
+                        json: options.json,
+                        fix: options.fix,
+                        skip_model_probe: options.skip_model_probe,
+                    },
+                )
+                .await
+            }
+        };
+    }
+
     let (config_path, mut config) = mvp::config::load(options.config.as_deref())?;
     let mut checks = Vec::new();
     let mut fixes = Vec::new();
@@ -339,7 +363,7 @@ fn durable_audit_retention_doctor_check(
     }
 }
 
-fn durable_audit_target_issue(path: &Path) -> Option<String> {
+pub(crate) fn durable_audit_target_issue(path: &Path) -> Option<String> {
     durable_audit_target_issue_with_probe(path, durable_audit_runtime_probe)
 }
 

--- a/crates/daemon/src/doctor_security_cli.rs
+++ b/crates/daemon/src/doctor_security_cli.rs
@@ -1,0 +1,1744 @@
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+
+use loongclaw_app as mvp;
+use loongclaw_contracts::SecretRef;
+use loongclaw_spec::CliResult;
+use serde::Serialize;
+use serde_json::json;
+
+use crate::doctor_cli::durable_audit_target_issue;
+
+#[derive(Debug, Clone)]
+pub struct DoctorSecurityCommandOptions {
+    pub config: Option<String>,
+    pub json: bool,
+    pub fix: bool,
+    pub skip_model_probe: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecurityFindingStatus {
+    Covered,
+    Partial,
+    Exposed,
+    Unknown,
+}
+
+impl SecurityFindingStatus {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Covered => "covered",
+            Self::Partial => "partial",
+            Self::Exposed => "exposed",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecurityFindingSeverity {
+    Info,
+    Warn,
+    Critical,
+}
+
+impl SecurityFindingSeverity {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SecurityFinding {
+    pub id: String,
+    pub title: String,
+    pub status: SecurityFindingStatus,
+    pub severity: SecurityFindingSeverity,
+    pub summary: String,
+    pub evidence: Vec<String>,
+    pub next_steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SecurityAuditSummary {
+    pub covered: usize,
+    pub partial: usize,
+    pub exposed: usize,
+    pub unknown: usize,
+    pub info: usize,
+    pub warn: usize,
+    pub critical: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorSecurityAuditExecution {
+    pub resolved_config_path: String,
+    pub ok: bool,
+    pub summary: SecurityAuditSummary,
+    pub findings: Vec<SecurityFinding>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecretReferenceKind {
+    Env,
+    File,
+    Exec,
+    InlineLiteral,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SecretObservation {
+    field_path: String,
+    kind: SecretReferenceKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct SecretObservationCounts {
+    env: usize,
+    file: usize,
+    exec: usize,
+    inline_literal: usize,
+}
+
+impl SecretObservationCounts {
+    fn record(&mut self, kind: SecretReferenceKind) {
+        match kind {
+            SecretReferenceKind::Env => self.env += 1,
+            SecretReferenceKind::File => self.file += 1,
+            SecretReferenceKind::Exec => self.exec += 1,
+            SecretReferenceKind::InlineLiteral => self.inline_literal += 1,
+        }
+    }
+}
+
+pub async fn run_doctor_security_cli(options: DoctorSecurityCommandOptions) -> CliResult<()> {
+    if options.fix {
+        return Err("doctor security does not support --fix".to_owned());
+    }
+
+    if options.skip_model_probe {
+        return Err("doctor security does not support --skip-model-probe".to_owned());
+    }
+
+    let config_path = options.config.as_deref();
+    let execution = execute_doctor_security_command(config_path).await?;
+
+    if options.json {
+        let payload = doctor_security_cli_json(&execution);
+        let encoded = serde_json::to_string_pretty(&payload)
+            .map_err(|error| format!("serialize doctor security output failed: {error}"))?;
+        println!("{encoded}");
+        return Ok(());
+    }
+
+    let rendered = render_doctor_security_cli_text(&execution);
+    println!("{rendered}");
+
+    if !execution.ok {
+        return Err("doctor security detected exposed surfaces".to_owned());
+    }
+
+    Ok(())
+}
+
+pub async fn execute_doctor_security_command(
+    config: Option<&str>,
+) -> CliResult<DoctorSecurityAuditExecution> {
+    let (config_path, config) = mvp::config::load(config)?;
+    let execution = build_doctor_security_execution(&config_path, &config).await?;
+    Ok(execution)
+}
+
+pub fn doctor_security_cli_json(execution: &DoctorSecurityAuditExecution) -> serde_json::Value {
+    json!({
+        "command": "security",
+        "config": execution.resolved_config_path,
+        "ok": execution.ok,
+        "summary": execution.summary,
+        "findings": execution.findings,
+    })
+}
+
+pub fn render_doctor_security_cli_text(execution: &DoctorSecurityAuditExecution) -> String {
+    let mut lines = Vec::new();
+    let config_line = format!("doctor security config={}", execution.resolved_config_path);
+    lines.push(config_line);
+
+    let summary = &execution.summary;
+    let summary_line = format!(
+        "security summary: covered={} partial={} exposed={} unknown={} info={} warn={} critical={} ok={}",
+        summary.covered,
+        summary.partial,
+        summary.exposed,
+        summary.unknown,
+        summary.info,
+        summary.warn,
+        summary.critical,
+        execution.ok
+    );
+    lines.push(summary_line);
+
+    for finding in &execution.findings {
+        let finding_line = format!(
+            "- {} [{} / {}] {}",
+            finding.title,
+            finding.status.as_str(),
+            finding.severity.as_str(),
+            finding.summary
+        );
+        lines.push(finding_line);
+
+        for evidence in &finding.evidence {
+            let evidence_line = format!("  evidence: {evidence}");
+            lines.push(evidence_line);
+        }
+
+        for next_step in &finding.next_steps {
+            let next_step_line = format!("  next: {next_step}");
+            lines.push(next_step_line);
+        }
+    }
+
+    lines.join("\n")
+}
+
+async fn build_doctor_security_execution(
+    config_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<DoctorSecurityAuditExecution> {
+    let runtime = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        config,
+        Some(config_path),
+    );
+    let browser_companion_diagnostics =
+        crate::browser_companion_diagnostics::collect_browser_companion_diagnostics(config).await;
+
+    let mut findings = Vec::new();
+
+    let audit_finding = assess_audit_retention(config);
+    findings.push(audit_finding);
+
+    let shell_finding = assess_shell_execution(config, &runtime);
+    findings.push(shell_finding);
+
+    let file_root_finding = assess_tool_file_root(config, &runtime);
+    findings.push(file_root_finding);
+
+    let web_fetch_finding = assess_web_fetch(runtime.web_fetch.clone());
+    findings.push(web_fetch_finding);
+
+    let external_skills_finding = assess_external_skills(runtime.external_skills.clone());
+    findings.push(external_skills_finding);
+
+    let secret_hygiene_finding = assess_secret_hygiene(config_path, config)?;
+    findings.push(secret_hygiene_finding);
+
+    let browser_finding = assess_browser_surfaces(&runtime, browser_companion_diagnostics.as_ref());
+    findings.push(browser_finding);
+
+    let summary = summarize_findings(&findings);
+    let ok = summary.exposed == 0;
+    let resolved_config_path = config_path.display().to_string();
+
+    Ok(DoctorSecurityAuditExecution {
+        resolved_config_path,
+        ok,
+        summary,
+        findings,
+    })
+}
+
+fn assess_audit_retention(config: &mvp::config::LoongClawConfig) -> SecurityFinding {
+    let audit_mode = config.audit.mode;
+    let audit_mode_name = audit_mode.as_str();
+    let journal_path = config.audit.resolved_path();
+    let journal_path_string = journal_path.display().to_string();
+    let mut evidence = Vec::new();
+    let mode_evidence = format!("audit.mode={audit_mode_name}");
+    evidence.push(mode_evidence);
+    let path_evidence = format!("audit.journal={journal_path_string}");
+    evidence.push(path_evidence);
+
+    if matches!(audit_mode, mvp::config::AuditMode::InMemory) {
+        let summary =
+            "Audit evidence is kept in memory only and will be lost on restart.".to_owned();
+        let next_steps = vec![
+            "Switch to audit.mode = \"fanout\" or audit.mode = \"jsonl\".".to_owned(),
+            "Re-run doctor security after enabling durable audit retention.".to_owned(),
+        ];
+        return build_finding(
+            "audit_retention",
+            "Audit Retention",
+            SecurityFindingStatus::Exposed,
+            SecurityFindingSeverity::Critical,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    let runtime_issue = durable_audit_target_issue(&journal_path);
+    if let Some(runtime_issue) = runtime_issue {
+        let issue_evidence = format!("runtime_probe={runtime_issue}");
+        evidence.push(issue_evidence);
+        let summary =
+            "Durable audit retention is configured, but the journal target is not runtime-ready."
+                .to_owned();
+        let next_steps = vec![
+            "Repair the audit journal path or parent directory permissions.".to_owned(),
+            "Run loongclaw doctor to confirm the journal path opens cleanly.".to_owned(),
+        ];
+        return build_finding(
+            "audit_retention",
+            "Audit Retention",
+            SecurityFindingStatus::Exposed,
+            SecurityFindingSeverity::Critical,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    let summary =
+        "Durable audit retention is active and the journal target passed the runtime probe."
+            .to_owned();
+    let next_steps = Vec::new();
+    build_finding(
+        "audit_retention",
+        "Audit Retention",
+        SecurityFindingStatus::Covered,
+        SecurityFindingSeverity::Info,
+        summary,
+        evidence,
+        next_steps,
+    )
+}
+
+fn assess_shell_execution(
+    config: &mvp::config::LoongClawConfig,
+    runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+) -> SecurityFinding {
+    let default_mode = runtime.shell_default_mode;
+    let allow_count = runtime.shell_allow.len();
+    let deny_count = runtime.shell_deny.len();
+    let approval_mode = render_tool_approval_mode(config.tools.approval.mode);
+    let autonomy_profile = config.tools.autonomy_profile.as_str();
+
+    let mut evidence = Vec::new();
+    let default_mode_evidence = format!(
+        "tools.shell_default_mode={}",
+        render_shell_default_mode(default_mode)
+    );
+    evidence.push(default_mode_evidence);
+    let allow_count_evidence = format!("tools.shell_allow.count={allow_count}");
+    evidence.push(allow_count_evidence);
+    let deny_count_evidence = format!("tools.shell_deny.count={deny_count}");
+    evidence.push(deny_count_evidence);
+    let approval_mode_evidence = format!("tools.approval.mode={approval_mode}");
+    evidence.push(approval_mode_evidence);
+    let autonomy_profile_evidence = format!("tools.autonomy_profile={autonomy_profile}");
+    evidence.push(autonomy_profile_evidence);
+
+    if matches!(
+        default_mode,
+        mvp::tools::shell_policy_ext::ShellPolicyDefault::Allow
+    ) {
+        let summary =
+            "Shell execution allows unknown commands by default, which leaves the runtime open-ended."
+                .to_owned();
+        let next_steps = vec![
+            "Set tools.shell_default_mode = \"deny\".".to_owned(),
+            "Keep tools.shell_allow to the smallest practical command set.".to_owned(),
+        ];
+        return build_finding(
+            "shell_execution",
+            "Shell Execution",
+            SecurityFindingStatus::Exposed,
+            SecurityFindingSeverity::Critical,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    if allow_count == 0 {
+        let summary =
+            "Shell execution is effectively disabled by default-deny with an empty allowlist."
+                .to_owned();
+        let next_steps = Vec::new();
+        return build_finding(
+            "shell_execution",
+            "Shell Execution",
+            SecurityFindingStatus::Covered,
+            SecurityFindingSeverity::Info,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    let summary =
+        "Shell execution is default-deny, but allowlisted commands remain available without OS-level isolation."
+            .to_owned();
+    let next_steps = vec![
+        "Review whether every command in tools.shell_allow still needs to be present.".to_owned(),
+        "Prefer approval gating for risky shell workflows when commands must remain available."
+            .to_owned(),
+    ];
+    build_finding(
+        "shell_execution",
+        "Shell Execution",
+        SecurityFindingStatus::Partial,
+        SecurityFindingSeverity::Warn,
+        summary,
+        evidence,
+        next_steps,
+    )
+}
+
+fn assess_tool_file_root(
+    config: &mvp::config::LoongClawConfig,
+    runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+) -> SecurityFinding {
+    let explicit_root = config.tools.file_root.as_deref();
+    let effective_root = runtime
+        .file_root
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("."));
+    let effective_root_string = effective_root.display().to_string();
+    let root_exists = effective_root.exists();
+
+    let mut evidence = Vec::new();
+    let explicit_root_value = explicit_root.unwrap_or("(current working directory)");
+    let explicit_root_evidence = format!("tools.file_root={explicit_root_value}");
+    evidence.push(explicit_root_evidence);
+    let effective_root_evidence = format!("effective_tool_root={effective_root_string}");
+    evidence.push(effective_root_evidence);
+    let root_exists_evidence = format!("effective_tool_root.exists={root_exists}");
+    evidence.push(root_exists_evidence);
+
+    let explicit_root_missing = explicit_root
+        .map(str::trim)
+        .is_none_or(|value| value.is_empty());
+    if explicit_root_missing {
+        let summary =
+            "File tools still fall back to the current working directory because tools.file_root is unset."
+                .to_owned();
+        let next_steps = vec![
+            "Set tools.file_root to a dedicated workspace path.".to_owned(),
+            "Run loongclaw doctor --fix if you want the workspace directory created automatically."
+                .to_owned(),
+        ];
+        return build_finding(
+            "tool_file_root",
+            "Tool File Root",
+            SecurityFindingStatus::Exposed,
+            SecurityFindingSeverity::Critical,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    let summary =
+        "File tools are rooted to an explicit workspace path, but confinement remains tool-layer rather than OS-enforced."
+            .to_owned();
+    let next_steps = vec![
+        "Keep tools.file_root on a narrow workspace path instead of a broad home-directory root."
+            .to_owned(),
+    ];
+    build_finding(
+        "tool_file_root",
+        "Tool File Root",
+        SecurityFindingStatus::Partial,
+        SecurityFindingSeverity::Warn,
+        summary,
+        evidence,
+        next_steps,
+    )
+}
+
+fn assess_web_fetch(policy: mvp::tools::runtime_config::WebFetchRuntimePolicy) -> SecurityFinding {
+    let mut evidence = Vec::new();
+    let enabled_evidence = format!("tools.web.enabled={}", policy.enabled);
+    evidence.push(enabled_evidence);
+    let private_hosts_evidence = format!(
+        "tools.web.allow_private_hosts={}",
+        policy.allow_private_hosts
+    );
+    evidence.push(private_hosts_evidence);
+    let allowed_domain_count = policy.allowed_domains.len();
+    let allowed_domain_count_evidence =
+        format!("tools.web.allowed_domains.count={allowed_domain_count}");
+    evidence.push(allowed_domain_count_evidence);
+    let blocked_domain_count = policy.blocked_domains.len();
+    let blocked_domain_count_evidence =
+        format!("tools.web.blocked_domains.count={blocked_domain_count}");
+    evidence.push(blocked_domain_count_evidence);
+
+    if !policy.enabled {
+        let summary = "Web fetch is disabled for the local runtime.".to_owned();
+        let next_steps = Vec::new();
+        return build_finding(
+            "web_fetch",
+            "Web Fetch Egress",
+            SecurityFindingStatus::Covered,
+            SecurityFindingSeverity::Info,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    if policy.allow_private_hosts {
+        let summary =
+            "Web fetch allows private hosts, which weakens the default SSRF boundary for operator workloads."
+                .to_owned();
+        let next_steps = vec![
+            "Set tools.web.allow_private_hosts = false unless private-network fetch is required."
+                .to_owned(),
+        ];
+        return build_finding(
+            "web_fetch",
+            "Web Fetch Egress",
+            SecurityFindingStatus::Exposed,
+            SecurityFindingSeverity::Critical,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    if policy.enforce_allowed_domains {
+        let summary =
+            "Web fetch denies private hosts and is constrained to an explicit domain allowlist."
+                .to_owned();
+        let next_steps = Vec::new();
+        return build_finding(
+            "web_fetch",
+            "Web Fetch Egress",
+            SecurityFindingStatus::Covered,
+            SecurityFindingSeverity::Info,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    let summary =
+        "Web fetch denies private hosts, but public-domain access is still open-ended because no allowlist is configured."
+            .to_owned();
+    let next_steps = vec![
+        "Add tools.web.allowed_domains when the runtime only needs a known destination set."
+            .to_owned(),
+    ];
+    build_finding(
+        "web_fetch",
+        "Web Fetch Egress",
+        SecurityFindingStatus::Partial,
+        SecurityFindingSeverity::Warn,
+        summary,
+        evidence,
+        next_steps,
+    )
+}
+
+fn assess_external_skills(
+    policy: mvp::tools::runtime_config::ExternalSkillsRuntimePolicy,
+) -> SecurityFinding {
+    let mut evidence = Vec::new();
+    let enabled_evidence = format!("external_skills.enabled={}", policy.enabled);
+    evidence.push(enabled_evidence);
+    let approval_evidence = format!(
+        "external_skills.require_download_approval={}",
+        policy.require_download_approval
+    );
+    evidence.push(approval_evidence);
+    let allow_count = policy.allowed_domains.len();
+    let allow_count_evidence = format!("external_skills.allowed_domains.count={allow_count}");
+    evidence.push(allow_count_evidence);
+    let block_count = policy.blocked_domains.len();
+    let block_count_evidence = format!("external_skills.blocked_domains.count={block_count}");
+    evidence.push(block_count_evidence);
+    let auto_expose_evidence = format!(
+        "external_skills.auto_expose_installed={}",
+        policy.auto_expose_installed
+    );
+    evidence.push(auto_expose_evidence);
+
+    if !policy.enabled {
+        let summary = "External skills are disabled for this runtime.".to_owned();
+        let next_steps = Vec::new();
+        return build_finding(
+            "external_skills",
+            "External Skills",
+            SecurityFindingStatus::Covered,
+            SecurityFindingSeverity::Info,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    if policy.auto_expose_installed || !policy.require_download_approval {
+        let summary =
+            "External skills are enabled with a posture that can auto-expose or download without explicit approval."
+                .to_owned();
+        let next_steps = vec![
+            "Keep external_skills.require_download_approval = true.".to_owned(),
+            "Keep external_skills.auto_expose_installed = false until a review step completes."
+                .to_owned(),
+        ];
+        return build_finding(
+            "external_skills",
+            "External Skills",
+            SecurityFindingStatus::Exposed,
+            SecurityFindingSeverity::Critical,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    let summary =
+        "External skills are approval-gated, but the current runtime still lacks provenance scanning and isolated execution."
+            .to_owned();
+    let mut next_steps = Vec::new();
+    if policy.allowed_domains.is_empty() {
+        next_steps.push(
+            "Pin external_skills.allowed_domains to the smallest trusted host set.".to_owned(),
+        );
+    }
+    next_steps.push("Keep installed skills dark until operator review completes.".to_owned());
+    build_finding(
+        "external_skills",
+        "External Skills",
+        SecurityFindingStatus::Partial,
+        SecurityFindingSeverity::Warn,
+        summary,
+        evidence,
+        next_steps,
+    )
+}
+
+fn assess_secret_hygiene(
+    config_path: &Path,
+    config: &mvp::config::LoongClawConfig,
+) -> CliResult<SecurityFinding> {
+    let mut observations = collect_secret_observations(config);
+    observations.sort_by(|left, right| left.field_path.cmp(&right.field_path));
+
+    let counts = summarize_secret_observations(&observations);
+    let env_pointer_diagnostics = collect_env_pointer_diagnostics(config);
+    let inline_paths =
+        observation_paths_for_kind(&observations, SecretReferenceKind::InlineLiteral);
+    let exec_paths = observation_paths_for_kind(&observations, SecretReferenceKind::Exec);
+
+    let mut evidence = Vec::new();
+    let counts_evidence = format!(
+        "secret_refs env={} file={} exec={} inline_literal={}",
+        counts.env, counts.file, counts.exec, counts.inline_literal
+    );
+    evidence.push(counts_evidence);
+
+    if !inline_paths.is_empty() {
+        let inline_evidence = format!("inline_literal_paths={}", inline_paths.join(", "));
+        evidence.push(inline_evidence);
+    }
+
+    if !exec_paths.is_empty() {
+        let exec_evidence = format!("exec_paths={}", exec_paths.join(", "));
+        evidence.push(exec_evidence);
+    }
+
+    let env_pointer_count = env_pointer_diagnostics.len();
+    let env_pointer_count_evidence =
+        format!("config.env_pointer_diagnostics.count={env_pointer_count}");
+    evidence.push(env_pointer_count_evidence);
+
+    for diagnostic in env_pointer_diagnostics {
+        let diagnostic_evidence = format!(
+            "diagnostic {} field={} severity={}",
+            diagnostic.code, diagnostic.field_path, diagnostic.severity
+        );
+        evidence.push(diagnostic_evidence);
+    }
+
+    let config_mode = config_file_mode(config_path)?;
+    if let Some(config_mode) = config_mode {
+        let mode_evidence = format!("config.permissions={config_mode}");
+        evidence.push(mode_evidence);
+    }
+
+    if counts.inline_literal > 0 {
+        let permission_issue = config_file_permission_issue(config_path)?;
+        if let Some(permission_issue) = permission_issue {
+            evidence.push(permission_issue);
+        }
+
+        let summary =
+            "Inline secret literals are present in the config, so credential material is stored directly on disk."
+                .to_owned();
+        let mut next_steps = Vec::new();
+        next_steps.push(
+            "Move inline secrets to env or file secret refs and re-run doctor security.".to_owned(),
+        );
+        if cfg!(unix) {
+            next_steps.push(
+                "Restrict the config file to chmod 600 when secrets must stay on disk.".to_owned(),
+            );
+        }
+        return Ok(build_finding(
+            "secret_hygiene",
+            "Secret Hygiene",
+            SecurityFindingStatus::Exposed,
+            SecurityFindingSeverity::Critical,
+            summary,
+            evidence,
+            next_steps,
+        ));
+    }
+
+    if counts.exec > 0 || !collect_env_pointer_diagnostics(config).is_empty() {
+        let summary =
+            "Secret references avoid inline literals, but some entries still rely on host exec or env-pointer cleanup."
+                .to_owned();
+        let mut next_steps = Vec::new();
+        if counts.exec > 0 {
+            next_steps.push(
+                "Prefer env or file secret refs when exec-based secret resolution is not required."
+                    .to_owned(),
+            );
+        }
+        if !collect_env_pointer_diagnostics(config).is_empty() {
+            next_steps.push(
+                "Normalize env-pointer fields so the config stays on the canonical secret-ref path."
+                    .to_owned(),
+            );
+        }
+        return Ok(build_finding(
+            "secret_hygiene",
+            "Secret Hygiene",
+            SecurityFindingStatus::Partial,
+            SecurityFindingSeverity::Warn,
+            summary,
+            evidence,
+            next_steps,
+        ));
+    }
+
+    let summary =
+        "Configured secrets use env/file references without inline literals or exec-based secret resolution."
+            .to_owned();
+    let next_steps = Vec::new();
+    Ok(build_finding(
+        "secret_hygiene",
+        "Secret Hygiene",
+        SecurityFindingStatus::Covered,
+        SecurityFindingSeverity::Info,
+        summary,
+        evidence,
+        next_steps,
+    ))
+}
+
+fn assess_browser_surfaces(
+    runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+    diagnostics: Option<&crate::browser_companion_diagnostics::BrowserCompanionDiagnostics>,
+) -> SecurityFinding {
+    let browser_enabled = runtime.browser.enabled;
+    let browser_tier = runtime.browser_execution_security_tier();
+    let companion_enabled = runtime.browser_companion.enabled;
+    let companion_tier = runtime.browser_companion_execution_security_tier();
+
+    let mut evidence = Vec::new();
+    let browser_enabled_evidence = format!("tools.browser.enabled={browser_enabled}");
+    evidence.push(browser_enabled_evidence);
+    let browser_tier_evidence = format!("browser.execution_tier={}", browser_tier.as_str());
+    evidence.push(browser_tier_evidence);
+    let companion_enabled_evidence = format!("tools.browser_companion.enabled={companion_enabled}");
+    evidence.push(companion_enabled_evidence);
+    let companion_tier_evidence = format!(
+        "browser_companion.execution_tier={}",
+        companion_tier.as_str()
+    );
+    evidence.push(companion_tier_evidence);
+
+    if !companion_enabled {
+        let summary = if browser_enabled {
+            "Browser automation stays on the built-in restricted lane because the managed browser companion is disabled."
+                .to_owned()
+        } else {
+            "Browser automation surfaces are disabled.".to_owned()
+        };
+        let next_steps = Vec::new();
+        return build_finding(
+            "browser_surfaces",
+            "Browser Surfaces",
+            SecurityFindingStatus::Covered,
+            SecurityFindingSeverity::Info,
+            summary,
+            evidence,
+            next_steps,
+        );
+    }
+
+    if let Some(diagnostics) = diagnostics {
+        let install_evidence =
+            format!("browser_companion.install={}", diagnostics.install_detail());
+        evidence.push(install_evidence);
+        if let Some(runtime_gate_detail) = diagnostics.runtime_gate_detail() {
+            let gate_evidence = format!("browser_companion.runtime_gate={runtime_gate_detail}");
+            evidence.push(gate_evidence);
+        }
+
+        if !diagnostics.install_ready() || !diagnostics.runtime_ready {
+            let summary =
+                "The browser companion lane is enabled, but install or runtime readiness is still incomplete."
+                    .to_owned();
+            let next_steps = vec![
+                "Keep the built-in browser lane as the active path until the companion runtime is fully ready."
+                    .to_owned(),
+                "Run loongclaw doctor to repair the companion install/runtime gate.".to_owned(),
+            ];
+            return build_finding(
+                "browser_surfaces",
+                "Browser Surfaces",
+                SecurityFindingStatus::Partial,
+                SecurityFindingSeverity::Warn,
+                summary,
+                evidence,
+                next_steps,
+            );
+        }
+    }
+
+    let summary =
+        "The managed browser companion lane is active, but this command does not prove remote/browser auth equivalence beyond local runtime readiness."
+            .to_owned();
+    let next_steps = vec![
+        "Keep browser companion deployment local-first unless you have separately reviewed its auth boundary."
+            .to_owned(),
+    ];
+    build_finding(
+        "browser_surfaces",
+        "Browser Surfaces",
+        SecurityFindingStatus::Unknown,
+        SecurityFindingSeverity::Warn,
+        summary,
+        evidence,
+        next_steps,
+    )
+}
+
+fn build_finding(
+    id: &str,
+    title: &str,
+    status: SecurityFindingStatus,
+    severity: SecurityFindingSeverity,
+    summary: String,
+    evidence: Vec<String>,
+    next_steps: Vec<String>,
+) -> SecurityFinding {
+    SecurityFinding {
+        id: id.to_owned(),
+        title: title.to_owned(),
+        status,
+        severity,
+        summary,
+        evidence,
+        next_steps,
+    }
+}
+
+fn summarize_findings(findings: &[SecurityFinding]) -> SecurityAuditSummary {
+    let mut summary = SecurityAuditSummary {
+        covered: 0,
+        partial: 0,
+        exposed: 0,
+        unknown: 0,
+        info: 0,
+        warn: 0,
+        critical: 0,
+    };
+
+    for finding in findings {
+        match finding.status {
+            SecurityFindingStatus::Covered => summary.covered += 1,
+            SecurityFindingStatus::Partial => summary.partial += 1,
+            SecurityFindingStatus::Exposed => summary.exposed += 1,
+            SecurityFindingStatus::Unknown => summary.unknown += 1,
+        }
+
+        match finding.severity {
+            SecurityFindingSeverity::Info => summary.info += 1,
+            SecurityFindingSeverity::Warn => summary.warn += 1,
+            SecurityFindingSeverity::Critical => summary.critical += 1,
+        }
+    }
+
+    summary
+}
+
+fn collect_env_pointer_diagnostics(
+    config: &mvp::config::LoongClawConfig,
+) -> Vec<mvp::config::ConfigValidationDiagnostic> {
+    let diagnostics = config.validation_diagnostics();
+    diagnostics
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code.starts_with("config.env_pointer."))
+        .collect()
+}
+
+fn collect_secret_observations(config: &mvp::config::LoongClawConfig) -> Vec<SecretObservation> {
+    let mut observations = Vec::new();
+
+    collect_provider_secret_observations(config, &mut observations);
+    collect_web_search_secret_observations(config, &mut observations);
+    collect_channel_secret_observations(config, &mut observations);
+
+    observations
+}
+
+fn collect_provider_secret_observations(
+    config: &mvp::config::LoongClawConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    if config.providers.is_empty() {
+        let api_key_path = "provider.api_key".to_owned();
+        push_secret_ref_observation(observations, api_key_path, config.provider.api_key.as_ref());
+        let oauth_path = "provider.oauth_access_token".to_owned();
+        push_secret_ref_observation(
+            observations,
+            oauth_path,
+            config.provider.oauth_access_token.as_ref(),
+        );
+        return;
+    }
+
+    for (profile_id, profile) in &config.providers {
+        let api_key_path = format!("providers.{profile_id}.api_key");
+        push_secret_ref_observation(
+            observations,
+            api_key_path,
+            profile.provider.api_key.as_ref(),
+        );
+        let oauth_path = format!("providers.{profile_id}.oauth_access_token");
+        push_secret_ref_observation(
+            observations,
+            oauth_path,
+            profile.provider.oauth_access_token.as_ref(),
+        );
+    }
+}
+
+fn collect_web_search_secret_observations(
+    config: &mvp::config::LoongClawConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let brave_path = "tools.web_search.brave_api_key".to_owned();
+    push_string_secret_observation(
+        observations,
+        brave_path,
+        config.tools.web_search.brave_api_key.as_deref(),
+    );
+
+    let tavily_path = "tools.web_search.tavily_api_key".to_owned();
+    push_string_secret_observation(
+        observations,
+        tavily_path,
+        config.tools.web_search.tavily_api_key.as_deref(),
+    );
+
+    let perplexity_path = "tools.web_search.perplexity_api_key".to_owned();
+    push_string_secret_observation(
+        observations,
+        perplexity_path,
+        config.tools.web_search.perplexity_api_key.as_deref(),
+    );
+
+    let exa_path = "tools.web_search.exa_api_key".to_owned();
+    push_string_secret_observation(
+        observations,
+        exa_path,
+        config.tools.web_search.exa_api_key.as_deref(),
+    );
+
+    let jina_path = "tools.web_search.jina_api_key".to_owned();
+    push_string_secret_observation(
+        observations,
+        jina_path,
+        config.tools.web_search.jina_api_key.as_deref(),
+    );
+}
+
+fn collect_channel_secret_observations(
+    config: &mvp::config::LoongClawConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    collect_telegram_secret_observations(&config.telegram, observations);
+    collect_feishu_secret_observations(&config.feishu, observations);
+    collect_matrix_secret_observations(&config.matrix, observations);
+    collect_wecom_secret_observations(&config.wecom, observations);
+    collect_discord_secret_observations(&config.discord, observations);
+    collect_line_secret_observations(&config.line, observations);
+    collect_dingtalk_secret_observations(&config.dingtalk, observations);
+    collect_webhook_secret_observations(&config.webhook, observations);
+    collect_email_secret_observations(&config.email, observations);
+    collect_slack_secret_observations(&config.slack, observations);
+    collect_google_chat_secret_observations(&config.google_chat, observations);
+    collect_mattermost_secret_observations(&config.mattermost, observations);
+    collect_nextcloud_talk_secret_observations(&config.nextcloud_talk, observations);
+    collect_synology_chat_secret_observations(&config.synology_chat, observations);
+    collect_teams_secret_observations(&config.teams, observations);
+    collect_imessage_secret_observations(&config.imessage, observations);
+    collect_whatsapp_secret_observations(&config.whatsapp, observations);
+}
+
+fn collect_telegram_secret_observations(
+    config: &mvp::config::TelegramChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let bot_token_path = "telegram.bot_token".to_owned();
+    push_secret_ref_observation(observations, bot_token_path, config.bot_token.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let bot_token_path = format!("telegram.accounts.{account_id}.bot_token");
+        push_secret_ref_observation(observations, bot_token_path, account.bot_token.as_ref());
+    }
+}
+
+fn collect_feishu_secret_observations(
+    config: &mvp::config::FeishuChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let app_id_path = "feishu.app_id".to_owned();
+    push_secret_ref_observation(observations, app_id_path, config.app_id.as_ref());
+    let app_secret_path = "feishu.app_secret".to_owned();
+    push_secret_ref_observation(observations, app_secret_path, config.app_secret.as_ref());
+    let verification_path = "feishu.verification_token".to_owned();
+    push_secret_ref_observation(
+        observations,
+        verification_path,
+        config.verification_token.as_ref(),
+    );
+    let encrypt_key_path = "feishu.encrypt_key".to_owned();
+    push_secret_ref_observation(observations, encrypt_key_path, config.encrypt_key.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let app_id_path = format!("feishu.accounts.{account_id}.app_id");
+        push_secret_ref_observation(observations, app_id_path, account.app_id.as_ref());
+        let app_secret_path = format!("feishu.accounts.{account_id}.app_secret");
+        push_secret_ref_observation(observations, app_secret_path, account.app_secret.as_ref());
+        let verification_path = format!("feishu.accounts.{account_id}.verification_token");
+        push_secret_ref_observation(
+            observations,
+            verification_path,
+            account.verification_token.as_ref(),
+        );
+        let encrypt_key_path = format!("feishu.accounts.{account_id}.encrypt_key");
+        push_secret_ref_observation(observations, encrypt_key_path, account.encrypt_key.as_ref());
+    }
+}
+
+fn collect_matrix_secret_observations(
+    config: &mvp::config::MatrixChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let access_token_path = "matrix.access_token".to_owned();
+    push_secret_ref_observation(
+        observations,
+        access_token_path,
+        config.access_token.as_ref(),
+    );
+
+    for (account_id, account) in &config.accounts {
+        let access_token_path = format!("matrix.accounts.{account_id}.access_token");
+        push_secret_ref_observation(
+            observations,
+            access_token_path,
+            account.access_token.as_ref(),
+        );
+    }
+}
+
+fn collect_wecom_secret_observations(
+    config: &mvp::config::WecomChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let bot_id_path = "wecom.bot_id".to_owned();
+    push_secret_ref_observation(observations, bot_id_path, config.bot_id.as_ref());
+    let secret_path = "wecom.secret".to_owned();
+    push_secret_ref_observation(observations, secret_path, config.secret.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let bot_id_path = format!("wecom.accounts.{account_id}.bot_id");
+        push_secret_ref_observation(observations, bot_id_path, account.bot_id.as_ref());
+        let secret_path = format!("wecom.accounts.{account_id}.secret");
+        push_secret_ref_observation(observations, secret_path, account.secret.as_ref());
+    }
+}
+
+fn collect_discord_secret_observations(
+    config: &mvp::config::DiscordChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let bot_token_path = "discord.bot_token".to_owned();
+    push_secret_ref_observation(observations, bot_token_path, config.bot_token.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let bot_token_path = format!("discord.accounts.{account_id}.bot_token");
+        push_secret_ref_observation(observations, bot_token_path, account.bot_token.as_ref());
+    }
+}
+
+fn collect_line_secret_observations(
+    config: &mvp::config::LineChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let access_token_path = "line.channel_access_token".to_owned();
+    push_secret_ref_observation(
+        observations,
+        access_token_path,
+        config.channel_access_token.as_ref(),
+    );
+    let secret_path = "line.channel_secret".to_owned();
+    push_secret_ref_observation(observations, secret_path, config.channel_secret.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let access_token_path = format!("line.accounts.{account_id}.channel_access_token");
+        push_secret_ref_observation(
+            observations,
+            access_token_path,
+            account.channel_access_token.as_ref(),
+        );
+        let secret_path = format!("line.accounts.{account_id}.channel_secret");
+        push_secret_ref_observation(observations, secret_path, account.channel_secret.as_ref());
+    }
+}
+
+fn collect_dingtalk_secret_observations(
+    config: &mvp::config::DingtalkChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let webhook_path = "dingtalk.webhook_url".to_owned();
+    push_secret_ref_observation(observations, webhook_path, config.webhook_url.as_ref());
+    let secret_path = "dingtalk.secret".to_owned();
+    push_secret_ref_observation(observations, secret_path, config.secret.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let webhook_path = format!("dingtalk.accounts.{account_id}.webhook_url");
+        push_secret_ref_observation(observations, webhook_path, account.webhook_url.as_ref());
+        let secret_path = format!("dingtalk.accounts.{account_id}.secret");
+        push_secret_ref_observation(observations, secret_path, account.secret.as_ref());
+    }
+}
+
+fn collect_webhook_secret_observations(
+    config: &mvp::config::WebhookChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let endpoint_path = "webhook.endpoint_url".to_owned();
+    push_secret_ref_observation(observations, endpoint_path, config.endpoint_url.as_ref());
+    let auth_token_path = "webhook.auth_token".to_owned();
+    push_secret_ref_observation(observations, auth_token_path, config.auth_token.as_ref());
+    let signing_secret_path = "webhook.signing_secret".to_owned();
+    push_secret_ref_observation(
+        observations,
+        signing_secret_path,
+        config.signing_secret.as_ref(),
+    );
+
+    for (account_id, account) in &config.accounts {
+        let endpoint_path = format!("webhook.accounts.{account_id}.endpoint_url");
+        push_secret_ref_observation(observations, endpoint_path, account.endpoint_url.as_ref());
+        let auth_token_path = format!("webhook.accounts.{account_id}.auth_token");
+        push_secret_ref_observation(observations, auth_token_path, account.auth_token.as_ref());
+        let signing_secret_path = format!("webhook.accounts.{account_id}.signing_secret");
+        push_secret_ref_observation(
+            observations,
+            signing_secret_path,
+            account.signing_secret.as_ref(),
+        );
+    }
+}
+
+fn collect_email_secret_observations(
+    config: &mvp::config::EmailChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let smtp_username_path = "email.smtp_username".to_owned();
+    push_secret_ref_observation(
+        observations,
+        smtp_username_path,
+        config.smtp_username.as_ref(),
+    );
+    let smtp_password_path = "email.smtp_password".to_owned();
+    push_secret_ref_observation(
+        observations,
+        smtp_password_path,
+        config.smtp_password.as_ref(),
+    );
+    let imap_username_path = "email.imap_username".to_owned();
+    push_secret_ref_observation(
+        observations,
+        imap_username_path,
+        config.imap_username.as_ref(),
+    );
+    let imap_password_path = "email.imap_password".to_owned();
+    push_secret_ref_observation(
+        observations,
+        imap_password_path,
+        config.imap_password.as_ref(),
+    );
+
+    for (account_id, account) in &config.accounts {
+        let smtp_username_path = format!("email.accounts.{account_id}.smtp_username");
+        push_secret_ref_observation(
+            observations,
+            smtp_username_path,
+            account.smtp_username.as_ref(),
+        );
+        let smtp_password_path = format!("email.accounts.{account_id}.smtp_password");
+        push_secret_ref_observation(
+            observations,
+            smtp_password_path,
+            account.smtp_password.as_ref(),
+        );
+        let imap_username_path = format!("email.accounts.{account_id}.imap_username");
+        push_secret_ref_observation(
+            observations,
+            imap_username_path,
+            account.imap_username.as_ref(),
+        );
+        let imap_password_path = format!("email.accounts.{account_id}.imap_password");
+        push_secret_ref_observation(
+            observations,
+            imap_password_path,
+            account.imap_password.as_ref(),
+        );
+    }
+}
+
+fn collect_slack_secret_observations(
+    config: &mvp::config::SlackChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let bot_token_path = "slack.bot_token".to_owned();
+    push_secret_ref_observation(observations, bot_token_path, config.bot_token.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let bot_token_path = format!("slack.accounts.{account_id}.bot_token");
+        push_secret_ref_observation(observations, bot_token_path, account.bot_token.as_ref());
+    }
+}
+
+fn collect_google_chat_secret_observations(
+    config: &mvp::config::GoogleChatChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let webhook_path = "google_chat.webhook_url".to_owned();
+    push_secret_ref_observation(observations, webhook_path, config.webhook_url.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let webhook_path = format!("google_chat.accounts.{account_id}.webhook_url");
+        push_secret_ref_observation(observations, webhook_path, account.webhook_url.as_ref());
+    }
+}
+
+fn collect_mattermost_secret_observations(
+    config: &mvp::config::MattermostChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let bot_token_path = "mattermost.bot_token".to_owned();
+    push_secret_ref_observation(observations, bot_token_path, config.bot_token.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let bot_token_path = format!("mattermost.accounts.{account_id}.bot_token");
+        push_secret_ref_observation(observations, bot_token_path, account.bot_token.as_ref());
+    }
+}
+
+fn collect_nextcloud_talk_secret_observations(
+    config: &mvp::config::NextcloudTalkChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let shared_secret_path = "nextcloud_talk.shared_secret".to_owned();
+    push_secret_ref_observation(
+        observations,
+        shared_secret_path,
+        config.shared_secret.as_ref(),
+    );
+
+    for (account_id, account) in &config.accounts {
+        let shared_secret_path = format!("nextcloud_talk.accounts.{account_id}.shared_secret");
+        push_secret_ref_observation(
+            observations,
+            shared_secret_path,
+            account.shared_secret.as_ref(),
+        );
+    }
+}
+
+fn collect_synology_chat_secret_observations(
+    config: &mvp::config::SynologyChatChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let token_path = "synology_chat.token".to_owned();
+    push_secret_ref_observation(observations, token_path, config.token.as_ref());
+    let incoming_url_path = "synology_chat.incoming_url".to_owned();
+    push_secret_ref_observation(
+        observations,
+        incoming_url_path,
+        config.incoming_url.as_ref(),
+    );
+
+    for (account_id, account) in &config.accounts {
+        let token_path = format!("synology_chat.accounts.{account_id}.token");
+        push_secret_ref_observation(observations, token_path, account.token.as_ref());
+        let incoming_url_path = format!("synology_chat.accounts.{account_id}.incoming_url");
+        push_secret_ref_observation(
+            observations,
+            incoming_url_path,
+            account.incoming_url.as_ref(),
+        );
+    }
+}
+
+fn collect_teams_secret_observations(
+    config: &mvp::config::TeamsChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let webhook_path = "teams.webhook_url".to_owned();
+    push_secret_ref_observation(observations, webhook_path, config.webhook_url.as_ref());
+    let app_id_path = "teams.app_id".to_owned();
+    push_secret_ref_observation(observations, app_id_path, config.app_id.as_ref());
+    let app_password_path = "teams.app_password".to_owned();
+    push_secret_ref_observation(
+        observations,
+        app_password_path,
+        config.app_password.as_ref(),
+    );
+
+    for (account_id, account) in &config.accounts {
+        let webhook_path = format!("teams.accounts.{account_id}.webhook_url");
+        push_secret_ref_observation(observations, webhook_path, account.webhook_url.as_ref());
+        let app_id_path = format!("teams.accounts.{account_id}.app_id");
+        push_secret_ref_observation(observations, app_id_path, account.app_id.as_ref());
+        let app_password_path = format!("teams.accounts.{account_id}.app_password");
+        push_secret_ref_observation(
+            observations,
+            app_password_path,
+            account.app_password.as_ref(),
+        );
+    }
+}
+
+fn collect_imessage_secret_observations(
+    config: &mvp::config::ImessageChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let bridge_token_path = "imessage.bridge_token".to_owned();
+    push_secret_ref_observation(
+        observations,
+        bridge_token_path,
+        config.bridge_token.as_ref(),
+    );
+
+    for (account_id, account) in &config.accounts {
+        let bridge_token_path = format!("imessage.accounts.{account_id}.bridge_token");
+        push_secret_ref_observation(
+            observations,
+            bridge_token_path,
+            account.bridge_token.as_ref(),
+        );
+    }
+}
+
+fn collect_whatsapp_secret_observations(
+    config: &mvp::config::WhatsappChannelConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let access_token_path = "whatsapp.access_token".to_owned();
+    push_secret_ref_observation(
+        observations,
+        access_token_path,
+        config.access_token.as_ref(),
+    );
+    let verify_token_path = "whatsapp.verify_token".to_owned();
+    push_secret_ref_observation(
+        observations,
+        verify_token_path,
+        config.verify_token.as_ref(),
+    );
+    let app_secret_path = "whatsapp.app_secret".to_owned();
+    push_secret_ref_observation(observations, app_secret_path, config.app_secret.as_ref());
+
+    for (account_id, account) in &config.accounts {
+        let access_token_path = format!("whatsapp.accounts.{account_id}.access_token");
+        push_secret_ref_observation(
+            observations,
+            access_token_path,
+            account.access_token.as_ref(),
+        );
+        let verify_token_path = format!("whatsapp.accounts.{account_id}.verify_token");
+        push_secret_ref_observation(
+            observations,
+            verify_token_path,
+            account.verify_token.as_ref(),
+        );
+        let app_secret_path = format!("whatsapp.accounts.{account_id}.app_secret");
+        push_secret_ref_observation(observations, app_secret_path, account.app_secret.as_ref());
+    }
+}
+
+fn push_string_secret_observation(
+    observations: &mut Vec<SecretObservation>,
+    field_path: String,
+    raw_value: Option<&str>,
+) {
+    let Some(raw_value) = raw_value else {
+        return;
+    };
+
+    let trimmed_value = raw_value.trim();
+    if trimmed_value.is_empty() {
+        return;
+    }
+
+    let secret_ref = SecretRef::Inline(trimmed_value.to_owned());
+    let kind = classify_secret_ref_kind(&secret_ref);
+    let Some(kind) = kind else {
+        return;
+    };
+
+    let observation = SecretObservation { field_path, kind };
+    observations.push(observation);
+}
+
+fn push_secret_ref_observation(
+    observations: &mut Vec<SecretObservation>,
+    field_path: String,
+    secret_ref: Option<&SecretRef>,
+) {
+    let Some(secret_ref) = secret_ref else {
+        return;
+    };
+
+    let kind = classify_secret_ref_kind(secret_ref);
+    let Some(kind) = kind else {
+        return;
+    };
+
+    let observation = SecretObservation { field_path, kind };
+    observations.push(observation);
+}
+
+fn classify_secret_ref_kind(secret_ref: &SecretRef) -> Option<SecretReferenceKind> {
+    match secret_ref {
+        SecretRef::Env { .. } => Some(SecretReferenceKind::Env),
+        SecretRef::File { .. } => Some(SecretReferenceKind::File),
+        SecretRef::Exec { .. } => Some(SecretReferenceKind::Exec),
+        SecretRef::Inline(_) => {
+            if secret_ref.inline_literal_value().is_some() {
+                return Some(SecretReferenceKind::InlineLiteral);
+            }
+
+            if secret_ref.explicit_env_name().is_some() {
+                return Some(SecretReferenceKind::Env);
+            }
+
+            None
+        }
+    }
+}
+
+fn summarize_secret_observations(observations: &[SecretObservation]) -> SecretObservationCounts {
+    let mut counts = SecretObservationCounts::default();
+
+    for observation in observations {
+        counts.record(observation.kind);
+    }
+
+    counts
+}
+
+fn observation_paths_for_kind(
+    observations: &[SecretObservation],
+    kind: SecretReferenceKind,
+) -> Vec<String> {
+    observations
+        .iter()
+        .filter(|observation| observation.kind == kind)
+        .map(|observation| observation.field_path.clone())
+        .collect()
+}
+
+fn render_shell_default_mode(
+    mode: mvp::tools::shell_policy_ext::ShellPolicyDefault,
+) -> &'static str {
+    match mode {
+        mvp::tools::shell_policy_ext::ShellPolicyDefault::Deny => "deny",
+        mvp::tools::shell_policy_ext::ShellPolicyDefault::Allow => "allow",
+    }
+}
+
+fn render_tool_approval_mode(mode: mvp::config::GovernedToolApprovalMode) -> &'static str {
+    match mode {
+        mvp::config::GovernedToolApprovalMode::Disabled => "disabled",
+        mvp::config::GovernedToolApprovalMode::MediumBalanced => "medium_balanced",
+        mvp::config::GovernedToolApprovalMode::Strict => "strict",
+    }
+}
+
+fn config_file_mode(config_path: &Path) -> CliResult<Option<String>> {
+    #[cfg(unix)]
+    {
+        let metadata = fs::metadata(config_path).map_err(|error| {
+            format!(
+                "inspect config permissions for {} failed: {error}",
+                config_path.display()
+            )
+        })?;
+        let mode = metadata.permissions().mode() & 0o777;
+        let rendered_mode = format!("0o{mode:03o}");
+        Ok(Some(rendered_mode))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = config_path;
+        Ok(None)
+    }
+}
+
+fn config_file_permission_issue(config_path: &Path) -> CliResult<Option<String>> {
+    #[cfg(unix)]
+    {
+        let metadata = fs::metadata(config_path).map_err(|error| {
+            format!(
+                "inspect config permissions for {} failed: {error}",
+                config_path.display()
+            )
+        })?;
+        let mode = metadata.permissions().mode() & 0o777;
+        let group_or_world_bits = mode & 0o077;
+        if group_or_world_bits == 0 {
+            return Ok(None);
+        }
+
+        let rendered_mode = format!(
+            "config file mode is 0o{mode:03o}; inline secrets should be stored under 0o600 or stricter"
+        );
+        Ok(Some(rendered_mode))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = config_path;
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test_support::ScopedEnv;
+    use loongclaw_contracts::SecretRef;
+
+    fn temp_config_path(label: &str) -> PathBuf {
+        let epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let file_name = format!("loongclaw-doctor-security-{label}-{epoch}.toml");
+        std::env::temp_dir().join(file_name)
+    }
+
+    fn write_placeholder_config(path: &Path) {
+        fs::write(path, "active_provider = \"openai\"\n").expect("write placeholder config");
+    }
+
+    fn finding_by_id<'a>(findings: &'a [SecurityFinding], id: &str) -> &'a SecurityFinding {
+        findings
+            .iter()
+            .find(|finding| finding.id == id)
+            .unwrap_or_else(|| panic!("missing finding `{id}`"))
+    }
+
+    #[tokio::test]
+    async fn default_shell_execution_is_covered_when_allowlist_is_empty() {
+        let path = temp_config_path("shell-covered");
+        write_placeholder_config(&path);
+
+        let config = mvp::config::LoongClawConfig::default();
+        let execution = build_doctor_security_execution(&path, &config)
+            .await
+            .expect("build security execution");
+        let finding = finding_by_id(&execution.findings, "shell_execution");
+
+        assert_eq!(finding.status, SecurityFindingStatus::Covered);
+        assert_eq!(finding.severity, SecurityFindingSeverity::Info);
+        assert!(
+            finding.summary.contains("effectively disabled"),
+            "unexpected summary: {}",
+            finding.summary
+        );
+    }
+
+    #[tokio::test]
+    async fn secret_hygiene_exposes_inline_literals() {
+        let path = temp_config_path("inline-secret");
+        write_placeholder_config(&path);
+
+        #[cfg(unix)]
+        {
+            let metadata = fs::metadata(&path).expect("config metadata");
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(0o644);
+            fs::set_permissions(&path, permissions).expect("set config permissions");
+        }
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.api_key = Some(SecretRef::Inline("inline-secret".to_owned()));
+
+        let execution = build_doctor_security_execution(&path, &config)
+            .await
+            .expect("build security execution");
+        let finding = finding_by_id(&execution.findings, "secret_hygiene");
+
+        assert_eq!(finding.status, SecurityFindingStatus::Exposed);
+        assert_eq!(finding.severity, SecurityFindingSeverity::Critical);
+        assert!(
+            finding
+                .evidence
+                .iter()
+                .any(|line| line.contains("provider.api_key")),
+            "expected provider.api_key evidence: {:?}",
+            finding.evidence
+        );
+    }
+
+    #[tokio::test]
+    async fn external_skills_expose_when_auto_expose_or_approval_is_open() {
+        let path = temp_config_path("external-skills");
+        write_placeholder_config(&path);
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.external_skills.enabled = true;
+        config.external_skills.require_download_approval = false;
+        config.external_skills.auto_expose_installed = true;
+
+        let execution = build_doctor_security_execution(&path, &config)
+            .await
+            .expect("build security execution");
+        let finding = finding_by_id(&execution.findings, "external_skills");
+
+        assert_eq!(finding.status, SecurityFindingStatus::Exposed);
+        assert_eq!(finding.severity, SecurityFindingSeverity::Critical);
+    }
+
+    #[tokio::test]
+    async fn browser_surfaces_become_unknown_when_companion_is_ready() {
+        let path = temp_config_path("browser-companion");
+        write_placeholder_config(&path);
+
+        let temp_dir = std::env::temp_dir();
+        let command_path = temp_dir.join("loongclaw-browser-companion-security-test.sh");
+        let script = "#!/bin/sh\necho 1.2.3\n";
+        fs::write(&command_path, script).expect("write browser companion script");
+
+        #[cfg(unix)]
+        {
+            let metadata = fs::metadata(&command_path).expect("script metadata");
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&command_path, permissions).expect("chmod script");
+        }
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(command_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.2.3".to_owned());
+
+        let mut env = ScopedEnv::new();
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+
+        let execution = build_doctor_security_execution(&path, &config)
+            .await
+            .expect("build security execution");
+        let finding = finding_by_id(&execution.findings, "browser_surfaces");
+
+        let _ = fs::remove_file(&command_path);
+
+        assert_eq!(finding.status, SecurityFindingStatus::Unknown);
+        assert_eq!(finding.severity, SecurityFindingSeverity::Warn);
+    }
+
+    #[test]
+    fn json_payload_uses_security_command_name() {
+        let execution = DoctorSecurityAuditExecution {
+            resolved_config_path: "/tmp/config.toml".to_owned(),
+            ok: true,
+            summary: SecurityAuditSummary {
+                covered: 1,
+                partial: 0,
+                exposed: 0,
+                unknown: 0,
+                info: 1,
+                warn: 0,
+                critical: 0,
+            },
+            findings: vec![build_finding(
+                "audit_retention",
+                "Audit Retention",
+                SecurityFindingStatus::Covered,
+                SecurityFindingSeverity::Info,
+                "durable".to_owned(),
+                Vec::new(),
+                Vec::new(),
+            )],
+        };
+
+        let payload = doctor_security_cli_json(&execution);
+
+        assert_eq!(payload["command"], "security");
+        assert_eq!(payload["summary"]["covered"], 1);
+        assert_eq!(payload["findings"][0]["id"], "audit_retention");
+    }
+
+    #[tokio::test]
+    async fn run_doctor_security_cli_rejects_unsupported_parent_flags() {
+        let fix_error = run_doctor_security_cli(DoctorSecurityCommandOptions {
+            config: None,
+            json: false,
+            fix: true,
+            skip_model_probe: false,
+        })
+        .await
+        .expect_err("doctor security should reject --fix");
+
+        let probe_error = run_doctor_security_cli(DoctorSecurityCommandOptions {
+            config: None,
+            json: false,
+            fix: false,
+            skip_model_probe: true,
+        })
+        .await
+        .expect_err("doctor security should reject --skip-model-probe");
+
+        assert!(fix_error.contains("--fix"));
+        assert!(probe_error.contains("--skip-model-probe"));
+    }
+}

--- a/crates/daemon/src/doctor_security_cli.rs
+++ b/crates/daemon/src/doctor_security_cli.rs
@@ -110,6 +110,8 @@ struct SecretObservationCounts {
     inline_literal: usize,
 }
 
+const PROVIDER_SECRET_HEADER_NAMES: &[&str] = &["authorization", "x-api-key"];
+
 impl SecretObservationCounts {
     fn record(&mut self, kind: SecretReferenceKind) {
         match kind {
@@ -138,11 +140,10 @@ pub async fn run_doctor_security_cli(options: DoctorSecurityCommandOptions) -> C
         let encoded = serde_json::to_string_pretty(&payload)
             .map_err(|error| format!("serialize doctor security output failed: {error}"))?;
         println!("{encoded}");
-        return Ok(());
+    } else {
+        let rendered = render_doctor_security_cli_text(&execution);
+        println!("{rendered}");
     }
-
-    let rendered = render_doctor_security_cli_text(&execution);
-    println!("{rendered}");
 
     if !execution.ok {
         return Err("doctor security detected exposed surfaces".to_owned());
@@ -237,7 +238,15 @@ async fn build_doctor_security_execution(
     let web_fetch_finding = assess_web_fetch(runtime.web_fetch.clone());
     findings.push(web_fetch_finding);
 
-    let external_skills_finding = assess_external_skills(runtime.external_skills.clone());
+    let external_skills_finding =
+        match crate::external_skills_policy_probe::resolve_effective_external_skills_policy(
+            &runtime,
+        ) {
+            Ok(policy_probe) => assess_external_skills(policy_probe),
+            Err(error) => {
+                assess_external_skills_probe_failure(runtime.external_skills.clone(), error)
+            }
+        };
     findings.push(external_skills_finding);
 
     let secret_hygiene_finding = assess_secret_hygiene(config_path, config)?;
@@ -554,11 +563,15 @@ fn assess_web_fetch(policy: mvp::tools::runtime_config::WebFetchRuntimePolicy) -
 }
 
 fn assess_external_skills(
-    policy: mvp::tools::runtime_config::ExternalSkillsRuntimePolicy,
+    policy_probe: crate::external_skills_policy_probe::EffectiveExternalSkillsPolicyProbe,
 ) -> SecurityFinding {
+    let policy = policy_probe.policy;
+    let override_active = policy_probe.override_active;
     let mut evidence = Vec::new();
     let enabled_evidence = format!("external_skills.enabled={}", policy.enabled);
     evidence.push(enabled_evidence);
+    let override_active_evidence = format!("external_skills.override_active={override_active}");
+    evidence.push(override_active_evidence);
     let approval_evidence = format!(
         "external_skills.require_download_approval={}",
         policy.require_download_approval
@@ -624,6 +637,49 @@ fn assess_external_skills(
         "external_skills",
         "External Skills",
         SecurityFindingStatus::Partial,
+        SecurityFindingSeverity::Warn,
+        summary,
+        evidence,
+        next_steps,
+    )
+}
+
+fn assess_external_skills_probe_failure(
+    config_projection: mvp::tools::runtime_config::ExternalSkillsRuntimePolicy,
+    error: String,
+) -> SecurityFinding {
+    let mut evidence = Vec::new();
+    let error_evidence = format!("effective_policy_probe.error={error}");
+    evidence.push(error_evidence);
+    let enabled_evidence = format!(
+        "config_projection.external_skills.enabled={}",
+        config_projection.enabled
+    );
+    evidence.push(enabled_evidence);
+    let approval_evidence = format!(
+        "config_projection.external_skills.require_download_approval={}",
+        config_projection.require_download_approval
+    );
+    evidence.push(approval_evidence);
+    let auto_expose_evidence = format!(
+        "config_projection.external_skills.auto_expose_installed={}",
+        config_projection.auto_expose_installed
+    );
+    evidence.push(auto_expose_evidence);
+
+    let summary =
+        "The effective external-skills runtime policy could not be resolved through the policy surface, so the live posture is unknown."
+            .to_owned();
+    let next_steps = vec![
+        "Run `loongclaw skills policy show --json` to confirm the effective runtime policy."
+            .to_owned(),
+        "Repair the external_skills.policy tool path before relying on this audit result."
+            .to_owned(),
+    ];
+    build_finding(
+        "external_skills",
+        "External Skills",
+        SecurityFindingStatus::Unknown,
         SecurityFindingSeverity::Warn,
         summary,
         evidence,
@@ -914,32 +970,55 @@ fn collect_provider_secret_observations(
     config: &mvp::config::LoongClawConfig,
     observations: &mut Vec<SecretObservation>,
 ) {
-    if config.providers.is_empty() {
-        let api_key_path = "provider.api_key".to_owned();
-        push_secret_ref_observation(observations, api_key_path, config.provider.api_key.as_ref());
-        let oauth_path = "provider.oauth_access_token".to_owned();
-        push_secret_ref_observation(
-            observations,
-            oauth_path,
-            config.provider.oauth_access_token.as_ref(),
-        );
-        return;
-    }
+    collect_single_provider_secret_observations("provider", &config.provider, observations);
 
     for (profile_id, profile) in &config.providers {
-        let api_key_path = format!("providers.{profile_id}.api_key");
-        push_secret_ref_observation(
+        let field_prefix = format!("providers.{profile_id}");
+        collect_single_provider_secret_observations(
+            field_prefix.as_str(),
+            &profile.provider,
             observations,
-            api_key_path,
-            profile.provider.api_key.as_ref(),
-        );
-        let oauth_path = format!("providers.{profile_id}.oauth_access_token");
-        push_secret_ref_observation(
-            observations,
-            oauth_path,
-            profile.provider.oauth_access_token.as_ref(),
         );
     }
+}
+
+fn collect_single_provider_secret_observations(
+    field_prefix: &str,
+    provider: &mvp::config::ProviderConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    let api_key_path = format!("{field_prefix}.api_key");
+    push_secret_ref_observation(observations, api_key_path, provider.api_key.as_ref());
+
+    let oauth_path = format!("{field_prefix}.oauth_access_token");
+    push_secret_ref_observation(
+        observations,
+        oauth_path,
+        provider.oauth_access_token.as_ref(),
+    );
+
+    collect_provider_header_secret_observations(field_prefix, provider, observations);
+}
+
+fn collect_provider_header_secret_observations(
+    field_prefix: &str,
+    provider: &mvp::config::ProviderConfig,
+    observations: &mut Vec<SecretObservation>,
+) {
+    for (header_name, header_value) in &provider.headers {
+        if !provider_header_may_contain_secret(header_name.as_str()) {
+            continue;
+        }
+
+        let field_path = format!("{field_prefix}.headers.{header_name}");
+        push_string_secret_observation(observations, field_path, Some(header_value.as_str()));
+    }
+}
+
+fn provider_header_may_contain_secret(header_name: &str) -> bool {
+    PROVIDER_SECRET_HEADER_NAMES
+        .iter()
+        .any(|candidate| header_name.eq_ignore_ascii_case(candidate))
 }
 
 fn collect_web_search_secret_observations(
@@ -1556,6 +1635,8 @@ mod tests {
 
     use crate::test_support::ScopedEnv;
     use loongclaw_contracts::SecretRef;
+    use std::process::Command;
+    use std::sync::MutexGuard;
 
     fn temp_config_path(label: &str) -> PathBuf {
         let epoch = std::time::SystemTime::now()
@@ -1575,6 +1656,52 @@ mod tests {
             .iter()
             .find(|finding| finding.id == id)
             .unwrap_or_else(|| panic!("missing finding `{id}`"))
+    }
+
+    fn portable_browser_companion_probe() -> (String, String) {
+        let output = Command::new("rustc")
+            .arg("--version")
+            .output()
+            .expect("run rustc --version");
+        assert!(output.status.success(), "rustc --version should succeed");
+
+        let observed_version = String::from_utf8(output.stdout).expect("utf-8 rustc version");
+        let observed_version = observed_version.trim().to_owned();
+        let expected_version = observed_version
+            .split_whitespace()
+            .nth(1)
+            .expect("rustc version token")
+            .to_owned();
+
+        ("rustc".to_owned(), expected_version)
+    }
+
+    struct ExternalSkillsPolicyResetGuard {
+        _lock: MutexGuard<'static, ()>,
+        runtime_config: mvp::tools::runtime_config::ToolRuntimeConfig,
+    }
+
+    impl ExternalSkillsPolicyResetGuard {
+        fn new(runtime_config: &mvp::tools::runtime_config::ToolRuntimeConfig) -> Self {
+            let lock = crate::test_support::lock_daemon_test_environment();
+            Self {
+                _lock: lock,
+                runtime_config: runtime_config.clone(),
+            }
+        }
+    }
+
+    impl Drop for ExternalSkillsPolicyResetGuard {
+        fn drop(&mut self) {
+            let request = kernel::ToolCoreRequest {
+                tool_name: "external_skills.policy".to_owned(),
+                payload: serde_json::json!({
+                    "action": "reset",
+                    "policy_update_approved": true,
+                }),
+            };
+            let _ = mvp::tools::execute_tool_core_with_config(request, &self.runtime_config);
+        }
     }
 
     #[tokio::test]
@@ -1631,6 +1758,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn secret_hygiene_scans_legacy_provider_fields_and_auth_headers_with_profiles_present() {
+        let path = temp_config_path("provider-secret-headers");
+        write_placeholder_config(&path);
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.api_key = Some(SecretRef::Inline("legacy-inline-secret".to_owned()));
+        config
+            .provider
+            .headers
+            .insert("X-API-Key".to_owned(), "top-level-header-secret".to_owned());
+
+        let mut profile = mvp::config::ProviderProfileConfig::default();
+        profile.provider.headers.insert(
+            "Authorization".to_owned(),
+            "Bearer profile-secret".to_owned(),
+        );
+        config.providers.insert("openai".to_owned(), profile);
+
+        let execution = build_doctor_security_execution(&path, &config)
+            .await
+            .expect("build security execution");
+        let finding = finding_by_id(&execution.findings, "secret_hygiene");
+        let rendered_evidence = finding.evidence.join("\n");
+
+        assert_eq!(finding.status, SecurityFindingStatus::Exposed);
+        assert!(rendered_evidence.contains("provider.api_key"));
+        assert!(rendered_evidence.contains("provider.headers.X-API-Key"));
+        assert!(rendered_evidence.contains("providers.openai.headers.Authorization"));
+    }
+
+    #[tokio::test]
     async fn external_skills_expose_when_auto_expose_or_approval_is_open() {
         let path = temp_config_path("external-skills");
         write_placeholder_config(&path);
@@ -1650,27 +1808,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn external_skills_audit_uses_effective_policy_override() {
+        let path = temp_config_path("external-skills-override");
+        write_placeholder_config(&path);
+
+        let config = mvp::config::LoongClawConfig::default();
+        let runtime_config = mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+            &config,
+            Some(&path),
+        );
+        let _reset_guard = ExternalSkillsPolicyResetGuard::new(&runtime_config);
+
+        let request = kernel::ToolCoreRequest {
+            tool_name: "external_skills.policy".to_owned(),
+            payload: serde_json::json!({
+                "action": "set",
+                "policy_update_approved": true,
+                "enabled": true,
+                "require_download_approval": false,
+                "allowed_domains": ["override.example"],
+                "blocked_domains": ["blocked.example"],
+            }),
+        };
+        mvp::tools::execute_tool_core_with_config(request, &runtime_config)
+            .expect("override external skills policy");
+
+        let execution = build_doctor_security_execution(&path, &config)
+            .await
+            .expect("build security execution");
+        let finding = finding_by_id(&execution.findings, "external_skills");
+        let rendered_evidence = finding.evidence.join("\n");
+
+        assert_eq!(finding.status, SecurityFindingStatus::Exposed);
+        assert!(rendered_evidence.contains("external_skills.override_active=true"));
+        assert!(rendered_evidence.contains("external_skills.enabled=true"));
+        assert!(rendered_evidence.contains("external_skills.allowed_domains.count=1"));
+    }
+
+    #[tokio::test]
     async fn browser_surfaces_become_unknown_when_companion_is_ready() {
         let path = temp_config_path("browser-companion");
         write_placeholder_config(&path);
 
-        let temp_dir = std::env::temp_dir();
-        let command_path = temp_dir.join("loongclaw-browser-companion-security-test.sh");
-        let script = "#!/bin/sh\necho 1.2.3\n";
-        fs::write(&command_path, script).expect("write browser companion script");
-
-        #[cfg(unix)]
-        {
-            let metadata = fs::metadata(&command_path).expect("script metadata");
-            let mut permissions = metadata.permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&command_path, permissions).expect("chmod script");
-        }
+        let (command_name, expected_version) = portable_browser_companion_probe();
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.tools.browser_companion.enabled = true;
-        config.tools.browser_companion.command = Some(command_path.display().to_string());
-        config.tools.browser_companion.expected_version = Some("1.2.3".to_owned());
+        config.tools.browser_companion.command = Some(command_name);
+        config.tools.browser_companion.expected_version = Some(expected_version);
 
         let mut env = ScopedEnv::new();
         env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
@@ -1679,8 +1864,6 @@ mod tests {
             .await
             .expect("build security execution");
         let finding = finding_by_id(&execution.findings, "browser_surfaces");
-
-        let _ = fs::remove_file(&command_path);
 
         assert_eq!(finding.status, SecurityFindingStatus::Unknown);
         assert_eq!(finding.severity, SecurityFindingSeverity::Warn);
@@ -1740,5 +1923,26 @@ mod tests {
 
         assert!(fix_error.contains("--fix"));
         assert!(probe_error.contains("--skip-model-probe"));
+    }
+
+    #[tokio::test]
+    async fn run_doctor_security_cli_json_fails_when_exposed_findings_exist() {
+        let path = temp_config_path("json-exposed");
+        let path_string = path.display().to_string();
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.audit.mode = mvp::config::AuditMode::InMemory;
+        mvp::config::write(Some(path_string.as_str()), &config, true).expect("write config");
+
+        let error = run_doctor_security_cli(DoctorSecurityCommandOptions {
+            config: Some(path_string),
+            json: true,
+            fix: false,
+            skip_model_probe: false,
+        })
+        .await
+        .expect_err("json mode should fail when exposed findings exist");
+
+        assert!(error.contains("exposed surfaces"));
     }
 }

--- a/crates/daemon/src/external_skills_policy_probe.rs
+++ b/crates/daemon/src/external_skills_policy_probe.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use kernel::ToolCoreRequest;
+use loongclaw_app as mvp;
+use serde_json::{Value, json};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EffectiveExternalSkillsPolicyProbe {
+    pub(crate) policy: mvp::tools::runtime_config::ExternalSkillsRuntimePolicy,
+    pub(crate) override_active: bool,
+}
+
+pub(crate) fn resolve_effective_external_skills_policy(
+    tool_runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
+) -> Result<EffectiveExternalSkillsPolicyProbe, String> {
+    let request = ToolCoreRequest {
+        tool_name: "external_skills.policy".to_owned(),
+        payload: json!({
+            "action": "get",
+        }),
+    };
+    let outcome = mvp::tools::execute_tool_core_with_config(request, tool_runtime)
+        .map_err(|error| format!("resolve effective external skills policy failed: {error}"))?;
+    let payload = outcome.payload;
+    let policy = external_skills_policy_from_payload(&payload)?;
+    let override_active = payload
+        .get("override_active")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let probe = EffectiveExternalSkillsPolicyProbe {
+        policy,
+        override_active,
+    };
+    Ok(probe)
+}
+
+fn external_skills_policy_from_payload(
+    payload: &Value,
+) -> Result<mvp::tools::runtime_config::ExternalSkillsRuntimePolicy, String> {
+    let policy = payload
+        .get("policy")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "external skills policy payload missing `policy` object".to_owned())?;
+
+    let enabled = policy
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| "external skills policy payload missing boolean `enabled`".to_owned())?;
+
+    let require_download_approval = policy
+        .get("require_download_approval")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| {
+            "external skills policy payload missing boolean `require_download_approval`".to_owned()
+        })?;
+
+    let allowed_domains = json_string_set(policy.get("allowed_domains"), "policy.allowed_domains")?;
+    let blocked_domains = json_string_set(policy.get("blocked_domains"), "policy.blocked_domains")?;
+
+    let install_root = policy
+        .get("install_root")
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
+
+    let auto_expose_installed = policy
+        .get("auto_expose_installed")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| {
+            "external skills policy payload missing boolean `auto_expose_installed`".to_owned()
+        })?;
+
+    let resolved = mvp::tools::runtime_config::ExternalSkillsRuntimePolicy {
+        enabled,
+        require_download_approval,
+        allowed_domains,
+        blocked_domains,
+        install_root,
+        auto_expose_installed,
+    };
+    Ok(resolved)
+}
+
+fn json_string_set(value: Option<&Value>, field_name: &str) -> Result<BTreeSet<String>, String> {
+    let values = value
+        .as_array()
+        .ok_or_else(|| format!("external skills policy `{field_name}` must be an array"))?;
+
+    let mut collected = BTreeSet::new();
+
+    for raw_value in values {
+        let string_value = raw_value.as_str().ok_or_else(|| {
+            format!("external skills policy `{field_name}` must contain only strings")
+        })?;
+        let owned_value = string_value.to_owned();
+        collected.insert(owned_value);
+    }
+
+    Ok(collected)
+}

--- a/crates/daemon/src/external_skills_policy_probe.rs
+++ b/crates/daemon/src/external_skills_policy_probe.rs
@@ -83,7 +83,7 @@ fn external_skills_policy_from_payload(
 
 fn json_string_set(value: Option<&Value>, field_name: &str) -> Result<BTreeSet<String>, String> {
     let values = value
-        .as_array()
+        .and_then(Value::as_array)
         .ok_or_else(|| format!("external skills policy `{field_name}` must be an array"))?;
 
     let mut collected = BTreeSet::new();

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -83,6 +83,7 @@ mod channel_send_target_kind;
 mod cli_handoff;
 pub mod completions_cli;
 pub mod doctor_cli;
+pub mod doctor_security_cli;
 pub mod feishu_cli;
 pub mod feishu_support;
 pub mod gateway;
@@ -514,17 +515,19 @@ pub enum Commands {
     /// Run configuration diagnostics and optionally apply safe config/path fixes
     Doctor {
         /// Config file path to validate (defaults to auto-discovery)
-        #[arg(long)]
+        #[arg(long, global = true)]
         config: Option<String>,
         /// Apply safe auto-fixes for detected diagnostics
-        #[arg(long, default_value_t = false)]
+        #[arg(long, global = true, default_value_t = false)]
         fix: bool,
         /// Emit machine-readable JSON diagnostics
-        #[arg(long, default_value_t = false)]
+        #[arg(long, global = true, default_value_t = false)]
         json: bool,
         /// Skip provider model probing during diagnostics
-        #[arg(long, default_value_t = false)]
+        #[arg(long, global = true, default_value_t = false)]
         skip_model_probe: bool,
+        #[command(subcommand)]
+        command: Option<doctor_cli::DoctorCommands>,
     },
     /// Inspect the retained audit journal through a bounded CLI surface
     Audit {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -84,6 +84,7 @@ mod cli_handoff;
 pub mod completions_cli;
 pub mod doctor_cli;
 pub mod doctor_security_cli;
+mod external_skills_policy_probe;
 pub mod feishu_cli;
 pub mod feishu_support;
 pub mod gateway;

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -226,12 +226,14 @@ async fn main() {
             fix,
             json,
             skip_model_probe,
+            command,
         } => {
             doctor_cli::run_doctor_cli(doctor_cli::DoctorCommandOptions {
                 config,
                 fix,
                 json,
                 skip_model_probe,
+                command,
             })
             .await
         }

--- a/crates/daemon/src/runtime_snapshot_support.rs
+++ b/crates/daemon/src/runtime_snapshot_support.rs
@@ -328,9 +328,11 @@ fn collect_runtime_snapshot_external_skills_state(
         "shadowed_skills": [],
     });
 
-    let (effective_policy, override_active) =
-        match runtime_snapshot_effective_external_skills_policy(tool_runtime) {
-            Ok(policy_state) => policy_state,
+    let policy_probe =
+        match crate::external_skills_policy_probe::resolve_effective_external_skills_policy(
+            tool_runtime,
+        ) {
+            Ok(policy_probe) => policy_probe,
             Err(error) => {
                 return (
                     RuntimeSnapshotExternalSkillsState {
@@ -350,6 +352,9 @@ fn collect_runtime_snapshot_external_skills_state(
                 );
             }
         };
+
+    let effective_policy = policy_probe.policy;
+    let override_active = policy_probe.override_active;
 
     let mut effective_tool_runtime = tool_runtime.clone();
     effective_tool_runtime.external_skills = effective_policy.clone();
@@ -407,81 +412,6 @@ fn collect_runtime_snapshot_external_skills_state(
     }
 }
 
-fn runtime_snapshot_effective_external_skills_policy(
-    tool_runtime: &mvp::tools::runtime_config::ToolRuntimeConfig,
-) -> Result<
-    (
-        mvp::tools::runtime_config::ExternalSkillsRuntimePolicy,
-        bool,
-    ),
-    String,
-> {
-    let outcome = mvp::tools::execute_tool_core_with_config(
-        ToolCoreRequest {
-            tool_name: "external_skills.policy".to_owned(),
-            payload: json!({
-                "action": "get",
-            }),
-        },
-        tool_runtime,
-    )
-    .map_err(|error| format!("resolve effective external skills policy failed: {error}"))?;
-
-    let policy = runtime_snapshot_external_skills_policy_from_payload(&outcome.payload)?;
-    let override_active = outcome
-        .payload
-        .get("override_active")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    Ok((policy, override_active))
-}
-
-fn runtime_snapshot_external_skills_policy_from_payload(
-    payload: &Value,
-) -> Result<mvp::tools::runtime_config::ExternalSkillsRuntimePolicy, String> {
-    let policy = payload
-        .get("policy")
-        .and_then(Value::as_object)
-        .ok_or_else(|| {
-            "runtime snapshot external skills policy payload missing `policy`".to_owned()
-        })?;
-
-    Ok(mvp::tools::runtime_config::ExternalSkillsRuntimePolicy {
-        enabled: policy
-            .get("enabled")
-            .and_then(Value::as_bool)
-            .ok_or_else(|| {
-                "runtime snapshot external skills policy missing `enabled`".to_owned()
-            })?,
-        require_download_approval: policy
-            .get("require_download_approval")
-            .and_then(Value::as_bool)
-            .ok_or_else(|| {
-                "runtime snapshot external skills policy missing `require_download_approval`"
-                    .to_owned()
-            })?,
-        allowed_domains: json_string_array_to_set(
-            policy.get("allowed_domains"),
-            "runtime snapshot external skills policy.allowed_domains",
-        )?,
-        blocked_domains: json_string_array_to_set(
-            policy.get("blocked_domains"),
-            "runtime snapshot external skills policy.blocked_domains",
-        )?,
-        install_root: policy
-            .get("install_root")
-            .and_then(Value::as_str)
-            .map(Path::new)
-            .map(Path::to_path_buf),
-        auto_expose_installed: policy
-            .get("auto_expose_installed")
-            .and_then(Value::as_bool)
-            .ok_or_else(|| {
-                "runtime snapshot external skills policy missing `auto_expose_installed`".to_owned()
-            })?,
-    })
-}
-
 fn runtime_snapshot_tool_digest(
     visible_tool_names: &[String],
     capability_snapshot: &str,
@@ -496,23 +426,6 @@ fn runtime_snapshot_tool_digest(
 
 fn json_array_len(value: Option<&Value>) -> usize {
     value.and_then(Value::as_array).map_or(0, Vec::len)
-}
-
-fn json_string_array_to_set(
-    value: Option<&Value>,
-    context: &str,
-) -> Result<BTreeSet<String>, String> {
-    let items = value
-        .and_then(Value::as_array)
-        .ok_or_else(|| format!("{context} must be an array"))?;
-    items
-        .iter()
-        .map(|item| {
-            item.as_str()
-                .map(str::to_owned)
-                .ok_or_else(|| format!("{context} must contain only strings"))
-        })
-        .collect()
 }
 
 fn build_runtime_snapshot_restore_spec(

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -55,6 +55,100 @@ fn welcome_subcommand_help_advertises_first_run_shortcuts() {
 }
 
 #[test]
+fn doctor_help_mentions_security_subcommand() {
+    let help = render_cli_help(["doctor"]);
+
+    assert!(
+        help.contains("security"),
+        "doctor help should advertise the security audit subcommand: {help}"
+    );
+    assert!(
+        help.contains("--config <CONFIG>"),
+        "doctor help should keep the shared config flag visible: {help}"
+    );
+}
+
+#[test]
+fn doctor_security_help_mentions_security_exposure_audit() {
+    let help = render_cli_help(["doctor", "security"]);
+
+    assert!(
+        help.contains("security exposure"),
+        "doctor security help should describe the exposure audit: {help}"
+    );
+    assert!(
+        help.contains("Usage: security"),
+        "doctor security help should render a dedicated usage block: {help}"
+    );
+}
+
+#[test]
+fn doctor_security_cli_parses_subcommand_and_global_flags() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "doctor",
+        "--config",
+        "/tmp/loongclaw.toml",
+        "security",
+        "--json",
+    ])
+    .expect("`doctor security --json` should parse");
+
+    match cli.command {
+        Some(Commands::Doctor {
+            config,
+            fix,
+            json,
+            skip_model_probe,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(!fix);
+            assert!(json);
+            assert!(!skip_model_probe);
+            assert_eq!(
+                command,
+                Some(loongclaw_daemon::doctor_cli::DoctorCommands::Security)
+            );
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn doctor_security_cli_accepts_global_flags_after_subcommand() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "doctor",
+        "security",
+        "--config",
+        "/tmp/loongclaw.toml",
+        "--skip-model-probe",
+    ])
+    .expect("global doctor flags should remain valid after the security subcommand");
+
+    match cli.command {
+        Some(Commands::Doctor {
+            config,
+            fix,
+            json,
+            skip_model_probe,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(!fix);
+            assert!(!json);
+            assert!(skip_model_probe);
+            assert_eq!(
+                command,
+                Some(loongclaw_daemon::doctor_cli::DoctorCommands::Security)
+            );
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn setup_subcommand_is_removed() {
     let error = try_parse_cli(["loongclaw", "setup"])
         .expect_err("`setup` should no longer parse as a valid subcommand");

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -146,6 +146,38 @@ fn doctor_security_cli_accepts_global_flags_after_subcommand() {
         }
         other => panic!("unexpected command parsed: {other:?}"),
     }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build test runtime");
+
+    let fix_error = runtime
+        .block_on(loongclaw_daemon::doctor_cli::run_doctor_cli(
+            loongclaw_daemon::doctor_cli::DoctorCommandOptions {
+                config: None,
+                fix: true,
+                json: false,
+                skip_model_probe: false,
+                command: Some(loongclaw_daemon::doctor_cli::DoctorCommands::Security),
+            },
+        ))
+        .expect_err("doctor security should reject --fix at runtime");
+
+    let probe_error = runtime
+        .block_on(loongclaw_daemon::doctor_cli::run_doctor_cli(
+            loongclaw_daemon::doctor_cli::DoctorCommandOptions {
+                config: None,
+                fix: false,
+                json: false,
+                skip_model_probe: true,
+                command: Some(loongclaw_daemon::doctor_cli::DoctorCommands::Security),
+            },
+        ))
+        .expect_err("doctor security should reject --skip-model-probe at runtime");
+
+    assert!(fix_error.contains("--fix"));
+    assert!(probe_error.contains("--skip-model-probe"));
 }
 
 #[test]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -81,6 +81,13 @@ Tool-specific request approval currently lives in the `PolicyExtensionChain`; th
 - Explicit no-audit behavior remains opt-in only and should stay reserved for narrow fixture seams
 - No HMAC chain for tamper evidence (TD-007)
 
+### Operator Security Posture Audit
+
+- `loongclaw doctor security` is the operator-facing exposure audit for the current local runtime
+- It reports `covered`, `partial`, `exposed`, and `unknown` findings instead of collapsing everything into pass/fail
+- Current audit categories include durable audit retention, shell posture, tool file-root confinement, web-fetch egress, external-skills posture, secret hygiene, and browser automation surfaces
+- `loongclaw doctor security --json` provides a stable machine-readable report for local automation and support workflows
+
 ### Web HTTP SSRF Guardrails
 
 - `web.fetch`, `web.search`, and the shared browser-side URL validators intentionally build their HTTP clients with `reqwest::ClientBuilder::no_proxy()`

--- a/docs/product-specs/doctor.md
+++ b/docs/product-specs/doctor.md
@@ -14,6 +14,13 @@ can recover a broken setup without reverse-engineering runtime internals.
 - [ ] `loongclaw doctor --json` produces stable machine-readable output for
       automation and support tooling, including machine-readable `next_steps`
       when doctor can recommend a concrete repair or first-value command.
+- [ ] `loongclaw doctor security` provides a separate security exposure and
+      config hygiene audit instead of overloading the general health report.
+- [ ] `loongclaw doctor security --json` emits a stable machine-readable
+      contract with `command`, `config`, `ok`, `summary`, and `findings`.
+- [ ] Security findings use the explicit posture vocabulary
+      `covered | partial | exposed | unknown` so operators can distinguish
+      strong coverage from soft guardrails and unresolved surfaces.
 - [ ] Text-mode doctor output ends with concrete next actions such as
       credential env hints, `doctor --fix`, first-turn ask/chat commands, and
       optional browser preview enable or runtime setup commands when relevant.
@@ -25,6 +32,12 @@ can recover a broken setup without reverse-engineering runtime internals.
 - [ ] Doctor checks cover the current MVP path: config presence, provider
       readiness, SQLite memory readiness, shipped channel prerequisites, and
       the optional browser preview companion readiness path.
+- [ ] `doctor security` covers the current operator-facing security posture:
+      audit retention durability, shell default policy, explicit tool file
+      root, web fetch egress, external skills download posture, secret storage
+      hygiene, and browser automation readiness posture.
+- [ ] `doctor security` rejects `--fix` and `--skip-model-probe` instead of
+      silently accepting unsupported parent-command flags.
 - [ ] Durable audit readiness checks exercise the runtime `open + lock + unlock`
       path for JSONL retention instead of relying on metadata-only validation.
 - [ ] When `tools.browser_companion.enabled=true`, doctor surfaces companion

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-29T00:09:06Z
+- Generated at: 2026-03-29T03:10:44Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -24,7 +24,7 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6396 | 6400 | 4 | 104 | 110 | 6 | 99.9% | TIGHT |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9964 | 11200 | 1236 | 92 | 120 | 28 | 89.0% | WATCH |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14206 | 15000 | 794 | 54 | 70 | 16 | 94.7% | WATCH |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 4998 | 6000 | 1002 | 172 | 190 | 18 | 90.5% | WATCH |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5002 | 6000 | 998 | 172 | 190 | 18 | 90.5% | WATCH |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
 ## Prioritization Signals
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=channel_mod lines=6396 functions=104 -->
 <!-- arch-hotspot key=turn_coordinator lines=9964 functions=92 -->
 <!-- arch-hotspot key=tools_mod lines=14206 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=4998 functions=172 -->
+<!-- arch-hotspot key=daemon_lib lines=5002 functions=172 -->
 <!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw had general runtime health diagnostics, but it did not have a first-class operator command that audits current security exposure and config hygiene across the local runtime.
- Why it matters:
  Operators need evidence-backed posture reporting for audit durability, shell posture, file-root confinement, web egress, external-skills exposure, secret storage hygiene, and browser surfaces before they can trust a local setup.
- What changed:
  Added `loongclaw doctor security` as a dedicated audit subcommand with text and JSON output, explicit `covered|partial|exposed|unknown` findings, runtime-derived evidence, and focused tests and docs.
- What did not change (scope boundary):
  This PR does not add OS-level sandboxing, provenance scanning, or automatic security remediation. The existing `loongclaw doctor` behavior stays intact.

## Linked Issues

- Closes #655
- Related #420

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-daemon doctor -- --nocapture
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
cargo run -p loongclaw-daemon -- doctor security --config <temp-config> --json

Results:
- All listed cargo checks passed.
- One first pass of `cargo test --workspace --locked` hit an unrelated flaky ACPX test in `loongclaw-app`; rerunning that targeted test passed, and the full workspace rerun passed cleanly.
- Manual CLI run produced the expected JSON contract with `command`, `config`, `ok`, `summary`, and `findings`.
- `task verify` could not be run in this environment because the `task` binary is not installed.
- Env-mutating tests use `crate::test_support::ScopedEnv`, which serializes process-global env changes behind the daemon test env lock and restores original values on drop.
```

## User-visible / Operator-visible Changes

- Added `loongclaw doctor security` for a dedicated local security exposure audit.
- Added `loongclaw doctor security --json` for machine-readable posture reporting.
- `loongclaw doctor` now exposes a `security` subcommand while preserving existing top-level behavior.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to remove the new subcommand. Existing `loongclaw doctor` behavior remains isolated from the new audit path.
- Observable failure symptoms reviewers should watch for:
  CLI parsing regressions under `loongclaw doctor ...`, missing JSON fields in `doctor security --json`, or unsupported inherited flags being silently ignored instead of rejected.

## Reviewer Focus

- Check the new audit contract and evidence derivation in `crates/daemon/src/doctor_security_cli.rs`.
- Confirm `crates/daemon/src/doctor_cli.rs`, `crates/daemon/src/lib.rs`, and `crates/daemon/src/main.rs` preserve existing doctor behavior while routing the new subcommand correctly.
- Review `crates/daemon/tests/integration/cli_tests.rs` for flag-order parsing coverage and `docs/product-specs/doctor.md` for contract drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `loongclaw doctor security` command to audit security exposure and configuration hygiene across multiple audit areas
  * Security findings are classified with multi-state results: covered, partial, exposed, or unknown
  * Provides human-readable text output for operator review and stable JSON format for automation and tool integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->