### PR TITLE
Harden outbound HTTP trust boundaries for browser and channel surfaces

### DIFF
--- a/crates/app/src/channel/dingtalk.rs
+++ b/crates/app/src/channel/dingtalk.rs
@@ -6,7 +6,10 @@ use crate::{CliResult, config::ResolvedDingtalkChannelConfig};
 
 use super::{
     ChannelOutboundTargetKind,
-    http::{build_outbound_http_client, read_json_or_text_response, response_body_detail},
+    http::{
+        ChannelOutboundHttpPolicy, build_outbound_http_client, read_json_or_text_response,
+        response_body_detail, validate_outbound_http_target,
+    },
 };
 
 type DingtalkHmacSha256 = hmac::Hmac<sha2::Sha256>;
@@ -16,6 +19,7 @@ pub(super) async fn run_dingtalk_send(
     target_kind: ChannelOutboundTargetKind,
     endpoint_url: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Endpoint {
         return Err(format!(
@@ -24,13 +28,8 @@ pub(super) async fn run_dingtalk_send(
         ));
     }
 
-    let trimmed_endpoint_url = endpoint_url.trim();
-    if trimmed_endpoint_url.is_empty() {
-        return Err("dingtalk outbound target endpoint is empty".to_owned());
-    }
-
     let secret = resolved.secret();
-    let request_url = build_dingtalk_request_url(trimmed_endpoint_url, secret.as_deref())?;
+    let request_url = build_dingtalk_request_url(endpoint_url, secret.as_deref(), policy)?;
     let request_body = json!({
         "msgtype": "text",
         "text": {
@@ -38,7 +37,7 @@ pub(super) async fn run_dingtalk_send(
         },
     });
 
-    let client = build_outbound_http_client("dingtalk send")?;
+    let client = build_outbound_http_client("dingtalk send", policy)?;
     let request = client.post(request_url).json(&request_body);
     let response = request
         .send()
@@ -61,9 +60,12 @@ pub(super) async fn run_dingtalk_send(
     Ok(())
 }
 
-fn build_dingtalk_request_url(endpoint_url: &str, secret: Option<&str>) -> CliResult<String> {
-    let mut url = reqwest::Url::parse(endpoint_url)
-        .map_err(|error| format!("dingtalk webhook url is invalid: {error}"))?;
+fn build_dingtalk_request_url(
+    endpoint_url: &str,
+    secret: Option<&str>,
+    policy: ChannelOutboundHttpPolicy,
+) -> CliResult<String> {
+    let mut url = validate_outbound_http_target("dingtalk webhook url", endpoint_url, policy)?;
 
     let secret = secret
         .map(str::trim)

--- a/crates/app/src/channel/discord.rs
+++ b/crates/app/src/channel/discord.rs
@@ -2,13 +2,17 @@ use serde_json::{Value, json};
 
 use crate::{CliResult, config::ResolvedDiscordChannelConfig};
 
-use super::ChannelOutboundTargetKind;
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 pub(super) async fn run_discord_send(
     resolved: &ResolvedDiscordChannelConfig,
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Conversation {
         return Err(format!(
@@ -30,13 +34,15 @@ pub(super) async fn run_discord_send(
         "{}/channels/{channel_id}/messages",
         api_base_url.trim_end_matches('/')
     );
+    let request_url =
+        validate_outbound_http_target("discord api_base_url", request_url.as_str(), policy)?;
     let request_body = json!({
         "content": text,
     });
 
-    let client = reqwest::Client::new();
+    let client = build_outbound_http_client("discord send", policy)?;
     let request = client
-        .post(request_url.as_str())
+        .post(request_url)
         .header(reqwest::header::AUTHORIZATION, format!("Bot {bot_token}"))
         .json(&request_body);
     let response = request

--- a/crates/app/src/channel/google_chat.rs
+++ b/crates/app/src/channel/google_chat.rs
@@ -4,7 +4,10 @@ use crate::{CliResult, config::ResolvedGoogleChatChannelConfig};
 
 use super::{
     ChannelOutboundTargetKind,
-    http::{build_outbound_http_client, read_json_or_text_response, response_body_detail},
+    http::{
+        ChannelOutboundHttpPolicy, build_outbound_http_client, read_json_or_text_response,
+        response_body_detail, validate_outbound_http_target,
+    },
 };
 
 pub(super) async fn run_google_chat_send(
@@ -12,6 +15,7 @@ pub(super) async fn run_google_chat_send(
     target_kind: ChannelOutboundTargetKind,
     endpoint_url: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Endpoint {
         return Err(format!(
@@ -20,17 +24,18 @@ pub(super) async fn run_google_chat_send(
         ));
     }
 
-    let trimmed_endpoint_url = endpoint_url.trim();
-    if trimmed_endpoint_url.is_empty() {
-        return Err("google chat outbound target endpoint is empty".to_owned());
-    }
+    let request_url = validate_outbound_http_target(
+        "google chat outbound target endpoint",
+        endpoint_url,
+        policy,
+    )?;
 
     let request_body = json!({
         "text": text,
     });
 
-    let client = build_outbound_http_client("google chat send")?;
-    let request = client.post(trimmed_endpoint_url).json(&request_body);
+    let client = build_outbound_http_client("google chat send", policy)?;
+    let request = client.post(request_url).json(&request_body);
     let response = request
         .send()
         .await

--- a/crates/app/src/channel/http.rs
+++ b/crates/app/src/channel/http.rs
@@ -83,6 +83,36 @@ pub(super) fn response_body_detail(body: &str) -> String {
     trimmed_body.to_owned()
 }
 
+pub(super) fn redact_endpoint_status_url(raw_url: &str) -> Option<String> {
+    let trimmed_url = raw_url.trim();
+    let parsed_url = reqwest::Url::parse(trimmed_url).ok()?;
+    let has_userinfo = !parsed_url.username().is_empty() || parsed_url.password().is_some();
+    let has_query = parsed_url.query().is_some();
+    let has_fragment = parsed_url.fragment().is_some();
+    if !has_userinfo && !has_query && !has_fragment {
+        return Some(trimmed_url.to_owned());
+    }
+
+    let mut redacted_url = parsed_url;
+    let _ = redacted_url.set_username("");
+    let _ = redacted_url.set_password(None);
+    redacted_url.set_query(None);
+    redacted_url.set_fragment(None);
+    Some(redacted_url.to_string())
+}
+
+pub(super) fn redact_generic_webhook_status_url(raw_url: &str) -> Option<String> {
+    let trimmed_url = raw_url.trim();
+    let parsed_url = reqwest::Url::parse(trimmed_url).ok()?;
+    let mut redacted_url = parsed_url;
+    let _ = redacted_url.set_username("");
+    let _ = redacted_url.set_password(None);
+    redacted_url.set_path("/");
+    redacted_url.set_query(None);
+    redacted_url.set_fragment(None);
+    Some(redacted_url.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/app/src/channel/http.rs
+++ b/crates/app/src/channel/http.rs
@@ -1,16 +1,63 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::Value;
 
-use crate::CliResult;
+use crate::{CliResult, config::LoongClawConfig};
 
 const DEFAULT_OUTBOUND_HTTP_TIMEOUT: Duration = Duration::from_secs(15);
 
-pub(super) fn build_outbound_http_client(context: &str) -> CliResult<reqwest::Client> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) struct ChannelOutboundHttpPolicy {
+    pub allow_private_hosts: bool,
+}
+
+pub(super) fn outbound_http_policy_from_config(
+    config: &LoongClawConfig,
+) -> ChannelOutboundHttpPolicy {
+    ChannelOutboundHttpPolicy {
+        allow_private_hosts: config.outbound_http.allow_private_hosts,
+    }
+}
+
+pub(super) fn build_outbound_http_client(
+    context: &str,
+    policy: ChannelOutboundHttpPolicy,
+) -> CliResult<reqwest::Client> {
+    let resolver = crate::tools::web_http::SsrfSafeResolver {
+        allow_private_hosts: policy.allow_private_hosts,
+    };
     reqwest::Client::builder()
+        .dns_resolver(Arc::new(resolver))
+        .redirect(reqwest::redirect::Policy::none())
         .timeout(DEFAULT_OUTBOUND_HTTP_TIMEOUT)
+        .no_proxy()
         .build()
         .map_err(|error| format!("build {context} http client failed: {error}"))
+}
+
+pub(super) fn validate_outbound_http_target(
+    field_name: &str,
+    raw_url: &str,
+    policy: ChannelOutboundHttpPolicy,
+) -> Result<reqwest::Url, String> {
+    let trimmed_url = raw_url.trim();
+    if trimmed_url.is_empty() {
+        return Err(format!("{field_name} is empty"));
+    }
+
+    let parsed_url = reqwest::Url::parse(trimmed_url)
+        .map_err(|error| format!("{field_name} is invalid: {error}"))?;
+    let options = crate::tools::web_http::HttpTargetValidationOptions {
+        allow_private_hosts: policy.allow_private_hosts,
+        reject_userinfo: true,
+        resolve_dns: false,
+        enforce_allowed_domains: false,
+        allowed_domains: None,
+        blocked_domains: None,
+    };
+    crate::tools::web_http::validate_http_target(&parsed_url, &options, field_name)?;
+    Ok(parsed_url)
 }
 
 pub(super) async fn read_json_or_text_response(
@@ -34,4 +81,137 @@ pub(super) fn response_body_detail(body: &str) -> String {
     }
 
     trimmed_body.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::time::Duration;
+
+    fn spawn_test_http_server(
+        response: String,
+        accept_timeout: Duration,
+    ) -> Result<(String, std::thread::JoinHandle<Result<bool, String>>), String> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .map_err(|error| format!("bind test server: {error}"))?;
+        let address = listener
+            .local_addr()
+            .map_err(|error| format!("read test server address: {error}"))?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| format!("set test server nonblocking mode: {error}"))?;
+
+        let handle = std::thread::spawn(move || -> Result<bool, String> {
+            let deadline = std::time::Instant::now() + accept_timeout;
+
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _peer)) => {
+                        let mut request_buffer = [0_u8; 1024];
+                        let _ = stream.read(&mut request_buffer);
+                        stream
+                            .write_all(response.as_bytes())
+                            .map_err(|error| format!("write test server response: {error}"))?;
+                        stream
+                            .flush()
+                            .map_err(|error| format!("flush test server response: {error}"))?;
+                        return Ok(true);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if std::time::Instant::now() >= deadline {
+                            return Ok(false);
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => {
+                        return Err(format!("accept test server connection: {error}"));
+                    }
+                }
+            }
+        });
+
+        let url = format!("http://127.0.0.1:{}/", address.port());
+        Ok((url, handle))
+    }
+
+    #[test]
+    fn outbound_http_target_rejects_userinfo() {
+        let policy = ChannelOutboundHttpPolicy::default();
+        let error = validate_outbound_http_target(
+            "webhook.endpoint_url",
+            "https://user:pass@example.com/hook",
+            policy,
+        )
+        .expect_err("credential-bearing urls should be rejected");
+
+        assert!(error.contains("must not embed credentials"));
+    }
+
+    #[test]
+    fn outbound_http_target_blocks_private_hosts_by_default() {
+        let policy = ChannelOutboundHttpPolicy::default();
+        let error =
+            validate_outbound_http_target("signal.service_url", "http://127.0.0.1:8080", policy)
+                .expect_err("private hosts should be blocked by default");
+
+        assert!(error.contains("private or special-use"));
+    }
+
+    #[test]
+    fn outbound_http_target_allows_private_hosts_when_policy_is_enabled() {
+        let policy = ChannelOutboundHttpPolicy {
+            allow_private_hosts: true,
+        };
+        let url =
+            validate_outbound_http_target("signal.service_url", "http://127.0.0.1:8080", policy)
+                .expect("private hosts should be allowed when the policy is widened");
+
+        assert_eq!(url.as_str(), "http://127.0.0.1:8080/");
+    }
+
+    #[test]
+    fn outbound_http_client_does_not_follow_redirects() {
+        let policy = ChannelOutboundHttpPolicy {
+            allow_private_hosts: true,
+        };
+
+        let final_response =
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok".to_owned();
+        let (final_url, final_handle) =
+            spawn_test_http_server(final_response, Duration::from_millis(250))
+                .expect("spawn final test server");
+
+        let redirect_response = format!(
+            "HTTP/1.1 302 Found\r\nLocation: {final_url}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+        let (redirect_url, redirect_handle) =
+            spawn_test_http_server(redirect_response, Duration::from_secs(2))
+                .expect("spawn redirect test server");
+
+        let client =
+            build_outbound_http_client("redirect test", policy).expect("build outbound client");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+        let response = runtime
+            .block_on(async { client.get(redirect_url).send().await })
+            .expect("send redirect test request");
+
+        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+
+        let redirect_requested = redirect_handle
+            .join()
+            .expect("join redirect server thread")
+            .expect("redirect server result");
+        let final_requested = final_handle
+            .join()
+            .expect("join final server thread")
+            .expect("final server result");
+
+        assert!(redirect_requested);
+        assert!(!final_requested);
+    }
 }

--- a/crates/app/src/channel/http.rs
+++ b/crates/app/src/channel/http.rs
@@ -123,7 +123,7 @@ mod tests {
                         if std::time::Instant::now() >= deadline {
                             return Ok(false);
                         }
-                        std::thread::sleep(Duration::from_millis(10));
+                        std::thread::park_timeout(Duration::from_millis(10));
                     }
                     Err(error) => {
                         return Err(format!("accept test server connection: {error}"));

--- a/crates/app/src/channel/imessage.rs
+++ b/crates/app/src/channel/imessage.rs
@@ -2,7 +2,10 @@ use serde::Serialize;
 
 use crate::{CliResult, config::ResolvedImessageChannelConfig};
 
-use super::{ChannelOutboundTargetKind, http::build_outbound_http_client};
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 #[derive(Debug, Serialize)]
 struct ImessageSendRequestBody {
@@ -16,6 +19,7 @@ pub(super) async fn run_imessage_send(
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     ensure_imessage_target_kind(target_kind)?;
 
@@ -25,7 +29,8 @@ pub(super) async fn run_imessage_send(
     let bridge_token = resolved.bridge_token().ok_or_else(|| {
         "imessage bridge_token missing (set imessage.bridge_token or env)".to_owned()
     })?;
-    let request_url = build_imessage_request_url(bridge_url.as_str(), bridge_token.as_str())?;
+    let request_url =
+        build_imessage_request_url(bridge_url.as_str(), bridge_token.as_str(), policy)?;
 
     let chat_guid = target_id.trim();
     if chat_guid.is_empty() {
@@ -37,7 +42,7 @@ pub(super) async fn run_imessage_send(
         message: text.to_owned(),
     };
 
-    let client = build_outbound_http_client("imessage send")?;
+    let client = build_outbound_http_client("imessage send", policy)?;
     let request = client.post(request_url).json(&request_body);
     let response = request
         .send()
@@ -58,19 +63,17 @@ fn ensure_imessage_target_kind(target_kind: ChannelOutboundTargetKind) -> CliRes
     ))
 }
 
-fn build_imessage_request_url(bridge_url: &str, bridge_token: &str) -> CliResult<reqwest::Url> {
-    let trimmed_bridge_url = bridge_url.trim();
-    if trimmed_bridge_url.is_empty() {
-        return Err("imessage bridge_url is empty".to_owned());
-    }
-
+fn build_imessage_request_url(
+    bridge_url: &str,
+    bridge_token: &str,
+    policy: ChannelOutboundHttpPolicy,
+) -> CliResult<reqwest::Url> {
     let trimmed_bridge_token = bridge_token.trim();
     if trimmed_bridge_token.is_empty() {
         return Err("imessage bridge_token is empty".to_owned());
     }
 
-    let mut request_url = reqwest::Url::parse(trimmed_bridge_url)
-        .map_err(|error| format!("imessage bridge_url is invalid: {error}"))?;
+    let mut request_url = validate_outbound_http_target("imessage bridge_url", bridge_url, policy)?;
     let mut path_segments = request_url.path_segments_mut().map_err(|_path_error| {
         "imessage bridge_url cannot be used as a hierarchical base url".to_owned()
     })?;
@@ -115,9 +118,15 @@ mod tests {
 
     #[test]
     fn build_imessage_request_url_preserves_base_path_and_guid_query() {
-        let request_url =
-            build_imessage_request_url("https://bluebubbles.example.test/base", "bridge-password")
-                .expect("build imessage request url");
+        let policy = ChannelOutboundHttpPolicy {
+            allow_private_hosts: false,
+        };
+        let request_url = build_imessage_request_url(
+            "https://bluebubbles.example.test/base",
+            "bridge-password",
+            policy,
+        )
+        .expect("build imessage request url");
 
         assert_eq!(
             request_url.as_str(),

--- a/crates/app/src/channel/line.rs
+++ b/crates/app/src/channel/line.rs
@@ -2,13 +2,17 @@ use serde_json::json;
 
 use crate::{CliResult, config::ResolvedLineChannelConfig};
 
-use super::{ChannelOutboundTargetKind, http::build_outbound_http_client};
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 pub(super) async fn run_line_send(
     resolved: &ResolvedLineChannelConfig,
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Address {
         return Err(format!(
@@ -28,6 +32,8 @@ pub(super) async fn run_line_send(
     let api_base_url = resolved.resolved_api_base_url();
     let trimmed_api_base_url = api_base_url.trim_end_matches('/');
     let request_url = format!("{trimmed_api_base_url}/message/push");
+    let request_url =
+        validate_outbound_http_target("line api_base_url", request_url.as_str(), policy)?;
     let request_body = json!({
         "to": recipient,
         "messages": [
@@ -38,9 +44,9 @@ pub(super) async fn run_line_send(
         ],
     });
 
-    let client = build_outbound_http_client("line send")?;
+    let client = build_outbound_http_client("line send", policy)?;
     let request = client
-        .post(request_url.as_str())
+        .post(request_url)
         .bearer_auth(channel_access_token)
         .json(&request_body);
     let response = request

--- a/crates/app/src/channel/mattermost.rs
+++ b/crates/app/src/channel/mattermost.rs
@@ -4,7 +4,10 @@ use crate::{CliResult, config::ResolvedMattermostChannelConfig};
 
 use super::{
     ChannelOutboundTargetKind,
-    http::{build_outbound_http_client, read_json_or_text_response, response_body_detail},
+    http::{
+        ChannelOutboundHttpPolicy, build_outbound_http_client, read_json_or_text_response,
+        response_body_detail, validate_outbound_http_target,
+    },
 };
 
 pub(super) async fn run_mattermost_send(
@@ -12,6 +15,7 @@ pub(super) async fn run_mattermost_send(
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Conversation {
         return Err(format!(
@@ -33,14 +37,16 @@ pub(super) async fn run_mattermost_send(
 
     let trimmed_server_url = server_url.trim_end_matches('/');
     let request_url = format!("{trimmed_server_url}/api/v4/posts");
+    let request_url =
+        validate_outbound_http_target("mattermost server_url", request_url.as_str(), policy)?;
     let request_body = json!({
         "channel_id": channel_id,
         "message": text,
     });
 
-    let client = build_outbound_http_client("mattermost send")?;
+    let client = build_outbound_http_client("mattermost send", policy)?;
     let request = client
-        .post(request_url.as_str())
+        .post(request_url)
         .bearer_auth(bot_token)
         .json(&request_body);
     let response = request

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -1252,6 +1252,10 @@ impl<R> ChannelCommandContext<R> {
             }
         }
     }
+
+    fn outbound_http_policy(&self) -> http::ChannelOutboundHttpPolicy {
+        http::outbound_http_policy_from_config(&self.config)
+    }
 }
 
 #[cfg(any(
@@ -2504,7 +2508,6 @@ pub async fn run_discord_send(
     #[cfg(feature = "channel-discord")]
     {
         let context = load_discord_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2519,7 +2522,7 @@ pub async fn run_discord_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -2560,7 +2563,6 @@ pub async fn run_signal_send(
     #[cfg(feature = "channel-signal")]
     {
         let context = signal_command::load_signal_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2575,7 +2577,7 @@ pub async fn run_signal_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -2671,7 +2673,6 @@ pub async fn run_slack_send(
     #[cfg(feature = "channel-slack")]
     {
         let context = load_slack_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2686,7 +2687,7 @@ pub async fn run_slack_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -2727,7 +2728,6 @@ pub async fn run_line_send(
     #[cfg(feature = "channel-line")]
     {
         let context = load_line_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2740,7 +2740,7 @@ pub async fn run_line_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -2781,7 +2781,6 @@ pub async fn run_dingtalk_send(
     #[cfg(feature = "channel-dingtalk")]
     {
         let context = load_dingtalk_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let send_target = resolve_endpoint_backed_send_target(
             "dingtalk",
             target,
@@ -2806,7 +2805,7 @@ pub async fn run_dingtalk_send(
                         target_kind,
                         endpoint_url.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -2849,7 +2848,6 @@ pub async fn run_whatsapp_send(
     #[cfg(feature = "channel-whatsapp")]
     {
         let context = load_whatsapp_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2864,7 +2862,7 @@ pub async fn run_whatsapp_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -2959,7 +2957,6 @@ pub async fn run_webhook_send(
     #[cfg(feature = "channel-webhook")]
     {
         let context = load_webhook_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let send_target = resolve_endpoint_backed_send_target(
             "webhook",
             target,
@@ -2984,7 +2981,7 @@ pub async fn run_webhook_send(
                         target_kind,
                         endpoint_url.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -3031,7 +3028,6 @@ pub async fn run_google_chat_send(
     #[cfg(feature = "channel-google-chat")]
     {
         let context = load_google_chat_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let send_target = resolve_endpoint_backed_send_target(
             "google-chat",
             target,
@@ -3056,7 +3052,7 @@ pub async fn run_google_chat_send(
                         target_kind,
                         endpoint_url.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -3099,7 +3095,6 @@ pub async fn run_teams_send(
     #[cfg(feature = "channel-teams")]
     {
         let context = load_teams_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let send_target = resolve_endpoint_backed_send_target(
             "teams",
             target,
@@ -3124,7 +3119,7 @@ pub async fn run_teams_send(
                         target_kind,
                         endpoint_url.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -3171,7 +3166,6 @@ pub async fn run_mattermost_send(
     #[cfg(feature = "channel-mattermost")]
     {
         let context = load_mattermost_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -3186,7 +3180,7 @@ pub async fn run_mattermost_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -3234,7 +3228,6 @@ pub async fn run_nextcloud_talk_send(
     #[cfg(feature = "channel-nextcloud-talk")]
     {
         let context = load_nextcloud_talk_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -3249,7 +3242,7 @@ pub async fn run_nextcloud_talk_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -3295,7 +3288,6 @@ pub async fn run_synology_chat_send(
     #[cfg(feature = "channel-synology-chat")]
     {
         let context = load_synology_chat_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target
             .map(str::trim)
             .filter(|value| !value.is_empty())
@@ -3314,7 +3306,7 @@ pub async fn run_synology_chat_send(
                         target_kind,
                         target.as_deref(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })
@@ -3410,7 +3402,6 @@ pub async fn run_imessage_send(
     #[cfg(feature = "channel-imessage")]
     {
         let context = load_imessage_command_context(config_path, account_id)?;
-        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -3425,7 +3416,7 @@ pub async fn run_imessage_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
-                        outbound_http_policy,
+                        context.outbound_http_policy(),
                     )
                     .await
                 })

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -2505,6 +2505,7 @@ pub async fn run_discord_send(
     #[cfg(feature = "channel-discord")]
     {
         let context = load_discord_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2519,6 +2520,7 @@ pub async fn run_discord_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -2560,6 +2562,7 @@ pub async fn run_signal_send(
     #[cfg(feature = "channel-signal")]
     {
         let context = signal_command::load_signal_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2574,6 +2577,7 @@ pub async fn run_signal_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -2670,6 +2674,7 @@ pub async fn run_slack_send(
     #[cfg(feature = "channel-slack")]
     {
         let context = load_slack_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2684,6 +2689,7 @@ pub async fn run_slack_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -2725,6 +2731,7 @@ pub async fn run_line_send(
     #[cfg(feature = "channel-line")]
     {
         let context = load_line_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2737,6 +2744,7 @@ pub async fn run_line_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -2778,6 +2786,7 @@ pub async fn run_dingtalk_send(
     #[cfg(feature = "channel-dingtalk")]
     {
         let context = load_dingtalk_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let send_target = resolve_endpoint_backed_send_target(
             "dingtalk",
             target,
@@ -2802,6 +2811,7 @@ pub async fn run_dingtalk_send(
                         target_kind,
                         endpoint_url.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -2844,6 +2854,7 @@ pub async fn run_whatsapp_send(
     #[cfg(feature = "channel-whatsapp")]
     {
         let context = load_whatsapp_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -2858,6 +2869,7 @@ pub async fn run_whatsapp_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -2952,6 +2964,7 @@ pub async fn run_webhook_send(
     #[cfg(feature = "channel-webhook")]
     {
         let context = load_webhook_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let send_target = resolve_endpoint_backed_send_target(
             "webhook",
             target,
@@ -2976,6 +2989,7 @@ pub async fn run_webhook_send(
                         target_kind,
                         endpoint_url.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -3022,6 +3036,7 @@ pub async fn run_google_chat_send(
     #[cfg(feature = "channel-google-chat")]
     {
         let context = load_google_chat_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let send_target = resolve_endpoint_backed_send_target(
             "google-chat",
             target,
@@ -3046,6 +3061,7 @@ pub async fn run_google_chat_send(
                         target_kind,
                         endpoint_url.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -3088,6 +3104,7 @@ pub async fn run_teams_send(
     #[cfg(feature = "channel-teams")]
     {
         let context = load_teams_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let send_target = resolve_endpoint_backed_send_target(
             "teams",
             target,
@@ -3112,6 +3129,7 @@ pub async fn run_teams_send(
                         target_kind,
                         endpoint_url.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -3158,6 +3176,7 @@ pub async fn run_mattermost_send(
     #[cfg(feature = "channel-mattermost")]
     {
         let context = load_mattermost_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -3172,6 +3191,7 @@ pub async fn run_mattermost_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -3219,6 +3239,7 @@ pub async fn run_nextcloud_talk_send(
     #[cfg(feature = "channel-nextcloud-talk")]
     {
         let context = load_nextcloud_talk_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -3233,6 +3254,7 @@ pub async fn run_nextcloud_talk_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -3278,6 +3300,7 @@ pub async fn run_synology_chat_send(
     #[cfg(feature = "channel-synology-chat")]
     {
         let context = load_synology_chat_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target
             .map(str::trim)
             .filter(|value| !value.is_empty())
@@ -3296,6 +3319,7 @@ pub async fn run_synology_chat_send(
                         target_kind,
                         target.as_deref(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })
@@ -3391,6 +3415,7 @@ pub async fn run_imessage_send(
     #[cfg(feature = "channel-imessage")]
     {
         let context = load_imessage_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
         run_channel_send_command(
@@ -3405,6 +3430,7 @@ pub async fn run_imessage_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -2495,7 +2495,6 @@ pub async fn run_discord_send(
     if !cfg!(feature = "channel-discord") {
         return Err("discord channel is disabled (enable feature `channel-discord`)".to_owned());
     }
-
     #[cfg(not(feature = "channel-discord"))]
     {
         let _ = (config_path, account_id, target, target_kind, text);
@@ -2552,7 +2551,6 @@ pub async fn run_signal_send(
     if !cfg!(feature = "channel-signal") {
         return Err("signal channel is disabled (enable feature `channel-signal`)".to_owned());
     }
-
     #[cfg(not(feature = "channel-signal"))]
     {
         let _ = (config_path, account_id, target, target_kind, text);
@@ -2664,7 +2662,6 @@ pub async fn run_slack_send(
     if !cfg!(feature = "channel-slack") {
         return Err("slack channel is disabled (enable feature `channel-slack`)".to_owned());
     }
-
     #[cfg(not(feature = "channel-slack"))]
     {
         let _ = (config_path, account_id, target, target_kind, text);
@@ -2721,7 +2718,6 @@ pub async fn run_line_send(
     if !cfg!(feature = "channel-line") {
         return Err("line channel is disabled (enable feature `channel-line`)".to_owned());
     }
-
     #[cfg(not(feature = "channel-line"))]
     {
         let _ = (config_path, account_id, target, target_kind, text);
@@ -2776,7 +2772,6 @@ pub async fn run_dingtalk_send(
     if !cfg!(feature = "channel-dingtalk") {
         return Err("dingtalk channel is disabled (enable feature `channel-dingtalk`)".to_owned());
     }
-
     #[cfg(not(feature = "channel-dingtalk"))]
     {
         let _ = (config_path, account_id, target, target_kind, text);

--- a/crates/app/src/channel/nextcloud_talk.rs
+++ b/crates/app/src/channel/nextcloud_talk.rs
@@ -3,7 +3,10 @@ use serde::Serialize;
 
 use crate::{CliResult, config::ResolvedNextcloudTalkChannelConfig};
 
-use super::{ChannelOutboundTargetKind, http::build_outbound_http_client};
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 type NextcloudTalkHmacSha256 = hmac::Hmac<sha2::Sha256>;
 
@@ -23,6 +26,7 @@ pub(super) async fn run_nextcloud_talk_send(
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Conversation {
         return Err(format!(
@@ -54,9 +58,10 @@ pub(super) async fn run_nextcloud_talk_send(
         random_header.as_str(),
         request_body_json.as_str(),
     )?;
-    let request_url = build_nextcloud_talk_request_url(server_url.as_str(), conversation_token)?;
+    let request_url =
+        build_nextcloud_talk_request_url(server_url.as_str(), conversation_token, policy)?;
 
-    let client = build_outbound_http_client("nextcloud talk send")?;
+    let client = build_outbound_http_client("nextcloud talk send", policy)?;
     let request = client
         .post(request_url)
         .header(reqwest::header::ACCEPT, "application/json")
@@ -84,9 +89,9 @@ fn build_random_reference_id() -> String {
 fn build_nextcloud_talk_request_url(
     server_url: &str,
     conversation_token: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<String> {
-    let mut url = reqwest::Url::parse(server_url)
-        .map_err(|error| format!("nextcloud talk server_url is invalid: {error}"))?;
+    let mut url = validate_outbound_http_target("nextcloud talk server_url", server_url, policy)?;
     let mut path_segments = url.path_segments_mut().map_err(|_path_error| {
         "nextcloud talk server_url cannot be used as a hierarchical base url".to_owned()
     })?;
@@ -146,9 +151,15 @@ mod tests {
 
     #[test]
     fn build_nextcloud_talk_request_url_preserves_base_path() {
-        let request_url =
-            build_nextcloud_talk_request_url("https://cloud.example.test/nextcloud", "room-token")
-                .expect("build nextcloud talk request url");
+        let policy = ChannelOutboundHttpPolicy {
+            allow_private_hosts: false,
+        };
+        let request_url = build_nextcloud_talk_request_url(
+            "https://cloud.example.test/nextcloud",
+            "room-token",
+            policy,
+        )
+        .expect("build nextcloud talk request url");
 
         assert_eq!(
             request_url,

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -9260,110 +9260,6 @@ mod tests {
     }
 
     #[test]
-    fn signal_status_blocks_default_private_service_url_without_override() {
-        let mut config = LoongClawConfig::default();
-        config.signal.enabled = true;
-
-        let snapshots = channel_status_snapshots(&config);
-        let signal = snapshots
-            .iter()
-            .find(|snapshot| snapshot.id == "signal")
-            .expect("signal snapshot");
-        let send = signal.operation("send").expect("signal send operation");
-        let serve = signal.operation("serve").expect("signal serve operation");
-
-        assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
-        assert!(
-            send.issues
-                .iter()
-                .any(|issue| issue.contains("account is missing")),
-            "send issues should require a signal account"
-        );
-        assert!(
-            send.issues
-                .iter()
-                .any(|issue| issue.contains("private or special-use")),
-            "default signal service URL should be blocked until the operator widens outbound_http"
-        );
-        assert_eq!(serve.health, ChannelOperationHealth::Unsupported);
-        assert_eq!(
-            signal.api_base_url.as_deref(),
-            Some("http://127.0.0.1:8080")
-        );
-        assert!(serve.runtime.is_none());
-    }
-
-    #[test]
-    fn signal_status_rejects_non_http_service_url() {
-        let mut config = LoongClawConfig::default();
-        config.signal.enabled = true;
-        config.signal.signal_account = Some("+15550001111".to_owned());
-        config.signal.service_url = Some("file:///tmp/signal-api".to_owned());
-
-        let snapshots = channel_status_snapshots(&config);
-        let signal = snapshots
-            .iter()
-            .find(|snapshot| snapshot.id == "signal")
-            .expect("signal snapshot");
-        let send = signal.operation("send").expect("signal send operation");
-
-        assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
-        assert!(
-            send.issues
-                .iter()
-                .any(|issue| issue.contains("requires http or https")),
-            "send issues should reject non-http signal service urls"
-        );
-    }
-
-    #[test]
-    fn signal_status_allows_private_service_url_when_outbound_http_override_is_enabled() {
-        let mut config = LoongClawConfig::default();
-        config.signal.enabled = true;
-        config.signal.signal_account = Some("+15550001111".to_owned());
-        config.outbound_http.allow_private_hosts = true;
-
-        let snapshots = channel_status_snapshots(&config);
-        let signal = snapshots
-            .iter()
-            .find(|snapshot| snapshot.id == "signal")
-            .expect("signal snapshot");
-        let send = signal.operation("send").expect("signal send operation");
-
-        assert_eq!(send.health, ChannelOperationHealth::Ready);
-        assert!(
-            send.issues.is_empty(),
-            "widened outbound_http policy should allow the default local signal bridge"
-        );
-    }
-
-    #[test]
-    fn google_chat_status_rejects_credential_bearing_webhook_url() {
-        let mut config = LoongClawConfig::default();
-        config.google_chat.enabled = true;
-        config.google_chat.webhook_url = Some(loongclaw_contracts::SecretRef::Inline(
-            "https://user:pass@chat.googleapis.com/v1/spaces/AAAA/messages".to_owned(),
-        ));
-
-        let snapshots = channel_status_snapshots(&config);
-        let google_chat = snapshots
-            .iter()
-            .find(|snapshot| snapshot.id == "google-chat")
-            .expect("google chat snapshot");
-        let send = google_chat
-            .operation("send")
-            .expect("google chat send operation");
-
-        assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
-        assert!(
-            send.issues
-                .iter()
-                .any(|issue| issue.contains("must not embed credentials")),
-            "send issues should reject credential-bearing google chat webhook urls"
-        );
-    }
-
-    #[test]
     fn irc_status_reports_ready_send_and_planned_serve() {
         let mut config = LoongClawConfig::default();
         config.irc.enabled = true;
@@ -9928,3 +9824,6 @@ mod tests {
         std::env::temp_dir().join(unique)
     }
 }
+
+#[cfg(test)]
+mod trust_boundary_tests;

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -3479,10 +3479,14 @@ fn validate_http_url(
     value: &str,
     policy: super::http::ChannelOutboundHttpPolicy,
     issues: &mut Vec<String>,
-) {
+) -> Option<reqwest::Url> {
     let validation = super::http::validate_outbound_http_target(field, value, policy);
-    if let Err(error) = validation {
-        issues.push(error);
+    match validation {
+        Ok(url) => Some(url),
+        Err(error) => {
+            issues.push(error);
+            None
+        }
     }
 }
 
@@ -4401,29 +4405,6 @@ fn build_imessage_snapshots(
         .collect()
 }
 
-fn redact_endpoint_status_url(raw: Option<String>) -> Option<String> {
-    let raw = raw?;
-    let parsed = reqwest::Url::parse(raw.as_str()).ok()?;
-    let mut redacted = parsed;
-    let _ = redacted.set_username("");
-    let _ = redacted.set_password(None);
-    redacted.set_query(None);
-    redacted.set_fragment(None);
-    Some(redacted.to_string())
-}
-
-fn redact_generic_webhook_status_url(raw: Option<String>) -> Option<String> {
-    let raw = raw?;
-    let parsed = reqwest::Url::parse(raw.as_str()).ok()?;
-    let mut redacted = parsed;
-    let _ = redacted.set_username("");
-    let _ = redacted.set_password(None);
-    redacted.set_path("/");
-    redacted.set_query(None);
-    redacted.set_fragment(None);
-    Some(redacted.to_string())
-}
-
 fn build_dingtalk_snapshot_for_account(
     descriptor: &ChannelRegistryDescriptor,
     compiled: bool,
@@ -4438,9 +4419,9 @@ fn build_dingtalk_snapshot_for_account(
     if webhook_url.is_none() {
         send_issues.push("webhook_url is missing".to_owned());
     }
-    if let Some(webhook_url) = webhook_url.as_deref() {
-        validate_http_url("webhook_url", webhook_url, http_policy, &mut send_issues);
-    }
+    let validated_webhook_url = webhook_url
+        .as_deref()
+        .and_then(|url| validate_http_url("webhook_url", url, http_policy, &mut send_issues));
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -4498,7 +4479,10 @@ fn build_dingtalk_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: redact_endpoint_status_url(webhook_url),
+        api_base_url: validated_webhook_url
+            .as_ref()
+            .and(webhook_url.as_deref())
+            .and_then(super::http::redact_endpoint_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -4517,10 +4501,10 @@ fn build_discord_snapshot_for_account(
         send_issues.push("bot_token is missing".to_owned());
     }
 
-    let api_base_url = resolved.resolved_api_base_url();
-    validate_http_url(
+    let resolved_api_base_url = resolved.resolved_api_base_url();
+    let api_base_url = validate_http_url(
         "api_base_url",
-        api_base_url.as_str(),
+        resolved_api_base_url.as_str(),
         http_policy,
         &mut send_issues,
     );
@@ -4578,7 +4562,9 @@ fn build_discord_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: Some(api_base_url),
+        api_base_url: api_base_url
+            .as_ref()
+            .and_then(|_| super::http::redact_endpoint_status_url(resolved_api_base_url.as_str())),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -4597,10 +4583,10 @@ fn build_slack_snapshot_for_account(
         send_issues.push("bot_token is missing".to_owned());
     }
 
-    let api_base_url = resolved.resolved_api_base_url();
-    validate_http_url(
+    let resolved_api_base_url = resolved.resolved_api_base_url();
+    let api_base_url = validate_http_url(
         "api_base_url",
-        api_base_url.as_str(),
+        resolved_api_base_url.as_str(),
         http_policy,
         &mut send_issues,
     );
@@ -4658,7 +4644,9 @@ fn build_slack_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: Some(api_base_url),
+        api_base_url: api_base_url
+            .as_ref()
+            .and_then(|_| super::http::redact_endpoint_status_url(resolved_api_base_url.as_str())),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -4677,10 +4665,10 @@ fn build_line_snapshot_for_account(
         send_issues.push("channel_access_token is missing".to_owned());
     }
 
-    let api_base_url = resolved.resolved_api_base_url();
-    validate_http_url(
+    let resolved_api_base_url = resolved.resolved_api_base_url();
+    let api_base_url = validate_http_url(
         "api_base_url",
-        api_base_url.as_str(),
+        resolved_api_base_url.as_str(),
         http_policy,
         &mut send_issues,
     );
@@ -4738,7 +4726,9 @@ fn build_line_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: Some(api_base_url),
+        api_base_url: api_base_url
+            .as_ref()
+            .and_then(|_| super::http::redact_endpoint_status_url(resolved_api_base_url.as_str())),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -4760,10 +4750,10 @@ fn build_whatsapp_snapshot_for_account(
         send_issues.push("phone_number_id is missing".to_owned());
     }
 
-    let api_base_url = resolved.resolved_api_base_url();
-    validate_http_url(
+    let resolved_api_base_url = resolved.resolved_api_base_url();
+    let api_base_url = validate_http_url(
         "api_base_url",
-        api_base_url.as_str(),
+        resolved_api_base_url.as_str(),
         http_policy,
         &mut send_issues,
     );
@@ -4824,7 +4814,9 @@ fn build_whatsapp_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: Some(api_base_url),
+        api_base_url: api_base_url
+            .as_ref()
+            .and_then(|_| super::http::redact_endpoint_status_url(resolved_api_base_url.as_str())),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -4978,9 +4970,9 @@ fn build_webhook_snapshot_for_account(
     if endpoint_url.is_none() {
         send_issues.push("endpoint_url is missing".to_owned());
     }
-    if let Some(endpoint_url) = endpoint_url.as_deref() {
-        validate_http_url("endpoint_url", endpoint_url, http_policy, &mut send_issues);
-    }
+    let validated_endpoint_url = endpoint_url
+        .as_deref()
+        .and_then(|url| validate_http_url("endpoint_url", url, http_policy, &mut send_issues));
 
     let auth_token = resolved.auth_token();
     let auth_validation = build_webhook_auth_header_from_parts(
@@ -5068,7 +5060,10 @@ fn build_webhook_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: redact_generic_webhook_status_url(endpoint_url),
+        api_base_url: validated_endpoint_url
+            .as_ref()
+            .and(endpoint_url.as_deref())
+            .and_then(super::http::redact_generic_webhook_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -5088,9 +5083,9 @@ fn build_google_chat_snapshot_for_account(
     if webhook_url.is_none() {
         send_issues.push("webhook_url is missing".to_owned());
     }
-    if let Some(webhook_url) = webhook_url.as_deref() {
-        validate_http_url("webhook_url", webhook_url, http_policy, &mut send_issues);
-    }
+    let validated_webhook_url = webhook_url
+        .as_deref()
+        .and_then(|url| validate_http_url("webhook_url", url, http_policy, &mut send_issues));
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -5145,7 +5140,10 @@ fn build_google_chat_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: redact_endpoint_status_url(webhook_url),
+        api_base_url: validated_webhook_url
+            .as_ref()
+            .and(webhook_url.as_deref())
+            .and_then(super::http::redact_endpoint_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -5165,9 +5163,9 @@ fn build_mattermost_snapshot_for_account(
     if server_url.is_none() {
         send_issues.push("server_url is missing".to_owned());
     }
-    if let Some(server_url) = server_url.as_deref() {
-        validate_http_url("server_url", server_url, http_policy, &mut send_issues);
-    }
+    let validated_server_url = server_url
+        .as_deref()
+        .and_then(|url| validate_http_url("server_url", url, http_policy, &mut send_issues));
     if resolved.bot_token().is_none() {
         send_issues.push("bot_token is missing".to_owned());
     }
@@ -5225,7 +5223,10 @@ fn build_mattermost_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: server_url,
+        api_base_url: validated_server_url
+            .as_ref()
+            .and(server_url.as_deref())
+            .and_then(super::http::redact_endpoint_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -5245,9 +5246,9 @@ fn build_nextcloud_talk_snapshot_for_account(
     if server_url.is_none() {
         send_issues.push("server_url is missing".to_owned());
     }
-    if let Some(server_url) = server_url.as_deref() {
-        validate_http_url("server_url", server_url, http_policy, &mut send_issues);
-    }
+    let validated_server_url = server_url
+        .as_deref()
+        .and_then(|url| validate_http_url("server_url", url, http_policy, &mut send_issues));
     if resolved.shared_secret().is_none() {
         send_issues.push("shared_secret is missing".to_owned());
     }
@@ -5305,7 +5306,10 @@ fn build_nextcloud_talk_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: server_url,
+        api_base_url: validated_server_url
+            .as_ref()
+            .and(server_url.as_deref())
+            .and_then(super::http::redact_endpoint_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -5325,9 +5329,9 @@ fn build_synology_chat_snapshot_for_account(
     if incoming_url.is_none() {
         send_issues.push("incoming_url is missing".to_owned());
     }
-    if let Some(incoming_url) = incoming_url.as_deref() {
-        validate_http_url("incoming_url", incoming_url, http_policy, &mut send_issues);
-    }
+    let validated_incoming_url = incoming_url
+        .as_deref()
+        .and_then(|url| validate_http_url("incoming_url", url, http_policy, &mut send_issues));
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -5393,7 +5397,10 @@ fn build_synology_chat_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: redact_endpoint_status_url(incoming_url),
+        api_base_url: validated_incoming_url
+            .as_ref()
+            .and(incoming_url.as_deref())
+            .and_then(super::http::redact_endpoint_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -5416,9 +5423,9 @@ fn build_signal_snapshot_for_account(
     if service_url.is_none() {
         send_issues.push("service_url is missing".to_owned());
     }
-    if let Some(service_url) = service_url.as_deref() {
-        validate_http_url("service_url", service_url, http_policy, &mut send_issues);
-    }
+    let validated_service_url = service_url
+        .as_deref()
+        .and_then(|url| validate_http_url("service_url", url, http_policy, &mut send_issues));
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -5476,7 +5483,10 @@ fn build_signal_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: service_url,
+        api_base_url: validated_service_url
+            .as_ref()
+            .and(service_url.as_deref())
+            .and_then(super::http::redact_endpoint_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -5496,9 +5506,9 @@ fn build_teams_snapshot_for_account(
     if webhook_url.is_none() {
         send_issues.push("webhook_url is missing".to_owned());
     }
-    if let Some(webhook_url) = webhook_url.as_deref() {
-        validate_http_url("webhook_url", webhook_url, http_policy, &mut send_issues);
-    }
+    let validated_webhook_url = webhook_url
+        .as_deref()
+        .and_then(|url| validate_http_url("webhook_url", url, http_policy, &mut send_issues));
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -5565,7 +5575,10 @@ fn build_teams_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: redact_endpoint_status_url(webhook_url),
+        api_base_url: validated_webhook_url
+            .as_ref()
+            .and(webhook_url.as_deref())
+            .and_then(super::http::redact_endpoint_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -5585,9 +5598,9 @@ fn build_imessage_snapshot_for_account(
     if bridge_url.is_none() {
         send_issues.push("bridge_url is missing".to_owned());
     }
-    if let Some(bridge_url) = bridge_url.as_deref() {
-        validate_http_url("bridge_url", bridge_url, http_policy, &mut send_issues);
-    }
+    let validated_bridge_url = bridge_url
+        .as_deref()
+        .and_then(|url| validate_http_url("bridge_url", url, http_policy, &mut send_issues));
     if resolved.bridge_token().is_none() {
         send_issues.push("bridge_token is missing".to_owned());
     }
@@ -5649,7 +5662,10 @@ fn build_imessage_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: bridge_url,
+        api_base_url: validated_bridge_url
+            .as_ref()
+            .and(bridge_url.as_deref())
+            .and_then(super::http::redact_endpoint_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -3474,26 +3474,16 @@ fn channel_status_snapshots_with_now(
     snapshots
 }
 
-fn validate_http_url(field: &str, value: &str, issues: &mut Vec<String>) {
-    let parsed_url = reqwest::Url::parse(value);
-    let url = match parsed_url {
-        Ok(url) => url,
-        Err(error) => {
-            let issue = format!("{field} is invalid: {error}");
-            issues.push(issue);
-            return;
-        }
-    };
-
-    let scheme = url.scheme();
-    let is_http = scheme == "http";
-    let is_https = scheme == "https";
-    if is_http || is_https {
-        return;
+fn validate_http_url(
+    field: &str,
+    value: &str,
+    policy: super::http::ChannelOutboundHttpPolicy,
+    issues: &mut Vec<String>,
+) {
+    let validation = super::http::validate_outbound_http_target(field, value, policy);
+    if let Err(error) = validation {
+        issues.push(error);
     }
-
-    let issue = format!("{field} must use http or https, got {scheme}");
-    issues.push(issue);
 }
 
 #[cfg(test)]
@@ -3792,6 +3782,7 @@ fn build_discord_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-discord");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.discord.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -3811,6 +3802,7 @@ fn build_discord_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_discord_snapshot(
                     descriptor,
@@ -3832,6 +3824,7 @@ fn build_slack_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-slack");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.slack.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -3851,6 +3844,7 @@ fn build_slack_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_slack_snapshot(
                     descriptor,
@@ -3872,6 +3866,7 @@ fn build_line_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-line");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.line.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -3891,6 +3886,7 @@ fn build_line_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_line_snapshot(
                     descriptor,
@@ -3912,6 +3908,7 @@ fn build_dingtalk_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-dingtalk");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.dingtalk.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -3931,6 +3928,7 @@ fn build_dingtalk_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_dingtalk_snapshot(
                     descriptor,
@@ -3952,6 +3950,7 @@ fn build_whatsapp_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-whatsapp");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.whatsapp.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -3971,6 +3970,7 @@ fn build_whatsapp_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_whatsapp_snapshot(
                     descriptor,
@@ -4032,6 +4032,7 @@ fn build_webhook_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-webhook");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.webhook.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -4051,6 +4052,7 @@ fn build_webhook_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_webhook_snapshot(
                     descriptor,
@@ -4072,6 +4074,7 @@ fn build_google_chat_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-google-chat");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.google_chat.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -4091,6 +4094,7 @@ fn build_google_chat_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_google_chat_snapshot(
                     descriptor,
@@ -4112,6 +4116,7 @@ fn build_signal_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-signal");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.signal.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -4131,6 +4136,7 @@ fn build_signal_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_signal_snapshot(
                     descriptor,
@@ -4152,6 +4158,7 @@ fn build_teams_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-teams");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.teams.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -4171,6 +4178,7 @@ fn build_teams_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_teams_snapshot(
                     descriptor,
@@ -4192,6 +4200,7 @@ fn build_mattermost_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-mattermost");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.mattermost.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -4211,6 +4220,7 @@ fn build_mattermost_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_mattermost_snapshot(
                     descriptor,
@@ -4232,6 +4242,7 @@ fn build_nextcloud_talk_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-nextcloud-talk");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.nextcloud_talk.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -4251,6 +4262,7 @@ fn build_nextcloud_talk_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_nextcloud_talk_snapshot(
                     descriptor,
@@ -4272,6 +4284,7 @@ fn build_synology_chat_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-synology-chat");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.synology_chat.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -4291,6 +4304,7 @@ fn build_synology_chat_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_synology_chat_snapshot(
                     descriptor,
@@ -4352,6 +4366,7 @@ fn build_imessage_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-imessage");
+    let http_policy = super::http::outbound_http_policy_from_config(config);
     let default_selection = config.imessage.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -4371,6 +4386,7 @@ fn build_imessage_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_imessage_snapshot(
                     descriptor,
@@ -4414,6 +4430,7 @@ fn build_dingtalk_snapshot_for_account(
     resolved: ResolvedDingtalkChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -4421,9 +4438,8 @@ fn build_dingtalk_snapshot_for_account(
     if webhook_url.is_none() {
         send_issues.push("webhook_url is missing".to_owned());
     }
-    let parsed_webhook_url = webhook_url.as_deref().map(reqwest::Url::parse).transpose();
-    if let Err(error) = parsed_webhook_url {
-        send_issues.push(format!("webhook_url is invalid: {error}"));
+    if let Some(webhook_url) = webhook_url.as_deref() {
+        validate_http_url("webhook_url", webhook_url, http_policy, &mut send_issues);
     }
 
     let send_operation = if !compiled {
@@ -4494,6 +4510,7 @@ fn build_discord_snapshot_for_account(
     resolved: ResolvedDiscordChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
     if resolved.bot_token().is_none() {
@@ -4501,7 +4518,12 @@ fn build_discord_snapshot_for_account(
     }
 
     let api_base_url = resolved.resolved_api_base_url();
-    validate_http_url("api_base_url", api_base_url.as_str(), &mut send_issues);
+    validate_http_url(
+        "api_base_url",
+        api_base_url.as_str(),
+        http_policy,
+        &mut send_issues,
+    );
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -4568,6 +4590,7 @@ fn build_slack_snapshot_for_account(
     resolved: ResolvedSlackChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
     if resolved.bot_token().is_none() {
@@ -4575,7 +4598,12 @@ fn build_slack_snapshot_for_account(
     }
 
     let api_base_url = resolved.resolved_api_base_url();
-    validate_http_url("api_base_url", api_base_url.as_str(), &mut send_issues);
+    validate_http_url(
+        "api_base_url",
+        api_base_url.as_str(),
+        http_policy,
+        &mut send_issues,
+    );
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -4642,6 +4670,7 @@ fn build_line_snapshot_for_account(
     resolved: ResolvedLineChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
     if resolved.channel_access_token().is_none() {
@@ -4649,10 +4678,12 @@ fn build_line_snapshot_for_account(
     }
 
     let api_base_url = resolved.resolved_api_base_url();
-    let api_base_url_parse = reqwest::Url::parse(api_base_url.as_str());
-    if let Err(error) = api_base_url_parse {
-        send_issues.push(format!("api_base_url is invalid: {error}"));
-    }
+    validate_http_url(
+        "api_base_url",
+        api_base_url.as_str(),
+        http_policy,
+        &mut send_issues,
+    );
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -4719,6 +4750,7 @@ fn build_whatsapp_snapshot_for_account(
     resolved: ResolvedWhatsappChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
     if resolved.access_token().is_none() {
@@ -4729,7 +4761,12 @@ fn build_whatsapp_snapshot_for_account(
     }
 
     let api_base_url = resolved.resolved_api_base_url();
-    validate_http_url("api_base_url", api_base_url.as_str(), &mut send_issues);
+    validate_http_url(
+        "api_base_url",
+        api_base_url.as_str(),
+        http_policy,
+        &mut send_issues,
+    );
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -4933,6 +4970,7 @@ fn build_webhook_snapshot_for_account(
     resolved: ResolvedWebhookChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -4941,7 +4979,7 @@ fn build_webhook_snapshot_for_account(
         send_issues.push("endpoint_url is missing".to_owned());
     }
     if let Some(endpoint_url) = endpoint_url.as_deref() {
-        validate_http_url("endpoint_url", endpoint_url, &mut send_issues);
+        validate_http_url("endpoint_url", endpoint_url, http_policy, &mut send_issues);
     }
 
     let auth_token = resolved.auth_token();
@@ -5042,6 +5080,7 @@ fn build_google_chat_snapshot_for_account(
     resolved: ResolvedGoogleChatChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -5049,9 +5088,8 @@ fn build_google_chat_snapshot_for_account(
     if webhook_url.is_none() {
         send_issues.push("webhook_url is missing".to_owned());
     }
-    let parsed_webhook_url = webhook_url.as_deref().map(reqwest::Url::parse).transpose();
-    if let Err(error) = parsed_webhook_url {
-        send_issues.push(format!("webhook_url is invalid: {error}"));
+    if let Some(webhook_url) = webhook_url.as_deref() {
+        validate_http_url("webhook_url", webhook_url, http_policy, &mut send_issues);
     }
 
     let send_operation = if !compiled {
@@ -5119,6 +5157,7 @@ fn build_mattermost_snapshot_for_account(
     resolved: ResolvedMattermostChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -5126,9 +5165,8 @@ fn build_mattermost_snapshot_for_account(
     if server_url.is_none() {
         send_issues.push("server_url is missing".to_owned());
     }
-    let parsed_server_url = server_url.as_deref().map(reqwest::Url::parse).transpose();
-    if let Err(error) = parsed_server_url {
-        send_issues.push(format!("server_url is invalid: {error}"));
+    if let Some(server_url) = server_url.as_deref() {
+        validate_http_url("server_url", server_url, http_policy, &mut send_issues);
     }
     if resolved.bot_token().is_none() {
         send_issues.push("bot_token is missing".to_owned());
@@ -5199,6 +5237,7 @@ fn build_nextcloud_talk_snapshot_for_account(
     resolved: ResolvedNextcloudTalkChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -5206,9 +5245,8 @@ fn build_nextcloud_talk_snapshot_for_account(
     if server_url.is_none() {
         send_issues.push("server_url is missing".to_owned());
     }
-    let parsed_server_url = server_url.as_deref().map(reqwest::Url::parse).transpose();
-    if let Err(error) = parsed_server_url {
-        send_issues.push(format!("server_url is invalid: {error}"));
+    if let Some(server_url) = server_url.as_deref() {
+        validate_http_url("server_url", server_url, http_policy, &mut send_issues);
     }
     if resolved.shared_secret().is_none() {
         send_issues.push("shared_secret is missing".to_owned());
@@ -5279,6 +5317,7 @@ fn build_synology_chat_snapshot_for_account(
     resolved: ResolvedSynologyChatChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -5286,9 +5325,8 @@ fn build_synology_chat_snapshot_for_account(
     if incoming_url.is_none() {
         send_issues.push("incoming_url is missing".to_owned());
     }
-    let parsed_incoming_url = incoming_url.as_deref().map(reqwest::Url::parse).transpose();
-    if let Err(error) = parsed_incoming_url {
-        send_issues.push(format!("incoming_url is invalid: {error}"));
+    if let Some(incoming_url) = incoming_url.as_deref() {
+        validate_http_url("incoming_url", incoming_url, http_policy, &mut send_issues);
     }
 
     let send_operation = if !compiled {
@@ -5367,6 +5405,7 @@ fn build_signal_snapshot_for_account(
     resolved: ResolvedSignalChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
     if resolved.signal_account().is_none() {
@@ -5378,7 +5417,7 @@ fn build_signal_snapshot_for_account(
         send_issues.push("service_url is missing".to_owned());
     }
     if let Some(service_url) = service_url.as_deref() {
-        validate_http_url("service_url", service_url, &mut send_issues);
+        validate_http_url("service_url", service_url, http_policy, &mut send_issues);
     }
 
     let send_operation = if !compiled {
@@ -5449,6 +5488,7 @@ fn build_teams_snapshot_for_account(
     resolved: ResolvedTeamsChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -5456,9 +5496,8 @@ fn build_teams_snapshot_for_account(
     if webhook_url.is_none() {
         send_issues.push("webhook_url is missing".to_owned());
     }
-    let parsed_webhook_url = webhook_url.as_deref().map(reqwest::Url::parse).transpose();
-    if let Err(error) = parsed_webhook_url {
-        send_issues.push(format!("webhook_url is invalid: {error}"));
+    if let Some(webhook_url) = webhook_url.as_deref() {
+        validate_http_url("webhook_url", webhook_url, http_policy, &mut send_issues);
     }
 
     let send_operation = if !compiled {
@@ -5538,6 +5577,7 @@ fn build_imessage_snapshot_for_account(
     resolved: ResolvedImessageChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: super::http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
 
@@ -5546,7 +5586,7 @@ fn build_imessage_snapshot_for_account(
         send_issues.push("bridge_url is missing".to_owned());
     }
     if let Some(bridge_url) = bridge_url.as_deref() {
-        validate_http_url("bridge_url", bridge_url, &mut send_issues);
+        validate_http_url("bridge_url", bridge_url, http_policy, &mut send_issues);
     }
     if resolved.bridge_token().is_none() {
         send_issues.push("bridge_token is missing".to_owned());
@@ -9165,7 +9205,7 @@ mod tests {
         assert!(
             send.issues
                 .iter()
-                .any(|issue| issue.contains("api_base_url must use http or https")),
+                .any(|issue| issue.contains("requires http or https")),
             "send issues should reject non-http discord api base urls"
         );
     }
@@ -9220,7 +9260,7 @@ mod tests {
     }
 
     #[test]
-    fn signal_status_requires_account_for_send() {
+    fn signal_status_blocks_default_private_service_url_without_override() {
         let mut config = LoongClawConfig::default();
         config.signal.enabled = true;
 
@@ -9242,8 +9282,8 @@ mod tests {
         assert!(
             send.issues
                 .iter()
-                .all(|issue| !issue.contains("service_url is missing")),
-            "default signal service URL should satisfy the service endpoint requirement"
+                .any(|issue| issue.contains("private or special-use")),
+            "default signal service URL should be blocked until the operator widens outbound_http"
         );
         assert_eq!(serve.health, ChannelOperationHealth::Unsupported);
         assert_eq!(
@@ -9271,8 +9311,55 @@ mod tests {
         assert!(
             send.issues
                 .iter()
-                .any(|issue| issue.contains("service_url must use http or https")),
+                .any(|issue| issue.contains("requires http or https")),
             "send issues should reject non-http signal service urls"
+        );
+    }
+
+    #[test]
+    fn signal_status_allows_private_service_url_when_outbound_http_override_is_enabled() {
+        let mut config = LoongClawConfig::default();
+        config.signal.enabled = true;
+        config.signal.signal_account = Some("+15550001111".to_owned());
+        config.outbound_http.allow_private_hosts = true;
+
+        let snapshots = channel_status_snapshots(&config);
+        let signal = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "signal")
+            .expect("signal snapshot");
+        let send = signal.operation("send").expect("signal send operation");
+
+        assert_eq!(send.health, ChannelOperationHealth::Ready);
+        assert!(
+            send.issues.is_empty(),
+            "widened outbound_http policy should allow the default local signal bridge"
+        );
+    }
+
+    #[test]
+    fn google_chat_status_rejects_credential_bearing_webhook_url() {
+        let mut config = LoongClawConfig::default();
+        config.google_chat.enabled = true;
+        config.google_chat.webhook_url = Some(loongclaw_contracts::SecretRef::Inline(
+            "https://user:pass@chat.googleapis.com/v1/spaces/AAAA/messages".to_owned(),
+        ));
+
+        let snapshots = channel_status_snapshots(&config);
+        let google_chat = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "google-chat")
+            .expect("google chat snapshot");
+        let send = google_chat
+            .operation("send")
+            .expect("google chat send operation");
+
+        assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
+        assert!(
+            send.issues
+                .iter()
+                .any(|issue| issue.contains("must not embed credentials")),
+            "send issues should reject credential-bearing google chat webhook urls"
         );
     }
 

--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -5578,7 +5578,7 @@ fn build_teams_snapshot_for_account(
         api_base_url: validated_webhook_url
             .as_ref()
             .and(webhook_url.as_deref())
-            .and_then(super::http::redact_endpoint_status_url),
+            .and_then(super::http::redact_generic_webhook_status_url),
         notes,
         operations: vec![send_operation, serve_operation],
     }
@@ -8754,7 +8754,7 @@ mod tests {
     }
 
     #[test]
-    fn channel_status_snapshots_redact_endpoint_query_secrets_for_webhook_channels() {
+    fn channel_status_snapshots_redact_webhook_channel_status_urls() {
         let config: LoongClawConfig = serde_json::from_value(serde_json::json!({
             "dingtalk": {
                 "enabled": true,
@@ -8803,7 +8803,7 @@ mod tests {
         );
         assert_eq!(
             teams.api_base_url.as_deref(),
-            Some("https://outlook.office.com/webhook/abc123/IncomingWebhook/demo")
+            Some("https://outlook.office.com/")
         );
         assert_eq!(
             synology_chat.api_base_url.as_deref(),

--- a/crates/app/src/channel/registry/trust_boundary_tests.rs
+++ b/crates/app/src/channel/registry/trust_boundary_tests.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+#[test]
+fn signal_status_blocks_default_private_service_url_without_override() {
+    let mut config = LoongClawConfig::default();
+    config.signal.enabled = true;
+
+    let snapshots = channel_status_snapshots(&config);
+    let signal = snapshots
+        .iter()
+        .find(|snapshot| snapshot.id == "signal")
+        .expect("signal snapshot");
+    let send = signal.operation("send").expect("signal send operation");
+    let serve = signal.operation("serve").expect("signal serve operation");
+
+    assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
+    assert!(
+        send.issues
+            .iter()
+            .any(|issue| issue.contains("account is missing")),
+        "send issues should require a signal account"
+    );
+    assert!(
+        send.issues
+            .iter()
+            .any(|issue| issue.contains("private or special-use")),
+        "default signal service URL should be blocked until the operator widens outbound_http"
+    );
+    assert_eq!(serve.health, ChannelOperationHealth::Unsupported);
+    assert_eq!(
+        signal.api_base_url.as_deref(),
+        Some("http://127.0.0.1:8080")
+    );
+    assert!(serve.runtime.is_none());
+}
+
+#[test]
+fn signal_status_rejects_non_http_service_url() {
+    let mut config = LoongClawConfig::default();
+    config.signal.enabled = true;
+    config.signal.signal_account = Some("+15550001111".to_owned());
+    config.signal.service_url = Some("file:///tmp/signal-api".to_owned());
+
+    let snapshots = channel_status_snapshots(&config);
+    let signal = snapshots
+        .iter()
+        .find(|snapshot| snapshot.id == "signal")
+        .expect("signal snapshot");
+    let send = signal.operation("send").expect("signal send operation");
+
+    assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
+    assert!(
+        send.issues
+            .iter()
+            .any(|issue| issue.contains("requires http or https")),
+        "send issues should reject non-http signal service urls"
+    );
+}
+
+#[test]
+fn signal_status_allows_private_service_url_when_outbound_http_override_is_enabled() {
+    let mut config = LoongClawConfig::default();
+    config.signal.enabled = true;
+    config.signal.signal_account = Some("+15550001111".to_owned());
+    config.outbound_http.allow_private_hosts = true;
+
+    let snapshots = channel_status_snapshots(&config);
+    let signal = snapshots
+        .iter()
+        .find(|snapshot| snapshot.id == "signal")
+        .expect("signal snapshot");
+    let send = signal.operation("send").expect("signal send operation");
+
+    assert_eq!(send.health, ChannelOperationHealth::Ready);
+    assert!(
+        send.issues.is_empty(),
+        "widened outbound_http policy should allow the default local signal bridge"
+    );
+}
+
+#[test]
+fn google_chat_status_rejects_credential_bearing_webhook_url() {
+    let mut config = LoongClawConfig::default();
+    config.google_chat.enabled = true;
+    config.google_chat.webhook_url = Some(loongclaw_contracts::SecretRef::Inline(
+        "https://user:pass@chat.googleapis.com/v1/spaces/AAAA/messages".to_owned(),
+    ));
+
+    let snapshots = channel_status_snapshots(&config);
+    let google_chat = snapshots
+        .iter()
+        .find(|snapshot| snapshot.id == "google-chat")
+        .expect("google chat snapshot");
+    let send = google_chat
+        .operation("send")
+        .expect("google chat send operation");
+
+    assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
+    assert!(
+        send.issues
+            .iter()
+            .any(|issue| issue.contains("must not embed credentials")),
+        "send issues should reject credential-bearing google chat webhook urls"
+    );
+}

--- a/crates/app/src/channel/registry/trust_boundary_tests.rs
+++ b/crates/app/src/channel/registry/trust_boundary_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn signal_status_blocks_default_private_service_url_without_override() {
+fn signal_status_hides_blocked_private_service_url_without_override() {
     let mut config = LoongClawConfig::default();
     config.signal.enabled = true;
 
@@ -27,9 +27,9 @@ fn signal_status_blocks_default_private_service_url_without_override() {
         "default signal service URL should be blocked until the operator widens outbound_http"
     );
     assert_eq!(serve.health, ChannelOperationHealth::Unsupported);
-    assert_eq!(
-        signal.api_base_url.as_deref(),
-        Some("http://127.0.0.1:8080")
+    assert!(
+        signal.api_base_url.is_none(),
+        "blocked private service urls should not be emitted in status output"
     );
     assert!(serve.runtime.is_none());
 }
@@ -58,6 +58,33 @@ fn signal_status_rejects_non_http_service_url() {
 }
 
 #[test]
+fn signal_status_hides_credential_bearing_service_url() {
+    let mut config = LoongClawConfig::default();
+    config.signal.enabled = true;
+    config.signal.signal_account = Some("+15550001111".to_owned());
+    config.signal.service_url = Some("https://user:pass@signal.example.test/api".to_owned());
+
+    let snapshots = channel_status_snapshots(&config);
+    let signal = snapshots
+        .iter()
+        .find(|snapshot| snapshot.id == "signal")
+        .expect("signal snapshot");
+    let send = signal.operation("send").expect("signal send operation");
+
+    assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
+    assert!(
+        send.issues
+            .iter()
+            .any(|issue| issue.contains("must not embed credentials")),
+        "send issues should reject credential-bearing signal service urls"
+    );
+    assert!(
+        signal.api_base_url.is_none(),
+        "credential-bearing service urls should not be emitted in status output"
+    );
+}
+
+#[test]
 fn signal_status_allows_private_service_url_when_outbound_http_override_is_enabled() {
     let mut config = LoongClawConfig::default();
     config.signal.enabled = true;
@@ -75,6 +102,10 @@ fn signal_status_allows_private_service_url_when_outbound_http_override_is_enabl
     assert!(
         send.issues.is_empty(),
         "widened outbound_http policy should allow the default local signal bridge"
+    );
+    assert_eq!(
+        signal.api_base_url.as_deref(),
+        Some("http://127.0.0.1:8080")
     );
 }
 

--- a/crates/app/src/channel/registry/twitch.rs
+++ b/crates/app/src/channel/registry/twitch.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::channel::http;
 
 const TWITCH_ENABLED_REQUIREMENT: ChannelCatalogOperationRequirement =
     ChannelCatalogOperationRequirement {
@@ -92,6 +93,7 @@ pub(super) fn build_twitch_snapshots(
     _now_ms: u64,
 ) -> Vec<ChannelStatusSnapshot> {
     let compiled = cfg!(feature = "channel-twitch");
+    let http_policy = http::outbound_http_policy_from_config(config);
     let default_selection = config.twitch.default_configured_account_selection();
     let default_configured_account_id = default_selection.id.clone();
     let default_account_source = default_selection.source;
@@ -113,6 +115,7 @@ pub(super) fn build_twitch_snapshots(
                     resolved,
                     is_default_account,
                     default_account_source,
+                    http_policy,
                 ),
                 Err(error) => build_invalid_twitch_snapshot(
                     descriptor,
@@ -133,21 +136,28 @@ fn build_twitch_snapshot_for_account(
     resolved: ResolvedTwitchChannelConfig,
     is_default_account: bool,
     default_account_source: ChannelDefaultAccountSelectionSource,
+    http_policy: http::ChannelOutboundHttpPolicy,
 ) -> ChannelStatusSnapshot {
     let mut send_issues = Vec::new();
     if resolved.access_token().is_none() {
         send_issues.push("access_token is missing".to_owned());
     }
 
-    let api_base_url = resolved.resolved_api_base_url();
-    validate_http_url("api_base_url", api_base_url.as_str(), &mut send_issues);
-    let status_api_base_url = redact_endpoint_status_url(Some(api_base_url.clone()))
-        .unwrap_or_else(|| api_base_url.clone());
+    let resolved_api_base_url = resolved.resolved_api_base_url();
+    let api_base_url = validate_twitch_base_url(
+        "api_base_url",
+        resolved_api_base_url.as_str(),
+        http_policy,
+        &mut send_issues,
+    );
 
-    let oauth_base_url = resolved.resolved_oauth_base_url();
-    validate_http_url("oauth_base_url", oauth_base_url.as_str(), &mut send_issues);
-    let status_oauth_base_url = redact_endpoint_status_url(Some(oauth_base_url.clone()))
-        .unwrap_or_else(|| oauth_base_url.clone());
+    let resolved_oauth_base_url = resolved.resolved_oauth_base_url();
+    let oauth_base_url = validate_twitch_base_url(
+        "oauth_base_url",
+        resolved_oauth_base_url.as_str(),
+        http_policy,
+        &mut send_issues,
+    );
 
     let send_operation = if !compiled {
         unsupported_operation(
@@ -182,8 +192,13 @@ fn build_twitch_snapshot_for_account(
         format!("configured_account={}", resolved.configured_account_label),
         format!("account_id={}", resolved.account.id),
         format!("account={}", resolved.account.label),
-        format!("oauth_base_url={status_oauth_base_url}"),
     ];
+    let status_oauth_base_url = oauth_base_url
+        .as_ref()
+        .and_then(|_| http::redact_endpoint_status_url(resolved_oauth_base_url.as_str()));
+    if let Some(status_oauth_base_url) = status_oauth_base_url {
+        notes.push(format!("oauth_base_url={status_oauth_base_url}"));
+    }
     if !resolved.channel_names.is_empty() {
         let future_serve_channel_names = resolved.channel_names.join(",");
         notes.push(format!(
@@ -209,10 +224,31 @@ fn build_twitch_snapshot_for_account(
         transport: descriptor.transport,
         compiled,
         enabled: resolved.enabled,
-        api_base_url: Some(status_api_base_url),
+        api_base_url: api_base_url
+            .as_ref()
+            .and_then(|_| http::redact_endpoint_status_url(resolved_api_base_url.as_str())),
         notes,
         operations: vec![send_operation, serve_operation],
     }
+}
+
+fn validate_twitch_base_url(
+    field: &str,
+    value: &str,
+    policy: http::ChannelOutboundHttpPolicy,
+    issues: &mut Vec<String>,
+) -> Option<reqwest::Url> {
+    let validated_url = validate_http_url(field, value, policy, issues)?;
+    if validated_url.query().is_some() {
+        issues.push(format!("{field} must not include a query string"));
+        return None;
+    }
+    if validated_url.fragment().is_some() {
+        issues.push(format!("{field} must not include a url fragment"));
+        return None;
+    }
+
+    Some(validated_url)
 }
 
 fn build_invalid_twitch_snapshot(
@@ -318,14 +354,61 @@ mod tests {
     }
 
     #[test]
-    fn twitch_status_redacts_override_urls_in_snapshot_output() {
+    fn twitch_status_hides_query_bearing_override_urls_in_snapshot_output() {
         let mut config = LoongClawConfig::default();
         config.twitch.enabled = true;
         config.twitch.access_token = Some(loongclaw_contracts::SecretRef::Inline(
             "twitch-user-token".to_owned(),
         ));
-        config.twitch.api_base_url =
-            Some("https://user:secret@api.twitch.test/helix?token=secret".to_owned());
+        config.twitch.api_base_url = Some("https://api.twitch.test/helix?token=secret".to_owned());
+        config.twitch.oauth_base_url =
+            Some("https://id.twitch.test/oauth2?client=secret".to_owned());
+
+        let snapshots = channel_status_snapshots(&config);
+        let twitch = snapshots
+            .iter()
+            .find(|snapshot| snapshot.id == "twitch")
+            .expect("twitch snapshot");
+        let send = twitch.operation("send").expect("twitch send operation");
+
+        assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
+        assert!(
+            send.issues
+                .iter()
+                .any(|issue| issue == "api_base_url must not include a query string"),
+            "send issues should reject twitch api base urls with query strings"
+        );
+        assert!(
+            send.issues
+                .iter()
+                .any(|issue| issue == "oauth_base_url must not include a query string"),
+            "send issues should reject twitch oauth base urls with query strings"
+        );
+        assert!(
+            twitch.api_base_url.is_none(),
+            "query-bearing twitch api urls should not be emitted in status output"
+        );
+        assert!(
+            twitch
+                .notes
+                .iter()
+                .all(|note| !note.starts_with("oauth_base_url=")),
+            "query-bearing twitch oauth urls should not be emitted in status notes"
+        );
+        assert!(
+            twitch.notes.iter().all(|note| !note.contains("secret")),
+            "status output should not leak query-bearing override secrets"
+        );
+    }
+
+    #[test]
+    fn twitch_status_hides_blocked_or_invalid_urls_in_snapshot_output() {
+        let mut config = LoongClawConfig::default();
+        config.twitch.enabled = true;
+        config.twitch.access_token = Some(loongclaw_contracts::SecretRef::Inline(
+            "twitch-user-token".to_owned(),
+        ));
+        config.twitch.api_base_url = Some("http://127.0.0.1:8080/helix".to_owned());
         config.twitch.oauth_base_url =
             Some("https://oauth:secret@id.twitch.test/oauth2?client=secret".to_owned());
 
@@ -334,21 +417,35 @@ mod tests {
             .iter()
             .find(|snapshot| snapshot.id == "twitch")
             .expect("twitch snapshot");
+        let send = twitch.operation("send").expect("twitch send operation");
 
-        assert_eq!(
-            twitch.api_base_url.as_deref(),
-            Some("https://api.twitch.test/helix")
+        assert_eq!(send.health, ChannelOperationHealth::Misconfigured);
+        assert!(
+            send.issues
+                .iter()
+                .any(|issue| issue.contains("private or special-use")),
+            "send issues should reject blocked private twitch api urls"
+        );
+        assert!(
+            send.issues
+                .iter()
+                .any(|issue| issue.contains("must not embed credentials")),
+            "send issues should reject credential-bearing twitch oauth urls"
+        );
+        assert!(
+            twitch.api_base_url.is_none(),
+            "blocked twitch api urls should not be emitted in status output"
         );
         assert!(
             twitch
                 .notes
                 .iter()
-                .any(|note| note == "oauth_base_url=https://id.twitch.test/oauth2"),
-            "status notes should redact override oauth urls"
+                .all(|note| !note.starts_with("oauth_base_url=")),
+            "invalid twitch oauth urls should not be emitted in status notes"
         );
         assert!(
             twitch.notes.iter().all(|note| !note.contains("secret")),
-            "status output should not leak override credentials"
+            "status output should not leak rejected twitch oauth credentials"
         );
     }
 }

--- a/crates/app/src/channel/signal.rs
+++ b/crates/app/src/channel/signal.rs
@@ -2,13 +2,17 @@ use serde_json::json;
 
 use crate::{CliResult, config::ResolvedSignalChannelConfig};
 
-use super::ChannelOutboundTargetKind;
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 pub(super) async fn run_signal_send(
     resolved: &ResolvedSignalChannelConfig,
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Address {
         return Err(format!(
@@ -29,14 +33,16 @@ pub(super) async fn run_signal_send(
     }
 
     let request_url = format!("{}/v2/send", service_url.trim_end_matches('/'));
+    let request_url =
+        validate_outbound_http_target("signal service_url", request_url.as_str(), policy)?;
     let request_body = json!({
         "message": text,
         "number": account,
         "recipients": [recipient],
     });
 
-    let client = reqwest::Client::new();
-    let request = client.post(request_url.as_str()).json(&request_body);
+    let client = build_outbound_http_client("signal send", policy)?;
+    let request = client.post(request_url).json(&request_body);
     let response = request
         .send()
         .await

--- a/crates/app/src/channel/slack.rs
+++ b/crates/app/src/channel/slack.rs
@@ -2,13 +2,17 @@ use serde_json::{Value, json};
 
 use crate::{CliResult, config::ResolvedSlackChannelConfig};
 
-use super::ChannelOutboundTargetKind;
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 pub(super) async fn run_slack_send(
     resolved: &ResolvedSlackChannelConfig,
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Conversation {
         return Err(format!(
@@ -27,14 +31,16 @@ pub(super) async fn run_slack_send(
 
     let api_base_url = resolved.resolved_api_base_url();
     let request_url = format!("{}/chat.postMessage", api_base_url.trim_end_matches('/'));
+    let request_url =
+        validate_outbound_http_target("slack api_base_url", request_url.as_str(), policy)?;
     let request_body = json!({
         "channel": channel_id,
         "text": text,
     });
 
-    let client = reqwest::Client::new();
+    let client = build_outbound_http_client("slack send", policy)?;
     let request = client
-        .post(request_url.as_str())
+        .post(request_url)
         .bearer_auth(bot_token)
         .json(&request_body);
     let response = request

--- a/crates/app/src/channel/synology_chat.rs
+++ b/crates/app/src/channel/synology_chat.rs
@@ -2,7 +2,10 @@ use serde::Serialize;
 
 use crate::{CliResult, config::ResolvedSynologyChatChannelConfig};
 
-use super::{ChannelOutboundTargetKind, http::build_outbound_http_client};
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 #[derive(Debug, Serialize)]
 struct SynologyChatWebhookPayload {
@@ -16,6 +19,7 @@ pub(super) async fn run_synology_chat_send(
     target_kind: ChannelOutboundTargetKind,
     target_id: Option<&str>,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Address {
         return Err(format!(
@@ -27,12 +31,12 @@ pub(super) async fn run_synology_chat_send(
     let incoming_url = resolved.incoming_url().ok_or_else(|| {
         "synology_chat incoming_url missing (set synology_chat.incoming_url or env)".to_owned()
     })?;
-    let request_url = reqwest::Url::parse(incoming_url.as_str())
-        .map_err(|error| format!("synology chat incoming_url is invalid: {error}"))?;
+    let request_url =
+        validate_outbound_http_target("synology chat incoming_url", incoming_url.as_str(), policy)?;
     let target_user_id = parse_synology_chat_target_user_id(target_id)?;
     let request_payload_json = build_synology_chat_payload_json(text, target_user_id)?;
 
-    let client = build_outbound_http_client("synology chat send")?;
+    let client = build_outbound_http_client("synology chat send", policy)?;
     let request = client
         .post(request_url)
         .form(&[("payload", request_payload_json)]);

--- a/crates/app/src/channel/teams.rs
+++ b/crates/app/src/channel/teams.rs
@@ -2,7 +2,10 @@ use serde::Serialize;
 
 use crate::{CliResult, config::ResolvedTeamsChannelConfig};
 
-use super::{ChannelOutboundTargetKind, http::build_outbound_http_client};
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 const TEAMS_ADAPTIVE_CARD_SCHEMA: &str = "http://adaptivecards.io/schemas/adaptive-card.json";
 const TEAMS_ADAPTIVE_CARD_CONTENT_TYPE: &str = "application/vnd.microsoft.card.adaptive";
@@ -44,12 +47,13 @@ pub(super) async fn run_teams_send(
     target_kind: ChannelOutboundTargetKind,
     endpoint_url: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     ensure_teams_target_kind(target_kind)?;
-    let request_url = parse_teams_endpoint_url(endpoint_url)?;
+    let request_url = parse_teams_endpoint_url(endpoint_url, policy)?;
     let request_body = build_teams_webhook_payload(text);
 
-    let client = build_outbound_http_client("teams send")?;
+    let client = build_outbound_http_client("teams send", policy)?;
     let request = client.post(request_url).json(&request_body);
     let response = request
         .send()
@@ -70,14 +74,11 @@ fn ensure_teams_target_kind(target_kind: ChannelOutboundTargetKind) -> CliResult
     ))
 }
 
-fn parse_teams_endpoint_url(endpoint_url: &str) -> CliResult<reqwest::Url> {
-    let trimmed_endpoint_url = endpoint_url.trim();
-    if trimmed_endpoint_url.is_empty() {
-        return Err("teams outbound target endpoint is empty".to_owned());
-    }
-
-    reqwest::Url::parse(trimmed_endpoint_url)
-        .map_err(|error| format!("teams outbound target endpoint is invalid: {error}"))
+fn parse_teams_endpoint_url(
+    endpoint_url: &str,
+    policy: ChannelOutboundHttpPolicy,
+) -> CliResult<reqwest::Url> {
+    validate_outbound_http_target("teams outbound target endpoint", endpoint_url, policy)
 }
 
 fn build_teams_webhook_payload(text: &str) -> TeamsWebhookPayload {

--- a/crates/app/src/channel/tlon.rs
+++ b/crates/app/src/channel/tlon.rs
@@ -7,7 +7,10 @@ use crate::{CliResult, config::ResolvedTlonChannelConfig};
 
 use super::{
     ChannelOutboundTargetKind,
-    http::{build_outbound_http_client, response_body_detail},
+    http::{
+        ChannelOutboundHttpPolicy, build_outbound_http_client, response_body_detail,
+        validate_outbound_http_target,
+    },
 };
 
 const TLON_LOGIN_PATH: &str = "/~/login";
@@ -37,6 +40,7 @@ pub(super) async fn run_tlon_send(
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     ensure_tlon_target_kind(target_kind)?;
 
@@ -48,7 +52,10 @@ pub(super) async fn run_tlon_send(
     let url_value = resolved
         .url()
         .ok_or_else(|| "tlon url missing (set tlon.url or env)".to_owned())?;
-    let base_url = normalize_tlon_base_url(url_value.as_str())?;
+    let normalized_base_url = normalize_tlon_base_url(url_value.as_str())?;
+    let validated_base_url =
+        validate_outbound_http_target("tlon.url", normalized_base_url.as_str(), policy)?;
+    let base_url = validated_base_url.to_string();
 
     let code = resolved
         .code()
@@ -56,7 +63,7 @@ pub(super) async fn run_tlon_send(
     let target = parse_tlon_send_target(target_id)?;
     let text = normalize_tlon_text(text)?;
 
-    let client = build_outbound_http_client("tlon send")?;
+    let client = build_outbound_http_client("tlon send", policy)?;
     let cookie = login_tlon_ship(&client, base_url.as_str(), code.as_str()).await?;
     let channel_id = build_tlon_channel_id()?;
     let ship_name = from_ship.trim_start_matches('~');
@@ -660,6 +667,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "~nec",
             "hello\nworld",
+            allow_private_hosts_policy(),
         )
         .await;
 
@@ -716,6 +724,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "group:~bus/chat-room",
             "hello group",
+            allow_private_hosts_policy(),
         )
         .await;
 
@@ -759,6 +768,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "~nec",
             "hello",
+            allow_private_hosts_policy(),
         )
         .await;
 
@@ -786,6 +796,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "~nec",
             "hello",
+            allow_private_hosts_policy(),
         )
         .await
         .expect_err("missing login cookie should fail");
@@ -825,6 +836,22 @@ mod tests {
             fragment_error,
             "tlon url must not include a path, query, or fragment"
         );
+    }
+
+    #[tokio::test]
+    async fn run_tlon_send_rejects_private_hosts_by_default() {
+        let resolved = build_resolved_tlon_config("http://127.0.0.1:8080");
+        let error = run_tlon_send(
+            &resolved,
+            ChannelOutboundTargetKind::Conversation,
+            "~nec",
+            "hello",
+            ChannelOutboundHttpPolicy::default(),
+        )
+        .await
+        .expect_err("private hosts should be blocked by default");
+
+        assert!(error.contains("private or special-use"));
     }
 
     #[test]
@@ -916,6 +943,12 @@ mod tests {
             url_env: None,
             code: Some(SecretRef::Inline("lidlut-tabwed-pillex-ridrup".to_owned())),
             code_env: None,
+        }
+    }
+
+    fn allow_private_hosts_policy() -> ChannelOutboundHttpPolicy {
+        ChannelOutboundHttpPolicy {
+            allow_private_hosts: true,
         }
     }
 }

--- a/crates/app/src/channel/tlon_command.rs
+++ b/crates/app/src/channel/tlon_command.rs
@@ -100,6 +100,7 @@ pub async fn run_tlon_send(
     #[cfg(feature = "channel-tlon")]
     {
         let context = load_tlon_command_context(config_path, account_id)?;
+        let outbound_http_policy = super::http::outbound_http_policy_from_config(&context.config);
         let target_text = target.to_owned();
         let message_text = text.to_owned();
         initialize_tlon_runtime(&context.config, context.resolved_path.as_path());
@@ -109,6 +110,7 @@ pub async fn run_tlon_send(
             target_kind,
             target_text.as_str(),
             message_text.as_str(),
+            outbound_http_policy,
         )
         .await?;
 

--- a/crates/app/src/channel/twitch.rs
+++ b/crates/app/src/channel/twitch.rs
@@ -5,7 +5,10 @@ use crate::{CliResult, config::ResolvedTwitchChannelConfig};
 
 use super::{
     ChannelOutboundTargetKind,
-    http::{build_outbound_http_client, read_json_or_text_response, response_body_detail},
+    http::{
+        ChannelOutboundHttpPolicy, build_outbound_http_client, read_json_or_text_response,
+        response_body_detail, validate_outbound_http_target,
+    },
 };
 
 const TWITCH_USER_WRITE_CHAT_SCOPE: &str = "user:write:chat";
@@ -63,6 +66,7 @@ pub(super) async fn run_twitch_send(
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Conversation {
         return Err(format!(
@@ -80,9 +84,9 @@ pub(super) async fn run_twitch_send(
         .access_token()
         .ok_or_else(|| "twitch access token missing (set twitch.access_token or env)".to_owned())?;
 
-    let client = build_outbound_http_client("twitch send")?;
+    let client = build_outbound_http_client("twitch send", policy)?;
     let validated_token =
-        validate_twitch_access_token(&client, resolved, access_token.as_str()).await?;
+        validate_twitch_access_token(&client, resolved, access_token.as_str(), policy).await?;
     ensure_twitch_send_scope(&validated_token)?;
 
     let broadcaster = resolve_twitch_broadcaster(
@@ -91,12 +95,16 @@ pub(super) async fn run_twitch_send(
         access_token.as_str(),
         validated_token.client_id.as_str(),
         normalized_target_id,
+        policy,
     )
     .await?;
 
-    let api_base_url = resolved.resolved_api_base_url();
-    let trimmed_api_base_url = api_base_url.trim_end_matches('/');
-    let request_url = format!("{trimmed_api_base_url}/chat/messages");
+    let request_url = build_twitch_request_url(
+        "twitch api_base_url",
+        resolved.resolved_api_base_url().as_str(),
+        "chat/messages",
+        policy,
+    )?;
     let request_body = serde_json::json!({
         "broadcaster_id": broadcaster.broadcaster_id,
         "sender_id": validated_token.user_id,
@@ -121,13 +129,17 @@ async fn validate_twitch_access_token(
     client: &reqwest::Client,
     resolved: &ResolvedTwitchChannelConfig,
     access_token: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<ValidatedTwitchToken> {
-    let oauth_base_url = resolved.resolved_oauth_base_url();
-    let trimmed_oauth_base_url = oauth_base_url.trim_end_matches('/');
-    let request_url = format!("{trimmed_oauth_base_url}/validate");
+    let request_url = build_twitch_request_url(
+        "twitch oauth_base_url",
+        resolved.resolved_oauth_base_url().as_str(),
+        "validate",
+        policy,
+    )?;
     let authorization_value = format!("OAuth {access_token}");
     let request = client
-        .get(request_url.as_str())
+        .get(request_url)
         .header("Authorization", authorization_value);
     let response = request
         .send()
@@ -211,6 +223,7 @@ async fn resolve_twitch_broadcaster(
     access_token: &str,
     client_id: &str,
     target_id: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<ResolvedTwitchBroadcaster> {
     let trimmed_target = target_id.trim();
     if trimmed_target.is_empty() {
@@ -218,9 +231,12 @@ async fn resolve_twitch_broadcaster(
     }
 
     let not_found_error = format!("twitch broadcaster `{trimmed_target}` was not found");
-    let api_base_url = resolved.resolved_api_base_url();
-    let trimmed_api_base_url = api_base_url.trim_end_matches('/');
-    let request_url = format!("{trimmed_api_base_url}/users");
+    let request_url = build_twitch_request_url(
+        "twitch api_base_url",
+        resolved.resolved_api_base_url().as_str(),
+        "users",
+        policy,
+    )?;
     let is_numeric_target = trimmed_target.chars().all(|value| value.is_ascii_digit());
 
     if !is_numeric_target {
@@ -314,6 +330,28 @@ async fn lookup_twitch_broadcaster(
     });
 
     Ok(resolved_broadcaster)
+}
+
+fn build_twitch_request_url(
+    field_name: &str,
+    base_url: &str,
+    path_suffix: &str,
+    policy: ChannelOutboundHttpPolicy,
+) -> CliResult<reqwest::Url> {
+    let trimmed_base_url = base_url.trim();
+    let parsed_base_url = validate_outbound_http_target(field_name, trimmed_base_url, policy)?;
+    if parsed_base_url.query().is_some() {
+        return Err(format!("{field_name} must not include a query string"));
+    }
+    if parsed_base_url.fragment().is_some() {
+        return Err(format!("{field_name} must not include a url fragment"));
+    }
+
+    let normalized_base_url = trimmed_base_url.trim_end_matches('/');
+    let raw_request_url = format!("{normalized_base_url}/{path_suffix}");
+    let request_url = reqwest::Url::parse(raw_request_url.as_str())
+        .map_err(|error| format!("{field_name} is invalid: {error}"))?;
+    Ok(request_url)
 }
 
 async fn ensure_twitch_send_success(response: reqwest::Response) -> CliResult<()> {
@@ -418,6 +456,12 @@ mod tests {
         validate_scopes: Arc<Mutex<Vec<String>>>,
     }
 
+    fn private_host_test_policy() -> ChannelOutboundHttpPolicy {
+        ChannelOutboundHttpPolicy {
+            allow_private_hosts: true,
+        }
+    }
+
     #[tokio::test]
     async fn run_twitch_send_validates_token_resolves_target_and_sends_message() {
         let state = MockTwitchState::default();
@@ -445,6 +489,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "streamer",
             "hello from loongclaw",
+            private_host_test_policy(),
         )
         .await;
 
@@ -519,6 +564,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "streamer",
             "hello from loongclaw",
+            private_host_test_policy(),
         )
         .await
         .expect_err("missing scope should fail");
@@ -555,6 +601,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "   ",
             "hello from loongclaw",
+            private_host_test_policy(),
         )
         .await
         .expect_err("blank targets should fail");
@@ -600,6 +647,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "12345",
             "hello from loongclaw",
+            private_host_test_policy(),
         )
         .await;
 
@@ -648,6 +696,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "987654",
             "hello from loongclaw",
+            private_host_test_policy(),
         )
         .await;
 
@@ -696,6 +745,7 @@ mod tests {
             ChannelOutboundTargetKind::Conversation,
             "55555",
             "hello from loongclaw",
+            private_host_test_policy(),
         )
         .await
         .expect_err("ambiguous numeric targets should fail");
@@ -740,6 +790,7 @@ mod tests {
             ChannelOutboundTargetKind::Address,
             "streamer",
             "hello from loongclaw",
+            private_host_test_policy(),
         )
         .await
         .expect_err("address targets should fail");
@@ -748,6 +799,57 @@ mod tests {
             error,
             "twitch send requires conversation target kind, got address"
         );
+    }
+
+    #[test]
+    fn build_twitch_request_url_preserves_base_path() {
+        let policy = ChannelOutboundHttpPolicy {
+            allow_private_hosts: false,
+        };
+        let request_url = build_twitch_request_url(
+            "twitch api_base_url",
+            "https://api.twitch.example/base",
+            "chat/messages",
+            policy,
+        )
+        .expect("build twitch request url");
+
+        assert_eq!(
+            request_url.as_str(),
+            "https://api.twitch.example/base/chat/messages"
+        );
+    }
+
+    #[test]
+    fn build_twitch_request_url_rejects_private_hosts_without_override() {
+        let policy = ChannelOutboundHttpPolicy {
+            allow_private_hosts: false,
+        };
+        let error = build_twitch_request_url(
+            "twitch api_base_url",
+            "http://127.0.0.1:8080/helix",
+            "chat/messages",
+            policy,
+        )
+        .expect_err("private hosts should be rejected");
+
+        assert!(error.contains("private or special-use"));
+    }
+
+    #[test]
+    fn build_twitch_request_url_rejects_base_urls_with_query_strings() {
+        let policy = ChannelOutboundHttpPolicy {
+            allow_private_hosts: false,
+        };
+        let error = build_twitch_request_url(
+            "twitch api_base_url",
+            "https://api.twitch.example/helix?token=secret",
+            "chat/messages",
+            policy,
+        )
+        .expect_err("query-bearing base urls should be rejected");
+
+        assert_eq!(error, "twitch api_base_url must not include a query string");
     }
 
     fn build_mock_twitch_router(state: MockTwitchState) -> Router {

--- a/crates/app/src/channel/twitch_command.rs
+++ b/crates/app/src/channel/twitch_command.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use super::{
     ChannelCommandContext, ChannelOutboundTargetKind, ChannelSendCommandSpec, LoongClawConfig,
-    run_channel_send_command, twitch,
+    http, run_channel_send_command, twitch,
 };
 use crate::CliResult;
 use crate::config::{self, ResolvedTwitchChannelConfig};
@@ -61,6 +61,7 @@ pub async fn run_twitch_send(
     #[cfg(feature = "channel-twitch")]
     {
         let context = load_twitch_command_context(config_path, account_id)?;
+        let outbound_http_policy = http::outbound_http_policy_from_config(&context.config);
         let target = target.to_owned();
         let text = text.to_owned();
 
@@ -76,6 +77,7 @@ pub async fn run_twitch_send(
                         target_kind,
                         target.as_str(),
                         text.as_str(),
+                        outbound_http_policy,
                     )
                     .await
                 })

--- a/crates/app/src/channel/webhook.rs
+++ b/crates/app/src/channel/webhook.rs
@@ -8,7 +8,10 @@ use crate::{
 
 use super::{
     ChannelOutboundTargetKind,
-    http::{build_outbound_http_client, response_body_detail},
+    http::{
+        ChannelOutboundHttpPolicy, build_outbound_http_client, response_body_detail,
+        validate_outbound_http_target,
+    },
     webhook_auth::build_webhook_auth_header_from_parts,
 };
 
@@ -25,14 +28,15 @@ pub(super) async fn run_webhook_send(
     target_kind: ChannelOutboundTargetKind,
     endpoint_url: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     ensure_webhook_target_kind(target_kind)?;
 
-    let request_url = parse_webhook_endpoint_url(endpoint_url)?;
+    let request_url = parse_webhook_endpoint_url(endpoint_url, policy)?;
     let request_body = build_webhook_request_body(resolved, text)?;
     let auth_header = build_webhook_auth_header(resolved)?;
 
-    let client = build_outbound_http_client("webhook send")?;
+    let client = build_outbound_http_client("webhook send", policy)?;
     let mut request = client
         .post(request_url)
         .header(CONTENT_TYPE, request_body.content_type)
@@ -61,24 +65,11 @@ fn ensure_webhook_target_kind(target_kind: ChannelOutboundTargetKind) -> CliResu
     ))
 }
 
-fn parse_webhook_endpoint_url(endpoint_url: &str) -> CliResult<reqwest::Url> {
-    let trimmed_endpoint_url = endpoint_url.trim();
-    if trimmed_endpoint_url.is_empty() {
-        return Err("webhook outbound target endpoint is empty".to_owned());
-    }
-
-    let request_url = reqwest::Url::parse(trimmed_endpoint_url)
-        .map_err(|error| format!("webhook outbound target endpoint is invalid: {error}"))?;
-    let scheme = request_url.scheme();
-    let is_http = scheme == "http";
-    let is_https = scheme == "https";
-    if is_http || is_https {
-        return Ok(request_url);
-    }
-
-    Err(format!(
-        "webhook outbound target endpoint must use http or https, got {scheme}"
-    ))
+fn parse_webhook_endpoint_url(
+    endpoint_url: &str,
+    policy: ChannelOutboundHttpPolicy,
+) -> CliResult<reqwest::Url> {
+    validate_outbound_http_target("webhook outbound target endpoint", endpoint_url, policy)
 }
 
 fn build_webhook_request_body(

--- a/crates/app/src/channel/whatsapp.rs
+++ b/crates/app/src/channel/whatsapp.rs
@@ -2,13 +2,17 @@ use serde_json::{Value, json};
 
 use crate::{CliResult, config::ResolvedWhatsappChannelConfig};
 
-use super::ChannelOutboundTargetKind;
+use super::{
+    ChannelOutboundTargetKind,
+    http::{ChannelOutboundHttpPolicy, build_outbound_http_client, validate_outbound_http_target},
+};
 
 pub(super) async fn run_whatsapp_send(
     resolved: &ResolvedWhatsappChannelConfig,
     target_kind: ChannelOutboundTargetKind,
     target_id: &str,
     text: &str,
+    policy: ChannelOutboundHttpPolicy,
 ) -> CliResult<()> {
     if target_kind != ChannelOutboundTargetKind::Address {
         return Err(format!(
@@ -34,6 +38,8 @@ pub(super) async fn run_whatsapp_send(
         api_base_url.trim_end_matches('/'),
         phone_number_id.trim()
     );
+    let request_url =
+        validate_outbound_http_target("whatsapp api_base_url", request_url.as_str(), policy)?;
     let request_body = json!({
         "messaging_product": "whatsapp",
         "recipient_type": "individual",
@@ -45,9 +51,9 @@ pub(super) async fn run_whatsapp_send(
         },
     });
 
-    let client = reqwest::Client::new();
+    let client = build_outbound_http_client("whatsapp send", policy)?;
     let request = client
-        .post(request_url.as_str())
+        .post(request_url)
         .bearer_auth(access_token)
         .json(&request_body);
     let response = request

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -4,6 +4,7 @@ mod conversation;
 mod feishu_integration;
 mod irc;
 mod memory;
+mod outbound_http;
 mod provider;
 mod runtime;
 mod shared;
@@ -66,6 +67,8 @@ pub(crate) use irc::{
 pub use memory::{
     MemoryBackendKind, MemoryConfig, MemoryIngestMode, MemoryMode, MemoryProfile, MemorySystemKind,
 };
+#[allow(unused_imports)]
+pub use outbound_http::OutboundHttpConfig;
 #[allow(unused_imports)]
 pub use provider::{
     ModelCatalogProbeRecovery, ProviderAuthScheme, ProviderConfig, ProviderFeatureFamily,

--- a/crates/app/src/config/outbound_http.rs
+++ b/crates/app/src/config/outbound_http.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct OutboundHttpConfig {
+    #[serde(default)]
+    pub allow_private_hosts: bool,
+}
+
+impl OutboundHttpConfig {
+    #[must_use]
+    pub const fn is_default(&self) -> bool {
+        !self.allow_private_hosts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outbound_http_defaults_to_public_only_mode() {
+        let config = OutboundHttpConfig::default();
+        assert!(!config.allow_private_hosts);
+        assert!(config.is_default());
+    }
+}

--- a/crates/app/src/config/runtime.rs
+++ b/crates/app/src/config/runtime.rs
@@ -22,6 +22,7 @@ use super::{
     conversation::ConversationConfig,
     feishu_integration::FeishuIntegrationConfig,
     memory::MemoryConfig,
+    outbound_http::OutboundHttpConfig,
     provider::{ProviderConfig, ProviderKind, ProviderProfileConfig},
     shared::{
         ConfigValidationIssue, ConfigValidationLocale, ConfigValidationSeverity,
@@ -135,6 +136,8 @@ pub struct LoongClawConfig {
     pub feishu_integration: FeishuIntegrationConfig,
     #[serde(default)]
     pub conversation: ConversationConfig,
+    #[serde(default, skip_serializing_if = "OutboundHttpConfig::is_default")]
+    pub outbound_http: OutboundHttpConfig,
     #[serde(default)]
     pub tools: ToolConfig,
     #[serde(default)]
@@ -3486,5 +3489,17 @@ model = "gpt-5"
         let parsed = toml::from_str::<LoongClawConfig>(&encoded).expect("parse encoded config");
 
         assert_eq!(parsed.audit, config.audit);
+    }
+
+    #[test]
+    #[cfg(feature = "config-toml")]
+    fn outbound_http_config_round_trips_private_host_override() {
+        let mut config = LoongClawConfig::default();
+        config.outbound_http.allow_private_hosts = true;
+
+        let encoded = encode_toml_config(&config).expect("encode config");
+        let parsed = toml::from_str::<LoongClawConfig>(&encoded).expect("parse encoded config");
+
+        assert!(parsed.outbound_http.allow_private_hosts);
     }
 }

--- a/crates/app/src/config/tools.rs
+++ b/crates/app/src/config/tools.rs
@@ -235,6 +235,12 @@ pub struct BrowserCompanionToolConfig {
     pub expected_version: Option<String>,
     #[serde(default = "default_browser_companion_timeout_seconds")]
     pub timeout_seconds: u64,
+    #[serde(default)]
+    pub allow_private_hosts: bool,
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+    #[serde(default)]
+    pub blocked_domains: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -469,6 +475,9 @@ impl Default for BrowserCompanionToolConfig {
             command: None,
             expected_version: None,
             timeout_seconds: default_browser_companion_timeout_seconds(),
+            allow_private_hosts: false,
+            allowed_domains: Vec::new(),
+            blocked_domains: Vec::new(),
         }
     }
 }
@@ -839,6 +848,16 @@ pub(crate) fn web_search_provider_parameter_description() -> String {
     format!(
         "Search provider. Defaults to '{DEFAULT_WEB_SEARCH_PROVIDER}'. Supported providers: {WEB_SEARCH_PROVIDER_VALID_VALUES}. DuckDuckGo works without a key. Brave, Tavily, Perplexity, Exa, and Jina use tools.web_search.brave_api_key / tools.web_search.tavily_api_key / tools.web_search.perplexity_api_key / tools.web_search.exa_api_key / tools.web_search.jina_api_key or the {WEB_SEARCH_BRAVE_API_KEY_ENV} / {WEB_SEARCH_TAVILY_API_KEY_ENV} / {WEB_SEARCH_PERPLEXITY_API_KEY_ENV} / {WEB_SEARCH_EXA_API_KEY_ENV} / {WEB_SEARCH_JINA_API_KEY_ENV} / {WEB_SEARCH_JINA_AUTH_TOKEN_ENV} environment variable fallbacks."
     )
+}
+
+impl BrowserCompanionToolConfig {
+    pub fn normalized_allowed_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.allowed_domains)
+    }
+
+    pub fn normalized_blocked_domains(&self) -> Vec<String> {
+        normalize_domain_entries(&self.blocked_domains)
+    }
 }
 
 impl ExternalSkillsConfig {
@@ -1502,6 +1521,9 @@ enabled = true
 command = "loongclaw-browser-companion"
 expected_version = "1.2.3"
 timeout_seconds = 7
+allow_private_hosts = true
+allowed_domains = ["Docs.Example.com", "docs.example.com", " api.example.com "]
+blocked_domains = ["internal.example", " INTERNAL.EXAMPLE "]
 "#;
         let parsed =
             toml::from_str::<crate::config::LoongClawConfig>(raw).expect("parse tool config");
@@ -1516,6 +1538,28 @@ timeout_seconds = 7
             Some("1.2.3")
         );
         assert_eq!(parsed.tools.browser_companion.timeout_seconds, 7);
+        assert!(parsed.tools.browser_companion.allow_private_hosts);
+        assert_eq!(
+            parsed.tools.browser_companion.normalized_allowed_domains(),
+            vec!["api.example.com".to_owned(), "docs.example.com".to_owned()]
+        );
+        assert_eq!(
+            parsed.tools.browser_companion.normalized_blocked_domains(),
+            vec!["internal.example".to_owned()]
+        );
+    }
+
+    #[test]
+    fn browser_companion_defaults_to_safe_public_mode() {
+        let config = BrowserCompanionToolConfig::default();
+        assert!(!config.enabled);
+        assert!(!config.allow_private_hosts);
+        assert!(config.allowed_domains.is_empty());
+        assert!(config.blocked_domains.is_empty());
+        assert_eq!(
+            config.timeout_seconds,
+            default_browser_companion_timeout_seconds()
+        );
     }
 
     /// When `shell_deny` is absent, it must default to empty — users start

--- a/crates/app/src/tools/browser.rs
+++ b/crates/app/src/tools/browser.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
@@ -283,11 +283,16 @@ fn execute_browser_click(
 fn build_browser_client(
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<Client, String> {
+    let resolver = super::web_http::SsrfSafeResolver {
+        allow_private_hosts: config.web_fetch.allow_private_hosts,
+    };
     Client::builder()
         .cookie_store(true)
+        .dns_resolver(Arc::new(resolver))
         .redirect(reqwest::redirect::Policy::none())
         .timeout(Duration::from_secs(config.web_fetch.timeout_seconds))
         .user_agent("LoongClaw-Browser/0.1")
+        .no_proxy()
         .build()
         .map_err(|error| format!("failed to build HTTP client for browser tools: {error}"))
 }
@@ -674,6 +679,7 @@ fn collapse_whitespace(input: &str) -> String {
 #[allow(clippy::panic)]
 mod tests {
     use super::*;
+    use crate::test_support::ScopedEnv;
     use std::io;
     use std::io::{Read, Write};
     use std::net::TcpListener;
@@ -889,6 +895,29 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert_eq!(links[0]["id"], json!(1));
         assert_eq!(links[0]["text"], json!("Continue"));
+        handle.join().expect("server thread");
+    }
+
+    #[test]
+    fn browser_open_ignores_proxy_environment_for_allowed_targets() {
+        let (base_url, handle) = spawn_browser_fixture_server(1);
+        let config = local_browser_config();
+        let mut env = ScopedEnv::new();
+        env.set("HTTP_PROXY", "http://127.0.0.1:1");
+        env.set("http_proxy", "http://127.0.0.1:1");
+
+        let outcome = execute_browser_tool_with_config(
+            scoped_request(
+                "browser.open",
+                json!({"url": base_url}),
+                "test-open-no-proxy",
+            ),
+            &config,
+        )
+        .expect("browser.open should bypass ambient proxy configuration");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["title"], json!("Fixture Home"));
         handle.join().expect("server thread");
     }
 

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -423,6 +423,12 @@ fn execute_browser_companion_request(
     }
 
     let command = browser_companion_command(policy)?;
+    validate_browser_companion_request_target(
+        request.tool_name.as_str(),
+        operation,
+        payload,
+        policy,
+    )?;
     let session_id = if operation.requires_existing_session() {
         let session_id =
             required_payload_string(payload, "session_id", request.tool_name.as_str())?;
@@ -445,6 +451,7 @@ fn execute_browser_companion_request(
             arguments: browser_companion_arguments(payload),
         },
     )?;
+    validate_browser_companion_result_target(request.tool_name.as_str(), &result, policy)?;
 
     match operation {
         BrowserCompanionOperation::SessionStart => {
@@ -513,6 +520,67 @@ fn browser_companion_arguments(payload: &Map<String, Value>) -> Value {
     arguments.remove(super::BROWSER_SESSION_SCOPE_FIELD);
     arguments.remove("session_id");
     Value::Object(arguments)
+}
+
+fn validate_browser_companion_request_target(
+    tool_name: &str,
+    operation: BrowserCompanionOperation,
+    payload: &Map<String, Value>,
+    policy: &super::runtime_config::BrowserCompanionRuntimePolicy,
+) -> Result<(), String> {
+    let starts_session = operation == BrowserCompanionOperation::SessionStart;
+    let navigates = operation == BrowserCompanionOperation::Navigate;
+    if !starts_session && !navigates {
+        return Ok(());
+    }
+
+    let raw_url = required_payload_string(payload, "url", tool_name)?;
+    validate_browser_companion_target_url(
+        raw_url.as_str(),
+        policy,
+        format!("{tool_name} payload.url").as_str(),
+    )
+}
+
+fn validate_browser_companion_result_target(
+    tool_name: &str,
+    result: &Value,
+    policy: &super::runtime_config::BrowserCompanionRuntimePolicy,
+) -> Result<(), String> {
+    let page_url = result
+        .get("page_url")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let Some(page_url) = page_url else {
+        return Ok(());
+    };
+
+    validate_browser_companion_target_url(
+        page_url,
+        policy,
+        format!("{tool_name} result.page_url").as_str(),
+    )
+}
+
+fn validate_browser_companion_target_url(
+    raw_url: &str,
+    policy: &super::runtime_config::BrowserCompanionRuntimePolicy,
+    surface_name: &str,
+) -> Result<(), String> {
+    let parsed_url = reqwest::Url::parse(raw_url)
+        .map_err(|error| format!("{surface_name} is invalid: {error}"))?;
+    let options = super::web_http::HttpTargetValidationOptions {
+        allow_private_hosts: policy.allow_private_hosts,
+        reject_userinfo: false,
+        resolve_dns: false,
+        enforce_allowed_domains: policy.enforce_allowed_domains,
+        allowed_domains: policy
+            .enforce_allowed_domains
+            .then_some(&policy.allowed_domains),
+        blocked_domains: Some(&policy.blocked_domains),
+    };
+    super::web_http::validate_http_target(&parsed_url, &options, surface_name).map(|_| ())
 }
 
 fn required_payload_string(
@@ -740,11 +808,28 @@ mod tests {
         }
     }
 
+    struct ResultRunner {
+        calls: AtomicUsize,
+        result: Value,
+    }
+
+    impl super::BrowserCompanionRunner for ResultRunner {
+        fn invoke(
+            &self,
+            _command: &str,
+            _timeout_seconds: u64,
+            _request: &super::BrowserCompanionProtocolRequest,
+        ) -> Result<Value, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.result.clone())
+        }
+    }
+
     #[test]
     fn browser_companion_session_start_reports_balanced_execution_tier() {
         let request = ToolCoreRequest {
             tool_name: "browser.companion.session.start".to_owned(),
-            payload: json!({}),
+            payload: json!({"url": "http://127.0.0.1/start"}),
         };
         let payload = request
             .payload
@@ -757,6 +842,10 @@ mod tests {
             command: Some("browser-companion".to_owned()),
             expected_version: Some("1.5.0".to_owned()),
             timeout_seconds: 5,
+            allow_private_hosts: true,
+            enforce_allowed_domains: false,
+            allowed_domains: std::collections::BTreeSet::new(),
+            blocked_domains: std::collections::BTreeSet::new(),
         };
 
         let outcome = super::execute_browser_companion_request(
@@ -797,5 +886,93 @@ mod tests {
 
         assert_eq!(stopped.payload["session_id"], json!(session_id));
         assert_eq!(stopped.payload["operation"], json!("session.stop"));
+    }
+
+    #[test]
+    fn browser_companion_session_start_rejects_blocked_payload_url_before_spawn() {
+        let request = ToolCoreRequest {
+            tool_name: "browser.companion.session.start".to_owned(),
+            payload: json!({"url": "https://blocked.example.com"}),
+        };
+        let payload = request
+            .payload
+            .as_object()
+            .expect("browser companion payload object")
+            .clone();
+        let policy = super::super::runtime_config::BrowserCompanionRuntimePolicy {
+            enabled: true,
+            ready: true,
+            command: Some("browser-companion".to_owned()),
+            expected_version: None,
+            timeout_seconds: 5,
+            allow_private_hosts: false,
+            enforce_allowed_domains: false,
+            allowed_domains: std::collections::BTreeSet::new(),
+            blocked_domains: std::collections::BTreeSet::from(["blocked.example.com".to_owned()]),
+        };
+        let runner = ResultRunner {
+            calls: AtomicUsize::new(0),
+            result: json!({"page_url": "https://blocked.example.com"}),
+        };
+
+        let error = super::execute_browser_companion_request(
+            request,
+            &payload,
+            "test-scope",
+            &policy,
+            &runner,
+            true,
+        )
+        .expect_err("blocked url should fail before companion spawn");
+
+        assert!(
+            error.contains("blocked host"),
+            "expected blocked-host error, got {error}"
+        );
+        assert_eq!(runner.calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn browser_companion_revalidates_returned_page_url() {
+        let request = ToolCoreRequest {
+            tool_name: "browser.companion.session.start".to_owned(),
+            payload: json!({"url": "http://127.0.0.1/start"}),
+        };
+        let payload = request
+            .payload
+            .as_object()
+            .expect("browser companion payload object")
+            .clone();
+        let policy = super::super::runtime_config::BrowserCompanionRuntimePolicy {
+            enabled: true,
+            ready: true,
+            command: Some("browser-companion".to_owned()),
+            expected_version: None,
+            timeout_seconds: 5,
+            allow_private_hosts: true,
+            enforce_allowed_domains: false,
+            allowed_domains: std::collections::BTreeSet::new(),
+            blocked_domains: std::collections::BTreeSet::from(["internal.example".to_owned()]),
+        };
+        let runner = ResultRunner {
+            calls: AtomicUsize::new(0),
+            result: json!({"page_url": "https://internal.example"}),
+        };
+
+        let error = super::execute_browser_companion_request(
+            request,
+            &payload,
+            "test-scope",
+            &policy,
+            &runner,
+            true,
+        )
+        .expect_err("returned page_url outside policy should fail closed");
+
+        assert!(
+            error.contains("blocked host"),
+            "expected returned page_url revalidation, got {error}"
+        );
+        assert_eq!(runner.calls.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -81,7 +81,7 @@ impl BrowserCompanionOperation {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 struct BrowserCompanionProtocolRequest {
     protocol: &'static str,
     tool_name: String,
@@ -438,20 +438,32 @@ fn execute_browser_companion_request(
         format!("browser-companion-{}", next_browser_companion_sequence())
     };
 
-    let result = runner.invoke(
-        command,
-        policy.timeout_seconds,
-        &BrowserCompanionProtocolRequest {
-            protocol: BROWSER_COMPANION_PROTOCOL,
-            tool_name: request.tool_name.clone(),
-            operation: operation.protocol_name(),
-            action_class: operation.action_class(),
-            session_scope: scope_id.to_owned(),
-            session_id: session_id.clone(),
-            arguments: browser_companion_arguments(payload),
-        },
-    )?;
-    validate_browser_companion_result_target(request.tool_name.as_str(), &result, policy)?;
+    let protocol_request = BrowserCompanionProtocolRequest {
+        protocol: BROWSER_COMPANION_PROTOCOL,
+        tool_name: request.tool_name.clone(),
+        operation: operation.protocol_name(),
+        action_class: operation.action_class(),
+        session_scope: scope_id.to_owned(),
+        session_id: session_id.clone(),
+        arguments: browser_companion_arguments(payload),
+    };
+    let result = runner.invoke(command, policy.timeout_seconds, &protocol_request)?;
+    let result_validation =
+        validate_browser_companion_result_target(request.tool_name.as_str(), &result, policy);
+    if let Err(error) = result_validation {
+        let cleanup = cleanup_browser_companion_after_invalid_result(
+            operation,
+            scope_id,
+            session_id.as_str(),
+            command,
+            policy.timeout_seconds,
+            runner,
+        );
+        if let Err(cleanup_error) = cleanup {
+            return Err(format!("{error}; {cleanup_error}"));
+        }
+        return Err(error);
+    }
 
     match operation {
         BrowserCompanionOperation::SessionStart => {
@@ -487,6 +499,44 @@ fn execute_browser_companion_request(
             "result": result,
         }),
     })
+}
+
+fn cleanup_browser_companion_after_invalid_result(
+    operation: BrowserCompanionOperation,
+    scope_id: &str,
+    session_id: &str,
+    command: &str,
+    timeout_seconds: u64,
+    runner: &dyn BrowserCompanionRunner,
+) -> Result<(), String> {
+    if operation == BrowserCompanionOperation::SessionStop {
+        return Ok(());
+    }
+
+    let stop_request = BrowserCompanionProtocolRequest {
+        protocol: BROWSER_COMPANION_PROTOCOL,
+        tool_name: "browser.companion.session.stop".to_owned(),
+        operation: BrowserCompanionOperation::SessionStop.protocol_name(),
+        action_class: BrowserCompanionOperation::SessionStop.action_class(),
+        session_scope: scope_id.to_owned(),
+        session_id: session_id.to_owned(),
+        arguments: Value::Object(Map::new()),
+    };
+    let remote_cleanup = runner.invoke(command, timeout_seconds, &stop_request);
+    let local_cleanup = remove_browser_companion_session_if_present(scope_id, session_id);
+
+    let mut cleanup_issues = Vec::new();
+    if let Err(error) = remote_cleanup {
+        cleanup_issues.push(format!("browser_companion_remote_cleanup_failed: {error}"));
+    }
+    if let Err(error) = local_cleanup {
+        cleanup_issues.push(format!("browser_companion_local_cleanup_failed: {error}"));
+    }
+    if cleanup_issues.is_empty() {
+        return Ok(());
+    }
+
+    Err(cleanup_issues.join("; "))
 }
 
 fn browser_companion_command(
@@ -570,15 +620,20 @@ fn validate_browser_companion_target_url(
 ) -> Result<(), String> {
     let parsed_url = reqwest::Url::parse(raw_url)
         .map_err(|error| format!("{surface_name} is invalid: {error}"))?;
+    let web_policy = policy.web_policy();
+    let allowed_domains = if web_policy.enforce_allowed_domains {
+        Some(&web_policy.allowed_domains)
+    } else {
+        None
+    };
+    let blocked_domains = Some(&web_policy.blocked_domains);
     let options = super::web_http::HttpTargetValidationOptions {
-        allow_private_hosts: policy.allow_private_hosts,
+        allow_private_hosts: web_policy.allow_private_hosts,
         reject_userinfo: false,
         resolve_dns: false,
-        enforce_allowed_domains: policy.enforce_allowed_domains,
-        allowed_domains: policy
-            .enforce_allowed_domains
-            .then_some(&policy.allowed_domains),
-        blocked_domains: Some(&policy.blocked_domains),
+        enforce_allowed_domains: web_policy.enforce_allowed_domains,
+        allowed_domains,
+        blocked_domains,
     };
     super::web_http::validate_http_target(&parsed_url, &options, surface_name).map(|_| ())
 }
@@ -656,11 +711,31 @@ fn remove_browser_companion_session(scope_id: &str, session_id: &str) -> Result<
     Ok(())
 }
 
+fn remove_browser_companion_session_if_present(
+    scope_id: &str,
+    session_id: &str,
+) -> Result<(), String> {
+    let mut sessions = browser_companion_sessions()
+        .lock()
+        .map_err(|error| format!("browser companion session store lock poisoned: {error}"))?;
+    let Some(scope_sessions) = sessions.get_mut(scope_id) else {
+        return Ok(());
+    };
+    scope_sessions.remove(session_id);
+    if scope_sessions.is_empty() {
+        sessions.remove(scope_id);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
         io,
-        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+        sync::{
+            Mutex,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
         time::Duration,
     };
 
@@ -810,6 +885,7 @@ mod tests {
 
     struct ResultRunner {
         calls: AtomicUsize,
+        requests: Mutex<Vec<super::BrowserCompanionProtocolRequest>>,
         result: Value,
     }
 
@@ -818,9 +894,14 @@ mod tests {
             &self,
             _command: &str,
             _timeout_seconds: u64,
-            _request: &super::BrowserCompanionProtocolRequest,
+            request: &super::BrowserCompanionProtocolRequest,
         ) -> Result<Value, String> {
             self.calls.fetch_add(1, Ordering::Relaxed);
+            let mut requests = self
+                .requests
+                .lock()
+                .expect("lock browser companion request log");
+            requests.push(request.clone());
             Ok(self.result.clone())
         }
     }
@@ -912,6 +993,7 @@ mod tests {
         };
         let runner = ResultRunner {
             calls: AtomicUsize::new(0),
+            requests: Mutex::new(Vec::new()),
             result: json!({"page_url": "https://blocked.example.com"}),
         };
 
@@ -956,6 +1038,7 @@ mod tests {
         };
         let runner = ResultRunner {
             calls: AtomicUsize::new(0),
+            requests: Mutex::new(Vec::new()),
             result: json!({"page_url": "https://internal.example"}),
         };
 
@@ -973,6 +1056,100 @@ mod tests {
             error.contains("blocked host"),
             "expected returned page_url revalidation, got {error}"
         );
-        assert_eq!(runner.calls.load(Ordering::Relaxed), 1);
+        assert_eq!(runner.calls.load(Ordering::Relaxed), 2);
+
+        let requests = runner
+            .requests
+            .lock()
+            .expect("lock browser companion request log");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].operation, "session.start");
+        assert_eq!(requests[1].operation, "session.stop");
+        assert_eq!(requests[0].session_id, requests[1].session_id);
+    }
+
+    #[test]
+    fn browser_companion_boundary_failure_drops_existing_session() {
+        let scope_id = "test-scope-boundary-cleanup";
+        let policy = super::super::runtime_config::BrowserCompanionRuntimePolicy {
+            enabled: true,
+            ready: true,
+            command: Some("browser-companion".to_owned()),
+            expected_version: None,
+            timeout_seconds: 5,
+            allow_private_hosts: true,
+            enforce_allowed_domains: false,
+            allowed_domains: std::collections::BTreeSet::new(),
+            blocked_domains: std::collections::BTreeSet::from(["internal.example".to_owned()]),
+        };
+        let start_request = ToolCoreRequest {
+            tool_name: "browser.companion.session.start".to_owned(),
+            payload: json!({"url": "http://127.0.0.1/start"}),
+        };
+        let start_payload = start_request
+            .payload
+            .as_object()
+            .expect("browser companion payload object")
+            .clone();
+        let start_outcome = super::execute_browser_companion_request(
+            start_request,
+            &start_payload,
+            scope_id,
+            &policy,
+            &OkRunner,
+            true,
+        )
+        .expect("browser companion session start should succeed");
+        let session_id = start_outcome.payload["session_id"]
+            .as_str()
+            .expect("session id should be text")
+            .to_owned();
+
+        let navigate_request = ToolCoreRequest {
+            tool_name: "browser.companion.navigate".to_owned(),
+            payload: json!({
+                "session_id": session_id,
+                "url": "http://127.0.0.1/next"
+            }),
+        };
+        let navigate_payload = navigate_request
+            .payload
+            .as_object()
+            .expect("browser companion payload object")
+            .clone();
+        let runner = ResultRunner {
+            calls: AtomicUsize::new(0),
+            requests: Mutex::new(Vec::new()),
+            result: json!({"page_url": "https://internal.example"}),
+        };
+
+        let error = super::execute_browser_companion_request(
+            navigate_request,
+            &navigate_payload,
+            scope_id,
+            &policy,
+            &runner,
+            true,
+        )
+        .expect_err("returned page_url outside policy should fail closed");
+
+        assert!(
+            error.contains("blocked host"),
+            "expected returned page_url revalidation, got {error}"
+        );
+        assert!(
+            super::ensure_browser_companion_session(scope_id, session_id.as_str()).is_err(),
+            "boundary cleanup should drop the existing local companion session"
+        );
+        assert_eq!(runner.calls.load(Ordering::Relaxed), 2);
+
+        let requests = runner
+            .requests
+            .lock()
+            .expect("lock browser companion request log");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].operation, "navigate");
+        assert_eq!(requests[1].operation, "session.stop");
+        assert_eq!(requests[0].session_id, requests[1].session_id);
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -53,12 +53,7 @@ mod tool_search;
 // public web.fetch tool is compiled out.
 #[cfg(any(feature = "tool-webfetch", feature = "tool-browser"))]
 mod web_fetch;
-#[cfg(any(
-    feature = "tool-webfetch",
-    feature = "tool-browser",
-    feature = "tool-websearch"
-))]
-mod web_http;
+pub(crate) mod web_http;
 mod web_search;
 
 pub use catalog::{

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -273,6 +273,8 @@ impl BrowserCompanionRuntimePolicy {
         }
     }
 
+    /// Project the companion's destination-boundary policy into the shared web
+    /// policy shape without inheriting unrelated fetch-only transport limits.
     #[must_use]
     pub fn web_policy(&self) -> WebFetchRuntimePolicy {
         WebFetchRuntimePolicy {
@@ -821,6 +823,12 @@ impl ToolRuntimeConfig {
             per_tool_timeout: tool_execution_per_tool_timeout,
         };
 
+        let browser_companion_allow_private_hosts = web_fetch_allow_private_hosts;
+        let browser_companion_allowed_domains = web_fetch_allowed_domains.clone();
+        let browser_companion_blocked_domains = web_fetch_blocked_domains.clone();
+        let browser_companion_enforce_allowed_domains =
+            !browser_companion_allowed_domains.is_empty();
+
         Self {
             file_root,
             config_path,
@@ -841,10 +849,10 @@ impl ToolRuntimeConfig {
                 browser_companion_command.as_deref(),
                 browser_companion_expected_version.as_deref(),
                 browser_companion_timeout_seconds,
-                false,
-                BTreeSet::new(),
-                BTreeSet::new(),
-                false,
+                browser_companion_allow_private_hosts,
+                browser_companion_allowed_domains,
+                browser_companion_blocked_domains,
+                browser_companion_enforce_allowed_domains,
             ),
             web_fetch: WebFetchRuntimePolicy {
                 enabled: web_fetch_enabled,
@@ -1140,7 +1148,31 @@ pub(crate) fn browser_companion_runtime_policy_with_env_fallback(
 ) -> BrowserCompanionRuntimePolicy {
     let env_command = parse_env_string("LOONGCLAW_BROWSER_COMPANION_COMMAND");
     let env_expected_version = parse_env_string("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
-    let allowed_domains = config.browser_companion.normalized_allowed_domains();
+    let default_browser_companion = crate::config::BrowserCompanionToolConfig::default();
+    let use_env_web_policy = config.browser_companion == default_browser_companion;
+    let allow_private_hosts = if use_env_web_policy {
+        parse_env_bool("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS").unwrap_or(false)
+    } else {
+        config.browser_companion.allow_private_hosts
+    };
+    let allowed_domains = if use_env_web_policy {
+        parse_env_domain_list("LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS")
+    } else {
+        config
+            .browser_companion
+            .normalized_allowed_domains()
+            .into_iter()
+            .collect()
+    };
+    let blocked_domains = if use_env_web_policy {
+        parse_env_domain_list("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS")
+    } else {
+        config
+            .browser_companion
+            .normalized_blocked_domains()
+            .into_iter()
+            .collect()
+    };
     let enforce_allowed_domains = !allowed_domains.is_empty();
     browser_companion_runtime_policy(
         config.browser_companion.enabled
@@ -1158,13 +1190,9 @@ pub(crate) fn browser_companion_runtime_policy_with_env_fallback(
             .or(env_expected_version.as_deref()),
         parse_env_u64("LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS")
             .unwrap_or(config.browser_companion.timeout_seconds),
-        config.browser_companion.allow_private_hosts,
-        allowed_domains.into_iter().collect(),
-        config
-            .browser_companion
-            .normalized_blocked_domains()
-            .into_iter()
-            .collect(),
+        allow_private_hosts,
+        allowed_domains,
+        blocked_domains,
         enforce_allowed_domains,
     )
 }
@@ -1894,6 +1922,26 @@ mod tests {
             Some("1.2.3")
         );
         assert_eq!(config.browser_companion.timeout_seconds, 11);
+        assert!(config.browser_companion.allow_private_hosts);
+        assert!(
+            config
+                .browser_companion
+                .allowed_domains
+                .contains("docs.example.com")
+        );
+        assert!(
+            config
+                .browser_companion
+                .allowed_domains
+                .contains("api.example.com")
+        );
+        assert!(
+            config
+                .browser_companion
+                .blocked_domains
+                .contains("internal.example")
+        );
+        assert!(config.browser_companion.enforce_allowed_domains);
         assert!(!config.web_fetch.enabled);
         assert!(config.web_fetch.allow_private_hosts);
         assert!(
@@ -2174,6 +2222,35 @@ mod tests {
         );
         assert_eq!(policy.expected_version.as_deref(), Some("1.2.3"));
         assert_eq!(policy.timeout_seconds, 11);
+    }
+
+    #[test]
+    fn browser_companion_runtime_policy_with_env_fallback_reuses_web_fetch_boundaries() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONGCLAW_BROWSER_COMPANION_ENABLED", "true");
+        env.set("LOONGCLAW_BROWSER_COMPANION_READY", "true");
+        env.set("LOONGCLAW_WEB_FETCH_ALLOW_PRIVATE_HOSTS", "true");
+        env.set(
+            "LOONGCLAW_WEB_FETCH_ALLOWED_DOMAINS",
+            "docs.example.com,api.example.com",
+        );
+        env.set("LOONGCLAW_WEB_FETCH_BLOCKED_DOMAINS", "internal.example");
+
+        let policy = browser_companion_runtime_policy_with_env_fallback(
+            &crate::config::ToolConfig::default(),
+        );
+
+        assert!(policy.allow_private_hosts);
+        assert!(policy.enforce_allowed_domains);
+        assert_eq!(
+            policy.allowed_domains,
+            BTreeSet::from(["api.example.com".to_owned(), "docs.example.com".to_owned(),])
+        );
+        assert_eq!(
+            policy.blocked_domains,
+            BTreeSet::from(["internal.example".to_owned()])
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -236,6 +236,10 @@ pub struct BrowserCompanionRuntimePolicy {
     pub command: Option<String>,
     pub expected_version: Option<String>,
     pub timeout_seconds: u64,
+    pub allow_private_hosts: bool,
+    pub enforce_allowed_domains: bool,
+    pub allowed_domains: BTreeSet<String>,
+    pub blocked_domains: BTreeSet<String>,
 }
 
 impl Default for BrowserCompanionRuntimePolicy {
@@ -246,6 +250,10 @@ impl Default for BrowserCompanionRuntimePolicy {
             command: None,
             expected_version: None,
             timeout_seconds: crate::config::DEFAULT_BROWSER_COMPANION_TIMEOUT_SECONDS,
+            allow_private_hosts: false,
+            enforce_allowed_domains: false,
+            allowed_domains: BTreeSet::new(),
+            blocked_domains: BTreeSet::new(),
         }
     }
 }
@@ -262,6 +270,20 @@ impl BrowserCompanionRuntimePolicy {
             ExecutionSecurityTier::Balanced
         } else {
             ExecutionSecurityTier::Restricted
+        }
+    }
+
+    #[must_use]
+    pub fn web_policy(&self) -> WebFetchRuntimePolicy {
+        WebFetchRuntimePolicy {
+            enabled: self.enabled,
+            allow_private_hosts: self.allow_private_hosts,
+            enforce_allowed_domains: self.enforce_allowed_domains,
+            allowed_domains: self.allowed_domains.clone(),
+            blocked_domains: self.blocked_domains.clone(),
+            timeout_seconds: self.timeout_seconds,
+            max_bytes: crate::config::DEFAULT_WEB_FETCH_MAX_BYTES,
+            max_redirects: crate::config::DEFAULT_WEB_FETCH_MAX_REDIRECTS,
         }
     }
 }
@@ -536,6 +558,10 @@ impl ToolRuntimeConfig {
     pub fn from_loongclaw_config(config: &LoongClawConfig, config_path: Option<&Path>) -> Self {
         let web_fetch_allowed_domains = config.tools.web.normalized_allowed_domains();
         let web_fetch_enforce_allowed_domains = !web_fetch_allowed_domains.is_empty();
+        let browser_companion_allowed_domains =
+            config.tools.browser_companion.normalized_allowed_domains();
+        let browser_companion_enforce_allowed_domains =
+            !browser_companion_allowed_domains.is_empty();
         Self {
             file_root: Some(config.tools.resolved_file_root()),
             shell_allow: config
@@ -572,6 +598,15 @@ impl ToolRuntimeConfig {
                 config.tools.browser_companion.command.as_deref(),
                 config.tools.browser_companion.expected_version.as_deref(),
                 config.tools.browser_companion.timeout_seconds,
+                config.tools.browser_companion.allow_private_hosts,
+                browser_companion_allowed_domains.into_iter().collect(),
+                config
+                    .tools
+                    .browser_companion
+                    .normalized_blocked_domains()
+                    .into_iter()
+                    .collect(),
+                browser_companion_enforce_allowed_domains,
             ),
             web_fetch: WebFetchRuntimePolicy {
                 enabled: config.tools.web.enabled,
@@ -806,6 +841,10 @@ impl ToolRuntimeConfig {
                 browser_companion_command.as_deref(),
                 browser_companion_expected_version.as_deref(),
                 browser_companion_timeout_seconds,
+                false,
+                BTreeSet::new(),
+                BTreeSet::new(),
+                false,
             ),
             web_fetch: WebFetchRuntimePolicy {
                 enabled: web_fetch_enabled,
@@ -1077,12 +1116,22 @@ fn resolve_web_search_secret_binding(
 pub(crate) fn browser_companion_runtime_policy_from_tool_config(
     config: &crate::config::ToolConfig,
 ) -> BrowserCompanionRuntimePolicy {
+    let allowed_domains = config.browser_companion.normalized_allowed_domains();
+    let enforce_allowed_domains = !allowed_domains.is_empty();
     browser_companion_runtime_policy(
         config.browser_companion.enabled,
         parse_env_bool("LOONGCLAW_BROWSER_COMPANION_READY").unwrap_or(false),
         config.browser_companion.command.as_deref(),
         config.browser_companion.expected_version.as_deref(),
         config.browser_companion.timeout_seconds,
+        config.browser_companion.allow_private_hosts,
+        allowed_domains.into_iter().collect(),
+        config
+            .browser_companion
+            .normalized_blocked_domains()
+            .into_iter()
+            .collect(),
+        enforce_allowed_domains,
     )
 }
 
@@ -1091,6 +1140,8 @@ pub(crate) fn browser_companion_runtime_policy_with_env_fallback(
 ) -> BrowserCompanionRuntimePolicy {
     let env_command = parse_env_string("LOONGCLAW_BROWSER_COMPANION_COMMAND");
     let env_expected_version = parse_env_string("LOONGCLAW_BROWSER_COMPANION_EXPECTED_VERSION");
+    let allowed_domains = config.browser_companion.normalized_allowed_domains();
+    let enforce_allowed_domains = !allowed_domains.is_empty();
     browser_companion_runtime_policy(
         config.browser_companion.enabled
             || parse_env_bool("LOONGCLAW_BROWSER_COMPANION_ENABLED").unwrap_or(false),
@@ -1107,6 +1158,14 @@ pub(crate) fn browser_companion_runtime_policy_with_env_fallback(
             .or(env_expected_version.as_deref()),
         parse_env_u64("LOONGCLAW_BROWSER_COMPANION_TIMEOUT_SECONDS")
             .unwrap_or(config.browser_companion.timeout_seconds),
+        config.browser_companion.allow_private_hosts,
+        allowed_domains.into_iter().collect(),
+        config
+            .browser_companion
+            .normalized_blocked_domains()
+            .into_iter()
+            .collect(),
+        enforce_allowed_domains,
     )
 }
 
@@ -1116,6 +1175,10 @@ fn browser_companion_runtime_policy(
     command: Option<&str>,
     expected_version: Option<&str>,
     timeout_seconds: u64,
+    allow_private_hosts: bool,
+    allowed_domains: BTreeSet<String>,
+    blocked_domains: BTreeSet<String>,
+    enforce_allowed_domains: bool,
 ) -> BrowserCompanionRuntimePolicy {
     BrowserCompanionRuntimePolicy {
         enabled,
@@ -1123,6 +1186,10 @@ fn browser_companion_runtime_policy(
         command: normalize_optional_string(command),
         expected_version: normalize_optional_string(expected_version),
         timeout_seconds: timeout_seconds.max(1),
+        allow_private_hosts,
+        enforce_allowed_domains,
+        allowed_domains,
+        blocked_domains,
     }
 }
 
@@ -1536,6 +1603,10 @@ mod tests {
                 command: Some("loongclaw-browser-companion".to_owned()),
                 expected_version: Some("1.2.3".to_owned()),
                 timeout_seconds: 9,
+                allow_private_hosts: false,
+                enforce_allowed_domains: false,
+                allowed_domains: BTreeSet::new(),
+                blocked_domains: BTreeSet::new(),
             },
             web_fetch: WebFetchRuntimePolicy {
                 enabled: false,
@@ -1642,6 +1713,13 @@ mod tests {
         config.tools.browser_companion.timeout_seconds = 7;
         config.tools.browser_companion.command = Some("loongclaw-browser-companion".to_owned());
         config.tools.browser_companion.expected_version = Some("1.2.3".to_owned());
+        config.tools.browser_companion.allow_private_hosts = true;
+        config.tools.browser_companion.allowed_domains =
+            vec!["Docs.Example.com".to_owned(), "api.example.com".to_owned()];
+        config.tools.browser_companion.blocked_domains = vec![
+            "internal.example".to_owned(),
+            " INTERNAL.EXAMPLE ".to_owned(),
+        ];
 
         let runtime = ToolRuntimeConfig::from_loongclaw_config(&config, None);
         assert!(runtime.browser_companion.enabled);
@@ -1655,6 +1733,16 @@ mod tests {
             Some("1.2.3")
         );
         assert_eq!(runtime.browser_companion.timeout_seconds, 7);
+        assert!(runtime.browser_companion.allow_private_hosts);
+        assert!(runtime.browser_companion.enforce_allowed_domains);
+        assert_eq!(
+            runtime.browser_companion.allowed_domains,
+            BTreeSet::from(["api.example.com".to_owned(), "docs.example.com".to_owned()])
+        );
+        assert_eq!(
+            runtime.browser_companion.blocked_domains,
+            BTreeSet::from(["internal.example".to_owned()])
+        );
     }
 
     #[test]
@@ -2010,6 +2098,10 @@ mod tests {
             command: Some("loongclaw-browser-companion".to_owned()),
             expected_version: Some("1.2.3".to_owned()),
             timeout_seconds: 9,
+            allow_private_hosts: false,
+            enforce_allowed_domains: true,
+            allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+            blocked_domains: BTreeSet::from(["internal.example".to_owned()]),
         };
 
         assert!(policy.enabled);
@@ -2021,6 +2113,16 @@ mod tests {
         );
         assert_eq!(policy.expected_version.as_deref(), Some("1.2.3"));
         assert_eq!(policy.timeout_seconds, 9);
+        assert!(!policy.allow_private_hosts);
+        assert!(policy.enforce_allowed_domains);
+        assert_eq!(
+            policy.allowed_domains,
+            BTreeSet::from(["docs.example.com".to_owned()])
+        );
+        assert_eq!(
+            policy.blocked_domains,
+            BTreeSet::from(["internal.example".to_owned()])
+        );
     }
 
     #[test]
@@ -2030,10 +2132,21 @@ mod tests {
         let mut config = crate::config::ToolConfig::default();
         config.browser_companion.enabled = true;
         config.browser_companion.timeout_seconds = 0;
+        config.browser_companion.allowed_domains = vec!["Docs.Example.com".to_owned()];
+        config.browser_companion.blocked_domains = vec!["internal.example".to_owned()];
 
         let policy = browser_companion_runtime_policy_from_tool_config(&config);
 
         assert_eq!(policy.timeout_seconds, 1);
+        assert!(policy.enforce_allowed_domains);
+        assert_eq!(
+            policy.allowed_domains,
+            BTreeSet::from(["docs.example.com".to_owned()])
+        );
+        assert_eq!(
+            policy.blocked_domains,
+            BTreeSet::from(["internal.example".to_owned()])
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/web_fetch.rs
+++ b/crates/app/src/tools/web_fetch.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 #[cfg(feature = "tool-webfetch")]
 use serde_json::{Map, Value, json};
@@ -255,103 +253,18 @@ pub(crate) fn validate_web_target(
     policy: &super::runtime_config::WebFetchRuntimePolicy,
     surface_name: &str,
 ) -> Result<String, String> {
-    use std::net::{IpAddr, ToSocketAddrs};
+    let options = super::web_http::HttpTargetValidationOptions {
+        allow_private_hosts: policy.allow_private_hosts,
+        reject_userinfo: false,
+        resolve_dns: true,
+        enforce_allowed_domains: policy.enforce_allowed_domains,
+        allowed_domains: policy
+            .enforce_allowed_domains
+            .then_some(&policy.allowed_domains),
+        blocked_domains: Some(&policy.blocked_domains),
+    };
 
-    match url.scheme() {
-        "http" | "https" => {}
-        other => {
-            return Err(format!(
-                "{surface_name} requires http or https url, got scheme `{other}`"
-            ));
-        }
-    }
-
-    let host = url
-        .host_str()
-        .map(str::to_ascii_lowercase)
-        .ok_or_else(|| format!("{surface_name} url `{url}` has no host"))?;
-
-    if let Some(rule) = first_matching_domain_rule(&host, &policy.blocked_domains) {
-        return Err(format!(
-            "{surface_name} blocked host `{host}` because it matches blocked domain rule `{rule}`"
-        ));
-    }
-    if policy.enforce_allowed_domains
-        && first_matching_domain_rule(&host, &policy.allowed_domains).is_none()
-    {
-        return Err(format!(
-            "{surface_name} denied host `{host}` because it is not in allowed_domains"
-        ));
-    }
-
-    if policy.allow_private_hosts {
-        return Ok(host);
-    }
-
-    if host == "localhost" {
-        return Err(format!(
-            "{surface_name} blocked private or special-use host `localhost`"
-        ));
-    }
-
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if super::web_http::is_private_or_special_ip(ip) {
-            return Err(format!(
-                "{surface_name} blocked private or special-use address `{ip}`"
-            ));
-        }
-        return Ok(host);
-    }
-
-    let port = url
-        .port_or_known_default()
-        .ok_or_else(|| format!("{surface_name} url `{url}` has no known port"))?;
-    let addrs = (host.as_str(), port)
-        .to_socket_addrs()
-        .map_err(|error| format!("{surface_name} failed to resolve host `{host}`: {error}"))?;
-
-    let mut saw_addr = false;
-    for addr in addrs {
-        saw_addr = true;
-        if super::web_http::is_private_or_special_ip(addr.ip()) {
-            return Err(format!(
-                "{surface_name} blocked private or special-use address `{}` for host `{host}`",
-                addr.ip()
-            ));
-        }
-    }
-
-    if !saw_addr {
-        return Err(format!(
-            "{surface_name} resolved no addresses for host `{host}`"
-        ));
-    }
-
-    Ok(host)
-}
-
-#[cfg(any(
-    feature = "tool-webfetch",
-    feature = "tool-browser",
-    feature = "tool-websearch"
-))]
-fn first_matching_domain_rule<'a>(host: &str, rules: &'a BTreeSet<String>) -> Option<&'a str> {
-    rules
-        .iter()
-        .find(|rule| domain_rule_matches(host, rule.as_str()))
-        .map(String::as_str)
-}
-
-#[cfg(any(
-    feature = "tool-webfetch",
-    feature = "tool-browser",
-    feature = "tool-websearch"
-))]
-fn domain_rule_matches(host: &str, rule: &str) -> bool {
-    if let Some(suffix) = rule.strip_prefix("*.") {
-        return host == suffix || host.ends_with(&format!(".{suffix}"));
-    }
-    host == rule
+    super::web_http::validate_http_target(url, &options, surface_name)
 }
 
 #[cfg(any(

--- a/crates/app/src/tools/web_http.rs
+++ b/crates/app/src/tools/web_http.rs
@@ -37,10 +37,11 @@ pub(crate) fn validate_http_target(
         ));
     }
 
-    let host = url
+    let raw_host = url
         .host_str()
-        .map(str::to_ascii_lowercase)
+        .map(normalize_domain_text)
         .ok_or_else(|| format!("{surface_name} url has no host"))?;
+    let host = raw_host;
 
     let blocked_rule = options
         .blocked_domains
@@ -274,14 +275,25 @@ fn first_matching_domain_rule<'a>(host: &str, rules: &'a BTreeSet<String>) -> Op
         .map(String::as_str)
 }
 
+/// Wildcard rules in the `*.example.com` form intentionally match both the
+/// apex domain (`example.com`) and any subdomain beneath it.
 fn domain_rule_matches(host: &str, rule: &str) -> bool {
-    if let Some(suffix) = rule.strip_prefix("*.") {
-        let suffix_match = host == suffix;
-        let subdomain_match = host.ends_with(format!(".{suffix}").as_str());
+    let normalized_host = normalize_domain_text(host);
+    let normalized_rule = normalize_domain_text(rule);
+
+    if let Some(suffix) = normalized_rule.strip_prefix("*.") {
+        let suffix_match = normalized_host == suffix;
+        let subdomain_match = normalized_host.ends_with(format!(".{suffix}").as_str());
         return suffix_match || subdomain_match;
     }
 
-    host == rule
+    normalized_host == normalized_rule
+}
+
+fn normalize_domain_text(value: &str) -> String {
+    let trimmed_value = value.trim();
+    let trimmed_root_label = trimmed_value.trim_end_matches('.');
+    trimmed_root_label.to_ascii_lowercase()
 }
 
 #[cfg(all(test, any(feature = "tool-webfetch", feature = "tool-websearch")))]
@@ -449,5 +461,37 @@ mod tests {
             !must(accepted_request, "test server exited with error"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn validate_http_target_blocks_trailing_dot_localhost_alias() {
+        let url = must(
+            reqwest::Url::parse("http://localhost./"),
+            "parse localhost alias url",
+        );
+        let options = HttpTargetValidationOptions {
+            allow_private_hosts: false,
+            reject_userinfo: true,
+            resolve_dns: false,
+            enforce_allowed_domains: false,
+            allowed_domains: None,
+            blocked_domains: None,
+        };
+
+        let error = validate_http_target(&url, &options, "web.fetch")
+            .expect_err("localhost. should stay blocked when private hosts are disabled");
+
+        assert!(
+            error.contains("localhost"),
+            "expected localhost validation error, got {error}"
+        );
+    }
+
+    #[test]
+    fn domain_rule_matches_treats_wildcard_rules_as_apex_aware() {
+        assert!(domain_rule_matches("example.com", "*.example.com"));
+        assert!(domain_rule_matches("api.example.com", "*.example.com"));
+        assert!(domain_rule_matches("API.EXAMPLE.COM.", "*.example.com."));
+        assert!(!domain_rule_matches("example.net", "*.example.com"));
     }
 }

--- a/crates/app/src/tools/web_http.rs
+++ b/crates/app/src/tools/web_http.rs
@@ -1,7 +1,115 @@
-/// Shared HTTP utilities for web tools (web.fetch, web.search).
-/// Provides SSRF-safe DNS resolution and other common patterns.
-#[cfg(any(feature = "tool-webfetch", feature = "tool-websearch"))]
+/// Shared HTTP utilities for outbound HTTP surfaces.
+use std::collections::BTreeSet;
 use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HttpTargetValidationOptions<'a> {
+    pub allow_private_hosts: bool,
+    pub reject_userinfo: bool,
+    pub resolve_dns: bool,
+    pub enforce_allowed_domains: bool,
+    pub allowed_domains: Option<&'a BTreeSet<String>>,
+    pub blocked_domains: Option<&'a BTreeSet<String>>,
+}
+
+pub(crate) fn validate_http_target(
+    url: &reqwest::Url,
+    options: &HttpTargetValidationOptions<'_>,
+    surface_name: &str,
+) -> Result<String, String> {
+    use std::net::{IpAddr, ToSocketAddrs};
+
+    let scheme = url.scheme();
+    let is_http = scheme == "http";
+    let is_https = scheme == "https";
+    if !is_http && !is_https {
+        return Err(format!(
+            "{surface_name} requires http or https url, got scheme `{scheme}`"
+        ));
+    }
+
+    let username = url.username();
+    let password = url.password();
+    let has_userinfo = !username.is_empty() || password.is_some();
+    if options.reject_userinfo && has_userinfo {
+        return Err(format!(
+            "{surface_name} must not embed credentials in the url userinfo section"
+        ));
+    }
+
+    let host = url
+        .host_str()
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| format!("{surface_name} url has no host"))?;
+
+    let blocked_rule = options
+        .blocked_domains
+        .and_then(|rules| first_matching_domain_rule(host.as_str(), rules));
+    if let Some(rule) = blocked_rule {
+        return Err(format!(
+            "{surface_name} blocked host `{host}` because it matches blocked domain rule `{rule}`"
+        ));
+    }
+
+    let allowed_rule = options
+        .allowed_domains
+        .and_then(|rules| first_matching_domain_rule(host.as_str(), rules));
+    if options.enforce_allowed_domains && allowed_rule.is_none() {
+        return Err(format!(
+            "{surface_name} denied host `{host}` because it is not in allowed_domains"
+        ));
+    }
+
+    if options.allow_private_hosts {
+        return Ok(host);
+    }
+
+    if host == "localhost" {
+        return Err(format!(
+            "{surface_name} blocked private or special-use host `localhost`"
+        ));
+    }
+
+    let parsed_ip = host.parse::<IpAddr>();
+    if let Ok(ip) = parsed_ip {
+        if is_private_or_special_ip(ip) {
+            return Err(format!(
+                "{surface_name} blocked private or special-use address `{ip}`"
+            ));
+        }
+        return Ok(host);
+    }
+
+    if !options.resolve_dns {
+        return Ok(host);
+    }
+
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| format!("{surface_name} url has no known port"))?;
+    let addrs = (host.as_str(), port)
+        .to_socket_addrs()
+        .map_err(|error| format!("{surface_name} failed to resolve host `{host}`: {error}"))?;
+
+    let mut saw_addr = false;
+    for addr in addrs {
+        saw_addr = true;
+        if is_private_or_special_ip(addr.ip()) {
+            return Err(format!(
+                "{surface_name} blocked private or special-use address `{}` for host `{host}`",
+                addr.ip()
+            ));
+        }
+    }
+
+    if !saw_addr {
+        return Err(format!(
+            "{surface_name} resolved no addresses for host `{host}`"
+        ));
+    }
+
+    Ok(host)
+}
 
 /// Bridge sync-to-async execution for web tools.
 ///
@@ -48,12 +156,10 @@ where
 /// Custom DNS resolver that rejects private/special-use IP addresses at
 /// connection time, eliminating the TOCTOU window between validation and
 /// the HTTP client's own DNS resolution.
-#[cfg(any(feature = "tool-webfetch", feature = "tool-websearch"))]
 pub struct SsrfSafeResolver {
     pub allow_private_hosts: bool,
 }
 
-#[cfg(any(feature = "tool-webfetch", feature = "tool-websearch"))]
 impl reqwest::dns::Resolve for SsrfSafeResolver {
     fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
         let allow_private = self.allow_private_hosts;
@@ -93,7 +199,6 @@ impl reqwest::dns::Resolve for SsrfSafeResolver {
 }
 
 /// Build an SSRF-safe HTTP client for web tools.
-#[cfg(any(feature = "tool-webfetch", feature = "tool-websearch"))]
 pub fn build_ssrf_safe_client(
     allow_private_hosts: bool,
     timeout_seconds: u64,
@@ -112,11 +217,6 @@ pub fn build_ssrf_safe_client(
         .map_err(|error| format!("failed to build SSRF-safe HTTP client: {error}"))
 }
 
-#[cfg(any(
-    feature = "tool-webfetch",
-    feature = "tool-browser",
-    feature = "tool-websearch"
-))]
 pub(crate) fn is_private_or_special_ip(ip: std::net::IpAddr) -> bool {
     use std::net::IpAddr;
 
@@ -126,11 +226,6 @@ pub(crate) fn is_private_or_special_ip(ip: std::net::IpAddr) -> bool {
     }
 }
 
-#[cfg(any(
-    feature = "tool-webfetch",
-    feature = "tool-browser",
-    feature = "tool-websearch"
-))]
 pub(crate) fn is_private_or_special_ipv4(ip: std::net::Ipv4Addr) -> bool {
     let octets = ip.octets();
     let first = octets[0];
@@ -153,11 +248,6 @@ pub(crate) fn is_private_or_special_ipv4(ip: std::net::Ipv4Addr) -> bool {
         || first >= 240
 }
 
-#[cfg(any(
-    feature = "tool-webfetch",
-    feature = "tool-browser",
-    feature = "tool-websearch"
-))]
 pub(crate) fn is_private_or_special_ipv6(ip: std::net::Ipv6Addr) -> bool {
     if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
         return true;
@@ -175,6 +265,23 @@ pub(crate) fn is_private_or_special_ipv6(ip: std::net::Ipv6Addr) -> bool {
         || ((segments[0] & 0xffc0) == 0xfe80)
         || ((segments[0] & 0xffc0) == 0xfec0)
         || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+}
+
+fn first_matching_domain_rule<'a>(host: &str, rules: &'a BTreeSet<String>) -> Option<&'a str> {
+    rules
+        .iter()
+        .find(|rule| domain_rule_matches(host, rule.as_str()))
+        .map(String::as_str)
+}
+
+fn domain_rule_matches(host: &str, rule: &str) -> bool {
+    if let Some(suffix) = rule.strip_prefix("*.") {
+        let suffix_match = host == suffix;
+        let subdomain_match = host.ends_with(format!(".{suffix}").as_str());
+        return suffix_match || subdomain_match;
+    }
+
+    host == rule
 }
 
 #[cfg(all(test, any(feature = "tool-webfetch", feature = "tool-websearch")))]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -68,7 +68,7 @@ Tool-specific request approval currently lives in the `PolicyExtensionChain`; th
 - `web.fetch`, `web.search`, and the shared browser-side URL validators intentionally build their HTTP clients with `reqwest::ClientBuilder::no_proxy()`
 - This keeps DNS resolution and connect-time routing inside the same SSRF-safe policy boundary instead of delegating host decisions to ambient `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, or `NO_PROXY` environment settings
 - The built-in browser surface now uses the same SSRF-safe client construction, so browser navigation no longer trusts ambient proxy environment variables for host reachability decisions
-- The managed browser companion validates both the requested navigation target and the returned `page_url` against its runtime web policy, which prevents the companion from silently crossing into blocked or private destinations after launch
+- The managed browser companion validates both the requested navigation target and the returned `page_url` against its runtime web policy, and it tears down companion session state if a returned `page_url` falls outside that policy
 - Config-backed outbound channel endpoints now share one outbound HTTP trust policy: URLs must use `http` or `https`, must not embed credentials, and block private or special-use hosts by default
 - Channel outbound HTTP clients do not auto-follow redirects, which prevents an initially trusted endpoint from silently crossing into a different destination after the first response
 - Operators who intentionally target a local or private bridge can widen that boundary with `[outbound_http] allow_private_hosts = true`; the default remains fail-closed for public-only outbound delivery

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -67,6 +67,11 @@ Tool-specific request approval currently lives in the `PolicyExtensionChain`; th
 
 - `web.fetch`, `web.search`, and the shared browser-side URL validators intentionally build their HTTP clients with `reqwest::ClientBuilder::no_proxy()`
 - This keeps DNS resolution and connect-time routing inside the same SSRF-safe policy boundary instead of delegating host decisions to ambient `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, or `NO_PROXY` environment settings
+- The built-in browser surface now uses the same SSRF-safe client construction, so browser navigation no longer trusts ambient proxy environment variables for host reachability decisions
+- The managed browser companion validates both the requested navigation target and the returned `page_url` against its runtime web policy, which prevents the companion from silently crossing into blocked or private destinations after launch
+- Config-backed outbound channel endpoints now share one outbound HTTP trust policy: URLs must use `http` or `https`, must not embed credentials, and block private or special-use hosts by default
+- Channel outbound HTTP clients do not auto-follow redirects, which prevents an initially trusted endpoint from silently crossing into a different destination after the first response
+- Operators who intentionally target a local or private bridge can widen that boundary with `[outbound_http] allow_private_hosts = true`; the default remains fail-closed for public-only outbound delivery
 - Trade-off: corporate proxy-only egress is not currently supported for these web tools because a proxy hop would weaken the same-host assumptions behind the private-address guard
 - If proxy-aware web tooling is added later, it should preserve the same SSRF guarantees rather than silently bypassing them
 

--- a/docs/product-specs/channel-setup.md
+++ b/docs/product-specs/channel-setup.md
@@ -166,6 +166,12 @@ surfaces:
   reply-loop runtime
 - their `serve` metadata remains planned or unsupported until the gateway layer
   and the underlying inbound transport contract are implemented
+- their HTTP targets must use `http` or `https`, must not embed credentials,
+  block private or special-use hosts by default, and do not auto-follow
+  redirects
+- operators who intentionally send through a private bridge, loopback service,
+  or self-hosted endpoint should set `[outbound_http] allow_private_hosts = true`
+  at the top level of `loongclaw.toml`
 
 ### Webhook
 
@@ -184,6 +190,19 @@ Generic Webhook is shipped as a minimal config-backed outbound POST surface:
   override the endpoint with `--target` for one-off delivery
 - `webhook.public_base_url` and `webhook.signing_secret` remain reserved for
   the planned inbound serve contract and are not required for send readiness
+
+### Signal
+
+Signal is shipped through a `signal-cli` REST bridge send surface:
+
+- configure `signal.account`
+- use `signal.service_url` to point at the bridge; when unset, LoongClaw
+  defaults to `http://127.0.0.1:8080`
+- because outbound HTTP delivery defaults to public-only mode, the default
+  local bridge requires `[outbound_http] allow_private_hosts = true`
+- use `signal-send` with a Signal account target such as an E.164 number
+- `signal-serve` remains planned until LoongClaw owns a real inbound listener
+  contract
 
 ### Email
 

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-27T18:04:05Z
+- Generated at: 2026-03-27T18:18:56Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -21,15 +21,15 @@
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9845 | 10500 | 655 | 88 | 90 | 2 | 97.8% | TIGHT |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9759 | 9800 | 41 | 90 | 90 | 0 | 100.0% | TIGHT |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6405 | 6400 | -5 | 104 | 110 | 6 | 100.1% | BREACH |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6396 | 6400 | 4 | 104 | 110 | 6 | 99.9% | TIGHT |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9964 | 11200 | 1236 | 92 | 120 | 28 | 89.0% | WATCH |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14194 | 15000 | 806 | 54 | 70 | 16 | 94.6% | WATCH |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5917 | 6000 | 83 | 190 | 190 | 0 | 100.0% | TIGHT |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): channel_mod (100.1%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (95.4%), acpx_runtime (96.3%), channel_registry (97.8%), channel_config (100.0%), daemon_lib (100.0%)
+- BREACH hotspots (>100% of any tracked budget): none
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (95.4%), acpx_runtime (96.3%), channel_registry (97.8%), channel_config (100.0%), channel_mod (99.9%), daemon_lib (100.0%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (92.4%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.6%), onboard_cli (94.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -66,7 +66,7 @@
 <!-- arch-hotspot key=channel_registry lines=9845 functions=88 -->
 <!-- arch-hotspot key=channel_config lines=9759 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
-<!-- arch-hotspot key=channel_mod lines=6405 functions=104 -->
+<!-- arch-hotspot key=channel_mod lines=6396 functions=104 -->
 <!-- arch-hotspot key=turn_coordinator lines=9964 functions=92 -->
 <!-- arch-hotspot key=tools_mod lines=14194 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=5917 functions=190 -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-27T17:42:20Z
+- Generated at: 2026-03-27T18:04:05Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -18,19 +18,19 @@
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3327 | 3600 | 273 | 8 | 12 | 4 | 92.4% | WATCH |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2696 | 2800 | 104 | 56 | 65 | 9 | 96.3% | TIGHT |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9843 | 10500 | 657 | 90 | 90 | 0 | 100.0% | TIGHT |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9845 | 10500 | 655 | 88 | 90 | 2 | 97.8% | TIGHT |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9759 | 9800 | 41 | 90 | 90 | 0 | 100.0% | TIGHT |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6384 | 6400 | 16 | 104 | 110 | 6 | 99.8% | TIGHT |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6405 | 6400 | -5 | 104 | 110 | 6 | 100.1% | BREACH |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 9964 | 11200 | 1236 | 92 | 120 | 28 | 89.0% | WATCH |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14199 | 15000 | 801 | 54 | 70 | 16 | 94.7% | WATCH |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14194 | 15000 | 806 | 54 | 70 | 16 | 94.6% | WATCH |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5917 | 6000 | 83 | 190 | 190 | 0 | 100.0% | TIGHT |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (95.4%), acpx_runtime (96.3%), channel_registry (100.0%), channel_config (100.0%), channel_mod (99.8%), daemon_lib (100.0%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (92.4%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.7%), onboard_cli (94.4%)
+- BREACH hotspots (>100% of any tracked budget): channel_mod (100.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (95.4%), acpx_runtime (96.3%), channel_registry (97.8%), channel_config (100.0%), daemon_lib (100.0%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (92.4%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.6%), onboard_cli (94.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -63,12 +63,12 @@
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3327 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2696 functions=56 -->
-<!-- arch-hotspot key=channel_registry lines=9843 functions=90 -->
+<!-- arch-hotspot key=channel_registry lines=9845 functions=88 -->
 <!-- arch-hotspot key=channel_config lines=9759 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
-<!-- arch-hotspot key=channel_mod lines=6384 functions=104 -->
+<!-- arch-hotspot key=channel_mod lines=6405 functions=104 -->
 <!-- arch-hotspot key=turn_coordinator lines=9964 functions=92 -->
-<!-- arch-hotspot key=tools_mod lines=14199 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14194 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=5917 functions=190 -->
 <!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  Outbound HTTP trust boundaries were inconsistent across built-in browser flows, browser companion navigation, and config-backed outbound channel endpoints.
- Why it matters:
  This left shipped surfaces with weaker SSRF hygiene than `web.fetch` / `web.search`, allowed credential-bearing outbound URLs on channel paths, and made private-host behavior inconsistent for operators.
- What changed:
  Built-in browser transport now uses the SSRF-safe `no_proxy()` client path, browser companion navigation is bound to an explicit destination policy, and config-backed outbound channel URLs now share one outbound HTTP trust policy with runtime transport enforcement plus an operator-visible `outbound_http.allow_private_hosts` override.
- What did not change (scope boundary):
  This PR does not add OS-level browser sandboxing, a repo-wide generic policy framework for every future extension surface, or unrelated provider transport changes.

## Linked Issues

- Closes #662
- Related #662

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [x] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  Default behavior now fails closed for private or special-use outbound channel targets, which changes readiness for local bridge defaults such as Signal unless operators opt in.
- Rollout / guardrails:
  The new top-level `[outbound_http] allow_private_hosts = true` override is explicit and documented. Browser companion allowed/block domain policy remains operator-controlled and separate from channel config.
- Rollback path:
  Revert the commits in this PR to restore the previous outbound trust behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app --all-features
cargo test --workspace --locked
cargo test --workspace --all-features --locked
LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
diff CLAUDE.md AGENTS.md
scripts/check-docs.sh
python3 scripts/sync_github_labels.py --check
bash scripts/test_sync_github_labels.sh
```

Results:
- All commands above passed after rebasing onto the current `dev` base.
- Targeted package validation also passed after fixing two root causes in the shared HTTP validator: enforced-empty allowlists were accidentally inferred as "not enforced", and browser companion URL validation was performing environment-sensitive DNS resolution instead of applying its own explicit destination policy.
- The rebased branch also restores shared outbound HTTP readiness enforcement in `channel/registry.rs` and moves the outbound HTTP-specific registry regressions into a dedicated child test module so the registry file stays within the repository's architecture budget.
- `scripts/check-docs.sh` passed with existing non-blocking release-artifact warnings under `.docs/`.
- I also ran `cargo deny check advisories bans licenses sources`; it fails on an existing repository baseline unrelated to this diff because `quoted_printable v0.5.2` carries license `0BSD`, which is not currently allowlisted in `deny.toml`. This PR does not change dependencies or the lockfile.
- Existing env-mutating tests continue to use scoped helpers and serialized test patterns already present in the repo; this PR did not add new ad-hoc process-global env mutation.

Before / after behavior:
- Before: built-in browser transport could still rely on a weaker outbound client path; browser companion had no explicit destination-bound runtime policy; config-backed outbound channels accepted parseable HTTP(S) URLs without shared credential/private-host enforcement.
- After: browser transport uses SSRF-safe `no_proxy()` client semantics, browser companion validates requested and returned URLs against runtime policy, and config-backed outbound channels reject embedded credentials plus private/special-use targets by default.
- Boundary regression coverage includes:
  - shared outbound HTTP validation for non-HTTP schemes, embedded credentials, and private-host overrides
  - browser companion pre-spawn blocking and returned `page_url` revalidation
  - channel registry readiness changes for Signal default localhost bridge and Google Chat credential-bearing webhook URLs
  - top-level TOML round-trip coverage for `[outbound_http] allow_private_hosts = true`

## User-visible / Operator-visible Changes

- Config-backed outbound channels now block private or special-use HTTP targets by default unless operators set `[outbound_http] allow_private_hosts = true`.
- Signal's default local bridge URL (`http://127.0.0.1:8080`) now requires that explicit override.
- Browser companion runtime policy now supports private-host and allowed/block-domain controls for requested and returned URLs.
- Docs now describe the real outbound trust boundary for browser and channel surfaces.

## Failure Recovery

- Fast rollback or disable path:
  Revert the commits in this PR, or temporarily set `[outbound_http] allow_private_hosts = true` for deployments that intentionally depend on private/self-hosted channel endpoints.
- Observable failure symptoms reviewers should watch for:
  Channel send readiness flips from ready to misconfigured with messages about embedded credentials or private/special-use hosts; browser companion navigation fails before spawn or after result validation when a URL falls outside policy.

## Reviewer Focus

- Shared validator flow in `crates/app/src/tools/web_http.rs` and its caller split between `web.fetch`, browser companion, and channel outbound HTTP.
- Channel/runtime parity: config validation and runtime transport should now enforce the same boundary for config-backed outbound surfaces.
- Operator-facing behavior change for local bridges, especially Signal and any self-hosted/private channel endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel send flows now honor a configurable outbound HTTP policy for controlled delivery.

* **Security Enhancements**
  * Outbound targets must use http/https, disallow embedded credentials, and block private/special-use hosts by default.
  * Outbound HTTP clients no longer auto-follow redirects.
  * Browser companion validates navigation targets and tears down sessions when returned pages violate policy.

* **Configuration**
  * Added [outbound_http] with allow_private_hosts to opt into private-host delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->