### PR TITLE
feat(daemon): emit dry-run memory stage profile payloads

### DIFF
--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1726,7 +1726,7 @@ fn build_runtime_capability_promotion_planned_payload(
 pub fn render_runtime_capability_promotion_plan_text(
     report: &RuntimeCapabilityPromotionPlanReport,
 ) -> String {
-    [
+    let mut lines = vec![
         format!("family_id={}", report.family_id),
         format!("promotable={}", report.promotable),
         format!(
@@ -1778,10 +1778,6 @@ pub fn render_runtime_capability_promotion_plan_text(
             render_string_values_with_separator(&report.rollback_hints, " | ")
         ),
         format!(
-            "planned_payload={}",
-            render_runtime_capability_planned_payload_summary(report.planned_payload.as_ref())
-        ),
-        format!(
             "provenance_candidate_ids={}",
             render_string_values(&report.provenance.candidate_ids)
         ),
@@ -1800,19 +1796,26 @@ pub fn render_runtime_capability_promotion_plan_text(
                 " | "
             )
         ),
-    ]
-    .join("\n")
+    ];
+
+    if let Some(planned_payload) = render_runtime_capability_planned_payload_summary(
+        report.planned_payload.as_ref(),
+    ) {
+        lines.push(format!("planned_payload={planned_payload}"));
+    }
+
+    lines.join("\n")
 }
 
 fn render_runtime_capability_planned_payload_summary(
     payload: Option<&RuntimeCapabilityPromotionPlannedPayload>,
-) -> String {
+) -> Option<String> {
     match payload {
-        Some(payload) => format!(
-            "memory_stage_profile:{}:{}",
-            payload.memory_stage_profile.artifact_kind, payload.memory_stage_profile.profile.id
-        ),
-        None => "null".to_owned(),
+        Some(payload) => Some(format!(
+            "profile_id={}",
+            payload.memory_stage_profile.profile.id
+        )),
+        None => None,
     }
 }
 

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1817,13 +1817,7 @@ pub fn render_runtime_capability_promotion_plan_text(
 fn render_runtime_capability_planned_payload_summary(
     payload: Option<&RuntimeCapabilityPromotionPlannedPayload>,
 ) -> Option<String> {
-    match payload {
-        Some(payload) => Some(format!(
-            "profile_id={}",
-            payload.memory_stage_profile.profile.id
-        )),
-        None => None,
-    }
+    payload.map(|payload| format!("profile_id={}", payload.memory_stage_profile.profile.id))
 }
 
 fn render_family_readiness_checks(checks: &[RuntimeCapabilityFamilyReadinessCheck]) -> String {

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -1685,14 +1685,6 @@ fn build_runtime_capability_promotion_planned_payload(
 ) -> Option<RuntimeCapabilityPromotionPlannedPayload> {
     match planned_artifact.target_kind {
         RuntimeCapabilityTarget::MemoryStageProfile => {
-            let mut accepted_artifacts = artifacts
-                .iter()
-                .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Accepted)
-                .cloned()
-                .collect::<Vec<_>>();
-            sort_runtime_capability_artifacts(&mut accepted_artifacts);
-            let accepted_evidence = build_family_evidence_digest(&accepted_artifacts);
-
             Some(RuntimeCapabilityPromotionPlannedPayload {
                 memory_stage_profile: RuntimeCapabilityMemoryStageProfileDryRunPayload {
                     schema_version: 1,
@@ -1704,22 +1696,37 @@ fn build_runtime_capability_promotion_planned_payload(
                         required_capabilities: planned_artifact.required_capabilities.clone(),
                         tags: planned_artifact.tags.clone(),
                     },
-                    provenance: RuntimeCapabilityMemoryStageProfileDryRunProvenance {
-                        family_id: family_id.to_owned(),
-                        accepted_candidate_ids: accepted_artifacts
-                            .iter()
-                            .map(|artifact| artifact.candidate_id.clone())
-                            .collect(),
-                        evidence_digest: RuntimeCapabilityMemoryStageProfileDryRunEvidenceDigest {
-                            changed_surfaces: accepted_evidence.changed_surfaces,
-                        },
-                    },
+                    provenance: build_memory_stage_profile_dry_run_provenance(family_id, artifacts),
                 },
             })
         }
         RuntimeCapabilityTarget::ManagedSkill
         | RuntimeCapabilityTarget::ProgrammaticFlow
         | RuntimeCapabilityTarget::ProfileNoteAddendum => None,
+    }
+}
+
+fn build_memory_stage_profile_dry_run_provenance(
+    family_id: &str,
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+) -> RuntimeCapabilityMemoryStageProfileDryRunProvenance {
+    let mut accepted_artifacts = artifacts
+        .iter()
+        .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Accepted)
+        .cloned()
+        .collect::<Vec<_>>();
+    sort_runtime_capability_artifacts(&mut accepted_artifacts);
+    let accepted_evidence = build_family_evidence_digest(&accepted_artifacts);
+
+    RuntimeCapabilityMemoryStageProfileDryRunProvenance {
+        family_id: family_id.to_owned(),
+        accepted_candidate_ids: accepted_artifacts
+            .iter()
+            .map(|artifact| artifact.candidate_id.clone())
+            .collect(),
+        evidence_digest: RuntimeCapabilityMemoryStageProfileDryRunEvidenceDigest {
+            changed_surfaces: accepted_evidence.changed_surfaces,
+        },
     }
 }
 
@@ -1798,9 +1805,9 @@ pub fn render_runtime_capability_promotion_plan_text(
         ),
     ];
 
