### PR TITLE
feat: add background tasks CLI over session runtime

### DIFF
--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -87,7 +87,7 @@ pub use turn_checkpoint::{
     TurnCheckpointTailRepairRuntimeProbe, TurnCheckpointTailRepairSource,
     TurnCheckpointTailRepairStatus,
 };
-pub use turn_coordinator::ConversationTurnCoordinator;
+pub use turn_coordinator::{ConversationTurnCoordinator, spawn_background_delegate_with_runtime};
 pub use turn_engine::{
     AppToolDispatcher, DefaultAppToolDispatcher, NoopAppToolDispatcher, ProviderTurn, ToolDecision,
     ToolIntent, ToolOutcome, TurnEngine, TurnFailure, TurnFailureKind, TurnResult,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -16232,6 +16232,30 @@ async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_
 }
 
 #[cfg(feature = "memory-sqlite")]
+async fn wait_for_async_delegate_request_count(
+    spawner: &Arc<FakeAsyncDelegateSpawner>,
+    expected_count: usize,
+) {
+    let timeout_duration = std::time::Duration::from_secs(2);
+    let wait_result = tokio::time::timeout(timeout_duration, async {
+        loop {
+            let request_count = spawner
+                .requests
+                .lock()
+                .expect("async delegate requests lock")
+                .len();
+            if request_count == expected_count {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+
+    wait_result.expect("timed out waiting for async delegate request");
+}
+
+#[cfg(feature = "memory-sqlite")]
 #[tokio::test]
 async fn spawn_background_delegate_with_runtime_creates_missing_root_session_scope() {
     let db_path = std::env::temp_dir().join(format!(
@@ -16295,17 +16319,7 @@ async fn spawn_background_delegate_with_runtime_creates_missing_root_session_sco
         crate::session::repository::SessionState::Ready
     );
 
-    for _ in 0..10 {
-        let request_count = spawner
-            .requests
-            .lock()
-            .expect("async delegate requests lock")
-            .len();
-        if request_count == 1 {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    wait_for_async_delegate_request_count(&spawner, 1).await;
 
     let requests = spawner
         .requests
@@ -16371,17 +16385,7 @@ async fn spawn_background_delegate_with_runtime_uses_default_timeout_when_omitte
 
     assert_eq!(outcome.payload["timeout_seconds"], 77);
 
-    for _ in 0..10 {
-        let request_count = spawner
-            .requests
-            .lock()
-            .expect("async delegate requests lock")
-            .len();
-        if request_count == 1 {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    wait_for_async_delegate_request_count(&spawner, 1).await;
 
     let requests = spawner
         .requests

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -16233,6 +16233,166 @@ async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn spawn_background_delegate_with_runtime_creates_missing_root_session_scope() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-background-task", "create-root")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_async_delegate_spawner(spawner.clone())
+        .with_durable_memory_config(memory_config.clone());
+
+    let outcome = crate::conversation::spawn_background_delegate_with_runtime(
+        &config,
+        &runtime,
+        "task-root",
+        "collect repo health",
+        Some("health-check".to_owned()),
+        Some(42),
+        ConversationRuntimeBinding::direct(),
+    )
+    .await
+    .expect("background task should queue successfully");
+
+    let child_session_id = outcome.payload["child_session_id"]
+        .as_str()
+        .expect("child session id")
+        .to_owned();
+    let root_session = repo
+        .load_session("task-root")
+        .expect("load root session")
+        .expect("root session record");
+    assert_eq!(
+        root_session.kind,
+        crate::session::repository::SessionKind::Root
+    );
+    assert_eq!(root_session.parent_session_id, None);
+
+    let child_session = repo
+        .load_session(&child_session_id)
+        .expect("load child session")
+        .expect("child session record");
+    assert_eq!(
+        child_session.kind,
+        crate::session::repository::SessionKind::DelegateChild
+    );
+    assert_eq!(
+        child_session.parent_session_id.as_deref(),
+        Some("task-root")
+    );
+    assert_eq!(child_session.label.as_deref(), Some("health-check"));
+    assert_eq!(
+        child_session.state,
+        crate::session::repository::SessionState::Ready
+    );
+
+    for _ in 0..10 {
+        let request_count = spawner
+            .requests
+            .lock()
+            .expect("async delegate requests lock")
+            .len();
+        if request_count == 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let requests = spawner
+        .requests
+        .lock()
+        .expect("async delegate requests lock");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].parent_session_id, "task-root");
+    assert_eq!(requests[0].task, "collect repo health");
+    assert_eq!(requests[0].label.as_deref(), Some("health-check"));
+    assert_eq!(requests[0].timeout_seconds, 42);
+
+    let events = repo
+        .list_delegate_lifecycle_events(&child_session_id)
+        .expect("delegate lifecycle events");
+    assert!(
+        events
+            .iter()
+            .any(|event| event.event_kind == "delegate_queued"),
+        "queued child should persist a delegate_queued event"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn spawn_background_delegate_with_runtime_uses_default_timeout_when_omitted() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-background-task", "default-timeout")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.delegate.timeout_seconds = 77;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "task-root".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let runtime = FakeRuntime::with_turns_and_completions(vec![], vec![], vec![])
+        .with_async_delegate_spawner(spawner.clone())
+        .with_durable_memory_config(memory_config.clone());
+
+    let outcome = crate::conversation::spawn_background_delegate_with_runtime(
+        &config,
+        &runtime,
+        "task-root",
+        "sync release checklist",
+        None,
+        None,
+        ConversationRuntimeBinding::direct(),
+    )
+    .await
+    .expect("background task should queue successfully");
+
+    assert_eq!(outcome.payload["timeout_seconds"], 77);
+
+    for _ in 0..10 {
+        let request_count = spawner
+            .requests
+            .lock()
+            .expect("async delegate requests lock")
+            .len();
+        if request_count == 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let requests = spawner
+        .requests
+        .lock()
+        .expect("async delegate requests lock");
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].timeout_seconds, 77);
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_creation() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4076,16 +4076,19 @@ pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Si
     binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     let session_context = runtime.session_context(config, session_id, binding)?;
-    let effective_timeout_seconds =
-        timeout_seconds.unwrap_or(config.tools.delegate.timeout_seconds);
-    let task_text = task.to_owned();
+    let delegate_request = crate::tools::delegate::normalize_delegate_request(
+        task,
+        label.as_deref(),
+        timeout_seconds,
+        config.tools.delegate.timeout_seconds,
+    )?;
     enqueue_delegate_async_with_runtime(
         config,
         runtime,
         &session_context,
-        task_text,
-        label,
-        effective_timeout_seconds,
+        delegate_request.task,
+        delegate_request.label,
+        delegate_request.timeout_seconds,
         binding,
     )
     .await

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3983,11 +3983,13 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
 }
 
 #[cfg(feature = "memory-sqlite")]
-async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
+async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
     session_context: &SessionContext,
-    payload: Value,
+    task: String,
+    label: Option<String>,
+    timeout_seconds: u64,
     binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     if !config.tools.delegate.enabled {
@@ -3999,14 +4001,13 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
     let spawner = runtime
         .async_delegate_spawner(config)
         .ok_or_else(|| "delegate_async_not_configured".to_owned())?;
-    let delegate_request = crate::tools::delegate::parse_delegate_request_with_default_timeout(
-        &payload,
-        config.tools.delegate.timeout_seconds,
-    )?;
     let child_session_id = crate::tools::delegate::next_delegate_session_id();
-    let child_label = delegate_request.label.clone();
+    let child_label = label.clone();
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
+
+    ensure_session_exists_for_runtime_self_continuity(&repo, &session_context.session_id)?;
+
     let next_child_depth = next_delegate_child_depth_for_delegate(config, &repo, session_context)?;
     let runtime_self_continuity =
         effective_runtime_self_continuity_for_session(config, session_context);
@@ -4018,53 +4019,113 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
                 config,
                 binding,
                 ConstrainedSubagentMode::Async,
-                delegate_request.timeout_seconds,
+                timeout_seconds,
                 next_child_depth,
                 active_children,
             );
-            Ok((
-                CreateSessionWithEventRequest {
-                    session: NewSessionRecord {
-                        session_id: child_session_id.clone(),
-                        kind: SessionKind::DelegateChild,
-                        parent_session_id: Some(session_context.session_id.clone()),
-                        label: child_label.clone(),
-                        state: SessionState::Ready,
-                    },
-                    event_kind: "delegate_queued".to_owned(),
-                    actor_session_id: Some(session_context.session_id.clone()),
-                    event_payload_json: execution.spawn_payload_with_runtime_self_continuity(
-                        &delegate_request.task,
-                        child_label.as_deref(),
-                        runtime_self_continuity.as_ref(),
-                    ),
-                },
-                execution,
-            ))
+            let event_payload_json = execution.spawn_payload_with_runtime_self_continuity(
+                &task,
+                child_label.as_deref(),
+                runtime_self_continuity.as_ref(),
+            );
+            let session = NewSessionRecord {
+                session_id: child_session_id.clone(),
+                kind: SessionKind::DelegateChild,
+                parent_session_id: Some(session_context.session_id.clone()),
+                label: child_label.clone(),
+                state: SessionState::Ready,
+            };
+            let request = CreateSessionWithEventRequest {
+                session,
+                event_kind: "delegate_queued".to_owned(),
+                actor_session_id: Some(session_context.session_id.clone()),
+                event_payload_json,
+            };
+            Ok((request, execution))
         },
     )?;
 
-    spawn_async_delegate_detached(
-        runtime_handle,
-        memory_config,
-        spawner,
-        AsyncDelegateSpawnRequest {
-            child_session_id: child_session_id.clone(),
-            parent_session_id: session_context.session_id.clone(),
-            task: delegate_request.task,
-            label: child_label,
-            execution,
-            runtime_self_continuity,
-            timeout_seconds: delegate_request.timeout_seconds,
-            kernel_context: binding.kernel_context().cloned(),
-        },
-    );
+    let kernel_context = binding.kernel_context().cloned();
+    let request = AsyncDelegateSpawnRequest {
+        child_session_id: child_session_id.clone(),
+        parent_session_id: session_context.session_id.clone(),
+        task,
+        label: child_label,
+        execution,
+        runtime_self_continuity,
+        timeout_seconds,
+        kernel_context,
+    };
+    spawn_async_delegate_detached(runtime_handle, memory_config, spawner, request);
 
     Ok(crate::tools::delegate::delegate_async_queued_outcome(
         child_session_id,
+        label,
+        timeout_seconds,
+    ))
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    task: &str,
+    label: Option<String>,
+    timeout_seconds: Option<u64>,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+    let session_context = runtime.session_context(config, session_id, binding)?;
+    let effective_timeout_seconds =
+        timeout_seconds.unwrap_or(config.tools.delegate.timeout_seconds);
+    let task_text = task.to_owned();
+    enqueue_delegate_async_with_runtime(
+        config,
+        runtime,
+        &session_context,
+        task_text,
+        label,
+        effective_timeout_seconds,
+        binding,
+    )
+    .await
+}
+
+#[cfg(not(feature = "memory-sqlite"))]
+pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Sized>(
+    _config: &LoongClawConfig,
+    _runtime: &R,
+    _session_id: &str,
+    _task: &str,
+    _label: Option<String>,
+    _timeout_seconds: Option<u64>,
+    _binding: ConversationRuntimeBinding<'_>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+    Err("delegate_async requires sqlite memory support (enable feature `memory-sqlite`)".to_owned())
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_context: &SessionContext,
+    payload: Value,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+    let delegate_request = crate::tools::delegate::parse_delegate_request_with_default_timeout(
+        &payload,
+        config.tools.delegate.timeout_seconds,
+    )?;
+    enqueue_delegate_async_with_runtime(
+        config,
+        runtime,
+        session_context,
+        delegate_request.task,
         delegate_request.label,
         delegate_request.timeout_seconds,
-    ))
+        binding,
+    )
+    .await
 }
 
 #[cfg(not(feature = "memory-sqlite"))]

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -4,8 +4,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{Value, json};
 
-use super::payload::{optional_payload_string, required_payload_string};
-
 #[cfg(test)]
 pub const DEFAULT_TIMEOUT_SECONDS: u64 = 60;
 
@@ -25,18 +23,50 @@ pub(crate) fn parse_delegate_request_with_default_timeout(
     payload: &Value,
     default_timeout_seconds: u64,
 ) -> Result<DelegateRequest, String> {
-    let task = required_payload_string(payload, "task", "delegate tool")?;
-    let label = optional_payload_string(payload, "label");
-    let timeout_seconds = payload
-        .get("timeout_seconds")
-        .and_then(Value::as_u64)
-        .unwrap_or(default_timeout_seconds);
+    let raw_task = payload.get("task").and_then(Value::as_str).unwrap_or("");
+    let raw_label = payload.get("label").and_then(Value::as_str);
+    let timeout_seconds = payload.get("timeout_seconds").and_then(Value::as_u64);
+
+    normalize_delegate_request(
+        raw_task,
+        raw_label,
+        timeout_seconds,
+        default_timeout_seconds,
+    )
+}
+
+pub(crate) fn normalize_delegate_request(
+    task: &str,
+    label: Option<&str>,
+    timeout_seconds: Option<u64>,
+    default_timeout_seconds: u64,
+) -> Result<DelegateRequest, String> {
+    let normalized_task = normalize_required_delegate_text(task, "task")?;
+    let normalized_label = normalize_optional_delegate_text(label);
+    let effective_timeout_seconds = timeout_seconds.unwrap_or(default_timeout_seconds);
 
     Ok(DelegateRequest {
-        task,
-        label,
-        timeout_seconds,
+        task: normalized_task,
+        label: normalized_label,
+        timeout_seconds: effective_timeout_seconds,
     })
+}
+
+fn normalize_required_delegate_text(value: &str, field: &str) -> Result<String, String> {
+    let trimmed_value = value.trim();
+    if trimmed_value.is_empty() {
+        return Err(format!("delegate tool requires payload.{field}"));
+    }
+    Ok(trimmed_value.to_owned())
+}
+
+fn normalize_optional_delegate_text(value: Option<&str>) -> Option<String> {
+    let raw_value = value?;
+    let trimmed_value = raw_value.trim();
+    if trimmed_value.is_empty() {
+        return None;
+    }
+    Some(trimmed_value.to_owned())
 }
 
 pub(crate) fn next_delegate_session_id() -> String {
@@ -138,6 +168,20 @@ mod tests {
         .expect("delegate request");
         assert_eq!(request.task, "research");
         assert_eq!(request.label, None);
+        assert_eq!(request.timeout_seconds, DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    #[test]
+    fn normalize_delegate_request_trims_cli_inputs() {
+        let request = normalize_delegate_request(
+            "  research  ",
+            Some("  release-check  "),
+            None,
+            DEFAULT_TIMEOUT_SECONDS,
+        )
+        .expect("delegate request");
+        assert_eq!(request.task, "research");
+        assert_eq!(request.label.as_deref(), Some("release-check"));
         assert_eq!(request.timeout_seconds, DEFAULT_TIMEOUT_SECONDS);
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -113,8 +113,8 @@ mod runtime_snapshot_support;
 pub mod skills_cli;
 pub mod source_presentation;
 pub mod supervisor;
-mod tlon_cli;
 pub mod tasks_cli;
+mod tlon_cli;
 
 pub use gateway::read_models::{ChannelsCliJsonPayload, ChannelsCliJsonSchema};
 pub use loongclaw_spec::programmatic::{

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -114,6 +114,7 @@ pub mod skills_cli;
 pub mod source_presentation;
 pub mod supervisor;
 mod tlon_cli;
+pub mod tasks_cli;
 
 pub use gateway::read_models::{ChannelsCliJsonPayload, ChannelsCliJsonSchema};
 pub use loongclaw_spec::programmatic::{
@@ -547,6 +548,17 @@ pub enum Commands {
         json: bool,
         #[command(subcommand)]
         command: skills_cli::SkillsCommands,
+    },
+    /// Manage async background tasks on top of the current session runtime
+    Tasks {
+        #[arg(long, global = true)]
+        config: Option<String>,
+        #[arg(long, global = true, default_value_t = false)]
+        json: bool,
+        #[arg(long, global = true, default_value = "default")]
+        session: String,
+        #[command(subcommand)]
+        command: tasks_cli::TasksCommands,
     },
     #[command(
         visible_alias = "plugin",

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -255,6 +255,20 @@ async fn main() {
             json,
             command,
         }),
+        Commands::Tasks {
+            config,
+            json,
+            session,
+            command,
+        } => {
+            tasks_cli::run_tasks_cli(tasks_cli::TasksCommandOptions {
+                config,
+                json,
+                session,
+                command,
+            })
+            .await
+        }
         Commands::Plugins { json, command } => {
             plugins_cli::run_plugins_cli(plugins_cli::PluginsCommandOptions { json, command }).await
         }

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -228,7 +228,8 @@ async fn execute_create_command(
     )
     .await?;
     let task_id = required_string_field(&queued.payload, "child_session_id", "tasks create")?;
-    let task_detail = build_task_detail(memory_config, tool_config, current_session_id, &task_id)?;
+    let (task_detail, task_lookup_error) =
+        build_best_effort_task_detail(memory_config, tool_config, current_session_id, &task_id);
     let recipes = build_task_recipes(resolved_config_path, current_session_id, &task_id);
     let next_steps = build_task_next_steps();
     let payload = json!({
@@ -237,6 +238,7 @@ async fn execute_create_command(
         "current_session_id": current_session_id,
         "queued_outcome": queued.payload,
         "task": task_detail,
+        "task_lookup_error": task_lookup_error,
         "recipes": recipes,
         "next_steps": next_steps,
     });
@@ -254,23 +256,14 @@ fn execute_list_command(
     include_archived: bool,
 ) -> CliResult<Value> {
     let raw_limit = limit.clamp(1, 200);
-    let scan_limit = 200usize;
-    let sessions_payload = json!({
-        "limit": scan_limit,
-        "state": state,
-        "kind": "delegate_child",
-        "overdue_only": overdue_only,
-        "include_archived": include_archived,
-        "include_delegate_lifecycle": true,
-    });
-    let sessions_outcome = execute_app_tool_request(
+    let session_ids = load_visible_background_task_ids(
         memory_config,
         tool_config,
         current_session_id,
-        "sessions_list",
-        sessions_payload,
+        state,
+        overdue_only,
+        include_archived,
     )?;
-    let session_ids = extract_async_background_task_ids(&sessions_outcome.payload)?;
     let matched_count = session_ids.len();
 
     let mut tasks = Vec::new();
@@ -417,6 +410,7 @@ fn execute_cancel_command(
     task_id: &str,
     dry_run: bool,
 ) -> CliResult<Value> {
+    validate_background_task_target(memory_config, tool_config, current_session_id, task_id)?;
     let payload = json!({
         "session_id": task_id,
         "dry_run": dry_run,
@@ -428,7 +422,8 @@ fn execute_cancel_command(
         "session_cancel",
         payload,
     )?;
-    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let (task, task_lookup_error) =
+        build_best_effort_task_detail(memory_config, tool_config, current_session_id, task_id);
     let mutation_result = extract_single_mutation_result(&outcome.payload);
     let result = mutation_result
         .as_ref()
@@ -460,6 +455,7 @@ fn execute_cancel_command(
         "message": message,
         "action": action,
         "task": task,
+        "task_lookup_error": task_lookup_error,
     });
     Ok(output)
 }
@@ -472,6 +468,7 @@ fn execute_recover_command(
     task_id: &str,
     dry_run: bool,
 ) -> CliResult<Value> {
+    validate_background_task_target(memory_config, tool_config, current_session_id, task_id)?;
     let payload = json!({
         "session_id": task_id,
         "dry_run": dry_run,
@@ -483,7 +480,8 @@ fn execute_recover_command(
         "session_recover",
         payload,
     )?;
-    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let (task, task_lookup_error) =
+        build_best_effort_task_detail(memory_config, tool_config, current_session_id, task_id);
     let mutation_result = extract_single_mutation_result(&outcome.payload);
     let result = mutation_result
         .as_ref()
@@ -515,6 +513,7 @@ fn execute_recover_command(
         "message": message,
         "action": action,
         "task": task,
+        "task_lookup_error": task_lookup_error,
     });
     Ok(output)
 }
@@ -555,26 +554,41 @@ fn execute_app_tool_request(
     Ok(outcome)
 }
 
-fn extract_async_background_task_ids(payload: &Value) -> CliResult<Vec<String>> {
-    let sessions = payload
-        .get("sessions")
-        .and_then(Value::as_array)
-        .ok_or_else(|| "tasks list payload missing sessions array".to_owned())?;
+fn load_visible_background_task_ids(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    state: Option<&str>,
+    overdue_only: bool,
+    include_archived: bool,
+) -> CliResult<Vec<String>> {
+    let repo = mvp::session::repository::SessionRepository::new(memory_config)?;
+    let mut sessions = repo.list_visible_sessions(current_session_id)?;
+    if tool_config.sessions.visibility == mvp::config::SessionVisibility::SelfOnly {
+        sessions.retain(|session| session.session_id == current_session_id);
+    }
+    if let Some(raw_state) = state {
+        let required_state = parse_task_state_filter(raw_state)?;
+        sessions.retain(|session| session.state == required_state);
+    }
+    sessions.retain(|session| session.kind == mvp::session::repository::SessionKind::DelegateChild);
+    if !include_archived {
+        sessions.retain(|session| session.archived_at.is_none());
+    }
+
     let mut task_ids = Vec::new();
     for session in sessions {
-        let session_id = required_string_field(session, "session_id", "tasks list session entry")?;
-        let delegate_lifecycle = session
-            .get("delegate_lifecycle")
-            .cloned()
-            .unwrap_or(Value::Null);
-        let mode = delegate_lifecycle
-            .get("mode")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        if mode != "async" {
+        let task_id = session.session_id;
+        let status_payload =
+            load_task_status_payload(memory_config, tool_config, current_session_id, &task_id)?;
+        let status_summary = summarize_task_status_payload(&status_payload)?;
+        if !status_summary.is_background_task {
             continue;
         }
-        task_ids.push(session_id);
+        if overdue_only && !status_summary.is_overdue {
+            continue;
+        }
+        task_ids.push(task_id);
     }
     Ok(task_ids)
 }
@@ -587,6 +601,7 @@ fn build_task_detail(
 ) -> CliResult<Value> {
     let status_payload =
         load_task_status_payload(memory_config, tool_config, current_session_id, task_id)?;
+    ensure_background_task_status_payload(&status_payload, task_id)?;
     let approvals_payload =
         load_task_approvals_payload(memory_config, tool_config, current_session_id, task_id)?;
     let tool_policy_payload =
@@ -600,14 +615,6 @@ fn build_task_detail(
         .get("delegate_lifecycle")
         .cloned()
         .unwrap_or(Value::Null);
-    let session_kind = session.get("kind").and_then(Value::as_str).unwrap_or("");
-    let delegate_mode = delegate.get("mode").and_then(Value::as_str).unwrap_or("");
-    if session_kind != "delegate_child" || delegate_mode != "async" {
-        return Err(format!(
-            "tasks_cli_not_background_task: session `{task_id}` is not an async delegate child"
-        ));
-    }
-
     let label = session.get("label").cloned().unwrap_or(Value::Null);
     let session_state = session.get("state").cloned().unwrap_or(Value::Null);
     let phase = delegate.get("phase").cloned().unwrap_or(Value::Null);
@@ -690,6 +697,105 @@ fn build_task_detail(
         "recent_events": recent_events,
     });
     Ok(detail)
+}
+
+fn build_best_effort_task_detail(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    task_id: &str,
+) -> (Value, Value) {
+    let detail_result = build_task_detail(memory_config, tool_config, current_session_id, task_id);
+    match detail_result {
+        Ok(task_detail) => (task_detail, Value::Null),
+        Err(error) => {
+            let fallback_task = fallback_task_detail(current_session_id, task_id);
+            let lookup_error = Value::String(error);
+            (fallback_task, lookup_error)
+        }
+    }
+}
+
+fn fallback_task_detail(current_session_id: &str, task_id: &str) -> Value {
+    json!({
+        "task_id": task_id,
+        "session_id": task_id,
+        "scope_session_id": current_session_id,
+        "label": Value::Null,
+        "session_state": Value::Null,
+        "phase": Value::Null,
+        "timeout_seconds": Value::Null,
+        "last_error": Value::Null,
+        "approval": {
+            "matched_count": 0,
+            "returned_count": 0,
+            "attention_summary": Value::Null,
+            "requests": [],
+        },
+        "tool_policy": Value::Null,
+    })
+}
+
+fn validate_background_task_target(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    task_id: &str,
+) -> CliResult<()> {
+    let status_payload =
+        load_task_status_payload(memory_config, tool_config, current_session_id, task_id)?;
+    ensure_background_task_status_payload(&status_payload, task_id)
+}
+
+fn ensure_background_task_status_payload(status_payload: &Value, task_id: &str) -> CliResult<()> {
+    let status_summary = summarize_task_status_payload(status_payload)?;
+    if !status_summary.is_background_task {
+        return Err(format!(
+            "tasks_cli_not_background_task: session `{task_id}` is not an async delegate child"
+        ));
+    }
+    Ok(())
+}
+
+fn summarize_task_status_payload(status_payload: &Value) -> CliResult<TaskStatusSummary> {
+    let session = status_payload
+        .get("session")
+        .ok_or_else(|| "task status payload missing session object".to_owned())?;
+    let delegate = status_payload
+        .get("delegate_lifecycle")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let session_kind = session.get("kind").and_then(Value::as_str).unwrap_or("");
+    let delegate_mode = delegate.get("mode").and_then(Value::as_str).unwrap_or("");
+    let staleness_state = delegate
+        .get("staleness")
+        .and_then(|value| value.get("state"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let is_background_task = session_kind == "delegate_child" && delegate_mode == "async";
+    let is_overdue = staleness_state == "overdue";
+
+    Ok(TaskStatusSummary {
+        is_background_task,
+        is_overdue,
+    })
+}
+
+fn parse_task_state_filter(raw_state: &str) -> CliResult<mvp::session::repository::SessionState> {
+    match raw_state {
+        "ready" => Ok(mvp::session::repository::SessionState::Ready),
+        "running" => Ok(mvp::session::repository::SessionState::Running),
+        "completed" => Ok(mvp::session::repository::SessionState::Completed),
+        "failed" => Ok(mvp::session::repository::SessionState::Failed),
+        "timed_out" => Ok(mvp::session::repository::SessionState::TimedOut),
+        _ => Err(format!("invalid session tool payload.state: `{raw_state}`")),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TaskStatusSummary {
+    is_background_task: bool,
+    is_overdue: bool,
 }
 
 fn load_task_status_payload(
@@ -836,6 +942,7 @@ fn render_tasks_create_text(payload: &Value) -> CliResult<String> {
             .unwrap_or("unknown")
     ));
     lines.extend(render_task_detail_lines(task)?);
+    append_task_lookup_error_line(payload, &mut lines);
 
     if !recipes.is_empty() {
         lines.push("recipes:".to_owned());
@@ -1003,6 +1110,7 @@ fn render_tasks_mutation_text(payload: &Value) -> CliResult<String> {
         lines.push(rendered_action);
     }
     lines.extend(render_task_detail_lines(task)?);
+    append_task_lookup_error_line(payload, &mut lines);
     Ok(lines.join("\n"))
 }
 
@@ -1097,6 +1205,13 @@ fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
         "effective_runtime_narrowing: {rendered_runtime_narrowing}"
     ));
     Ok(lines)
+}
+
+fn append_task_lookup_error_line(payload: &Value, lines: &mut Vec<String>) {
+    let Some(task_lookup_error) = payload.get("task_lookup_error").and_then(Value::as_str) else {
+        return;
+    };
+    lines.push(format!("task_lookup_error: {task_lookup_error}"));
 }
 
 fn render_string_array(values: &[Value]) -> String {

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -1,0 +1,1113 @@
+use clap::Subcommand;
+use kernel::ToolCoreRequest;
+use loongclaw_app as mvp;
+use loongclaw_contracts::ToolCoreOutcome;
+use loongclaw_spec::CliResult;
+use serde_json::{Value, json};
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum TasksCommands {
+    /// Queue one async background task on top of the current session runtime
+    Create {
+        task: String,
+        #[arg(long)]
+        label: Option<String>,
+        #[arg(long)]
+        timeout_seconds: Option<u64>,
+    },
+    /// List visible async background tasks for the scoped session
+    List {
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        #[arg(long)]
+        state: Option<String>,
+        #[arg(long, default_value_t = false)]
+        overdue_only: bool,
+        #[arg(long, default_value_t = false)]
+        include_archived: bool,
+    },
+    /// Inspect one visible async background task
+    #[command(visible_alias = "info")]
+    Status { task_id: String },
+    /// Show recent lifecycle events for one visible async background task
+    Events {
+        task_id: String,
+        #[arg(long)]
+        after_id: Option<i64>,
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
+    /// Wait on one visible async background task and return incremental events
+    Wait {
+        task_id: String,
+        #[arg(long)]
+        after_id: Option<i64>,
+        #[arg(long, default_value_t = 1_000)]
+        timeout_ms: u64,
+    },
+    /// Cancel one visible async background task
+    Cancel {
+        task_id: String,
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
+    /// Recover one visible overdue async background task
+    Recover {
+        task_id: String,
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct TasksCommandOptions {
+    pub config: Option<String>,
+    pub json: bool,
+    pub session: String,
+    pub command: TasksCommands,
+}
+
+#[derive(Debug, Clone)]
+pub struct TasksCommandExecution {
+    pub resolved_config_path: String,
+    pub current_session_id: String,
+    pub payload: Value,
+}
+
+pub async fn run_tasks_cli(options: TasksCommandOptions) -> CliResult<()> {
+    let as_json = options.json;
+    let execution = execute_tasks_command(options).await?;
+    if as_json {
+        let pretty = serde_json::to_string_pretty(&execution.payload)
+            .map_err(|error| format!("serialize tasks CLI output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    let rendered = render_tasks_cli_text(&execution)?;
+    println!("{rendered}");
+    Ok(())
+}
+
+pub async fn execute_tasks_command(
+    options: TasksCommandOptions,
+) -> CliResult<TasksCommandExecution> {
+    let TasksCommandOptions {
+        config,
+        json: _,
+        session,
+        command,
+    } = options;
+    let (resolved_path, config) = mvp::config::load(config.as_deref())?;
+    mvp::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+
+    let current_session_id = normalize_session_scope(&session)?;
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let tool_config = &config.tools;
+
+    let payload = match command {
+        TasksCommands::Create {
+            task,
+            label,
+            timeout_seconds,
+        } => {
+            execute_create_command(
+                &resolved_path.display().to_string(),
+                &config,
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &task,
+                label,
+                timeout_seconds,
+            )
+            .await?
+        }
+        TasksCommands::List {
+            limit,
+            state,
+            overdue_only,
+            include_archived,
+        } => execute_list_command(
+            &resolved_path.display().to_string(),
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            limit,
+            state.as_deref(),
+            overdue_only,
+            include_archived,
+        )?,
+        TasksCommands::Status { task_id } => execute_status_command(
+            &resolved_path.display().to_string(),
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &task_id,
+        )?,
+        TasksCommands::Events {
+            task_id,
+            after_id,
+            limit,
+        } => execute_events_command(
+            &resolved_path.display().to_string(),
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &task_id,
+            after_id,
+            limit,
+        )?,
+        TasksCommands::Wait {
+            task_id,
+            after_id,
+            timeout_ms,
+        } => {
+            execute_wait_command(
+                &resolved_path.display().to_string(),
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &task_id,
+                after_id,
+                timeout_ms,
+            )
+            .await?
+        }
+        TasksCommands::Cancel { task_id, dry_run } => execute_cancel_command(
+            &resolved_path.display().to_string(),
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &task_id,
+            dry_run,
+        )?,
+        TasksCommands::Recover { task_id, dry_run } => execute_recover_command(
+            &resolved_path.display().to_string(),
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &task_id,
+            dry_run,
+        )?,
+    };
+
+    Ok(TasksCommandExecution {
+        resolved_config_path: resolved_path.display().to_string(),
+        current_session_id,
+        payload,
+    })
+}
+
+async fn execute_create_command(
+    resolved_config_path: &str,
+    config: &mvp::config::LoongClawConfig,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    task: &str,
+    label: Option<String>,
+    timeout_seconds: Option<u64>,
+) -> CliResult<Value> {
+    let runtime = mvp::conversation::DefaultConversationRuntime::from_config_or_env(config)?;
+    let kernel_context = mvp::context::bootstrap_kernel_context_with_config(
+        "cli-tasks",
+        mvp::context::DEFAULT_TOKEN_TTL_S,
+        config,
+    )?;
+    let binding = mvp::conversation::ConversationRuntimeBinding::kernel(&kernel_context);
+    let queued = mvp::conversation::spawn_background_delegate_with_runtime(
+        config,
+        &runtime,
+        current_session_id,
+        task,
+        label,
+        timeout_seconds,
+        binding,
+    )
+    .await?;
+    let task_id = required_string_field(&queued.payload, "child_session_id", "tasks create")?;
+    let task_detail = build_task_detail(memory_config, tool_config, current_session_id, &task_id)?;
+    let recipes = build_task_recipes(resolved_config_path, current_session_id, &task_id);
+    let next_steps = build_task_next_steps();
+    let payload = json!({
+        "command": "create",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "queued_outcome": queued.payload,
+        "task": task_detail,
+        "recipes": recipes,
+        "next_steps": next_steps,
+    });
+    Ok(payload)
+}
+
+fn execute_list_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    limit: usize,
+    state: Option<&str>,
+    overdue_only: bool,
+    include_archived: bool,
+) -> CliResult<Value> {
+    let raw_limit = limit.clamp(1, 200);
+    let scan_limit = 200usize;
+    let sessions_payload = json!({
+        "limit": scan_limit,
+        "state": state,
+        "kind": "delegate_child",
+        "overdue_only": overdue_only,
+        "include_archived": include_archived,
+        "include_delegate_lifecycle": true,
+    });
+    let sessions_outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "sessions_list",
+        sessions_payload,
+    )?;
+    let session_ids = extract_async_background_task_ids(&sessions_outcome.payload)?;
+    let matched_count = session_ids.len();
+
+    let mut tasks = Vec::new();
+    for session_id in session_ids {
+        if tasks.len() >= raw_limit {
+            break;
+        }
+        let task = build_task_detail(memory_config, tool_config, current_session_id, &session_id)?;
+        tasks.push(task);
+    }
+
+    let returned_count = tasks.len();
+    let payload = json!({
+        "command": "list",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "filters": {
+            "limit": raw_limit,
+            "state": state,
+            "overdue_only": overdue_only,
+            "include_archived": include_archived,
+        },
+        "matched_count": matched_count,
+        "returned_count": returned_count,
+        "tasks": tasks,
+    });
+    Ok(payload)
+}
+
+fn execute_status_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    task_id: &str,
+) -> CliResult<Value> {
+    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let payload = json!({
+        "command": "status",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "task": task,
+    });
+    Ok(payload)
+}
+
+fn execute_events_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    task_id: &str,
+    after_id: Option<i64>,
+    limit: usize,
+) -> CliResult<Value> {
+    let _ = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let event_limit = limit.clamp(1, 200);
+    let payload = json!({
+        "session_id": task_id,
+        "after_id": after_id,
+        "limit": event_limit,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "session_events",
+        payload,
+    )?;
+    let next_after_id = outcome
+        .payload
+        .get("next_after_id")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let events = outcome
+        .payload
+        .get("events")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+    let output = json!({
+        "command": "events",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "task_id": task_id,
+        "after_id": after_id,
+        "next_after_id": next_after_id,
+        "events": events,
+    });
+    Ok(output)
+}
+
+async fn execute_wait_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    task_id: &str,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+) -> CliResult<Value> {
+    let _ = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let payload = json!({
+        "session_id": task_id,
+        "after_id": after_id,
+        "timeout_ms": timeout_ms.clamp(1, 30_000),
+    });
+    let outcome = mvp::tools::wait_for_session_with_config(
+        payload,
+        current_session_id,
+        memory_config,
+        tool_config,
+    )
+    .await?;
+    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let wait_payload = outcome.payload;
+    let next_after_id = wait_payload
+        .get("next_after_id")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let events = wait_payload
+        .get("events")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+    let output = json!({
+        "command": "wait",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "task_id": task_id,
+        "wait_status": outcome.status,
+        "after_id": after_id,
+        "timeout_ms": timeout_ms.clamp(1, 30_000),
+        "next_after_id": next_after_id,
+        "events": events,
+        "task": task,
+    });
+    Ok(output)
+}
+
+fn execute_cancel_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    task_id: &str,
+    dry_run: bool,
+) -> CliResult<Value> {
+    let payload = json!({
+        "session_id": task_id,
+        "dry_run": dry_run,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "session_cancel",
+        payload,
+    )?;
+    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let mutation_result = extract_single_mutation_result(&outcome.payload);
+    let result = mutation_result
+        .as_ref()
+        .and_then(|value| value.get("result"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let message = mutation_result
+        .as_ref()
+        .and_then(|value| value.get("message"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let action = outcome
+        .payload
+        .get("cancel_action")
+        .cloned()
+        .or_else(|| {
+            mutation_result
+                .as_ref()
+                .and_then(|value| value.get("action"))
+                .cloned()
+        })
+        .unwrap_or(Value::Null);
+    let output = json!({
+        "command": "cancel",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "dry_run": dry_run,
+        "result": result,
+        "message": message,
+        "action": action,
+        "task": task,
+    });
+    Ok(output)
+}
+
+fn execute_recover_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    task_id: &str,
+    dry_run: bool,
+) -> CliResult<Value> {
+    let payload = json!({
+        "session_id": task_id,
+        "dry_run": dry_run,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "session_recover",
+        payload,
+    )?;
+    let task = build_task_detail(memory_config, tool_config, current_session_id, task_id)?;
+    let mutation_result = extract_single_mutation_result(&outcome.payload);
+    let result = mutation_result
+        .as_ref()
+        .and_then(|value| value.get("result"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let message = mutation_result
+        .as_ref()
+        .and_then(|value| value.get("message"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let action = outcome
+        .payload
+        .get("recovery_action")
+        .cloned()
+        .or_else(|| {
+            mutation_result
+                .as_ref()
+                .and_then(|value| value.get("action"))
+                .cloned()
+        })
+        .unwrap_or(Value::Null);
+    let output = json!({
+        "command": "recover",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "dry_run": dry_run,
+        "result": result,
+        "message": message,
+        "action": action,
+        "task": task,
+    });
+    Ok(output)
+}
+
+fn extract_single_mutation_result(payload: &Value) -> Option<Value> {
+    let results = payload.get("results")?.as_array()?;
+    if results.len() != 1 {
+        return None;
+    }
+    results.first().cloned()
+}
+
+fn normalize_session_scope(raw: &str) -> CliResult<String> {
+    let session = raw.trim();
+    if session.is_empty() {
+        return Err("tasks CLI requires a non-empty session scope".to_owned());
+    }
+    Ok(session.to_owned())
+}
+
+fn execute_app_tool_request(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    tool_name: &str,
+    payload: Value,
+) -> CliResult<ToolCoreOutcome> {
+    let request = ToolCoreRequest {
+        tool_name: tool_name.to_owned(),
+        payload,
+    };
+    let outcome = mvp::tools::execute_app_tool_with_config(
+        request,
+        current_session_id,
+        memory_config,
+        tool_config,
+    )?;
+    Ok(outcome)
+}
+
+fn extract_async_background_task_ids(payload: &Value) -> CliResult<Vec<String>> {
+    let sessions = payload
+        .get("sessions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tasks list payload missing sessions array".to_owned())?;
+    let mut task_ids = Vec::new();
+    for session in sessions {
+        let session_id = required_string_field(session, "session_id", "tasks list session entry")?;
+        let delegate_lifecycle = session
+            .get("delegate_lifecycle")
+            .cloned()
+            .unwrap_or(Value::Null);
+        let mode = delegate_lifecycle
+            .get("mode")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if mode != "async" {
+            continue;
+        }
+        task_ids.push(session_id);
+    }
+    Ok(task_ids)
+}
+
+fn build_task_detail(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    task_id: &str,
+) -> CliResult<Value> {
+    let status_payload =
+        load_task_status_payload(memory_config, tool_config, current_session_id, task_id)?;
+    let approvals_payload =
+        load_task_approvals_payload(memory_config, tool_config, current_session_id, task_id)?;
+    let tool_policy_payload =
+        load_task_tool_policy_payload(memory_config, tool_config, current_session_id, task_id)?;
+
+    let session = status_payload
+        .get("session")
+        .cloned()
+        .ok_or_else(|| "task status payload missing session object".to_owned())?;
+    let delegate = status_payload
+        .get("delegate_lifecycle")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let session_kind = session.get("kind").and_then(Value::as_str).unwrap_or("");
+    let delegate_mode = delegate.get("mode").and_then(Value::as_str).unwrap_or("");
+    if session_kind != "delegate_child" || delegate_mode != "async" {
+        return Err(format!(
+            "tasks_cli_not_background_task: session `{task_id}` is not an async delegate child"
+        ));
+    }
+
+    let label = session.get("label").cloned().unwrap_or(Value::Null);
+    let session_state = session.get("state").cloned().unwrap_or(Value::Null);
+    let phase = delegate.get("phase").cloned().unwrap_or(Value::Null);
+    let mode = delegate.get("mode").cloned().unwrap_or(Value::Null);
+    let timeout_seconds = delegate
+        .get("timeout_seconds")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let created_at = session.get("created_at").cloned().unwrap_or(Value::Null);
+    let updated_at = session.get("updated_at").cloned().unwrap_or(Value::Null);
+    let archived = session.get("archived").cloned().unwrap_or(Value::Null);
+    let last_error = session.get("last_error").cloned().unwrap_or(Value::Null);
+    let approval_requests = approvals_payload
+        .get("requests")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+    let approval_attention_summary = approvals_payload
+        .get("attention_summary")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let approval_matched_count = approvals_payload
+        .get("matched_count")
+        .cloned()
+        .unwrap_or_else(|| json!(0));
+    let approval_returned_count = approvals_payload
+        .get("returned_count")
+        .cloned()
+        .unwrap_or_else(|| json!(0));
+    let tool_policy = tool_policy_payload
+        .get("policy")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let terminal_outcome_state = status_payload
+        .get("terminal_outcome_state")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let terminal_outcome_missing_reason = status_payload
+        .get("terminal_outcome_missing_reason")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let recovery = status_payload
+        .get("recovery")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let terminal_outcome = status_payload
+        .get("terminal_outcome")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let recent_events = status_payload
+        .get("recent_events")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    let detail = json!({
+        "task_id": task_id,
+        "session_id": task_id,
+        "scope_session_id": current_session_id,
+        "label": label,
+        "session_state": session_state,
+        "phase": phase,
+        "mode": mode,
+        "timeout_seconds": timeout_seconds,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "archived": archived,
+        "last_error": last_error,
+        "approval": {
+            "matched_count": approval_matched_count,
+            "returned_count": approval_returned_count,
+            "attention_summary": approval_attention_summary,
+            "requests": approval_requests,
+        },
+        "tool_policy": tool_policy,
+        "session": session,
+        "delegate": delegate,
+        "terminal_outcome_state": terminal_outcome_state,
+        "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
+        "recovery": recovery,
+        "terminal_outcome": terminal_outcome,
+        "recent_events": recent_events,
+    });
+    Ok(detail)
+}
+
+fn load_task_status_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    task_id: &str,
+) -> CliResult<Value> {
+    let payload = json!({
+        "session_id": task_id,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "session_status",
+        payload,
+    )?;
+    Ok(outcome.payload)
+}
+
+fn load_task_approvals_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    task_id: &str,
+) -> CliResult<Value> {
+    let payload = json!({
+        "session_id": task_id,
+        "limit": 20,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "approval_requests_list",
+        payload,
+    )?;
+    Ok(outcome.payload)
+}
+
+fn load_task_tool_policy_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    task_id: &str,
+) -> CliResult<Value> {
+    let payload = json!({
+        "session_id": task_id,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "session_tool_policy_status",
+        payload,
+    )?;
+    Ok(outcome.payload)
+}
+
+fn build_task_recipes(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    task_id: &str,
+) -> Vec<String> {
+    let command_name = crate::CLI_COMMAND_NAME;
+    let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
+    let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
+    let task_arg = crate::cli_handoff::shell_quote_argument(task_id);
+
+    let status_recipe = format!(
+        "{command_name} tasks status --config {config_arg} --session {session_arg} {task_arg}"
+    );
+    let wait_recipe = format!(
+        "{command_name} tasks wait --config {config_arg} --session {session_arg} {task_arg}"
+    );
+    let events_recipe = format!(
+        "{command_name} tasks events --config {config_arg} --session {session_arg} {task_arg}"
+    );
+
+    vec![status_recipe, wait_recipe, events_recipe]
+}
+
+fn build_task_next_steps() -> Vec<String> {
+    let step_one =
+        "Use `tasks status` to inspect approval, policy narrowing, and lifecycle state.".to_owned();
+    let step_two =
+        "Use `tasks wait` for bounded progress checks or `tasks events` for raw lifecycle history."
+            .to_owned();
+    let step_three =
+        "Use `tasks cancel` or `tasks recover` only after the task state confirms that the action is valid."
+            .to_owned();
+    vec![step_one, step_two, step_three]
+}
+
+fn required_string_field(value: &Value, field: &str, context: &str) -> CliResult<String> {
+    let text = value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{context} missing string field `{field}`"))?;
+    Ok(text.to_owned())
+}
+
+pub fn render_tasks_cli_text(execution: &TasksCommandExecution) -> CliResult<String> {
+    let command = execution
+        .payload
+        .get("command")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "tasks CLI payload missing command".to_owned())?;
+
+    let rendered = match command {
+        "create" => render_tasks_create_text(&execution.payload)?,
+        "list" => render_tasks_list_text(&execution.payload)?,
+        "status" => render_tasks_status_text(&execution.payload)?,
+        "events" => render_tasks_events_text(&execution.payload)?,
+        "wait" => render_tasks_wait_text(&execution.payload)?,
+        "cancel" | "recover" => render_tasks_mutation_text(&execution.payload)?,
+        other => {
+            return Err(format!("unknown tasks CLI render command `{other}`"));
+        }
+    };
+    Ok(rendered)
+}
+
+fn render_tasks_create_text(payload: &Value) -> CliResult<String> {
+    let task = payload
+        .get("task")
+        .ok_or_else(|| "tasks create payload missing task".to_owned())?;
+    let recipes = payload
+        .get("recipes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tasks create payload missing recipes".to_owned())?;
+    let next_steps = payload
+        .get("next_steps")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tasks create payload missing next_steps".to_owned())?;
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "background task queued in session `{}`",
+        payload
+            .get("current_session_id")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+    ));
+    lines.extend(render_task_detail_lines(task)?);
+
+    if !recipes.is_empty() {
+        lines.push("recipes:".to_owned());
+        for recipe in recipes {
+            let text = recipe.as_str().unwrap_or("");
+            lines.push(format!("- {text}"));
+        }
+    }
+
+    if !next_steps.is_empty() {
+        lines.push("next steps:".to_owned());
+        for step in next_steps {
+            let text = step.as_str().unwrap_or("");
+            lines.push(format!("- {text}"));
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_tasks_list_text(payload: &Value) -> CliResult<String> {
+    let tasks = payload
+        .get("tasks")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tasks list payload missing tasks array".to_owned())?;
+    let matched_count = payload
+        .get("matched_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let returned_count = payload
+        .get("returned_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let scope = payload
+        .get("current_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "visible background tasks from session `{scope}`: {returned_count}/{matched_count}"
+    ));
+    if tasks.is_empty() {
+        lines.push("No async background tasks are currently visible.".to_owned());
+        return Ok(lines.join("\n"));
+    }
+
+    for task in tasks {
+        let line = render_task_brief_line(task)?;
+        lines.push(format!("- {line}"));
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_tasks_status_text(payload: &Value) -> CliResult<String> {
+    let task = payload
+        .get("task")
+        .ok_or_else(|| "tasks status payload missing task".to_owned())?;
+    let lines = render_task_detail_lines(task)?;
+    Ok(lines.join("\n"))
+}
+
+fn render_tasks_events_text(payload: &Value) -> CliResult<String> {
+    let task_id = payload
+        .get("task_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let events = payload
+        .get("events")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tasks events payload missing events array".to_owned())?;
+    let next_after_id = payload
+        .get("next_after_id")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "events for `{task_id}` (next_after_id={next_after_id})"
+    ));
+    if events.is_empty() {
+        lines.push("No newer events.".to_owned());
+        return Ok(lines.join("\n"));
+    }
+
+    for event in events {
+        let event_id = event.get("id").and_then(Value::as_i64).unwrap_or_default();
+        let event_kind = event
+            .get("event_kind")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let ts = event.get("ts").and_then(Value::as_i64).unwrap_or_default();
+        lines.push(format!("- #{event_id} {event_kind} ts={ts}"));
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_tasks_wait_text(payload: &Value) -> CliResult<String> {
+    let wait_status = payload
+        .get("wait_status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let task = payload
+        .get("task")
+        .ok_or_else(|| "tasks wait payload missing task".to_owned())?;
+    let events = payload
+        .get("events")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "tasks wait payload missing events array".to_owned())?;
+    let next_after_id = payload
+        .get("next_after_id")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "wait result: {wait_status} (next_after_id={next_after_id})"
+    ));
+    lines.extend(render_task_detail_lines(task)?);
+    if !events.is_empty() {
+        lines.push("observed events:".to_owned());
+        for event in events {
+            let event_id = event.get("id").and_then(Value::as_i64).unwrap_or_default();
+            let event_kind = event
+                .get("event_kind")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            lines.push(format!("- #{event_id} {event_kind}"));
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_tasks_mutation_text(payload: &Value) -> CliResult<String> {
+    let command = payload
+        .get("command")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let task = payload
+        .get("task")
+        .ok_or_else(|| "tasks mutation payload missing task".to_owned())?;
+    let action = payload.get("action").cloned().unwrap_or(Value::Null);
+    let dry_run = payload
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let result = payload.get("result").and_then(Value::as_str);
+    let message = payload.get("message").and_then(Value::as_str);
+
+    let mut lines = Vec::new();
+    lines.push(format!("{command} dry_run={dry_run}"));
+    if let Some(result) = result {
+        lines.push(format!("result: {result}"));
+    }
+    if let Some(message) = message {
+        lines.push(format!("message: {message}"));
+    }
+    if !action.is_null() {
+        let rendered_action = serde_json::to_string_pretty(&action)
+            .map_err(|error| format!("render action failed: {error}"))?;
+        lines.push("action:".to_owned());
+        lines.push(rendered_action);
+    }
+    lines.extend(render_task_detail_lines(task)?);
+    Ok(lines.join("\n"))
+}
+
+fn render_task_brief_line(task: &Value) -> CliResult<String> {
+    let task_id = required_string_field(task, "task_id", "task summary")?;
+    let state = task
+        .get("session_state")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let phase = task
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let label = task.get("label").and_then(Value::as_str).unwrap_or("-");
+    let approval_attention = task
+        .get("approval")
+        .and_then(|value| value.get("attention_summary"))
+        .and_then(|value| value.get("needs_attention_count"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let line = format!(
+        "{task_id} state={state} phase={phase} label={label} approval_attention={approval_attention}"
+    );
+    Ok(line)
+}
+
+fn render_task_detail_lines(task: &Value) -> CliResult<Vec<String>> {
+    let task_id = required_string_field(task, "task_id", "task detail")?;
+    let scope_session_id = task
+        .get("scope_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let label = task.get("label").and_then(Value::as_str).unwrap_or("-");
+    let state = task
+        .get("session_state")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let phase = task
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let timeout_seconds = task
+        .get("timeout_seconds")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".to_owned());
+    let last_error = task
+        .get("last_error")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let approval_total = task
+        .get("approval")
+        .and_then(|value| value.get("matched_count"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let approval_attention = task
+        .get("approval")
+        .and_then(|value| value.get("attention_summary"))
+        .and_then(|value| value.get("needs_attention_count"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let effective_tool_ids = task
+        .get("tool_policy")
+        .and_then(|value| value.get("effective_tool_ids"))
+        .and_then(Value::as_array)
+        .map(|values| render_string_array(values))
+        .unwrap_or_else(|| "-".to_owned());
+    let effective_runtime_narrowing = task
+        .get("tool_policy")
+        .and_then(|value| value.get("effective_runtime_narrowing"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let rendered_runtime_narrowing = if effective_runtime_narrowing.is_null() {
+        "-".to_owned()
+    } else {
+        serde_json::to_string(&effective_runtime_narrowing)
+            .map_err(|error| format!("render runtime narrowing failed: {error}"))?
+    };
+
+    let mut lines = Vec::new();
+    lines.push(format!("task_id: {task_id}"));
+    lines.push(format!("scope_session_id: {scope_session_id}"));
+    lines.push(format!("label: {label}"));
+    lines.push(format!("state: {state}"));
+    lines.push(format!("phase: {phase}"));
+    lines.push(format!("timeout_seconds: {timeout_seconds}"));
+    lines.push(format!("last_error: {last_error}"));
+    lines.push(format!("approval_requests: {approval_total}"));
+    lines.push(format!("approval_attention: {approval_attention}"));
+    lines.push(format!("effective_tool_ids: {effective_tool_ids}"));
+    lines.push(format!(
+        "effective_runtime_narrowing: {rendered_runtime_narrowing}"
+    ));
+    Ok(lines)
+}
+
+fn render_string_array(values: &[Value]) -> String {
+    let mut items = Vec::new();
+    for value in values {
+        if let Some(text) = value.as_str() {
+            items.push(text.to_owned());
+        }
+    }
+    if items.is_empty() {
+        return "-".to_owned();
+    }
+    items.join(", ")
+}

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -1,3 +1,5 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use clap::Subcommand;
 use kernel::ToolCoreRequest;
 use loongclaw_app as mvp;
@@ -578,19 +580,110 @@ fn load_visible_background_task_ids(
 
     let mut task_ids = Vec::new();
     for session in sessions {
-        let task_id = session.session_id;
-        let status_payload =
-            load_task_status_payload(memory_config, tool_config, current_session_id, &task_id)?;
-        let status_summary = summarize_task_status_payload(&status_payload)?;
+        let status_summary = summarize_visible_background_task(&repo, &session)?;
         if !status_summary.is_background_task {
             continue;
         }
         if overdue_only && !status_summary.is_overdue {
             continue;
         }
+        let task_id = session.session_id;
         task_ids.push(task_id);
     }
     Ok(task_ids)
+}
+
+fn summarize_visible_background_task(
+    repo: &mvp::session::repository::SessionRepository,
+    session: &mvp::session::repository::SessionSummaryRecord,
+) -> CliResult<TaskStatusSummary> {
+    let delegate_kind = mvp::session::repository::SessionKind::DelegateChild;
+    if session.kind != delegate_kind {
+        return Ok(TaskStatusSummary {
+            is_background_task: false,
+            is_overdue: false,
+        });
+    }
+
+    let delegate_events = repo.list_delegate_lifecycle_events(&session.session_id)?;
+    let mut queued_at = None;
+    let mut started_at = None;
+    let mut queued_timeout_seconds = None;
+    let mut started_timeout_seconds = None;
+    let mut execution_mode = None;
+
+    for event in delegate_events {
+        let event_kind = event.event_kind.as_str();
+        let execution = mvp::conversation::ConstrainedSubagentExecution::from_event_payload(
+            &event.payload_json,
+        );
+        let event_mode = execution.as_ref().map(|value| value.mode);
+        let event_timeout_seconds = event
+            .payload_json
+            .get("timeout_seconds")
+            .and_then(Value::as_u64)
+            .or_else(|| execution.as_ref().map(|value| value.timeout_seconds));
+
+        match event_kind {
+            "delegate_queued" => {
+                queued_at = Some(event.ts);
+                if execution_mode.is_none() {
+                    execution_mode = event_mode;
+                }
+                if queued_timeout_seconds.is_none() {
+                    queued_timeout_seconds = event_timeout_seconds;
+                }
+            }
+            "delegate_started" => {
+                started_at = Some(event.ts);
+                if execution_mode.is_none() {
+                    execution_mode = event_mode;
+                }
+                if started_timeout_seconds.is_none() {
+                    started_timeout_seconds = event_timeout_seconds;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let async_mode = mvp::conversation::ConstrainedSubagentMode::Async;
+    let inline_mode = mvp::conversation::ConstrainedSubagentMode::Inline;
+    let effective_mode = execution_mode.unwrap_or_else(|| {
+        if queued_at.is_some() || session.state == mvp::session::repository::SessionState::Ready {
+            async_mode
+        } else {
+            inline_mode
+        }
+    });
+    let timeout_seconds = started_timeout_seconds.or(queued_timeout_seconds);
+    let reference_at = match session.state {
+        mvp::session::repository::SessionState::Ready => queued_at,
+        mvp::session::repository::SessionState::Running => started_at.or(queued_at),
+        mvp::session::repository::SessionState::Completed => None,
+        mvp::session::repository::SessionState::Failed => None,
+        mvp::session::repository::SessionState::TimedOut => None,
+    };
+    let now_ts = current_unix_timestamp();
+    let is_overdue = match (reference_at, timeout_seconds) {
+        (Some(reference_at), Some(timeout_seconds)) => {
+            let elapsed_seconds = now_ts.saturating_sub(reference_at).max(0) as u64;
+            elapsed_seconds > timeout_seconds
+        }
+        _ => false,
+    };
+    let is_background_task = effective_mode == async_mode;
+
+    Ok(TaskStatusSummary {
+        is_background_task,
+        is_overdue,
+    })
+}
+
+fn current_unix_timestamp() -> i64 {
+    let now = SystemTime::now();
+    let duration = now.duration_since(UNIX_EPOCH).unwrap_or_default();
+    duration.as_secs().min(i64::MAX as u64) as i64
 }
 
 fn build_task_detail(

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -104,6 +104,7 @@ mod runtime_snapshot_cli;
 mod skills_cli;
 mod spec_runtime;
 mod spec_runtime_bridge;
+mod tasks_cli;
 
 #[test]
 fn cli_uses_loongclaw_program_name() {

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -19,6 +19,27 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
     canonical_temp_dir.join(format!("{prefix}-{nanos}"))
 }
 
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(prefix: &str) -> Self {
+        let path = unique_temp_dir(prefix);
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.path).ok();
+    }
+}
+
 struct TasksCliEnvironmentGuard {
     _lock: MutexGuard<'static, ()>,
     saved: Vec<(String, Option<OsString>)>,
@@ -69,6 +90,9 @@ impl TasksCliEnvironmentGuard {
         let mut saved = Vec::new();
         for key in TASKS_RUNTIME_ENV_KEYS {
             saved.push(((*key).to_owned(), std::env::var_os(key)));
+            unsafe {
+                std::env::remove_var(key);
+            }
         }
         for (key, value) in pairs {
             let already_saved = saved.iter().any(|(saved_key, _)| saved_key == key);
@@ -103,39 +127,44 @@ impl Drop for TasksCliEnvironmentGuard {
     }
 }
 
-fn write_tasks_config(root: &Path) -> PathBuf {
+fn write_tasks_config_with(
+    root: &Path,
+    configure: impl FnOnce(&mut mvp::config::LoongClawConfig),
+) -> PathBuf {
     fs::create_dir_all(root).expect("create fixture root");
     let config_path = root.join("loongclaw.toml");
     let mut config = mvp::config::LoongClawConfig::default();
     config.memory.sqlite_path = root.join("memory.sqlite3").display().to_string();
     config.tools.file_root = Some(root.display().to_string());
     config.tools.sessions.allow_mutation = true;
+    configure(&mut config);
     mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
         .expect("write config fixture");
     config_path
 }
 
+fn write_tasks_config(root: &Path) -> PathBuf {
+    write_tasks_config_with(root, |_| {})
+}
+
 fn seed_background_task(config_path: &Path, root_session_id: &str, task_id: &str) {
-    let config = mvp::config::load(Some(config_path.to_string_lossy().as_ref()))
-        .expect("load config")
-        .1;
-    let memory_config =
-        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
-        .expect("session repository");
-    repo.create_session(mvp::session::repository::NewSessionRecord {
-        session_id: root_session_id.to_owned(),
-        kind: mvp::session::repository::SessionKind::Root,
-        parent_session_id: None,
-        label: Some("Ops Root".to_owned()),
-        state: mvp::session::repository::SessionState::Ready,
-    })
-    .expect("create root session");
+    let repo = load_session_repository(config_path);
+    seed_background_task_record(&repo, root_session_id, task_id, true);
+}
+
+fn seed_background_task_record(
+    repo: &mvp::session::repository::SessionRepository,
+    root_session_id: &str,
+    task_id: &str,
+    include_runtime_metadata: bool,
+) {
+    ensure_root_session(repo, root_session_id);
+    let task_label = "Release Check";
     repo.create_session(mvp::session::repository::NewSessionRecord {
         session_id: task_id.to_owned(),
         kind: mvp::session::repository::SessionKind::DelegateChild,
         parent_session_id: Some(root_session_id.to_owned()),
-        label: Some("Release Check".to_owned()),
+        label: Some(task_label.to_owned()),
         state: mvp::session::repository::SessionState::Ready,
     })
     .expect("create child session");
@@ -145,11 +174,14 @@ fn seed_background_task(config_path: &Path, root_session_id: &str, task_id: &str
         actor_session_id: Some(root_session_id.to_owned()),
         payload_json: json!({
             "task": "check release readiness",
-            "label": "Release Check",
+            "label": task_label,
             "timeout_seconds": 60,
         }),
     })
     .expect("append delegate_queued event");
+    if !include_runtime_metadata {
+        return;
+    }
     repo.ensure_approval_request(mvp::session::repository::NewApprovalRequestRecord {
         approval_request_id: "apr-task-1".to_owned(),
         session_id: task_id.to_owned(),
@@ -172,6 +204,24 @@ fn seed_background_task(config_path: &Path, root_session_id: &str, task_id: &str
         runtime_narrowing: mvp::tools::runtime_config::ToolRuntimeNarrowing::default(),
     })
     .expect("upsert session tool policy");
+}
+
+fn ensure_root_session(repo: &mvp::session::repository::SessionRepository, root_session_id: &str) {
+    let existing_root = repo
+        .load_session(root_session_id)
+        .expect("load root session");
+    if existing_root.is_some() {
+        return;
+    }
+
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: root_session_id.to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Ops Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
 }
 
 fn load_session_repository(config_path: &Path) -> mvp::session::repository::SessionRepository {
@@ -309,11 +359,24 @@ fn tasks_wait_cli_parses_session_and_timeout_flags() {
     }
 }
 
+#[test]
+fn tasks_cli_environment_guard_clears_tracked_env_vars_before_applying_overrides() {
+    unsafe {
+        std::env::set_var("LOONGCLAW_SQLITE_PATH", "/tmp/host-value.sqlite3");
+    }
+    let _guard = TasksCliEnvironmentGuard::set(&[]);
+    let cleared_value = std::env::var_os("LOONGCLAW_SQLITE_PATH");
+    assert_eq!(cleared_value, None);
+    unsafe {
+        std::env::remove_var("LOONGCLAW_SQLITE_PATH");
+    }
+}
+
 #[tokio::test]
 async fn execute_tasks_command_list_returns_visible_background_tasks() {
-    let root = unique_temp_dir("loongclaw-tasks-cli-list");
+    let root = TempDirGuard::new("loongclaw-tasks-cli-list");
     let _env = TasksCliEnvironmentGuard::set(&[]);
-    let config_path = write_tasks_config(&root);
+    let config_path = write_tasks_config(root.path());
     seed_background_task(&config_path, "ops-root", "delegate:task-1");
 
     let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
@@ -337,15 +400,13 @@ async fn execute_tasks_command_list_returns_visible_background_tasks() {
     assert_eq!(execution.payload["returned_count"], 1);
     assert_eq!(execution.payload["tasks"][0]["task_id"], "delegate:task-1");
     assert_eq!(execution.payload["tasks"][0]["phase"], "queued");
-
-    fs::remove_dir_all(&root).ok();
 }
 
 #[tokio::test]
 async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
-    let root = unique_temp_dir("loongclaw-tasks-cli-status");
+    let root = TempDirGuard::new("loongclaw-tasks-cli-status");
     let _env = TasksCliEnvironmentGuard::set(&[]);
-    let config_path = write_tasks_config(&root);
+    let config_path = write_tasks_config(root.path());
     seed_background_task(&config_path, "ops-root", "delegate:task-1");
 
     let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
@@ -379,15 +440,13 @@ async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
         rendered.contains("effective_tool_ids: file.read"),
         "status render should surface effective tool ids: {rendered}"
     );
-
-    fs::remove_dir_all(&root).ok();
 }
 
 #[tokio::test]
 async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow_up_recipes() {
-    let root = unique_temp_dir("loongclaw-tasks-cli-create");
+    let root = TempDirGuard::new("loongclaw-tasks-cli-create");
     let _env = TasksCliEnvironmentGuard::set(&[]);
-    let config_path = write_tasks_config(&root);
+    let config_path = write_tasks_config(root.path());
 
     let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
         loongclaw_daemon::tasks_cli::TasksCommandOptions {
@@ -456,15 +515,92 @@ async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow
         child_session.kind,
         mvp::session::repository::SessionKind::DelegateChild
     );
+}
 
-    fs::remove_dir_all(&root).ok();
+#[tokio::test]
+async fn execute_tasks_command_create_returns_queued_outcome_when_task_hydration_fails() {
+    let root = TempDirGuard::new("loongclaw-tasks-cli-create-best-effort");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config_with(root.path(), |config| {
+        config.tools.sessions.enabled = false;
+    });
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::Create {
+                task: "research release readiness".to_owned(),
+                label: Some("Release Check".to_owned()),
+                timeout_seconds: Some(45),
+            },
+        },
+    )
+    .await
+    .expect("tasks create should still succeed");
+
+    let queued_task_id = execution.payload["queued_outcome"]["child_session_id"]
+        .as_str()
+        .expect("queued task id");
+    let rendered = loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution)
+        .expect("render tasks create");
+
+    assert_eq!(execution.payload["command"], "create");
+    assert_eq!(execution.payload["task"]["task_id"], queued_task_id);
+    assert_eq!(execution.payload["task"]["scope_session_id"], "ops-root");
+    assert!(
+        execution.payload["task_lookup_error"]
+            .as_str()
+            .expect("task lookup error")
+            .contains("session tools are disabled"),
+        "expected hydration failure to surface lookup error, got: {:?}",
+        execution.payload
+    );
+    assert!(
+        rendered.contains("task_lookup_error:"),
+        "rendered create output should surface hydration warning: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn execute_tasks_command_list_counts_background_tasks_beyond_session_tool_limit() {
+    let root = TempDirGuard::new("loongclaw-tasks-cli-list-many");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(root.path());
+    let repo = load_session_repository(&config_path);
+    ensure_root_session(&repo, "ops-root");
+    for index in 0..101 {
+        let task_id = format!("delegate:list-{index:03}");
+        seed_background_task_record(&repo, "ops-root", &task_id, false);
+    }
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::List {
+                limit: 20,
+                state: None,
+                overdue_only: false,
+                include_archived: false,
+            },
+        },
+    )
+    .await
+    .expect("tasks list should succeed");
+
+    assert_eq!(execution.payload["command"], "list");
+    assert_eq!(execution.payload["matched_count"], 101);
+    assert_eq!(execution.payload["returned_count"], 20);
 }
 
 #[tokio::test]
 async fn execute_tasks_command_events_and_wait_surface_incremental_payloads() {
-    let root = unique_temp_dir("loongclaw-tasks-cli-events");
+    let root = TempDirGuard::new("loongclaw-tasks-cli-events");
     let _env = TasksCliEnvironmentGuard::set(&[]);
-    let config_path = write_tasks_config(&root);
+    let config_path = write_tasks_config(root.path());
     seed_background_task(&config_path, "ops-root", "delegate:task-1");
 
     let events_execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
@@ -514,15 +650,13 @@ async fn execute_tasks_command_events_and_wait_surface_incremental_payloads() {
     assert_eq!(wait_execution.payload["wait_status"], "timeout");
     assert_eq!(wait_execution.payload["events"], json!([]));
     assert_eq!(wait_execution.payload["task"]["task_id"], "delegate:task-1");
-
-    fs::remove_dir_all(&root).ok();
 }
 
 #[tokio::test]
 async fn execute_tasks_command_cancel_dry_run_surfaces_cancel_action() {
-    let root = unique_temp_dir("loongclaw-tasks-cli-cancel");
+    let root = TempDirGuard::new("loongclaw-tasks-cli-cancel");
     let _env = TasksCliEnvironmentGuard::set(&[]);
-    let config_path = write_tasks_config(&root);
+    let config_path = write_tasks_config(root.path());
     seed_background_task(&config_path, "ops-root", "delegate:task-1");
 
     let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
@@ -547,15 +681,13 @@ async fn execute_tasks_command_cancel_dry_run_surfaces_cancel_action() {
     );
     assert_eq!(execution.payload["task"]["task_id"], "delegate:task-1");
     assert_eq!(execution.payload["task"]["phase"], "queued");
-
-    fs::remove_dir_all(&root).ok();
 }
 
 #[tokio::test]
 async fn execute_tasks_command_recover_dry_run_surfaces_non_recoverable_result() {
-    let root = unique_temp_dir("loongclaw-tasks-cli-recover");
+    let root = TempDirGuard::new("loongclaw-tasks-cli-recover");
     let _env = TasksCliEnvironmentGuard::set(&[]);
-    let config_path = write_tasks_config(&root);
+    let config_path = write_tasks_config(root.path());
     seed_background_task(&config_path, "ops-root", "delegate:task-1");
 
     let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
@@ -584,6 +716,4 @@ async fn execute_tasks_command_recover_dry_run_surfaces_non_recoverable_result()
         execution.payload
     );
     assert!(execution.payload["action"].is_null());
-
-    fs::remove_dir_all(&root).ok();
 }

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -1,0 +1,589 @@
+#![allow(unsafe_code)]
+
+use super::*;
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    sync::MutexGuard,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let temp_dir = std::env::temp_dir();
+    let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
+    canonical_temp_dir.join(format!("{prefix}-{nanos}"))
+}
+
+struct TasksCliEnvironmentGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: Vec<(String, Option<OsString>)>,
+}
+
+const TASKS_RUNTIME_ENV_KEYS: &[&str] = &[
+    "LOONGCLAW_BROWSER_COMPANION_COMMAND",
+    "LOONGCLAW_BROWSER_COMPANION_ENABLED",
+    "LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION",
+    "LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS",
+    "LOONGCLAW_BROWSER_ENABLED",
+    "LOONGCLAW_BROWSER_MAX_LINKS",
+    "LOONGCLAW_BROWSER_MAX_SESSIONS",
+    "LOONGCLAW_BROWSER_MAX_TEXT_CHARS",
+    "LOONGCLAW_CONFIG_PATH",
+    "LOONGCLAW_EXTERNAL_SKILLS_ALLOWED_DOMAINS",
+    "LOONGCLAW_EXTERNAL_SKILLS_AUTO_EXPOSE_INSTALLED",
+    "LOONGCLAW_EXTERNAL_SKILLS_BLOCKED_DOMAINS",
+    "LOONGCLAW_EXTERNAL_SKILLS_ENABLED",
+    "LOONGCLAW_EXTERNAL_SKILLS_INSTALL_ROOT",
+    "LOONGCLAW_EXTERNAL_SKILLS_REQUIRE_DOWNLOAD_APPROVAL",
+    "LOONGCLAW_FILE_ROOT",
+    "LOONGCLAW_MEMORY_BACKEND",
+    "LOONGCLAW_MEMORY_PROFILE",
+    "LOONGCLAW_MEMORY_PROFILE_NOTE",
+    "LOONGCLAW_MEMORY_SUMMARY_MAX_CHARS",
+    "LOONGCLAW_SHELL_ALLOWLIST",
+    "LOONGCLAW_SHELL_DEFAULT_MODE",
+    "LOONGCLAW_SHELL_DENY",
+    "LOONGCLAW_SLIDING_WINDOW",
+    "LOONGCLAW_SQLITE_PATH",
+    "LOONGCLAW_TOOL_DELEGATE_ENABLED",
+    "LOONGCLAW_TOOL_MESSAGES_ENABLED",
+    "LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION",
+    "LOONGCLAW_TOOL_SESSIONS_ENABLED",
+    "LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS",
+    "LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS",
+    "LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS",
+    "LOONGCLAW_WEB_FETCH_ENABLED",
+    "LOONGCLAW_WEB_FETCH_MAX_BYTES",
+    "LOONGCLAW_WEB_FETCH_MAX_REDIRECTS",
+    "LOONGCLAW_WEB_FETCH_TIMEOUT_SECONDS",
+];
+
+impl TasksCliEnvironmentGuard {
+    fn set(pairs: &[(&str, Option<&str>)]) -> Self {
+        let lock = super::lock_daemon_test_environment();
+        let mut saved = Vec::new();
+        for key in TASKS_RUNTIME_ENV_KEYS {
+            saved.push(((*key).to_owned(), std::env::var_os(key)));
+        }
+        for (key, value) in pairs {
+            let already_saved = saved.iter().any(|(saved_key, _)| saved_key == key);
+            if !already_saved {
+                saved.push(((*key).to_owned(), std::env::var_os(key)));
+            }
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(key);
+                },
+            }
+        }
+        Self { _lock: lock, saved }
+    }
+}
+
+impl Drop for TasksCliEnvironmentGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..).rev() {
+            match value {
+                Some(value) => unsafe {
+                    std::env::set_var(&key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(&key);
+                },
+            }
+        }
+    }
+}
+
+fn write_tasks_config(root: &Path) -> PathBuf {
+    fs::create_dir_all(root).expect("create fixture root");
+    let config_path = root.join("loongclaw.toml");
+    let mut config = mvp::config::LoongClawConfig::default();
+    config.memory.sqlite_path = root.join("memory.sqlite3").display().to_string();
+    config.tools.file_root = Some(root.display().to_string());
+    config.tools.sessions.allow_mutation = true;
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("write config fixture");
+    config_path
+}
+
+fn seed_background_task(config_path: &Path, root_session_id: &str, task_id: &str) {
+    let config = mvp::config::load(Some(config_path.to_string_lossy().as_ref()))
+        .expect("load config")
+        .1;
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = mvp::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: root_session_id.to_owned(),
+        kind: mvp::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Ops Root".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: task_id.to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some(root_session_id.to_owned()),
+        label: Some("Release Check".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: task_id.to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some(root_session_id.to_owned()),
+        payload_json: json!({
+            "task": "check release readiness",
+            "label": "Release Check",
+            "timeout_seconds": 60,
+        }),
+    })
+    .expect("append delegate_queued event");
+    repo.ensure_approval_request(mvp::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-task-1".to_owned(),
+        session_id: task_id.to_owned(),
+        turn_id: "turn-task-1".to_owned(),
+        tool_call_id: "call-task-1".to_owned(),
+        tool_name: "delegate_async".to_owned(),
+        approval_key: "tool:delegate_async".to_owned(),
+        request_payload_json: json!({
+            "tool_name": "delegate_async",
+        }),
+        governance_snapshot_json: json!({
+            "reason": "operator approval required",
+            "rule_id": "test_delegate_async",
+        }),
+    })
+    .expect("create approval request");
+    repo.upsert_session_tool_policy(mvp::session::repository::NewSessionToolPolicyRecord {
+        session_id: task_id.to_owned(),
+        requested_tool_ids: vec!["file.read".to_owned()],
+        runtime_narrowing: mvp::tools::runtime_config::ToolRuntimeNarrowing::default(),
+    })
+    .expect("upsert session tool policy");
+}
+
+fn load_session_repository(config_path: &Path) -> mvp::session::repository::SessionRepository {
+    let loaded =
+        mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
+    let config = loaded.1;
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    mvp::session::repository::SessionRepository::new(&memory_config).expect("session repository")
+}
+
+#[test]
+fn tasks_create_cli_parses_global_flags_after_subcommand() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "tasks",
+        "create",
+        "research release status",
+        "--label",
+        "release-scan",
+        "--timeout-seconds",
+        "90",
+        "--session",
+        "ops-root",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("tasks create CLI should parse");
+
+    match cli.command {
+        Some(Commands::Tasks {
+            config,
+            json,
+            session,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            assert_eq!(session, "ops-root");
+            match command {
+                loongclaw_daemon::tasks_cli::TasksCommands::Create {
+                    task,
+                    label,
+                    timeout_seconds,
+                } => {
+                    assert_eq!(task, "research release status");
+                    assert_eq!(label.as_deref(), Some("release-scan"));
+                    assert_eq!(timeout_seconds, Some(90));
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::List { .. } => {
+                    panic!("unexpected tasks subcommand parsed: List")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Status { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Status")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Events { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Events")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Wait { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Wait")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Cancel { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Cancel")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Recover { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Recover")
+                }
+            }
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn tasks_wait_cli_parses_session_and_timeout_flags() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "tasks",
+        "wait",
+        "delegate:abc123",
+        "--after-id",
+        "10",
+        "--timeout-ms",
+        "2500",
+        "--session",
+        "ops-root",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("tasks wait CLI should parse");
+
+    match cli.command {
+        Some(Commands::Tasks {
+            config,
+            json,
+            session,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            assert_eq!(session, "ops-root");
+            match command {
+                loongclaw_daemon::tasks_cli::TasksCommands::Wait {
+                    task_id,
+                    after_id,
+                    timeout_ms,
+                } => {
+                    assert_eq!(task_id, "delegate:abc123");
+                    assert_eq!(after_id, Some(10));
+                    assert_eq!(timeout_ms, 2500);
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Create { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Create")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::List { .. } => {
+                    panic!("unexpected tasks subcommand parsed: List")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Status { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Status")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Events { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Events")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Cancel { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Cancel")
+                }
+                loongclaw_daemon::tasks_cli::TasksCommands::Recover { .. } => {
+                    panic!("unexpected tasks subcommand parsed: Recover")
+                }
+            }
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn execute_tasks_command_list_returns_visible_background_tasks() {
+    let root = unique_temp_dir("loongclaw-tasks-cli-list");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(&root);
+    seed_background_task(&config_path, "ops-root", "delegate:task-1");
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::List {
+                limit: 20,
+                state: None,
+                overdue_only: false,
+                include_archived: false,
+            },
+        },
+    )
+    .await
+    .expect("tasks list should succeed");
+
+    assert_eq!(execution.payload["command"], "list");
+    assert_eq!(execution.payload["matched_count"], 1);
+    assert_eq!(execution.payload["returned_count"], 1);
+    assert_eq!(execution.payload["tasks"][0]["task_id"], "delegate:task-1");
+    assert_eq!(execution.payload["tasks"][0]["phase"], "queued");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn execute_tasks_command_status_surfaces_approval_and_tool_policy() {
+    let root = unique_temp_dir("loongclaw-tasks-cli-status");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(&root);
+    seed_background_task(&config_path, "ops-root", "delegate:task-1");
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::Status {
+                task_id: "delegate:task-1".to_owned(),
+            },
+        },
+    )
+    .await
+    .expect("tasks status should succeed");
+
+    assert_eq!(execution.payload["command"], "status");
+    assert_eq!(execution.payload["task"]["task_id"], "delegate:task-1");
+    assert_eq!(execution.payload["task"]["approval"]["matched_count"], 1);
+    assert_eq!(
+        execution.payload["task"]["tool_policy"]["effective_tool_ids"][0],
+        "file.read"
+    );
+
+    let rendered = loongclaw_daemon::tasks_cli::render_tasks_cli_text(&execution)
+        .expect("render tasks status");
+    assert!(
+        rendered.contains("approval_requests: 1"),
+        "status render should surface approval count: {rendered}"
+    );
+    assert!(
+        rendered.contains("effective_tool_ids: file.read"),
+        "status render should surface effective tool ids: {rendered}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn execute_tasks_command_create_queues_background_task_and_surfaces_follow_up_recipes() {
+    let root = unique_temp_dir("loongclaw-tasks-cli-create");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(&root);
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::Create {
+                task: "research release readiness".to_owned(),
+                label: Some("Release Check".to_owned()),
+                timeout_seconds: Some(45),
+            },
+        },
+    )
+    .await
+    .expect("tasks create should succeed");
+
+    let task_id = execution.payload["task"]["task_id"]
+        .as_str()
+        .expect("task id");
+    let recipes = execution.payload["recipes"]
+        .as_array()
+        .expect("recipes array");
+
+    assert_eq!(execution.payload["command"], "create");
+    assert_eq!(execution.payload["current_session_id"], "ops-root");
+    assert_eq!(execution.payload["task"]["scope_session_id"], "ops-root");
+    assert_eq!(execution.payload["task"]["label"], "Release Check");
+    assert_eq!(execution.payload["task"]["timeout_seconds"], 45);
+    assert_eq!(
+        execution.payload["task"]["session"]["kind"],
+        "delegate_child"
+    );
+    assert!(task_id.starts_with("delegate:"));
+    assert_eq!(recipes.len(), 3);
+    assert!(
+        recipes[0]
+            .as_str()
+            .expect("status recipe")
+            .contains("tasks status"),
+        "expected status follow-up recipe"
+    );
+    assert_eq!(
+        execution.payload["next_steps"]
+            .as_array()
+            .expect("next steps array")
+            .len(),
+        3
+    );
+
+    let repo = load_session_repository(&config_path);
+    let root_session = repo
+        .load_session("ops-root")
+        .expect("load root session")
+        .expect("root session");
+    let child_session = repo
+        .load_session(task_id)
+        .expect("load child session")
+        .expect("child session");
+
+    assert_eq!(
+        root_session.kind,
+        mvp::session::repository::SessionKind::Root
+    );
+    assert_eq!(child_session.parent_session_id.as_deref(), Some("ops-root"));
+    assert_eq!(
+        child_session.kind,
+        mvp::session::repository::SessionKind::DelegateChild
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn execute_tasks_command_events_and_wait_surface_incremental_payloads() {
+    let root = unique_temp_dir("loongclaw-tasks-cli-events");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(&root);
+    seed_background_task(&config_path, "ops-root", "delegate:task-1");
+
+    let events_execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::Events {
+                task_id: "delegate:task-1".to_owned(),
+                after_id: None,
+                limit: 20,
+            },
+        },
+    )
+    .await
+    .expect("tasks events should succeed");
+
+    let next_after_id = events_execution.payload["next_after_id"]
+        .as_i64()
+        .expect("next_after_id");
+
+    assert_eq!(events_execution.payload["command"], "events");
+    assert_eq!(events_execution.payload["task_id"], "delegate:task-1");
+    assert_eq!(
+        events_execution.payload["events"][0]["event_kind"],
+        "delegate_queued"
+    );
+    assert!(next_after_id >= 1);
+
+    let wait_execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::Wait {
+                task_id: "delegate:task-1".to_owned(),
+                after_id: Some(next_after_id),
+                timeout_ms: 1,
+            },
+        },
+    )
+    .await
+    .expect("tasks wait should succeed");
+
+    assert_eq!(wait_execution.payload["command"], "wait");
+    assert_eq!(wait_execution.payload["task_id"], "delegate:task-1");
+    assert_eq!(wait_execution.payload["wait_status"], "timeout");
+    assert_eq!(wait_execution.payload["events"], json!([]));
+    assert_eq!(wait_execution.payload["task"]["task_id"], "delegate:task-1");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn execute_tasks_command_cancel_dry_run_surfaces_cancel_action() {
+    let root = unique_temp_dir("loongclaw-tasks-cli-cancel");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(&root);
+    seed_background_task(&config_path, "ops-root", "delegate:task-1");
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::Cancel {
+                task_id: "delegate:task-1".to_owned(),
+                dry_run: true,
+            },
+        },
+    )
+    .await
+    .expect("tasks cancel dry run should succeed");
+
+    assert_eq!(execution.payload["command"], "cancel");
+    assert_eq!(execution.payload["dry_run"], true);
+    assert_eq!(
+        execution.payload["action"]["kind"],
+        "queued_async_cancelled"
+    );
+    assert_eq!(execution.payload["task"]["task_id"], "delegate:task-1");
+    assert_eq!(execution.payload["task"]["phase"], "queued");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[tokio::test]
+async fn execute_tasks_command_recover_dry_run_surfaces_non_recoverable_result() {
+    let root = unique_temp_dir("loongclaw-tasks-cli-recover");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(&root);
+    seed_background_task(&config_path, "ops-root", "delegate:task-1");
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::Recover {
+                task_id: "delegate:task-1".to_owned(),
+                dry_run: true,
+            },
+        },
+    )
+    .await
+    .expect("tasks recover dry run should succeed");
+
+    assert_eq!(execution.payload["command"], "recover");
+    assert_eq!(execution.payload["dry_run"], true);
+    assert_eq!(execution.payload["result"], "skipped_not_recoverable");
+    assert!(
+        execution.payload["message"]
+            .as_str()
+            .expect("recover message")
+            .contains("session_recover_not_recoverable"),
+        "expected recover dry run to surface root cause, got: {:?}",
+        execution.payload
+    );
+    assert!(execution.payload["action"].is_null());
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -87,9 +87,31 @@ const TASKS_RUNTIME_ENV_KEYS: &[&str] = &[
 impl TasksCliEnvironmentGuard {
     fn set(pairs: &[(&str, Option<&str>)]) -> Self {
         let lock = super::lock_daemon_test_environment();
+        Self::set_with_lock(lock, &[], pairs)
+    }
+
+    fn set_with_seeded_env(seeded_pairs: &[(&str, &str)], pairs: &[(&str, Option<&str>)]) -> Self {
+        let lock = super::lock_daemon_test_environment();
+        Self::set_with_lock(lock, seeded_pairs, pairs)
+    }
+
+    fn set_with_lock(
+        lock: MutexGuard<'static, ()>,
+        seeded_pairs: &[(&str, &str)],
+        pairs: &[(&str, Option<&str>)],
+    ) -> Self {
         let mut saved = Vec::new();
-        for key in TASKS_RUNTIME_ENV_KEYS {
+        for (key, value) in seeded_pairs {
             saved.push(((*key).to_owned(), std::env::var_os(key)));
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+        for key in TASKS_RUNTIME_ENV_KEYS {
+            let already_saved = saved.iter().any(|(saved_key, _)| saved_key == key);
+            if !already_saved {
+                saved.push(((*key).to_owned(), std::env::var_os(key)));
+            }
             unsafe {
                 std::env::remove_var(key);
             }
@@ -361,15 +383,12 @@ fn tasks_wait_cli_parses_session_and_timeout_flags() {
 
 #[test]
 fn tasks_cli_environment_guard_clears_tracked_env_vars_before_applying_overrides() {
-    unsafe {
-        std::env::set_var("LOONGCLAW_SQLITE_PATH", "/tmp/host-value.sqlite3");
-    }
-    let _guard = TasksCliEnvironmentGuard::set(&[]);
+    let _guard = TasksCliEnvironmentGuard::set_with_seeded_env(
+        &[("LOONGCLAW_SQLITE_PATH", "/tmp/host-value.sqlite3")],
+        &[],
+    );
     let cleared_value = std::env::var_os("LOONGCLAW_SQLITE_PATH");
     assert_eq!(cleared_value, None);
-    unsafe {
-        std::env::remove_var("LOONGCLAW_SQLITE_PATH");
-    }
 }
 
 #[tokio::test]

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-29T03:42:07Z
+- Generated at: 2026-03-29T03:42:23Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-29T03:28:15Z
+- Generated at: 2026-03-29T03:42:07Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -22,15 +22,15 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9759 | 9800 | 41 | 90 | 90 | 0 | 100.0% | TIGHT |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6396 | 6400 | 4 | 104 | 110 | 6 | 99.9% | TIGHT |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9964 | 11200 | 1236 | 92 | 120 | 28 | 89.0% | WATCH |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10028 | 11200 | 1172 | 95 | 120 | 25 | 89.5% | WATCH |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14206 | 15000 | 794 | 54 | 70 | 16 | 94.7% | WATCH |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5002 | 6000 | 998 | 172 | 190 | 18 | 90.5% | WATCH |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5014 | 6000 | 986 | 172 | 190 | 18 | 90.5% | WATCH |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), channel_mod (99.9%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (90.8%), memory_mod (87.5%), acp_manager (92.4%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.7%), daemon_lib (90.5%), onboard_cli (94.4%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (90.8%), memory_mod (87.5%), acp_manager (92.4%), chat_runtime (93.4%), turn_coordinator (89.5%), tools_mod (94.7%), daemon_lib (90.5%), onboard_cli (94.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -67,9 +67,9 @@
 <!-- arch-hotspot key=channel_config lines=9759 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
 <!-- arch-hotspot key=channel_mod lines=6396 functions=104 -->
-<!-- arch-hotspot key=turn_coordinator lines=9964 functions=92 -->
+<!-- arch-hotspot key=turn_coordinator lines=10028 functions=95 -->
 <!-- arch-hotspot key=tools_mod lines=14206 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=5002 functions=172 -->
+<!-- arch-hotspot key=daemon_lib lines=5014 functions=172 -->
 <!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  Background async delegate sessions exist in the session runtime, but operators do not have a productized CLI surface to create and manage them end to end.
- Why it matters:
  Background work is hard to queue, inspect, wait on, or recover without dropping to lower-level session tools and reconstructing runtime state manually.
- What changed:
  Added a shared helper in the conversation coordinator so daemon flows can enqueue async delegates without duplicating coordinator logic and while ensuring a missing root session scope is created before child lineage is persisted.
  Added `loongclaw tasks create|list|status|events|wait|cancel|recover` as a thin operator CLI over existing session, approval, and tool-policy runtime truth.
  Normalized single-task `--dry-run` cancel and recover output so operator-facing payloads now surface action, result, and message instead of exposing raw batch semantics.
  Added daemon integration coverage for create, list, status, events, wait, cancel, and recover, plus app-level regression coverage for root-scope creation and default timeout behavior.
  Hardened daemon task tests against process-global `LOONGCLAW_*` env leakage by capturing and restoring the runtime env set used by `initialize_runtime_environment`.
- What did not change (scope boundary):
  No new task store or parallel task model.
  No scheduler, cron, heartbeat, daemon ownership, service installation, or Web UI work.
  No provider execution-path change beyond exposing existing session-runtime surfaces through a first-class CLI.

## Linked Issues

- Closes #656
- Related #217
- Related #652

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-daemon tasks_cli -- --nocapture
cargo test --workspace --locked
cargo test --workspace --all-features --locked
scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh

Result summary:
- All cargo fmt / clippy / test commands passed.
- scripts/check_architecture_boundaries.sh passed.
- scripts/check_dep_graph.sh passed.
- The daemon task integration fixture serializes process-global env with TasksCliEnvironmentGuard and restores the captured LOONGCLAW_* runtime keys on drop.
- task is not installed in this environment, so I ran the underlying architecture / dep-graph scripts directly.
- task check:conventions could not run here because the required convention-engineering skill/config is not present locally.
```

## User-visible / Operator-visible Changes

- `loongclaw tasks create` now queues async background work from the current session scope and returns immediate follow-up recipes.
- `loongclaw tasks list`, `status`, `events`, `wait`, `cancel`, and `recover` now expose lifecycle, approval attention, effective tool narrowing, and dry-run mutation feedback through one operator-facing CLI namespace.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `846b9df9`, or avoid the additive `tasks` namespace and keep using the underlying `session_*` and `approval_requests_list` runtime tools directly.
- Observable failure symptoms reviewers should watch for:
  Newly created task sessions missing their root parent lineage.
  `tasks cancel --dry-run` or `tasks recover --dry-run` returning `action: null` without a matching `result` or `message`.
  `tasks list` surfacing non-async delegate sessions as background tasks.

## Reviewer Focus

- `crates/daemon/src/tasks_cli.rs`:
  Review the single-task translation over batch session tools, especially dry-run normalization and task detail assembly.
- `crates/app/src/conversation/turn_coordinator.rs`:
  Review the shared async delegate helper and root-session continuity behavior.
- `crates/daemon/tests/integration/tasks_cli.rs`:
  Review the process-global env restoration guard and operator-visible contract coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "tasks" CLI to manage async background tasks (create, list, status/info, events, wait, cancel, recover) with global options for config, JSON output, and session scope.
  * Exposed runtime background delegate spawn entrypoint supporting labels and configurable/defaulted timeouts.

* **Tests**
  * Added extensive unit and integration tests covering tasks CLI flows, delegate enqueueing, timeout defaults, and end-to-end behaviors.

* **Documentation**
  * Updated architecture report timestamps and hotspot metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->