### PR TITLE
docs: align roadmap gateway security boundary wording

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -332,7 +332,8 @@ Remaining deliverables:
   - Web UI implementation as a thin shell over existing ask/chat, onboarding,
     dashboard, and browser semantics, not a separate assistant runtime
   - current product mode stays same-origin and localhost-only by default, but
-    that operating boundary is not the long-term architecture endpoint
+    that bind policy is a security and rollout boundary for the current slice,
+    not the long-term architecture endpoint
 - gateway service foundation:
   - land the first explicit daemon-owned gateway owner contract through
     `gateway run`, `gateway status`, and `gateway stop`, while keeping


### PR DESCRIPTION
## summary

- problem: `docs/ROADMAP.md` still used the older "operating boundary" wording after #667, leaving one remaining mismatch in the gateway and Web UI framing.
- what changed: aligned the roadmap wording with the merged gateway security-boundary docs so localhost-only default binding is described as the current security and rollout boundary, not the long-term product ceiling.
- scope boundary: docs only; one roadmap wording fix; no runtime, bind policy, or auth behavior changes.

## linked issues

- Closes #666
- Follow-up to #667

## change type

- [ ] bug fix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] security hardening
- [ ] ci / workflow / release

## touched areas

- [x] contracts / protocol / spec
- [ ] daemon / cli / install
- [ ] providers / routing
- [ ] tools
- [ ] browser automation
- [ ] channels / integrations
- [ ] acp / conversation / session runtime
- [ ] memory / context assembly
- [ ] config / migration / onboarding
- [x] docs / contributor workflow
- [ ] ci / release / workflows

## validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] `scripts/check-docs.sh`
- [ ] `LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh`

commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
scripts/check-docs.sh
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh

all cargo and non-strict docs checks passed.
strict docs checking still fails on pre-existing missing local release/trace governance artifacts under .docs/releases/ and .docs/traces/ that this follow-up does not touch.
```

## reviewer focus

- confirm `docs/ROADMAP.md` now uses the same security-boundary wording as the merged gateway architecture and Web UI docs.
- confirm this remains a docs-only follow-up and does not overstate any change to shipped gateway exposure policy.
