### PR TITLE
Converge provider descriptor projections for internal SDK seams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,11 +164,14 @@ cargo test --workspace --all-features
 
 ### Recipe: Add a Provider
 
-1. Copy `crates/app/src/provider/transport.rs` as a starting point
-2. Implement the HTTP transport for your provider's API
-3. Update `crates/app/src/provider/mod.rs` to route to your provider based on config
-4. Add tests in the same file
+1. Start from `crates/app/src/config/provider.rs` and add or update the static provider descriptor facts first:
+   canonical id, aliases, protocol family, auth defaults, and setup-facing defaults
+2. Update `crates/app/src/provider/contracts.rs` only for request-time behavior that genuinely belongs in the runtime contract:
+   transport mode, payload adaptation, validation rules, capability defaults, or error classification
+3. Extend the relevant runtime modules such as `transport.rs`, `provider_validation_runtime.rs`, or request/runtime helpers only after the descriptor and runtime contract seams are clear
+4. Add or extend provider-family conformance and regression tests so descriptor facts, runtime-contract derivation, and setup/auth guidance stay aligned
 5. If the provider needs a feature flag, add it to `crates/app/Cargo.toml`
+6. Read [SDK Docs](docs/sdk/index.md) and the provider convergence plan before large provider-family refactors
 
 ### Recipe: Add a Tool
 

--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ For the full layered execution model, see [ARCHITECTURE.md](ARCHITECTURE.md) and
 | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | [Architecture](ARCHITECTURE.md)                             | Crate map and layered execution overview                                                                    |
 | [Core Beliefs](docs/design-docs/core-beliefs.md)            | Core engineering principles                                                                                 |
+| [SDK Docs](docs/sdk/index.md)                               | Capability authoring, internal integration seams, validator meaning, and promotion-oriented SDK references  |
 | [Roadmap](docs/ROADMAP.md)                                  | Stage-based milestones and direction                                                                        |
 | [Product Sense](docs/PRODUCT_SENSE.md)                      | Current product contract and user journey                                                                   |
 | [Product Specs](docs/product-specs/index.md)                | User-facing requirements for onboarding, ask, doctor, channels, and memory                                  |

