### PR TITLE
Fix flaky app config tests caused by unsynchronized env mutation

### DIFF
--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -2558,7 +2558,9 @@ fi
 
 if args_contain "$*" 'prompt --session'; then
   drain_stdin
-  sleep 30
+  while :; do
+    :
+  done
   exit 0
 fi
 

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -129,7 +129,20 @@ mod tests {
     use loongclaw_contracts::SecretRef;
 
     use super::*;
+    use crate::test_support::ScopedEnv;
     use std::collections::BTreeSet;
+
+    fn clear_config_test_secret_envs(env: &mut ScopedEnv) {
+        for key in [
+            "LOONGCLAW_TEST_API_KEY_REF",
+            "LOONGCLAW_TEST_MISSING_API_KEY",
+            "LOONGCLAW_TEST_LEGACY_FALLBACK",
+            "LOONGCLAW_TEST_TYPED_SECRET_REF",
+            "LOONGCLAW_TEST_TELEGRAM_SECRET_REF",
+        ] {
+            env.remove(key);
+        }
+    }
 
     fn expected_service_channel_ids() -> Vec<&'static str> {
         let mut service_ids = Vec::new();
@@ -880,9 +893,11 @@ mod tests {
         // Use a dedicated env var instead of PATH — Windows PATH contains `;`
         // which `split_secret_candidates` treats as a candidate separator,
         // causing `api_key()` to return only the first segment.
+        let mut env = ScopedEnv::new();
+        clear_config_test_secret_envs(&mut env);
         let env_key = "LOONGCLAW_TEST_API_KEY_REF";
         let env_val = "test-secret-value-for-env-ref";
-        crate::process_env::set_var(env_key, env_val);
+        env.set(env_key, env_val);
 
         let cases = vec![
             format!("${{{env_key}}}"),
@@ -909,12 +924,13 @@ mod tests {
                 "authorization_header should resolve env ref for {raw_api_key}"
             );
         }
-
-        crate::process_env::remove_var(env_key);
     }
 
     #[test]
     fn provider_api_key_missing_explicit_env_reference_is_not_treated_as_literal() {
+        let mut env = ScopedEnv::new();
+        clear_config_test_secret_envs(&mut env);
+
         let config = ProviderConfig {
             kind: ProviderKind::Ollama,
             api_key: Some(SecretRef::Inline(
@@ -930,6 +946,9 @@ mod tests {
 
     #[test]
     fn provider_api_key_missing_explicit_env_reference_does_not_fall_back_to_legacy_env() {
+        let mut env = ScopedEnv::new();
+        clear_config_test_secret_envs(&mut env);
+
         let config = ProviderConfig {
             kind: ProviderKind::Openai,
             api_key: Some(SecretRef::Inline(
@@ -947,9 +966,11 @@ mod tests {
     fn provider_api_key_env_legacy_fallback_still_works() {
         // Use a dedicated env var instead of PATH — Windows PATH contains `;`
         // which `split_secret_candidates` treats as a candidate separator.
+        let mut env = ScopedEnv::new();
+        clear_config_test_secret_envs(&mut env);
         let env_key = "LOONGCLAW_TEST_LEGACY_FALLBACK";
         let env_val = "test-secret-value-for-legacy";
-        crate::process_env::set_var(env_key, env_val);
+        env.set(env_key, env_val);
 
         let config = ProviderConfig {
             kind: ProviderKind::Ollama,
@@ -959,15 +980,15 @@ mod tests {
         };
 
         assert_eq!(config.api_key().as_deref(), Some(env_val));
-
-        crate::process_env::remove_var(env_key);
     }
 
     #[test]
     fn provider_api_key_supports_typed_env_secret_ref() {
+        let mut env = ScopedEnv::new();
+        clear_config_test_secret_envs(&mut env);
         let env_key = "LOONGCLAW_TEST_TYPED_SECRET_REF";
         let env_val = "typed-secret-value";
-        crate::process_env::set_var(env_key, env_val);
+        env.set(env_key, env_val);
 
         let config = ProviderConfig {
             kind: ProviderKind::Ollama,
@@ -983,8 +1004,6 @@ mod tests {
             config.authorization_header().as_deref(),
             Some("Bearer typed-secret-value")
         );
-
-        crate::process_env::remove_var(env_key);
     }
 
     #[test]
@@ -1608,9 +1627,11 @@ reasoning_extra_body_omit_model_hints = ["disable-thinking"]
     #[test]
     #[cfg(feature = "channel-telegram")]
     fn telegram_bot_token_supports_typed_env_secret_ref() {
+        let mut env = ScopedEnv::new();
+        clear_config_test_secret_envs(&mut env);
         let env_key = "LOONGCLAW_TEST_TELEGRAM_SECRET_REF";
         let env_val = "123456789:telegram-secret";
-        crate::process_env::set_var(env_key, env_val);
+        env.set(env_key, env_val);
 
         let config = TelegramChannelConfig {
             bot_token: Some(SecretRef::Env {
@@ -1621,8 +1642,6 @@ reasoning_extra_body_omit_model_hints = ["disable-thinking"]
         };
 
         assert_eq!(config.bot_token().as_deref(), Some(env_val));
-
-        crate::process_env::remove_var(env_key);
     }
 
     #[test]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1956,7 +1956,12 @@ mod tests {
         let mut file = std::fs::File::create(script_path).expect("create browser companion script");
         file.write_all(body.as_bytes())
             .expect("write browser companion script");
-        let mut permissions = file.metadata().expect("script metadata").permissions();
+        file.sync_all()
+            .expect("sync browser companion script to disk");
+        drop(file);
+        let mut permissions = std::fs::metadata(script_path)
+            .expect("script metadata")
+            .permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(script_path, permissions).expect("chmod browser companion script");
     }

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-29T03:10:44Z
+- Generated at: 2026-03-29T03:28:15Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -17,7 +17,7 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3327 | 3600 | 273 | 8 | 12 | 4 | 92.4% | WATCH |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2696 | 2800 | 104 | 56 | 65 | 9 | 96.3% | TIGHT |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2698 | 2800 | 102 | 56 | 65 | 9 | 96.4% | TIGHT |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9846 | 10500 | 654 | 88 | 90 | 2 | 97.8% | TIGHT |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9759 | 9800 | 41 | 90 | 90 | 0 | 100.0% | TIGHT |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6821 | 7300 | 479 | 145 | 160 | 15 | 93.4% | WATCH |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.3%), channel_registry (97.8%), channel_config (100.0%), channel_mod (99.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), channel_mod (99.9%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (90.8%), memory_mod (87.5%), acp_manager (92.4%), chat_runtime (93.4%), turn_coordinator (89.0%), tools_mod (94.7%), daemon_lib (90.5%), onboard_cli (94.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -62,7 +62,7 @@
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3327 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2696 functions=56 -->
+<!-- arch-hotspot key=acpx_runtime lines=2698 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=9846 functions=88 -->
 <!-- arch-hotspot key=channel_config lines=9759 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6821 functions=145 -->


### PR DESCRIPTION
Closes #668

## Summary

- replace direct process environment mutation in `crates/app/src/config/mod.rs` tests with `ScopedEnv`
- clear dedicated `LOONGCLAW_TEST_*` variables at the start of each affected test
- keep production configuration and secret resolution behavior unchanged

## Root Cause

Several config tests were writing process-global environment variables without the serialized test lock. In parallel `cargo test` runs, those tests could leak shared state into unrelated cases, which is why failures often surfaced in `tools::web_search::tests::*` even though `web.search` was not the source of the bug.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved environment variable isolation in test suites to prevent cross-test contamination.
  * Enhanced test infrastructure for mock script and file operations with better cleanup and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->