### PR TITLE
feat: add discovery-first skills search and recommendation

### DIFF
--- a/crates/app/src/channel/http.rs
+++ b/crates/app/src/channel/http.rs
@@ -117,8 +117,52 @@ pub(super) fn redact_generic_webhook_status_url(raw_url: &str) -> Option<String>
 mod tests {
     use super::*;
     use std::io::{Read, Write};
-    use std::net::TcpListener;
+    use std::net::{TcpListener, TcpStream};
     use std::time::Duration;
+
+    fn read_test_http_request(stream: &mut TcpStream) -> Result<(), String> {
+        let read_timeout = Duration::from_millis(250);
+        stream
+            .set_read_timeout(Some(read_timeout))
+            .map_err(|error| format!("set test server read timeout: {error}"))?;
+
+        let mut request_bytes = Vec::new();
+
+        loop {
+            let mut chunk = [0_u8; 256];
+            let read_result = stream.read(&mut chunk);
+
+            match read_result {
+                Ok(0) => {
+                    return Err(
+                        "read test server request reached eof before headers completed".to_owned(),
+                    );
+                }
+                Ok(bytes_read) => {
+                    let chunk_slice = &chunk[..bytes_read];
+                    request_bytes.extend_from_slice(chunk_slice);
+
+                    let has_header_terminator =
+                        request_bytes.windows(4).any(|window| window == b"\r\n\r\n");
+
+                    if has_header_terminator {
+                        return Ok(());
+                    }
+                }
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::TimedOut
+                        || error.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                    return Err(
+                        "read test server request timed out before headers completed".to_owned(),
+                    );
+                }
+                Err(error) => {
+                    return Err(format!("read test server request: {error}"));
+                }
+            }
+        }
+    }
 
     fn spawn_test_http_server(
         response: String,
@@ -139,8 +183,7 @@ mod tests {
             loop {
                 match listener.accept() {
                     Ok((mut stream, _peer)) => {
-                        let mut request_buffer = [0_u8; 1024];
-                        let _ = stream.read(&mut request_buffer);
+                        read_test_http_request(&mut stream)?;
                         stream
                             .write_all(response.as_bytes())
                             .map_err(|error| format!("write test server response: {error}"))?;

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -5286,6 +5286,8 @@ async fn handle_turn_with_runtime_compacts_when_token_threshold_reached() {
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
 async fn handle_turn_with_runtime_flushes_durable_memory_before_compaction() {
+    let durable_flush_lock = crate::test_support::durable_memory_flush_test_lock();
+    let _durable_flush_guard = durable_flush_lock.lock().await;
     let workspace_root = crate::test_support::unique_temp_dir("pre-compaction-durable-flush");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
 
@@ -5369,6 +5371,8 @@ async fn handle_turn_with_runtime_flushes_durable_memory_before_compaction() {
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
 async fn handle_turn_with_runtime_does_not_flush_durable_memory_when_compaction_is_skipped() {
+    let durable_flush_lock = crate::test_support::durable_memory_flush_test_lock();
+    let _durable_flush_guard = durable_flush_lock.lock().await;
     let workspace_root = crate::test_support::unique_temp_dir("pre-compaction-durable-skip");
     std::fs::create_dir_all(&workspace_root).expect("create workspace root");
 

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -269,6 +269,8 @@ fn load_prompt_context_with_diagnostics_omits_legacy_identity_from_profile_proje
 #[cfg(feature = "memory-sqlite")]
 #[test]
 fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
+    let durable_flush_lock = crate::test_support::durable_memory_flush_test_lock();
+    let _durable_flush_guard = durable_flush_lock.blocking_lock();
     let _guard = core_dispatch_test_lock()
         .lock()
         .expect("core dispatch test lock");
@@ -335,6 +337,8 @@ fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
 #[cfg(feature = "memory-sqlite")]
 #[test]
 fn pre_compaction_durable_flush_skips_when_no_summary_checkpoint_exists() {
+    let durable_flush_lock = crate::test_support::durable_memory_flush_test_lock();
+    let _durable_flush_guard = durable_flush_lock.blocking_lock();
     let _guard = core_dispatch_test_lock()
         .lock()
         .expect("core dispatch test lock");

--- a/crates/app/src/test_support.rs
+++ b/crates/app/src/test_support.rs
@@ -79,6 +79,12 @@ pub(crate) fn unique_temp_dir(prefix: &str) -> PathBuf {
     std::env::temp_dir().join(format!("{prefix}-{}-{id}", std::process::id()))
 }
 
+#[cfg(test)]
+pub(crate) fn durable_memory_flush_test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 #[cfg(all(test, unix))]
 pub(crate) fn write_executable_script_atomically(
     script_path: &std::path::Path,

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -157,6 +157,7 @@ struct SkillEligibility {
     missing_env: Vec<String>,
     missing_bin: Vec<String>,
     missing_paths: Vec<String>,
+    missing_config: Vec<String>,
     issues: Vec<String>,
 }
 
@@ -958,27 +959,19 @@ pub(crate) fn execute_external_skills_operator_inspect_tool_with_config(
     )
 }
 
-pub(crate) fn execute_external_skills_operator_search_tool_with_config(
-    query: &str,
-    limit: usize,
+pub(super) fn execute_external_skills_search_tool_with_config(
+    request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    execute_external_skills_operator_discovery_tool_with_config(
-        query,
-        limit,
-        config,
-        SkillDiscoveryMode::Search,
-    )
+    execute_external_skills_discovery_tool_with_config(request, config, SkillDiscoveryMode::Search)
 }
 
-pub(crate) fn execute_external_skills_operator_recommend_tool_with_config(
-    query: &str,
-    limit: usize,
+pub(super) fn execute_external_skills_recommend_tool_with_config(
+    request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
-    execute_external_skills_operator_discovery_tool_with_config(
-        query,
-        limit,
+    execute_external_skills_discovery_tool_with_config(
+        request,
         config,
         SkillDiscoveryMode::Recommend,
     )
@@ -1081,44 +1074,34 @@ fn execute_external_skills_inspect_for_audience(
     })
 }
 
-fn execute_external_skills_operator_discovery_tool_with_config(
-    query: &str,
-    limit: usize,
+fn execute_external_skills_discovery_tool_with_config(
+    request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
     mode: SkillDiscoveryMode,
 ) -> Result<ToolCoreOutcome, String> {
-    let trimmed_query = query.trim();
-    if trimmed_query.is_empty() {
-        return Err("skills discovery requires a non-empty query".to_owned());
-    }
-    if limit == 0 {
-        return Err("skills discovery limit must be greater than zero".to_owned());
-    }
+    let (trimmed_query, limit) = parse_external_skills_discovery_request(&request)?;
+    let tool_name = discovery_tool_name(mode);
 
     let inventory = discover_skill_inventory(config)?;
     let visible_skill_count = inventory.skills.len();
     let shadowed_skill_count = inventory.shadowed_skills.len();
     let blocked_skill_count = inventory.blocked_skill_errors.len();
-    let tool_name = match mode {
-        SkillDiscoveryMode::Search => "skills.search",
-        SkillDiscoveryMode::Recommend => "skills.recommend",
-    };
 
     let results = build_ranked_skill_discovery_results(
         inventory.skills.as_slice(),
-        trimmed_query,
+        trimmed_query.as_str(),
         limit,
         SkillDiscoveryResolution::Active,
     );
     let shadowed_results = build_ranked_skill_discovery_results(
         inventory.shadowed_skills.as_slice(),
-        trimmed_query,
+        trimmed_query.as_str(),
         limit,
         SkillDiscoveryResolution::Shadowed,
     );
     let blocked_results = build_ranked_blocked_skill_discovery_results(
         &inventory.blocked_skill_errors,
-        trimmed_query,
+        trimmed_query.as_str(),
         limit,
     );
     let inventory_summary = SkillDiscoveryInventorySummary {
@@ -1140,6 +1123,44 @@ fn execute_external_skills_operator_discovery_tool_with_config(
             "blocked_results": blocked_results,
         }),
     })
+}
+
+fn parse_external_skills_discovery_request(
+    request: &ToolCoreRequest,
+) -> Result<(String, usize), String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| format!("{} payload must be an object", request.tool_name))?;
+    let trimmed_query = payload
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("{} requires payload.query", request.tool_name))?;
+    let raw_limit = payload
+        .get("limit")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("{} requires payload.limit", request.tool_name))?;
+    if raw_limit == 0 {
+        return Err(format!(
+            "{} payload.limit must be greater than zero",
+            request.tool_name
+        ));
+    }
+    let limit = usize::try_from(raw_limit)
+        .map_err(|error| format!("invalid discovery limit `{raw_limit}`: {error}"))?;
+    Ok((trimmed_query.to_owned(), limit))
+}
+
+fn discovery_tool_name(mode: SkillDiscoveryMode) -> &'static str {
+    // Search and recommend currently share the same discovery pipeline.
+    // If mode-specific ranking or filtering lands later, update both this
+    // mapping and the downstream discovery behavior together.
+    match mode {
+        SkillDiscoveryMode::Search => "external_skills.search",
+        SkillDiscoveryMode::Recommend => "external_skills.recommend",
+    }
 }
 
 fn build_ranked_skill_discovery_results(
@@ -2299,11 +2320,19 @@ fn evaluate_skill_eligibility(
             .iter()
             .map(|path| format!("missing path `{path}`")),
     );
+    let mut missing_config = Vec::new();
     for selector in &frontmatter.required_config {
-        match runtime_config_selector_enabled(config, selector) {
+        let selector_enabled = runtime_config_selector_enabled(config, selector);
+        match selector_enabled {
             Some(true) => {}
-            Some(false) => issues.push(format!("config gate `{selector}` is disabled")),
-            None => issues.push(format!("unsupported config gate `{selector}`")),
+            Some(false) => {
+                missing_config.push(selector.clone());
+                issues.push(format!("config gate `{selector}` is disabled"));
+            }
+            None => {
+                missing_config.push(selector.clone());
+                issues.push(format!("unsupported config gate `{selector}`"));
+            }
         }
     }
     let available = issues.is_empty();
@@ -2313,6 +2342,7 @@ fn evaluate_skill_eligibility(
         missing_env,
         missing_bin,
         missing_paths,
+        missing_config,
         issues,
     }
 }
@@ -4312,6 +4342,106 @@ mod tests {
                     .expect("instructions should be text")
                     .contains("Project-only instructions"),
                 "invoke should load project-scope instructions"
+            );
+
+            fs::remove_dir_all(&root).ok();
+            fs::remove_dir_all(&home).ok();
+        });
+    }
+
+    #[test]
+    fn discovery_search_and_recommend_route_through_tool_core() {
+        with_managed_runtime_test(|| {
+            let root = unique_temp_dir("loongclaw-ext-skill-discovery-search");
+            let home = unique_temp_dir("loongclaw-ext-skill-discovery-search-home");
+            fs::create_dir_all(&root).expect("create fixture root");
+            fs::create_dir_all(&home).expect("create home root");
+
+            write_file(
+                &root,
+                "source/release-guard/SKILL.md",
+                "---\nname: release-guard\ndescription: Guard release discipline.\ninvocation_policy: both\n---\n\n# Release Guard\n\nKeep release flows tight.\n",
+            );
+            write_file(
+                &root,
+                ".agents/skills/release-guard/SKILL.md",
+                "---\nname: release-guard\ndescription: Project-scoped release helper.\n---\n\nProject release fallback.\n",
+            );
+            write_file(
+                &root,
+                ".agents/skills/release-broken/SKILL.md",
+                "---\nname: release-broken\ndescription: Broken release helper.\n",
+            );
+
+            let config = managed_runtime_config(&root);
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.set("HOME", &home);
+
+            crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.install".to_owned(),
+                    payload: json!({
+                        "path": "source/release-guard"
+                    }),
+                },
+                &config,
+            )
+            .expect("install should succeed");
+
+            let search_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.search".to_owned(),
+                    payload: json!({
+                        "query": "release",
+                        "limit": 5,
+                    }),
+                },
+                &config,
+            )
+            .expect("search should succeed");
+            assert_eq!(
+                search_outcome.payload["tool_name"],
+                "external_skills.search"
+            );
+            assert_eq!(
+                search_outcome.payload["results"][0]["skill_id"],
+                "release-guard"
+            );
+            assert!(
+                search_outcome.payload["shadowed_results"]
+                    .as_array()
+                    .expect("shadowed_results should be an array")
+                    .iter()
+                    .any(|result| result["skill_id"] == "release-guard"),
+                "search should surface shadowed duplicates"
+            );
+            assert!(
+                search_outcome.payload["blocked_results"]
+                    .as_array()
+                    .expect("blocked_results should be an array")
+                    .iter()
+                    .any(|result| result["skill_id"] == "release-broken"),
+                "search should surface blocked candidates"
+            );
+
+            let recommend_outcome = crate::tools::execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: "external_skills.recommend".to_owned(),
+                    payload: json!({
+                        "query": "release helper",
+                        "limit": 3,
+                    }),
+                },
+                &config,
+            )
+            .expect("recommend should succeed");
+            assert_eq!(
+                recommend_outcome.payload["tool_name"],
+                "external_skills.recommend"
+            );
+            assert_eq!(
+                recommend_outcome.payload["results"][0]["skill_id"],
+                "release-guard"
             );
 
             fs::remove_dir_all(&root).ok();

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -16,6 +16,8 @@ use serde_yaml::Value as YamlValue;
 use sha2::{Digest, Sha256};
 use tar::Archive;
 
+use super::tool_search::{rank_searchable_entries, searchable_entry_from_manual_definition};
+
 const DEFAULT_DOWNLOAD_DIR_NAME: &str = "external-skills-downloads";
 const DEFAULT_INSTALL_DIR_NAME: &str = "external-skills-installed";
 const DEFAULT_SKILL_FILENAME: &str = "SKILL.md";
@@ -213,6 +215,42 @@ struct SkillDiscoveryInventory {
     skills: Vec<DiscoveredSkillEntry>,
     shadowed_skills: Vec<DiscoveredSkillEntry>,
     blocked_skill_errors: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum SkillDiscoveryResolution {
+    Active,
+    Shadowed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillDiscoveryMode {
+    Search,
+    Recommend,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct SkillDiscoveryInventorySummary {
+    visible_skill_count: usize,
+    shadowed_skill_count: usize,
+    blocked_skill_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct RankedSkillDiscoveryResult {
+    #[serde(flatten)]
+    skill: DiscoveredSkillEntry,
+    resolution: SkillDiscoveryResolution,
+    match_reasons: Vec<String>,
+    limitations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RankedBlockedSkillDiscoveryResult {
+    skill_id: String,
+    error: String,
+    match_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -920,6 +958,32 @@ pub(crate) fn execute_external_skills_operator_inspect_tool_with_config(
     )
 }
 
+pub(crate) fn execute_external_skills_operator_search_tool_with_config(
+    query: &str,
+    limit: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    execute_external_skills_operator_discovery_tool_with_config(
+        query,
+        limit,
+        config,
+        SkillDiscoveryMode::Search,
+    )
+}
+
+pub(crate) fn execute_external_skills_operator_recommend_tool_with_config(
+    query: &str,
+    limit: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    execute_external_skills_operator_discovery_tool_with_config(
+        query,
+        limit,
+        config,
+        SkillDiscoveryMode::Recommend,
+    )
+}
+
 pub(super) fn execute_external_skills_remove_tool_with_config(
     request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
@@ -1015,6 +1079,419 @@ fn execute_external_skills_inspect_for_audience(
             ),
         }),
     })
+}
+
+fn execute_external_skills_operator_discovery_tool_with_config(
+    query: &str,
+    limit: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+    mode: SkillDiscoveryMode,
+) -> Result<ToolCoreOutcome, String> {
+    let trimmed_query = query.trim();
+    if trimmed_query.is_empty() {
+        return Err("skills discovery requires a non-empty query".to_owned());
+    }
+    if limit == 0 {
+        return Err("skills discovery limit must be greater than zero".to_owned());
+    }
+
+    let inventory = discover_skill_inventory(config)?;
+    let visible_skill_count = inventory.skills.len();
+    let shadowed_skill_count = inventory.shadowed_skills.len();
+    let blocked_skill_count = inventory.blocked_skill_errors.len();
+    let tool_name = match mode {
+        SkillDiscoveryMode::Search => "skills.search",
+        SkillDiscoveryMode::Recommend => "skills.recommend",
+    };
+
+    let results = build_ranked_skill_discovery_results(
+        inventory.skills.as_slice(),
+        trimmed_query,
+        limit,
+        SkillDiscoveryResolution::Active,
+    );
+    let shadowed_results = build_ranked_skill_discovery_results(
+        inventory.shadowed_skills.as_slice(),
+        trimmed_query,
+        limit,
+        SkillDiscoveryResolution::Shadowed,
+    );
+    let blocked_results = build_ranked_blocked_skill_discovery_results(
+        &inventory.blocked_skill_errors,
+        trimmed_query,
+        limit,
+    );
+    let inventory_summary = SkillDiscoveryInventorySummary {
+        visible_skill_count,
+        shadowed_skill_count,
+        blocked_skill_count,
+    };
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "adapter": "core-tools",
+            "tool_name": tool_name,
+            "query": trimmed_query,
+            "limit": limit,
+            "inventory_summary": inventory_summary,
+            "results": results,
+            "shadowed_results": shadowed_results,
+            "blocked_results": blocked_results,
+        }),
+    })
+}
+
+fn build_ranked_skill_discovery_results(
+    skills: &[DiscoveredSkillEntry],
+    query: &str,
+    limit: usize,
+    resolution: SkillDiscoveryResolution,
+) -> Vec<RankedSkillDiscoveryResult> {
+    let mut searchable_entries = Vec::new();
+    let mut skills_by_identity = BTreeMap::new();
+
+    for skill in skills {
+        let search_identity = skill_search_identity(skill, resolution);
+        let searchable_entry = searchable_entry_from_skill(skill, resolution, &search_identity);
+        searchable_entries.push(searchable_entry);
+        skills_by_identity.insert(search_identity, skill.clone());
+    }
+
+    let ranking = rank_searchable_entries(searchable_entries, query, limit);
+    let mut ranked_results = Vec::new();
+    for ranked_entry in ranking.results {
+        let search_identity = ranked_entry.entry.canonical_name;
+        let Some(skill) = skills_by_identity.remove(&search_identity) else {
+            continue;
+        };
+        let match_reasons = render_skill_discovery_match_reasons(ranked_entry.why);
+        let limitations = build_skill_discovery_limitations(&skill, resolution);
+        let ranked_result = RankedSkillDiscoveryResult {
+            skill,
+            resolution,
+            match_reasons,
+            limitations,
+        };
+        ranked_results.push(ranked_result);
+    }
+
+    ranked_results
+}
+
+fn build_ranked_blocked_skill_discovery_results(
+    blocked_skill_errors: &BTreeMap<String, String>,
+    query: &str,
+    limit: usize,
+) -> Vec<RankedBlockedSkillDiscoveryResult> {
+    let mut searchable_entries = Vec::new();
+    let mut blocked_entries_by_identity = BTreeMap::new();
+
+    for (skill_id, error) in blocked_skill_errors {
+        let search_identity = format!("{skill_id}::blocked");
+        let required_fields = vec![skill_id.clone()];
+        let required_field_groups = vec![vec![skill_id.clone()]];
+        let tags = vec![
+            "external_skills".to_owned(),
+            "skill".to_owned(),
+            "blocked".to_owned(),
+        ];
+        let searchable_entry = searchable_entry_from_manual_definition(
+            search_identity.as_str(),
+            error.as_str(),
+            error.as_str(),
+            required_fields,
+            required_field_groups,
+            tags,
+        );
+        searchable_entries.push(searchable_entry);
+        blocked_entries_by_identity.insert(search_identity, (skill_id.clone(), error.clone()));
+    }
+
+    let ranking = rank_searchable_entries(searchable_entries, query, limit);
+    let mut ranked_results = Vec::new();
+    for ranked_entry in ranking.results {
+        let search_identity = ranked_entry.entry.canonical_name;
+        let Some((skill_id, error)) = blocked_entries_by_identity.remove(&search_identity) else {
+            continue;
+        };
+        let match_reasons = render_skill_discovery_match_reasons(ranked_entry.why);
+        let ranked_result = RankedBlockedSkillDiscoveryResult {
+            skill_id,
+            error,
+            match_reasons,
+        };
+        ranked_results.push(ranked_result);
+    }
+
+    ranked_results
+}
+
+fn searchable_entry_from_skill(
+    skill: &DiscoveredSkillEntry,
+    resolution: SkillDiscoveryResolution,
+    search_identity: &str,
+) -> super::tool_search::SearchableToolEntry {
+    let summary = build_skill_search_summary(skill);
+    let argument_hint = build_skill_search_argument_hint(skill, resolution);
+    let required_fields = build_skill_search_required_fields(skill);
+    let required_field_groups = build_skill_search_required_field_groups(&required_fields);
+    let tags = build_skill_search_tags(skill, resolution);
+    searchable_entry_from_manual_definition(
+        search_identity,
+        summary.as_str(),
+        argument_hint.as_str(),
+        required_fields,
+        required_field_groups,
+        tags,
+    )
+}
+
+fn build_skill_search_summary(skill: &DiscoveredSkillEntry) -> String {
+    let display_name = skill.display_name.trim();
+    let summary = skill.summary.trim();
+    let display_name_missing = display_name.is_empty();
+    if display_name_missing {
+        return summary.to_owned();
+    }
+    let summary_missing = summary.is_empty();
+    if summary_missing {
+        return display_name.to_owned();
+    }
+
+    let display_name_matches_summary = display_name.eq_ignore_ascii_case(summary);
+    if display_name_matches_summary {
+        return display_name.to_owned();
+    }
+
+    format!("{display_name}. {summary}")
+}
+
+fn build_skill_search_argument_hint(
+    skill: &DiscoveredSkillEntry,
+    resolution: SkillDiscoveryResolution,
+) -> String {
+    let mut fragments = Vec::new();
+    let display_name = skill.display_name.clone();
+    fragments.push(display_name);
+
+    let scope_fragment = format!("scope {}", discovered_skill_scope_id(skill.scope));
+    fragments.push(scope_fragment);
+
+    let source_kind_fragment = format!("source {}", skill.source_kind);
+    fragments.push(source_kind_fragment);
+
+    let visibility_fragment = format!(
+        "visibility {}",
+        skill_model_visibility_id(skill.model_visibility)
+    );
+    fragments.push(visibility_fragment);
+
+    let invocation_fragment = format!(
+        "invocation {}",
+        invocation_policy_id(skill.invocation_policy)
+    );
+    fragments.push(invocation_fragment);
+
+    if resolution == SkillDiscoveryResolution::Shadowed {
+        fragments.push("shadowed by a higher-precedence resolved skill".to_owned());
+    }
+    if !skill.active {
+        fragments.push("inactive resolved skill".to_owned());
+    }
+    for issue in &skill.eligibility.issues {
+        fragments.push(issue.clone());
+    }
+    for required_env in &skill.required_env {
+        let fragment = format!("env {required_env}");
+        fragments.push(fragment);
+    }
+    for required_bin in &skill.required_bin {
+        let fragment = format!("binary {required_bin}");
+        fragments.push(fragment);
+    }
+    for required_path in &skill.required_paths {
+        let fragment = format!("path {required_path}");
+        fragments.push(fragment);
+    }
+    for required_config in &skill.required_config {
+        let fragment = format!("config {required_config}");
+        fragments.push(fragment);
+    }
+    for allowed_tool in &skill.allowed_tools {
+        let fragment = format!("allowed tool {allowed_tool}");
+        fragments.push(fragment);
+    }
+    for blocked_tool in &skill.blocked_tools {
+        let fragment = format!("blocked tool {blocked_tool}");
+        fragments.push(fragment);
+    }
+
+    fragments.join("; ")
+}
+
+fn build_skill_search_required_fields(skill: &DiscoveredSkillEntry) -> Vec<String> {
+    let mut required_fields = BTreeSet::new();
+    for required_env in &skill.required_env {
+        required_fields.insert(required_env.clone());
+    }
+    for required_bin in &skill.required_bin {
+        required_fields.insert(required_bin.clone());
+    }
+    for required_path in &skill.required_paths {
+        required_fields.insert(required_path.clone());
+    }
+    for required_config in &skill.required_config {
+        required_fields.insert(required_config.clone());
+    }
+
+    required_fields.into_iter().collect()
+}
+
+fn build_skill_search_required_field_groups(required_fields: &[String]) -> Vec<Vec<String>> {
+    let fields_missing = required_fields.is_empty();
+    if fields_missing {
+        return Vec::new();
+    }
+
+    vec![required_fields.to_vec()]
+}
+
+fn build_skill_search_tags(
+    skill: &DiscoveredSkillEntry,
+    resolution: SkillDiscoveryResolution,
+) -> Vec<String> {
+    let mut tags = BTreeSet::new();
+    tags.insert("external_skills".to_owned());
+    tags.insert("skill".to_owned());
+    tags.insert(discovered_skill_scope_id(skill.scope).to_owned());
+    tags.insert(skill.source_kind.clone());
+    tags.insert(skill_model_visibility_id(skill.model_visibility).to_owned());
+    tags.insert(invocation_policy_id(skill.invocation_policy).to_owned());
+    tags.insert(skill_discovery_resolution_id(resolution).to_owned());
+
+    let eligibility_tag = if skill.eligibility.available {
+        "eligible"
+    } else {
+        "ineligible"
+    };
+    tags.insert(eligibility_tag.to_owned());
+
+    if !skill.active {
+        tags.insert("inactive".to_owned());
+    }
+    for allowed_tool in &skill.allowed_tools {
+        tags.insert(allowed_tool.clone());
+    }
+    for blocked_tool in &skill.blocked_tools {
+        tags.insert(blocked_tool.clone());
+    }
+
+    tags.into_iter().collect()
+}
+
+fn build_skill_discovery_limitations(
+    skill: &DiscoveredSkillEntry,
+    resolution: SkillDiscoveryResolution,
+) -> Vec<String> {
+    let mut limitations = Vec::new();
+    if resolution == SkillDiscoveryResolution::Shadowed {
+        limitations.push(
+            "shadowed by a higher-precedence resolved skill with the same `skill_id`".to_owned(),
+        );
+    }
+    if !skill.active {
+        limitations.push("resolved winner is inactive".to_owned());
+    }
+    if skill.model_visibility == SkillModelVisibility::Hidden {
+        limitations.push("hidden from the model surface".to_owned());
+    }
+    if skill.invocation_policy == SkillInvocationPolicy::Manual {
+        limitations.push("manual-only invocation".to_owned());
+    }
+    for issue in &skill.eligibility.issues {
+        limitations.push(issue.clone());
+    }
+
+    limitations
+}
+
+fn render_skill_discovery_match_reasons(raw_reasons: Vec<String>) -> Vec<String> {
+    let mut rendered_reasons = Vec::new();
+    for raw_reason in raw_reasons {
+        let rendered_reason = render_skill_discovery_match_reason(raw_reason.as_str());
+        rendered_reasons.push(rendered_reason);
+    }
+
+    rendered_reasons
+}
+
+fn render_skill_discovery_match_reason(raw_reason: &str) -> String {
+    if raw_reason == "name_phrase" {
+        return "matched skill id directly".to_owned();
+    }
+    if raw_reason == "summary_phrase" {
+        return "matched display name or summary directly".to_owned();
+    }
+    if raw_reason == "argument_phrase" {
+        return "matched discovery metadata or prerequisite text".to_owned();
+    }
+    if raw_reason == "schema_phrase" {
+        return "matched required capability or prerequisite fields".to_owned();
+    }
+    if raw_reason == "tag_phrase" {
+        return "matched discovery tags directly".to_owned();
+    }
+    if raw_reason == "coarse_fallback" {
+        return "fallback discovery ranking kept this candidate visible".to_owned();
+    }
+    if raw_reason == "coarse_discovery_tool" {
+        return "discovery-oriented metadata boosted this candidate".to_owned();
+    }
+
+    let Some((kind, value)) = raw_reason.split_once(':') else {
+        return raw_reason.to_owned();
+    };
+    match kind {
+        "name" => format!("skill id matched `{value}`"),
+        "summary" => format!("display name or summary matched `{value}`"),
+        "argument" => format!("metadata matched `{value}`"),
+        "schema" => format!("requirements matched `{value}`"),
+        "tag" => format!("classification matched `{value}`"),
+        "concept" => format!("query intent matched `{value}`"),
+        "category" => format!("query category matched `{value}`"),
+        _ => raw_reason.to_owned(),
+    }
+}
+
+fn skill_search_identity(
+    skill: &DiscoveredSkillEntry,
+    resolution: SkillDiscoveryResolution,
+) -> String {
+    let resolution_id = skill_discovery_resolution_id(resolution);
+    format!("{}::{resolution_id}::{}", skill.skill_id, skill.sha256)
+}
+
+fn skill_discovery_resolution_id(resolution: SkillDiscoveryResolution) -> &'static str {
+    match resolution {
+        SkillDiscoveryResolution::Active => "active",
+        SkillDiscoveryResolution::Shadowed => "shadowed",
+    }
+}
+
+fn discovered_skill_scope_id(scope: DiscoveredSkillScope) -> &'static str {
+    match scope {
+        DiscoveredSkillScope::Managed => "managed",
+        DiscoveredSkillScope::User => "user",
+        DiscoveredSkillScope::Project => "project",
+    }
+}
+
+fn skill_model_visibility_id(visibility: SkillModelVisibility) -> &'static str {
+    match visibility {
+        SkillModelVisibility::Visible => "visible",
+        SkillModelVisibility::Hidden => "hidden",
+    }
 }
 
 fn policy_override_store() -> &'static RwLock<ExternalSkillsPolicyOverride> {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -111,24 +111,6 @@ pub fn external_skills_operator_inspect_with_config(
     external_skills::execute_external_skills_operator_inspect_tool_with_config(skill_id, config)
 }
 