--- a/crates/app/src/config/mod.rs
+++ b/crates/app/src/config/mod.rs
@@ -71,12 +71,14 @@ pub use memory::{
 pub use outbound_http::OutboundHttpConfig;
 #[allow(unused_imports)]
 pub use provider::{
-    ModelCatalogProbeRecovery, ProviderAuthScheme, ProviderConfig, ProviderFeatureFamily,
-    ProviderKind, ProviderProfileConfig, ProviderProfileHealthModeConfig,
-    ProviderProfileStateBackendKind, ProviderProtocolFamily, ProviderReasoningExtraBodyModeConfig,
-    ProviderToolSchemaModeConfig, ProviderTransportFallback, ProviderTransportPolicy,
-    ProviderTransportReadiness, ProviderTransportReadinessLevel, ProviderWireApi, ReasoningEffort,
-    parse_provider_kind_id,
+    ModelCatalogProbeRecovery, PROVIDER_DESCRIPTOR_SCHEMA_VERSION, ProviderAuthScheme,
+    ProviderConfig, ProviderDescriptorAuth, ProviderDescriptorDocument, ProviderDescriptorFeature,
+    ProviderDescriptorHeader, ProviderDescriptorRegionEndpoint, ProviderDescriptorRegionVariant,
+    ProviderDescriptorSchema, ProviderFeatureFamily, ProviderKind, ProviderProfileConfig,
+    ProviderProfileHealthModeConfig, ProviderProfileStateBackendKind, ProviderProtocolFamily,
+    ProviderReasoningExtraBodyModeConfig, ProviderToolSchemaModeConfig, ProviderTransportFallback,
+    ProviderTransportPolicy, ProviderTransportReadiness, ProviderTransportReadinessLevel,
+    ProviderWireApi, ReasoningEffort, parse_provider_kind_id,
 };
 #[allow(unused_imports)]
 pub use runtime::{

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -99,6 +99,19 @@ pub enum ProviderFeatureFamily {
 }
 
 impl ProviderFeatureFamily {
+    pub fn support_facts(self) -> ProviderFeatureSupportFacts {
+        let gate_name = self.feature_gate_name();
+        let enabled_in_build = self.is_enabled_in_build();
+        let disabled_message = self.disabled_message();
+
+        ProviderFeatureSupportFacts {
+            family: self,
+            gate_name,
+            enabled_in_build,
+            disabled_message,
+        }
+    }
+
     pub fn feature_gate_name(self) -> &'static str {
         match self {
             Self::Anthropic => "provider-anthropic",
@@ -188,6 +201,37 @@ pub struct ProviderTransportPolicy {
     pub models_endpoint: String,
     pub readiness: ProviderTransportReadiness,
     pub fallback: Option<ProviderTransportFallback>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderFeatureSupportFacts {
+    pub family: ProviderFeatureFamily,
+    pub gate_name: &'static str,
+    pub enabled_in_build: bool,
+    pub disabled_message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderAuthSupportFacts {
+    pub hint_env_names: Vec<String>,
+    pub requires_explicit_configuration: bool,
+    pub guidance_hint: Option<String>,
+    pub alternative_configuration_hint: Option<String>,
+    pub missing_configuration_message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderRegionEndpointSupportFacts {
+    pub note: Option<String>,
+    pub catalog_failure_hint: Option<String>,
+    pub request_failure_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderSupportFacts {
+    pub feature: ProviderFeatureSupportFacts,
+    pub auth: ProviderAuthSupportFacts,
+    pub region_endpoint: ProviderRegionEndpointSupportFacts,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1224,23 +1268,65 @@ impl ProviderConfig {
         env_names
     }
 
+    pub fn support_facts(&self) -> ProviderSupportFacts {
+        let feature = self.kind.feature_family().support_facts();
+        let auth = self.build_auth_support_facts();
+        let region_endpoint = self.build_region_endpoint_support_facts();
+
+        ProviderSupportFacts {
+            feature,
+            auth,
+            region_endpoint,
+        }
+    }
+
     pub fn requires_explicit_auth_configuration(&self) -> bool {
-        !self.auth_hint_env_names().is_empty()
+        let support_facts = self.support_facts();
+        support_facts.auth.requires_explicit_configuration
     }
 
     pub fn auth_guidance_hint(&self) -> Option<String> {
-        let profile = self.kind.profile();
-        profile.auth_guidance_hint()
+        let support_facts = self.support_facts();
+        support_facts.auth.guidance_hint
     }
 
     pub fn missing_auth_configuration_message(&self) -> String {
+        let support_facts = self.support_facts();
+        support_facts.auth.missing_configuration_message
+    }
+
+    fn build_auth_support_facts(&self) -> ProviderAuthSupportFacts {
         let env_names = self.auth_hint_env_names();
+        let requires_explicit_configuration = !env_names.is_empty();
+        let guidance_hint = self.build_auth_guidance_hint();
+        let alternative_configuration_hint = self.build_alternative_auth_configuration_hint();
+        let missing_configuration_message = self.build_missing_auth_configuration_message(
+            &env_names,
+            guidance_hint.as_deref(),
+            alternative_configuration_hint.as_deref(),
+        );
+
+        ProviderAuthSupportFacts {
+            hint_env_names: env_names,
+            requires_explicit_configuration,
+            guidance_hint,
+            alternative_configuration_hint,
+            missing_configuration_message,
+        }
+    }
+
+    fn build_missing_auth_configuration_message(
+        &self,
+        env_names: &[String],
+        guidance_hint: Option<&str>,
+        alternative_configuration_hint: Option<&str>,
+    ) -> String {
         let mut configuration_paths = vec!["configure provider credentials".to_owned()];
         if !env_names.is_empty() {
             configuration_paths.push(format!("set {} in env", env_names.join(", ")));
         }
-        if let Some(hint) = self.alternative_auth_configuration_hint() {
-            configuration_paths.push(hint);
+        if let Some(hint) = alternative_configuration_hint {
+            configuration_paths.push(hint.to_owned());
         }
         let mut message = "provider credentials are missing".to_owned();
         if let Some(detail) = self.missing_auth_runtime_detail() {
@@ -1249,14 +1335,19 @@ impl ProviderConfig {
         }
         message.push_str("; ");
         message.push_str(join_guidance_options(&configuration_paths).as_str());
-        if let Some(hint) = self.auth_guidance_hint() {
+        if let Some(hint) = guidance_hint {
             message.push(' ');
-            message.push_str(hint.as_str());
+            message.push_str(hint);
         }
         message
     }
 
-    fn alternative_auth_configuration_hint(&self) -> Option<String> {
+    fn build_auth_guidance_hint(&self) -> Option<String> {
+        let profile = self.kind.profile();
+        profile.auth_guidance_hint()
+    }
+
+    fn build_alternative_auth_configuration_hint(&self) -> Option<String> {
         let profile = self.kind.profile();
         let hint = profile.alternative_auth_configuration_hint();
         hint.map(str::to_owned)
@@ -1724,20 +1815,32 @@ impl ProviderConfig {
         None
     }
 
+    fn build_region_endpoint_support_facts(&self) -> ProviderRegionEndpointSupportFacts {
+        let guide = self.kind.region_endpoint_guide();
+        let note = guide.map(|value| value.note(self));
+        let catalog_failure_hint = guide.map(|value| value.failure_hint(self));
+        let request_failure_hint = guide.map(|value| value.request_failure_hint(self));
+
+        ProviderRegionEndpointSupportFacts {
+            note,
+            catalog_failure_hint,
+            request_failure_hint,
+        }
+    }
+
     pub fn region_endpoint_note(&self) -> Option<String> {
-        Some(self.kind.region_endpoint_guide()?.note(self))
+        let support_facts = self.support_facts();
+        support_facts.region_endpoint.note
     }
 
     pub fn region_endpoint_failure_hint(&self) -> Option<String> {
-        Some(self.kind.region_endpoint_guide()?.failure_hint(self))
+        let support_facts = self.support_facts();
+        support_facts.region_endpoint.catalog_failure_hint
     }
 
     pub fn request_region_endpoint_failure_hint(&self) -> Option<String> {
-        Some(
-            self.kind
-                .region_endpoint_guide()?
-                .request_failure_hint(self),
-        )
+        let support_facts = self.support_facts();
+        support_facts.region_endpoint.request_failure_hint
     }
 
     fn uses_byteplus_coding_plan_path(&self) -> bool {
@@ -3831,6 +3934,84 @@ mod tests {
         assert!(custom_hint.contains("Authorization"));
         assert!(custom_hint.contains("X-API-Key"));
         assert!(custom_hint.contains("provider.headers"));
+    }
+
+    #[test]
+    fn provider_feature_support_facts_are_stable() {
+        let facts = ProviderFeatureFamily::Volcengine.support_facts();
+
+        assert_eq!(facts.family, ProviderFeatureFamily::Volcengine);
+        assert_eq!(facts.gate_name, "provider-volcengine");
+        assert_eq!(
+            facts.enabled_in_build,
+            ProviderFeatureFamily::Volcengine.is_enabled_in_build()
+        );
+        assert_eq!(
+            facts.disabled_message,
+            "volcengine provider is disabled (enable feature `provider-volcengine`)"
+        );
+    }
+
+    #[test]
+    fn provider_support_facts_preserve_auth_guidance_and_missing_auth_message() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::ByteplusCoding,
+            ..ProviderConfig::default()
+        };
+
+        let support_facts = provider.support_facts();
+        let auth_support = support_facts.auth;
+        let guidance_hint = auth_support
+            .guidance_hint
+            .expect("byteplus coding should expose auth guidance");
+
+        assert!(auth_support.requires_explicit_configuration);
+        assert!(
+            auth_support
+                .hint_env_names
+                .contains(&"BYTEPLUS_API_KEY".to_owned())
+        );
+        assert!(guidance_hint.contains("BytePlus"));
+        assert!(guidance_hint.contains("BYTEPLUS_API_KEY"));
+        assert!(guidance_hint.contains("Authorization: Bearer <BYTEPLUS_API_KEY>"));
+        assert!(
+            auth_support
+                .missing_configuration_message
+                .contains("BYTEPLUS_API_KEY")
+        );
+        assert!(
+            auth_support
+                .missing_configuration_message
+                .contains("BytePlus")
+        );
+    }
+
+    #[test]
+    fn provider_support_facts_preserve_region_endpoint_hints() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            ..ProviderConfig::default()
+        };
+
+        let support_facts = provider.support_facts();
+        let region_endpoint_support = support_facts.region_endpoint;
+        let note = region_endpoint_support
+            .note
+            .expect("minimax should expose a region endpoint note");
+        let catalog_failure_hint = region_endpoint_support
+            .catalog_failure_hint
+            .expect("minimax should expose a catalog failure hint");
+        let request_failure_hint = region_endpoint_support
+            .request_failure_hint
+            .expect("minimax should expose a request failure hint");
+
+        assert!(note.contains("MiniMax region endpoint"));
+        assert!(note.contains("https://api.minimaxi.com"));
+        assert!(note.contains("https://api.minimax.io"));
+        assert!(catalog_failure_hint.contains("https://api.minimaxi.com"));
+        assert!(catalog_failure_hint.contains("https://api.minimax.io"));
+        assert!(request_failure_hint.contains("https://api.minimaxi.com"));
+        assert!(request_failure_hint.contains("https://api.minimax.io"));
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -35,7 +35,7 @@ impl ProviderProfile {
         let kind = self.kind;
         if kind == ProviderKind::Bedrock {
             return Some(
-                "configure AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY with AWS_REGION or AWS_DEFAULT_REGION for SigV4",
+                "configure AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY with BEDROCK_AWS_REGION, AWS_REGION, or AWS_DEFAULT_REGION for SigV4",
             );
         }
         if kind == ProviderKind::Custom {
@@ -159,7 +159,7 @@ impl ProviderFeatureFamily {
         match self {
             Self::Anthropic => "anthropic provider family",
             Self::Bedrock => "bedrock provider family",
-            Self::Volcengine => "volcengine provider",
+            Self::Volcengine => "volcengine provider family",
             Self::OpenAiCompatible => "openai-compatible provider family",
         }
     }
@@ -1403,7 +1403,9 @@ impl ProviderConfig {
         let protocol_family = self.kind.protocol_family().as_str().to_owned();
         let default_headers = provider_descriptor_headers(profile);
         let default_user_agent = self.kind.default_user_agent().map(str::to_owned);
-        let configuration_hint = self.kind.configuration_hint().map(str::to_owned);
+        let configuration_hint = self
+            .configuration_hint()
+            .or_else(|| self.kind.configuration_hint().map(str::to_owned));
         let default_model = self.kind.default_model().map(str::to_owned);
         let recommended_onboarding_model =
             self.kind.recommended_onboarding_model().map(str::to_owned);
@@ -2746,7 +2748,7 @@ impl ProviderKind {
     pub fn configuration_hint(self) -> Option<&'static str> {
         if self == ProviderKind::Bedrock {
             Some(
-                "set `AWS_REGION`/`AWS_DEFAULT_REGION` or replace `<region>` in `provider.base_url` with your Bedrock runtime region",
+                "set `BEDROCK_AWS_REGION`/`AWS_REGION`/`AWS_DEFAULT_REGION` or replace `<region>` in `provider.base_url` with your Bedrock runtime region",
             )
         } else if self == ProviderKind::CloudflareAiGateway {
             Some(
@@ -4225,7 +4227,7 @@ mod tests {
         );
         assert_eq!(
             volcengine_message,
-            "volcengine provider is disabled (enable feature `provider-volcengine`)"
+            "volcengine provider family is disabled (enable feature `provider-volcengine`)"
         );
         assert_eq!(
             openai_message,
@@ -4262,6 +4264,7 @@ mod tests {
 
         assert!(bedrock_hint.contains("AWS_ACCESS_KEY_ID"));
         assert!(bedrock_hint.contains("AWS_SECRET_ACCESS_KEY"));
+        assert!(bedrock_hint.contains("BEDROCK_AWS_REGION"));
         assert!(bedrock_hint.contains("AWS_REGION"));
 
         assert!(custom_hint.contains("Authorization"));
@@ -4281,7 +4284,7 @@ mod tests {
         );
         assert_eq!(
             facts.disabled_message,
-            "volcengine provider is disabled (enable feature `provider-volcengine`)"
+            "volcengine provider family is disabled (enable feature `provider-volcengine`)"
         );
     }
 
@@ -4442,6 +4445,24 @@ mod tests {
         );
         assert_eq!(encoded["auth"]["hint_env_names"], json!([]));
         assert_eq!(encoded["region_endpoint"]["variants"], json!([]));
+    }
+
+    #[test]
+    fn provider_descriptor_document_prefers_dynamic_configuration_hint() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Custom,
+            ..ProviderConfig::default()
+        };
+
+        let descriptor = provider.descriptor_document();
+        let encoded = encode_provider_descriptor(&descriptor);
+        let configuration_hint = encoded["configuration_hint"]
+            .as_str()
+            .expect("custom descriptor should expose a configuration hint");
+
+        assert!(configuration_hint.contains("tenant-scoped base_url configuration"));
+        assert!(configuration_hint.contains("current template"));
+        assert!(configuration_hint.contains("https://<openai-compatible-host>/v1"));
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -30,6 +30,43 @@ pub struct ProviderProfile {
     pub feature_family: ProviderFeatureFamily,
 }
 
+impl ProviderProfile {
+    pub fn alternative_auth_configuration_hint(self) -> Option<&'static str> {
+        let kind = self.kind;
+        if kind == ProviderKind::Bedrock {
+            return Some(
+                "configure AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY with AWS_REGION or AWS_DEFAULT_REGION for SigV4",
+            );
+        }
+        if kind == ProviderKind::Custom {
+            return Some("add `Authorization` / `X-API-Key` in `provider.headers`");
+        }
+        None
+    }
+
+    pub fn auth_guidance_hint(self) -> Option<String> {
+        let feature_family = self.feature_family;
+        if feature_family != ProviderFeatureFamily::Volcengine {
+            return None;
+        }
+
+        let provider_label = self.auth_guidance_provider_label();
+        let env_name = self.default_api_key_env.unwrap_or("PROVIDER_API_KEY");
+        let hint = format!(
+            "LoongClaw's {provider_label} OpenAI-compatible path uses `provider.api_key` / `{env_name}` and sends `Authorization: Bearer <{env_name}>`; AK/SK request signing is not used on this path"
+        );
+        Some(hint)
+    }
+
+    fn auth_guidance_provider_label(self) -> &'static str {
+        let kind = self.kind;
+        if matches!(kind, ProviderKind::Byteplus | ProviderKind::ByteplusCoding) {
+            return "BytePlus";
+        }
+        "Volcengine"
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderProtocolFamily {
     OpenAiChatCompletions,
@@ -59,6 +96,42 @@ pub enum ProviderFeatureFamily {
     Anthropic,
     Bedrock,
     Volcengine,
+}
+
+impl ProviderFeatureFamily {
+    pub fn feature_gate_name(self) -> &'static str {
+        match self {
+            Self::Anthropic => "provider-anthropic",
+            Self::Bedrock => "provider-bedrock",
+            Self::Volcengine => "provider-volcengine",
+            Self::OpenAiCompatible => "provider-openai",
+        }
+    }
+
+    pub fn disabled_message(self) -> String {
+        let subject = self.disabled_message_subject();
+        let feature_name = self.feature_gate_name();
+        let message = format!("{subject} is disabled (enable feature `{feature_name}`)");
+        message
+    }
+
+    pub fn is_enabled_in_build(self) -> bool {
+        match self {
+            Self::Anthropic => cfg!(feature = "provider-anthropic"),
+            Self::Bedrock => cfg!(feature = "provider-bedrock"),
+            Self::Volcengine => cfg!(feature = "provider-volcengine"),
+            Self::OpenAiCompatible => cfg!(feature = "provider-openai"),
+        }
+    }
+
+    fn disabled_message_subject(self) -> &'static str {
+        match self {
+            Self::Anthropic => "anthropic provider family",
+            Self::Bedrock => "bedrock provider family",
+            Self::Volcengine => "volcengine provider",
+            Self::OpenAiCompatible => "openai-compatible provider family",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -1156,25 +1229,8 @@ impl ProviderConfig {
     }
 
     pub fn auth_guidance_hint(&self) -> Option<String> {
-        if self.kind.feature_family() == ProviderFeatureFamily::Volcengine {
-            let provider_label = if matches!(
-                self.kind,
-                ProviderKind::Byteplus | ProviderKind::ByteplusCoding
-            ) {
-                "BytePlus"
-            } else {
-                "Volcengine"
-            };
-            let env_name = self
-                .kind
-                .default_api_key_env()
-                .unwrap_or("PROVIDER_API_KEY");
-            Some(format!(
-                "LoongClaw's {provider_label} OpenAI-compatible path uses `provider.api_key` / `{env_name}` and sends `Authorization: Bearer <{env_name}>`; AK/SK request signing is not used on this path"
-            ))
-        } else {
-            None
-        }
+        let profile = self.kind.profile();
+        profile.auth_guidance_hint()
     }
 
     pub fn missing_auth_configuration_message(&self) -> String {
@@ -1201,16 +1257,9 @@ impl ProviderConfig {
     }
 
     fn alternative_auth_configuration_hint(&self) -> Option<String> {
-        if self.kind == ProviderKind::Bedrock {
-            Some(
-                "configure AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY with AWS_REGION or AWS_DEFAULT_REGION for SigV4"
-                    .to_owned(),
-            )
-        } else if self.kind == ProviderKind::Custom {
-            Some("add `Authorization` / `X-API-Key` in `provider.headers`".to_owned())
-        } else {
-            None
-        }
+        let profile = self.kind.profile();
+        let hint = profile.alternative_auth_configuration_hint();
+        hint.map(str::to_owned)
     }
 
     pub fn transport_policy(&self) -> ProviderTransportPolicy {
@@ -3124,7 +3173,7 @@ const PROVIDER_PROFILES: [ProviderProfile; 41] = [
     ProviderProfile {
         kind: ProviderKind::StepPlan,
         id: "step_plan",
-        aliases: &["stepfun_step_plan", "step_plan"],
+        aliases: &["stepfun_step_plan"],
         base_url: "https://api.stepfun.ai",
         chat_completions_path: "/step_plan/v1/chat/completions",
         models_path: Some("/step_plan/v1/models"),
@@ -3672,6 +3721,8 @@ fn derive_responses_path(chat_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::{BTreeMap, BTreeSet};
+
     use crate::test_support::ScopedEnv;
     use loongclaw_contracts::SecretRef;
 
@@ -3680,6 +3731,106 @@ mod tests {
         for kind in ProviderKind::all_sorted() {
             assert_eq!(kind.profile().kind, *kind);
         }
+    }
+
+    #[test]
+    fn provider_profile_aliases_are_unique_and_do_not_shadow_ids() {
+        let mut provider_ids = BTreeSet::new();
+        for kind in ProviderKind::all_sorted() {
+            let profile = kind.profile();
+            let provider_id = profile.id;
+            let inserted = provider_ids.insert(provider_id);
+            assert!(inserted, "duplicate provider id detected: {provider_id}");
+        }
+
+        let mut alias_owners = BTreeMap::new();
+        for kind in ProviderKind::all_sorted() {
+            let profile = kind.profile();
+            let provider_id = profile.id;
+            for alias in profile.aliases {
+                let normalized_alias = alias.trim();
+                assert!(
+                    !normalized_alias.is_empty(),
+                    "provider `{provider_id}` contains an empty alias"
+                );
+                assert_ne!(
+                    normalized_alias, provider_id,
+                    "provider `{provider_id}` repeats its canonical id as an alias"
+                );
+                assert!(
+                    !provider_ids.contains(normalized_alias),
+                    "provider alias `{normalized_alias}` collides with a canonical provider id"
+                );
+
+                let previous_owner = alias_owners.insert(normalized_alias.to_owned(), provider_id);
+                assert!(
+                    previous_owner.is_none(),
+                    "provider alias `{normalized_alias}` is shared by `{}` and `{provider_id}`",
+                    previous_owner.unwrap_or_default()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn provider_feature_family_gate_messages_are_stable() {
+        let anthropic_message = ProviderFeatureFamily::Anthropic.disabled_message();
+        let bedrock_message = ProviderFeatureFamily::Bedrock.disabled_message();
+        let volcengine_message = ProviderFeatureFamily::Volcengine.disabled_message();
+        let openai_message = ProviderFeatureFamily::OpenAiCompatible.disabled_message();
+
+        assert_eq!(
+            anthropic_message,
+            "anthropic provider family is disabled (enable feature `provider-anthropic`)"
+        );
+        assert_eq!(
+            bedrock_message,
+            "bedrock provider family is disabled (enable feature `provider-bedrock`)"
+        );
+        assert_eq!(
+            volcengine_message,
+            "volcengine provider is disabled (enable feature `provider-volcengine`)"
+        );
+        assert_eq!(
+            openai_message,
+            "openai-compatible provider family is disabled (enable feature `provider-openai`)"
+        );
+    }
+
+    #[test]
+    fn provider_profile_static_auth_hints_are_stable() {
+        let byteplus_hint = ProviderKind::ByteplusCoding
+            .profile()
+            .auth_guidance_hint()
+            .expect("byteplus coding should expose auth guidance");
+        let volcengine_hint = ProviderKind::Volcengine
+            .profile()
+            .auth_guidance_hint()
+            .expect("volcengine should expose auth guidance");
+        let bedrock_hint = ProviderKind::Bedrock
+            .profile()
+            .alternative_auth_configuration_hint()
+            .expect("bedrock should expose a SigV4 fallback hint");
+        let custom_hint = ProviderKind::Custom
+            .profile()
+            .alternative_auth_configuration_hint()
+            .expect("custom provider should expose header guidance");
+
+        assert!(byteplus_hint.contains("BytePlus"));
+        assert!(byteplus_hint.contains("BYTEPLUS_API_KEY"));
+        assert!(byteplus_hint.contains("Authorization: Bearer <BYTEPLUS_API_KEY>"));
+
+        assert!(volcengine_hint.contains("Volcengine"));
+        assert!(volcengine_hint.contains("ARK_API_KEY"));
+        assert!(volcengine_hint.contains("AK/SK request signing is not used"));
+
+        assert!(bedrock_hint.contains("AWS_ACCESS_KEY_ID"));
+        assert!(bedrock_hint.contains("AWS_SECRET_ACCESS_KEY"));
+        assert!(bedrock_hint.contains("AWS_REGION"));
+
+        assert!(custom_hint.contains("Authorization"));
+        assert!(custom_hint.contains("X-API-Key"));
+        assert!(custom_hint.contains("provider.headers"));
     }
 
     #[test]

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -90,6 +90,15 @@ pub enum ProviderAuthScheme {
     XApiKey,
 }
 
+impl ProviderAuthScheme {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Bearer => "bearer",
+            Self::XApiKey => "x_api_key",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderFeatureFamily {
     OpenAiCompatible,
@@ -99,6 +108,15 @@ pub enum ProviderFeatureFamily {
 }
 
 impl ProviderFeatureFamily {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenAiCompatible => "openai_compatible",
+            Self::Anthropic => "anthropic",
+            Self::Bedrock => "bedrock",
+            Self::Volcengine => "volcengine",
+        }
+    }
+
     pub fn support_facts(self) -> ProviderFeatureSupportFacts {
         let gate_name = self.feature_gate_name();
         let enabled_in_build = self.is_enabled_in_build();
@@ -232,6 +250,77 @@ pub struct ProviderSupportFacts {
     pub feature: ProviderFeatureSupportFacts,
     pub auth: ProviderAuthSupportFacts,
     pub region_endpoint: ProviderRegionEndpointSupportFacts,
+}
+
+pub const PROVIDER_DESCRIPTOR_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProviderDescriptorSchema {
+    pub version: u32,
+    pub surface: &'static str,
+    pub purpose: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProviderDescriptorHeader {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProviderDescriptorFeature {
+    pub family: String,
+    pub gate_name: String,
+    pub enabled_in_build: bool,
+    pub disabled_message: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProviderDescriptorAuth {
+    pub scheme: String,
+    pub auth_optional: bool,
+    pub model_probe_auth_optional: bool,
+    pub default_api_key_env: Option<String>,
+    pub api_key_env_aliases: Vec<String>,
+    pub default_oauth_access_token_env: Option<String>,
+    pub oauth_access_token_env_aliases: Vec<String>,
+    pub hint_env_names: Vec<String>,
+    pub requires_explicit_configuration: bool,
+    pub guidance_hint: Option<String>,
+    pub alternative_configuration_hint: Option<String>,
+    pub missing_configuration_message: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProviderDescriptorRegionVariant {
+    pub label: String,
+    pub base_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProviderDescriptorRegionEndpoint {
+    pub family_label: Option<String>,
+    pub variants: Vec<ProviderDescriptorRegionVariant>,
+    pub note: Option<String>,
+    pub catalog_failure_hint: Option<String>,
+    pub request_failure_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProviderDescriptorDocument {
+    pub schema: ProviderDescriptorSchema,
+    pub kind: String,
+    pub display_name: String,
+    pub aliases: Vec<String>,
+    pub protocol_family: String,
+    pub default_headers: Vec<ProviderDescriptorHeader>,
+    pub default_user_agent: Option<String>,
+    pub configuration_hint: Option<String>,
+    pub default_model: Option<String>,
+    pub recommended_onboarding_model: Option<String>,
+    pub feature: ProviderDescriptorFeature,
+    pub auth: ProviderDescriptorAuth,
+    pub region_endpoint: ProviderDescriptorRegionEndpoint,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1280,6 +1369,46 @@ impl ProviderConfig {
         }
     }
 
+    pub fn descriptor_document(&self) -> ProviderDescriptorDocument {
+        let profile = self.kind.profile();
+        let support_facts = self.support_facts();
+        let schema = ProviderDescriptorSchema {
+            version: PROVIDER_DESCRIPTOR_SCHEMA_VERSION,
+            surface: "provider_descriptor",
+            purpose: "internal_sdk_contract",
+        };
+        let kind = self.kind.as_str().to_owned();
+        let display_name = self.kind.display_name().to_owned();
+        let aliases = provider_descriptor_aliases(profile);
+        let protocol_family = self.kind.protocol_family().as_str().to_owned();
+        let default_headers = provider_descriptor_headers(profile);
+        let default_user_agent = self.kind.default_user_agent().map(str::to_owned);
+        let configuration_hint = self.kind.configuration_hint().map(str::to_owned);
+        let default_model = self.kind.default_model().map(str::to_owned);
+        let recommended_onboarding_model =
+            self.kind.recommended_onboarding_model().map(str::to_owned);
+        let feature = build_provider_descriptor_feature(&support_facts.feature);
+        let auth = self.build_provider_descriptor_auth(&support_facts.auth);
+        let region_endpoint =
+            self.build_provider_descriptor_region_endpoint(&support_facts.region_endpoint);
+
+        ProviderDescriptorDocument {
+            schema,
+            kind,
+            display_name,
+            aliases,
+            protocol_family,
+            default_headers,
+            default_user_agent,
+            configuration_hint,
+            default_model,
+            recommended_onboarding_model,
+            feature,
+            auth,
+            region_endpoint,
+        }
+    }
+
     pub fn requires_explicit_auth_configuration(&self) -> bool {
         let support_facts = self.support_facts();
         support_facts.auth.requires_explicit_configuration
@@ -1308,6 +1437,43 @@ impl ProviderConfig {
 
         ProviderAuthSupportFacts {
             hint_env_names: env_names,
+            requires_explicit_configuration,
+            guidance_hint,
+            alternative_configuration_hint,
+            missing_configuration_message,
+        }
+    }
+
+    fn build_provider_descriptor_auth(
+        &self,
+        auth_support: &ProviderAuthSupportFacts,
+    ) -> ProviderDescriptorAuth {
+        let scheme = self.kind.auth_scheme().as_str().to_owned();
+        let auth_optional = self.kind.auth_optional();
+        let model_probe_auth_optional = self.kind.model_probe_auth_optional();
+        let default_api_key_env = self.kind.default_api_key_env().map(str::to_owned);
+        let api_key_env_aliases = provider_descriptor_env_aliases(self.kind.api_key_env_aliases());
+        let default_oauth_access_token_env = self
+            .kind
+            .default_oauth_access_token_env()
+            .map(str::to_owned);
+        let oauth_access_token_env_aliases =
+            provider_descriptor_env_aliases(self.kind.oauth_access_token_env_aliases());
+        let hint_env_names = auth_support.hint_env_names.clone();
+        let requires_explicit_configuration = auth_support.requires_explicit_configuration;
+        let guidance_hint = auth_support.guidance_hint.clone();
+        let alternative_configuration_hint = auth_support.alternative_configuration_hint.clone();
+        let missing_configuration_message = auth_support.missing_configuration_message.clone();
+
+        ProviderDescriptorAuth {
+            scheme,
+            auth_optional,
+            model_probe_auth_optional,
+            default_api_key_env,
+            api_key_env_aliases,
+            default_oauth_access_token_env,
+            oauth_access_token_env_aliases,
+            hint_env_names,
             requires_explicit_configuration,
             guidance_hint,
             alternative_configuration_hint,
@@ -1822,6 +1988,28 @@ impl ProviderConfig {
         let request_failure_hint = guide.map(|value| value.request_failure_hint(self));
 
         ProviderRegionEndpointSupportFacts {
+            note,
+            catalog_failure_hint,
+            request_failure_hint,
+        }
+    }
+
+    fn build_provider_descriptor_region_endpoint(
+        &self,
+        region_endpoint_support: &ProviderRegionEndpointSupportFacts,
+    ) -> ProviderDescriptorRegionEndpoint {
+        let region_endpoint_info = self.kind.region_endpoint_info();
+        let family_label = region_endpoint_info
+            .as_ref()
+            .map(|info| info.family_label.to_owned());
+        let variants = provider_descriptor_region_variants(region_endpoint_info);
+        let note = region_endpoint_support.note.clone();
+        let catalog_failure_hint = region_endpoint_support.catalog_failure_hint.clone();
+        let request_failure_hint = region_endpoint_support.request_failure_hint.clone();
+
+        ProviderDescriptorRegionEndpoint {
+            family_label,
+            variants,
             note,
             catalog_failure_hint,
             request_failure_hint,
@@ -2666,6 +2854,78 @@ impl ProviderKind {
             variants,
         })
     }
+}
+
+fn provider_descriptor_aliases(profile: &ProviderProfile) -> Vec<String> {
+    let mut aliases = Vec::new();
+
+    for alias in profile.aliases {
+        let alias = (*alias).to_owned();
+        aliases.push(alias);
+    }
+
+    aliases
+}
+
+fn provider_descriptor_headers(profile: &ProviderProfile) -> Vec<ProviderDescriptorHeader> {
+    let mut headers = Vec::new();
+
+    for (name, value) in profile.default_headers {
+        let header = ProviderDescriptorHeader {
+            name: (*name).to_owned(),
+            value: (*value).to_owned(),
+        };
+        headers.push(header);
+    }
+
+    headers
+}
+
+fn provider_descriptor_env_aliases(raw_aliases: &[&str]) -> Vec<String> {
+    let mut aliases = Vec::new();
+
+    for raw_alias in raw_aliases {
+        let alias = (*raw_alias).to_owned();
+        aliases.push(alias);
+    }
+
+    aliases
+}
+
+fn build_provider_descriptor_feature(
+    feature_support: &ProviderFeatureSupportFacts,
+) -> ProviderDescriptorFeature {
+    let family = feature_support.family.as_str().to_owned();
+    let gate_name = feature_support.gate_name.to_owned();
+    let enabled_in_build = feature_support.enabled_in_build;
+    let disabled_message = feature_support.disabled_message.clone();
+
+    ProviderDescriptorFeature {
+        family,
+        gate_name,
+        enabled_in_build,
+        disabled_message,
+    }
+}
+
+fn provider_descriptor_region_variants(
+    region_endpoint_info: Option<ProviderRegionEndpointInfo>,
+) -> Vec<ProviderDescriptorRegionVariant> {
+    let mut variants = Vec::new();
+
+    let Some(region_endpoint_info) = region_endpoint_info else {
+        return variants;
+    };
+
+    for variant in region_endpoint_info.variants {
+        let descriptor_variant = ProviderDescriptorRegionVariant {
+            label: variant.label.to_owned(),
+            base_url: variant.base_url.to_owned(),
+        };
+        variants.push(descriptor_variant);
+    }
+
+    variants
 }
 
 pub fn parse_provider_kind_id(raw: &str) -> Option<ProviderKind> {
@@ -3824,10 +4084,15 @@ fn derive_responses_path(chat_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::{Value, json};
     use std::collections::{BTreeMap, BTreeSet};
 
     use crate::test_support::ScopedEnv;
     use loongclaw_contracts::SecretRef;
+
+    fn encode_provider_descriptor(descriptor: &ProviderDescriptorDocument) -> Value {
+        serde_json::to_value(descriptor).expect("serialize provider descriptor document")
+    }
 
     #[test]
     fn provider_profile_lookup_matches_kind() {
@@ -4008,6 +4273,113 @@ mod tests {
         assert!(note.contains("MiniMax region endpoint"));
         assert!(note.contains("https://api.minimaxi.com"));
         assert!(note.contains("https://api.minimax.io"));
+        assert!(catalog_failure_hint.contains("https://api.minimaxi.com"));
+        assert!(catalog_failure_hint.contains("https://api.minimax.io"));
+        assert!(request_failure_hint.contains("https://api.minimaxi.com"));
+        assert!(request_failure_hint.contains("https://api.minimax.io"));
+    }
+
+    #[test]
+    fn provider_descriptor_document_preserves_x_api_key_contract_facts() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Anthropic,
+            ..ProviderConfig::default()
+        };
+
+        let descriptor = provider.descriptor_document();
+        let encoded = encode_provider_descriptor(&descriptor);
+        let hint_env_names = encoded["auth"]["hint_env_names"]
+            .as_array()
+            .expect("hint env names should be an array");
+
+        assert_eq!(
+            encoded["schema"]["version"],
+            json!(PROVIDER_DESCRIPTOR_SCHEMA_VERSION)
+        );
+        assert_eq!(encoded["schema"]["surface"], json!("provider_descriptor"));
+        assert_eq!(encoded["schema"]["purpose"], json!("internal_sdk_contract"));
+        assert_eq!(encoded["kind"], json!("anthropic"));
+        assert_eq!(encoded["display_name"], json!("Anthropic"));
+        assert_eq!(encoded["protocol_family"], json!("anthropic_messages"));
+        assert_eq!(encoded["feature"]["family"], json!("anthropic"));
+        assert_eq!(encoded["auth"]["scheme"], json!("x_api_key"));
+        assert_eq!(
+            encoded["auth"]["default_api_key_env"],
+            json!("ANTHROPIC_API_KEY")
+        );
+        assert_eq!(
+            encoded["auth"]["requires_explicit_configuration"],
+            json!(true)
+        );
+        assert!(
+            hint_env_names.contains(&json!("ANTHROPIC_API_KEY")),
+            "anthropic descriptor should surface the canonical x-api-key env hint"
+        );
+        assert_eq!(
+            encoded["default_headers"][0]["name"],
+            json!("anthropic-version")
+        );
+    }
+
+    #[test]
+    fn provider_descriptor_document_marks_auth_optional_profiles_without_required_envs() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Ollama,
+            ..ProviderConfig::default()
+        };
+
+        let descriptor = provider.descriptor_document();
+        let encoded = encode_provider_descriptor(&descriptor);
+
+        assert_eq!(encoded["kind"], json!("ollama"));
+        assert_eq!(encoded["auth"]["scheme"], json!("bearer"));
+        assert_eq!(encoded["auth"]["auth_optional"], json!(true));
+        assert_eq!(encoded["auth"]["model_probe_auth_optional"], json!(true));
+        assert_eq!(
+            encoded["auth"]["requires_explicit_configuration"],
+            json!(false)
+        );
+        assert_eq!(encoded["auth"]["hint_env_names"], json!([]));
+        assert_eq!(encoded["region_endpoint"]["variants"], json!([]));
+    }
+
+    #[test]
+    fn provider_descriptor_document_preserves_region_endpoint_variants_and_hints() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Minimax,
+            ..ProviderConfig::default()
+        };
+
+        let descriptor = provider.descriptor_document();
+        let encoded = encode_provider_descriptor(&descriptor);
+        let note = encoded["region_endpoint"]["note"]
+            .as_str()
+            .expect("minimax descriptor should expose a region note");
+        let catalog_failure_hint = encoded["region_endpoint"]["catalog_failure_hint"]
+            .as_str()
+            .expect("minimax descriptor should expose a catalog failure hint");
+        let request_failure_hint = encoded["region_endpoint"]["request_failure_hint"]
+            .as_str()
+            .expect("minimax descriptor should expose a request failure hint");
+
+        assert_eq!(encoded["region_endpoint"]["family_label"], json!("MiniMax"));
+        assert_eq!(
+            encoded["region_endpoint"]["variants"][0]["label"],
+            json!("CN")
+        );
+        assert_eq!(
+            encoded["region_endpoint"]["variants"][0]["base_url"],
+            json!("https://api.minimaxi.com")
+        );
+        assert_eq!(
+            encoded["region_endpoint"]["variants"][1]["label"],
+            json!("Global")
+        );
+        assert_eq!(
+            encoded["region_endpoint"]["variants"][1]["base_url"],
+            json!("https://api.minimax.io")
+        );
+        assert!(note.contains("MiniMax region endpoint"));
         assert!(catalog_failure_hint.contains("https://api.minimaxi.com"));
         assert!(catalog_failure_hint.contains("https://api.minimax.io"));
         assert!(request_failure_hint.contains("https://api.minimaxi.com"));

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -595,7 +595,8 @@ pub enum ProviderKind {
         alias = "cloudflare_ai",
         alias = "cloudflare-ai",
         alias = "cloudflare_ai_gateway",
-        alias = "cloudflare-ai-gateway"
+        alias = "cloudflare-ai-gateway",
+        alias = "cloudflare"
     )]
     CloudflareAiGateway,
     #[serde(alias = "cohere_compatible")]
@@ -616,7 +617,7 @@ pub enum ProviderKind {
     KimiCoding,
     #[serde(alias = "groq_compatible")]
     Groq,
-    #[serde(alias = "fireworks_compatible")]
+    #[serde(alias = "fireworks_compatible", alias = "fireworks-ai")]
     Fireworks,
     #[serde(alias = "mistral_compatible")]
     Mistral,
@@ -624,7 +625,12 @@ pub enum ProviderKind {
     Minimax,
     #[serde(alias = "novita_compatible")]
     Novita,
-    #[serde(alias = "nvidia_compatible", alias = "nvidia_nim")]
+    #[serde(
+        alias = "nvidia_compatible",
+        alias = "nvidia_nim",
+        alias = "nvidia-nim",
+        alias = "build.nvidia.com"
+    )]
     Nvidia,
     #[serde(alias = "llama.cpp", alias = "llama_cpp")]
     Llamacpp,
@@ -655,7 +661,11 @@ pub enum ProviderKind {
     Stepfun,
     #[serde(alias = "stepfun_step_plan", alias = "step_plan")]
     StepPlan,
-    #[serde(alias = "together_compatible", alias = "together_ai")]
+    #[serde(
+        alias = "together_compatible",
+        alias = "together_ai",
+        alias = "together-ai"
+    )]
     Together,
     #[serde(alias = "venice_compatible")]
     Venice,
@@ -663,18 +673,24 @@ pub enum ProviderKind {
         alias = "vercel_ai",
         alias = "vercel-ai",
         alias = "vercel_ai_gateway",
-        alias = "vercel-ai-gateway"
+        alias = "vercel-ai-gateway",
+        alias = "vercel"
     )]
     VercelAiGateway,
-    #[serde(alias = "volcengine_custom", alias = "volcengine_compatible")]
+    #[serde(
+        alias = "volcengine_custom",
+        alias = "volcengine_compatible",
+        alias = "doubao",
+        alias = "ark"
+    )]
     Volcengine,
     #[serde(alias = "volcengine_coding_compatible")]
     VolcengineCoding,
-    #[serde(alias = "xai_compatible")]
+    #[serde(alias = "xai_compatible", alias = "grok")]
     Xai,
-    #[serde(alias = "zai_compatible")]
+    #[serde(alias = "zai_compatible", alias = "z.ai")]
     Zai,
-    #[serde(alias = "zhipu_compatible")]
+    #[serde(alias = "zhipu_compatible", alias = "glm", alias = "bigmodel")]
     Zhipu,
     #[serde(alias = "deepseek_compatible")]
     Deepseek,
@@ -1349,10 +1365,14 @@ impl ProviderConfig {
 
     pub fn auth_hint_env_names(&self) -> Vec<String> {
         let mut env_names = Vec::new();
-        push_secret_ref_env_name(&mut env_names, self.oauth_access_token.as_ref());
-        push_secret_ref_env_name(&mut env_names, self.api_key.as_ref());
-        for env_name in self.credential_env_names() {
-            push_unique_env_key(&mut env_names, Some(env_name.as_str()));
+        match self.kind.auth_scheme() {
+            ProviderAuthScheme::Bearer => {
+                self.push_oauth_access_token_hint_env_names(&mut env_names);
+                self.push_api_key_hint_env_names(&mut env_names);
+            }
+            ProviderAuthScheme::XApiKey => {
+                self.push_api_key_hint_env_names(&mut env_names);
+            }
         }
         env_names
     }
@@ -1511,6 +1531,30 @@ impl ProviderConfig {
     fn build_auth_guidance_hint(&self) -> Option<String> {
         let profile = self.kind.profile();
         profile.auth_guidance_hint()
+    }
+
+    fn push_oauth_access_token_hint_env_names(&self, env_names: &mut Vec<String>) {
+        push_secret_ref_env_name(env_names, self.oauth_access_token.as_ref());
+        if has_configured_secret_ref(self.oauth_access_token.as_ref()) {
+            return;
+        }
+
+        let oauth_env_names = self.oauth_access_token_env_names();
+        for oauth_env_name in oauth_env_names {
+            push_unique_env_key(env_names, Some(oauth_env_name.as_str()));
+        }
+    }
+
+    fn push_api_key_hint_env_names(&self, env_names: &mut Vec<String>) {
+        push_secret_ref_env_name(env_names, self.api_key.as_ref());
+        if has_configured_secret_ref(self.api_key.as_ref()) {
+            return;
+        }
+
+        let api_key_env_names = self.api_key_env_names();
+        for api_key_env_name in api_key_env_names {
+            push_unique_env_key(env_names, Some(api_key_env_name.as_str()));
+        }
     }
 
     fn build_alternative_auth_configuration_hint(&self) -> Option<String> {
@@ -4141,6 +4185,30 @@ mod tests {
     }
 
     #[test]
+    fn provider_profile_aliases_round_trip_through_provider_kind_deserialization() {
+        for kind in ProviderKind::all_sorted() {
+            let profile = kind.profile();
+            let canonical_id = format!("\"{}\"", profile.id);
+            let parsed_canonical = serde_json::from_str::<ProviderKind>(canonical_id.as_str())
+                .expect("canonical provider id should deserialize");
+            assert_eq!(
+                parsed_canonical, *kind,
+                "canonical provider id should deserialize to its matching provider kind"
+            );
+
+            for alias in profile.aliases {
+                let raw_alias = format!("\"{alias}\"");
+                let parsed_alias = serde_json::from_str::<ProviderKind>(raw_alias.as_str())
+                    .expect("provider alias should deserialize");
+                assert_eq!(
+                    parsed_alias, *kind,
+                    "provider alias `{alias}` should deserialize to the same provider kind as parse_provider_kind_id"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn provider_feature_family_gate_messages_are_stable() {
         let anthropic_message = ProviderFeatureFamily::Anthropic.disabled_message();
         let bedrock_message = ProviderFeatureFamily::Bedrock.disabled_message();
@@ -4248,6 +4316,39 @@ mod tests {
             auth_support
                 .missing_configuration_message
                 .contains("BytePlus")
+        );
+    }
+
+    #[test]
+    fn auth_hint_env_names_respect_explicit_api_key_env_binding_precedence() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Openai,
+            api_key: Some(SecretRef::Env {
+                env: "TEAM_OPENAI_KEY".to_owned(),
+            }),
+            ..ProviderConfig::default()
+        };
+
+        let env_names = provider.auth_hint_env_names();
+
+        assert_eq!(env_names, vec!["TEAM_OPENAI_KEY".to_owned()]);
+    }
+
+    #[test]
+    fn auth_hint_env_names_keep_api_key_fallback_after_explicit_oauth_env_binding() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::Openai,
+            oauth_access_token: Some(SecretRef::Env {
+                env: "TEAM_OPENAI_OAUTH".to_owned(),
+            }),
+            ..ProviderConfig::default()
+        };
+
+        let env_names = provider.auth_hint_env_names();
+
+        assert_eq!(
+            env_names,
+            vec!["TEAM_OPENAI_OAUTH".to_owned(), "OPENAI_API_KEY".to_owned(),]
         );
     }
 

--- a/crates/app/src/provider/catalog_executor.rs
+++ b/crates/app/src/provider/catalog_executor.rs
@@ -33,15 +33,18 @@ fn render_catalog_status_failure_message(
     max_attempts: usize,
     response_body: &serde_json::Value,
 ) -> String {
+    let support_facts = provider.support_facts();
+    let auth_support = support_facts.auth;
+    let region_endpoint_support = support_facts.region_endpoint;
     let mut message = format!(
         "provider model-list returned status {status_code} on attempt {attempt}/{max_attempts}: {response_body}"
     );
     if matches!(status_code, 401 | 403) {
-        if let Some(hint) = provider.auth_guidance_hint() {
+        if let Some(hint) = auth_support.guidance_hint {
             message.push(' ');
             message.push_str(hint.as_str());
         }
-        if let Some(hint) = provider.region_endpoint_failure_hint() {
+        if let Some(hint) = region_endpoint_support.catalog_failure_hint {
             message.push(' ');
             message.push_str(hint.as_str());
         }
@@ -241,5 +244,29 @@ mod tests {
                 case.status_code, case.attempt
             );
         }
+    }
+
+    #[test]
+    fn render_catalog_status_failure_message_includes_region_hint_for_auth_rejection() {
+        let provider = ProviderConfig {
+            kind: crate::config::ProviderKind::Minimax,
+            ..ProviderConfig::default()
+        };
+
+        let message = render_catalog_status_failure_message(
+            &provider,
+            401,
+            1,
+            3,
+            &serde_json::json!({
+                "error": {
+                    "message": "invalid api key"
+                }
+            }),
+        );
+
+        assert!(message.contains("provider model-list returned status 401"));
+        assert!(message.contains("https://api.minimaxi.com"));
+        assert!(message.contains("https://api.minimax.io"));
     }
 }

--- a/crates/app/src/provider/provider_validation_runtime.rs
+++ b/crates/app/src/provider/provider_validation_runtime.rs
@@ -1,43 +1,14 @@
 use crate::CliResult;
 use crate::config::{LoongClawConfig, ProviderConfig};
 
-use super::contracts::{ProviderFeatureFamily, provider_runtime_contract};
+use super::contracts::provider_runtime_contract;
 
 pub(super) fn validate_provider_feature_gate(config: &LoongClawConfig) -> CliResult<()> {
-    let runtime_contract = provider_runtime_contract(&config.provider);
-    match runtime_contract.feature_family {
-        ProviderFeatureFamily::Anthropic => {
-            if !cfg!(feature = "provider-anthropic") {
-                return Err(
-                    "anthropic provider family is disabled (enable feature `provider-anthropic`)"
-                        .to_owned(),
-                );
-            }
-        }
-        ProviderFeatureFamily::Bedrock => {
-            if !cfg!(feature = "provider-bedrock") {
-                return Err(
-                    "bedrock provider family is disabled (enable feature `provider-bedrock`)"
-                        .to_owned(),
-                );
-            }
-        }
-        ProviderFeatureFamily::VolcengineCompatible => {
-            if !cfg!(feature = "provider-volcengine") {
-                return Err(
-                    "volcengine provider is disabled (enable feature `provider-volcengine`)"
-                        .to_owned(),
-                );
-            }
-        }
-        ProviderFeatureFamily::OpenAiCompatible => {
-            if !cfg!(feature = "provider-openai") {
-                return Err(
-                    "openai-compatible provider family is disabled (enable feature `provider-openai`)"
-                        .to_owned(),
-                );
-            }
-        }
+    let feature_family = config.provider.kind.feature_family();
+    let feature_enabled = feature_family.is_enabled_in_build();
+    if !feature_enabled {
+        let message = feature_family.disabled_message();
+        return Err(message);
     }
     Ok(())
 }

--- a/crates/app/src/provider/provider_validation_runtime.rs
+++ b/crates/app/src/provider/provider_validation_runtime.rs
@@ -4,11 +4,10 @@ use crate::config::{LoongClawConfig, ProviderConfig};
 use super::contracts::provider_runtime_contract;
 
 pub(super) fn validate_provider_feature_gate(config: &LoongClawConfig) -> CliResult<()> {
-    let feature_family = config.provider.kind.feature_family();
-    let feature_enabled = feature_family.is_enabled_in_build();
-    if !feature_enabled {
-        let message = feature_family.disabled_message();
-        return Err(message);
+    let support_facts = config.provider.support_facts();
+    let feature_support = support_facts.feature;
+    if !feature_support.enabled_in_build {
+        return Err(feature_support.disabled_message);
     }
     Ok(())
 }
@@ -39,7 +38,9 @@ pub(super) fn validate_provider_configuration(config: &LoongClawConfig) -> CliRe
 }
 
 pub(super) async fn validate_provider_auth_readiness(config: &LoongClawConfig) -> CliResult<()> {
-    if !config.provider.requires_explicit_auth_configuration() {
+    let support_facts = config.provider.support_facts();
+    let auth_support = support_facts.auth;
+    if !auth_support.requires_explicit_configuration {
         return Ok(());
     }
 
@@ -47,7 +48,7 @@ pub(super) async fn validate_provider_auth_readiness(config: &LoongClawConfig) -
         return Ok(());
     }
 
-    Err(config.provider.missing_auth_configuration_message())
+    Err(auth_support.missing_configuration_message)
 }
 
 fn provider_uses_kimi_coding_endpoint(provider: &ProviderConfig) -> bool {

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -116,15 +116,18 @@ fn render_status_failure_message(
     max_attempts: usize,
     response_body: &Value,
 ) -> String {
+    let support_facts = provider.support_facts();
+    let auth_support = support_facts.auth;
+    let region_endpoint_support = support_facts.region_endpoint;
     let mut message = format!(
         "provider returned status {status_code} for model `{model}` on attempt {attempt}/{max_attempts}: {response_body}"
     );
     if matches!(reason, ProviderFailoverReason::AuthRejected) {
-        if let Some(hint) = provider.auth_guidance_hint() {
+        if let Some(hint) = auth_support.guidance_hint {
             message.push(' ');
             message.push_str(hint.as_str());
         }
-        if let Some(hint) = provider.request_region_endpoint_failure_hint() {
+        if let Some(hint) = region_endpoint_support.request_failure_hint {
             message.push(' ');
             message.push_str(hint.as_str());
         }
@@ -1233,6 +1236,32 @@ mod tests {
                 case.status_code, case.attempt, case.auto_model_mode, case.api_error
             );
         }
+    }
+
+    #[test]
+    fn render_status_failure_message_includes_auth_guidance_for_auth_rejection() {
+        let provider = ProviderConfig {
+            kind: crate::config::ProviderKind::ByteplusCoding,
+            ..ProviderConfig::default()
+        };
+
+        let message = render_status_failure_message(
+            &provider,
+            ProviderFailoverReason::AuthRejected,
+            401,
+            "doubao-seed-1-6-thinking",
+            1,
+            3,
+            &json!({
+                "error": {
+                    "message": "invalid api key"
+                }
+            }),
+        );
+
+        assert!(message.contains("BytePlus"));
+        assert!(message.contains("BYTEPLUS_API_KEY"));
+        assert!(message.contains("Authorization: Bearer <BYTEPLUS_API_KEY>"));
     }
 
     #[test]

--- a/crates/app/src/provider/request_executor.rs
+++ b/crates/app/src/provider/request_executor.rs
@@ -1249,7 +1249,7 @@ mod tests {
             &provider,
             ProviderFailoverReason::AuthRejected,
             401,
-            "doubao-seed-1-6-thinking",
+            "doubao-seed-1-6-thinking-250715",
             1,
             3,
             &json!({

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -180,9 +180,9 @@ pub(super) async fn resolve_request_auth_context(
                 bedrock_region: Some(region),
             });
         }
-        let feature_family = provider.kind.feature_family();
-        let message = feature_family.disabled_message();
-        Err(message)
+        let support_facts = provider.support_facts();
+        let feature_support = support_facts.feature;
+        Err(feature_support.disabled_message)
     }
 }
 

--- a/crates/app/src/provider/transport.rs
+++ b/crates/app/src/provider/transport.rs
@@ -180,7 +180,9 @@ pub(super) async fn resolve_request_auth_context(
                 bedrock_region: Some(region),
             });
         }
-        Err("bedrock provider family is disabled (enable feature `provider-bedrock`)".to_owned())
+        let feature_family = provider.kind.feature_family();
+        let message = feature_family.disabled_message();
+        Err(message)
     }
 }
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1356,6 +1356,8 @@ fn provider_credentials_doctor_check(
     has_provider_credentials: bool,
 ) -> DoctorCheck {
     let provider_label = crate::provider_presentation::active_provider_detail_label(config);
+    let support_facts = config.provider.support_facts();
+    let auth_support = support_facts.auth;
     if has_provider_credentials {
         return DoctorCheck {
             name: "provider credentials".to_owned(),
@@ -1364,19 +1366,17 @@ fn provider_credentials_doctor_check(
         };
     }
 
-    let hints = provider_credential_policy::provider_credential_env_hints(&config.provider);
-    let mut detail = if hints.is_empty() {
-        "provider credentials are missing".to_owned()
-    } else {
-        format!(
-            "provider credentials are missing (try env: {})",
-            hints.join(", ")
-        )
-    };
-    if let Some(hint) = config.provider.auth_guidance_hint() {
-        detail.push(' ');
-        detail.push_str(hint.as_str());
+    if !auth_support.requires_explicit_configuration {
+        return DoctorCheck {
+            name: "provider credentials".to_owned(),
+            level: DoctorCheckLevel::Pass,
+            detail: format!(
+                "{provider_label}: provider credentials are optional for this provider"
+            ),
+        };
     }
+
+    let detail = auth_support.missing_configuration_message;
     DoctorCheck {
         name: "provider credentials".to_owned(),
         level: DoctorCheckLevel::Warn,
@@ -3316,7 +3316,8 @@ mod tests {
         );
         assert!(
             next_steps.iter().any(|step| {
-                step == "Set provider credentials in env: OPENAI_CODEX_OAUTH_TOKEN or OPENAI_API_KEY"
+                step
+                    == "Set provider credentials in env: OPENAI_CODEX_OAUTH_TOKEN or OPENAI_OAUTH_ACCESS_TOKEN or OPENAI_API_KEY"
             }),
             "doctor should turn missing provider auth into a concrete next step: {next_steps:#?}"
         );
@@ -3349,6 +3350,22 @@ mod tests {
         assert_eq!(check.level, DoctorCheckLevel::Warn);
         assert!(check.detail.contains("ARK_API_KEY"));
         assert!(check.detail.contains("Authorization: Bearer <ARK_API_KEY>"));
+    }
+
+    #[test]
+    fn provider_credentials_doctor_check_passes_for_auth_optional_provider() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Ollama;
+        config.provider.api_key = None;
+        config.provider.api_key_env = None;
+        config.provider.oauth_access_token = None;
+        config.provider.oauth_access_token_env = None;
+
+        let check = provider_credentials_doctor_check(&config, false);
+
+        assert_eq!(check.name, "provider credentials");
+        assert_eq!(check.level, DoctorCheckLevel::Pass);
+        assert!(check.detail.contains("optional for this provider"));
     }
 
     #[test]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -76,6 +76,7 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
     config_mutated |= maybe_apply_channel_env_fix(&mut config, options.fix, &mut fixes);
 
     let has_provider_credentials = mvp::provider::provider_auth_ready(&config).await;
+    let provider_requires_explicit_auth = config.provider.requires_explicit_auth_configuration();
     checks.push(provider_credentials_doctor_check(
         &config,
         has_provider_credentials,
@@ -89,7 +90,7 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
             level: DoctorCheckLevel::Warn,
             detail: "skipped by --skip-model-probe".to_owned(),
         });
-    } else if !has_provider_credentials {
+    } else if !has_provider_credentials && provider_requires_explicit_auth {
         checks.push(DoctorCheck {
             name: "provider model probe".to_owned(),
             level: DoctorCheckLevel::Warn,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2487,15 +2487,7 @@ fn build_runtime_snapshot_provider_profile_state(
 }
 
 fn runtime_snapshot_provider_credentials_resolved(provider: &mvp::config::ProviderConfig) -> bool {
-    if provider.resolved_auth_secret().is_some() {
-        return true;
-    }
-
-    ["authorization", "x-api-key"].iter().any(|header_name| {
-        provider
-            .header_value(header_name)
-            .is_some_and(|value| !value.trim().is_empty())
-    })
+    provider_credential_policy::provider_has_locally_available_credentials(provider)
 }
 
 fn collect_runtime_snapshot_external_skills_state(

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2198,6 +2198,7 @@ pub struct RuntimeSnapshotProviderProfileState {
     pub profile_id: String,
     pub is_active: bool,
     pub default_for_kind: bool,
+    pub descriptor: mvp::config::ProviderDescriptorDocument,
     pub kind: mvp::config::ProviderKind,
     pub model: String,
     pub wire_api: mvp::config::ProviderWireApi,
@@ -2458,6 +2459,7 @@ fn build_runtime_snapshot_provider_profile_state(
     is_active: bool,
 ) -> RuntimeSnapshotProviderProfileState {
     let provider = &profile.provider;
+    let descriptor = provider.descriptor_document();
     let mut header_names = provider.headers.keys().cloned().collect::<Vec<_>>();
     header_names.sort();
 
@@ -2465,6 +2467,7 @@ fn build_runtime_snapshot_provider_profile_state(
         profile_id: profile_id.to_owned(),
         is_active,
         default_for_kind: profile.default_for_kind,
+        descriptor,
         kind: provider.kind,
         model: provider.model.clone(),
         wire_api: provider.wire_api,
@@ -5509,10 +5512,13 @@ fn runtime_snapshot_provider_json(snapshot: &RuntimeSnapshotProviderState) -> Va
 }
 
 fn runtime_snapshot_provider_profile_json(profile: &RuntimeSnapshotProviderProfileState) -> Value {
+    let descriptor = runtime_snapshot_provider_descriptor_json(&profile.descriptor);
+
     json!({
         "profile_id": profile.profile_id,
         "is_active": profile.is_active,
         "default_for_kind": profile.default_for_kind,
+        "descriptor": descriptor,
         "kind": profile.kind.as_str(),
         "model": profile.model,
         "wire_api": profile.wire_api.as_str(),
@@ -5530,6 +5536,12 @@ fn runtime_snapshot_provider_profile_json(profile: &RuntimeSnapshotProviderProfi
         "header_names": profile.header_names,
         "preferred_models": profile.preferred_models,
     })
+}
+
+fn runtime_snapshot_provider_descriptor_json(
+    descriptor: &mvp::config::ProviderDescriptorDocument,
+) -> Value {
+    serde_json::to_value(descriptor).expect("provider descriptor document should serialize")
 }
 
 fn runtime_snapshot_context_engine_json(

--- a/crates/daemon/src/migration/discovery.rs
+++ b/crates/daemon/src/migration/discovery.rs
@@ -7,6 +7,8 @@ use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
 use serde::Deserialize;
 
+use crate::provider_credential_policy;
+
 use super::channels;
 use super::provider_transport::ImportedProviderTransport;
 use super::types::{
@@ -42,7 +44,8 @@ pub fn classify_current_setup(output_path: &Path) -> CurrentSetupState {
         return CurrentSetupState::Repairable;
     };
     let readiness = resolve_channel_import_readiness_from_config(&config);
-    let has_provider_auth = config.provider.authorization_header().is_some();
+    let has_provider_auth =
+        provider_credential_policy::provider_has_locally_available_credentials(&config.provider);
     let channel_blockers = channels::enabled_channels_have_blockers(&config, &readiness);
     if channel_blockers {
         return CurrentSetupState::Repairable;
@@ -601,7 +604,8 @@ fn codex_wire_api_looks_openai_compatible(raw: &str) -> bool {
 
 fn provider_import_surface(config: &mvp::config::LoongClawConfig) -> Option<ImportSurface> {
     let provider_changed = config.provider.differs_from_default();
-    let credentials_ready = config.provider.authorization_header().is_some();
+    let credentials_ready =
+        provider_credential_policy::provider_has_locally_available_credentials(&config.provider);
     if !provider_changed && !credentials_ready {
         return None;
     }
@@ -692,5 +696,18 @@ mod tests {
                 .any(|surface| surface.domain == SetupDomainKind::Cli),
             "changing prompt-pack personality metadata should mark the CLI domain as imported: {surfaces:#?}"
         );
+    }
+
+    #[test]
+    fn provider_import_surface_marks_x_api_key_provider_ready() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("ANTHROPIC_API_KEY", "test-anthropic-key");
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Anthropic;
+        config.provider.model = "claude-sonnet-4-5".to_owned();
+
+        let surface = provider_import_surface(&config).expect("provider surface should exist");
+
+        assert_eq!(surface.level, ImportSurfaceLevel::Ready);
     }
 }

--- a/crates/daemon/src/migration/planner.rs
+++ b/crates/daemon/src/migration/planner.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 
 use loongclaw_app as mvp;
 
+use crate::provider_credential_policy;
+
 use super::channels;
 use super::discovery::{build_import_candidate, resolve_channel_import_readiness_from_config};
 use super::provider_transport;
@@ -187,7 +189,9 @@ fn compose_provider_domain(
 
     Some(DomainPreview {
         kind: SetupDomainKind::Provider,
-        status: if merged_config.provider.authorization_header().is_some() {
+        status: if provider_credential_policy::provider_has_locally_available_credentials(
+            &merged_config.provider,
+        ) {
             PreviewStatus::Ready
         } else {
             PreviewStatus::NeedsReview
@@ -266,8 +270,10 @@ fn supplement_provider_config(
     let mut source = source.clone();
     source.canonicalize_configured_auth_env_bindings();
     let default_provider = mvp::config::ProviderConfig::default();
-    let target_has_auth = target.authorization_header().is_some();
-    let source_has_auth = source.authorization_header().is_some();
+    let target_has_auth =
+        provider_credential_policy::provider_has_locally_available_credentials(target);
+    let source_has_auth =
+        provider_credential_policy::provider_has_locally_available_credentials(&source);
     let mut changed = false;
     if (target.model.trim().is_empty() || target.model.eq_ignore_ascii_case("auto"))
         && !source.model.trim().is_empty()
@@ -289,6 +295,29 @@ fn supplement_provider_config(
     {
         target.oauth_access_token = source.oauth_access_token.clone();
         changed = true;
+    }
+    let target_missing_auth_config =
+        target.api_key.is_none() && target.oauth_access_token.is_none();
+    let should_materialize_source_env_binding =
+        source_has_auth && (target_missing_auth_config || !target_has_auth);
+    if should_materialize_source_env_binding {
+        let source_binding =
+            provider_credential_policy::provider_available_credential_env_binding(&source);
+        let target_binding =
+            provider_credential_policy::configured_provider_credential_env_binding(target);
+        let binding_changed = source_binding != target_binding;
+        let source_binding = if binding_changed {
+            source_binding
+        } else {
+            None
+        };
+        if let Some(source_binding) = source_binding {
+            provider_credential_policy::apply_provider_credential_env_binding(
+                target,
+                &source_binding,
+            );
+            changed = true;
+        }
     }
     if target.endpoint.is_none() && source.endpoint.is_some() {
         target.endpoint = source.endpoint.clone();
@@ -418,6 +447,29 @@ mod tests {
             })
         );
         assert_eq!(merged_config.provider.api_key_env, None);
+    }
+
+    #[test]
+    fn supplement_provider_config_accepts_x_api_key_source_credentials() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("ANTHROPIC_API_KEY", "test-anthropic-key");
+        let mut target =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Anthropic);
+        target.api_key = None;
+        target.set_api_key_env(None);
+
+        let source =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Anthropic);
+
+        let changed = supplement_provider_config(&mut target, &source);
+
+        assert!(changed);
+        assert_eq!(
+            target.api_key,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "ANTHROPIC_API_KEY".to_owned(),
+            })
+        );
     }
 }
 

--- a/crates/daemon/src/migration/planner.rs
+++ b/crates/daemon/src/migration/planner.rs
@@ -269,10 +269,6 @@ fn supplement_provider_config(
     let mut source = source.clone();
     source.canonicalize_configured_auth_env_bindings();
     let default_provider = mvp::config::ProviderConfig::default();
-    let target_has_auth =
-        provider_credential_policy::provider_has_locally_available_credentials(target);
-    let source_has_auth =
-        provider_credential_policy::provider_has_locally_available_credentials(&source);
     let mut changed = false;
     if (target.model.trim().is_empty() || target.model.eq_ignore_ascii_case("auto"))
         && !source.model.trim().is_empty()
@@ -281,22 +277,31 @@ fn supplement_provider_config(
         changed = true;
     }
     changed |= provider_transport::supplement_provider_transport(target, &source);
-    if (target.api_key.is_none() || (!target_has_auth && source_has_auth))
+    let target_has_auth_header =
+        provider_credential_policy::provider_has_configured_auth_header(target);
+    let target_has_auth =
+        provider_credential_policy::provider_has_locally_available_credentials(target);
+    let target_has_configured_auth =
+        target.api_key.is_some() || target.oauth_access_token.is_some() || target_has_auth_header;
+    let source_has_auth =
+        provider_credential_policy::provider_has_locally_available_credentials(&source);
+    if !target_has_auth_header
+        && (target.api_key.is_none() || (!target_has_auth && source_has_auth))
         && source.api_key.is_some()
         && target.api_key != source.api_key
     {
         target.api_key = source.api_key.clone();
         changed = true;
     }
-    if (target.oauth_access_token.is_none() || (!target_has_auth && source_has_auth))
+    if !target_has_auth_header
+        && (target.oauth_access_token.is_none() || (!target_has_auth && source_has_auth))
         && source.oauth_access_token.is_some()
         && target.oauth_access_token != source.oauth_access_token
     {
         target.oauth_access_token = source.oauth_access_token.clone();
         changed = true;
     }
-    let target_missing_auth_config =
-        target.api_key.is_none() && target.oauth_access_token.is_none();
+    let target_missing_auth_config = !target_has_configured_auth;
     let should_materialize_source_env_binding = source_has_auth && target_missing_auth_config;
     if should_materialize_source_env_binding {
         let source_binding =
@@ -492,6 +497,30 @@ mod tests {
             })
         );
         assert_eq!(target.oauth_access_token, None);
+    }
+
+    #[test]
+    fn supplement_provider_config_preserves_target_auth_headers() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("OPENAI_API_KEY", "test-openai-key");
+
+        let mut target =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        target.headers = std::collections::BTreeMap::from([(
+            "authorization".to_owned(),
+            "Bearer team-auth-header".to_owned(),
+        )]);
+
+        let source = mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+
+        let _changed = supplement_provider_config(&mut target, &source);
+
+        assert_eq!(target.api_key, None);
+        assert_eq!(target.oauth_access_token, None);
+        assert_eq!(
+            target.header_value("authorization"),
+            Some("Bearer team-auth-header")
+        );
     }
 }
 

--- a/crates/daemon/src/migration/planner.rs
+++ b/crates/daemon/src/migration/planner.rs
@@ -189,9 +189,8 @@ fn compose_provider_domain(
 
     Some(DomainPreview {
         kind: SetupDomainKind::Provider,
-        status: if provider_credential_policy::provider_has_locally_available_credentials(
-            &merged_config.provider,
-        ) {
+        status: if provider_credential_policy::provider_is_credential_ready(&merged_config.provider)
+        {
             PreviewStatus::Ready
         } else {
             PreviewStatus::NeedsReview
@@ -298,8 +297,7 @@ fn supplement_provider_config(
     }
     let target_missing_auth_config =
         target.api_key.is_none() && target.oauth_access_token.is_none();
-    let should_materialize_source_env_binding =
-        source_has_auth && (target_missing_auth_config || !target_has_auth);
+    let should_materialize_source_env_binding = source_has_auth && target_missing_auth_config;
     if should_materialize_source_env_binding {
         let source_binding =
             provider_credential_policy::provider_available_credential_env_binding(&source);
@@ -470,6 +468,30 @@ mod tests {
                 env: "ANTHROPIC_API_KEY".to_owned(),
             })
         );
+    }
+
+    #[test]
+    fn supplement_provider_config_preserves_explicit_target_auth_bindings() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("OPENAI_API_KEY", "test-openai-key");
+
+        let mut target =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+        target.api_key = Some(loongclaw_contracts::SecretRef::Env {
+            env: "TEAM_OPENAI_KEY".to_owned(),
+        });
+
+        let source = mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+
+        let _changed = supplement_provider_config(&mut target, &source);
+
+        assert_eq!(
+            target.api_key,
+            Some(loongclaw_contracts::SecretRef::Env {
+                env: "TEAM_OPENAI_KEY".to_owned(),
+            })
+        );
+        assert_eq!(target.oauth_access_token, None);
     }
 }
 

--- a/crates/daemon/src/migration/provider_selection.rs
+++ b/crates/daemon/src/migration/provider_selection.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use loongclaw_app as mvp;
 
+use crate::provider_credential_policy;
+
 use super::{ImportCandidate, ImportSourceKind, PreviewStatus, SetupDomainKind};
 
 pub const PROVIDER_SELECTOR_PLACEHOLDER: &str = mvp::config::PROVIDER_SELECTOR_PLACEHOLDER;
@@ -399,7 +401,9 @@ fn provider_choice_status_rank(status: PreviewStatus) -> u8 {
 }
 
 fn provider_status_for_choice(choice: &ImportedProviderChoice) -> PreviewStatus {
-    if choice.config.authorization_header().is_some() {
+    let credentials_ready =
+        provider_credential_policy::provider_has_locally_available_credentials(&choice.config);
+    if credentials_ready {
         PreviewStatus::Ready
     } else {
         PreviewStatus::NeedsReview
@@ -597,5 +601,24 @@ mod tests {
             })
         );
         assert_eq!(resolved.api_key_env, None);
+    }
+
+    #[test]
+    fn provider_status_for_choice_marks_x_api_key_provider_ready() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("ANTHROPIC_API_KEY", "test-anthropic-key");
+        let choice = ImportedProviderChoice {
+            profile_id: "anthropic".to_owned(),
+            kind: mvp::config::ProviderKind::Anthropic,
+            source: "environment".to_owned(),
+            summary: String::new(),
+            config: mvp::config::ProviderConfig::fresh_for_kind(
+                mvp::config::ProviderKind::Anthropic,
+            ),
+        };
+
+        let status = provider_status_for_choice(&choice);
+
+        assert_eq!(status, PreviewStatus::Ready);
     }
 }

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -6924,6 +6924,40 @@ mod tests {
     }
 
     #[test]
+    fn provider_credential_check_accepts_x_api_key_provider_env_credentials() {
+        let mut env = ScopedEnv::new();
+        env.set("ANTHROPIC_API_KEY", "test-anthropic-key");
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Anthropic;
+        config.provider.api_key = None;
+        config.provider.api_key_env = None;
+        config.provider.oauth_access_token = None;
+        config.provider.oauth_access_token_env = None;
+
+        let check = provider_credential_check(&config);
+
+        assert_eq!(check.name, "provider credentials");
+        assert_eq!(check.level, OnboardCheckLevel::Pass);
+        assert!(check.detail.contains("ANTHROPIC_API_KEY is available"));
+    }
+
+    #[test]
+    fn provider_credential_check_passes_for_auth_optional_provider() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.provider.kind = mvp::config::ProviderKind::Ollama;
+        config.provider.api_key = None;
+        config.provider.api_key_env = None;
+        config.provider.oauth_access_token = None;
+        config.provider.oauth_access_token_env = None;
+
+        let check = provider_credential_check(&config);
+
+        assert_eq!(check.name, "provider credentials");
+        assert_eq!(check.level, OnboardCheckLevel::Pass);
+        assert!(check.detail.contains("optional for this provider"));
+    }
+
+    #[test]
     fn preferred_api_key_env_default_ignores_invalid_configured_secret_literal() {
         let secret = "sk-live-direct-secret-value";
         let mut config = mvp::config::LoongClawConfig::default();

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -2057,7 +2057,9 @@ async fn load_onboarding_model_catalog(
     if options.non_interactive || options.skip_model_probe {
         return Vec::new();
     }
-    if !mvp::provider::provider_auth_ready(config).await {
+    let has_provider_credentials = mvp::provider::provider_auth_ready(config).await;
+    let provider_requires_explicit_auth = config.provider.requires_explicit_auth_configuration();
+    if !has_provider_credentials && provider_requires_explicit_auth {
         return Vec::new();
     }
     mvp::provider::fetch_available_models(config)

--- a/crates/daemon/src/onboard_preflight.rs
+++ b/crates/daemon/src/onboard_preflight.rs
@@ -180,6 +180,8 @@ pub(crate) fn is_explicitly_accepted_non_interactive_warning(
 pub fn provider_credential_check(config: &mvp::config::LoongClawConfig) -> OnboardCheck {
     let provider = &config.provider;
     let provider_prefix = provider_check_detail_prefix(config);
+    let support_facts = provider.support_facts();
+    let auth_support = support_facts.auth;
     let inline_oauth = secret_ref_has_inline_literal(provider.oauth_access_token.as_ref());
 
     if inline_oauth {
@@ -202,7 +204,20 @@ pub fn provider_credential_check(config: &mvp::config::LoongClawConfig) -> Onboa
         };
     }
 
-    if provider.authorization_header().is_some() {
+    if !auth_support.requires_explicit_configuration {
+        return OnboardCheck {
+            name: "provider credentials",
+            level: OnboardCheckLevel::Pass,
+            detail: format!(
+                "{provider_prefix}: provider credentials are optional for this provider"
+            ),
+            non_interactive_warning_policy: OnboardNonInteractiveWarningPolicy::Block,
+        };
+    }
+
+    let has_local_credentials =
+        crate::provider_credential_policy::provider_has_locally_available_credentials(provider);
+    if has_local_credentials {
         let detail = crate::provider_credential_policy::provider_credential_env_hint(provider)
             .map(|env_name| format!("{env_name} is available"))
             .unwrap_or_else(|| "provider credentials are available".to_owned());
@@ -215,14 +230,7 @@ pub fn provider_credential_check(config: &mvp::config::LoongClawConfig) -> Onboa
         };
     }
 
-    let mut detail = crate::provider_credential_policy::provider_credential_env_hint(provider)
-        .map(|env_name| format!("{env_name} is not set"))
-        .unwrap_or_else(|| "provider credentials are not configured".to_owned());
-
-    if let Some(hint) = provider.auth_guidance_hint() {
-        detail.push(' ');
-        detail.push_str(hint.as_str());
-    }
+    let detail = auth_support.missing_configuration_message;
 
     OnboardCheck {
         name: "provider credentials",

--- a/crates/daemon/src/provider_credential_policy.rs
+++ b/crates/daemon/src/provider_credential_policy.rs
@@ -14,18 +14,10 @@ pub(crate) struct ProviderCredentialEnvBinding {
 }
 
 pub(crate) fn provider_credential_env_hints(provider: &mvp::config::ProviderConfig) -> Vec<String> {
-    let mut hints = Vec::new();
-    let configured_oauth = provider.configured_oauth_access_token_env_override();
-    let configured_api_key = provider.configured_api_key_env_override();
-    let default_oauth = provider.kind.default_oauth_access_token_env();
-    let default_api_key = provider.kind.default_api_key_env();
+    let support_facts = provider.support_facts();
+    let auth_support = support_facts.auth;
 
-    push_provider_credential_env_hint(&mut hints, configured_oauth.as_deref());
-    push_provider_credential_env_hint(&mut hints, configured_api_key.as_deref());
-    push_provider_credential_env_hint(&mut hints, default_oauth);
-    push_provider_credential_env_hint(&mut hints, default_api_key);
-
-    hints
+    auth_support.hint_env_names
 }
 
 pub(crate) fn provider_credential_env_hint(
@@ -78,6 +70,65 @@ pub(crate) fn configured_provider_credential_env_binding(
     );
 
     configured_oauth.or(configured_api_key)
+}
+
+pub(crate) fn provider_available_credential_env_binding(
+    provider: &mvp::config::ProviderConfig,
+) -> Option<ProviderCredentialEnvBinding> {
+    let env_hints = provider_credential_env_hints(provider);
+
+    for env_name in env_hints {
+        let env_value = std::env::var(env_name.as_str()).ok();
+        let has_value = env_value
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+        if !has_value {
+            continue;
+        }
+
+        let field = selected_provider_credential_env_field(provider, env_name.as_str());
+        let binding = ProviderCredentialEnvBinding { field, env_name };
+
+        return Some(binding);
+    }
+
+    None
+}
+
+pub(crate) fn apply_provider_credential_env_binding(
+    provider: &mut mvp::config::ProviderConfig,
+    binding: &ProviderCredentialEnvBinding,
+) {
+    let env_name = Some(binding.env_name.clone());
+
+    match binding.field {
+        ProviderCredentialEnvField::ApiKey => {
+            provider.clear_oauth_access_token_env_binding();
+            provider.set_api_key_env_binding(env_name);
+        }
+        ProviderCredentialEnvField::OAuthAccessToken => {
+            provider.clear_api_key_env_binding();
+            provider.set_oauth_access_token_env_binding(env_name);
+        }
+    }
+}
+
+pub(crate) fn provider_has_locally_available_credentials(
+    provider: &mvp::config::ProviderConfig,
+) -> bool {
+    if provider.resolved_auth_secret().is_some() {
+        return true;
+    }
+
+    for header_name in ["authorization", "x-api-key"] {
+        let header_value = provider.header_value(header_name);
+        let has_value = header_value.is_some_and(|value| !value.trim().is_empty());
+        if has_value {
+            return true;
+        }
+    }
+
+    false
 }
 
 pub(crate) fn provider_has_inline_credential(provider: &mvp::config::ProviderConfig) -> bool {
@@ -176,20 +227,6 @@ fn env_name_matches_api_key_binding(
     configured_api_key.as_deref() == Some(env_name)
 }
 
-fn push_provider_credential_env_hint(hints: &mut Vec<String>, maybe_env_name: Option<&str>) {
-    let normalized = maybe_env_name.and_then(normalize_provider_credential_env_name);
-    let Some(env_name) = normalized else {
-        return;
-    };
-
-    let already_present = hints.iter().any(|existing| existing == &env_name);
-    if already_present {
-        return;
-    }
-
-    hints.push(env_name);
-}
-
 fn provider_credential_env_name_is_safe(raw: &str) -> bool {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -265,5 +302,37 @@ mod tests {
         let rendered = render_provider_credential_source_value(Some("sk-live-direct-secret-value"));
 
         assert_eq!(rendered.as_deref(), Some("environment variable"));
+    }
+
+    #[test]
+    fn provider_has_locally_available_credentials_accepts_x_api_key_providers() {
+        let mut env = mvp::test_support::ScopedEnv::new();
+        env.set("ANTHROPIC_API_KEY", "test-anthropic-key");
+        let provider = mvp::config::ProviderConfig {
+            kind: mvp::config::ProviderKind::Anthropic,
+            ..mvp::config::ProviderConfig::default()
+        };
+
+        let has_credentials = provider_has_locally_available_credentials(&provider);
+
+        assert!(has_credentials);
+    }
+
+    #[test]
+    fn provider_available_credential_env_binding_uses_first_populated_env_hint() {
+        let mut env = mvp::test_support::ScopedEnv::new();
+        env.set("OPENAI_API_KEY", "test-openai-key");
+        let provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);
+
+        let binding = provider_available_credential_env_binding(&provider);
+
+        assert_eq!(
+            binding,
+            Some(ProviderCredentialEnvBinding {
+                field: ProviderCredentialEnvField::ApiKey,
+                env_name: "OPENAI_API_KEY".to_owned(),
+            })
+        );
     }
 }

--- a/crates/daemon/src/provider_credential_policy.rs
+++ b/crates/daemon/src/provider_credential_policy.rs
@@ -122,15 +122,7 @@ pub(crate) fn provider_has_locally_available_credentials(
         return true;
     }
 
-    for header_name in ["authorization", "x-api-key"] {
-        let header_value = provider.header_value(header_name);
-        let has_value = header_value.is_some_and(|value| !value.trim().is_empty());
-        if has_value {
-            return true;
-        }
-    }
-
-    false
+    provider_has_configured_auth_header(provider)
 }
 
 pub(crate) fn provider_is_credential_ready(provider: &mvp::config::ProviderConfig) -> bool {
@@ -196,6 +188,18 @@ fn binding_for_env_name(
 ) -> Option<ProviderCredentialEnvBinding> {
     let env_name = raw_env_name.and_then(normalize_provider_credential_env_name)?;
     Some(ProviderCredentialEnvBinding { field, env_name })
+}
+
+pub(crate) fn provider_has_configured_auth_header(provider: &mvp::config::ProviderConfig) -> bool {
+    for header_name in ["authorization", "x-api-key"] {
+        let header_value = provider.header_value(header_name);
+        let has_value = header_value.is_some_and(|value| !value.trim().is_empty());
+        if has_value {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn env_name_matches_oauth_binding(provider: &mvp::config::ProviderConfig, env_name: &str) -> bool {
@@ -341,6 +345,20 @@ mod tests {
         let has_credentials = provider_has_locally_available_credentials(&provider);
 
         assert!(has_credentials);
+    }
+
+    #[test]
+    fn provider_has_configured_auth_header_accepts_header_only_auth() {
+        let mut provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Custom);
+        provider.headers.insert(
+            "authorization".to_owned(),
+            "Bearer test-custom-token".to_owned(),
+        );
+
+        let has_configured_auth = provider_has_configured_auth_header(&provider);
+
+        assert!(has_configured_auth);
     }
 
     #[test]

--- a/crates/daemon/src/provider_credential_policy.rs
+++ b/crates/daemon/src/provider_credential_policy.rs
@@ -103,10 +103,12 @@ pub(crate) fn apply_provider_credential_env_binding(
 
     match binding.field {
         ProviderCredentialEnvField::ApiKey => {
+            provider.oauth_access_token = None;
             provider.clear_oauth_access_token_env_binding();
             provider.set_api_key_env_binding(env_name);
         }
         ProviderCredentialEnvField::OAuthAccessToken => {
+            provider.api_key = None;
             provider.clear_api_key_env_binding();
             provider.set_oauth_access_token_env_binding(env_name);
         }
@@ -129,6 +131,14 @@ pub(crate) fn provider_has_locally_available_credentials(
     }
 
     false
+}
+
+pub(crate) fn provider_is_credential_ready(provider: &mvp::config::ProviderConfig) -> bool {
+    if !provider.requires_explicit_auth_configuration() {
+        return true;
+    }
+
+    provider_has_locally_available_credentials(provider)
 }
 
 pub(crate) fn provider_has_inline_credential(provider: &mvp::config::ProviderConfig) -> bool {
@@ -316,6 +326,54 @@ mod tests {
         let has_credentials = provider_has_locally_available_credentials(&provider);
 
         assert!(has_credentials);
+    }
+
+    #[test]
+    fn provider_has_locally_available_credentials_accepts_header_only_x_api_key_providers() {
+        let mut provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Anthropic);
+        provider.api_key = None;
+        provider.headers.insert(
+            "x-api-key".to_owned(),
+            "test-anthropic-header-key".to_owned(),
+        );
+
+        let has_credentials = provider_has_locally_available_credentials(&provider);
+
+        assert!(has_credentials);
+    }
+
+    #[test]
+    fn provider_available_credential_env_binding_preserves_oauth_env_bindings() {
+        let mut env = mvp::test_support::ScopedEnv::new();
+        env.set("OPENAI_SESSION_TOKEN", "test-openai-session-token");
+        let provider = mvp::config::ProviderConfig {
+            kind: mvp::config::ProviderKind::Openai,
+            oauth_access_token: Some(SecretRef::Env {
+                env: "OPENAI_SESSION_TOKEN".to_owned(),
+            }),
+            ..mvp::config::ProviderConfig::default()
+        };
+
+        let binding = provider_available_credential_env_binding(&provider);
+
+        assert_eq!(
+            binding,
+            Some(ProviderCredentialEnvBinding {
+                field: ProviderCredentialEnvField::OAuthAccessToken,
+                env_name: "OPENAI_SESSION_TOKEN".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn provider_is_credential_ready_accepts_auth_optional_providers() {
+        let provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Ollama);
+
+        let is_ready = provider_is_credential_ready(&provider);
+
+        assert!(is_ready);
     }
 
     #[test]

--- a/crates/daemon/src/provider_model_probe_policy.rs
+++ b/crates/daemon/src/provider_model_probe_policy.rs
@@ -207,7 +207,9 @@ fn append_region_hint(
         return detail;
     }
 
-    let Some(hint) = config.provider.region_endpoint_failure_hint() else {
+    let support_facts = config.provider.support_facts();
+    let region_endpoint_support = support_facts.region_endpoint;
+    let Some(hint) = region_endpoint_support.catalog_failure_hint else {
         return detail;
     };
 
@@ -225,7 +227,10 @@ fn provider_model_probe_region_endpoint_hint(
         return None;
     }
 
-    config.provider.region_endpoint_failure_hint()
+    let support_facts = config.provider.support_facts();
+    let region_endpoint_support = support_facts.region_endpoint;
+
+    region_endpoint_support.catalog_failure_hint
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/provider_presentation.rs
+++ b/crates/daemon/src/provider_presentation.rs
@@ -1,5 +1,7 @@
 use loongclaw_app as mvp;
 
+use crate::provider_credential_policy;
+
 pub fn guided_provider_label(kind: mvp::config::ProviderKind) -> &'static str {
     kind.display_name()
 }
@@ -110,9 +112,30 @@ pub fn provider_identity_summary_with_credential_state(
 }
 
 pub fn provider_credential_state(config: &mvp::config::ProviderConfig) -> &'static str {
-    if config.authorization_header().is_some() {
+    let credentials_ready =
+        provider_credential_policy::provider_has_locally_available_credentials(config);
+    if credentials_ready {
         "credentials resolved"
     } else {
         "credential still missing"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_credential_state_accepts_x_api_key_provider_env_credentials() {
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("ANTHROPIC_API_KEY", "test-anthropic-key");
+        let config = mvp::config::ProviderConfig {
+            kind: mvp::config::ProviderKind::Anthropic,
+            ..mvp::config::ProviderConfig::default()
+        };
+
+        let credential_state = provider_credential_state(&config);
+
+        assert_eq!(credential_state, "credentials resolved");
     }
 }

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4905,9 +4905,13 @@ fn onboard_api_key_env_screen_redacts_invalid_current_source_and_keeps_clear_hin
             .any(|line| line == "- type :clear to clear the configured credential env"),
         "credential-env screen should still offer the clear token when the configured env pointer is present but redacted: {lines:#?}"
     );
+    let current_source_line = lines
+        .iter()
+        .find(|line| line.starts_with("- current source:"))
+        .expect("credential-env screen should include the current source line");
     assert!(
-        lines.iter().all(|line| !line.contains(secret)),
-        "credential-env screen must never echo the invalid secret-like configured env pointer: {lines:#?}"
+        !current_source_line.contains(secret),
+        "credential-env screen must never echo the invalid secret-like configured env pointer in the current source line: {lines:#?}"
     );
 }
 

--- a/crates/daemon/tests/integration/onboard_cli.rs
+++ b/crates/daemon/tests/integration/onboard_cli.rs
@@ -4913,6 +4913,13 @@ fn onboard_api_key_env_screen_redacts_invalid_current_source_and_keeps_clear_hin
         !current_source_line.contains(secret),
         "credential-env screen must never echo the invalid secret-like configured env pointer in the current source line: {lines:#?}"
     );
+    assert!(
+        lines
+            .iter()
+            .filter(|line| !line.starts_with("- example: "))
+            .all(|line| !line.contains(secret)),
+        "credential-env screen must never echo the invalid secret-like configured env pointer in any rendered line: {lines:#?}"
+    );
 }
 
 #[test]

--- a/crates/daemon/tests/integration/runtime_snapshot_cli.rs
+++ b/crates/daemon/tests/integration/runtime_snapshot_cli.rs
@@ -299,6 +299,78 @@ fn runtime_snapshot_json_payload_marks_x_api_key_profiles_as_credential_resolved
     )
     .expect("anthropic provider profile should be present");
     assert_eq!(anthropic_profile["credential_resolved"], true);
+    assert_eq!(
+        anthropic_profile["descriptor"]["schema"]["version"],
+        serde_json::json!(mvp::config::PROVIDER_DESCRIPTOR_SCHEMA_VERSION)
+    );
+    assert_eq!(
+        anthropic_profile["descriptor"]["auth"]["scheme"],
+        serde_json::json!("x_api_key")
+    );
+    assert_eq!(
+        anthropic_profile["descriptor"]["auth"]["requires_explicit_configuration"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        anthropic_profile["descriptor"]["feature"]["family"],
+        serde_json::json!("anthropic")
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_snapshot_json_payload_preserves_auth_optional_provider_descriptor_contract() {
+    let root = unique_temp_dir("loongclaw-runtime-snapshot-auth-optional");
+    let _env = RuntimeSnapshotEnvGuard::set(&[
+        ("RUNTIME_SNAPSHOT_DEEPSEEK_KEY", Some("demo-token")),
+        ("LOONGCLAW_BROWSER_COMPANION_READY", Some("true")),
+    ]);
+    let (config_path, mut config) = write_runtime_snapshot_config(&root);
+    config.providers.insert(
+        "ollama-local".to_owned(),
+        mvp::config::ProviderProfileConfig {
+            default_for_kind: false,
+            provider: mvp::config::ProviderConfig {
+                kind: mvp::config::ProviderKind::Ollama,
+                model: "qwen2.5-coder".to_owned(),
+                ..Default::default()
+            },
+        },
+    );
+    mvp::config::write(Some(config_path.to_string_lossy().as_ref()), &config, true)
+        .expect("rewrite config fixture");
+
+    let snapshot = collect_runtime_snapshot_cli_state(Some(
+        config_path.to_str().expect("config path should be utf-8"),
+    ))
+    .expect("collect runtime snapshot");
+    let payload =
+        build_runtime_snapshot_cli_json_payload(&snapshot).expect("build runtime snapshot payload");
+
+    let ollama_profile = array_object_with_string_field(
+        &payload["provider"]["profiles"],
+        "profile_id",
+        "ollama-local",
+    )
+    .expect("ollama provider profile should be present");
+    assert_eq!(ollama_profile["credential_resolved"], false);
+    assert_eq!(
+        ollama_profile["descriptor"]["auth"]["scheme"],
+        serde_json::json!("bearer")
+    );
+    assert_eq!(
+        ollama_profile["descriptor"]["auth"]["auth_optional"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        ollama_profile["descriptor"]["auth"]["requires_explicit_configuration"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        ollama_profile["descriptor"]["auth"]["hint_env_names"],
+        serde_json::json!([])
+    );
 
     fs::remove_dir_all(&root).ok();
 }

--- a/docs/design-docs/capability-promotion-contract.md
+++ b/docs/design-docs/capability-promotion-contract.md
@@ -1,0 +1,69 @@
+# Capability Promotion Contract
+
+## Purpose
+
+This document defines how validated runtime behavior should become a durable
+capability asset in LoongClaw.
+
+Promotion should be treated as governed codification, not live
+self-modification.
+
+## Core Thesis
+
+The correct sequence is:
+
+1. run behavior
+2. capture evidence
+3. derive candidate
+4. assess readiness
+5. derive a dry-run promotion plan
+6. review
+7. codify into a bounded lower-layer asset
+8. reintroduce that asset through normal governed runtime paths
+
+## Promotion Ladder
+
+### Runtime experiment
+
+Evidence capture only.
+
+### Capability candidate
+
+One explicit codification proposal.
+
+### Capability family
+
+Aggregation and readiness over compatible candidates.
+
+### Promotion plan
+
+Dry-run mapping from one family to one bounded lower-layer target.
+
+### Promotion execution
+
+Future mutation layer, intentionally after the lower layers are explicit.
+
+## Canonical Targets
+
+Current bounded targets are:
+
+- `managed_skill`
+- `programmatic_flow`
+- `profile_note_addendum`
+
+These are not arbitrary.
+They are the lower-layer asset kinds that promotion should converge on instead
+of inventing a parallel ecosystem.
+
+## Boundedness Rules
+
+Promotion artifacts should stay explicit about:
+
+- target type
+- summary
+- bounded scope
+- required capabilities
+- provenance
+
+An artifact may be valid without being ready.
+That distinction is crucial for keeping promotion governed.

--- a/docs/design-docs/external-authoring-contract.md
+++ b/docs/design-docs/external-authoring-contract.md
@@ -1,0 +1,79 @@
+# External Authoring Contract
+
+## Purpose
+
+This document defines the public-facing authoring contract for LoongClaw
+capability artifacts.
+
+Its purpose is to let community authors build capability packages without
+depending on internal crate layout.
+
+## Core Thesis
+
+The public SDK should be contract-first, package-first, and artifact-first.
+
+LoongClaw should stabilize:
+
+- package identity
+- package layout
+- setup semantics
+- ownership semantics
+- validator meaning
+- install, inspect, and audit behavior
+
+before trying to stabilize internal helper APIs.
+
+## Public Capability Families
+
+### Managed skills
+
+Managed skills are the clearest current public capability family.
+
+They are:
+
+- installable
+- inspectable
+- operator-visible
+- compatible with bounded acquisition flows
+- natural promotion targets
+
+### Governed plugin packages
+
+These packages should remain manifest-first and lane-aware.
+
+They should declare:
+
+- identity
+- setup metadata
+- ownership intent
+- supported runtime lane
+
+without implying trusted in-process execution.
+
+### Workflow and flow assets
+
+These are strategically important, especially because promotion already points
+at `programmatic_flow` as a target family.
+
+They are still less concrete than managed skills today.
+
+## Public Principles
+
+Every public artifact family should follow the same rules:
+
+- explicit metadata
+- explicit setup surface
+- explicit ownership and intent
+- controlled runtime lanes
+- installability and inspectability
+
+## What Is Not Promised
+
+The public contract should not promise:
+
+- internal `crates/app` helper APIs
+- internal registry organization
+- executor layout
+- automatic self-evolution behavior
+
+Those remain internal or experimental until proven durable.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -7,14 +7,20 @@ Catalog of design documents and architectural decisions.
 | Document | Scope | Status |
 |----------|-------|--------|
 | [Core Beliefs](core-beliefs.md) | Engineering principles and taste enforcement | Living |
+| [Capability Promotion Contract](capability-promotion-contract.md) | Governed codification path from runtime evidence to durable capability assets | Active |
 | [Local Product Control Plane](local-product-control-plane.md) | Localhost-only platform layer above the runtime and below future HTTP/Web UI surfaces | Active |
 | [Discovery-First Tool Runtime Contract](discovery-first-tool-runtime-contract.md) | Provider-core tools, leases, parser rewrites, and follow-up turn contract | Active |
+| [External Authoring Contract](external-authoring-contract.md) | Public contract for capability packages and reusable capability assets | Active |
 | [Governance Simplification Classification](governance-simplification-classification.md) | Classifies governance surfaces as structural, transitional, cleanup-safe, or replacement-first | Active |
+| [Internal Integration SDK Contract](internal-integration-sdk-contract.md) | Maintainer-facing descriptor, registry, and projection contract for repository-owned surfaces | Active |
 | [Layered Kernel Design](layered-kernel-design.md) | L0-L9 kernel layer specification and boundary rules | Living |
 | [Plugin Package Manifest Contract](plugin-package-manifest-contract.md) | Manifest-first plugin metadata, setup surface, and slot ownership contract | Active |
 | [OpenClaw Plugin Compatibility Contract](openclaw-plugin-compatibility-contract.md) | Foreign dialect normalization, compatibility-mode gating, and polyglot plugin strategy | Active |
 | [Provider Runtime Roadmap](provider-runtime-roadmap.md) | Provider/runtime evolution strategy | Active |
 | [Reference Runtime Comparison](reference-runtime-comparison.md) | Productization gap analysis and convergence order for tasks, skills, and memory | Active |
+| [SDK Stability Policy](sdk-stability-policy.md) | Stability boundaries across product vocabulary, public contracts, internal seams, and promotion artifacts | Active |
+| [SDK Strategy](sdk-strategy.md) | Product-governed capability authoring, acquisition, and promotion strategy | Active |
+| [SDK Validator Contract](sdk-validator-contract.md) | Public validation semantics for capability artifacts, package contracts, and promotion inputs | Active |
 | [ACP/ACPX Pre-Embed](acp-acpx-preembed.md) | Advanced cryptographic primitives | Active |
 | [Harness Engineering](harness-engineering.md) | Environment design for agent-driven development | Active |
 

--- a/docs/design-docs/internal-integration-sdk-contract.md
+++ b/docs/design-docs/internal-integration-sdk-contract.md
@@ -1,0 +1,96 @@
+# Internal Integration SDK Contract
+
+## Purpose
+
+This document defines the maintainer-facing SDK contract for repository-owned
+surfaces inside LoongClaw.
+
+It answers one question:
+
+- how should a maintainer add or evolve a concrete runtime surface without
+  scattering identity, validation, and projection logic across the repository?
+
+## Core Thesis
+
+Every mature integration family should have one primary descriptor or registry
+seam that feeds its projections.
+
+The maintainer flow should be:
+
+1. declare the surface in the family-owned seam
+2. implement the runtime adapter or executor
+3. attach validation and support facts beside that seam
+4. let config, doctor, catalog, status, and docs consume shared projections
+5. add family-specific conformance tests
+
+## Families
+
+### Channels
+
+Channels are the clearest current internal SDK family.
+
+They already have descriptor and registry seams that drive:
+
+- catalog metadata
+- config validation
+- doctor projections
+- runtime-backed vs config-backed status
+
+### Tools
+
+Tools already use a catalog-driven internal seam.
+
+That family should keep using catalog metadata as the source of truth for:
+
+- visibility
+- capability action class
+- governance profile
+- runtime availability
+
+### Memory systems
+
+Memory systems already use a registry-and-metadata pattern.
+
+That structure should be preserved rather than flattened back into ad hoc
+backend branching.
+
+### Providers
+
+Providers already have runtime contracts, validation helpers, and transport
+abstractions, but their maintainer-facing seam is less obvious than channels.
+
+That makes providers the clearest Phase 1 convergence target.
+
+## Required Properties
+
+Every mature family should expose:
+
+- canonical identity
+- descriptor or registry ownership
+- projections into operator surfaces
+- explicit policy or governance facts when runtime decisions depend on them
+- conformance tests that prove descriptor-to-projection alignment
+
+## Product-Mode Compatibility
+
+Internal descriptor layers should increasingly be able to answer support facts
+such as:
+
+- whether the surface supports kernel-bound mutation
+- whether it supports approval round-trips
+- whether it may participate in bounded autonomous acquisition
+
+These must be declared facts, not local prompt heuristics.
+
+## Stability
+
+The internal integration SDK is an internal engineering contract.
+
+It should optimize for:
+
+- coherence
+- low drift
+- repeatable reviews
+- projection consistency
+
+It is not a public compatibility promise.

--- a/docs/design-docs/internal-integration-sdk-contract.md
+++ b/docs/design-docs/internal-integration-sdk-contract.md
@@ -67,6 +67,7 @@ Every mature family should expose:
 
 - canonical identity
 - descriptor or registry ownership
+- versioned descriptor documents once the family feeds shared JSON or SDK-facing read models
 - projections into operator surfaces
 - explicit policy or governance facts when runtime decisions depend on them
 - conformance tests that prove descriptor-to-projection alignment

--- a/docs/design-docs/sdk-stability-policy.md
+++ b/docs/design-docs/sdk-stability-policy.md
@@ -1,0 +1,53 @@
+# SDK Stability Policy
+
+## Purpose
+
+This document defines which SDK-adjacent surfaces should be treated as:
+
+- stable
+- additive
+- experimental
+- internal
+
+Its purpose is to prevent LoongClaw from making accidental compatibility
+promises in the wrong layers.
+
+## Core Rule
+
+LoongClaw should stabilize artifact and workflow contracts before stabilizing
+internal helper APIs.
+
+The default order should be:
+
+1. product vocabulary
+2. package and artifact contracts
+3. validator and projection semantics
+4. promotion artifact schemas
+5. only later, selective helper APIs if they prove durable
+
+## Stability Matrix
+
+| Surface | Recommended Stability |
+|---------|------------------------|
+| `product mode` vocabulary and operator-facing meaning | Stable |
+| high-level blocked-reason families | Additive |
+| internal integration SDK descriptor layout | Internal |
+| internal registry implementation details | Internal |
+| package manifest shapes | Additive moving toward Stable |
+| skill package layout | Additive moving toward Stable |
+| setup metadata semantics | Additive moving toward Stable |
+| ownership semantics | Additive moving toward Stable |
+| validator meaning | Additive |
+| controlled runtime-lane contract | Additive |
+| trust and provenance field shape | Additive |
+| runtime-capability candidate schema | Additive |
+| promotion plan taxonomy | Additive |
+| live promotion executors | Experimental |
+| learning or ranking layers | Experimental |
+| internal convenience helpers in `crates/app` | Internal |
+
+## Practical Reading
+
+- internal maintainer seams should stay movable
+- public artifact contracts should become predictable first
+- promotion should stabilize artifact meaning before executor automation

--- a/docs/design-docs/sdk-strategy.md
+++ b/docs/design-docs/sdk-strategy.md
@@ -1,0 +1,146 @@
+# LoongClaw SDK Strategy
+
+## Purpose
+
+This document defines the current SDK strategy for LoongClaw.
+
+LoongClaw should not frame its SDK as a generic plugin story.
+It should frame its SDK as a product-governed capability system that serves:
+
+- internal repository-owned integration work
+- external community authoring
+- governed promotion from runtime evidence to durable assets
+
+Companion documents:
+
+- `docs/design-docs/internal-integration-sdk-contract.md`
+- `docs/design-docs/external-authoring-contract.md`
+- `docs/design-docs/capability-promotion-contract.md`
+- `docs/design-docs/sdk-stability-policy.md`
+- `docs/design-docs/sdk-validator-contract.md`
+- `docs/plans/2026-03-28-sdk-strategy-implementation-roadmap.md`
+
+## Current Direction
+
+LoongClaw is no longer best described as a `discovery-first` product.
+
+The current direction is:
+
+- `discovery-first` as a lower-layer tool-selection substrate
+- `product mode` as the product-facing capability-acquisition surface
+- autonomy-policy as the internal runtime control kernel
+- governed promotion as the path from runtime evidence to durable capability
+  assets
+
+That distinction matters because the SDK must serve more than tool lookup.
+
+## Core Thesis
+
+LoongClaw's SDK should be defined by the contracts that let capability:
+
+1. be authored
+2. be integrated
+3. be acquired
+4. be governed
+5. be validated
+6. be promoted
+7. be reused
+
+The center of gravity is not "make extension code easier to write."
+The center of gravity is "make new capability enter the system safely,
+inspectably, and durably."
+
+## Design Goals
+
+1. Keep `product mode` as the operator-facing vocabulary for capability
+   acquisition.
+2. Keep autonomy-policy and kernel binding as hard runtime boundaries.
+3. Make internal integration work more repeatable for maintainers.
+4. Give external authors stable artifact contracts without freezing internal
+   crate structure.
+5. Make install, inspect, doctor, catalog, and audit consume shared metadata.
+6. Converge runtime-derived promotion targets with the same lower-layer asset
+   taxonomy used by manual authoring.
+
+## Non-Goals
+
+This strategy does not aim to:
+
+- expose the whole internal Rust module layout as a public SDK
+- replace `product mode` with `discovery-first`
+- make third-party native in-process plugins the default extension path
+- blur runtime policy with future learning or self-modification
+- auto-promote runtime behavior into live capability without review
+
+## Four-Layer SDK Model
+
+### 1. Product capability surface
+
+This is the operator-facing layer.
+
+It owns:
+
+- `product mode`
+- high-level acquisition posture
+- blocked-reason semantics
+- operator-visible explanation vocabulary
+
+### 2. Internal integration SDK
+
+This is the maintainer-facing layer.
+
+It owns the repository's descriptor, registry, and projection seams for:
+
+- providers
+- tools
+- channels
+- memory systems
+- future workflow or pack families where the same pattern applies
+
+### 3. External authoring contract
+
+This is the public author-facing layer.
+
+It should stabilize:
+
+- package identity
+- package layout
+- setup metadata
+- ownership intent
+- validator meaning
+- supported runtime lanes
+
+### 4. Governed promotion plane
+
+This is the codification layer between runtime evidence and durable assets.
+
+It should treat promotion as governed artifact generation, not live
+self-modification.
+
+## Public Capability Families
+
+The clearest current public capability family is managed skills.
+
+The next public families should converge around:
+
+- manifest-first governed plugin packages
+- workflow or flow assets
+- promotion artifacts that resolve into bounded lower-layer targets
+
+## Recommended Implementation Order
+
+1. converge internal maintainer seams
+2. stabilize external artifact contracts
+3. stabilize validator meaning
+4. align promotion targets with manual authoring taxonomy
+5. only then widen helper APIs or executor automation
+
+## Practical Implication
+
+When LoongClaw says "SDK", it should not mean one helper crate.
+It should mean one coherent capability lifecycle across:
+
+- product vocabulary
+- maintainer integration seams
+- external artifact contracts
+- governed promotion

--- a/docs/design-docs/sdk-validator-contract.md
+++ b/docs/design-docs/sdk-validator-contract.md
@@ -1,0 +1,121 @@
+# SDK Validator Contract
+
+## Purpose
+
+This document defines what LoongClaw validates for public capability artifacts.
+
+It exists to answer one practical question:
+
+- what should fail deterministically, what should warn, and what belongs to
+  doctor, install, or runtime policy instead of package validation?
+
+## Core Distinction
+
+Validator behavior must stay separate from:
+
+- doctor
+- install or activation
+- runtime policy
+
+Validation answers whether an artifact is structurally and semantically valid
+for its family.
+
+Doctor answers whether the current operator environment is ready.
+
+Install or activation performs governed mutation.
+
+Runtime policy answers whether the current session or product mode may use or
+acquire the capability right now.
+
+## Result Contract
+
+Every validator surface should converge on:
+
+- `valid`
+- `valid_with_warnings`
+- `invalid`
+
+## Diagnostic Meaning
+
+Validator diagnostics should be able to communicate:
+
+- artifact family
+- artifact identity when known
+- severity
+- category
+- short summary
+- subject path or field when available
+- remediation hint when available
+
+Recommended severities:
+
+- `error`
+- `warning`
+- `note`
+
+Recommended categories:
+
+- `discovery`
+- `structure`
+- `identity`
+- `metadata`
+- `ownership`
+- `runtime_lane`
+- `promotion`
+- `provenance`
+
+## Validation Phases
+
+LoongClaw should validate public capability artifacts in this sequence:
+
+1. discovery and root resolution
+2. structural safety
+3. identity normalization
+4. metadata and setup semantics
+5. runtime-lane and ownership compatibility
+6. promotion boundedness and evidence semantics when applicable
+
+## Families
+
+### Managed skills
+
+Managed-skill validation should enforce:
+
+- exactly one installable root
+- root contains `SKILL.md`
+- archive and path safety
+- symlink rejection where managed installs depend on local boundaries
+- a normalizable `skill_id`
+
+### Governed plugin packages
+
+Plugin validation should enforce:
+
+- manifest-first package discovery
+- deterministic package-vs-source conflict handling
+- required identity fields
+- setup metadata structure
+- ownership intent
+- controlled runtime lanes
+
+### Promotion artifacts
+
+Promotion validation should enforce:
+
+- explicit schema version, surface, and purpose
+- supported target taxonomy
+- bounded scope
+- required capabilities
+- provenance and readiness semantics
+
+## Stability
+
+Validator meaning should be treated as Additive moving toward Stable.
+
+LoongClaw should stabilize the meaning of:
+
+- errors vs warnings
+- major diagnostic categories
+- the separation between validation, doctor, install, and policy
+
+before trying to freeze exact renderer shape.

--- a/docs/plans/2026-03-28-sdk-strategy-implementation-roadmap.md
+++ b/docs/plans/2026-03-28-sdk-strategy-implementation-roadmap.md
@@ -1,0 +1,91 @@
+# SDK Strategy Implementation Roadmap
+
+Date: 2026-03-28
+Status: Proposed
+
+## Goal
+
+Turn the SDK strategy from architecture framing into a phased execution
+program.
+
+## Strategic Frame
+
+Implementation should follow LoongClaw's current direction:
+
+- `product mode` stays the operator-facing capability vocabulary
+- autonomy-policy becomes the internal runtime control kernel
+- internal SDK seams reduce maintainer wiring cost
+- external authoring contracts define public package shape
+- promotion contracts connect runtime evidence to reusable assets
+
+## Success Conditions
+
+This roadmap is successful when:
+
+- new repository-owned surfaces can be added through repeatable family seams
+- public authoring no longer depends on internal crate layout
+- install, doctor, catalog, runtime visibility, and audit agree on shared
+  metadata
+- promotion targets align with the same lower-layer asset taxonomy used by
+  manual authoring
+
+## Phase 1: Internal SDK Convergence
+
+Focus:
+
+- strengthen provider integration into a clearer maintainer-facing contract
+- keep channels on descriptor-driven seams
+- keep tools and memory systems projection-driven
+- add family-specific conformance tests
+
+Deliverables:
+
+- documented maintainer flow per integration family
+- provider SDK convergence plan for the least unified core family
+- clearer provider descriptor or contract seam
+- contributor guidance aligned with real family seams
+
+## Phase 2: Product-Mode And Autonomy Support Facts
+
+Focus:
+
+- make more surfaces declare support facts for approval, mutation, and bounded
+  autonomous acquisition
+
+## Phase 3: Public Authoring Contract Baseline
+
+Focus:
+
+- consolidate managed skills and manifest-first packages into a clearer public
+  contract
+- define validator behavior and compatibility expectations
+
+## Phase 4: Supply Chain And Governance Alignment
+
+Focus:
+
+- trust tiers
+- provenance
+- ownership conflict handling
+- stronger install, doctor, and audit alignment
+
+## Phase 5: Promotion Contract Convergence
+
+Focus:
+
+- align runtime-derived promotion targets with manually authored asset
+  taxonomy
+
+## Phase 6: Bounded Promotion Execution
+
+Focus:
+
+- design bounded mutation only after promotion inputs and dry-run plans are
+  explicit enough
+
+## Phase 7: Learning And Ranking Layers
+
+Focus:
+
+- keep future optimization above stable contracts rather than inside hard
+  runtime permissions

--- a/docs/plans/2026-03-29-provider-sdk-convergence-implementation-plan.md
+++ b/docs/plans/2026-03-29-provider-sdk-convergence-implementation-plan.md
@@ -1,0 +1,84 @@
+# Provider SDK Convergence Implementation Plan
+
+Date: 2026-03-29
+Status: Proposed
+
+## Goal
+
+Turn the provider family into a clearer internal SDK surface so maintainers can
+add or evolve a provider without rediscovering scattered seams across config,
+runtime contracts, validation, and tests.
+
+This plan is the provider-specific execution slice of Phase 1 in
+`docs/plans/2026-03-28-sdk-strategy-implementation-roadmap.md`.
+
+## Why This Slice Exists
+
+LoongClaw has already done meaningful provider-runtime decomposition:
+
+- request-session assembly
+- payload shaping
+- request dispatch
+- failover orchestration
+- catalog query flow
+- validation runtime
+- capability profile overrides
+
+That work improved runtime clarity, but not yet the maintainer authoring seam.
+
+## Current Architecture Evidence
+
+`crates/app/src/config/provider.rs` already owns the strongest static provider
+facts:
+
+- canonical id
+- aliases
+- protocol family
+- feature family
+- auth defaults
+- default headers
+
+`crates/app/src/provider/contracts.rs` already owns the strongest request-time
+behavior contract:
+
+- transport mode
+- payload adaptation
+- validation rules
+- capability defaults
+- error classification
+
+The missing piece is explicit convergence between those seams and the
+projection layer.
+
+## Core Decision
+
+LoongClaw should not introduce a second parallel provider registry.
+
+The right move is:
+
+1. treat `ProviderProfile` as the static provider descriptor seam
+2. treat `ProviderRuntimeContract` as the runtime behavior seam
+3. make validation, setup guidance, and conformance tests consume those seams
+   explicitly
+
+## Deliverables
+
+- one documented maintainer-facing provider family model
+- clearer ownership split between `ProviderProfile` and
+  `ProviderRuntimeContract`
+- reduced local recomputation in validation and setup guidance
+- provider-family conformance tests for descriptor uniqueness and
+  descriptor-to-runtime alignment
+- contributor docs that point maintainers to the correct provider family seams
+
+## Acceptance Criteria
+
+This slice is successful when:
+
+- a maintainer can identify one static descriptor seam for provider identity
+  and defaults
+- runtime behavior changes can be explained as contract derivation rather than
+  local branching
+- feature-gate, validation, and auth-guidance projections are traceable to the
+  provider descriptor seam
+- adding a new provider no longer depends on hidden edits by folklore

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-30T06:03:17Z
+- Generated at: 2026-03-30T06:52:32Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -24,13 +24,13 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6396 | 6400 | 4 | 104 | 110 | 6 | 99.9% | TIGHT |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10773 | 11200 | 427 | 97 | 120 | 23 | 96.2% | TIGHT |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14216 | 15000 | 784 | 54 | 70 | 16 | 94.8% | WATCH |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6289 | 6500 | 211 | 208 | 210 | 2 | 99.0% | TIGHT |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6293 | 6500 | 207 | 209 | 210 | 1 | 99.5% | TIGHT |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9292 | 9800 | 508 | 227 | 250 | 23 | 94.8% | WATCH |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), channel_mod (99.9%), turn_coordinator (96.2%), daemon_lib (99.0%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (90.8%), memory_mod (87.5%), acp_manager (92.4%), tools_mod (94.8%), onboard_cli (94.4%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), channel_mod (99.9%), turn_coordinator (96.2%), daemon_lib (99.5%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (90.8%), memory_mod (87.5%), acp_manager (92.4%), tools_mod (94.8%), onboard_cli (94.8%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -69,8 +69,8 @@
 <!-- arch-hotspot key=channel_mod lines=6396 functions=104 -->
 <!-- arch-hotspot key=turn_coordinator lines=10773 functions=97 -->
 <!-- arch-hotspot key=tools_mod lines=14216 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6289 functions=208 -->
-<!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->
+<!-- arch-hotspot key=daemon_lib lines=6293 functions=209 -->
+<!-- arch-hotspot key=onboard_cli lines=9292 functions=227 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->

--- a/docs/sdk/compatibility-matrix.md
+++ b/docs/sdk/compatibility-matrix.md
@@ -1,0 +1,34 @@
+# SDK Compatibility Matrix
+
+This matrix summarizes the current maturity posture of the main SDK-adjacent
+surfaces.
+
+## Layer Matrix
+
+| Layer | Current posture |
+|-------|-----------------|
+| Product capability surface | Stable to Additive |
+| Internal integration SDK | Internal |
+| External authoring contract | Additive moving toward Stable |
+| Capability promotion contract | Additive |
+| Live promotion executor | Experimental |
+| Learning or ranking layers | Experimental |
+
+## Asset Family Matrix
+
+| Asset family | Current reading |
+|--------------|-----------------|
+| Managed skills | Most practical public capability family today |
+| Manifest-first plugin packages | Active design direction with strong architectural contract |
+| Workflow / flow assets | Strategically important, less concretely packaged today |
+| Runtime-capability candidate artifacts | Shipped governance artifact family |
+| Promotion plan taxonomy | Strong read-only governance layer |
+
+## Internal Family Matrix
+
+| Family | Current reading |
+|--------|-----------------|
+| Channels | Most mature internal SDK family |
+| Tools | Strong internal catalog seam |
+| Memory systems | Clear registry seam |
+| Providers | Important convergence target, less unified than channels |

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -1,0 +1,64 @@
+# SDK Docs
+
+Practical entrypoint for LoongClaw SDK-related work.
+
+LoongClaw's SDK is not one helper crate.
+It is a set of contracts and workflows for capability:
+
+- authoring
+- integration
+- acquisition
+- validation
+- promotion
+
+## Who This Is For
+
+### Internal maintainers
+
+Start with:
+
+- [Internal Integration Quickstart](quickstart-internal.md)
+- [Internal Integration SDK Contract](../design-docs/internal-integration-sdk-contract.md)
+- [Provider SDK Convergence Plan](../plans/2026-03-29-provider-sdk-convergence-implementation-plan.md)
+
+### External authors
+
+Start with:
+
+- [External Authoring Quickstart](quickstart-external.md)
+- [External Authoring Contract](../design-docs/external-authoring-contract.md)
+- [SDK Validator Contract](../design-docs/sdk-validator-contract.md)
+- [SDK Stability Policy](../design-docs/sdk-stability-policy.md)
+
+### Promotion and capability-evolution work
+
+Start with:
+
+- [Capability Promotion Contract](../design-docs/capability-promotion-contract.md)
+- [SDK Strategy Implementation Roadmap](../plans/2026-03-28-sdk-strategy-implementation-roadmap.md)
+
+## Document Map
+
+| Document | Use it for |
+|----------|------------|
+| [Internal Integration Quickstart](quickstart-internal.md) | Adding or refactoring repository-owned surfaces |
+| [Provider SDK Convergence Plan](../plans/2026-03-29-provider-sdk-convergence-implementation-plan.md) | Converging the provider family into a clearer maintainer-facing seam |
+| [External Authoring Quickstart](quickstart-external.md) | Understanding what external authors should build today |
+| [Compatibility Matrix](compatibility-matrix.md) | Stability and maturity boundaries across SDK surfaces |
+| [SDK Strategy](../design-docs/sdk-strategy.md) | Overall architecture framing |
+| [SDK Stability Policy](../design-docs/sdk-stability-policy.md) | What is stable, additive, experimental, or internal |
+| [SDK Validator Contract](../design-docs/sdk-validator-contract.md) | What LoongClaw validates for capability artifacts |
+| [External Authoring Contract](../design-docs/external-authoring-contract.md) | Public package and artifact authoring contract |
+| [Capability Promotion Contract](../design-docs/capability-promotion-contract.md) | Governed codification path from runtime evidence to durable assets |
+
+## Current Reading Of The Repository
+
+LoongClaw is not best understood as a `discovery-first` product anymore.
+
+The current direction is:
+
+- `discovery-first` as a lower-layer substrate
+- `product mode` as the capability-acquisition surface
+- autonomy-policy as the internal decision kernel
+- governed promotion as the path from runtime evidence to durable capability
+  assets

--- a/docs/sdk/quickstart-external.md
+++ b/docs/sdk/quickstart-external.md
@@ -1,0 +1,56 @@
+# External Authoring Quickstart
+
+Use this guide when you want the shortest practical summary of what LoongClaw
+expects external authors to build.
+
+## Read This First
+
+- [External Authoring Contract](../design-docs/external-authoring-contract.md)
+- [SDK Validator Contract](../design-docs/sdk-validator-contract.md)
+- [SDK Stability Policy](../design-docs/sdk-stability-policy.md)
+
+## Public Stance
+
+LoongClaw's public SDK is contract-first and artifact-first.
+
+Do not assume the stable public surface is:
+
+- internal `crates/app` helper layout
+- internal registries
+- repository-only helper functions
+
+Instead, the public surface is moving toward:
+
+- package metadata
+- package layout
+- setup semantics
+- validation
+- controlled runtime lanes
+- install, inspect, and audit behavior
+
+## Which Family Fits?
+
+### Managed skill
+
+Best fit when the capability is reusable procedural guidance and should stay
+installable and inspectable.
+
+### Governed plugin package
+
+Best fit when the capability needs a runtime lane, setup metadata, and explicit
+ownership intent.
+
+### Workflow or flow asset
+
+Best fit when the behavior is more structured than prompt guidance and belongs
+closer to reusable orchestration.
+
+## Validation
+
+Use [SDK Validator Contract](../design-docs/sdk-validator-contract.md) when you
+need to understand the line between:
+
+- artifact-shape validation
+- doctor and setup readiness
+- install or activation failures
+- runtime policy denials

--- a/docs/sdk/quickstart-internal.md
+++ b/docs/sdk/quickstart-internal.md
@@ -1,0 +1,45 @@
+# Internal Integration Quickstart
+
+Use this guide when you are adding or evolving a repository-owned surface in
+LoongClaw.
+
+## Start Here
+
+Read:
+
+- [Internal Integration SDK Contract](../design-docs/internal-integration-sdk-contract.md)
+- [SDK Strategy](../design-docs/sdk-strategy.md)
+
+## Family Starting Points
+
+| Family | Primary code seam | Primary contract doc |
+|--------|-------------------|----------------------|
+| Channels | `crates/app/src/channel/sdk.rs`, `crates/app/src/channel/registry.rs` | [Channel Registry Integration Contract](../design-docs/channel-registry-integration-contract.md) |
+| Tools | `crates/app/src/tools/catalog.rs`, `crates/app/src/tools/mod.rs` | [SDK Strategy](../design-docs/sdk-strategy.md) |
+| Providers | `crates/app/src/config/provider.rs`, `crates/app/src/provider/contracts.rs`, `crates/app/src/provider/mod.rs` | [Provider SDK Convergence Plan](../plans/2026-03-29-provider-sdk-convergence-implementation-plan.md) |
+| Memory systems | `crates/app/src/memory/system_registry.rs` | [Internal Integration SDK Contract](../design-docs/internal-integration-sdk-contract.md) |
+
+## Maintainer Flow
+
+1. Start from the family-owned seam instead of scattered call sites.
+2. Declare canonical identity once.
+3. Attach validation and support facts beside the seam.
+4. Implement runtime behavior after the descriptor or contract is clear.
+5. Project through shared surfaces such as config, doctor, status, catalog, or
+   docs.
+6. Add family-specific conformance tests.
+7. Update docs using the same canonical vocabulary.
+
+## Practical Checklist
+
+- [ ] I started from the family-owned seam.
+- [ ] The surface has one canonical identity.
+- [ ] Validation and support facts live beside the descriptor or contract.
+- [ ] Runtime behavior consumes shared metadata instead of redefining it.
+- [ ] Operator surfaces derive from the same family metadata where practical.
+- [ ] Conformance or regression tests were added or extended.
+
+## See Also
+
+- [SDK Docs Index](index.md)
+- [Provider SDK Convergence Plan](../plans/2026-03-29-provider-sdk-convergence-implementation-plan.md)

--- a/docs/sdk/quickstart-internal.md
+++ b/docs/sdk/quickstart-internal.md
@@ -24,17 +24,19 @@ Read:
 1. Start from the family-owned seam instead of scattered call sites.
 2. Declare canonical identity once.
 3. Attach validation and support facts beside the seam.
-4. Implement runtime behavior after the descriptor or contract is clear.
-5. Project through shared surfaces such as config, doctor, status, catalog, or
+4. Version descriptor documents once they start feeding cross-surface JSON or SDK-facing read models.
+5. Implement runtime behavior after the descriptor or contract is clear.
+6. Project through shared surfaces such as config, doctor, status, catalog, or
    docs.
-6. Add family-specific conformance tests.
-7. Update docs using the same canonical vocabulary.
+7. Add family-specific conformance tests.
+8. Update docs using the same canonical vocabulary.
 
 ## Practical Checklist
 
 - [ ] I started from the family-owned seam.
 - [ ] The surface has one canonical identity.
 - [ ] Validation and support facts live beside the descriptor or contract.
+- [ ] Cross-surface descriptor documents are versioned before they become shared JSON contracts.
 - [ ] Runtime behavior consumes shared metadata instead of redefining it.
 - [ ] Operator surfaces derive from the same family metadata where practical.
 - [ ] Conformance or regression tests were added or extended.


### PR DESCRIPTION
## Summary

- Problem:
  Provider-maintainer seams were still split across config, runtime validation, transport messaging, daemon onboarding, doctor, migration planning, and operator-facing status surfaces. That left the daemon side with stale credential-readiness semantics even after the descriptor projection cleanup.
- Why it matters:
  Internal SDK work should start from one descriptor-driven seam before LoongClaw opens more capability-authoring surface to community contributors. If daemon/operator flows disagree with descriptor-owned facts, maintainers and future external contributors will get inconsistent setup, migration, and troubleshooting behavior.
- What changed:
  Moved static provider-family projections behind `ProviderProfile` and `ProviderFeatureFamily`, added structured `ProviderSupportFacts` in `ProviderConfig`, switched validation, request/catalog auth failures, and setup-time feature-gate messaging to consume one descriptor-owned projection, and then extended that convergence into daemon/operator surfaces. Doctor, onboarding, migration readiness, runtime snapshot reporting, and provider presentation now share one provider-credential readiness helper derived from support facts. This follow-up also fixes the remaining semantic drift for `x-api-key` providers, auth-optional providers, and env-backed migration supplementation.
- What did not change (scope boundary):
  This does not introduce a dynamic provider registry, does not widen public runtime plugin execution, and does not change product-mode or autonomy-policy behavior.

## Linked Issues

- Closes #680
- Related # none

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
scripts/check-docs.sh
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh

Focused regression checks run while iterating:
- cargo test --workspace --locked support_facts
- cargo test --workspace --locked render_status_failure_message
- cargo test --workspace --locked render_catalog_status_failure_message
- cargo test -p loongclaw-app acp::acpx::tests::runtime_backend_supports_local_abort_for_running_prompt -- --nocapture

Key runtime/provider assertions added or strengthened:
- provider profile alias uniqueness and canonical-id collision checks
- stable provider feature-gate messaging projections
- stable provider static auth/setup guidance projections
- stable structured provider support facts for feature-gate, auth, and region-endpoint hints
- request and catalog auth-failure messaging still surface the correct auth and region guidance after the projection convergence
- daemon onboarding, doctor, migration, runtime snapshot, and presentation surfaces now agree on one credential-readiness rule
- x-api-key providers are treated as ready when their actual support-facts-backed auth path resolves locally
- auth-optional providers no longer warn as if credentials are missing
- migration supplementation now materializes the actually populated credential env binding instead of reporting false readiness
- descriptor drift found and fixed for `ProviderKind::StepPlan`

scripts/check-docs.sh passed. LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh fails only on pre-existing release-artifact governance gaps for released versions v0.1.0-alpha.1 and v0.1.0-alpha.2 (missing local debug docs and .docs/traces metadata/index pointers), which are outside this PR scope.

One `cargo test --workspace --all-features --locked` rerun hit a transient failure in `acp::acpx::tests::runtime_backend_supports_local_abort_for_running_prompt` with `sleep: command not found` inside the fake ACPX script. The same test passed immediately in isolation, and the full all-features suite passed on the next rerun without code changes.
```

## User-visible / Operator-visible Changes

- Maintainers now have an explicit SDK entrypoint and contract docs for internal integration, external authoring, stability, validation, and governed promotion.
- Provider auth/setup guidance, feature-gate messaging, request/catalog auth-failure hints, and daemon-facing credential readiness checks now derive from one descriptor-owned support projection instead of scattered local branches.
- Anthropic-style `x-api-key` providers are no longer shown as missing credentials when the actual env-backed auth path is available.
- Auth-optional providers such as Ollama no longer emit false missing-credential warnings during onboarding and doctor flows.
- Migration planning now preserves the actually populated provider credential env binding instead of drifting into a false-ready but non-materialized config state.
- Contributor guidance for adding providers now points at the descriptor seam first.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR or the latest provider support-facts follow-up commit to restore the previous local projection branches and docs entrypoints.
- Observable failure symptoms reviewers should watch for:
  Provider disabled messages, missing-auth guidance, auth-failure region hints, onboarding or doctor credential state, or migration-import readiness changing unexpectedly; alias collisions for provider ids; or contributor docs pointing at stale provider seams.

## Reviewer Focus

- Review `crates/app/src/config/provider.rs` for whether `ProviderSupportFacts` is the right long-term ownership seam for feature-gate, auth, and region-endpoint projections.
- Review `crates/app/src/provider/provider_validation_runtime.rs`, `crates/app/src/provider/request_executor.rs`, `crates/app/src/provider/catalog_executor.rs`, and `crates/app/src/provider/transport.rs` for whether runtime consumers now project provider facts without duplicating local policy.
- Review `crates/daemon/src/provider_credential_policy.rs`, `crates/daemon/src/onboard_preflight.rs`, `crates/daemon/src/doctor_cli.rs`, and `crates/daemon/src/migration/planner.rs` for whether daemon/operator surfaces now use one support-facts-backed credential readiness rule without reintroducing env-binding drift.
- Review the new SDK docs for whether they frame LoongClaw correctly as product-mode plus governed promotion rather than discovery-first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive SDK documentation with guides for internal and external users covering capability authoring, validation, and promotion workflows.
  * Enhanced provider configuration system with improved credential detection and authentication guidance messaging.

* **Documentation**
  * Expanded SDK documentation with design contracts, stability policies, and implementation roadmaps.
  * Added integration and external authoring quickstart guides.

* **Bug Fixes**
  * Improved provider credential availability detection and setup readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->