### PR TITLE
Enforce product-mode autonomy preflight in turn runtime

### DIFF
--- a/crates/app/src/conversation/autonomy_policy.rs
+++ b/crates/app/src/conversation/autonomy_policy.rs
@@ -311,13 +311,13 @@ pub fn render_reason(
             snapshot.profile.as_str()
         ),
         SESSION_MUTATION_BUDGET_EXCEEDED_CODE => format!(
-            "autonomy policy denied `{tool_name}`: topology mutation budget exceeded for `{}`",
+            "autonomy policy denied `{tool_name}`: session mutation budget exceeded for `{}`",
             snapshot.profile.as_str()
         ),
         BINDING_MISSING_CODE => format!(
-            "autonomy policy denied `{tool_name}`: `{}` requires kernel-bound execution for {:?}",
+            "autonomy policy denied `{tool_name}`: `{}` requires kernel-bound execution for `{}`",
             snapshot.profile.as_str(),
-            action_class
+            action_class.as_str()
         ),
         _ => format!(
             "autonomy policy denied `{tool_name}` with reason `{reason_code}` under `{}`",

--- a/crates/app/src/conversation/autonomy_policy.rs
+++ b/crates/app/src/conversation/autonomy_policy.rs
@@ -10,14 +10,30 @@ pub const CAPABILITY_ACQUISITION_APPROVAL_CODE: &str =
 pub const CAPABILITY_ACQUISITION_BUDGET_EXCEEDED_CODE: &str =
     "autonomy_policy_capability_acquisition_budget_exceeded";
 pub const PROVIDER_SWITCH_APPROVAL_CODE: &str = "autonomy_policy_provider_switch_requires_approval";
+pub const PROVIDER_SWITCH_DISALLOWED_CODE: &str = "autonomy_policy_provider_switch_disallowed";
 pub const PROVIDER_SWITCH_BUDGET_EXCEEDED_CODE: &str =
     "autonomy_policy_provider_switch_budget_exceeded";
+pub const TOPOLOGY_MUTATION_APPROVAL_CODE: &str =
+    "autonomy_policy_topology_mutation_requires_approval";
+pub const TOPOLOGY_MUTATION_DISALLOWED_CODE: &str = "autonomy_policy_topology_mutation_disallowed";
+pub const TOPOLOGY_MUTATION_BUDGET_EXCEEDED_CODE: &str =
+    "autonomy_policy_topology_mutation_budget_exceeded";
+pub const POLICY_MUTATION_APPROVAL_CODE: &str = "autonomy_policy_policy_mutation_requires_approval";
+pub const POLICY_MUTATION_DISALLOWED_CODE: &str = "autonomy_policy_policy_mutation_disallowed";
+pub const POLICY_MUTATION_BUDGET_EXCEEDED_CODE: &str =
+    "autonomy_policy_policy_mutation_budget_exceeded";
+pub const SESSION_MUTATION_APPROVAL_CODE: &str =
+    "autonomy_policy_session_mutation_requires_approval";
+pub const SESSION_MUTATION_DISALLOWED_CODE: &str = "autonomy_policy_session_mutation_disallowed";
+pub const SESSION_MUTATION_BUDGET_EXCEEDED_CODE: &str =
+    "autonomy_policy_session_mutation_budget_exceeded";
 pub const BINDING_MISSING_CODE: &str = "autonomy_policy_binding_missing";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct AutonomyTurnBudgetState {
     pub capability_acquisitions_used: usize,
     pub provider_switches_used: usize,
+    pub topology_mutations_used: usize,
 }
 
 impl AutonomyTurnBudgetState {
@@ -32,11 +48,12 @@ impl AutonomyTurnBudgetState {
             CapabilityActionClass::RuntimeSwitch => {
                 self.provider_switches_used = self.provider_switches_used.saturating_add(1);
             }
-            CapabilityActionClass::Discover
-            | CapabilityActionClass::ExecuteExisting
-            | CapabilityActionClass::TopologyExpand
+            CapabilityActionClass::TopologyExpand
             | CapabilityActionClass::PolicyMutation
-            | CapabilityActionClass::SessionMutation => {}
+            | CapabilityActionClass::SessionMutation => {
+                self.topology_mutations_used = self.topology_mutations_used.saturating_add(1);
+            }
+            CapabilityActionClass::Discover | CapabilityActionClass::ExecuteExisting => {}
         }
     }
 }
@@ -109,11 +126,10 @@ pub fn action_mode(
         | CapabilityActionClass::CapabilityInstall
         | CapabilityActionClass::CapabilityLoad => Some(snapshot.capability_acquisition_mode),
         CapabilityActionClass::RuntimeSwitch => Some(snapshot.provider_switch_mode),
-        CapabilityActionClass::Discover
-        | CapabilityActionClass::ExecuteExisting
-        | CapabilityActionClass::TopologyExpand
+        CapabilityActionClass::TopologyExpand
         | CapabilityActionClass::PolicyMutation
-        | CapabilityActionClass::SessionMutation => None,
+        | CapabilityActionClass::SessionMutation => Some(snapshot.topology_mutation_mode),
+        CapabilityActionClass::Discover | CapabilityActionClass::ExecuteExisting => None,
     }
 }
 
@@ -131,11 +147,15 @@ fn budget_deny_reason(input: PolicyDecisionInput<'_>) -> Option<&'static str> {
             let limit = input.snapshot.budget.max_provider_switches_per_turn;
             would_exceed_budget(used, limit).then_some(PROVIDER_SWITCH_BUDGET_EXCEEDED_CODE)
         }
-        CapabilityActionClass::Discover
-        | CapabilityActionClass::ExecuteExisting
-        | CapabilityActionClass::TopologyExpand
+        CapabilityActionClass::TopologyExpand
         | CapabilityActionClass::PolicyMutation
-        | CapabilityActionClass::SessionMutation => None,
+        | CapabilityActionClass::SessionMutation => {
+            let used = input.budget.topology_mutations_used;
+            let limit = input.snapshot.budget.max_topology_mutations_per_turn;
+            let reason_code = topology_budget_reason_code(input.action_class);
+            would_exceed_budget(used, limit).then_some(reason_code)
+        }
+        CapabilityActionClass::Discover | CapabilityActionClass::ExecuteExisting => None,
     }
 }
 
@@ -151,11 +171,18 @@ fn approval_rule_id(action_class: CapabilityActionClass) -> &'static str {
             "autonomy_policy_capability_acquisition_requires_approval"
         }
         CapabilityActionClass::RuntimeSwitch => "autonomy_policy_provider_switch_requires_approval",
-        CapabilityActionClass::Discover
-        | CapabilityActionClass::ExecuteExisting
-        | CapabilityActionClass::TopologyExpand
-        | CapabilityActionClass::PolicyMutation
-        | CapabilityActionClass::SessionMutation => "autonomy_policy_not_applicable",
+        CapabilityActionClass::TopologyExpand => {
+            "autonomy_policy_topology_mutation_requires_approval"
+        }
+        CapabilityActionClass::PolicyMutation => {
+            "autonomy_policy_policy_mutation_requires_approval"
+        }
+        CapabilityActionClass::SessionMutation => {
+            "autonomy_policy_session_mutation_requires_approval"
+        }
+        CapabilityActionClass::Discover | CapabilityActionClass::ExecuteExisting => {
+            "autonomy_policy_not_applicable"
+        }
     }
 }
 
@@ -165,11 +192,12 @@ fn approval_reason_code(action_class: CapabilityActionClass) -> &'static str {
         | CapabilityActionClass::CapabilityInstall
         | CapabilityActionClass::CapabilityLoad => CAPABILITY_ACQUISITION_APPROVAL_CODE,
         CapabilityActionClass::RuntimeSwitch => PROVIDER_SWITCH_APPROVAL_CODE,
-        CapabilityActionClass::Discover
-        | CapabilityActionClass::ExecuteExisting
-        | CapabilityActionClass::TopologyExpand
-        | CapabilityActionClass::PolicyMutation
-        | CapabilityActionClass::SessionMutation => "autonomy_policy_not_applicable",
+        CapabilityActionClass::TopologyExpand => TOPOLOGY_MUTATION_APPROVAL_CODE,
+        CapabilityActionClass::PolicyMutation => POLICY_MUTATION_APPROVAL_CODE,
+        CapabilityActionClass::SessionMutation => SESSION_MUTATION_APPROVAL_CODE,
+        CapabilityActionClass::Discover | CapabilityActionClass::ExecuteExisting => {
+            "autonomy_policy_not_applicable"
+        }
     }
 }
 
@@ -181,11 +209,12 @@ fn deny_rule_id(action_class: CapabilityActionClass) -> &'static str {
             "autonomy_policy_capability_acquisition_disallowed"
         }
         CapabilityActionClass::RuntimeSwitch => "autonomy_policy_provider_switch_disallowed",
-        CapabilityActionClass::Discover
-        | CapabilityActionClass::ExecuteExisting
-        | CapabilityActionClass::TopologyExpand
-        | CapabilityActionClass::PolicyMutation
-        | CapabilityActionClass::SessionMutation => "autonomy_policy_not_applicable",
+        CapabilityActionClass::TopologyExpand => "autonomy_policy_topology_mutation_disallowed",
+        CapabilityActionClass::PolicyMutation => "autonomy_policy_policy_mutation_disallowed",
+        CapabilityActionClass::SessionMutation => "autonomy_policy_session_mutation_disallowed",
+        CapabilityActionClass::Discover | CapabilityActionClass::ExecuteExisting => {
+            "autonomy_policy_not_applicable"
+        }
     }
 }
 
@@ -194,12 +223,27 @@ fn deny_reason_code(action_class: CapabilityActionClass) -> &'static str {
         CapabilityActionClass::CapabilityFetch
         | CapabilityActionClass::CapabilityInstall
         | CapabilityActionClass::CapabilityLoad => CAPABILITY_ACQUISITION_DISALLOWED_CODE,
-        CapabilityActionClass::RuntimeSwitch => "autonomy_policy_provider_switch_disallowed",
+        CapabilityActionClass::RuntimeSwitch => PROVIDER_SWITCH_DISALLOWED_CODE,
+        CapabilityActionClass::TopologyExpand => TOPOLOGY_MUTATION_DISALLOWED_CODE,
+        CapabilityActionClass::PolicyMutation => POLICY_MUTATION_DISALLOWED_CODE,
+        CapabilityActionClass::SessionMutation => SESSION_MUTATION_DISALLOWED_CODE,
+        CapabilityActionClass::Discover | CapabilityActionClass::ExecuteExisting => {
+            "autonomy_policy_not_applicable"
+        }
+    }
+}
+
+fn topology_budget_reason_code(action_class: CapabilityActionClass) -> &'static str {
+    match action_class {
+        CapabilityActionClass::TopologyExpand => TOPOLOGY_MUTATION_BUDGET_EXCEEDED_CODE,
+        CapabilityActionClass::PolicyMutation => POLICY_MUTATION_BUDGET_EXCEEDED_CODE,
+        CapabilityActionClass::SessionMutation => SESSION_MUTATION_BUDGET_EXCEEDED_CODE,
         CapabilityActionClass::Discover
         | CapabilityActionClass::ExecuteExisting
-        | CapabilityActionClass::TopologyExpand
-        | CapabilityActionClass::PolicyMutation
-        | CapabilityActionClass::SessionMutation => "autonomy_policy_not_applicable",
+        | CapabilityActionClass::CapabilityFetch
+        | CapabilityActionClass::CapabilityInstall
+        | CapabilityActionClass::CapabilityLoad
+        | CapabilityActionClass::RuntimeSwitch => "autonomy_policy_not_applicable",
     }
 }
 
@@ -226,8 +270,48 @@ pub fn render_reason(
             "operator approval required before running `{tool_name}` under `{}` product mode",
             snapshot.profile.as_str()
         ),
