### PR TITLE
Feishu allowed_chat_ids supports * to allow all

### DIFF
--- a/crates/app/src/channel/feishu/mod.rs
+++ b/crates/app/src/channel/feishu/mod.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::sync::Arc;
+use std::collections::BTreeSet;
 
 use axum::{Router, routing::post};
 
@@ -21,6 +22,25 @@ mod websocket;
 use adapter::FeishuAdapter;
 use payload::normalize_webhook_path;
 use webhook::{FeishuWebhookState, feishu_webhook_handler};
+
+const FEISHU_ALLOWLIST_ALL_SENTINEL: &str = "*";
+
+pub(in crate::channel) fn feishu_allowlist_allows_all(allowed_chat_ids: &BTreeSet<String>) -> bool {
+    allowed_chat_ids
+        .iter()
+        .any(|chat_id| chat_id.trim() == FEISHU_ALLOWLIST_ALL_SENTINEL)
+}
+
+pub(in crate::channel) fn feishu_allowlist_allows_chat(
+    allowed_chat_ids: &BTreeSet<String>,
+    chat_id: &str,
+) -> bool {
+    let chat_id = chat_id.trim();
+    if chat_id.is_empty() {
+        return false;
+    }
+    feishu_allowlist_allows_all(allowed_chat_ids) || allowed_chat_ids.contains(chat_id)
+}
 
 pub(super) async fn run_feishu_send(
     config: &ResolvedFeishuChannelConfig,
@@ -155,6 +175,28 @@ mod tests {
     };
     use std::sync::Arc;
     use tokio::sync::Mutex;
+
+    fn set(ids: &[&str]) -> BTreeSet<String> {
+        ids.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn allowlist_allows_all_when_wildcard_present() {
+        assert!(feishu_allowlist_allows_all(&set(&["oc_demo", "*"])));
+        assert!(feishu_allowlist_allows_all(&set(&["  *  "])));
+        assert!(!feishu_allowlist_allows_all(&set(&["oc_demo"])));
+    }
+
+    #[test]
+    fn allowlist_allows_chat_for_exact_and_wildcard_matches() {
+        let exact_only = set(&["oc_demo"]);
+        assert!(feishu_allowlist_allows_chat(&exact_only, "oc_demo"));
+        assert!(!feishu_allowlist_allows_chat(&exact_only, "oc_other"));
+        assert!(!feishu_allowlist_allows_chat(&exact_only, " "));
+
+        let wildcard = set(&["*"]);
+        assert!(feishu_allowlist_allows_chat(&wildcard, "oc_other"));
+    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct MockRequest {

--- a/crates/app/src/channel/feishu/mod.rs
+++ b/crates/app/src/channel/feishu/mod.rs
@@ -1,6 +1,6 @@
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::Arc;
-use std::collections::BTreeSet;
 
 use axum::{Router, routing::post};
 

--- a/crates/app/src/channel/feishu/payload/inbound.rs
+++ b/crates/app/src/channel/feishu/payload/inbound.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value};
 use crate::CliResult;
 use crate::channel::{
     ChannelDeliveryResource, ChannelOutboundTarget, ChannelPlatform, ChannelSession,
+    feishu::feishu_allowlist_allows_chat,
 };
 use crate::crypto::timing_safe_eq;
 use crate::feishu::FeishuUserPrincipal;
@@ -179,7 +180,7 @@ pub(in crate::channel::feishu) fn parse_feishu_inbound_payload(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "feishu message event missing message.chat_id".to_owned())?;
-    if !allowed_chat_ids.contains(chat_id) {
+    if !feishu_allowlist_allows_chat(allowed_chat_ids, chat_id) {
         return Ok(FeishuWebhookAction::Ignore);
     }
 
@@ -445,7 +446,7 @@ fn is_allowed_feishu_card_callback_chat(
     else {
         return false;
     };
-    allowed_chat_ids.contains(open_chat_id)
+    feishu_allowlist_allows_chat(allowed_chat_ids, open_chat_id)
 }
 
 fn parse_feishu_card_callback_action(


### PR DESCRIPTION
## Summary

- **Problem:** Feishu `allowed_chat_ids` was enforced with exact matching only, so there was no explicit allow-all sentinel and behavior risked drifting across callsites.
- **Why it matters:** Operators who intentionally accept Feishu traffic from any chat need a backward-compatible sentinel without new config fields; a shared helper eases follow-up (session send, readiness).
- **What changed:**
  - Added `feishu_allowlist_allows_all` and `feishu_allowlist_allows_chat` in `crates/app/src/channel/feishu/mod.rs` (trimmed `"*"` ⇒ allow all; otherwise exact match; empty chat id ⇒ deny).
  - Inbound Feishu message filtering and card-callback chat checks in `crates/app/src/channel/feishu/payload/inbound.rs` now use `feishu_allowlist_allows_chat`.
  - Unit tests for the helper in `crates/app/src/channel/feishu/mod.rs`.
- **What did not change (scope boundary):** Config schema, migration, product docs. Other allowlist sites (e.g. session outbound guard in `channel/mod.rs`, registry / serve readiness) unchanged unless tracked in a follow-up—verify with `git grep feishu_allowlist`.

## Linked Issues

- Closes #
- Related #672

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- **Risk notes:** 
- **Rollout / guardrails:** 
- **Rollback path:** 

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app feishu_allowlist --locked
# Paste results after you run them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wildcard support ("*") to Feishu chat allowlist to permit all chats.

* **Bug Fixes**
  * Trim whitespace from configured and incoming chat IDs and reject empty/whitespace-only IDs.
  * Improved allowlist matching to reliably distinguish exact vs. wildcard entries.

* **Tests**
  * Added unit tests covering wildcard behavior and matching semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->