### PR TITLE
docs: clarify gateway localhost security boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,10 +338,11 @@ instability from true upstream unavailability.
    - dashboard
    - onboarding
 
-   The initial product mode stays same-origin and local by default.
+   The initial product mode stays same-origin and localhost-bound by default.
 
-   That local-first boundary is the current operating slice, not the long-term
-   architecture endpoint.
+   That default bind policy is a security boundary for the current operating
+   slice, not a statement that future gateway/service expansion is out of
+   scope or the long-term architecture endpoint.
 
    The long-term direction is to keep Web UI attached to the same daemon-owned
    gateway/service runtime rather than creating a second assistant runtime.

--- a/docs/plans/2026-03-27-gateway-service-architecture-design.md
+++ b/docs/plans/2026-03-27-gateway-service-architecture-design.md
@@ -33,7 +33,8 @@ service boundary with unclear ownership and rising integration debt.
 - `multi-channel-serve` should be treated as the first runtime-owner precursor,
   not as the long-term product noun.
 - Gateway is required for the accepted product direction, but the early slices
-  can remain local-first, localhost-only by default, and operator-governed.
+  can remain localhost-only by default, security-governed, and
+  operator-governed while the broader service contract matures.
 
 ## Current Architecture Evidence
 
@@ -253,6 +254,29 @@ The main architectural reasons claw-style systems add an explicit gateway are:
 LoongClaw now faces the same product pressures. The lesson to borrow is unified
 service ownership, not an automatic jump to hosted multi-tenant semantics.
 
+## Security Default, Not Product Retreat
+
+The current localhost-only bind policy should be understood as a security
+default, not as a strategic refusal of broader gateway capability.
+
+More specifically, the current policy means:
+
+- the gateway should not be publicly exposed by default
+- widening bind scope requires an explicit auth, lifecycle, and observability
+  contract
+- current Web UI and operator flows should attach through the daemon-owned
+  gateway surface instead of inventing a second runtime
+
+It does not mean:
+
+- remote browser or mobile pairing is out of scope
+- always-on service ownership is out of scope
+- stable bind and port ownership are out of scope
+- richer long-lived channel runtimes are out of scope
+
+The architectural mistake to avoid is treating "localhost-only by default" as a
+product noun. It is a rollout and security posture for the current slice.
+
 ## Design Goals
 
 1. Add an explicit gateway service boundary above existing daemon/operator
@@ -280,6 +304,8 @@ service ownership, not an automatic jump to hosted multi-tenant semantics.
   polling runtimes should remain supervised tasks where appropriate.
 - Do not force immediate public-internet exposure as part of the first gateway
   slice.
+- Do not treat the current localhost-only default as evidence that future
+  service-mode or remote attachment work is undesired.
 - Do not commit this slice to a hosted multi-tenant SaaS contract.
 
 ## Core Idea
@@ -453,6 +479,18 @@ The protocol crate should remain generic enough to support:
 - future local or remote control channels
 
 without hard-coding gateway business semantics into protocol types.
+
+### 6. Default bind policy is a security boundary
+
+The gateway can remain localhost-only by default for the current slice without
+turning that posture into the long-term product boundary.
+
+That means:
+
+- current slices should prefer loopback-only bind by default
+- future service mode may introduce stable or configurable bind ownership
+- broader exposure must follow explicit auth, token, operator-control, and
+  observability work
 
 ## Proposed Command Surface
 

--- a/docs/plans/2026-03-27-gateway-service-architecture-implementation-plan.md
+++ b/docs/plans/2026-03-27-gateway-service-architecture-implementation-plan.md
@@ -40,10 +40,13 @@ clippy, `task verify`
   the long-term architecture
 - keep current slice boundaries accurate, but describe them as incremental
   delivery steps toward a gateway service layer
-- update Web UI wording so it remains "not a second runtime" while no longer
-  implying that the local-only posture is the strategic endpoint
+- update Web UI wording so it remains "not a second runtime" while clearly
+  stating that localhost-only default binding is a security posture for the
+  current slice rather than the strategic endpoint
 - update browser companion wording so it remains optional while clearly pointing
   toward a future gateway-managed node model
+- keep "not publicly exposed by default" explicit so future service-mode work
+  is framed as governed expansion rather than a reversal of product direction
 
 **Step 2: Verify documentation consistency**
 
@@ -214,6 +217,9 @@ Initial routes should be read-only or tightly scoped:
 - `GET /v1/events`
 
 These should render the same gateway read models as the CLI.
+
+The first bind policy should remain loopback-only by default unless explicit
+gateway auth, operator controls, and product docs are widened together.
 
 **Step 2: Add a first event stream**
 

--- a/docs/product-specs/web-ui.md
+++ b/docs/product-specs/web-ui.md
@@ -18,18 +18,19 @@ The Web UI is expected to include:
 - dashboard
 - onboarding
 - a lightweight debug console