-    if let Some(planned_payload) = render_runtime_capability_planned_payload_summary(
-        report.planned_payload.as_ref(),
-    ) {
+    if let Some(planned_payload) =
+        render_runtime_capability_planned_payload_summary(report.planned_payload.as_ref())
+    {
         lines.push(format!("planned_payload={planned_payload}"));
     }
 

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -280,6 +280,40 @@ pub struct RuntimeCapabilityPromotionProvenance {
     pub latest_reviewed_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityPromotionPlannedPayload {
+    pub memory_stage_profile: RuntimeCapabilityMemoryStageProfileDryRunPayload,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityMemoryStageProfileDryRunPayload {
+    pub schema_version: u32,
+    pub artifact_kind: String,
+    pub profile: RuntimeCapabilityMemoryStageProfileDryRunProfile,
+    pub provenance: RuntimeCapabilityMemoryStageProfileDryRunProvenance,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityMemoryStageProfileDryRunProfile {
+    pub id: String,
+    pub summary: String,
+    pub review_scope: String,
+    pub required_capabilities: Vec<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityMemoryStageProfileDryRunProvenance {
+    pub family_id: String,
+    pub accepted_candidate_ids: Vec<String>,
+    pub evidence_digest: RuntimeCapabilityMemoryStageProfileDryRunEvidenceDigest,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityMemoryStageProfileDryRunEvidenceDigest {
+    pub changed_surfaces: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct RuntimeCapabilityPromotionPlanReport {
     pub generated_at: String,
@@ -294,6 +328,7 @@ pub struct RuntimeCapabilityPromotionPlanReport {
     pub approval_checklist: Vec<String>,
     pub rollback_hints: Vec<String>,
     pub provenance: RuntimeCapabilityPromotionProvenance,
+    pub planned_payload: Option<RuntimeCapabilityPromotionPlannedPayload>,
 }
 
 pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
@@ -477,6 +512,11 @@ pub fn execute_runtime_capability_plan_command(
         provenance: build_runtime_capability_promotion_provenance(
             &family_artifacts,
             &family.evidence,
+        ),
+        planned_payload: build_runtime_capability_promotion_planned_payload(
+            &family.family_id,
+            &planned_artifact,
+            &family_artifacts,
         ),
     })
 }
@@ -1638,6 +1678,51 @@ fn build_runtime_capability_promotion_provenance(
     }
 }
 
+fn build_runtime_capability_promotion_planned_payload(
+    family_id: &str,
+    planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
+    artifacts: &[RuntimeCapabilityArtifactDocument],
+) -> Option<RuntimeCapabilityPromotionPlannedPayload> {
+    match planned_artifact.target_kind {
+        RuntimeCapabilityTarget::MemoryStageProfile => {
+            let mut accepted_artifacts = artifacts
+                .iter()
+                .filter(|artifact| artifact.decision == RuntimeCapabilityDecision::Accepted)
+                .cloned()
+                .collect::<Vec<_>>();
+            sort_runtime_capability_artifacts(&mut accepted_artifacts);
+            let accepted_evidence = build_family_evidence_digest(&accepted_artifacts);
+
+            Some(RuntimeCapabilityPromotionPlannedPayload {
+                memory_stage_profile: RuntimeCapabilityMemoryStageProfileDryRunPayload {
+                    schema_version: 1,
+                    artifact_kind: planned_artifact.artifact_kind.clone(),
+                    profile: RuntimeCapabilityMemoryStageProfileDryRunProfile {
+                        id: planned_artifact.artifact_id.clone(),
+                        summary: planned_artifact.summary.clone(),
+                        review_scope: planned_artifact.bounded_scope.clone(),
+                        required_capabilities: planned_artifact.required_capabilities.clone(),
+                        tags: planned_artifact.tags.clone(),
+                    },
+                    provenance: RuntimeCapabilityMemoryStageProfileDryRunProvenance {
+                        family_id: family_id.to_owned(),
+                        accepted_candidate_ids: accepted_artifacts
+                            .iter()
+                            .map(|artifact| artifact.candidate_id.clone())
+                            .collect(),
+                        evidence_digest: RuntimeCapabilityMemoryStageProfileDryRunEvidenceDigest {
+                            changed_surfaces: accepted_evidence.changed_surfaces,
+                        },
+                    },
+                },
+            })
+        }
+        RuntimeCapabilityTarget::ManagedSkill
+        | RuntimeCapabilityTarget::ProgrammaticFlow
+        | RuntimeCapabilityTarget::ProfileNoteAddendum => None,
+    }
+}
+
 pub fn render_runtime_capability_promotion_plan_text(
     report: &RuntimeCapabilityPromotionPlanReport,
 ) -> String {
@@ -1693,6 +1778,10 @@ pub fn render_runtime_capability_promotion_plan_text(
             render_string_values_with_separator(&report.rollback_hints, " | ")
         ),
         format!(
+            "planned_payload={}",
+            render_runtime_capability_planned_payload_summary(report.planned_payload.as_ref())
+        ),
+        format!(
             "provenance_candidate_ids={}",
             render_string_values(&report.provenance.candidate_ids)
         ),
@@ -1713,6 +1802,18 @@ pub fn render_runtime_capability_promotion_plan_text(
         ),
     ]
     .join("\n")
+}
+
+fn render_runtime_capability_planned_payload_summary(
+    payload: Option<&RuntimeCapabilityPromotionPlannedPayload>,
+) -> String {
+    match payload {
+        Some(payload) => format!(
+            "memory_stage_profile:{}:{}",
+            payload.memory_stage_profile.artifact_kind, payload.memory_stage_profile.profile.id
+        ),
+        None => "null".to_owned(),
+    }
 }
 
 fn render_family_readiness_checks(checks: &[RuntimeCapabilityFamilyReadinessCheck]) -> String {

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -2576,7 +2576,7 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
 
     let candidate_a_path = root.join("artifacts/runtime-capability-memory-stage-profile-a.json");
     let candidate_b_path = root.join("artifacts/runtime-capability-memory-stage-profile-b.json");
-    propose_runtime_capability_variant_with_target(
+    let candidate_a = propose_runtime_capability_variant_with_target(
         &root,
         &run_a_path,
         "memory-stage-profile-a",
@@ -2586,7 +2586,7 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
         &["memory_read"],
         &["memory", "pipeline"],
     );
-    propose_runtime_capability_variant_with_target(
+    let candidate_b = propose_runtime_capability_variant_with_target(
         &root,
         &run_b_path,
         "memory-stage-profile-b",
@@ -2651,54 +2651,81 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
             .and_then(Value::as_str),
         Some(plan.planned_artifact.artifact_id.as_str())
     );
-    assert!(
+    assert_eq!(
         planned_payload
             .pointer("/profile/summary")
-            .and_then(Value::as_str)
-            .is_some(),
-        "payload should include the profile summary"
+            .and_then(Value::as_str),
+        Some("Promote governed memory pipeline intent into a reusable profile")
     );
-    assert!(
+    assert_eq!(
         planned_payload
             .pointer("/profile/review_scope")
-            .and_then(Value::as_str)
-            .is_some(),
-        "payload should include the profile review scope"
+            .and_then(Value::as_str),
+        Some("Governed memory pipeline promotion intent only")
     );
-    assert!(
-        planned_payload
-            .pointer("/profile/required_capabilities")
-            .and_then(Value::as_array)
-            .is_some(),
-        "payload should include the profile required capabilities"
-    );
-    assert!(
-        planned_payload
-            .pointer("/profile/tags")
-            .and_then(Value::as_array)
-            .is_some(),
-        "payload should include the profile tags"
-    );
-    assert!(
+    let required_capabilities = planned_payload
+        .pointer("/profile/required_capabilities")
+        .and_then(Value::as_array)
+        .expect("payload should include the profile required capabilities")
+        .iter()
+        .map(|value| value.as_str().expect("required capability should be a string"))
+        .collect::<Vec<_>>();
+    assert_eq!(required_capabilities, vec!["memory_read"]);
+    let tags = planned_payload
+        .pointer("/profile/tags")
+        .and_then(Value::as_array)
+        .expect("payload should include the profile tags")
+        .iter()
+        .map(|value| value.as_str().expect("tag should be a string"))
+        .collect::<Vec<_>>();
+    assert_eq!(tags, vec!["memory", "pipeline"]);
+    assert_eq!(
         planned_payload
             .pointer("/provenance/family_id")
-            .and_then(Value::as_str)
-            .is_some(),
-        "payload should include the provenance family id"
+            .and_then(Value::as_str),
+        Some(family.family_id.as_str())
+    );
+    let accepted_candidate_ids = planned_payload
+        .pointer("/provenance/accepted_candidate_ids")
+        .and_then(Value::as_array)
+        .expect("payload should include the accepted candidate ids")
+        .iter()
+        .map(|value| value.as_str().expect("candidate id should be a string"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        accepted_candidate_ids,
+        vec![
+            candidate_a.candidate_id.as_str(),
+            candidate_b.candidate_id.as_str(),
+        ]
+    );
+    let changed_surfaces = planned_payload
+        .pointer("/provenance/evidence_digest/changed_surfaces")
+        .and_then(Value::as_array)
+        .expect("payload should include the compact changed-surfaces digest")
+        .iter()
+        .map(|value| value.as_str().expect("changed surface should be a string"))
+        .collect::<Vec<_>>();
+    assert_eq!(changed_surfaces, Vec::<&str>::new());
+
+    let rendered =
+        loongclaw_daemon::runtime_capability_cli::render_runtime_capability_promotion_plan_text(
+            &plan,
+        );
+    assert!(
+        rendered.contains(&format!(
+            "planned_payload=profile_id={}",
+            plan.planned_artifact.artifact_id
+        )),
+        "rendered text should mention the payload compactly when present"
     );
     assert!(
-        planned_payload
-            .pointer("/provenance/accepted_candidate_ids")
-            .and_then(Value::as_array)
-            .is_some(),
-        "payload should include the accepted candidate ids"
+        !rendered.contains("planned_payload=null"),
+        "rendered text should omit null planned payload noise"
     );
     assert!(
-        planned_payload
-            .pointer("/provenance/evidence_digest/changed_surfaces")
-            .and_then(Value::as_array)
-            .is_some(),
-        "payload should include the compact changed-surfaces digest"
+        !rendered.contains("memory_stage_profile:memory_stage_profile"),
+        "rendered text should not repeat the payload discriminator"
     );
 
     fs::remove_dir_all(&root).ok();
@@ -2781,6 +2808,10 @@ fn runtime_capability_plan_omits_memory_stage_profile_payload_for_other_targets(
     )
     .expect("runtime capability plan should succeed");
     let payload = serde_json::to_value(&plan).expect("serialize runtime capability plan");
+    let rendered =
+        loongclaw_daemon::runtime_capability_cli::render_runtime_capability_promotion_plan_text(
+            &plan,
+        );
 
     assert!(
         payload.pointer("/planned_payload").is_some(),
@@ -2791,6 +2822,10 @@ fn runtime_capability_plan_omits_memory_stage_profile_payload_for_other_targets(
             .pointer("/planned_payload")
             .is_some_and(Value::is_null),
         "non-memory targets should serialize planned_payload as null"
+    );
+    assert!(
+        !rendered.contains("planned_payload="),
+        "non-memory targets should not render a planned payload line"
     );
 
     fs::remove_dir_all(&root).ok();

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -2555,19 +2555,17 @@ fn runtime_capability_plan_uses_memory_stage_profile_dry_run_artifact_surface() 
 #[test]
 fn runtime_capability_plan_emits_memory_stage_profile_payload() {
     let root = unique_temp_dir("loongclaw-runtime-capability-plan-memory-stage-profile-payload");
-    let config_path = write_runtime_capability_config(&root);
+    write_runtime_capability_config(&root);
 
-    let (run_a_path, _) = finish_runtime_experiment_variant(
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
         &root,
-        &config_path,
         "memory-stage-profile-a",
         -0.2,
         &[],
         loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
     );
-    let (run_b_path, _) = finish_runtime_experiment_variant(
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
         &root,
-        &config_path,
         "memory-stage-profile-b",
         -0.4,
         &[],
@@ -2706,7 +2704,10 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
         .iter()
         .map(|value| value.as_str().expect("changed surface should be a string"))
         .collect::<Vec<_>>();
-    assert_eq!(changed_surfaces, Vec::<&str>::new());
+    assert_eq!(
+        changed_surfaces,
+        vec!["context_engine_compaction", "memory_policy"]
+    );
 
     let rendered =
         loongclaw_daemon::runtime_capability_cli::render_runtime_capability_promotion_plan_text(

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -2553,6 +2553,158 @@ fn runtime_capability_plan_uses_memory_stage_profile_dry_run_artifact_surface() 
 }
 
 #[test]
+fn runtime_capability_plan_emits_memory_stage_profile_payload() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-memory-stage-profile-payload");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path = root.join("artifacts/runtime-capability-memory-stage-profile-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-memory-stage-profile-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+    let payload = serde_json::to_value(&plan).expect("serialize runtime capability plan");
+    let planned_payload = payload
+        .pointer("/planned_payload/memory_stage_profile")
+        .expect("memory-stage-profile plan should include a promoted payload");
+
+    assert_eq!(
+        planned_payload
+            .pointer("/schema_version")
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+    assert_eq!(
+        planned_payload
+            .pointer("/artifact_kind")
+            .and_then(Value::as_str),
+        Some("memory_stage_profile")
+    );
+    assert_eq!(
+        planned_payload
+            .pointer("/profile/id")
+            .and_then(Value::as_str),
+        Some(plan.planned_artifact.artifact_id.as_str())
+    );
+    assert!(
+        planned_payload
+            .pointer("/profile/summary")
+            .and_then(Value::as_str)
+            .is_some(),
+        "payload should include the profile summary"
+    );
+    assert!(
+        planned_payload
+            .pointer("/profile/review_scope")
+            .and_then(Value::as_str)
+            .is_some(),
+        "payload should include the profile review scope"
+    );
+    assert!(
+        planned_payload
+            .pointer("/profile/required_capabilities")
+            .and_then(Value::as_array)
+            .is_some(),
+        "payload should include the profile required capabilities"
+    );
+    assert!(
+        planned_payload
+            .pointer("/profile/tags")
+            .and_then(Value::as_array)
+            .is_some(),
+        "payload should include the profile tags"
+    );
+    assert!(
+        planned_payload
+            .pointer("/provenance/family_id")
+            .and_then(Value::as_str)
+            .is_some(),
+        "payload should include the provenance family id"
+    );
+    assert!(
+        planned_payload
+            .pointer("/provenance/accepted_candidate_ids")
+            .and_then(Value::as_array)
+            .is_some(),
+        "payload should include the accepted candidate ids"
+    );
+    assert!(
+        planned_payload
+            .pointer("/provenance/evidence_digest/changed_surfaces")
+            .and_then(Value::as_array)
+            .is_some(),
+        "payload should include the compact changed-surfaces digest"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_plan_marks_memory_stage_profile_promotable_with_memory_delta_evidence() {
     let root = unique_temp_dir("loongclaw-runtime-capability-plan-memory-stage-profile-ready");
     let (run_a_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -2553,8 +2553,8 @@ fn runtime_capability_plan_uses_memory_stage_profile_dry_run_artifact_surface() 
 }
 
 #[test]
-fn runtime_capability_plan_emits_memory_stage_profile_payload() {
-    let root = unique_temp_dir("loongclaw-runtime-capability-plan-memory-stage-profile-payload");
+fn runtime_capability_plan_scopes_memory_stage_profile_payload_provenance_to_accepted_evidence() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-memory-stage-profile-provenance");
     write_runtime_capability_config(&root);
 
     let (run_a_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
@@ -2584,7 +2584,7 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
         &["memory_read"],
         &["memory", "pipeline"],
     );
-    let candidate_b = propose_runtime_capability_variant_with_target(
+    let _candidate_b = propose_runtime_capability_variant_with_target(
         &root,
         &run_b_path,
         "memory-stage-profile-b",
@@ -2594,6 +2594,23 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
         &["memory_read"],
         &["memory", "pipeline"],
     );
+    rewrite_json_file(&candidate_b_path, |payload| {
+        let changed_surface_count = payload
+            .pointer("/source_run/snapshot_delta/changed_surface_count")
+            .and_then(Value::as_u64)
+            .expect(
+                "candidate fixture should include source_run.snapshot_delta.changed_surface_count",
+            );
+        *payload
+            .pointer_mut("/source_run/snapshot_delta/changed_surface_count")
+            .expect(
+                "candidate fixture should include source_run.snapshot_delta.changed_surface_count",
+            ) = Value::from(changed_surface_count + 1);
+        let acp_policy_after = payload
+            .pointer_mut("/source_run/snapshot_delta/acp_policy/after")
+            .expect("candidate fixture should include source_run.snapshot_delta.acp_policy.after");
+        *acp_policy_after = Value::String("rejected-only-policy".to_owned());
+    });
     review_runtime_capability_variant(
         &candidate_a_path,
         loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
@@ -2601,7 +2618,7 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
     );
     review_runtime_capability_variant(
         &candidate_b_path,
-        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Rejected,
         "memory-stage-profile-b",
     );
 
@@ -2630,6 +2647,17 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
     let planned_payload = payload
         .pointer("/planned_payload/memory_stage_profile")
         .expect("memory-stage-profile plan should include a promoted payload");
+    let family_changed_surfaces = payload
+        .pointer("/evidence/changed_surfaces")
+        .and_then(Value::as_array)
+        .expect("plan should preserve broader report-level changed surfaces")
+        .iter()
+        .map(|value| value.as_str().expect("changed surface should be a string"))
+        .collect::<Vec<_>>();
+    assert!(
+        family_changed_surfaces.contains(&"acp_policy"),
+        "broader report-level evidence should still include rejected family evidence"
+    );
 
     assert_eq!(
         planned_payload
@@ -2666,7 +2694,11 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
         .and_then(Value::as_array)
         .expect("payload should include the profile required capabilities")
         .iter()
-        .map(|value| value.as_str().expect("required capability should be a string"))
+        .map(|value| {
+            value
+                .as_str()
+                .expect("required capability should be a string")
+        })
         .collect::<Vec<_>>();
     assert_eq!(required_capabilities, vec!["memory_read"]);
     let tags = planned_payload
@@ -2692,10 +2724,7 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
         .collect::<Vec<_>>();
     assert_eq!(
         accepted_candidate_ids,
-        vec![
-            candidate_a.candidate_id.as_str(),
-            candidate_b.candidate_id.as_str(),
-        ]
+        vec![candidate_a.candidate_id.as_str()]
     );
     let changed_surfaces = planned_payload
         .pointer("/provenance/evidence_digest/changed_surfaces")
@@ -2707,6 +2736,10 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
     assert_eq!(
         changed_surfaces,
         vec!["context_engine_compaction", "memory_policy"]
+    );
+    assert!(
+        !changed_surfaces.contains(&"acp_policy"),
+        "payload provenance digest should exclude rejected-only changed surfaces"
     );
 
     let rendered =

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -2705,6 +2705,98 @@ fn runtime_capability_plan_emits_memory_stage_profile_payload() {
 }
 
 #[test]
+fn runtime_capability_plan_omits_memory_stage_profile_payload_for_other_targets() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-plan-non-memory-payload");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "managed-skill-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "managed-skill-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path = root.join("artifacts/runtime-capability-managed-skill-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-managed-skill-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "managed-skill-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "managed-skill-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "managed-skill-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "managed-skill-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let plan = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_plan_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityPlanCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect("runtime capability plan should succeed");
+    let payload = serde_json::to_value(&plan).expect("serialize runtime capability plan");
+
+    assert!(
+        payload.pointer("/planned_payload").is_some(),
+        "planned_payload field should always be present"
+    );
+    assert!(
+        payload
+            .pointer("/planned_payload")
+            .is_some_and(Value::is_null),
+        "non-memory targets should serialize planned_payload as null"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_plan_marks_memory_stage_profile_promotable_with_memory_delta_evidence() {
     let root = unique_temp_dir("loongclaw-runtime-capability-plan-memory-stage-profile-ready");
     let (run_a_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -57,3 +57,70 @@ experiment should be crystallized into a reusable lower-layer capability.
 - Persisted capability-family state or background indexing daemons
 - Persisted promotion-plan artifacts or plan caches
 - Candidate queues, dashboards, or autonomous ranking systems
+
+## Dry-Run Plan Payload
+
+`runtime-capability plan` now carries one additional dry-run payload field:
+`planned_payload`.
+
+- `planned_payload` is emitted only when the planned family target is
+  `memory_stage_profile`.
+- For `managed_skill`, `programmatic_flow`, and `profile_note_addendum`,
+  `planned_payload` stays `null`.
+- The payload is governed review data only. It does not auto-apply anything to
+  runtime, and it does not yet encode executable memory-stage settings.
+
+The JSON shape is:
+
+```json
+{
+  "planned_payload": {
+    "memory_stage_profile": {
+      "schema_version": 1,
+      "artifact_kind": "memory_stage_profile",
+      "profile": {
+        "id": "memory-stage-profile-...",
+        "summary": "Promote governed memory pipeline intent into a reusable profile",
+        "review_scope": "Governed memory pipeline promotion intent only",
+        "required_capabilities": ["memory_read"],
+        "tags": ["memory", "pipeline"]
+      },
+      "provenance": {
+        "family_id": "8f5c2d1a4b7e...",
+        "accepted_candidate_ids": ["capability-candidate-..."],
+        "evidence_digest": {
+          "changed_surfaces": [
+            "context_engine_compaction",
+            "memory_policy"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+For v1, `planned_payload.memory_stage_profile.profile` is derived directly from
+the existing proposal and planned-artifact data already present in the plan
+report:
+
+- `profile.id` comes from `planned_artifact.artifact_id`
+- `profile.summary` comes from `planned_artifact.summary`
+- `profile.review_scope` comes from `planned_artifact.bounded_scope`
+- `profile.required_capabilities` comes from
+  `planned_artifact.required_capabilities`
+- `profile.tags` comes from `planned_artifact.tags`
+- `artifact_kind` matches `planned_artifact.artifact_kind`
+
+The payload provenance is intentionally compact:
+
+- `provenance.family_id` names the indexed capability family that was planned
+- `provenance.accepted_candidate_ids` includes only accepted candidates in
+  stable family order
+- `provenance.evidence_digest.changed_surfaces` is a compact digest built from
+  accepted-candidate snapshot-delta evidence only
+
+That compact digest is narrower than the broader family-level plan evidence.
+Rejected-only or undecided-only delta surfaces may still appear under the main
+report `evidence.changed_surfaces`, but they are excluded from
+`planned_payload.memory_stage_profile.provenance.evidence_digest.changed_surfaces`.


### PR DESCRIPTION
## Summary

- Problem:
  `runtime-capability plan` could say a `memory_stage_profile` family was ready for promotion, but it still had no concrete dry-run promoted object for operators to review.
- Why it matters:
  readiness without a typed payload leaves promotion as a status-only decision instead of a reviewable artifact with explicit accepted-evidence provenance.
- What changed:
  added `planned_payload.memory_stage_profile` to the dry-run plan report, built from existing proposal/planned-artifact data plus accepted-only compact provenance; strengthened integration coverage for payload shape, text rendering, and accepted-only changed-surface behavior; documented the payload contract in the product spec.
- What did not change (scope boundary):
  this does not apply memory-stage profiles to live runtime, mutate config, add executor wiring, or introduce autonomous promotion.

## Linked Issues

- Closes none; follow-up only
- Related #455

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
rg -n "memory_stage_profile|planned payload|accepted_candidate_ids|changed_surfaces" docs/product-specs/runtime-capability.md crates/daemon/src/runtime_capability_cli.rs
  - completed successfully; confirmed docs/code references for the new payload contract

cargo test -p loongclaw-daemon runtime_capability_plan_emits_memory_stage_profile_payload -- --nocapture
  - passed

cargo test -p loongclaw-daemon runtime_capability_plan_omits_memory_stage_profile_payload_for_other_targets -- --nocapture
  - passed

cargo test -p loongclaw-daemon --test integration
  - sandbox run hit local-listener permission failures unrelated to this slice
  - reran on host; passed (722 passed, 0 failed)

cargo fmt --all -- --check
  - passed

cargo clippy -p loongclaw-daemon --tests -- -D warnings
  - passed after one verification-driven simplification in runtime_capability_cli.rs

cargo clippy --workspace --all-targets --all-features -- -D warnings
  - passed

cargo test --workspace --locked
  - passed on host

cargo test --workspace --all-features --locked
  - passed on host
```

## User-visible / Operator-visible Changes

- `runtime-capability plan` now emits a typed dry-run `planned_payload.memory_stage_profile` object for `memory_stage_profile` families.
- The payload includes reviewable profile metadata plus compact accepted-only provenance instead of only a readiness status.
- Non-memory targets keep `planned_payload = null`.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR; the change is additive to dry-run planning only and does not mutate live runtime state.
- Observable failure symptoms reviewers should watch for:
  memory-stage-profile plan JSON missing `planned_payload.memory_stage_profile`, accepted-only changed surfaces leaking rejected-only evidence, or noisy text rendering regressing to duplicate payload discriminators.

## Reviewer Focus

- `crates/daemon/src/runtime_capability_cli.rs`
  focus on the `planned_payload` JSON shape, the accepted-only provenance helper, and the compact text rendering path.
- `crates/daemon/tests/integration/runtime_capability_cli.rs`
  focus on the populated changed-surfaces assertions and the accepted-vs-rejected evidence split.
- `docs/product-specs/runtime-capability.md`
  focus on whether the documented payload fields match the actual plan output and keep the scope governance-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended `runtime-capability plan` dry-run output with a new `planned_payload` field for memory stage profile targets, displaying detailed provenance information scoped to accepted candidates.

* **Tests**
  * Added integration tests validating memory stage profile promotion planning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->