+        PROVIDER_SWITCH_DISALLOWED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: provider switch is disabled in `{}`",
+            snapshot.profile.as_str()
+        ),
         PROVIDER_SWITCH_BUDGET_EXCEEDED_CODE => format!(
             "autonomy policy denied `{tool_name}`: provider switch budget exceeded for `{}`",
+            snapshot.profile.as_str()
+        ),
+        TOPOLOGY_MUTATION_APPROVAL_CODE => format!(
+            "operator approval required before running `{tool_name}` under `{}` product mode",
+            snapshot.profile.as_str()
+        ),
+        TOPOLOGY_MUTATION_DISALLOWED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: topology expansion is disabled in `{}`",
+            snapshot.profile.as_str()
+        ),
+        TOPOLOGY_MUTATION_BUDGET_EXCEEDED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: topology mutation budget exceeded for `{}`",
+            snapshot.profile.as_str()
+        ),
+        POLICY_MUTATION_APPROVAL_CODE => format!(
+            "operator approval required before running `{tool_name}` under `{}` product mode",
+            snapshot.profile.as_str()
+        ),
+        POLICY_MUTATION_DISALLOWED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: policy mutation is disabled in `{}`",
+            snapshot.profile.as_str()
+        ),
+        POLICY_MUTATION_BUDGET_EXCEEDED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: topology mutation budget exceeded for `{}`",
+            snapshot.profile.as_str()
+        ),
+        SESSION_MUTATION_APPROVAL_CODE => format!(
+            "operator approval required before running `{tool_name}` under `{}` product mode",
+            snapshot.profile.as_str()
+        ),
+        SESSION_MUTATION_DISALLOWED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: session mutation is disabled in `{}`",
+            snapshot.profile.as_str()
+        ),
+        SESSION_MUTATION_BUDGET_EXCEEDED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: topology mutation budget exceeded for `{}`",
             snapshot.profile.as_str()
         ),
         BINDING_MISSING_CODE => format!(
@@ -256,7 +340,7 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn autonomy_policy_decision_requires_approval_for_guided_capability_install() {
+    fn autonomy_policy_decision_requires_kernel_binding_before_guided_capability_install() {
         let snapshot = AutonomyPolicySnapshot::from_profile(AutonomyProfile::GuidedAcquisition);
         let budget = AutonomyTurnBudgetState::default();
         let input = PolicyDecisionInput {
@@ -278,11 +362,45 @@ mod tests {
     }
 
     #[test]
+    fn autonomy_policy_decision_routes_topology_expand_through_mutation_mode() {
+        let snapshot = AutonomyPolicySnapshot {
+            profile: AutonomyProfile::GuidedAcquisition,
+            capability_acquisition_mode: AutonomyOperationMode::Deny,
+            provider_switch_mode: AutonomyOperationMode::Deny,
+            topology_mutation_mode: AutonomyOperationMode::ApprovalRequired,
+            requires_kernel_binding: false,
+            budget: crate::tools::runtime_config::AutonomyBudgetPolicy {
+                max_capability_acquisitions_per_turn: 0,
+                max_provider_switches_per_turn: 0,
+                max_topology_mutations_per_turn: 1,
+            },
+        };
+        let budget = AutonomyTurnBudgetState::default();
+        let input = PolicyDecisionInput {
+            snapshot: &snapshot,
+            action_class: CapabilityActionClass::TopologyExpand,
+            binding: ConversationRuntimeBinding::direct(),
+            budget: &budget,
+        };
+
+        let decision = evaluate_policy(input);
+
+        assert_eq!(
+            decision,
+            PolicyDecision::ApprovalRequired {
+                rule_id: "autonomy_policy_topology_mutation_requires_approval",
+                reason_code: TOPOLOGY_MUTATION_APPROVAL_CODE,
+            }
+        );
+    }
+
+    #[test]
     fn autonomy_policy_decision_enforces_capability_budget() {
         let snapshot = AutonomyPolicySnapshot::from_profile(AutonomyProfile::BoundedAutonomous);
         let budget = AutonomyTurnBudgetState {
             capability_acquisitions_used: 2,
             provider_switches_used: 0,
+            topology_mutations_used: 0,
         };
         let input = PolicyDecisionInput {
             snapshot: &snapshot,
@@ -298,6 +416,43 @@ mod tests {
             PolicyDecision::Deny {
                 rule_id: "autonomy_policy_budget_guard",
                 reason_code: CAPABILITY_ACQUISITION_BUDGET_EXCEEDED_CODE,
+            }
+        );
+    }
+
+    #[test]
+    fn autonomy_policy_decision_enforces_mutation_budget_for_session_mutation() {
+        let snapshot = AutonomyPolicySnapshot {
+            profile: AutonomyProfile::BoundedAutonomous,
+            capability_acquisition_mode: AutonomyOperationMode::Deny,
+            provider_switch_mode: AutonomyOperationMode::Deny,
+            topology_mutation_mode: AutonomyOperationMode::Allow,
+            requires_kernel_binding: false,
+            budget: crate::tools::runtime_config::AutonomyBudgetPolicy {
+                max_capability_acquisitions_per_turn: 0,
+                max_provider_switches_per_turn: 0,
+                max_topology_mutations_per_turn: 1,
+            },
+        };
+        let budget = AutonomyTurnBudgetState {
+            capability_acquisitions_used: 0,
+            provider_switches_used: 0,
+            topology_mutations_used: 1,
+        };
+        let input = PolicyDecisionInput {
+            snapshot: &snapshot,
+            action_class: CapabilityActionClass::SessionMutation,
+            binding: ConversationRuntimeBinding::direct(),
+            budget: &budget,
+        };
+
+        let decision = evaluate_policy(input);
+
+        assert_eq!(
+            decision,
+            PolicyDecision::Deny {
+                rule_id: "autonomy_policy_budget_guard",
+                reason_code: SESSION_MUTATION_BUDGET_EXCEEDED_CODE,
             }
         );
     }

--- a/crates/app/src/conversation/autonomy_policy.rs
+++ b/crates/app/src/conversation/autonomy_policy.rs
@@ -1,0 +1,334 @@
+use super::runtime_binding::ConversationRuntimeBinding;
+use crate::tools::CapabilityActionClass;
+use crate::tools::runtime_config::{AutonomyOperationMode, AutonomyPolicySnapshot};
+
+pub const AUTONOMY_POLICY_SOURCE: &str = "autonomy_policy";
+pub const CAPABILITY_ACQUISITION_DISALLOWED_CODE: &str =
+    "autonomy_policy_capability_acquisition_disallowed";
+pub const CAPABILITY_ACQUISITION_APPROVAL_CODE: &str =
+    "autonomy_policy_capability_acquisition_requires_approval";
+pub const CAPABILITY_ACQUISITION_BUDGET_EXCEEDED_CODE: &str =
+    "autonomy_policy_capability_acquisition_budget_exceeded";
+pub const PROVIDER_SWITCH_APPROVAL_CODE: &str = "autonomy_policy_provider_switch_requires_approval";
+pub const PROVIDER_SWITCH_BUDGET_EXCEEDED_CODE: &str =
+    "autonomy_policy_provider_switch_budget_exceeded";
+pub const BINDING_MISSING_CODE: &str = "autonomy_policy_binding_missing";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AutonomyTurnBudgetState {
+    pub capability_acquisitions_used: usize,
+    pub provider_switches_used: usize,
+}
+
+impl AutonomyTurnBudgetState {
+    pub fn record_action(&mut self, action_class: CapabilityActionClass) {
+        match action_class {
+            CapabilityActionClass::CapabilityFetch
+            | CapabilityActionClass::CapabilityInstall
+            | CapabilityActionClass::CapabilityLoad => {
+                self.capability_acquisitions_used =
+                    self.capability_acquisitions_used.saturating_add(1);
+            }
+            CapabilityActionClass::RuntimeSwitch => {
+                self.provider_switches_used = self.provider_switches_used.saturating_add(1);
+            }
+            CapabilityActionClass::Discover
+            | CapabilityActionClass::ExecuteExisting
+            | CapabilityActionClass::TopologyExpand
+            | CapabilityActionClass::PolicyMutation
+            | CapabilityActionClass::SessionMutation => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyDecision {
+    Allow,
+    ApprovalRequired {
+        rule_id: &'static str,
+        reason_code: &'static str,
+    },
+    Deny {
+        rule_id: &'static str,
+        reason_code: &'static str,
+    },
+}
+
+#[derive(Clone, Copy)]
+pub struct PolicyDecisionInput<'a> {
+    pub snapshot: &'a AutonomyPolicySnapshot,
+    pub action_class: CapabilityActionClass,
+    pub binding: ConversationRuntimeBinding<'a>,
+    pub budget: &'a AutonomyTurnBudgetState,
+}
+
+pub fn evaluate_policy(input: PolicyDecisionInput<'_>) -> PolicyDecision {
+    let Some(base_mode) = action_mode(input.snapshot, input.action_class) else {
+        return PolicyDecision::Allow;
+    };
+    if base_mode == AutonomyOperationMode::Deny {
+        return PolicyDecision::Deny {
+            rule_id: deny_rule_id(input.action_class),
+            reason_code: deny_reason_code(input.action_class),
+        };
+    }
+
+    if input.snapshot.requires_kernel_binding && !input.binding.is_kernel_bound() {
+        return PolicyDecision::Deny {
+            rule_id: "autonomy_policy_requires_kernel_binding",
+            reason_code: BINDING_MISSING_CODE,
+        };
+    }
+
+    if let Some(deny_reason_code) = budget_deny_reason(input) {
+        return PolicyDecision::Deny {
+            rule_id: "autonomy_policy_budget_guard",
+            reason_code: deny_reason_code,
+        };
+    }
+
+    match base_mode {
+        AutonomyOperationMode::Allow => PolicyDecision::Allow,
+        AutonomyOperationMode::ApprovalRequired => PolicyDecision::ApprovalRequired {
+            rule_id: approval_rule_id(input.action_class),
+            reason_code: approval_reason_code(input.action_class),
+        },
+        AutonomyOperationMode::Deny => PolicyDecision::Deny {
+            rule_id: deny_rule_id(input.action_class),
+            reason_code: deny_reason_code(input.action_class),
+        },
+    }
+}
+
+pub fn action_mode(
+    snapshot: &AutonomyPolicySnapshot,
+    action_class: CapabilityActionClass,
+) -> Option<AutonomyOperationMode> {
+    match action_class {
+        CapabilityActionClass::CapabilityFetch
+        | CapabilityActionClass::CapabilityInstall
+        | CapabilityActionClass::CapabilityLoad => Some(snapshot.capability_acquisition_mode),
+        CapabilityActionClass::RuntimeSwitch => Some(snapshot.provider_switch_mode),
+        CapabilityActionClass::Discover
+        | CapabilityActionClass::ExecuteExisting
+        | CapabilityActionClass::TopologyExpand
+        | CapabilityActionClass::PolicyMutation
+        | CapabilityActionClass::SessionMutation => None,
+    }
+}
+
+fn budget_deny_reason(input: PolicyDecisionInput<'_>) -> Option<&'static str> {
+    match input.action_class {
+        CapabilityActionClass::CapabilityFetch
+        | CapabilityActionClass::CapabilityInstall
+        | CapabilityActionClass::CapabilityLoad => {
+            let used = input.budget.capability_acquisitions_used;
+            let limit = input.snapshot.budget.max_capability_acquisitions_per_turn;
+            would_exceed_budget(used, limit).then_some(CAPABILITY_ACQUISITION_BUDGET_EXCEEDED_CODE)
+        }
+        CapabilityActionClass::RuntimeSwitch => {
+            let used = input.budget.provider_switches_used;
+            let limit = input.snapshot.budget.max_provider_switches_per_turn;
+            would_exceed_budget(used, limit).then_some(PROVIDER_SWITCH_BUDGET_EXCEEDED_CODE)
+        }
+        CapabilityActionClass::Discover
+        | CapabilityActionClass::ExecuteExisting
+        | CapabilityActionClass::TopologyExpand
+        | CapabilityActionClass::PolicyMutation
+        | CapabilityActionClass::SessionMutation => None,
+    }
+}
+
+fn would_exceed_budget(used: usize, limit: usize) -> bool {
+    used.saturating_add(1) > limit
+}
+
+fn approval_rule_id(action_class: CapabilityActionClass) -> &'static str {
+    match action_class {
+        CapabilityActionClass::CapabilityFetch
+        | CapabilityActionClass::CapabilityInstall
+        | CapabilityActionClass::CapabilityLoad => {
+            "autonomy_policy_capability_acquisition_requires_approval"
+        }
+        CapabilityActionClass::RuntimeSwitch => "autonomy_policy_provider_switch_requires_approval",
+        CapabilityActionClass::Discover
+        | CapabilityActionClass::ExecuteExisting
+        | CapabilityActionClass::TopologyExpand
+        | CapabilityActionClass::PolicyMutation
+        | CapabilityActionClass::SessionMutation => "autonomy_policy_not_applicable",
+    }
+}
+
+fn approval_reason_code(action_class: CapabilityActionClass) -> &'static str {
+    match action_class {
+        CapabilityActionClass::CapabilityFetch
+        | CapabilityActionClass::CapabilityInstall
+        | CapabilityActionClass::CapabilityLoad => CAPABILITY_ACQUISITION_APPROVAL_CODE,
+        CapabilityActionClass::RuntimeSwitch => PROVIDER_SWITCH_APPROVAL_CODE,
+        CapabilityActionClass::Discover
+        | CapabilityActionClass::ExecuteExisting
+        | CapabilityActionClass::TopologyExpand
+        | CapabilityActionClass::PolicyMutation
+        | CapabilityActionClass::SessionMutation => "autonomy_policy_not_applicable",
+    }
+}
+
+fn deny_rule_id(action_class: CapabilityActionClass) -> &'static str {
+    match action_class {
+        CapabilityActionClass::CapabilityFetch
+        | CapabilityActionClass::CapabilityInstall
+        | CapabilityActionClass::CapabilityLoad => {
+            "autonomy_policy_capability_acquisition_disallowed"
+        }
+        CapabilityActionClass::RuntimeSwitch => "autonomy_policy_provider_switch_disallowed",
+        CapabilityActionClass::Discover
+        | CapabilityActionClass::ExecuteExisting
+        | CapabilityActionClass::TopologyExpand
+        | CapabilityActionClass::PolicyMutation
+        | CapabilityActionClass::SessionMutation => "autonomy_policy_not_applicable",
+    }
+}
+
+fn deny_reason_code(action_class: CapabilityActionClass) -> &'static str {
+    match action_class {
+        CapabilityActionClass::CapabilityFetch
+        | CapabilityActionClass::CapabilityInstall
+        | CapabilityActionClass::CapabilityLoad => CAPABILITY_ACQUISITION_DISALLOWED_CODE,
+        CapabilityActionClass::RuntimeSwitch => "autonomy_policy_provider_switch_disallowed",
+        CapabilityActionClass::Discover
+        | CapabilityActionClass::ExecuteExisting
+        | CapabilityActionClass::TopologyExpand
+        | CapabilityActionClass::PolicyMutation
+        | CapabilityActionClass::SessionMutation => "autonomy_policy_not_applicable",
+    }
+}
+
+pub fn render_reason(
+    snapshot: &AutonomyPolicySnapshot,
+    action_class: CapabilityActionClass,
+    tool_name: &str,
+    reason_code: &str,
+) -> String {
+    match reason_code {
+        CAPABILITY_ACQUISITION_DISALLOWED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: capability acquisition is disabled in `{}`",
+            snapshot.profile.as_str()
+        ),
+        CAPABILITY_ACQUISITION_APPROVAL_CODE => format!(
+            "operator approval required before running `{tool_name}` under `{}` product mode",
+            snapshot.profile.as_str()
+        ),
+        CAPABILITY_ACQUISITION_BUDGET_EXCEEDED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: capability acquisition budget exceeded for `{}`",
+            snapshot.profile.as_str()
+        ),
+        PROVIDER_SWITCH_APPROVAL_CODE => format!(
+            "operator approval required before running `{tool_name}` under `{}` product mode",
+            snapshot.profile.as_str()
+        ),
+        PROVIDER_SWITCH_BUDGET_EXCEEDED_CODE => format!(
+            "autonomy policy denied `{tool_name}`: provider switch budget exceeded for `{}`",
+            snapshot.profile.as_str()
+        ),
+        BINDING_MISSING_CODE => format!(
+            "autonomy policy denied `{tool_name}`: `{}` requires kernel-bound execution for {:?}",
+            snapshot.profile.as_str(),
+            action_class
+        ),
+        _ => format!(
+            "autonomy policy denied `{tool_name}` with reason `{reason_code}` under `{}`",
+            snapshot.profile.as_str()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::KernelContext;
+    use crate::config::AutonomyProfile;
+    use crate::tools::runtime_config::AutonomyPolicySnapshot;
+    use loongclaw_contracts::{Capability, ExecutionRoute, HarnessKind};
+    use loongclaw_kernel::{
+        FixedClock, InMemoryAuditSink, LoongClawKernel, StaticPolicyEngine, VerticalPackManifest,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::Arc;
+
+    #[test]
+    fn autonomy_policy_decision_requires_approval_for_guided_capability_install() {
+        let snapshot = AutonomyPolicySnapshot::from_profile(AutonomyProfile::GuidedAcquisition);
+        let budget = AutonomyTurnBudgetState::default();
+        let input = PolicyDecisionInput {
+            snapshot: &snapshot,
+            action_class: CapabilityActionClass::CapabilityInstall,
+            binding: ConversationRuntimeBinding::direct(),
+            budget: &budget,
+        };
+
+        let decision = evaluate_policy(input);
+
+        assert_eq!(
+            decision,
+            PolicyDecision::Deny {
+                rule_id: "autonomy_policy_requires_kernel_binding",
+                reason_code: BINDING_MISSING_CODE,
+            }
+        );
+    }
+
+    #[test]
+    fn autonomy_policy_decision_enforces_capability_budget() {
+        let snapshot = AutonomyPolicySnapshot::from_profile(AutonomyProfile::BoundedAutonomous);
+        let budget = AutonomyTurnBudgetState {
+            capability_acquisitions_used: 2,
+            provider_switches_used: 0,
+        };
+        let input = PolicyDecisionInput {
+            snapshot: &snapshot,
+            action_class: CapabilityActionClass::CapabilityInstall,
+            binding: ConversationRuntimeBinding::kernel(kernel_context_placeholder()),
+            budget: &budget,
+        };
+
+        let decision = evaluate_policy(input);
+
+        assert_eq!(
+            decision,
+            PolicyDecision::Deny {
+                rule_id: "autonomy_policy_budget_guard",
+                reason_code: CAPABILITY_ACQUISITION_BUDGET_EXCEEDED_CODE,
+            }
+        );
+    }
+
+    fn kernel_context_placeholder() -> &'static KernelContext {
+        static HOLDER: std::sync::OnceLock<KernelContext> = std::sync::OnceLock::new();
+        HOLDER.get_or_init(|| {
+            let audit = Arc::new(InMemoryAuditSink::default());
+            let clock = Arc::new(FixedClock::new(1_700_000_000));
+            let mut kernel =
+                LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+            let pack = VerticalPackManifest {
+                pack_id: "autonomy-policy-test-pack".to_owned(),
+                domain: "testing".to_owned(),
+                version: "0.1.0".to_owned(),
+                default_route: ExecutionRoute {
+                    harness_kind: HarnessKind::EmbeddedPi,
+                    adapter: None,
+                },
+                allowed_connectors: BTreeSet::new(),
+                granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+                metadata: BTreeMap::new(),
+            };
+            kernel.register_pack(pack).expect("register pack");
+            let token = kernel
+                .issue_token("autonomy-policy-test-pack", "autonomy-policy-agent", 60)
+                .expect("issue token");
+            KernelContext {
+                kernel: Arc::new(kernel),
+                token,
+            }
+        })
+    }
+}

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics;
+mod autonomy_policy;
 mod compaction;
 mod context_engine;
 mod context_engine_registry;

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1482,6 +1482,20 @@ fn test_config() -> LoongClawConfig {
     }
 }
 
+fn enable_guided_autonomy(config: &mut LoongClawConfig) {
+    config.tools.autonomy_profile = AutonomyProfile::GuidedAcquisition;
+}
+
+fn preapprove_tool_call(config: &mut LoongClawConfig, tool_name: &str) {
+    let approval_key = format!("tool:{tool_name}");
+    let approved_calls = &mut config.tools.approval.approved_calls;
+    let is_already_approved = approved_calls.iter().any(|entry| entry == &approval_key);
+    if is_already_approved {
+        return;
+    }
+    approved_calls.push(approval_key);
+}
+
 fn test_kernel_context(agent_id: &str) -> KernelContext {
     crate::context::bootstrap_test_kernel_context(agent_id, 60)
         .expect("bootstrap test kernel context")
@@ -10703,7 +10717,7 @@ async fn sessions_send_rejects_unknown_target_session() {
     })
     .expect("create controller root");
 
-    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let session_context = SessionContext::root_with_tool_view(
         "controller-root",
         crate::tools::runtime_tool_view_for_config(&config.tools),
@@ -10757,7 +10771,7 @@ async fn sessions_send_rejects_delegate_child_target() {
     })
     .expect("create child target");
 
-    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let session_context = SessionContext::root_with_tool_view(
         "controller-root",
         crate::tools::runtime_tool_view_for_config(&config.tools),
@@ -11177,7 +11191,7 @@ async fn autonomy_policy_turn_engine_discovery_only_denies_capability_install() 
     config.tools.autonomy_profile = AutonomyProfile::DiscoveryOnly;
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-discovery-install-denied",
         60,
@@ -11261,7 +11275,7 @@ async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_ca
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
-    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-guided-install-approval",
         60,
@@ -11371,7 +11385,7 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_allows_capability_instal
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
-    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-bounded-install-allow",
         60,
@@ -11488,7 +11502,7 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_pr
 
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config).expect("session repository");
-    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
     let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
         "autonomy-bounded-provider-switch-approval",
         60,
@@ -11562,6 +11576,242 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_pr
     assert_eq!(
         governance_snapshot["reason_code"],
         "autonomy_policy_provider_switch_requires_approval"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_discovery_only_denies_topology_expand() {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-discovery-delegate-denied");
+    config.tools.autonomy_profile = AutonomyProfile::DiscoveryOnly;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-discovery-delegate-denied",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+    let session_id = "session-autonomy-discovery-delegate";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+    let tool_intent = provider_tool_intent(
+        "delegate",
+        json!({
+            "task": "spawn a child session"
+        }),
+        session_id,
+        "turn-autonomy-discovery-delegate",
+        "call-autonomy-discovery-delegate",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![tool_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(failure.code, "autonomy_policy_topology_mutation_disallowed");
+            assert!(
+                failure.reason.contains("topology expansion is disabled"),
+                "unexpected denial reason: {failure:?}"
+            );
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolDenied, got {other:?}");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_policy_mutation() {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-guided-policy-mutation-denied");
+    config.tools.autonomy_profile = AutonomyProfile::GuidedAcquisition;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-guided-policy-mutation-denied",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+    let session_id = "session-autonomy-guided-policy-mutation";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+    let tool_intent = provider_tool_intent(
+        "external_skills.policy",
+        json!({
+            "action": "get"
+        }),
+        session_id,
+        "turn-autonomy-guided-policy-mutation",
+        "call-autonomy-guided-policy-mutation",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![tool_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    let approval_request_id = match result {
+        TurnResult::NeedsApproval(requirement) => {
+            assert_eq!(
+                requirement.tool_name.as_deref(),
+                Some("external_skills.policy")
+            );
+            assert_eq!(
+                requirement.approval_key.as_deref(),
+                Some("tool:external_skills.policy")
+            );
+            requirement
+                .approval_request_id
+                .expect("approval request id should be persisted")
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected NeedsApproval, got {other:?}");
+        }
+    };
+
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let stored_request = repo
+        .load_approval_request(&approval_request_id)
+        .expect("load approval request")
+        .expect("approval request should exist");
+    let governance_snapshot = stored_request.governance_snapshot_json;
+    assert_eq!(stored_request.tool_name, "external_skills.policy");
+    assert_eq!(stored_request.approval_key, "tool:external_skills.policy");
+    assert_eq!(governance_snapshot["policy_source"], "autonomy_policy");
+    assert_eq!(
+        governance_snapshot["capability_action_class"],
+        "policy_mutation"
+    );
+    assert_eq!(
+        governance_snapshot["rule_id"],
+        "autonomy_policy_policy_mutation_requires_approval"
+    );
+    assert_eq!(
+        governance_snapshot["reason_code"],
+        "autonomy_policy_policy_mutation_requires_approval"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_session_mutation() {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let mut config = test_config();
+    config.memory.sqlite_path =
+        unique_memory_sqlite_path("autonomy-bounded-session-mutation-denied");
+    config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+    config.tools.sessions.allow_mutation = true;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-bounded-session-mutation-denied",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+    let session_id = "session-autonomy-bounded-session-mutation";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+    let tool_intent = provider_tool_intent(
+        "session_archive",
+        json!({
+            "session_id": "child-session",
+            "dry_run": true
+        }),
+        session_id,
+        "turn-autonomy-bounded-session-mutation",
+        "call-autonomy-bounded-session-mutation",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![tool_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    let approval_request_id = match result {
+        TurnResult::NeedsApproval(requirement) => {
+            assert_eq!(requirement.tool_name.as_deref(), Some("session_archive"));
+            assert_eq!(
+                requirement.approval_key.as_deref(),
+                Some("tool:session_archive")
+            );
+            requirement
+                .approval_request_id
+                .expect("approval request id should be persisted")
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected NeedsApproval, got {other:?}");
+        }
+    };
+
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let stored_request = repo
+        .load_approval_request(&approval_request_id)
+        .expect("load approval request")
+        .expect("approval request should exist");
+    let governance_snapshot = stored_request.governance_snapshot_json;
+    assert_eq!(stored_request.tool_name, "session_archive");
+    assert_eq!(stored_request.approval_key, "tool:session_archive");
+    assert_eq!(governance_snapshot["policy_source"], "autonomy_policy");
+    assert_eq!(
+        governance_snapshot["capability_action_class"],
+        "session_mutation"
+    );
+    assert_eq!(
+        governance_snapshot["rule_id"],
+        "autonomy_policy_session_mutation_requires_approval"
+    );
+    assert_eq!(
+        governance_snapshot["reason_code"],
+        "autonomy_policy_session_mutation_requires_approval"
     );
 }
 
@@ -15739,6 +15989,7 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
@@ -15779,6 +16030,7 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
     )
     .with_durable_memory_config(memory_config.clone());
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-approval-normal-lane");
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -15787,7 +16039,7 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
             "delegate this task",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("approval reply");
@@ -15838,6 +16090,8 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -15877,6 +16131,7 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
     )
     .with_durable_memory_config(memory_config.clone());
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-normal-lane");
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -15885,7 +16140,7 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("delegate handle turn success");
@@ -15972,6 +16227,8 @@ async fn handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -16075,6 +16332,8 @@ async fn handle_turn_with_runtime_delegate_rejects_spawn_when_prepare_subagent_s
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -16155,6 +16414,8 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -16400,6 +16661,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
     config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
@@ -16469,6 +16731,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
     )
     .with_durable_memory_config(memory_config.clone());
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-approval-resolve-approve-always");
 
     let approval_reply = coordinator
         .handle_turn_with_runtime(
@@ -16477,7 +16740,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &approval_runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("approval resolve reply");
@@ -16539,7 +16802,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &granted_runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("granted delegate reply");
@@ -16868,6 +17131,8 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -16914,6 +17179,7 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
     .with_durable_memory_config(memory_config.clone());
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-queue-failure");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -16921,7 +17187,7 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("delegate_async queue failure reply");
@@ -16957,6 +17223,8 @@ async fn handle_turn_with_runtime_delegate_async_rejects_when_active_child_limit
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     config.tools.delegate.max_active_children = 1;
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
@@ -17001,6 +17269,7 @@ async fn handle_turn_with_runtime_delegate_async_rejects_when_active_child_limit
     .with_durable_memory_config(memory_config.clone());
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-active-child-limit");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -17008,7 +17277,7 @@ async fn handle_turn_with_runtime_delegate_async_rejects_when_active_child_limit
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("delegate_async reply");
@@ -17048,6 +17317,8 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -17084,6 +17355,7 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     .with_durable_memory_config(memory_config.clone());
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-queued");
     let queued_call = tokio::spawn(async move {
         coordinator
             .handle_turn_with_runtime(
@@ -17092,7 +17364,7 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
                 "show raw json tool output",
                 ProviderErrorMode::Propagate,
                 &runtime,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
             )
             .await
     });
@@ -17145,8 +17417,8 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     assert_eq!(spawn_request.label.as_deref(), Some("async-child"));
     assert_eq!(spawn_request.timeout_seconds, 9);
     assert!(
-        spawn_request.kernel_context.is_none(),
-        "direct parent turns should keep async delegate children in direct mode"
+        spawn_request.kernel_context.is_some(),
+        "product-mode async delegate execution should preserve kernel binding"
     );
     assert_eq!(child.state, crate::session::repository::SessionState::Ready);
     assert_eq!(child.label.as_deref(), Some("async-child"));
@@ -17185,6 +17457,8 @@ async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spa
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -17283,6 +17557,8 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -17320,6 +17596,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
     .with_durable_memory_config(memory_config.clone());
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-failed");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -17327,7 +17604,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("delegate_async reply");
@@ -17398,6 +17675,8 @@ async fn handle_turn_with_runtime_kernel_delegate_async_spawn_failure_closes_lif
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -17503,6 +17782,8 @@ async fn handle_turn_with_runtime_delegate_async_spawn_panic_is_observable_after
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -17537,6 +17818,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_panic_is_observable_after
     .with_durable_memory_config(memory_config.clone());
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-panic");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -17544,7 +17826,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_panic_is_observable_after
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("delegate_async reply");
@@ -17615,6 +17897,8 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -17663,6 +17947,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
     .with_durable_memory_config(memory_config.clone());
 
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-persist-recovery");
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
@@ -17670,7 +17955,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("delegate_async reply");
@@ -17748,6 +18033,8 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -17795,6 +18082,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
     )
     .with_durable_memory_config(memory_config.clone());
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-nested-denied");
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -17803,7 +18091,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("nested delegate denial reply");
@@ -17829,6 +18117,8 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
         .expect("session repository");
@@ -17888,6 +18178,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
         "install local async delegate runtime"
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-nested-denied");
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -17896,7 +18187,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             runtime.as_ref(),
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("nested delegate_async denial reply");
@@ -17976,6 +18267,8 @@ async fn handle_turn_with_runtime_delegate_child_can_reenter_when_max_depth_allo
 
     let mut config = test_config();
     config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate");
     config.tools.delegate.max_depth = 2;
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = crate::session::repository::SessionRepository::new(&memory_config)
@@ -18030,6 +18323,7 @@ async fn handle_turn_with_runtime_delegate_child_can_reenter_when_max_depth_allo
     )
     .with_durable_memory_config(memory_config.clone());
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-delegate-nested-allowed");
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -18038,7 +18332,7 @@ async fn handle_turn_with_runtime_delegate_child_can_reenter_when_max_depth_allo
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("nested delegate success");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -11454,6 +11454,124 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_allows_capability_instal
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_bounded_autonomous_enforces_capability_budget() {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let workspace_root_name =
+        unique_acp_test_id("conversation-autonomy-policy", "bounded-install-budget");
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+
+    let skill_one_path = "source/demo-skill-1";
+    let skill_two_path = "source/demo-skill-2";
+    let skill_three_path = "source/demo-skill-3";
+
+    write_test_external_skill(&workspace_root, skill_one_path);
+    write_test_external_skill(&workspace_root, skill_two_path);
+    write_test_external_skill(&workspace_root, skill_three_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-bounded-install-budget");
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.external_skills.enabled = true;
+    config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-bounded-install-budget",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+    let session_id = "session-autonomy-bounded-install-budget";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+
+    let first_intent = provider_tool_intent(
+        "external_skills.install",
+        json!({
+            "path": skill_one_path
+        }),
+        session_id,
+        "turn-autonomy-bounded-install-budget",
+        "call-autonomy-bounded-install-budget-1",
+    );
+    let second_intent = provider_tool_intent(
+        "external_skills.install",
+        json!({
+            "path": skill_two_path
+        }),
+        session_id,
+        "turn-autonomy-bounded-install-budget",
+        "call-autonomy-bounded-install-budget-2",
+    );
+    let third_intent = provider_tool_intent(
+        "external_skills.install",
+        json!({
+            "path": skill_three_path
+        }),
+        session_id,
+        "turn-autonomy-bounded-install-budget",
+        "call-autonomy-bounded-install-budget-3",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![first_intent, second_intent, third_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(
+                failure.code,
+                "autonomy_policy_capability_acquisition_budget_exceeded"
+            );
+            assert!(
+                failure
+                    .reason
+                    .contains("capability acquisition budget exceeded"),
+                "unexpected denial reason: {failure:?}"
+            );
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolDenied, got {other:?}");
+        }
+    }
+
+    let installed_skill_root = workspace_root.join("external-skills-installed");
+    let installed_one = installed_skill_root.join("demo-skill-1").join("SKILL.md");
+    let installed_two = installed_skill_root.join("demo-skill-2").join("SKILL.md");
+    let installed_three = installed_skill_root.join("demo-skill-3").join("SKILL.md");
+
+    assert!(
+        !installed_one.exists(),
+        "budget denial should abort execution before the first install runs"
+    );
+    assert!(
+        !installed_two.exists(),
+        "budget denial should abort execution before the second install runs"
+    );
+    assert!(
+        !installed_three.exists(),
+        "budget denial should abort execution before the third install runs"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
 async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_provider_switch() {
     use crate::conversation::turn_engine::{
         DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
@@ -11558,8 +11676,16 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_pr
         .expect("load approval request")
         .expect("approval request should exist");
     let governance_snapshot = stored_request.governance_snapshot_json;
+    let (_, reloaded_config) =
+        crate::config::load(Some(config_path.to_str().expect("utf8 config path")))
+            .expect("reload provider switch config");
     assert_eq!(stored_request.tool_name, "provider.switch");
     assert_eq!(stored_request.approval_key, "tool:provider.switch");
+    assert_eq!(
+        reloaded_config.active_provider_id(),
+        Some("openai-gpt-5"),
+        "provider should remain unchanged before approval is granted"
+    );
     assert_eq!(governance_snapshot["policy_source"], "autonomy_policy");
     assert_eq!(
         governance_snapshot["autonomy_profile"],
@@ -11663,7 +11789,10 @@ async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_po
     let tool_intent = provider_tool_intent(
         "external_skills.policy",
         json!({
-            "action": "get"
+            "action": "set",
+            "policy_update_approved": true,
+            "enabled": true,
+            "allowed_domains": ["skills.sh"]
         }),
         session_id,
         "turn-autonomy-guided-policy-mutation",
@@ -11753,8 +11882,7 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_se
     let tool_intent = provider_tool_intent(
         "session_archive",
         json!({
-            "session_id": "child-session",
-            "dry_run": true
+            "session_id": "child-session"
         }),
         session_id,
         "turn-autonomy-bounded-session-mutation",

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -15,7 +15,9 @@ use rusqlite::Connection;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
-use super::super::config::{LoongClawConfig, MemoryProfile, MemorySystemKind, ProviderConfig};
+use super::super::config::{
+    AutonomyProfile, LoongClawConfig, MemoryProfile, MemorySystemKind, ProviderConfig,
+};
 use super::persistence::format_provider_error_reply;
 use super::runtime::DefaultConversationRuntime;
 use super::*;
@@ -37,8 +39,8 @@ use crate::memory::{
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    NewSessionEvent, NewSessionRecord, NewSessionToolPolicyRecord, SessionKind, SessionRepository,
-    SessionState,
+    NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord, NewSessionToolPolicyRecord,
+    SessionKind, SessionRepository, SessionState,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -1783,6 +1785,28 @@ fn effective_tool_request(request: &ToolCoreRequest) -> (String, &Value) {
     let arguments = request.payload.get("arguments").unwrap_or(&request.payload);
     (invoked_tool, arguments)
 }
+
+fn autonomy_runtime_session_context(
+    session_id: impl Into<String>,
+    config: &LoongClawConfig,
+) -> SessionContext {
+    let tool_view = crate::tools::runtime_tool_view_from_loongclaw_config(config);
+    SessionContext::root_with_tool_view(session_id, tool_view)
+}
+
+fn write_test_external_skill(
+    workspace_root: &std::path::Path,
+    relative_skill_root: &str,
+) -> std::path::PathBuf {
+    let skill_root = workspace_root.join(relative_skill_root);
+    std::fs::create_dir_all(&skill_root).expect("create external skill root");
+    let skill_body =
+        "# Demo Skill\n\nUse this skill when the task needs product-mode runtime discipline.\n";
+    let skill_path = skill_root.join("SKILL.md");
+    std::fs::write(&skill_path, skill_body).expect("write external skill");
+    skill_root
+}
+
 #[tokio::test]
 async fn default_runtime_supports_injected_context_engine() {
     let runtime = DefaultConversationRuntime::with_context_engine(StubContextEngine);
@@ -6690,6 +6714,7 @@ async fn handle_turn_with_runtime_tool_search_followup_checkpoint_uses_visible_c
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
 async fn handle_turn_with_runtime_provider_switch_tool_updates_provider_for_followup_round() {
     use crate::test_support::TurnTestHarness;
 
@@ -6717,6 +6742,25 @@ async fn handle_turn_with_runtime_provider_switch_tool_updates_provider_for_foll
     );
     config.provider = openai;
     config.active_provider = Some("openai-gpt-5".to_owned());
+    config.memory.sqlite_path = unique_acp_sqlite_path("provider-switch-followup-round");
+    config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    repo.create_session(NewSessionRecord {
+        session_id: "session-provider-switch".to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Provider Switch".to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create provider switch root session");
+    repo.upsert_approval_grant(NewApprovalGrantRecord {
+        scope_session_id: "session-provider-switch".to_owned(),
+        approval_key: "tool:provider.switch".to_owned(),
+        created_by_session_id: Some("session-provider-switch".to_owned()),
+    })
+    .expect("seed provider switch approval grant");
 
     std::fs::write(
         &config_path,
@@ -11113,6 +11157,415 @@ async fn turn_engine_truncates_oversized_tool_payload_summary() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_discovery_only_denies_capability_install() {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let workspace_root_name =
+        unique_acp_test_id("conversation-autonomy-policy", "discovery-install-denied");
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let _skill_root = write_test_external_skill(&workspace_root, "source/demo-skill");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-discovery-install-denied");
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.external_skills.enabled = true;
+    config.tools.autonomy_profile = AutonomyProfile::DiscoveryOnly;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-discovery-install-denied",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+    let session_id = "session-autonomy-discovery-install";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+    let tool_intent = provider_tool_intent(
+        "external_skills.install",
+        json!({
+            "path": "source/demo-skill"
+        }),
+        session_id,
+        "turn-autonomy-discovery-install",
+        "call-autonomy-discovery-install",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![tool_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(
+                failure.code,
+                "autonomy_policy_capability_acquisition_disallowed"
+            );
+            assert!(
+                failure
+                    .reason
+                    .contains("capability acquisition is disabled"),
+                "unexpected denial reason: {failure:?}"
+            );
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolDenied, got {other:?}");
+        }
+    }
+
+    let installed_skill_path = workspace_root
+        .join("external-skills-installed")
+        .join("demo-skill")
+        .join("SKILL.md");
+    assert!(
+        !installed_skill_path.exists(),
+        "discovery_only should block installation"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_capability_install() {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let workspace_root_name =
+        unique_acp_test_id("conversation-autonomy-policy", "guided-install-approval");
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let _skill_root = write_test_external_skill(&workspace_root, "source/demo-skill");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-guided-install-approval");
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.external_skills.enabled = true;
+    config.tools.autonomy_profile = AutonomyProfile::GuidedAcquisition;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-guided-install-approval",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+    let session_id = "session-autonomy-guided-install";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+    let tool_intent = provider_tool_intent(
+        "external_skills.install",
+        json!({
+            "path": "source/demo-skill"
+        }),
+        session_id,
+        "turn-autonomy-guided-install",
+        "call-autonomy-guided-install",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![tool_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    let approval_request_id = match result {
+        TurnResult::NeedsApproval(requirement) => {
+            assert_eq!(
+                requirement.tool_name.as_deref(),
+                Some("external_skills.install")
+            );
+            assert_eq!(
+                requirement.approval_key.as_deref(),
+                Some("tool:external_skills.install")
+            );
+            requirement
+                .approval_request_id
+                .expect("approval request id should be persisted")
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected NeedsApproval, got {other:?}");
+        }
+    };
+
+    let stored_request = repo
+        .load_approval_request(&approval_request_id)
+        .expect("load approval request")
+        .expect("approval request should exist");
+    let governance_snapshot = stored_request.governance_snapshot_json;
+    assert_eq!(stored_request.tool_name, "external_skills.install");
+    assert_eq!(stored_request.approval_key, "tool:external_skills.install");
+    assert_eq!(governance_snapshot["policy_source"], "autonomy_policy");
+    assert_eq!(
+        governance_snapshot["autonomy_profile"],
+        "guided_acquisition"
+    );
+    assert_eq!(
+        governance_snapshot["capability_action_class"],
+        "capability_install"
+    );
+    assert_eq!(
+        governance_snapshot["rule_id"],
+        "autonomy_policy_capability_acquisition_requires_approval"
+    );
+    assert_eq!(
+        governance_snapshot["reason_code"],
+        "autonomy_policy_capability_acquisition_requires_approval"
+    );
+
+    let installed_skill_path = workspace_root
+        .join("external-skills-installed")
+        .join("demo-skill")
+        .join("SKILL.md");
+    assert!(
+        !installed_skill_path.exists(),
+        "guided_acquisition should gate installation behind approval"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_bounded_autonomous_allows_capability_install_execution() {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let workspace_root_name =
+        unique_acp_test_id("conversation-autonomy-policy", "bounded-install-allow");
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let _skill_root = write_test_external_skill(&workspace_root, "source/demo-skill");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-bounded-install-allow");
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.external_skills.enabled = true;
+    config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-bounded-install-allow",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+    let session_id = "session-autonomy-bounded-install";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+    let tool_intent = provider_tool_intent(
+        "external_skills.install",
+        json!({
+            "path": "source/demo-skill"
+        }),
+        session_id,
+        "turn-autonomy-bounded-install",
+        "call-autonomy-bounded-install",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![tool_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    match result {
+        TurnResult::FinalText(text)
+        | TurnResult::StreamingText(text)
+        | TurnResult::StreamingDone(text) => {
+            let line = text.lines().next().expect("tool result line should exist");
+            let payload = line
+                .strip_prefix("[ok] ")
+                .expect("tool result line should keep [ok] prefix");
+            let envelope: Value =
+                serde_json::from_str(payload).expect("tool result envelope should be json");
+            assert_eq!(envelope["tool"], "external_skills.install");
+        }
+        other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected successful tool execution, got {other:?}");
+        }
+    }
+
+    let installed_skill_path = workspace_root
+        .join("external-skills-installed")
+        .join("demo-skill")
+        .join("SKILL.md");
+    assert!(
+        installed_skill_path.exists(),
+        "bounded_autonomous should allow installation to complete"
+    );
+
+    let approval_requests = repo
+        .list_approval_requests_for_session(session_id, None)
+        .expect("list approval requests");
+    assert!(
+        approval_requests.is_empty(),
+        "bounded_autonomous install should not persist approval requests"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_provider_switch() {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let workspace_root_name = unique_acp_test_id(
+        "conversation-autonomy-policy",
+        "bounded-provider-switch-approval",
+    );
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+
+    let mut config = test_config();
+    config.memory.sqlite_path =
+        unique_memory_sqlite_path("autonomy-bounded-provider-switch-approval");
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+
+    let mut openai = ProviderConfig::fresh_for_kind(crate::config::ProviderKind::Openai);
+    openai.model = "gpt-5".to_owned();
+    config.set_active_provider_profile(
+        "openai-gpt-5",
+        crate::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: openai.clone(),
+        },
+    );
+    let mut deepseek = ProviderConfig::fresh_for_kind(crate::config::ProviderKind::Deepseek);
+    deepseek.model = "deepseek-chat".to_owned();
+    config.providers.insert(
+        "deepseek-chat".to_owned(),
+        crate::config::ProviderProfileConfig {
+            default_for_kind: true,
+            provider: deepseek.clone(),
+        },
+    );
+    config.provider = openai;
+    config.active_provider = Some("openai-gpt-5".to_owned());
+
+    let config_path = workspace_root.join("loongclaw.toml");
+    let rendered_config = crate::config::render(&config).expect("render config");
+    std::fs::write(&config_path, rendered_config).expect("write config");
+    let canonical_config_path =
+        std::fs::canonicalize(&config_path).expect("canonicalize config path");
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config, config.clone());
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-bounded-provider-switch-approval",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+    let session_id = "session-autonomy-bounded-provider-switch";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+    let tool_intent = provider_tool_intent(
+        "provider.switch",
+        json!({
+            "selector": "deepseek",
+            "config_path": canonical_config_path.display().to_string()
+        }),
+        session_id,
+        "turn-autonomy-bounded-provider-switch",
+        "call-autonomy-bounded-provider-switch",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![tool_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::kernel(&kernel_ctx);
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    let approval_request_id = match result {
+        TurnResult::NeedsApproval(requirement) => {
+            assert_eq!(requirement.tool_name.as_deref(), Some("provider.switch"));
+            assert_eq!(
+                requirement.approval_key.as_deref(),
+                Some("tool:provider.switch")
+            );
+            requirement
+                .approval_request_id
+                .expect("approval request id should be persisted")
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected NeedsApproval, got {other:?}");
+        }
+    };
+
+    let stored_request = repo
+        .load_approval_request(&approval_request_id)
+        .expect("load approval request")
+        .expect("approval request should exist");
+    let governance_snapshot = stored_request.governance_snapshot_json;
+    assert_eq!(stored_request.tool_name, "provider.switch");
+    assert_eq!(stored_request.approval_key, "tool:provider.switch");
+    assert_eq!(governance_snapshot["policy_source"], "autonomy_policy");
+    assert_eq!(
+        governance_snapshot["autonomy_profile"],
+        "bounded_autonomous"
+    );
+    assert_eq!(
+        governance_snapshot["capability_action_class"],
+        "runtime_switch"
+    );
+    assert_eq!(
+        governance_snapshot["rule_id"],
+        "autonomy_policy_provider_switch_requires_approval"
+    );
+    assert_eq!(
+        governance_snapshot["reason_code"],
+        "autonomy_policy_provider_switch_requires_approval"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
     use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnResult};
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
@@ -11173,6 +11626,19 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
         token,
     };
 
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("external-skill-invoke-payload");
+    config.external_skills.enabled = true;
+    config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+    let dispatcher = crate::conversation::turn_engine::DefaultAppToolDispatcher::with_config(
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory),
+        config.clone(),
+    );
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "s1",
+        crate::tools::runtime_tool_view_from_loongclaw_config(&config),
+    );
+
     let engine = TurnEngine::new(5);
     let turn = ProviderTurn {
         assistant_text: "".to_owned(),
@@ -11185,21 +11651,13 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
         )],
         raw_meta: serde_json::Value::Null,
     };
-
-    let tool_view = crate::tools::runtime_tool_view_for_runtime_config(
-        &crate::tools::runtime_config::ToolRuntimeConfig {
-            external_skills: crate::tools::runtime_config::ExternalSkillsRuntimePolicy {
-                enabled: true,
-                ..crate::tools::runtime_config::ExternalSkillsRuntimePolicy::default()
-            },
-            ..crate::tools::runtime_config::ToolRuntimeConfig::default()
-        },
-    );
     let result = engine
-        .execute_turn_in_view(
+        .execute_turn_in_context(
             &turn,
-            &tool_view,
+            &session_context,
+            &dispatcher,
             super::runtime_binding::ConversationRuntimeBinding::kernel(&ctx),
+            None,
         )
         .await;
     match result {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4021,6 +4021,25 @@ impl<R> AppToolDispatcher for CoordinatorAppToolDispatcher<'_, R>
 where
     R: ConversationRuntime + ?Sized,
 {
+    async fn preflight_tool_intent_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
+        budget_state: &super::autonomy_policy::AutonomyTurnBudgetState,
+    ) -> Result<super::turn_engine::ToolPreflightOutcome, String> {
+        self.fallback
+            .preflight_tool_intent_with_binding(
+                session_context,
+                intent,
+                descriptor,
+                binding,
+                budget_state,
+            )
+            .await
+    }
+
     async fn maybe_require_approval(
         &self,
         session_context: &SessionContext,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -732,10 +732,6 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 #[cfg(feature = "memory-sqlite")]
                 {
                     let is_preapproved = self.is_tool_call_preapproved(&approval_key);
-                    if is_preapproved {
-                        return Ok(ToolPreflightOutcome::Allow);
-                    }
-
                     let is_predenied = self.is_tool_call_predenied(&approval_key);
                     if is_predenied {
                         return Err(format!(
@@ -743,28 +739,29 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                         ));
                     }
 
-                    if self.has_approval_grant(session_context, approval_key.as_str())? {
-                        return Ok(ToolPreflightOutcome::Allow);
+                    let has_approval_grant =
+                        self.has_approval_grant(session_context, approval_key.as_str())?;
+                    let autonomy_approval_is_satisfied = is_preapproved || has_approval_grant;
+                    if !autonomy_approval_is_satisfied {
+                        let governance_snapshot_json = json!({
+                            "policy_source": AUTONOMY_POLICY_SOURCE,
+                            "autonomy_profile": policy_snapshot.profile.as_str(),
+                            "capability_action_class": action_class.as_str(),
+                            "rule_id": rule_id,
+                            "reason_code": reason_code,
+                            "reason": reason,
+                        });
+                        let requirement = self.persist_approval_request(
+                            session_context,
+                            intent,
+                            descriptor,
+                            approval_key.as_str(),
+                            reason.as_str(),
+                            rule_id,
+                            governance_snapshot_json,
+                        )?;
+                        return Ok(ToolPreflightOutcome::NeedsApproval(requirement));
                     }
-
-                    let governance_snapshot_json = json!({
-                        "policy_source": AUTONOMY_POLICY_SOURCE,
-                        "autonomy_profile": policy_snapshot.profile.as_str(),
-                        "capability_action_class": action_class.as_str(),
-                        "rule_id": rule_id,
-                        "reason_code": reason_code,
-                        "reason": reason,
-                    });
-                    let requirement = self.persist_approval_request(
-                        session_context,
-                        intent,
-                        descriptor,
-                        approval_key.as_str(),
-                        reason.as_str(),
-                        rule_id,
-                        governance_snapshot_json,
-                    )?;
-                    return Ok(ToolPreflightOutcome::NeedsApproval(requirement));
                 }
             }
             PolicyDecision::Deny {
@@ -3257,6 +3254,132 @@ mod tests {
             .list_approval_requests_for_session("root-session", None)
             .expect("list approval requests");
         assert!(requests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn autonomy_policy_allowlist_does_not_bypass_prompt_session_consent() {
+        let memory_config = isolated_memory_config("autonomy-allowlist-prompt");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig {
+            autonomy_profile: AutonomyProfile::GuidedAcquisition,
+            ..ToolConfig::default()
+        };
+        tool_config.consent.default_mode = ToolConsentMode::Prompt;
+        let approved_calls = &mut tool_config.approval.approved_calls;
+        approved_calls.push("tool:external_skills.policy".to_owned());
+
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = kernel_context("turn-engine-autonomy-allowlist-prompt");
+        let turn = external_skills_policy_get_turn(
+            "root-session",
+            "turn-autonomy-allowlist-prompt",
+            "call-autonomy-allowlist-prompt",
+        );
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
+                None,
+            )
+            .await;
+
+        let TurnResult::NeedsApproval(requirement) = result else {
+            panic!("expected NeedsApproval, got {result:?}");
+        };
+        assert_eq!(
+            requirement.tool_name.as_deref(),
+            Some("external_skills.policy")
+        );
+        assert_eq!(
+            requirement.rule_id.as_str(),
+            "session_tool_consent_prompt_mode"
+        );
+
+        let requests = repo
+            .list_approval_requests_for_session("root-session", None)
+            .expect("list approval requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].tool_name, "external_skills.policy");
+        assert_eq!(requests[0].approval_key, "tool:external_skills.policy");
+    }
+
+    #[tokio::test]
+    async fn autonomy_policy_grant_does_not_bypass_prompt_session_consent() {
+        let memory_config = isolated_memory_config("autonomy-grant-prompt");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+        repo.upsert_approval_grant(NewApprovalGrantRecord {
+            scope_session_id: "root-session".to_owned(),
+            approval_key: "tool:external_skills.policy".to_owned(),
+            created_by_session_id: Some("root-session".to_owned()),
+        })
+        .expect("persist approval grant");
+
+        let mut tool_config = ToolConfig {
+            autonomy_profile: AutonomyProfile::GuidedAcquisition,
+            ..ToolConfig::default()
+        };
+        tool_config.consent.default_mode = ToolConsentMode::Prompt;
+
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = kernel_context("turn-engine-autonomy-grant-prompt");
+        let turn = external_skills_policy_get_turn(
+            "root-session",
+            "turn-autonomy-grant-prompt",
+            "call-autonomy-grant-prompt",
+        );
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
+                None,
+            )
+            .await;
+
+        let TurnResult::NeedsApproval(requirement) = result else {
+            panic!("expected NeedsApproval, got {result:?}");
+        };
+        assert_eq!(
+            requirement.tool_name.as_deref(),
+            Some("external_skills.policy")
+        );
+        assert_eq!(
+            requirement.rule_id.as_str(),
+            "session_tool_consent_prompt_mode"
+        );
+
+        let requests = repo
+            .list_approval_requests_for_session("root-session", None)
+            .expect("list approval requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].tool_name, "external_skills.policy");
+        assert_eq!(requests[0].approval_key, "tool:external_skills.policy");
     }
 
     #[tokio::test]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2766,7 +2766,7 @@ mod tests {
 
     #[tokio::test]
     async fn auto_mode_requires_approval_for_high_risk_core_tool() {
-        let memory_config = isolated_memory_config("provider-switch-core-approval");
+        let memory_config = isolated_memory_config("claw-migrate-core-approval");
         let repo = SessionRepository::new(&memory_config).expect("repository");
         repo.ensure_session(NewSessionRecord {
             session_id: "root-session".to_owned(),
@@ -2782,18 +2782,16 @@ mod tests {
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
-        let kernel_ctx =
-            crate::context::bootstrap_test_kernel_context("turn-engine-provider-switch", 60)
-                .expect("kernel context");
+        let kernel_ctx = kernel_context("turn-engine-claw-migrate-auto");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
                 &provider_tool_turn(
-                    "provider.switch",
-                    json!({ "selector": "openai" }),
+                    "claw.migrate",
+                    json!({}),
                     "root-session",
-                    "turn-provider-switch",
-                    "call-provider-switch",
+                    "turn-claw-migrate-auto",
+                    "call-claw-migrate-auto",
                 ),
                 &session_context,
                 &dispatcher,
@@ -2805,10 +2803,10 @@ mod tests {
         let TurnResult::NeedsApproval(requirement) = result else {
             panic!("expected NeedsApproval, got {result:?}");
         };
-        assert_eq!(requirement.tool_name.as_deref(), Some("provider.switch"));
+        assert_eq!(requirement.tool_name.as_deref(), Some("claw.migrate"));
         assert_eq!(
             requirement.approval_key.as_deref(),
-            Some("tool:provider.switch")
+            Some("tool:claw.migrate")
         );
         assert_eq!(
             requirement.rule_id.as_str(),
@@ -2823,13 +2821,13 @@ mod tests {
             .expect("load approval request")
             .expect("approval request row");
         assert_eq!(stored.status, ApprovalRequestStatus::Pending);
-        assert_eq!(stored.tool_name, "provider.switch");
+        assert_eq!(stored.tool_name, "claw.migrate");
         assert_eq!(stored.request_payload_json["execution_kind"], "core");
     }
 
     #[tokio::test]
     async fn full_session_consent_skips_approval_for_high_risk_core_tool() {
-        let memory_config = isolated_memory_config("provider-switch-core-full");
+        let memory_config = isolated_memory_config("claw-migrate-core-full");
         let repo = SessionRepository::new(&memory_config).expect("repository");
         repo.ensure_session(NewSessionRecord {
             session_id: "root-session".to_owned(),
@@ -2850,18 +2848,16 @@ mod tests {
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
-        let kernel_ctx =
-            crate::context::bootstrap_test_kernel_context("turn-engine-provider-switch-full", 60)
-                .expect("kernel context");
+        let kernel_ctx = kernel_context("turn-engine-claw-migrate-full");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
                 &provider_tool_turn(
-                    "provider.switch",
-                    json!({ "selector": "openai" }),
+                    "claw.migrate",
+                    json!({}),
                     "root-session",
-                    "turn-provider-switch-full",
-                    "call-provider-switch-full",
+                    "turn-claw-migrate-full",
+                    "call-claw-migrate-full",
                 ),
                 &session_context,
                 &dispatcher,
@@ -2876,14 +2872,14 @@ mod tests {
         assert!(
             failure
                 .reason
-                .contains("provider.switch requires a resolved runtime config path"),
+                .contains("claw.migrate requires payload.input_path"),
             "expected execution to reach the core tool, got: {failure:?}"
         );
     }
 
     #[tokio::test]
     async fn full_session_consent_still_requires_approval_for_governed_app_tool() {
-        let memory_config = isolated_memory_config("delegate-app-full");
+        let memory_config = isolated_memory_config("browser-companion-governed-full");
         let repo = SessionRepository::new(&memory_config).expect("repository");
         repo.ensure_session(NewSessionRecord {
             session_id: "root-session".to_owned(),
@@ -2902,60 +2898,23 @@ mod tests {
 
         let mut tool_config = ToolConfig::default();
         tool_config.approval.mode = GovernedToolApprovalMode::Strict;
-        let tool_view = runtime_tool_view_for_config(&tool_config);
+        tool_config.browser_companion.enabled = true;
+        tool_config.browser_companion.command = Some("browser-companion".to_owned());
+        let mut runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime_config.browser_companion.enabled = true;
+        runtime_config.browser_companion.ready = true;
+        runtime_config.browser_companion.command = Some("browser-companion".to_owned());
+        let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
-                &delegate_async_turn("root-session", "turn-delegate-full", "call-delegate-full"),
-                &session_context,
-                &dispatcher,
-                ConversationRuntimeBinding::direct(),
-                None,
-            )
-            .await;
-
-        let TurnResult::NeedsApproval(requirement) = result else {
-            panic!("expected NeedsApproval, got {result:?}");
-        };
-        assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
-        assert_eq!(
-            requirement.rule_id.as_str(),
-            "governed_tool_requires_approval"
-        );
-    }
-
-    #[tokio::test]
-    async fn governed_approval_allowlist_does_not_bypass_prompt_session_consent() {
-        let memory_config = isolated_memory_config("delegate-app-allowlist-prompt");
-        let repo = SessionRepository::new(&memory_config).expect("repository");
-        repo.ensure_session(NewSessionRecord {
-            session_id: "root-session".to_owned(),
-            kind: SessionKind::Root,
-            parent_session_id: None,
-            label: Some("Root".to_owned()),
-            state: SessionState::Ready,
-        })
-        .expect("ensure root session");
-
-        let mut tool_config = ToolConfig::default();
-        tool_config.consent.default_mode = ToolConsentMode::Prompt;
-        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
-        tool_config
-            .approval
-            .approved_calls
-            .push("tool:delegate_async".to_owned());
-        let tool_view = runtime_tool_view_for_config(&tool_config);
-        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
-        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
-
-        let result = TurnEngine::new(4)
-            .execute_turn_in_context(
-                &delegate_async_turn(
+                &browser_companion_click_turn(
                     "root-session",
-                    "turn-delegate-allowlist",
-                    "call-delegate-allowlist",
+                    "turn-browser-companion-governed-full",
+                    "call-browser-companion-governed-full",
+                    "browser-companion-governed-full",
                 ),
                 &session_context,
                 &dispatcher,
@@ -2967,7 +2926,68 @@ mod tests {
         let TurnResult::NeedsApproval(requirement) = result else {
             panic!("expected NeedsApproval, got {result:?}");
         };
-        assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+        assert_eq!(
+            requirement.tool_name.as_deref(),
+            Some("browser.companion.click")
+        );
+        assert_eq!(
+            requirement.rule_id.as_str(),
+            "governed_tool_requires_approval"
+        );
+    }
+
+    #[tokio::test]
+    async fn governed_approval_allowlist_does_not_bypass_prompt_session_consent() {
+        let memory_config = isolated_memory_config("browser-companion-allowlist-prompt");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.consent.default_mode = ToolConsentMode::Prompt;
+        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        tool_config.browser_companion.enabled = true;
+        tool_config.browser_companion.command = Some("browser-companion".to_owned());
+        tool_config
+            .approval
+            .approved_calls
+            .push("tool:browser.companion.click".to_owned());
+        let mut runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime_config.browser_companion.enabled = true;
+        runtime_config.browser_companion.ready = true;
+        runtime_config.browser_companion.command = Some("browser-companion".to_owned());
+        let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &browser_companion_click_turn(
+                    "root-session",
+                    "turn-browser-companion-allowlist",
+                    "call-browser-companion-allowlist",
+                    "browser-companion-allowlist",
+                ),
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        let TurnResult::NeedsApproval(requirement) = result else {
+            panic!("expected NeedsApproval, got {result:?}");
+        };
+        assert_eq!(
+            requirement.tool_name.as_deref(),
+            Some("browser.companion.click")
+        );
         assert_eq!(
             requirement.rule_id.as_str(),
             "session_tool_consent_prompt_mode"
@@ -2976,7 +2996,7 @@ mod tests {
 
     #[tokio::test]
     async fn governed_approval_grant_does_not_bypass_prompt_session_consent() {
-        let memory_config = isolated_memory_config("delegate-app-grant-prompt");
+        let memory_config = isolated_memory_config("browser-companion-grant-prompt");
         let repo = SessionRepository::new(&memory_config).expect("repository");
         repo.ensure_session(NewSessionRecord {
             session_id: "root-session".to_owned(),
@@ -2988,7 +3008,7 @@ mod tests {
         .expect("ensure root session");
         repo.upsert_approval_grant(NewApprovalGrantRecord {
             scope_session_id: "root-session".to_owned(),
-            approval_key: "tool:delegate_async".to_owned(),
+            approval_key: "tool:browser.companion.click".to_owned(),
             created_by_session_id: Some("root-session".to_owned()),
         })
         .expect("persist approval grant");
@@ -2996,13 +3016,24 @@ mod tests {
         let mut tool_config = ToolConfig::default();
         tool_config.consent.default_mode = ToolConsentMode::Prompt;
         tool_config.approval.mode = GovernedToolApprovalMode::Strict;
-        let tool_view = runtime_tool_view_for_config(&tool_config);
+        tool_config.browser_companion.enabled = true;
+        tool_config.browser_companion.command = Some("browser-companion".to_owned());
+        let mut runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime_config.browser_companion.enabled = true;
+        runtime_config.browser_companion.ready = true;
+        runtime_config.browser_companion.command = Some("browser-companion".to_owned());
+        let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
-                &delegate_async_turn("root-session", "turn-delegate-grant", "call-delegate-grant"),
+                &browser_companion_click_turn(
+                    "root-session",
+                    "turn-browser-companion-grant",
+                    "call-browser-companion-grant",
+                    "browser-companion-grant",
+                ),
                 &session_context,
                 &dispatcher,
                 ConversationRuntimeBinding::direct(),
@@ -3013,7 +3044,10 @@ mod tests {
         let TurnResult::NeedsApproval(requirement) = result else {
             panic!("expected NeedsApproval, got {result:?}");
         };
-        assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+        assert_eq!(
+            requirement.tool_name.as_deref(),
+            Some("browser.companion.click")
+        );
         assert_eq!(
             requirement.rule_id.as_str(),
             "session_tool_consent_prompt_mode"

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -478,6 +478,22 @@ impl DefaultAppToolDispatcher {
         )
     }
 
+    fn approval_key_for_descriptor(descriptor: &crate::tools::ToolDescriptor) -> String {
+        let tool_name = descriptor.name;
+        let approval_key = format!("tool:{tool_name}");
+        approval_key
+    }
+
+    fn is_tool_call_preapproved(&self, approval_key: &str) -> bool {
+        let approved_calls = &self.tool_config.approval.approved_calls;
+        approved_calls.iter().any(|entry| entry == approval_key)
+    }
+
+    fn is_tool_call_predenied(&self, approval_key: &str) -> bool {
+        let denied_calls = &self.tool_config.approval.denied_calls;
+        denied_calls.iter().any(|entry| entry == approval_key)
+    }
+
     #[cfg(feature = "memory-sqlite")]
     fn approval_request_payload_json(
         session_context: &SessionContext,
@@ -585,23 +601,13 @@ impl DefaultAppToolDispatcher {
             return Ok(None);
         }
 
-        let approval_key = format!("tool:{}", descriptor.name);
-        if self
-            .tool_config
-            .approval
-            .approved_calls
-            .iter()
-            .any(|entry| entry == &approval_key)
-        {
+        let approval_key = Self::approval_key_for_descriptor(descriptor);
+        let is_preapproved = self.is_tool_call_preapproved(&approval_key);
+        if is_preapproved {
             return Ok(None);
         }
-        if self
-            .tool_config
-            .approval
-            .denied_calls
-            .iter()
-            .any(|entry| entry == &approval_key)
-        {
+        let is_predenied = self.is_tool_call_predenied(&approval_key);
+        if is_predenied {
             return Err(format!(
                 "app_tool_denied: governed tool `{approval_key}` is denied by approval policy"
             ));
@@ -711,7 +717,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
             } => {
                 let reason =
                     render_reason(&policy_snapshot, action_class, descriptor.name, reason_code);
-                let approval_key = format!("tool:{}", descriptor.name);
+                let approval_key = Self::approval_key_for_descriptor(descriptor);
 
                 #[cfg(not(feature = "memory-sqlite"))]
                 {
@@ -725,6 +731,18 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
 
                 #[cfg(feature = "memory-sqlite")]
                 {
+                    let is_preapproved = self.is_tool_call_preapproved(&approval_key);
+                    if is_preapproved {
+                        return Ok(ToolPreflightOutcome::Allow);
+                    }
+
+                    let is_predenied = self.is_tool_call_predenied(&approval_key);
+                    if is_predenied {
+                        return Err(format!(
+                            "app_tool_denied: governed tool `{approval_key}` is denied by approval policy"
+                        ));
+                    }
+
                     if self.has_approval_grant(session_context, approval_key.as_str())? {
                         return Ok(ToolPreflightOutcome::Allow);
                     }
@@ -2272,7 +2290,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::config::{GovernedToolApprovalMode, ToolConfig};
+    use crate::config::{AutonomyProfile, GovernedToolApprovalMode, ToolConfig};
     use crate::session::repository::{
         ApprovalRequestStatus, NewApprovalGrantRecord, NewSessionRecord, SessionKind,
         SessionRepository, SessionState,
@@ -2290,6 +2308,11 @@ mod tests {
             sqlite_path: Some(db_path),
             ..MemoryRuntimeConfig::default()
         }
+    }
+
+    fn kernel_context(agent_id: &str) -> KernelContext {
+        crate::context::bootstrap_test_kernel_context(agent_id, 60)
+            .expect("bootstrap test kernel context")
     }
 
     fn delegate_async_turn(session_id: &str, turn_id: &str, tool_call_id: &str) -> ProviderTurn {
@@ -2321,6 +2344,34 @@ mod tests {
         tool_call_id: &str,
     ) -> ProviderTurn {
         delegate_async_turn(session_id, turn_id, tool_call_id)
+    }
+
+    fn external_skills_policy_get_turn(
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+    ) -> ProviderTurn {
+        let payload = json!({
+            "action": "get"
+        });
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "external_skills.policy",
+            payload,
+            Some(session_id),
+            Some(turn_id),
+        );
+        ProviderTurn {
+            assistant_text: "reading external skills policy".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name,
+                args_json,
+                source: "assistant".to_owned(),
+                session_id: session_id.to_owned(),
+                turn_id: turn_id.to_owned(),
+                tool_call_id: tool_call_id.to_owned(),
+            }],
+            raw_meta: json!({}),
+        }
     }
 
     fn browser_companion_click_turn(
@@ -2563,7 +2614,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn governed_tool_approval_request_is_persisted_for_delegate_async() {
+    async fn autonomy_policy_approval_request_is_persisted_for_delegate_async() {
         let memory_config = isolated_memory_config("persist");
         let repo = SessionRepository::new(&memory_config).expect("repository");
         repo.ensure_session(NewSessionRecord {
@@ -2575,18 +2626,21 @@ mod tests {
         })
         .expect("ensure root session");
 
-        let mut tool_config = ToolConfig::default();
-        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        let tool_config = ToolConfig {
+            autonomy_profile: AutonomyProfile::GuidedAcquisition,
+            ..ToolConfig::default()
+        };
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = kernel_context("turn-engine-autonomy-persist");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
                 &delegate_async_turn("root-session", "turn-1", "call-1"),
                 &session_context,
                 &dispatcher,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
                 None,
             )
             .await;
@@ -2600,7 +2654,7 @@ mod tests {
                 );
                 assert_eq!(
                     requirement.rule_id.as_str(),
-                    "governed_tool_requires_approval"
+                    "autonomy_policy_topology_mutation_requires_approval"
                 );
                 requirement
                     .approval_request_id
@@ -2625,10 +2679,18 @@ mod tests {
         assert_eq!(stored.tool_call_id, "call-1");
         assert_eq!(stored.turn_id, "turn-1");
         assert_eq!(stored.approval_key, "tool:delegate_async");
+        assert_eq!(
+            stored.governance_snapshot_json["policy_source"],
+            "autonomy_policy"
+        );
+        assert_eq!(
+            stored.governance_snapshot_json["capability_action_class"],
+            "topology_expand"
+        );
     }
 
     #[tokio::test]
-    async fn governed_tool_approval_request_is_persisted_for_discovered_delegate_async() {
+    async fn autonomy_policy_approval_request_is_persisted_for_discovered_delegate_async() {
         let memory_config = isolated_memory_config("persist-discovered");
         let repo = SessionRepository::new(&memory_config).expect("repository");
         repo.ensure_session(NewSessionRecord {
@@ -2640,11 +2702,14 @@ mod tests {
         })
         .expect("ensure root session");
 
-        let mut tool_config = ToolConfig::default();
-        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        let tool_config = ToolConfig {
+            autonomy_profile: AutonomyProfile::GuidedAcquisition,
+            ..ToolConfig::default()
+        };
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = kernel_context("turn-engine-autonomy-persist-discovered");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
@@ -2655,7 +2720,7 @@ mod tests {
                 ),
                 &session_context,
                 &dispatcher,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
                 None,
             )
             .await;
@@ -2956,7 +3021,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn governed_tool_approval_request_reuses_deterministic_id_for_same_blocked_call() {
+    async fn autonomy_policy_approval_request_reuses_deterministic_id_for_same_blocked_call() {
         let memory_config = isolated_memory_config("reuse");
         let repo = SessionRepository::new(&memory_config).expect("repository");
         repo.ensure_session(NewSessionRecord {
@@ -2968,19 +3033,22 @@ mod tests {
         })
         .expect("ensure root session");
 
-        let mut tool_config = ToolConfig::default();
-        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        let tool_config = ToolConfig {
+            autonomy_profile: AutonomyProfile::GuidedAcquisition,
+            ..ToolConfig::default()
+        };
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
         let turn = delegate_async_turn("root-session", "turn-reuse", "call-reuse");
+        let kernel_ctx = kernel_context("turn-engine-autonomy-reuse");
 
         let first = TurnEngine::new(4)
             .execute_turn_in_context(
                 &turn,
                 &session_context,
                 &dispatcher,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
                 None,
             )
             .await;
@@ -2989,7 +3057,7 @@ mod tests {
                 &turn,
                 &session_context,
                 &dispatcher,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
                 None,
             )
             .await;
@@ -3028,6 +3096,133 @@ mod tests {
             .expect("list approval requests");
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].approval_request_id, first_request_id);
+    }
+
+    #[tokio::test]
+    async fn autonomy_policy_preapproved_call_executes_without_persisting_request() {
+        let memory_config = isolated_memory_config("preapproved");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let approval_key = "tool:external_skills.policy".to_owned();
+        let mut tool_config = ToolConfig {
+            autonomy_profile: AutonomyProfile::GuidedAcquisition,
+            ..ToolConfig::default()
+        };
+        let approved_calls = &mut tool_config.approval.approved_calls;
+        approved_calls.push(approval_key);
+
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = kernel_context("turn-engine-autonomy-preapproved");
+        let turn =
+            external_skills_policy_get_turn("root-session", "turn-preapproved", "call-preapproved");
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
+                None,
+            )
+            .await;
+
+        let reply = match result {
+            TurnResult::FinalText(reply) => reply,
+            other @ TurnResult::NeedsApproval(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_)
+            | other @ TurnResult::StreamingText(_)
+            | other @ TurnResult::StreamingDone(_) => {
+                panic!("expected FinalText, got {other:?}")
+            }
+        };
+
+        assert!(
+            reply.contains("\"tool\":\"external_skills.policy\""),
+            "reply should include executed external_skills.policy output: {reply}"
+        );
+        assert!(
+            reply.contains("\"status\":\"ok\""),
+            "reply should surface a successful external_skills.policy outcome: {reply}"
+        );
+
+        let requests = repo
+            .list_approval_requests_for_session("root-session", None)
+            .expect("list approval requests");
+        assert!(requests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn autonomy_policy_predenied_call_returns_policy_denial_without_persisting_request() {
+        let memory_config = isolated_memory_config("predenied");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let denial_key = "tool:external_skills.policy".to_owned();
+        let mut tool_config = ToolConfig {
+            autonomy_profile: AutonomyProfile::GuidedAcquisition,
+            ..ToolConfig::default()
+        };
+        let denied_calls = &mut tool_config.approval.denied_calls;
+        denied_calls.push(denial_key);
+
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = kernel_context("turn-engine-autonomy-predenied");
+        let turn =
+            external_skills_policy_get_turn("root-session", "turn-predenied", "call-predenied");
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
+                None,
+            )
+            .await;
+
+        let failure = match result {
+            TurnResult::ToolDenied(failure) => failure,
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::NeedsApproval(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_)
+            | other @ TurnResult::StreamingText(_)
+            | other @ TurnResult::StreamingDone(_) => {
+                panic!("expected ToolDenied, got {other:?}")
+            }
+        };
+
+        assert_eq!(failure.code, "app_tool_denied");
+        assert!(
+            failure.reason.contains("tool:external_skills.policy"),
+            "denial should reference the statically denied approval key: {failure:?}"
+        );
+
+        let requests = repo
+            .list_approval_requests_for_session("root-session", None)
+            .expect("list approval requests");
+        assert!(requests.is_empty());
     }
 
     #[tokio::test]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -28,6 +28,10 @@ use crate::tools::{
     tool_catalog,
 };
 
+use super::autonomy_policy::{
+    AUTONOMY_POLICY_SOURCE, AutonomyTurnBudgetState, PolicyDecision, PolicyDecisionInput,
+    evaluate_policy, render_reason,
+};
 use super::runtime::SessionContext;
 use super::runtime_binding::ConversationRuntimeBinding;
 
@@ -101,6 +105,13 @@ impl ApprovalRequirement {
             approval_request_id,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolPreflightOutcome {
+    Allow,
+    NeedsApproval(ApprovalRequirement),
+    Denied(TurnFailure),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -260,6 +271,24 @@ pub(crate) fn classify_kernel_error(error: &KernelError) -> KernelFailureClass {
 
 #[async_trait]
 pub trait AppToolDispatcher: Send + Sync {
+    async fn preflight_tool_intent_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
+        _budget_state: &AutonomyTurnBudgetState,
+    ) -> Result<ToolPreflightOutcome, String> {
+        match self
+            .maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
+            .await
+        {
+            Ok(Some(requirement)) => Ok(ToolPreflightOutcome::NeedsApproval(requirement)),
+            Ok(None) => Ok(ToolPreflightOutcome::Allow),
+            Err(reason) => Err(reason),
+        }
+    }
+
     async fn maybe_require_approval(
         &self,
         _session_context: &SessionContext,
@@ -442,6 +471,179 @@ impl DefaultAppToolDispatcher {
             }
         }
     }
+
+    fn autonomy_policy_snapshot(&self) -> crate::tools::runtime_config::AutonomyPolicySnapshot {
+        crate::tools::runtime_config::AutonomyPolicySnapshot::from_profile(
+            self.tool_config.autonomy_profile,
+        )
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn approval_request_payload_json(
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+    ) -> serde_json::Value {
+        json!({
+            "session_id": session_context.session_id,
+            "parent_session_id": session_context.parent_session_id,
+            "turn_id": intent.turn_id,
+            "tool_call_id": intent.tool_call_id,
+            "tool_name": descriptor.name,
+            "args_json": intent.args_json,
+            "source": intent.source,
+            "execution_kind": match descriptor.execution_kind {
+                ToolExecutionKind::Core => "core",
+                ToolExecutionKind::App => "app",
+            },
+        })
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn persist_approval_request(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        approval_key: &str,
+        reason: &str,
+        rule_id: &str,
+        governance_snapshot_json: serde_json::Value,
+    ) -> Result<ApprovalRequirement, String> {
+        let repo = SessionRepository::new(&self.memory_config)?;
+        let kind = if session_context.parent_session_id.is_some() {
+            SessionKind::DelegateChild
+        } else {
+            SessionKind::Root
+        };
+        let _ = repo.ensure_session(NewSessionRecord {
+            session_id: session_context.session_id.clone(),
+            kind,
+            parent_session_id: session_context.parent_session_id.clone(),
+            label: None,
+            state: SessionState::Ready,
+        })?;
+
+        let approval_request_id =
+            governed_approval_request_id(session_context, descriptor.name, intent);
+        let request_payload_json =
+            Self::approval_request_payload_json(session_context, intent, descriptor);
+        let stored = repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id,
+            session_id: session_context.session_id.clone(),
+            turn_id: intent.turn_id.clone(),
+            tool_call_id: intent.tool_call_id.clone(),
+            tool_name: descriptor.name.to_owned(),
+            approval_key: approval_key.to_owned(),
+            request_payload_json,
+            governance_snapshot_json,
+        })?;
+
+        Ok(ApprovalRequirement::governed_tool(
+            descriptor.name,
+            approval_key,
+            reason,
+            rule_id,
+            Some(stored.approval_request_id),
+        ))
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn has_approval_grant(
+        &self,
+        session_context: &SessionContext,
+        approval_key: &str,
+    ) -> Result<bool, String> {
+        let repo = SessionRepository::new(&self.memory_config)?;
+        let scope_session_id = Self::lineage_root_session_id(&repo, session_context)?;
+        let grant = repo.load_approval_grant(&scope_session_id, approval_key)?;
+        Ok(grant.is_some())
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn maybe_require_governed_tool_approval_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+    ) -> Result<Option<ApprovalRequirement>, String> {
+        let governance = governance_profile_for_descriptor(descriptor);
+        if descriptor.execution_kind != ToolExecutionKind::App
+            || governance.approval_mode != ToolApprovalMode::PolicyDriven
+        {
+            return Ok(None);
+        }
+
+        let requires_approval = match self.tool_config.approval.mode {
+            GovernedToolApprovalMode::Disabled => false,
+            GovernedToolApprovalMode::MediumBalanced => {
+                governance.risk_class == crate::tools::ToolRiskClass::High
+            }
+            GovernedToolApprovalMode::Strict => true,
+        };
+        if !requires_approval {
+            return Ok(None);
+        }
+
+        let approval_key = format!("tool:{}", descriptor.name);
+        if self
+            .tool_config
+            .approval
+            .approved_calls
+            .iter()
+            .any(|entry| entry == &approval_key)
+        {
+            return Ok(None);
+        }
+        if self
+            .tool_config
+            .approval
+            .denied_calls
+            .iter()
+            .any(|entry| entry == &approval_key)
+        {
+            return Err(format!(
+                "app_tool_denied: governed tool `{approval_key}` is denied by approval policy"
+            ));
+        }
+        if self.has_approval_grant(session_context, approval_key.as_str())? {
+            return Ok(None);
+        }
+
+        let reason = format!(
+            "operator approval required before running `{}`",
+            descriptor.name
+        );
+        let rule_id = "governed_tool_requires_approval";
+        let governance_snapshot_json = json!({
+            "governance_scope": governance.scope.as_str(),
+            "risk_class": governance.risk_class.as_str(),
+            "approval_mode": governance.approval_mode.as_str(),
+            "rule_id": rule_id,
+            "reason": reason,
+        });
+        let requirement = self.persist_approval_request(
+            session_context,
+            intent,
+            descriptor,
+            approval_key.as_str(),
+            reason.as_str(),
+            rule_id,
+            governance_snapshot_json,
+        )?;
+        Ok(Some(requirement))
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    fn maybe_require_governed_tool_approval_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+    ) -> Result<Option<ApprovalRequirement>, String> {
+        let _ = (session_context, intent, descriptor);
+        Ok(None)
+    }
 }
 
 fn governed_approval_request_id(
@@ -484,6 +686,90 @@ impl Default for DefaultAppToolDispatcher {
 
 #[async_trait]
 impl AppToolDispatcher for DefaultAppToolDispatcher {
+    async fn preflight_tool_intent_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
+        budget_state: &AutonomyTurnBudgetState,
+    ) -> Result<ToolPreflightOutcome, String> {
+        let policy_snapshot = self.autonomy_policy_snapshot();
+        let action_class = descriptor.capability_action_class();
+        let policy_input = PolicyDecisionInput {
+            snapshot: &policy_snapshot,
+            action_class,
+            binding,
+            budget: budget_state,
+        };
+        let policy_decision = evaluate_policy(policy_input);
+        match policy_decision {
+            PolicyDecision::Allow => {}
+            PolicyDecision::ApprovalRequired {
+                rule_id,
+                reason_code,
+            } => {
+                let reason =
+                    render_reason(&policy_snapshot, action_class, descriptor.name, reason_code);
+                let approval_key = format!("tool:{}", descriptor.name);
+
+                #[cfg(not(feature = "memory-sqlite"))]
+                {
+                    let _ = (session_context, intent, approval_key);
+                    let failure = TurnFailure::policy_denied(
+                        "autonomy_policy_approval_support_missing",
+                        reason,
+                    );
+                    return Ok(ToolPreflightOutcome::Denied(failure));
+                }
+
+                #[cfg(feature = "memory-sqlite")]
+                {
+                    if self.has_approval_grant(session_context, approval_key.as_str())? {
+                        return Ok(ToolPreflightOutcome::Allow);
+                    }
+
+                    let governance_snapshot_json = json!({
+                        "policy_source": AUTONOMY_POLICY_SOURCE,
+                        "autonomy_profile": policy_snapshot.profile.as_str(),
+                        "capability_action_class": action_class.as_str(),
+                        "rule_id": rule_id,
+                        "reason_code": reason_code,
+                        "reason": reason,
+                    });
+                    let requirement = self.persist_approval_request(
+                        session_context,
+                        intent,
+                        descriptor,
+                        approval_key.as_str(),
+                        reason.as_str(),
+                        rule_id,
+                        governance_snapshot_json,
+                    )?;
+                    return Ok(ToolPreflightOutcome::NeedsApproval(requirement));
+                }
+            }
+            PolicyDecision::Deny {
+                rule_id: _rule_id,
+                reason_code,
+            } => {
+                let reason =
+                    render_reason(&policy_snapshot, action_class, descriptor.name, reason_code);
+                let failure = TurnFailure::policy_denied(reason_code, reason);
+                return Ok(ToolPreflightOutcome::Denied(failure));
+            }
+        }
+
+        match self
+            .maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
+            .await
+        {
+            Ok(Some(requirement)) => Ok(ToolPreflightOutcome::NeedsApproval(requirement)),
+            Ok(None) => Ok(ToolPreflightOutcome::Allow),
+            Err(reason) => Err(reason),
+        }
+    }
+
     async fn maybe_require_approval(
         &self,
         session_context: &SessionContext,
@@ -573,65 +859,14 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                     ToolConsentMode::Auto | ToolConsentMode::Full => None,
                 }
             };
-
-            let approval_key_is_allowed = governed_approval_eligible
-                && self
-                    .tool_config
-                    .approval
-                    .approved_calls
-                    .iter()
-                    .any(|entry| entry == &approval_key);
-            let approval_grant_exists = if governed_approval_eligible {
-                repo.load_approval_grant(&scope_session_id, &approval_key)?
-                    .is_some()
-            } else {
-                false
-            };
-            let governed_approval_satisfied = approval_key_is_allowed || approval_grant_exists;
-
-            let legacy_governed_requirement =
-                if governed_approval_eligible && !governed_approval_satisfied {
-                    let requires_approval = match self.tool_config.approval.mode {
-                        GovernedToolApprovalMode::Disabled => false,
-                        GovernedToolApprovalMode::MediumBalanced => {
-                            governance.risk_class == crate::tools::ToolRiskClass::High
-                        }
-                        GovernedToolApprovalMode::Strict => true,
-                    };
-                    requires_approval.then(|| {
-                        (
-                            "governed_tool_requires_approval",
-                            format!(
-                                "operator approval required before running `{}`",
-                                descriptor.name
-                            ),
-                        )
-                    })
-                } else {
-                    None
-                };
-
-            let Some((rule_id, reason)) =
-                session_consent_requirement.or(legacy_governed_requirement)
-            else {
-                return Ok(None);
+            let Some((rule_id, reason)) = session_consent_requirement else {
+                return self.maybe_require_governed_tool_approval_with_binding(
+                    session_context,
+                    intent,
+                    descriptor,
+                );
             };
 
-            let approval_request_id =
-                governed_approval_request_id(session_context, descriptor.name, intent);
-            let request_payload_json = json!({
-                "session_id": session_context.session_id,
-                "parent_session_id": session_context.parent_session_id,
-                "turn_id": intent.turn_id,
-                "tool_call_id": intent.tool_call_id,
-                "tool_name": descriptor.name,
-                "args_json": intent.args_json,
-                "source": intent.source,
-                "execution_kind": match descriptor.execution_kind {
-                    ToolExecutionKind::Core => "core",
-                    ToolExecutionKind::App => "app",
-                },
-            });
             let governance_snapshot_json = json!({
                 "governance_scope": governance.scope.as_str(),
                 "risk_class": governance.risk_class.as_str(),
@@ -640,24 +875,17 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 "rule_id": rule_id,
                 "reason": reason,
             });
-            let stored = repo.ensure_approval_request(NewApprovalRequestRecord {
-                approval_request_id,
-                session_id: session_context.session_id.clone(),
-                turn_id: intent.turn_id.clone(),
-                tool_call_id: intent.tool_call_id.clone(),
-                tool_name: descriptor.name.to_owned(),
-                approval_key: approval_key.clone(),
-                request_payload_json,
-                governance_snapshot_json,
-            })?;
-
-            Ok(Some(ApprovalRequirement::governed_tool(
-                descriptor.name,
-                approval_key,
-                reason,
+            let requirement = self.persist_approval_request(
+                session_context,
+                intent,
+                descriptor,
+                approval_key.as_str(),
+                reason.as_str(),
                 rule_id,
-                Some(stored.approval_request_id),
-            )))
+                governance_snapshot_json,
+            )?;
+
+            Ok(Some(requirement))
         }
     }
 
@@ -1287,6 +1515,7 @@ struct PreparedToolIntent {
     intent: ToolIntent,
     request: ToolCoreRequest,
     execution_kind: ToolExecutionKind,
+    capability_action_class: crate::tools::CapabilityActionClass,
     scheduling_class: ToolSchedulingClass,
     trusted_internal_context: bool,
 }
@@ -1528,12 +1757,23 @@ impl TurnEngine {
         }
 
         let mut prepared = Vec::new();
+        let mut autonomy_budget_state = AutonomyTurnBudgetState::default();
         for intent in &turn.tool_intents {
             match self
-                .prepare_tool_intent(intent, session_context, app_dispatcher, binding, ingress)
+                .prepare_tool_intent(
+                    intent,
+                    session_context,
+                    app_dispatcher,
+                    binding,
+                    &autonomy_budget_state,
+                    ingress,
+                )
                 .await
             {
-                Ok(prepared_intent) => prepared.push(prepared_intent),
+                Ok(prepared_intent) => {
+                    autonomy_budget_state.record_action(prepared_intent.capability_action_class);
+                    prepared.push(prepared_intent);
+                }
                 Err(result) => return (result, None),
             }
         }
@@ -1819,6 +2059,7 @@ impl TurnEngine {
         session_context: &SessionContext,
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
+        budget_state: &AutonomyTurnBudgetState,
         ingress: Option<&ConversationIngressContext>,
     ) -> Result<PreparedToolIntent, TurnResult> {
         let Some(resolved_tool) = crate::tools::resolve_tool_execution(&intent.tool_name) else {
@@ -1843,7 +2084,7 @@ impl TurnEngine {
             tool_name: resolved_tool.canonical_name.to_owned(),
             payload: augmented_payload,
         };
-        let (effective_execution_kind, effective_request, effective_intent) =
+        let (effective_execution_kind, effective_request, effective_intent, effective_tool_name) =
             if resolved_tool.canonical_name == "tool.invoke" {
                 match crate::tools::resolve_tool_invoke_request(&request) {
                     Ok((inner_resolved, inner_request)) => {
@@ -1855,22 +2096,86 @@ impl TurnEngine {
                             turn_id: intent.turn_id.clone(),
                             tool_call_id: intent.tool_call_id.clone(),
                         };
-                        (inner_resolved.execution_kind, inner_request, inner_intent)
+                        if inner_resolved.execution_kind == ToolExecutionKind::App {
+                            (
+                                ToolExecutionKind::App,
+                                inner_request,
+                                inner_intent,
+                                inner_resolved.canonical_name.to_owned(),
+                            )
+                        } else {
+                            (
+                                resolved_tool.execution_kind,
+                                request,
+                                inner_intent,
+                                inner_resolved.canonical_name.to_owned(),
+                            )
+                        }
                     }
-                    _ => (resolved_tool.execution_kind, request, intent.clone()),
+                    Err(_) => (
+                        resolved_tool.execution_kind,
+                        request,
+                        intent.clone(),
+                        resolved_tool.canonical_name.to_owned(),
+                    ),
                 }
             } else {
-                (resolved_tool.execution_kind, request, intent.clone())
+                (
+                    resolved_tool.execution_kind,
+                    request,
+                    intent.clone(),
+                    resolved_tool.canonical_name.to_owned(),
+                )
             };
         let catalog = crate::tools::tool_catalog();
-        let Some(descriptor) = catalog.resolve(effective_request.tool_name.as_str()) else {
-            let reason = format!("tool_descriptor_missing: {}", effective_request.tool_name);
+        // Some feature-scoped discoverable tools still execute through
+        // `tool.invoke` without a typed catalog descriptor. Fall back to the
+        // executable wrapper descriptor so existing runtime-only tools keep
+        // working while typed autonomy policy applies where metadata exists.
+        let descriptor = catalog.resolve(effective_tool_name.as_str()).or_else(|| {
+            if effective_request.tool_name == effective_tool_name {
+                return None;
+            }
+
+            catalog.resolve(effective_request.tool_name.as_str())
+        });
+        let Some(descriptor) = descriptor else {
+            let reason = format!("tool_descriptor_missing: {}", effective_tool_name);
             return Err(TurnResult::non_retryable_tool_error(
                 "tool_descriptor_missing",
                 reason,
             ));
         };
+        let capability_action_class = descriptor.capability_action_class();
         let scheduling_class = descriptor.scheduling_class();
+
+        match app_dispatcher
+            .preflight_tool_intent_with_binding(
+                session_context,
+                &effective_intent,
+                descriptor,
+                binding,
+                budget_state,
+            )
+            .await
+        {
+            Ok(ToolPreflightOutcome::Allow) => {}
+            Ok(ToolPreflightOutcome::NeedsApproval(requirement)) => {
+                return Err(TurnResult::NeedsApproval(requirement));
+            }
+            Ok(ToolPreflightOutcome::Denied(failure)) => {
+                return Err(TurnResult::ToolDenied(failure));
+            }
+            Err(reason) if reason.starts_with("app_tool_denied:") => {
+                return Err(TurnResult::policy_denied("app_tool_denied", reason));
+            }
+            Err(reason) => {
+                return Err(TurnResult::non_retryable_tool_error(
+                    "tool_preflight_failed",
+                    reason,
+                ));
+            }
+        }
 
         match effective_execution_kind {
             ToolExecutionKind::Core => {
@@ -1884,32 +2189,11 @@ impl TurnEngine {
             ToolExecutionKind::App => {}
         }
 
-        match app_dispatcher
-            .maybe_require_approval_with_binding(
-                session_context,
-                &effective_intent,
-                descriptor,
-                binding,
-            )
-            .await
-        {
-            Ok(Some(requirement)) => return Err(TurnResult::NeedsApproval(requirement)),
-            Ok(None) => {}
-            Err(reason) if reason.starts_with("app_tool_denied:") => {
-                return Err(TurnResult::policy_denied("app_tool_denied", reason));
-            }
-            Err(reason) => {
-                return Err(TurnResult::non_retryable_tool_error(
-                    "app_tool_preflight_failed",
-                    reason,
-                ));
-            }
-        }
-
         Ok(PreparedToolIntent {
             intent: intent.clone(),
             request: effective_request,
             execution_kind: effective_execution_kind,
+            capability_action_class,
             scheduling_class,
             trusted_internal_context: injected.trusted_internal_context
                 || (!injected_payload_uses_reserved_internal_context

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -575,7 +575,7 @@ fn build_tool_catalog() -> ToolCatalog {
             availability: runtime_session_tool_availability(),
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Sessions,
-            capability_action_class: CapabilityActionClass::PolicyMutation,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: DEFAULT_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: approval_request_resolve_definition,
         },
@@ -3723,7 +3723,7 @@ mod tests {
             ("delegate_async", CapabilityActionClass::TopologyExpand),
             (
                 "approval_request_resolve",
-                CapabilityActionClass::PolicyMutation,
+                CapabilityActionClass::ExecuteExisting,
             ),
             (
                 "external_skills.policy",

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -377,24 +377,24 @@ impl AutonomyPolicySnapshot {
                 profile,
                 capability_acquisition_mode: AutonomyOperationMode::ApprovalRequired,
                 provider_switch_mode: AutonomyOperationMode::ApprovalRequired,
-                topology_mutation_mode: AutonomyOperationMode::Deny,
+                topology_mutation_mode: AutonomyOperationMode::ApprovalRequired,
                 requires_kernel_binding: true,
                 budget: AutonomyBudgetPolicy {
                     max_capability_acquisitions_per_turn: 1,
                     max_provider_switches_per_turn: 1,
-                    max_topology_mutations_per_turn: 0,
+                    max_topology_mutations_per_turn: 1,
                 },
             },
             AutonomyProfile::BoundedAutonomous => Self {
                 profile,
                 capability_acquisition_mode: AutonomyOperationMode::Allow,
                 provider_switch_mode: AutonomyOperationMode::ApprovalRequired,
-                topology_mutation_mode: AutonomyOperationMode::Deny,
+                topology_mutation_mode: AutonomyOperationMode::ApprovalRequired,
                 requires_kernel_binding: true,
                 budget: AutonomyBudgetPolicy {
                     max_capability_acquisitions_per_turn: 2,
                     max_provider_switches_per_turn: 1,
-                    max_topology_mutations_per_turn: 0,
+                    max_topology_mutations_per_turn: 1,
                 },
             },
         }
@@ -1540,11 +1540,14 @@ mod tests {
             snapshot.provider_switch_mode,
             AutonomyOperationMode::ApprovalRequired
         );
-        assert_eq!(snapshot.topology_mutation_mode, AutonomyOperationMode::Deny);
+        assert_eq!(
+            snapshot.topology_mutation_mode,
+            AutonomyOperationMode::ApprovalRequired
+        );
         assert!(snapshot.requires_kernel_binding);
         assert_eq!(snapshot.budget.max_capability_acquisitions_per_turn, 1);
         assert_eq!(snapshot.budget.max_provider_switches_per_turn, 1);
-        assert_eq!(snapshot.budget.max_topology_mutations_per_turn, 0);
+        assert_eq!(snapshot.budget.max_topology_mutations_per_turn, 1);
     }
 
     #[test]
@@ -1565,11 +1568,14 @@ mod tests {
             snapshot.provider_switch_mode,
             AutonomyOperationMode::ApprovalRequired
         );
-        assert_eq!(snapshot.topology_mutation_mode, AutonomyOperationMode::Deny);
+        assert_eq!(
+            snapshot.topology_mutation_mode,
+            AutonomyOperationMode::ApprovalRequired
+        );
         assert!(snapshot.requires_kernel_binding);
         assert_eq!(snapshot.budget.max_capability_acquisitions_per_turn, 2);
         assert_eq!(snapshot.budget.max_provider_switches_per_turn, 1);
-        assert_eq!(snapshot.budget.max_topology_mutations_per_turn, 0);
+        assert_eq!(snapshot.budget.max_topology_mutations_per_turn, 1);
     }
 
     #[test]

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-30T02:33:36Z
+- Generated at: 2026-03-30T06:03:17Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9759 | 9800 | 41 | 90 | 90 | 0 | 100.0% | TIGHT |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6936 | 7300 | 364 | 146 | 160 | 14 | 95.0% | TIGHT |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 6396 | 6400 | 4 | 104 | 110 | 6 | 99.9% | TIGHT |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10754 | 11200 | 446 | 97 | 120 | 23 | 96.0% | TIGHT |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10773 | 11200 | 427 | 97 | 120 | 23 | 96.2% | TIGHT |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14216 | 15000 | 784 | 54 | 70 | 16 | 94.8% | WATCH |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6289 | 6500 | 211 | 208 | 210 | 2 | 99.0% | TIGHT |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9256 | 9800 | 544 | 227 | 250 | 23 | 94.4% | WATCH |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), channel_mod (99.9%), turn_coordinator (96.0%), daemon_lib (99.0%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), channel_mod (99.9%), turn_coordinator (96.2%), daemon_lib (99.0%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (90.8%), memory_mod (87.5%), acp_manager (92.4%), tools_mod (94.8%), onboard_cli (94.4%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -67,7 +67,7 @@
 <!-- arch-hotspot key=channel_config lines=9759 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6936 functions=146 -->
 <!-- arch-hotspot key=channel_mod lines=6396 functions=104 -->
-<!-- arch-hotspot key=turn_coordinator lines=10754 functions=97 -->
+<!-- arch-hotspot key=turn_coordinator lines=10773 functions=97 -->
 <!-- arch-hotspot key=tools_mod lines=14216 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6289 functions=208 -->
 <!-- arch-hotspot key=onboard_cli lines=9256 functions=227 -->


### PR DESCRIPTION
## Summary

- Problem:
  product-mode `autonomy_profile` and typed `CapabilityActionClass` metadata were already present, but live turn execution still left mutation-class surfaces and static approval policy edges outside the real turn-time autonomy contract.
- Why it matters:
  without deterministic gating for topology, policy, and session mutations, product mode remained partially advisory, `approval_request_resolve` sat on the wrong side of the mutation fence, and static `approved_calls` / `denied_calls` could not reliably shape autonomy preflight for product-mode execution.
- What changed:
  completed turn-time autonomy gating for `topology_expand`, `policy_mutation`, and `session_mutation`; compiled guided and bounded profiles to require approval for those mutation classes with a bounded per-turn mutation budget; reclassified `approval_request_resolve` as `execute_existing` to avoid approval recursion; taught autonomy preflight to honor static `approved_calls` / `denied_calls`; and, after rebasing onto the latest `dev`, realigned consent and governed-approval coverage so product-mode mutation gating remains the primary fence while session consent and governed approvals keep their intended precedence.
- What did not change (scope boundary):
  this slice still does not add Web UI work, governed-evolution workflow surfaces, or autonomous widening beyond the canonical product-mode decision table.

## Linked Issues

- Closes #679
- Related #455

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  mutation-class actions now share explicit turn-time policy and budget enforcement, and static approval config now participates in autonomy preflight instead of only the later governed-tool path.
- Rollout / guardrails:
  the change remains bounded to product-mode turn preflight, guided and bounded profiles still require kernel binding, and representative deny, approval, preapproved, predenied, session-consent, and governed-approval precedence paths are covered by regression tests.
- Rollback path:
  revert this PR after merge to restore the earlier preflight behavior on `dev`.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
scripts/bootstrap_release_local_artifacts.sh
bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
./scripts/check_dep_graph.sh
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
git diff --check
diff -u CLAUDE.md AGENTS.md
```

Results:

- All CI-parity cargo checks and repo-specific architecture/docs checks passed locally on head `0587cb49`.
- GitHub Actions CI run `23701777100` passed on the same head, including both Windows jobs:
  - `rust-test-default (windows-latest)`
  - `rust-test-all-features (windows-latest)`
- AGENTS.md and CLAUDE.md remain mirrored.
- Focused runtime regression coverage includes:
  - `conversation::tests::autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_policy_mutation`
  - `conversation::tests::autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_session_mutation`
  - `conversation::turn_engine::tests::autonomy_policy_preapproved_call_executes_without_persisting_request`
  - `conversation::turn_engine::tests::autonomy_policy_predenied_call_returns_policy_denial_without_persisting_request`
  - `conversation::turn_engine::tests::auto_mode_requires_approval_for_high_risk_core_tool`
  - `conversation::turn_engine::tests::full_session_consent_skips_approval_for_high_risk_core_tool`
  - `conversation::turn_engine::tests::full_session_consent_still_requires_approval_for_governed_app_tool`
  - `conversation::turn_engine::tests::governed_approval_allowlist_does_not_bypass_prompt_session_consent`
  - `conversation::turn_engine::tests::governed_approval_grant_does_not_bypass_prompt_session_consent`
- `task` / `task check:conventions` could not be run in this environment because the `task` CLI is not installed.

Before / after behavior:

- Before:
  product-mode turn preflight still treated `topology_expand`, `policy_mutation`, and `session_mutation` as effectively out of scope, `approval_request_resolve` was classified as a policy mutation, and static `approved_calls` / `denied_calls` did not shape autonomy preflight.
- After:
  mutation-class actions are governed by the canonical product-mode table and mutation budget, `approval_request_resolve` no longer self-recurses through policy-mutation gating, and static approval config now short-circuits autonomy preflight deterministically.
- Boundary / fallback coverage:
  - explicit typed mutation path: `delegate`, `external_skills.policy`, and session mutation tools now receive deterministic deny or approval outcomes based on the compiled autonomy profile
  - static policy path: `approved_calls` and `denied_calls` are honored before approval persistence
  - consent/governed precedence path: prompt-scoped session consent is still required for high-risk core tools, and governed app tools still remain approval-gated even when full session consent exists
  - budget boundary: guided and bounded product modes now cap topology mutations at one per turn with stable reason codes

## User-visible / Operator-visible Changes

- Product-mode turns now deterministically deny or require approval for topology expansion, policy mutation, and session mutation actions.
- Static approval policy entries in `approved_calls` and `denied_calls` now affect autonomy preflight directly, so operators get stable allow or deny outcomes without redundant approval persistence.
- Latest `dev` consent flow remains intact after the rebase, and the runtime now preserves the intended ordering between autonomy gating, session consent, and governed approvals.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR after merge.
- Observable failure symptoms reviewers should watch for:
  product-mode turns that call `delegate`, `delegate_async`, `external_skills.policy`, or session mutation tools may now surface autonomy-policy approval or deny outcomes where they previously flowed through weaker heuristics; misconfigurations would most likely appear as unexpected `app_tool_denied`, governed-tool approvals not appearing when expected, or mutation-budget denials.

## Reviewer Focus

- Review mutation-mode routing and per-turn mutation budgeting in `crates/app/src/conversation/autonomy_policy.rs`.
- Review static approval handling, session-consent ordering, and approval persistence ordering in `crates/app/src/conversation/turn_engine.rs`.
- Review action-class classification and product-mode snapshot defaults in `crates/app/src/tools/catalog.rs` and `crates/app/src/tools/runtime_config.rs`.
- Review the product-mode regression coverage updates in `crates/app/src/conversation/tests.rs` and `crates/app/src/conversation/turn_engine.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented autonomy policy evaluation to govern capability actions during conversations, including per-turn budgeting and action-specific approval requirements.
  * Added policy decision framework (Allow, Approval Required, Deny) with human-readable explanations for enforcement outcomes.

* **Tests**
  * Added comprehensive autonomy policy enforcement tests covering various policy profiles and action types.
  * Updated existing tests to support new policy framework integration.

* **Documentation**
  * Updated architecture metrics documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->