-- localhost-only by default in the current slice
+- localhost-only by default in the current slice for security
 - same-origin local product-mode serving in the current slice
 - shared read models and APIs with CLI and gateway-owned operator surfaces
 - an optional install path
 
 ## Architecture Direction
 
-The current shipping boundary stays local-first: same-origin, localhost-only by
-default, and implemented as a thin browser shell over the existing runtime.
+The current shipping boundary stays same-origin, localhost-only by default, and
+implemented as a thin browser shell over the existing runtime.
 
-That boundary is a delivery constraint for the current slice, not the long-term
-architecture endpoint.
+That default bind policy is a security and rollout constraint for the current
+slice, not the long-term architecture endpoint or a statement that future
+service-mode, paired-client, or broader gateway capabilities are out of scope.
 
 As gateway service work lands, the Web UI should become a first-class client of
 the daemon-owned gateway surface and continue to reuse the same conversation,
@@ -48,8 +49,8 @@ inventing a second browser-only runtime contract.
 - [ ] The Web UI includes chat, dashboard, and onboarding as first-class parts of the same experience.
 - [ ] The Web UI can be delivered in a same-origin local product mode and stays localhost-only by default in the current slice unless future policy and docs explicitly widen that boundary.
 - [ ] The current localhost-only posture is documented as a safety default for
-      the current slice, not as a reason to avoid a future daemon-owned
-      gateway service or paired-client architecture.
+      the current slice, not as a product claim that future daemon-owned
+      gateway service, pairing, or remote-capable architecture is unwanted.
 - [ ] The optional install path is documented and supported without making installation mandatory for source users.
 - [ ] The Web UI is positioned as an additional user-facing surface, not as a replacement for core CLI onboarding, doctor, or other foundational CLI flows.
 
@@ -58,5 +59,7 @@ inventing a second browser-only runtime contract.
 - claiming GA-level stability before productization is complete
 - treating the browser surface as a full CLI replacement
 - implying that public internet exposure is safe or supported by default
+- treating the default localhost-only posture as evidence that future
+  service-mode or pairing work is out of scope
 - treating the current localhost-only slice as the final architecture endpoint
 - expanding this spec into a hosted or multi-tenant web product


### PR DESCRIPTION
## Summary

- Problem: current gateway and Web UI docs still left room to misread localhost-only binding as a strategic local-first ceiling instead of a security default for the current slice.
- Why it matters: that ambiguity can distort gateway roadmap decisions in both directions, either freezing future service-mode work or encouraging premature exposure before auth, observability, and operator controls are ready.
- What changed: clarified README, Web UI spec, gateway architecture design, and the implementation plan so localhost-only by default is framed as a security and rollout boundary while preserving the path to future service-mode, pairing, and remote-capable gateway work.
- What did not change (scope boundary): no bind policy widened, no new listeners or auth flows were added, and no runtime/service behavior changed.

## Linked Issues

- Closes #666
- Related #646
- Related #650

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this PR changes the documented security and architecture boundary for gateway exposure, service-mode evolution, and Web UI framing.
- Rollout / guardrails: the docs now explicitly preserve localhost-only default binding for the current slice while stating that broader gateway capability requires explicit auth, operator-control, and observability work.
- Rollback path: revert this documentation slice if the wording proves misleading and restate the boundary before further gateway/service work lands.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --check
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh

`git diff --check` passed.
`LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh` confirmed no dead internal links, but the script failed on pre-existing missing local release/trace governance artifacts under `.docs/releases/` and `.docs/traces/` that this PR does not touch.
Manual review confirmed the wording now consistently treats localhost-only default binding as a security default rather than a strategic local-first endpoint.
```

## User-visible / Operator-visible Changes

- Docs now state that gateway localhost-only binding is the current security default, not the long-term product ceiling.
- Web UI and gateway architecture docs now preserve a clear path to future service-mode, pairing, and remote-capable gateway evolution without claiming public exposure is safe by default.

## Failure Recovery

- Fast rollback or disable path: revert this PR.
- Observable failure symptoms reviewers should watch for: wording that accidentally implies public exposure is already supported, or wording that still frames localhost-only binding as a strategic refusal of broader gateway capability.

## Reviewer Focus

- Review `docs/plans/2026-03-27-gateway-service-architecture-design.md` for the new “security default, not product retreat” framing and bind-policy boundary.
- Review `docs/product-specs/web-ui.md` and `README.md` to confirm the wording stays aligned with the current shipped localhost-only posture while not blocking future service-mode expansion.
- Review `docs/plans/2026-03-27-gateway-service-architecture-implementation-plan.md` to confirm the rollout guidance stays explicit about bind widening requiring auth and operator-control work.