-pub fn external_skills_operator_search_with_config(
-    query: &str,
-    limit: usize,
-    config: &runtime_config::ToolRuntimeConfig,
-) -> Result<ToolCoreOutcome, String> {
-    external_skills::execute_external_skills_operator_search_tool_with_config(query, limit, config)
-}
-
-pub fn external_skills_operator_recommend_with_config(
-    query: &str,
-    limit: usize,
-    config: &runtime_config::ToolRuntimeConfig,
-) -> Result<ToolCoreOutcome, String> {
-    external_skills::execute_external_skills_operator_recommend_tool_with_config(
-        query, limit, config,
-    )
-}
-
 pub(crate) fn discover_installable_external_skill_roots(
     root: &Path,
 ) -> Result<Vec<PathBuf>, String> {
@@ -795,6 +777,12 @@ fn dispatch_tool_request(
 ) -> Result<ToolCoreOutcome, String> {
     match request.tool_name.as_str() {
         "claw.migrate" => claw_migrate::execute_claw_migrate_tool_with_config(request, config),
+        "external_skills.search" => {
+            external_skills::execute_external_skills_search_tool_with_config(request, config)
+        }
+        "external_skills.recommend" => {
+            external_skills::execute_external_skills_recommend_tool_with_config(request, config)
+        }
         "external_skills.inspect" => {
             external_skills::execute_external_skills_inspect_tool_with_config(request, config)
         }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -111,6 +111,24 @@ pub fn external_skills_operator_inspect_with_config(
     external_skills::execute_external_skills_operator_inspect_tool_with_config(skill_id, config)
 }
 
+pub fn external_skills_operator_search_with_config(
+    query: &str,
+    limit: usize,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    external_skills::execute_external_skills_operator_search_tool_with_config(query, limit, config)
+}
+
+pub fn external_skills_operator_recommend_with_config(
+    query: &str,
+    limit: usize,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    external_skills::execute_external_skills_operator_recommend_tool_with_config(
+        query, limit, config,
+    )
+}
+
 pub(crate) fn discover_installable_external_skill_roots(
     root: &Path,
 ) -> Result<Vec<PathBuf>, String> {

--- a/crates/app/src/tools/tool_search.rs
+++ b/crates/app/src/tools/tool_search.rs
@@ -1061,6 +1061,51 @@ pub(super) fn searchable_entry_from_provider_definition(
     }
 }
 
+pub(super) fn searchable_entry_from_manual_definition(
+    canonical_name: &str,
+    summary: &str,
+    argument_hint: &str,
+    required_fields: Vec<String>,
+    required_field_groups: Vec<Vec<String>>,
+    tags: Vec<String>,
+) -> SearchableToolEntry {
+    let mut name_fragments = vec![canonical_name.to_owned()];
+    let canonical_name_variant = identifier_phrase_variant(canonical_name);
+    let variant_is_distinct = canonical_name_variant != canonical_name;
+    if variant_is_distinct {
+        name_fragments.push(canonical_name_variant);
+    }
+
+    let summary_text = summary.to_owned();
+    let argument_hint_text = argument_hint.to_owned();
+    let argument_fragments =
+        build_argument_fragments(argument_hint, &required_fields, &required_field_groups);
+
+    let mut schema_fragments = required_fields.clone();
+    for required_field_group in &required_field_groups {
+        let group_fragment = required_field_group.join(" ");
+        schema_fragments.push(group_fragment);
+    }
+
+    let search_document = SearchDocument::new(
+        name_fragments,
+        vec![summary_text.clone()],
+        argument_fragments,
+        schema_fragments,
+        tags.clone(),
+    );
+
+    SearchableToolEntry {
+        canonical_name: canonical_name.to_owned(),
+        summary: summary_text,
+        argument_hint: argument_hint_text,
+        required_fields,
+        required_field_groups,
+        tags,
+        search_document,
+    }
+}
+
 pub(super) fn search_argument_hint_from_provider_definition(
     parameters: &Value,
     preferred_parameter_order: &[(&str, &str)],

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -10,6 +10,7 @@ pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser comp
 
 const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
 const BROWSER_COMPANION_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+const BROWSER_COMPANION_PROBE_ATTEMPTS: usize = 2;
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -212,6 +213,22 @@ pub(crate) async fn collect_browser_companion_diagnostics(
 async fn probe_browser_companion_version(
     command: &str,
 ) -> Result<String, BrowserCompanionProbeError> {
+    for _attempt in 0..BROWSER_COMPANION_PROBE_ATTEMPTS {
+        let probe_result = probe_browser_companion_version_once(command).await;
+        match probe_result {
+            Err(BrowserCompanionProbeError::TimedOut) => {}
+            result => {
+                return result;
+            }
+        }
+    }
+
+    Err(BrowserCompanionProbeError::TimedOut)
+}
+
+async fn probe_browser_companion_version_once(
+    command: &str,
+) -> Result<String, BrowserCompanionProbeError> {
     let mut probe = Command::new(command);
     probe.arg(BROWSER_COMPANION_VERSION_ARG);
     probe.kill_on_drop(true);
@@ -384,6 +401,39 @@ mod tests {
                     && observed_version == "loongclaw-browser-companion 11.5.0"
             ),
             "partial version matches should still warn as mismatches: {diagnostics:#?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_browser_companion_diagnostics_retries_transient_probe_timeouts() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let temp_dir = browser_companion_temp_dir("transient-timeout");
+        let script_path = temp_dir.join("browser-companion");
+        let state_path = temp_dir.join("probe-state");
+        let script_body = format!(
+            "#!/bin/sh\nstate_path='{}'\nif [ ! -f \"$state_path\" ]; then\n  touch \"$state_path\"\n  sleep 4\nfi\necho 'loongclaw-browser-companion 1.5.0'\n",
+            state_path.display()
+        );
+        write_browser_companion_script(&script_path, script_body.as_str());
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+
+        let diagnostics = collect_browser_companion_diagnostics(&config)
+            .await
+            .expect("diagnostics should be collected");
+
+        assert_eq!(
+            diagnostics.install_status,
+            BrowserCompanionInstallStatus::Ready,
+            "transient probe timeouts should retry before surfacing an install warning: {diagnostics:#?}"
+        );
+        assert_eq!(
+            diagnostics.observed_version.as_deref(),
+            Some("loongclaw-browser-companion 1.5.0")
         );
     }
 

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -180,20 +180,22 @@ fn execute_non_policy_skills_command(
         SkillsCommands::Search { query, limit } => {
             let normalized_query = normalize_skills_discovery_query(query, "skills search")?;
             let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
-            mvp::tools::external_skills_operator_search_with_config(
+            let request = build_skills_discovery_tool_request(
+                "external_skills.search",
                 normalized_query.as_str(),
                 limit,
-                &tool_runtime_config,
-            )
+            );
+            mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)
         }
         SkillsCommands::Recommend { query, limit } => {
             let normalized_query = normalize_skills_discovery_query(query, "skills recommend")?;
             let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
-            mvp::tools::external_skills_operator_recommend_with_config(
+            let request = build_skills_discovery_tool_request(
+                "external_skills.recommend",
                 normalized_query.as_str(),
                 limit,
-                &tool_runtime_config,
-            )
+            );
+            mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)
         }
         SkillsCommands::Info { skill_id } => {
             let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
@@ -380,12 +382,8 @@ fn build_skill_follow_up_guidance(
     let missing_env = string_array_from_value(eligibility.get("missing_env"));
     let missing_bin = string_array_from_value(eligibility.get("missing_bin"));
     let missing_paths = string_array_from_value(eligibility.get("missing_paths"));
-    let required_config = string_array_from_value(skill.get("required_config").or_else(|| {
-        skill
-            .get("metadata")
-            .and_then(Value::as_object)
-            .and_then(|metadata| metadata.get("required_config"))
-    }));
+    let missing_config = string_array_from_value(eligibility.get("missing_config"));
+    let active = skill.get("active").and_then(Value::as_bool).unwrap_or(true);
     let config_path = resolved_path.display().to_string();
     let mut next_steps = Vec::new();
     let mut recipes = Vec::new();
@@ -409,15 +407,15 @@ fn build_skill_follow_up_guidance(
         let path_step = format!("Create or point required paths: {path_fragment}");
         next_steps.push(path_step);
     }
-    if !required_config.is_empty() {
-        let config_fragment = required_config.join(", ");
+    if !missing_config.is_empty() {
+        let config_fragment = missing_config.join(", ");
         let config_step = format!("Enable required config gates: {config_fragment}");
         next_steps.push(config_step);
     }
 
     let hidden_from_model = visibility == "hidden";
     let manual_only = invocation_policy == "manual";
-    let can_use_in_ask = available && !hidden_from_model && !manual_only;
+    let can_use_in_ask = active && available && !hidden_from_model && !manual_only;
     if can_use_in_ask {
         let ask_message = format!("Use the {skill_id} skill to help with the current task.");
         let ask_command = crate::cli_handoff::format_ask_with_config(&config_path, &ask_message);
@@ -436,6 +434,11 @@ fn build_skill_follow_up_guidance(
     } else if manual_only {
         next_steps.push(
             "This skill is manual-only and cannot be invoked through `external_skills.invoke`."
+                .to_owned(),
+        );
+    } else if !active {
+        next_steps.push(
+            "This skill is inactive and cannot be used in a conversation until it is reactivated."
                 .to_owned(),
         );
     } else if !available {
@@ -465,6 +468,20 @@ fn string_array_from_value(value: Option<&Value>) -> Vec<String> {
     }
 
     strings
+}
+
+fn build_skills_discovery_tool_request(
+    tool_name: &str,
+    query: &str,
+    limit: usize,
+) -> ToolCoreRequest {
+    ToolCoreRequest {
+        tool_name: tool_name.to_owned(),
+        payload: json!({
+            "query": query,
+            "limit": limit,
+        }),
+    }
 }
 
 fn build_skills_tool_request(command: SkillsCommands) -> CliResult<ToolCoreRequest> {
@@ -932,7 +949,10 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                 }
             }
         }
-        "skills.search" | "skills.recommend" => {
+        "skills.search"
+        | "skills.recommend"
+        | "external_skills.search"
+        | "external_skills.recommend" => {
             lines.push(format!(
                 "query={}",
                 payload.get("query").and_then(Value::as_str).unwrap_or("-")
@@ -964,7 +984,9 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                     .and_then(Value::as_u64)
                     .unwrap_or(0)
             ));
-            let results_heading = if tool_name == "skills.recommend" {
+            let is_recommendation =
+                matches!(tool_name, "skills.recommend" | "external_skills.recommend");
+            let results_heading = if is_recommendation {
                 "recommended skills:"
             } else {
                 "results:"
@@ -1157,6 +1179,10 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
             lines.push(format!(
                 "missing_paths={}",
                 render_string_list(eligibility.and_then(|value| value.get("missing_paths")))
+            ));
+            lines.push(format!(
+                "missing_config={}",
+                render_string_list(eligibility.and_then(|value| value.get("missing_config")))
             ));
             lines.push(format!(
                 "source_path={}",
@@ -1536,18 +1562,26 @@ fn render_skill_discovery_results_section(
             .get("resolution")
             .and_then(Value::as_str)
             .unwrap_or("active");
-        let inspect_subcommand = format!("skills info {skill_id}");
-        let inspect_command = crate::cli_handoff::format_subcommand_with_config(
-            &inspect_subcommand,
-            resolved_config_path,
-        );
         lines.push(format!(
             "- {} resolution={resolution}",
             render_skill_summary_line(result)
         ));
         render_optional_string_section(lines, "  match reasons:", result.get("match_reasons"))?;
         render_optional_string_section(lines, "  limitations:", result.get("limitations"))?;
-        lines.push(format!("  inspect={inspect_command}"));
+        if resolution == "active" {
+            let inspect_subcommand = format!("skills info {skill_id}");
+            let inspect_command = crate::cli_handoff::format_subcommand_with_config(
+                &inspect_subcommand,
+                resolved_config_path,
+            );
+            lines.push(format!("  inspect={inspect_command}"));
+        } else {
+            let skill_md_path = result
+                .get("skill_md_path")
+                .and_then(Value::as_str)
+                .unwrap_or("-");
+            lines.push(format!("  skill_md_path={skill_md_path}"));
+        }
     }
 
     Ok(())

--- a/crates/daemon/src/skills_cli.rs
+++ b/crates/daemon/src/skills_cli.rs
@@ -5,10 +5,25 @@ use loongclaw_spec::CliResult;
 use serde_json::{Map, Value, json};
 use std::{collections::BTreeSet, path::Path};
 
+const DEFAULT_SKILLS_SEARCH_LIMIT: usize = 5;
+const DEFAULT_SKILLS_RECOMMEND_LIMIT: usize = 3;
+
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum SkillsCommands {
     /// List discovered external skills across managed, user, and project scopes
     List,
+    /// Search the external-skills inventory from a task or capability phrase
+    Search {
+        query: Vec<String>,
+        #[arg(long, default_value_t = DEFAULT_SKILLS_SEARCH_LIMIT)]
+        limit: usize,
+    },
+    /// Recommend the best-fit external skills for an operator goal
+    Recommend {
+        query: Vec<String>,
+        #[arg(long, default_value_t = DEFAULT_SKILLS_RECOMMEND_LIMIT)]
+        limit: usize,
+    },
     /// Inspect one resolved external skill
     #[command(visible_alias = "inspect")]
     Info { skill_id: String },
@@ -124,6 +139,8 @@ pub fn execute_skills_command(options: SkillsCommandOptions) -> CliResult<Skills
             execute_enable_browser_preview_command(&resolved_path, &mut config, replace)?
         }
         command @ (SkillsCommands::List
+        | SkillsCommands::Search { .. }
+        | SkillsCommands::Recommend { .. }
         | SkillsCommands::Info { .. }
         | SkillsCommands::Fetch { .. }
         | SkillsCommands::Install { .. }
@@ -138,6 +155,18 @@ pub fn execute_skills_command(options: SkillsCommandOptions) -> CliResult<Skills
     })
 }
 
+#[derive(Debug, Clone)]
+struct SkillFollowUpRecipe {
+    label: String,
+    command: String,
+}
+
+#[derive(Debug, Clone)]
+struct SkillFollowUpGuidance {
+    next_steps: Vec<String>,
+    recipes: Vec<SkillFollowUpRecipe>,
+}
+
 fn execute_non_policy_skills_command(
     resolved_path: &Path,
     config: &mvp::config::LoongClawConfig,
@@ -145,23 +174,34 @@ fn execute_non_policy_skills_command(
 ) -> CliResult<ToolCoreOutcome> {
     match command {
         SkillsCommands::List => {
-            let tool_runtime_config =
-                mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
-                    config,
-                    Some(resolved_path),
-                );
+            let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
             mvp::tools::external_skills_operator_list_with_config(&tool_runtime_config)
         }
-        SkillsCommands::Info { skill_id } => {
-            let tool_runtime_config =
-                mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
-                    config,
-                    Some(resolved_path),
-                );
-            mvp::tools::external_skills_operator_inspect_with_config(
-                &skill_id,
+        SkillsCommands::Search { query, limit } => {
+            let normalized_query = normalize_skills_discovery_query(query, "skills search")?;
+            let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
+            mvp::tools::external_skills_operator_search_with_config(
+                normalized_query.as_str(),
+                limit,
                 &tool_runtime_config,
             )
+        }
+        SkillsCommands::Recommend { query, limit } => {
+            let normalized_query = normalize_skills_discovery_query(query, "skills recommend")?;
+            let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
+            mvp::tools::external_skills_operator_recommend_with_config(
+                normalized_query.as_str(),
+                limit,
+                &tool_runtime_config,
+            )
+        }
+        SkillsCommands::Info { skill_id } => {
+            let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
+            let inspect_outcome = mvp::tools::external_skills_operator_inspect_with_config(
+                &skill_id,
+                &tool_runtime_config,
+            )?;
+            decorate_skill_info_outcome(inspect_outcome, resolved_path)
         }
         SkillsCommands::Fetch {
             url,
@@ -183,14 +223,20 @@ fn execute_non_policy_skills_command(
             replace,
         ),
         SkillsCommands::InstallBundled { skill_id, replace } => {
-            execute_install_bundled_skill_command(resolved_path, config, &skill_id, replace)
+            let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
+            let install_outcome =
+                execute_install_bundled_skill_command(resolved_path, config, &skill_id, replace)?;
+            decorate_skill_install_outcome(install_outcome, resolved_path, &tool_runtime_config)
         }
-        command @ (SkillsCommands::Install { .. } | SkillsCommands::Remove { .. }) => {
-            let tool_runtime_config =
-                mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
-                    config,
-                    Some(resolved_path),
-                );
+        SkillsCommands::Install { .. } => {
+            let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
+            let request = build_skills_tool_request(command)?;
+            let install_outcome =
+                mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)?;
+            decorate_skill_install_outcome(install_outcome, resolved_path, &tool_runtime_config)
+        }
+        SkillsCommands::Remove { .. } => {
+            let tool_runtime_config = tool_runtime_config_for_skills_command(config, resolved_path);
             let request = build_skills_tool_request(command)?;
             mvp::tools::execute_tool_core_with_config(request, &tool_runtime_config)
         }
@@ -200,12 +246,236 @@ fn execute_non_policy_skills_command(
     }
 }
 
+fn tool_runtime_config_for_skills_command(
+    config: &mvp::config::LoongClawConfig,
+    resolved_path: &Path,
+) -> mvp::tools::runtime_config::ToolRuntimeConfig {
+    mvp::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(
+        config,
+        Some(resolved_path),
+    )
+}
+
+fn normalize_skills_discovery_query(
+    query_terms: Vec<String>,
+    command_name: &str,
+) -> CliResult<String> {
+    let trimmed_terms = query_terms
+        .into_iter()
+        .map(|term| term.trim().to_owned())
+        .filter(|term| !term.is_empty())
+        .collect::<Vec<_>>();
+    let joined_query = trimmed_terms.join(" ");
+    if joined_query.is_empty() {
+        return Err(format!("{command_name} requires a non-empty query"));
+    }
+
+    Ok(joined_query)
+}
+
+fn decorate_skill_info_outcome(
+    mut outcome: ToolCoreOutcome,
+    resolved_path: &Path,
+) -> CliResult<ToolCoreOutcome> {
+    let guidance =
+        build_skill_follow_up_guidance_from_info_payload(&outcome.payload, resolved_path)?;
+    attach_skill_follow_up_guidance(&mut outcome, guidance);
+    Ok(outcome)
+}
+
+fn decorate_skill_install_outcome(
+    mut outcome: ToolCoreOutcome,
+    resolved_path: &Path,
+    tool_runtime_config: &mvp::tools::runtime_config::ToolRuntimeConfig,
+) -> CliResult<ToolCoreOutcome> {
+    let payload = outcome
+        .payload
+        .as_object()
+        .ok_or_else(|| "skills install payload must be an object".to_owned())?;
+    let skill_id = payload
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "skills install payload missing `skill_id`".to_owned())?;
+    let inspect_outcome =
+        mvp::tools::external_skills_operator_inspect_with_config(skill_id, tool_runtime_config)?;
+    let mut guidance =
+        build_skill_follow_up_guidance_from_info_payload(&inspect_outcome.payload, resolved_path)?;
+    let config_path = resolved_path.display().to_string();
+    let inspect_subcommand = format!("skills info {skill_id}");
+    let inspect_command =
+        crate::cli_handoff::format_subcommand_with_config(&inspect_subcommand, &config_path);
+    let inspect_step = format!("Inspect the installed skill: {inspect_command}");
+    guidance.next_steps.insert(0, inspect_step);
+    attach_skill_follow_up_guidance(&mut outcome, guidance);
+    Ok(outcome)
+}
+
+fn attach_skill_follow_up_guidance(outcome: &mut ToolCoreOutcome, guidance: SkillFollowUpGuidance) {
+    let mut recipe_payload = Vec::new();
+    for recipe in guidance.recipes {
+        let recipe_value = json!({
+            "label": recipe.label,
+            "command": recipe.command,
+        });
+        recipe_payload.push(recipe_value);
+    }
+
+    if let Some(payload) = outcome.payload.as_object_mut() {
+        payload.insert("next_steps".to_owned(), json!(guidance.next_steps));
+        payload.insert("recipes".to_owned(), Value::Array(recipe_payload));
+    }
+}
+
+fn build_skill_follow_up_guidance_from_info_payload(
+    payload: &Value,
+    resolved_path: &Path,
+) -> CliResult<SkillFollowUpGuidance> {
+    let skill = payload
+        .get("skill")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "skills info payload missing `skill` object".to_owned())?;
+    build_skill_follow_up_guidance(skill, resolved_path)
+}
+
+fn build_skill_follow_up_guidance(
+    skill: &Map<String, Value>,
+    resolved_path: &Path,
+) -> CliResult<SkillFollowUpGuidance> {
+    let skill_id = skill
+        .get("skill_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "skill payload missing `skill_id`".to_owned())?;
+    let display_name = skill
+        .get("display_name")
+        .and_then(Value::as_str)
+        .unwrap_or(skill_id);
+    let skill_md_path = skill
+        .get("skill_md_path")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let visibility = skill
+        .get("model_visibility")
+        .and_then(Value::as_str)
+        .unwrap_or("visible");
+    let invocation_policy = skill
+        .get("invocation_policy")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            skill
+                .get("metadata")
+                .and_then(Value::as_object)
+                .and_then(|metadata| metadata.get("invocation_policy"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("model");
+    let eligibility = skill
+        .get("eligibility")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "skill payload missing `eligibility` object".to_owned())?;
+    let available = eligibility
+        .get("available")
+        .and_then(Value::as_bool)
+        .or_else(|| eligibility.get("eligible").and_then(Value::as_bool))
+        .unwrap_or(true);
+    let missing_env = string_array_from_value(eligibility.get("missing_env"));
+    let missing_bin = string_array_from_value(eligibility.get("missing_bin"));
+    let missing_paths = string_array_from_value(eligibility.get("missing_paths"));
+    let required_config = string_array_from_value(skill.get("required_config").or_else(|| {
+        skill
+            .get("metadata")
+            .and_then(Value::as_object)
+            .and_then(|metadata| metadata.get("required_config"))
+    }));
+    let config_path = resolved_path.display().to_string();
+    let mut next_steps = Vec::new();
+    let mut recipes = Vec::new();
+
+    let quoted_skill_path = crate::cli_handoff::shell_quote_argument(skill_md_path);
+    let review_step = format!("Review the skill instructions at {quoted_skill_path}");
+    next_steps.push(review_step);
+
+    if !missing_env.is_empty() {
+        let env_fragment = missing_env.join(", ");
+        let env_step = format!("Set required environment variables: {env_fragment}");
+        next_steps.push(env_step);
+    }
+    if !missing_bin.is_empty() {
+        let bin_fragment = missing_bin.join(", ");
+        let bin_step = format!("Install required commands on PATH: {bin_fragment}");
+        next_steps.push(bin_step);
+    }
+    if !missing_paths.is_empty() {
+        let path_fragment = missing_paths.join(", ");
+        let path_step = format!("Create or point required paths: {path_fragment}");
+        next_steps.push(path_step);
+    }
+    if !required_config.is_empty() {
+        let config_fragment = required_config.join(", ");
+        let config_step = format!("Enable required config gates: {config_fragment}");
+        next_steps.push(config_step);
+    }
+
+    let hidden_from_model = visibility == "hidden";
+    let manual_only = invocation_policy == "manual";
+    let can_use_in_ask = available && !hidden_from_model && !manual_only;
+    if can_use_in_ask {
+        let ask_message = format!("Use the {skill_id} skill to help with the current task.");
+        let ask_command = crate::cli_handoff::format_ask_with_config(&config_path, &ask_message);
+        let ask_step = format!("Try the skill in a conversation: {ask_command}");
+        next_steps.push(ask_step);
+        let recipe = SkillFollowUpRecipe {
+            label: format!("Try {display_name}"),
+            command: ask_command,
+        };
+        recipes.push(recipe);
+    } else if hidden_from_model {
+        next_steps.push(
+            "This skill is hidden from model discovery; keep the workflow operator-driven."
+                .to_owned(),
+        );
+    } else if manual_only {
+        next_steps.push(
+            "This skill is manual-only and cannot be invoked through `external_skills.invoke`."
+                .to_owned(),
+        );
+    } else if !available {
+        next_steps.push(
+            "Resolve the missing prerequisites above before trying this skill in a conversation."
+                .to_owned(),
+        );
+    }
+
+    Ok(SkillFollowUpGuidance {
+        next_steps,
+        recipes,
+    })
+}
+
+fn string_array_from_value(value: Option<&Value>) -> Vec<String> {
+    let Some(values) = value.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    let mut strings = Vec::new();
+    for value in values {
+        let Some(text) = value.as_str() else {
+            continue;
+        };
+        strings.push(text.to_owned());
+    }
+
+    strings
+}
+
 fn build_skills_tool_request(command: SkillsCommands) -> CliResult<ToolCoreRequest> {
     match command {
         SkillsCommands::List => Ok(ToolCoreRequest {
             tool_name: "external_skills.list".to_owned(),
             payload: json!({}),
         }),
+        SkillsCommands::Search { .. } | SkillsCommands::Recommend { .. } => {
+            Err("skills discovery requests are handled directly by the daemon CLI".to_owned())
+        }
         SkillsCommands::Info { skill_id } => Ok(ToolCoreRequest {
             tool_name: "external_skills.inspect".to_owned(),
             payload: json!({
@@ -267,7 +537,7 @@ fn execute_fetch_command(
         mvp::tools::execute_tool_core_with_config(fetch_request, &tool_runtime_config)?;
     let fetched = fetch_outcome.payload;
 
-    let installed = if install {
+    let mut installed = if install {
         let saved_path = fetched
             .get("saved_path")
             .and_then(Value::as_str)
@@ -280,6 +550,17 @@ fn execute_fetch_command(
     } else {
         None
     };
+
+    if let Some(installed_payload) = installed.as_mut() {
+        let mut installed_outcome = ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: installed_payload.clone(),
+        };
+        let decorated_outcome =
+            decorate_skill_install_outcome(installed_outcome, resolved_path, &tool_runtime_config)?;
+        installed_outcome = decorated_outcome;
+        *installed_payload = installed_outcome.payload;
+    }
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -651,6 +932,64 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                 }
             }
         }
+        "skills.search" | "skills.recommend" => {
+            lines.push(format!(
+                "query={}",
+                payload.get("query").and_then(Value::as_str).unwrap_or("-")
+            ));
+            let inventory_summary = payload
+                .get("inventory_summary")
+                .and_then(Value::as_object)
+                .ok_or_else(|| {
+                    "skills discovery payload missing `inventory_summary` object".to_owned()
+                })?;
+            lines.push(format!(
+                "visible_skill_count={}",
+                inventory_summary
+                    .get("visible_skill_count")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0)
+            ));
+            lines.push(format!(
+                "shadowed_skill_count={}",
+                inventory_summary
+                    .get("shadowed_skill_count")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0)
+            ));
+            lines.push(format!(
+                "blocked_skill_count={}",
+                inventory_summary
+                    .get("blocked_skill_count")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0)
+            ));
+            let results_heading = if tool_name == "skills.recommend" {
+                "recommended skills:"
+            } else {
+                "results:"
+            };
+            render_skill_discovery_results_section(
+                &mut lines,
+                results_heading,
+                payload.get("results"),
+                execution.resolved_config_path.as_str(),
+                "skills discovery payload missing `results` array",
+            )?;
+            render_skill_discovery_results_section(
+                &mut lines,
+                "shadowed matches:",
+                payload.get("shadowed_results"),
+                execution.resolved_config_path.as_str(),
+                "skills discovery payload missing `shadowed_results` array",
+            )?;
+            render_blocked_skill_discovery_results_section(
+                &mut lines,
+                "blocked matches:",
+                payload.get("blocked_results"),
+                "skills discovery payload missing `blocked_results` array",
+            )?;
+        }
         "skills.fetch" => {
             let fetched = payload
                 .get("fetched")
@@ -726,6 +1065,12 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                         .and_then(Value::as_bool)
                         .unwrap_or(false)
                 ));
+                render_optional_string_section(
+                    &mut lines,
+                    "next steps:",
+                    installed.get("next_steps"),
+                )?;
+                render_optional_recipe_section(&mut lines, "recipes:", installed.get("recipes"))?;
             }
         }
         "external_skills.inspect" => {
@@ -922,6 +1267,8 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                     lines.push(format!("- {}", render_skill_summary_line(shadowed_skill)));
                 }
             }
+            render_optional_string_section(&mut lines, "next steps:", payload.get("next_steps"))?;
+            render_optional_recipe_section(&mut lines, "recipes:", payload.get("recipes"))?;
         }
         "external_skills.install" | "skills.enable-browser-preview" => {
             lines.push(format!(
@@ -975,14 +1322,9 @@ pub fn render_skills_cli_text(execution: &SkillsCommandExecution) -> CliResult<S
                         .and_then(Value::as_bool)
                         .unwrap_or(false)
                 ));
-                render_string_section(
-                    &mut lines,
-                    "next steps:",
-                    payload.get("next_steps"),
-                    "skills enable-browser-preview payload missing `next_steps` array",
-                )?;
-                render_recipe_section(&mut lines, payload.get("recipes"))?;
             }
+            render_optional_string_section(&mut lines, "next steps:", payload.get("next_steps"))?;
+            render_optional_recipe_section(&mut lines, "recipes:", payload.get("recipes"))?;
         }
         "external_skills.remove" => {
             lines.push(format!(
@@ -1106,26 +1448,135 @@ fn render_string_section(
     Ok(())
 }
 
-fn render_recipe_section(lines: &mut Vec<String>, value: Option<&Value>) -> CliResult<()> {
-    let recipes = value.and_then(Value::as_array).ok_or_else(|| {
-        "skills enable-browser-preview payload missing `recipes` array".to_owned()
-    })?;
+fn render_optional_string_section(
+    lines: &mut Vec<String>,
+    heading: &str,
+    value: Option<&Value>,
+) -> CliResult<()> {
+    let Some(items) = value.and_then(Value::as_array) else {
+        return Ok(());
+    };
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    lines.push(heading.to_owned());
+    for item in items {
+        let rendered = item
+            .as_str()
+            .ok_or_else(|| format!("{heading} entries must be strings"))?;
+        lines.push(format!("- {rendered}"));
+    }
+    Ok(())
+}
+
+fn render_recipe_section(
+    lines: &mut Vec<String>,
+    heading: &str,
+    value: Option<&Value>,
+) -> CliResult<()> {
+    let recipes = value
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("{heading} payload missing recipe array"))?;
     if recipes.is_empty() {
         return Ok(());
     }
 
-    lines.push("recipes:".to_owned());
+    lines.push(heading.to_owned());
     for recipe in recipes {
         let label = recipe
             .get("label")
             .and_then(Value::as_str)
-            .ok_or_else(|| "browser preview recipe is missing `label`".to_owned())?;
+            .ok_or_else(|| format!("{heading} recipe is missing `label`"))?;
         let command = recipe
             .get("command")
             .and_then(Value::as_str)
-            .ok_or_else(|| "browser preview recipe is missing `command`".to_owned())?;
+            .ok_or_else(|| format!("{heading} recipe is missing `command`"))?;
         lines.push(format!("- {label}: {command}"));
     }
+    Ok(())
+}
+
+fn render_optional_recipe_section(
+    lines: &mut Vec<String>,
+    heading: &str,
+    value: Option<&Value>,
+) -> CliResult<()> {
+    let Some(recipes) = value.and_then(Value::as_array) else {
+        return Ok(());
+    };
+    if recipes.is_empty() {
+        return Ok(());
+    }
+
+    render_recipe_section(lines, heading, value)
+}
+
+fn render_skill_discovery_results_section(
+    lines: &mut Vec<String>,
+    heading: &str,
+    value: Option<&Value>,
+    resolved_config_path: &str,
+    missing_error: &str,
+) -> CliResult<()> {
+    let results = value
+        .and_then(Value::as_array)
+        .ok_or_else(|| missing_error.to_owned())?;
+    if results.is_empty() {
+        return Ok(());
+    }
+
+    lines.push(heading.to_owned());
+    for result in results {
+        let skill_id = result
+            .get("skill_id")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        let resolution = result
+            .get("resolution")
+            .and_then(Value::as_str)
+            .unwrap_or("active");
+        let inspect_subcommand = format!("skills info {skill_id}");
+        let inspect_command = crate::cli_handoff::format_subcommand_with_config(
+            &inspect_subcommand,
+            resolved_config_path,
+        );
+        lines.push(format!(
+            "- {} resolution={resolution}",
+            render_skill_summary_line(result)
+        ));
+        render_optional_string_section(lines, "  match reasons:", result.get("match_reasons"))?;
+        render_optional_string_section(lines, "  limitations:", result.get("limitations"))?;
+        lines.push(format!("  inspect={inspect_command}"));
+    }
+
+    Ok(())
+}
+
+fn render_blocked_skill_discovery_results_section(
+    lines: &mut Vec<String>,
+    heading: &str,
+    value: Option<&Value>,
+    missing_error: &str,
+) -> CliResult<()> {
+    let results = value
+        .and_then(Value::as_array)
+        .ok_or_else(|| missing_error.to_owned())?;
+    if results.is_empty() {
+        return Ok(());
+    }
+
+    lines.push(heading.to_owned());
+    for result in results {
+        let skill_id = result
+            .get("skill_id")
+            .and_then(Value::as_str)
+            .unwrap_or("-");
+        let error = result.get("error").and_then(Value::as_str).unwrap_or("-");
+        lines.push(format!("- skill_id={skill_id} blocked_error={error}"));
+        render_optional_string_section(lines, "  match reasons:", result.get("match_reasons"))?;
+    }
+
     Ok(())
 }
 

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -1480,6 +1480,10 @@ fn execute_skills_command_search_surfaces_active_shadowed_and_blocked_matches() 
     .expect("skills search should succeed");
 
     assert_eq!(
+        search.outcome.payload["tool_name"],
+        "external_skills.search"
+    );
+    assert_eq!(
         search.outcome.payload["results"][0]["skill_id"],
         "release-guard"
     );
@@ -1507,6 +1511,9 @@ fn execute_skills_command_search_surfaces_active_shadowed_and_blocked_matches() 
         "inspect=loongclaw skills info release-guard --config {}",
         shell_quote(&config_path.display().to_string())
     );
+    let inspect_occurrences = rendered.matches(expected_inspect.as_str()).count();
+    let shadowed_skill_md_path = root.join(".agents/skills/release-guard/SKILL.md");
+    let expected_shadowed_path = format!("  skill_md_path={}", shadowed_skill_md_path.display());
     assert!(
         rendered.contains("shadowed matches:"),
         "search text should render matching shadowed candidates: {rendered}"
@@ -1515,9 +1522,13 @@ fn execute_skills_command_search_surfaces_active_shadowed_and_blocked_matches() 
         rendered.contains("blocked matches:"),
         "search text should render matching blocked candidates: {rendered}"
     );
+    assert_eq!(
+        inspect_occurrences, 1,
+        "only active discovery results should surface skills info handoffs: {rendered}"
+    );
     assert!(
-        rendered.contains(expected_inspect.as_str()),
-        "search text should surface a concrete inspect handoff: {rendered}"
+        rendered.contains(expected_shadowed_path.as_str()),
+        "shadowed discovery results should point operators at the concrete skill file: {rendered}"
     );
 
     fs::remove_dir_all(&root).ok();
@@ -1584,7 +1595,7 @@ fn execute_skills_command_install_and_info_surface_first_use_guidance() {
     write_file(
         &root,
         "source/demo-skill/SKILL.md",
-        "---\nname: demo-skill\ndescription: Demo release helper.\ninvocation_policy: both\n---\n\n# Demo Skill\n\nHelp with release preparation.\n",
+        "---\nname: demo-skill\ndescription: Demo release helper.\ninvocation_policy: both\nrequired_config:\n- external_skills.enabled\n---\n\n# Demo Skill\n\nHelp with release preparation.\n",
     );
     let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
 
@@ -1613,6 +1624,13 @@ fn execute_skills_command_install_and_info_surface_first_use_guidance() {
             .iter()
             .any(|step| step.as_str() == Some(expected_inspect_step.as_str())),
         "install should surface a concrete inspect handoff: {install_next_steps:#?}"
+    );
+    assert!(
+        !install_next_steps.iter().any(|step| {
+            step.as_str()
+                .is_some_and(|value| value.contains("Enable required config gates"))
+        }),
+        "install guidance should not claim config gates are missing when they are already enabled: {install_next_steps:#?}"
     );
     let install_recipes = install.outcome.payload["recipes"]
         .as_array()
@@ -1646,6 +1664,13 @@ fn execute_skills_command_install_and_info_surface_first_use_guidance() {
             .iter()
             .any(|step| step.as_str() == Some(expected_ask_step.as_str())),
         "info should surface a concrete ask handoff: {info_next_steps:#?}"
+    );
+    assert!(
+        !info_next_steps.iter().any(|step| {
+            step.as_str()
+                .is_some_and(|value| value.contains("Enable required config gates"))
+        }),
+        "info guidance should not claim config gates are missing when they are already enabled: {info_next_steps:#?}"
     );
 
     let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(&info)
@@ -1705,6 +1730,80 @@ fn execute_skills_command_info_guidance_avoids_false_success_for_manual_or_hidde
     assert!(
         recipes.is_empty(),
         "manual-hidden guidance should not advertise ask recipes: {recipes:#?}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn execute_skills_command_info_guidance_avoids_false_success_for_inactive_skill() {
+    let root = unique_temp_dir("loongclaw-skills-cli-inactive-guidance");
+    let home = unique_temp_dir("loongclaw-skills-cli-inactive-guidance-home");
+    let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        "source/demo-skill/SKILL.md",
+        "# Managed Demo Skill\n\nInactive winners should not advertise ask flows.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: false,
+            },
+        },
+    )
+    .expect("skills install should succeed");
+
+    let index_path = root.join("managed-skills").join("index.json");
+    let index_raw = fs::read_to_string(&index_path).expect("read index");
+    let mut index: serde_json::Value = serde_json::from_str(&index_raw).expect("parse index");
+    let managed_entry = index["skills"]
+        .as_array_mut()
+        .expect("index skills should be an array")
+        .iter_mut()
+        .find(|skill| skill["skill_id"] == "demo-skill")
+        .expect("managed demo-skill entry should exist");
+    managed_entry["active"] = serde_json::json!(false);
+    let encoded_index = serde_json::to_string_pretty(&index).expect("encode index");
+    fs::write(&index_path, encoded_index).expect("write index");
+
+    let info = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Info {
+                skill_id: "demo-skill".to_owned(),
+            },
+        },
+    )
+    .expect("skills info should succeed for inactive skills");
+
+    let next_steps = info.outcome.payload["next_steps"]
+        .as_array()
+        .expect("inactive info should surface next steps");
+    assert!(
+        next_steps.iter().any(|step| {
+            step.as_str()
+                == Some(
+                    "This skill is inactive and cannot be used in a conversation until it is reactivated.",
+                )
+        }),
+        "inactive guidance should explain why ask handoffs are unavailable: {next_steps:#?}"
+    );
+    let recipes = info.outcome.payload["recipes"]
+        .as_array()
+        .expect("inactive info should surface recipes");
+    assert!(
+        recipes.is_empty(),
+        "inactive guidance should not advertise ask recipes: {recipes:#?}"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/skills_cli.rs
+++ b/crates/daemon/tests/integration/skills_cli.rs
@@ -153,6 +153,8 @@ fn skills_install_cli_parses_global_flags_after_subcommand() {
                     assert!(replace);
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Search { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Recommend { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Fetch { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
@@ -200,6 +202,8 @@ fn skills_install_bundled_cli_parses_global_flags_after_subcommand() {
                     assert!(replace);
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Search { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Recommend { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Fetch { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
@@ -214,6 +218,78 @@ fn skills_install_bundled_cli_parses_global_flags_after_subcommand() {
         }
         Some(other) => panic!("unexpected command parsed: {other:?}"),
         None => panic!("expected skills command to parse"),
+    }
+}
+
+#[test]
+fn skills_search_cli_parses_query_and_limit_after_subcommand() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "skills",
+        "search",
+        "browser",
+        "preview",
+        "--limit",
+        "7",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("skills search CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            match command {
+                loongclaw_daemon::skills_cli::SkillsCommands::Search { query, limit } => {
+                    assert_eq!(query, vec!["browser".to_owned(), "preview".to_owned()]);
+                    assert_eq!(limit, 7);
+                }
+                other => panic!("unexpected skills subcommand parsed: {other:?}"),
+            }
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn skills_recommend_cli_parses_query_and_limit_after_subcommand() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "skills",
+        "recommend",
+        "release",
+        "discipline",
+        "--limit",
+        "2",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("skills recommend CLI should parse");
+
+    match cli.command {
+        Some(Commands::Skills {
+            config,
+            json,
+            command,
+        }) => {
+            assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+            assert!(json);
+            match command {
+                loongclaw_daemon::skills_cli::SkillsCommands::Recommend { query, limit } => {
+                    assert_eq!(query, vec!["release".to_owned(), "discipline".to_owned()]);
+                    assert_eq!(limit, 2);
+                }
+                other => panic!("unexpected skills subcommand parsed: {other:?}"),
+            }
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
     }
 }
 
@@ -243,6 +319,8 @@ fn skills_enable_browser_preview_cli_parses_global_flags_after_subcommand() {
                     assert!(replace);
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Search { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Recommend { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Fetch { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
@@ -309,6 +387,8 @@ fn skills_policy_set_cli_parses_domain_and_approval_flags() {
                 }
             },
             other @ loongclaw_daemon::skills_cli::SkillsCommands::List
+            | other @ loongclaw_daemon::skills_cli::SkillsCommands::Search { .. }
+            | other @ loongclaw_daemon::skills_cli::SkillsCommands::Recommend { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Fetch { .. }
             | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
@@ -373,6 +453,8 @@ fn skills_fetch_cli_parses_install_flags_after_subcommand() {
                     assert!(replace);
                 }
                 other @ loongclaw_daemon::skills_cli::SkillsCommands::List
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Search { .. }
+                | other @ loongclaw_daemon::skills_cli::SkillsCommands::Recommend { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Info { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::Install { .. }
                 | other @ loongclaw_daemon::skills_cli::SkillsCommands::InstallBundled { .. }
@@ -1343,6 +1425,286 @@ fn execute_skills_command_operator_inspection_still_works_when_runtime_is_disabl
             .as_str()
             .expect("instructions preview should be text")
             .contains("Disabled runtime should still allow operator inspection")
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn execute_skills_command_search_surfaces_active_shadowed_and_blocked_matches() {
+    let root = unique_temp_dir("loongclaw-skills-cli-search");
+    let home = unique_temp_dir("loongclaw-skills-cli-search-home");
+    let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        "source/release-guard/SKILL.md",
+        "---\nname: release-guard\ndescription: Guard release discipline.\ninvocation_policy: both\n---\n\n# Release Guard\n\nKeep release flows tight.\n",
+    );
+    write_file(
+        &root,
+        ".agents/skills/release-guard/SKILL.md",
+        "---\nname: release-guard\ndescription: Project-scoped release helper.\n---\n\nProject release fallback.\n",
+    );
+    write_file(
+        &root,
+        ".agents/skills/release-broken/SKILL.md",
+        "---\nname: release-broken\ndescription: Broken release helper.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Install {
+                path: "source/release-guard".to_owned(),
+                skill_id: None,
+                replace: false,
+            },
+        },
+    )
+    .expect("skills install should succeed");
+
+    let search = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Search {
+                query: vec!["release".to_owned()],
+                limit: 5,
+            },
+        },
+    )
+    .expect("skills search should succeed");
+
+    assert_eq!(
+        search.outcome.payload["results"][0]["skill_id"],
+        "release-guard"
+    );
+    assert_eq!(search.outcome.payload["results"][0]["resolution"], "active");
+    assert!(
+        search.outcome.payload["shadowed_results"]
+            .as_array()
+            .expect("shadowed results should be an array")
+            .iter()
+            .any(|result| result["skill_id"] == "release-guard"),
+        "search should surface matching shadowed duplicates"
+    );
+    assert!(
+        search.outcome.payload["blocked_results"]
+            .as_array()
+            .expect("blocked results should be an array")
+            .iter()
+            .any(|result| result["skill_id"] == "release-broken"),
+        "search should surface blocked discovery candidates"
+    );
+
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(&search)
+        .expect("search text rendering should succeed");
+    let expected_inspect = format!(
+        "inspect=loongclaw skills info release-guard --config {}",
+        shell_quote(&config_path.display().to_string())
+    );
+    assert!(
+        rendered.contains("shadowed matches:"),
+        "search text should render matching shadowed candidates: {rendered}"
+    );
+    assert!(
+        rendered.contains("blocked matches:"),
+        "search text should render matching blocked candidates: {rendered}"
+    );
+    assert!(
+        rendered.contains(expected_inspect.as_str()),
+        "search text should surface a concrete inspect handoff: {rendered}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn execute_skills_command_recommend_surfaces_manual_only_limitations() {
+    let root = unique_temp_dir("loongclaw-skills-cli-recommend");
+    let home = unique_temp_dir("loongclaw-skills-cli-recommend-home");
+    let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        ".agents/skills/release-checklist/SKILL.md",
+        "---\nname: release-checklist\ndescription: Manual release checklist helper.\ninvocation_policy: manual\n---\n\nReview the release checklist manually.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    let recommend = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Recommend {
+                query: vec!["release".to_owned(), "checklist".to_owned()],
+                limit: 3,
+            },
+        },
+    )
+    .expect("skills recommend should succeed");
+
+    let first_result = recommend.outcome.payload["results"][0].clone();
+    assert_eq!(first_result["skill_id"], "release-checklist");
+    assert!(
+        first_result["limitations"]
+            .as_array()
+            .expect("limitations should be an array")
+            .iter()
+            .any(|value| value.as_str() == Some("manual-only invocation")),
+        "recommend should make manual-only limitations explicit"
+    );
+
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(&recommend)
+        .expect("recommend text rendering should succeed");
+    assert!(
+        rendered.contains("recommended skills:"),
+        "recommend text should render a recommendation heading: {rendered}"
+    );
+    assert!(
+        rendered.contains("manual-only invocation"),
+        "recommend text should surface manual-only limitations: {rendered}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn execute_skills_command_install_and_info_surface_first_use_guidance() {
+    let root = unique_temp_dir("loongclaw-skills-cli-follow-up");
+    let home = unique_temp_dir("loongclaw-skills-cli-follow-up-home");
+    let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        "source/demo-skill/SKILL.md",
+        "---\nname: demo-skill\ndescription: Demo release helper.\ninvocation_policy: both\n---\n\n# Demo Skill\n\nHelp with release preparation.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    let install = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Install {
+                path: "source/demo-skill".to_owned(),
+                skill_id: None,
+                replace: false,
+            },
+        },
+    )
+    .expect("skills install should succeed");
+
+    let install_next_steps = install.outcome.payload["next_steps"]
+        .as_array()
+        .expect("install should surface next steps");
+    let expected_inspect_step = format!(
+        "Inspect the installed skill: loongclaw skills info demo-skill --config {}",
+        shell_quote(&config_path.display().to_string())
+    );
+    assert!(
+        install_next_steps
+            .iter()
+            .any(|step| step.as_str() == Some(expected_inspect_step.as_str())),
+        "install should surface a concrete inspect handoff: {install_next_steps:#?}"
+    );
+    let install_recipes = install.outcome.payload["recipes"]
+        .as_array()
+        .expect("install should surface recipes");
+    assert!(
+        !install_recipes.is_empty(),
+        "install should surface an ask recipe for model-usable skills"
+    );
+
+    let info = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Info {
+                skill_id: "demo-skill".to_owned(),
+            },
+        },
+    )
+    .expect("skills info should succeed");
+
+    let info_next_steps = info.outcome.payload["next_steps"]
+        .as_array()
+        .expect("info should surface next steps");
+    let expected_ask_step = format!(
+        "Try the skill in a conversation: loongclaw ask --config {} --message {}",
+        shell_quote(&config_path.display().to_string()),
+        shell_quote("Use the demo-skill skill to help with the current task.")
+    );
+    assert!(
+        info_next_steps
+            .iter()
+            .any(|step| step.as_str() == Some(expected_ask_step.as_str())),
+        "info should surface a concrete ask handoff: {info_next_steps:#?}"
+    );
+
+    let rendered = loongclaw_daemon::skills_cli::render_skills_cli_text(&info)
+        .expect("info text rendering should succeed");
+    assert!(
+        rendered.contains("next steps:"),
+        "info text should render follow-up steps: {rendered}"
+    );
+    assert!(
+        rendered.contains("recipes:"),
+        "info text should render recipes: {rendered}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn execute_skills_command_info_guidance_avoids_false_success_for_manual_or_hidden_skill() {
+    let root = unique_temp_dir("loongclaw-skills-cli-manual-guidance");
+    let home = unique_temp_dir("loongclaw-skills-cli-manual-guidance-home");
+    let config_path = write_external_skills_config(&root, true);
+    fs::create_dir_all(&home).expect("create home root");
+    write_file(
+        &root,
+        ".agents/skills/manual-hidden/SKILL.md",
+        "---\nname: manual-hidden\ndescription: Operator-only release helper.\nmodel_visibility: hidden\ninvocation_policy: manual\n---\n\nApply these steps manually.\n",
+    );
+    let _env = SkillsCliEnvironmentGuard::set(&[("HOME", Some(home.to_string_lossy().as_ref()))]);
+
+    let info = loongclaw_daemon::skills_cli::execute_skills_command(
+        loongclaw_daemon::skills_cli::SkillsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: loongclaw_daemon::skills_cli::SkillsCommands::Info {
+                skill_id: "manual-hidden".to_owned(),
+            },
+        },
+    )
+    .expect("skills info should succeed for manual-hidden skills");
+
+    let next_steps = info.outcome.payload["next_steps"]
+        .as_array()
+        .expect("manual-hidden info should surface next steps");
+    assert!(
+        next_steps.iter().any(|step| {
+            step.as_str()
+                == Some(
+                    "This skill is hidden from model discovery; keep the workflow operator-driven.",
+                )
+        }),
+        "manual-hidden info should explain the operator-only path: {next_steps:#?}"
+    );
+    let recipes = info.outcome.payload["recipes"]
+        .as_array()
+        .expect("manual-hidden info should surface recipes");
+    assert!(
+        recipes.is_empty(),
+        "manual-hidden guidance should not advertise ask recipes: {recipes:#?}"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-29T03:42:23Z
+- Generated at: 2026-03-29T03:57:20Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -23,7 +23,7 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6396 | 6400 | 4 | 104 | 110 | 6 | 99.9% | TIGHT |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10028 | 11200 | 1172 | 95 | 120 | 25 | 89.5% | WATCH |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14206 | 15000 | 794 | 54 | 70 | 16 | 94.7% | WATCH |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14212 | 15000 | 788 | 54 | 70 | 16 | 94.7% | WATCH |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 5014 | 6000 | 986 | 172 | 190 | 18 | 90.5% | WATCH |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->
 <!-- arch-hotspot key=channel_mod lines=6396 functions=104 -->
 <!-- arch-hotspot key=turn_coordinator lines=10028 functions=95 -->
-<!-- arch-hotspot key=tools_mod lines=14206 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14212 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=5014 functions=172 -->
 <!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-29T03:57:20Z
+- Generated at: 2026-03-29T03:57:21Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14


### PR DESCRIPTION
## Summary

- Problem:
  External skills inventory truth existed, but operators still lacked a discovery-first way to search, compare, and act on active vs shadowed vs blocked skills without reading raw inventory details.
- Why it matters:
  Skills UX stalls early when operators cannot quickly answer which skill is usable now, which candidate is shadowed, and what next action is actually valid.
- What changed:
  Added external skill search/recommend operator APIs over the existing inventory, reused the current tool-search ranking path instead of adding a second ranking stack, added `skills search` and `skills recommend` CLI entry points, expanded CLI follow-up guidance so install/info flows only suggest truthful next steps for active, hidden, manual, or ineligible skills, and refreshed the tracked March 2026 architecture drift report so governance reflects the new `tools_mod` footprint.
- What did not change (scope boundary):
  No new marketplace or index model was introduced, no Web UI work was added, and this PR does not change install eligibility rules or invent fallback recipes for hidden/manual-only skills.

## Linked Issues

- Closes #664
- Related #292
- Related #652

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all -- --check
git diff --check
cargo test -p loongclaw-daemon skills_cli -- --nocapture
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-$(date -u +%Y-%m).md
scripts/bootstrap_release_local_artifacts.sh
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh

Results:
- Formatting, clippy, workspace tests, and all-features workspace tests passed.
- Architecture boundary, dependency graph, architecture drift freshness, and strict docs governance checks passed.
- skills_cli integration coverage now exercises search/recommend output separation, manual-only limitation messaging, and truthful follow-up guidance for install/info flows.
- `task check:conventions` was not run because `task` is not installed in this local environment.
```

## User-visible / Operator-visible Changes

- `loongclaw skills search <query...>` now returns active matches first and separately reports shadowed and blocked matches.
- `loongclaw skills recommend <query...>` now explains why a skill matched, what limitations apply, and what the operator can do next.
- `skills info`, `skills install`, `skills install-bundled`, and `skills fetch --install` now render follow-up guidance that matches actual eligibility instead of implying false-success flows.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to restore the previous skills CLI and external inventory rendering path and the refreshed architecture drift snapshot.
- Observable failure symptoms reviewers should watch for:
  Search or recommendation results misclassify a skill between active/shadowed/blocked buckets, CLI guidance suggests `ask`/install flows for skills that remain manual-only or hidden, or governance fails because the tracked architecture drift snapshot no longer matches current budgets.

## Reviewer Focus

- Verify that `crates/app/src/tools/external_skills.rs` reuses existing inventory truth without creating a second source of ranking or eligibility state.
- Verify that `crates/daemon/src/skills_cli.rs` keeps follow-up recipes truthful across active, shadowed, blocked, hidden, and manual-only skills.
- Spot check the new integration tests for edge cases where shadowed or blocked matches should stay visible without displacing active results.
- Confirm that `docs/releases/architecture-drift-2026-03.md` matches the updated `tools_mod` hotspot metrics expected by governance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search and recommend commands for discovering skills; results show inventory summary, ranked active results, shadowed matches, and blocked candidates with limitations.
  * CLI outputs include follow-up guidance (next steps and recipes) for installs and inspections.

* **Bug Fixes**
  * More robust browser companion probing to avoid transient timeout warnings.

* **Tests**
  * Added CLI parsing, execution, and rendering tests for search/recommend and guidance scenarios.

* **Documentation**
  * Updated architecture drift report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->