### PR TITLE
feat(daemon): govern memory stage profile promotion readiness

### DIFF
--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -215,14 +215,14 @@ pub struct RuntimeCapabilityMetricRange {
     pub max: f64,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
 pub struct RuntimeCapabilitySourceDecisionRollup {
     pub promoted: usize,
     pub rejected: usize,
     pub undecided: usize,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
 pub struct RuntimeCapabilityEvidenceDigest {
     pub total_candidates: usize,
     pub reviewed_candidates: usize,
@@ -941,26 +941,7 @@ fn evaluate_target_specific_readiness(
                 .cloned()
                 .collect::<Vec<_>>();
             let accepted_evidence = if accepted_artifacts.is_empty() {
-                RuntimeCapabilityEvidenceDigest {
-                    total_candidates: 0,
-                    reviewed_candidates: 0,
-                    undecided_candidates: 0,
-                    accepted_candidates: 0,
-                    rejected_candidates: 0,
-                    distinct_source_run_count: 0,
-                    distinct_experiment_count: 0,
-                    latest_candidate_at: None,
-                    latest_reviewed_at: None,
-                    source_decisions: RuntimeCapabilitySourceDecisionRollup {
-                        promoted: 0,
-                        rejected: 0,
-                        undecided: 0,
-                    },
-                    unique_warnings: Vec::new(),
-                    delta_candidate_count: 0,
-                    changed_surfaces: Vec::new(),
-                    metric_ranges: BTreeMap::new(),
-                }
+                RuntimeCapabilityEvidenceDigest::default()
             } else {
                 build_family_evidence_digest(&accepted_artifacts)
             };
@@ -1601,9 +1582,10 @@ fn build_runtime_capability_rollback_hints(
     planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
 ) -> Vec<String> {
     let capture_hint = match planned_artifact.target_kind {
-        RuntimeCapabilityTarget::MemoryStageProfile => {
-            "capture the current `memory_stage_profiles` state before applying this memory stage profile".to_owned()
-        }
+        RuntimeCapabilityTarget::MemoryStageProfile => format!(
+            "capture the current `{}` state before applying this memory stage profile",
+            planned_artifact.delivery_surface
+        ),
         RuntimeCapabilityTarget::ManagedSkill
         | RuntimeCapabilityTarget::ProgrammaticFlow
         | RuntimeCapabilityTarget::ProfileNoteAddendum => format!(

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -909,7 +909,7 @@ fn evaluate_family_readiness(
         accepted_source_integrity,
         warning_pressure,
     ];
-    checks.extend(evaluate_target_specific_readiness(artifacts, evidence));
+    checks.extend(evaluate_target_specific_readiness(artifacts));
     let status = if checks
         .iter()
         .any(|check| check.status == RuntimeCapabilityFamilyReadinessCheckStatus::Blocked)
@@ -928,7 +928,6 @@ fn evaluate_family_readiness(
 
 fn evaluate_target_specific_readiness(
     artifacts: &[RuntimeCapabilityArtifactDocument],
-    evidence: &RuntimeCapabilityEvidenceDigest,
 ) -> Vec<RuntimeCapabilityFamilyReadinessCheck> {
     let Some(target) = artifacts.first().map(|artifact| artifact.proposal.target) else {
         return Vec::new();
@@ -936,7 +935,38 @@ fn evaluate_target_specific_readiness(
 
     match target {
         RuntimeCapabilityTarget::MemoryStageProfile => {
-            vec![evaluate_memory_stage_profile_delta_evidence(evidence)]
+            let accepted_artifacts = artifacts
+                .iter()
+                .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Accepted)
+                .cloned()
+                .collect::<Vec<_>>();
+            let accepted_evidence = if accepted_artifacts.is_empty() {
+                RuntimeCapabilityEvidenceDigest {
+                    total_candidates: 0,
+                    reviewed_candidates: 0,
+                    undecided_candidates: 0,
+                    accepted_candidates: 0,
+                    rejected_candidates: 0,
+                    distinct_source_run_count: 0,
+                    distinct_experiment_count: 0,
+                    latest_candidate_at: None,
+                    latest_reviewed_at: None,
+                    source_decisions: RuntimeCapabilitySourceDecisionRollup {
+                        promoted: 0,
+                        rejected: 0,
+                        undecided: 0,
+                    },
+                    unique_warnings: Vec::new(),
+                    delta_candidate_count: 0,
+                    changed_surfaces: Vec::new(),
+                    metric_ranges: BTreeMap::new(),
+                }
+            } else {
+                build_family_evidence_digest(&accepted_artifacts)
+            };
+            vec![evaluate_memory_stage_profile_delta_evidence(
+                &accepted_evidence,
+            )]
         }
         RuntimeCapabilityTarget::ManagedSkill
         | RuntimeCapabilityTarget::ProgrammaticFlow

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -903,12 +903,13 @@ fn evaluate_family_readiness(
     let stability = evaluate_stability(evidence);
     let accepted_source_integrity = evaluate_accepted_source_integrity(artifacts, evidence);
     let warning_pressure = evaluate_warning_pressure(evidence);
-    let checks = vec![
+    let mut checks = vec![
         review_consensus,
         stability,
         accepted_source_integrity,
         warning_pressure,
     ];
+    checks.extend(evaluate_target_specific_readiness(artifacts, evidence));
     let status = if checks
         .iter()
         .any(|check| check.status == RuntimeCapabilityFamilyReadinessCheckStatus::Blocked)
@@ -923,6 +924,62 @@ fn evaluate_family_readiness(
         RuntimeCapabilityFamilyReadinessStatus::NotReady
     };
     RuntimeCapabilityFamilyReadiness { status, checks }
+}
+
+fn evaluate_target_specific_readiness(
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> Vec<RuntimeCapabilityFamilyReadinessCheck> {
+    let Some(target) = artifacts.first().map(|artifact| artifact.proposal.target) else {
+        return Vec::new();
+    };
+
+    match target {
+        RuntimeCapabilityTarget::MemoryStageProfile => {
+            vec![evaluate_memory_stage_profile_delta_evidence(evidence)]
+        }
+        RuntimeCapabilityTarget::ManagedSkill
+        | RuntimeCapabilityTarget::ProgrammaticFlow
+        | RuntimeCapabilityTarget::ProfileNoteAddendum => Vec::new(),
+    }
+}
+
+fn evaluate_memory_stage_profile_delta_evidence(
+    evidence: &RuntimeCapabilityEvidenceDigest,
+) -> RuntimeCapabilityFamilyReadinessCheck {
+    let has_memory_surface = evidence.changed_surfaces.iter().any(|surface| {
+        matches!(
+            surface.as_str(),
+            "memory_selected"
+                | "memory_policy"
+                | "context_engine_selected"
+                | "context_engine_compaction"
+        )
+    });
+
+    let (status, summary) = if evidence.delta_candidate_count == 0 {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            "memory-stage-profile families need snapshot-delta evidence from finished experiments"
+                .to_owned(),
+        )
+    } else if !has_memory_surface {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence,
+            "snapshot-delta evidence must include memory or context-engine surfaces".to_owned(),
+        )
+    } else {
+        (
+            RuntimeCapabilityFamilyReadinessCheckStatus::Pass,
+            "snapshot-delta evidence includes memory/context-engine surface changes".to_owned(),
+        )
+    };
+
+    RuntimeCapabilityFamilyReadinessCheck {
+        dimension: "memory_delta_evidence".to_owned(),
+        status,
+        summary,
+    }
 }
 
 fn evaluate_review_consensus(

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -102,6 +102,8 @@ pub enum RuntimeCapabilityTarget {
     ManagedSkill,
     ProgrammaticFlow,
     ProfileNoteAddendum,
+    #[value(alias = "memory_stage_profile")]
+    MemoryStageProfile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1356,6 +1358,7 @@ fn render_target(target: RuntimeCapabilityTarget) -> &'static str {
         RuntimeCapabilityTarget::ManagedSkill => "managed_skill",
         RuntimeCapabilityTarget::ProgrammaticFlow => "programmatic_flow",
         RuntimeCapabilityTarget::ProfileNoteAddendum => "profile_note_addendum",
+        RuntimeCapabilityTarget::MemoryStageProfile => "memory_stage_profile",
     }
 }
 
@@ -1447,6 +1450,11 @@ fn runtime_capability_promotion_target_contract(
         RuntimeCapabilityTarget::ProfileNoteAddendum => {
             ("profile_note_addendum", "profile_note", "profile-note")
         }
+        RuntimeCapabilityTarget::MemoryStageProfile => (
+            "memory_stage_profile",
+            "memory_stage_profiles",
+            "memory-stage-profile",
+        ),
     }
 }
 
@@ -1494,6 +1502,10 @@ fn build_runtime_capability_approval_checklist(
             "confirm the behavior belongs in advisory profile guidance rather than executable logic"
                 .to_owned()
         }
+        RuntimeCapabilityTarget::MemoryStageProfile => {
+            "confirm the behavior belongs in a governed memory stage profile rather than live runtime mutation"
+                .to_owned()
+        }
     });
     checklist
 }
@@ -1501,11 +1513,19 @@ fn build_runtime_capability_approval_checklist(
 fn build_runtime_capability_rollback_hints(
     planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
 ) -> Vec<String> {
-    vec![
-        format!(
+    let capture_hint = match planned_artifact.target_kind {
+        RuntimeCapabilityTarget::MemoryStageProfile => {
+            "capture the current `memory_stage_profiles` state before applying this memory stage profile".to_owned()
+        }
+        RuntimeCapabilityTarget::ManagedSkill
+        | RuntimeCapabilityTarget::ProgrammaticFlow
+        | RuntimeCapabilityTarget::ProfileNoteAddendum => format!(
             "capture the current `{}` state before applying artifact `{}`",
             planned_artifact.delivery_surface, planned_artifact.artifact_id
         ),
+    };
+    vec![
+        capture_hint,
         format!(
             "remove or revert `{}` from `{}` if downstream validation fails",
             planned_artifact.artifact_id, planned_artifact.delivery_surface

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -1017,6 +1017,63 @@ fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
 }
 
 #[test]
+fn runtime_capability_cli_parses_memory_stage_profile_target() {
+    let propose = try_parse_cli([
+        "loongclaw",
+        "runtime-capability",
+        "propose",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--output",
+        "/tmp/runtime-capability.json",
+        "--target",
+        "memory_stage_profile",
+        "--target-summary",
+        "Promote governed memory pipeline intent into a reusable profile",
+        "--bounded-scope",
+        "Governed memory pipeline promotion intent only",
+        "--required-capability",
+        "memory_read",
+        "--tag",
+        "memory",
+        "--tag",
+        "pipeline",
+    ])
+    .expect("`runtime-capability propose --target memory_stage_profile` should parse");
+
+    match propose.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                options,
+            ) => {
+                assert_eq!(options.run, "/tmp/runtime-experiment.json");
+                assert_eq!(options.output, "/tmp/runtime-capability.json");
+                assert_eq!(
+                    options.target,
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile
+                );
+                assert!(options.target_summary.contains("governed memory pipeline"));
+                assert_eq!(
+                    options.bounded_scope,
+                    "Governed memory pipeline promotion intent only"
+                );
+                assert_eq!(options.required_capability, vec!["memory_read".to_owned()]);
+                assert_eq!(options.tag, vec!["memory".to_owned(), "pipeline".to_owned()]);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn acp_event_summary_cli_rejects_zero_limit() {
     let error = run_acp_event_summary_cli(None, Some("session-a"), 0, false)
         .expect_err("zero limit must be rejected");

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -1074,6 +1074,54 @@ fn runtime_capability_cli_parses_memory_stage_profile_target() {
 }
 
 #[test]
+fn runtime_capability_cli_parses_memory_stage_profile_canonical_spelling() {
+    let propose = try_parse_cli([
+        "loongclaw",
+        "runtime-capability",
+        "propose",
+        "--run",
+        "/tmp/runtime-experiment.json",
+        "--output",
+        "/tmp/runtime-capability.json",
+        "--target",
+        "memory-stage-profile",
+        "--target-summary",
+        "Promote governed memory pipeline intent into a reusable profile",
+        "--bounded-scope",
+        "Governed memory pipeline promotion intent only",
+        "--required-capability",
+        "memory_read",
+        "--tag",
+        "memory",
+        "--tag",
+        "pipeline",
+    ])
+    .expect("`runtime-capability propose --target memory-stage-profile` should parse");
+
+    match propose.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                options,
+            ) => {
+                assert_eq!(
+                    options.target,
+                    loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile
+                );
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
 fn acp_event_summary_cli_rejects_zero_limit() {
     let error = run_acp_event_summary_cli(None, Some("session-a"), 0, false)
         .expect_err("zero limit must be rejected");

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -661,24 +661,6 @@ fn rewrite_runtime_capability_proposal(
     .expect("persist runtime capability artifact");
 }
 
-fn rewrite_runtime_capability_target(candidate_path: &Path, target: &str) {
-    let mut payload = serde_json::from_str::<Value>(
-        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
-    )
-    .expect("decode runtime capability artifact");
-    let proposal = payload
-        .as_object_mut()
-        .and_then(|artifact| artifact.get_mut("proposal"))
-        .and_then(Value::as_object_mut)
-        .expect("runtime capability artifact should include proposal");
-    proposal.insert("target".to_owned(), Value::String(target.to_owned()));
-    fs::write(
-        candidate_path,
-        serde_json::to_string_pretty(&payload).expect("encode runtime capability artifact"),
-    )
-    .expect("persist runtime capability artifact");
-}
-
 fn rewrite_runtime_capability_schema(candidate_path: &Path, surface: &str, purpose: &str) {
     let mut payload = serde_json::from_str::<Value>(
         &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -1780,6 +1780,91 @@ fn runtime_capability_index_marks_memory_stage_profile_not_ready_without_memory_
 }
 
 #[test]
+fn runtime_capability_index_uses_accepted_memory_delta_evidence_only() {
+    let root =
+        unique_temp_dir("loongclaw-runtime-capability-index-memory-stage-profile-accepted-only");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-accepted",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-rejected",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-accepted.json");
+    let candidate_b_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-rejected.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-accepted",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-rejected",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-accepted",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
+        "memory-stage-profile-rejected",
+    );
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+
+    let family = report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    assert_eq!(
+        family.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Blocked
+    );
+    assert!(
+        family.readiness.checks.iter().any(|check| {
+            check.dimension == "memory_delta_evidence"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "memory delta readiness should ignore rejected-only delta evidence"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_index_rejects_malformed_supported_artifact_during_scan() {
     let root = unique_temp_dir("loongclaw-runtime-capability-index-malformed");
     let config_path = write_runtime_capability_config(&root);
@@ -2577,10 +2662,12 @@ fn runtime_capability_plan_marks_memory_stage_profile_promotable_with_memory_del
         "ready memory-stage-profile family should pass memory delta evidence checks"
     );
     assert!(
-        plan.evidence
-            .changed_surfaces
-            .iter()
-            .any(|surface| surface == "memory_policy" || surface == "context_engine_compaction"),
+        plan.evidence.changed_surfaces.iter().any(|surface| {
+            surface == "memory_selected"
+                || surface == "memory_policy"
+                || surface == "context_engine_selected"
+                || surface == "context_engine_compaction"
+        }),
         "memory-stage-profile evidence should include memory/context surfaces"
     );
 

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -156,6 +156,28 @@ fn rewrite_runtime_capability_compare_config(config_path: &Path) {
     .expect("rewrite config fixture");
 }
 
+fn rewrite_runtime_capability_compare_config_for_memory_stage_profile(config_path: &Path) {
+    let (_, mut config) = mvp::config::load(Some(
+        config_path
+            .to_str()
+            .expect("config path should be valid utf-8"),
+    ))
+    .expect("load config fixture");
+    config.memory.profile = mvp::config::MemoryProfile::WindowPlusSummary;
+    config.conversation.compact_min_messages = Some(8);
+    config.conversation.compact_trigger_estimated_tokens = Some(512);
+    mvp::config::write(
+        Some(
+            config_path
+                .to_str()
+                .expect("config path should be valid utf-8"),
+        ),
+        &config,
+        true,
+    )
+    .expect("rewrite config fixture");
+}
+
 fn start_runtime_experiment(
     root: &Path,
     snapshot_path: &Path,
@@ -359,6 +381,66 @@ fn finish_runtime_experiment_variant_with_compare_delta(
                 run: run_path.display().to_string(),
                 result_snapshot: result_snapshot_path.display().to_string(),
                 evaluation_summary: format!("provider and tool policy updated ({slug})"),
+                metric: vec![
+                    "task_success=1".to_owned(),
+                    format!("cost_delta={cost_delta}"),
+                ],
+                warning: warnings.iter().map(|warning| (*warning).to_owned()).collect(),
+                decision,
+                status:
+                    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishStatus::Completed,
+                json: false,
+            },
+        )
+        .expect("runtime experiment finish should succeed");
+    (run_path, finished)
+}
+
+fn finish_runtime_experiment_variant_with_memory_compare_delta(
+    root: &Path,
+    slug: &str,
+    cost_delta: f64,
+    warnings: &[&str],
+    decision: loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision,
+) -> (
+    PathBuf,
+    loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentArtifactDocument,
+) {
+    let config_path = write_runtime_capability_config(root);
+    let (baseline_snapshot_path, baseline_snapshot_payload) = write_snapshot_artifact(
+        root,
+        &config_path,
+        &format!("artifacts/runtime-snapshot-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:00:00Z".to_owned(),
+            label: Some(format!("baseline-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some("snapshot-parent".to_owned()),
+        },
+    );
+    let (run_path, _) = start_runtime_experiment_variant(root, &baseline_snapshot_path, slug);
+
+    rewrite_runtime_capability_compare_config_for_memory_stage_profile(&config_path);
+
+    let baseline_snapshot_id = snapshot_id_from_payload(&baseline_snapshot_payload);
+    let (result_snapshot_path, _) = write_snapshot_artifact(
+        root,
+        &config_path,
+        &format!("artifacts/runtime-snapshot-result-{slug}.json"),
+        loongclaw_daemon::RuntimeSnapshotArtifactMetadata {
+            created_at: "2026-03-17T12:30:00Z".to_owned(),
+            label: Some(format!("candidate-{slug}")),
+            experiment_id: Some("exp-42".to_owned()),
+            parent_snapshot_id: Some(baseline_snapshot_id),
+        },
+    );
+
+    let finished =
+        loongclaw_daemon::runtime_experiment_cli::execute_runtime_experiment_finish_command(
+            loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentFinishCommandOptions {
+                run: run_path.display().to_string(),
+                result_snapshot: result_snapshot_path.display().to_string(),
+                evaluation_summary: format!("memory and context policy updated ({slug})"),
                 metric: vec![
                     "task_success=1".to_owned(),
                     format!("cost_delta={cost_delta}"),
@@ -1615,6 +1697,89 @@ fn runtime_capability_index_marks_family_blocked_on_conflicting_reviews() {
 }
 
 #[test]
+fn runtime_capability_index_marks_memory_stage_profile_not_ready_without_memory_delta_evidence() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-index-memory-stage-profile-not-ready");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path = root.join("artifacts/runtime-capability-memory-stage-profile-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-memory-stage-profile-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-b",
+    );
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+
+    let family = report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+    assert_eq!(
+        family.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::NotReady
+    );
+    assert!(
+        family.readiness.checks.iter().any(|check| {
+            check.dimension == "memory_delta_evidence"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::NeedsEvidence
+        }),
+        "memory-stage-profile families should require memory/context delta evidence"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_index_rejects_malformed_supported_artifact_during_scan() {
     let root = unique_temp_dir("loongclaw-runtime-capability-index-malformed");
     let config_path = write_runtime_capability_config(&root);
@@ -2315,6 +2480,108 @@ fn runtime_capability_plan_uses_memory_stage_profile_dry_run_artifact_surface() 
             .iter()
             .any(|hint| hint.contains("memory_stage_profiles")),
         "rollback hints should mention the memory stage profile delivery surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_marks_memory_stage_profile_promotable_with_memory_delta_evidence() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-memory-stage-profile-ready");
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-ready-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-ready-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-ready-a.json");
+    let candidate_b_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-ready-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-ready-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-ready-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-ready-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-ready-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+
+    assert!(
+        plan.promotable,
+        "memory-stage-profile family should be promotable"
+    );
+    assert_eq!(
+        plan.readiness.status,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessStatus::Ready
+    );
+    assert!(
+        plan.readiness.checks.iter().any(|check| {
+            check.dimension == "memory_delta_evidence"
+                && check.status
+                    == loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityFamilyReadinessCheckStatus::Pass
+        }),
+        "ready memory-stage-profile family should pass memory delta evidence checks"
+    );
+    assert!(
+        plan.evidence
+            .changed_surfaces
+            .iter()
+            .any(|surface| surface == "memory_policy" || surface == "context_engine_compaction"),
+        "memory-stage-profile evidence should include memory/context surfaces"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -579,6 +579,24 @@ fn rewrite_runtime_capability_proposal(
     .expect("persist runtime capability artifact");
 }
 
+fn rewrite_runtime_capability_target(candidate_path: &Path, target: &str) {
+    let mut payload = serde_json::from_str::<Value>(
+        &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
+    )
+    .expect("decode runtime capability artifact");
+    let proposal = payload
+        .as_object_mut()
+        .and_then(|artifact| artifact.get_mut("proposal"))
+        .and_then(Value::as_object_mut)
+        .expect("runtime capability artifact should include proposal");
+    proposal.insert("target".to_owned(), Value::String(target.to_owned()));
+    fs::write(
+        candidate_path,
+        serde_json::to_string_pretty(&payload).expect("encode runtime capability artifact"),
+    )
+    .expect("persist runtime capability artifact");
+}
+
 fn rewrite_runtime_capability_schema(candidate_path: &Path, surface: &str, purpose: &str) {
     let mut payload = serde_json::from_str::<Value>(
         &fs::read_to_string(candidate_path).expect("read runtime capability artifact"),
@@ -667,6 +685,46 @@ fn runtime_capability_propose_persists_candidate_from_finished_run() {
     assert!(
         candidate_path.exists(),
         "propose should persist the candidate artifact"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_propose_roundtrips_memory_stage_profile_target() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-propose-memory-stage-profile");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _run) = finish_runtime_experiment(&root, &config_path);
+    let candidate_path = root.join("artifacts/runtime-capability-memory-stage-profile.json");
+
+    loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_propose_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityProposeCommandOptions {
+            run: run_path.display().to_string(),
+            output: candidate_path.display().to_string(),
+            target:
+                loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+            target_summary: "Promote governed memory pipeline intent into a reusable profile"
+                .to_owned(),
+            bounded_scope: "Governed memory pipeline promotion intent only".to_owned(),
+            required_capability: vec!["memory_read".to_owned()],
+            tag: vec!["memory".to_owned(), "pipeline".to_owned()],
+            label: Some("memory-stage-profile-candidate".to_owned()),
+            json: false,
+        },
+    )
+    .expect("runtime capability propose should succeed");
+
+    let shown = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_show_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityShowCommandOptions {
+            candidate: candidate_path.display().to_string(),
+            json: false,
+        },
+    )
+    .expect("memory_stage_profile artifacts should round-trip through show");
+    let payload = serde_json::to_value(&shown).expect("serialize runtime capability artifact");
+    assert_eq!(
+        payload.pointer("/proposal/target").and_then(Value::as_str),
+        Some("memory_stage_profile")
     );
 
     fs::remove_dir_all(&root).ok();
@@ -2146,6 +2204,117 @@ fn runtime_capability_plan_reports_blocked_profile_note_family() {
             .iter()
             .any(|hint| hint.contains("profile_note")),
         "rollback hints should mention the profile note delivery surface"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_plan_uses_memory_stage_profile_dry_run_artifact_surface() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-memory-stage-profile");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path = root.join("artifacts/runtime-capability-memory-stage-profile-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-memory-stage-profile-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+    let payload = serde_json::to_value(&plan).expect("serialize runtime capability plan");
+
+    assert_eq!(
+        payload
+            .pointer("/planned_artifact/target_kind")
+            .and_then(Value::as_str),
+        Some("memory_stage_profile")
+    );
+    assert_eq!(plan.planned_artifact.artifact_kind, "memory_stage_profile");
+    assert_eq!(
+        plan.planned_artifact.delivery_surface,
+        "memory_stage_profiles"
+    );
+    assert!(
+        plan.planned_artifact
+            .artifact_id
+            .starts_with("memory-stage-profile-"),
+        "artifact id should carry the new memory-stage-profile prefix"
+    );
+    assert!(
+        plan.approval_checklist
+            .iter()
+            .any(|item| item.contains("memory stage profile")),
+        "checklist should include the target-specific memory stage profile review item"
+    );
+    assert!(
+        plan.rollback_hints
+            .iter()
+            .any(|hint| hint.contains("memory_stage_profiles")),
+        "rollback hints should mention the memory stage profile delivery surface"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -35,8 +35,9 @@ experiment should be crystallized into a reusable lower-layer capability.
 - [ ] Each capability family reports readiness as `ready`, `not_ready`, or
       `blocked` from explicit evidence checks rather than opaque heuristics.
 - [ ] `memory_stage_profile` families stay `not_ready` unless accepted
-      candidates include snapshot-delta evidence with at least one
-      memory-or-context-engine changed surface.
+      candidates include snapshot-delta evidence with at least one allowlisted
+      changed surface: `memory_selected`, `memory_policy`,
+      `context_engine_selected`, or `context_engine_compaction`.
 - [ ] `runtime-capability plan` resolves one indexed family into a dry-run
       promotion plan that describes the target lower-layer artifact, stable
       artifact id, blockers, approval checklist, rollback hints, provenance

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -13,7 +13,8 @@ experiment should be crystallized into a reusable lower-layer capability.
 - [ ] `runtime-capability propose` creates a persisted capability-candidate
       artifact from one finished `runtime-experiment` run.
 - [ ] The candidate artifact records one explicit target type:
-      `managed_skill`, `programmatic_flow`, or `profile_note_addendum`.
+      `managed_skill`, `programmatic_flow`, `profile_note_addendum`, or
+      `memory_stage_profile`.
 - [ ] The candidate artifact records one bounded scope, normalized tags, and
       normalized required capabilities without mutating live runtime state.
 - [ ] When the source run still points at recorded baseline and result snapshot
@@ -33,6 +34,9 @@ experiment should be crystallized into a reusable lower-layer capability.
       names across that family.
 - [ ] Each capability family reports readiness as `ready`, `not_ready`, or
       `blocked` from explicit evidence checks rather than opaque heuristics.
+- [ ] `memory_stage_profile` families stay `not_ready` unless accepted
+      candidates include snapshot-delta evidence with at least one
+      memory-or-context-engine changed surface.
 - [ ] `runtime-capability plan` resolves one indexed family into a dry-run
       promotion plan that describes the target lower-layer artifact, stable
       artifact id, blockers, approval checklist, rollback hints, provenance


### PR DESCRIPTION
## Summary

- Problem:
  `runtime-capability` could recognize `memory_stage_profile`, but it did not yet give that target a memory-specific readiness bar. A memory-stage-profile family could become `ready` from generic evidence alone.
- Why it matters:
  The remaining RFC work on `#455` is governed candidate-pipeline evaluation/promotion. If memory-stage-profile candidates can become promotable without memory/context delta evidence, the governance ladder is too weak to be trustworthy.
- What changed:
  Added `RuntimeCapabilityTarget::MemoryStageProfile`, wired its dry-run promotion contract, then added target-specific readiness logic that keeps memory-stage-profile families `not_ready` unless accepted candidates include snapshot-delta evidence with at least one memory/context-engine changed surface. Also added canonical CLI coverage for `memory-stage-profile` and updated the runtime-capability product spec.
- What did not change (scope boundary):
  This does not activate memory-stage profiles in live runtime, does not mutate config automatically, and does not define the final promoted memory-stage-profile payload/schema.

## Linked Issues

- Closes none; follow-up only
- Related #455

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
$HOME/.cargo/bin/cargo test -p loongclaw-daemon runtime_capability_cli_parses_memory_stage_profile_target -- --nocapture
  PASS

$HOME/.cargo/bin/cargo test -p loongclaw-daemon runtime_capability_cli_parses_memory_stage_profile_canonical_spelling -- --nocapture
  PASS

$HOME/.cargo/bin/cargo test -p loongclaw-daemon runtime_capability_propose_roundtrips_memory_stage_profile_target -- --nocapture
  PASS

$HOME/.cargo/bin/cargo test -p loongclaw-daemon runtime_capability_plan_uses_memory_stage_profile_dry_run_artifact_surface -- --nocapture
  PASS

$HOME/.cargo/bin/cargo test -p loongclaw-daemon runtime_capability_index_marks_memory_stage_profile_not_ready_without_memory_delta_evidence -- --nocapture
  PASS

$HOME/.cargo/bin/cargo test -p loongclaw-daemon runtime_capability_plan_marks_memory_stage_profile_promotable_with_memory_delta_evidence -- --nocapture
  PASS

$HOME/.cargo/bin/cargo test -p loongclaw-daemon --test integration
  PASS (719 passed, 0 failed)

$HOME/.cargo/bin/cargo fmt --all
  PASS

$HOME/.cargo/bin/cargo fmt --all -- --check
  PASS

$HOME/.cargo/bin/cargo clippy -p loongclaw-daemon --tests -- -D warnings
  PASS

$HOME/.cargo/bin/cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS

$HOME/.cargo/bin/cargo test --workspace --locked
  PASS

$HOME/.cargo/bin/cargo test --workspace --all-features --locked
  still running locally during PR creation; will update when it completes

Process-global env note:
  Existing daemon integration tests that mutate process-global env already restore or serialize state. This slice did not add new env-mutating tests.
```

## User-visible / Operator-visible Changes

- Operators can now use `runtime-capability` with `memory_stage_profile` / `memory-stage-profile` as a first-class governed target.
- Memory-stage-profile families now stay `not_ready` unless snapshot-delta evidence includes at least one memory/context-engine changed surface.
- Dry-run promotion plans for memory-stage-profile candidates still use the existing governed plan flow, but now only become promotable when that evidence bar is met.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR or cherry-pick-revert `c4025d1` and `71ed1d4` to remove the target and its readiness logic.
- Observable failure symptoms reviewers should watch for:
  `runtime-capability index` unexpectedly downgrading unrelated non-memory families, or memory-stage-profile families staying `not_ready` despite snapshot-delta evidence that clearly includes memory/context-engine surfaces.

## Reviewer Focus

- `crates/daemon/src/runtime_capability_cli.rs`
  Check the new `memory_delta_evidence` readiness check, especially the allowlisted changed surfaces and that it only applies to `MemoryStageProfile`.
- `crates/daemon/tests/integration/runtime_capability_cli.rs`
  Check that the new readiness tests use real snapshot-delta fixtures rather than synthetic artifact rewrites.
- `crates/daemon/tests/integration/cli_tests.rs`
  Check the canonical CLI spelling coverage.
- `docs/product-specs/runtime-capability.md`
  Check that the documented acceptance criteria match the implemented behavior and scope boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MemoryStageProfile as a new capability target; readiness is gated on accepted memory/context delta evidence and shows NotReady/Blocked until satisfied.
  * CLI accepts the new target via --target memory_stage_profile or --target memory-stage-profile.

* **Tests**
  * Added integration tests for CLI parsing, propose/show round-trips, readiness/plan behavior, and evidence-based promotion rules.

* **Documentation**
  * Updated acceptance criteria to document the new target and required evidence surfaces (memory_selected, memory_policy, context_engine_selected, context_engine_compaction).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->