### PR TITLE
feat: scaffold, inspect, and diagnose manifest-first plugin packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "rand 0.10.0",
  "reqwest",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -72,6 +72,7 @@ chrono.workspace = true
 base64.workspace = true
 rand.workspace = true
 sha2.workspace = true
+semver.workspace = true
 ed25519-dalek.workspace = true
 dunce = "1"
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -562,8 +562,8 @@ pub enum Commands {
     },
     #[command(
         visible_alias = "plugin",
-        about = "Inspect plugin governance truth and deduplicated operator action plans",
-        long_about = "Operator-facing plugin governance namespace for scanning one or more plugin roots, evaluating profile-aware preflight, and consuming the deduplicated operator action plan.\n\nThis command does not introduce a second policy engine. It reuses the existing spec `plugin_preflight` surface and exposes one thin CLI over the same governance contract."
+        about = "Author manifest-first plugin packages and inspect shared plugin governance truth",
+        long_about = "Manifest-first plugin namespace for bounded authoring bootstrap, scanning one or more plugin roots, evaluating profile-aware preflight, and consuming the deduplicated operator action plan.\n\nThis command does not introduce a second policy engine. It reuses the existing spec `plugin_preflight` surface for governance and adds one thin authoring scaffold for external package roots."
     )]
     Plugins {
         #[arg(long, global = true, default_value_t = false)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -563,7 +563,7 @@ pub enum Commands {
     #[command(
         visible_alias = "plugin",
         about = "Author manifest-first plugin packages and inspect shared plugin governance truth",
-        long_about = "Manifest-first plugin namespace for bounded authoring bootstrap, scanning one or more plugin roots, evaluating profile-aware preflight, and consuming the deduplicated operator action plan.\n\nThis command does not introduce a second policy engine. It reuses the existing spec `plugin_preflight` surface for governance and adds one thin authoring scaffold for external package roots."
+        long_about = "Manifest-first plugin namespace for bounded authoring bootstrap, inspecting manifest-first package inventory, evaluating profile-aware preflight, and consuming the deduplicated operator action plan.\n\nThis command does not introduce a second policy engine. It reuses the existing spec `plugin_inventory` and `plugin_preflight` surfaces for shared plugin truth and adds one thin authoring scaffold for external package roots."
     )]
     Plugins {
         #[arg(long, global = true, default_value_t = false)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -563,7 +563,7 @@ pub enum Commands {
     #[command(
         visible_alias = "plugin",
         about = "Author manifest-first plugin packages and inspect shared plugin governance truth",
-        long_about = "Manifest-first plugin namespace for bounded authoring bootstrap, inspecting manifest-first package inventory, evaluating profile-aware preflight, and consuming the deduplicated operator action plan.\n\nThis command does not introduce a second policy engine. It reuses the existing spec `plugin_inventory` and `plugin_preflight` surfaces for shared plugin truth and adds one thin authoring scaffold for external package roots."
+        long_about = "Manifest-first plugin namespace for bounded authoring bootstrap, inspecting manifest-first package inventory, diagnosing package-author contract issues, evaluating profile-aware preflight, and consuming the deduplicated operator action plan.\n\nThis command does not introduce a second policy engine. It reuses the existing spec `plugin_inventory` and `plugin_preflight` surfaces for shared plugin truth and adds thin author-facing surfaces for external package roots."
     )]
     Plugins {
         #[arg(long, global = true, default_value_t = false)]

--- a/crates/daemon/src/plugins_cli.rs
+++ b/crates/daemon/src/plugins_cli.rs
@@ -1090,18 +1090,12 @@ fn execute_plugins_init(command: PluginInitCommand) -> CliResult<PluginsInitExec
         bridge_kind.as_str(),
     );
 
-    fs::write(&manifest_path, rendered_manifest).map_err(|error| {
-        format!(
-            "write scaffold manifest `{}` failed: {error}",
-            manifest_path.display()
-        )
-    })?;
-    fs::write(&readme_path, rendered_readme).map_err(|error| {
-        format!(
-            "write scaffold readme `{}` failed: {error}",
-            readme_path.display()
-        )
-    })?;
+    write_plugin_scaffold_files(
+        &manifest_path,
+        rendered_manifest.as_str(),
+        &readme_path,
+        rendered_readme.as_str(),
+    )?;
 
     let manifest_path_string = manifest_path.display().to_string();
     let readme_path_string = readme_path.display().to_string();
@@ -1133,6 +1127,40 @@ fn normalize_required_cli_value(field_name: &str, raw: &str) -> CliResult<String
     }
 
     Ok(trimmed.to_owned())
+}
+
+fn write_plugin_scaffold_files(
+    manifest_path: &Path,
+    rendered_manifest: &str,
+    readme_path: &Path,
+    rendered_readme: &str,
+) -> CliResult<()> {
+    let manifest_write_result = fs::write(manifest_path, rendered_manifest);
+    if let Err(error) = manifest_write_result {
+        return Err(format!(
+            "write scaffold manifest `{}` failed: {error}",
+            manifest_path.display()
+        ));
+    }
+
+    let readme_write_result = fs::write(readme_path, rendered_readme);
+    if let Err(error) = readme_write_result {
+        let manifest_cleanup_result = fs::remove_file(manifest_path);
+        if let Err(cleanup_error) = manifest_cleanup_result {
+            return Err(format!(
+                "write scaffold readme `{}` failed: {error}; cleanup scaffold manifest `{}` failed: {cleanup_error}",
+                readme_path.display(),
+                manifest_path.display()
+            ));
+        }
+
+        return Err(format!(
+            "write scaffold readme `{}` failed: {error}",
+            readme_path.display()
+        ));
+    }
+
+    Ok(())
 }
 
 fn normalize_optional_cli_value(raw: Option<&str>) -> Option<String> {
@@ -4107,6 +4135,7 @@ mod tests {
             manifest.metadata.get("entrypoint").map(String::as_str),
             Some("https://localhost/invoke")
         );
+        let expected_host_version_req = format!(">={}", env!("CARGO_PKG_VERSION"));
         assert_eq!(
             manifest
                 .compatibility
@@ -4119,7 +4148,7 @@ mod tests {
                 .compatibility
                 .as_ref()
                 .and_then(|compatibility| compatibility.host_version_req.as_deref()),
-            Some(">=0.1.0-alpha.2")
+            Some(expected_host_version_req.as_str())
         );
 
         let rendered_readme =
@@ -4259,6 +4288,39 @@ mod tests {
         );
         assert_eq!(ir.runtime.adapter_family, "python-stdio-adapter");
         assert_eq!(ir.runtime.entrypoint_hint, "stdin/stdout::invoke");
+    }
+
+    #[test]
+    fn write_plugin_scaffold_files_rolls_back_manifest_when_readme_write_fails() {
+        let temp_root = unique_temp_dir("loongclaw-plugins-cli-init-rollback");
+        let package_root = Path::new(temp_root.as_str());
+        let manifest_path = package_root.join(PACKAGE_MANIFEST_FILE_NAME);
+        let readme_path = package_root.join(PLUGINS_INIT_README_FILE_NAME);
+        let expected_host_version_req = format!(">={}", env!("CARGO_PKG_VERSION"));
+
+        fs::create_dir_all(package_root).expect("create package root");
+        fs::create_dir(&readme_path).expect("create readme directory");
+
+        let manifest_contents = format!(
+            "{{\"compatibility\":{{\"host_version_req\":\"{expected_host_version_req}\"}}}}"
+        );
+        let error = write_plugin_scaffold_files(
+            &manifest_path,
+            manifest_contents.as_str(),
+            &readme_path,
+            "# scaffold",
+        )
+        .expect_err("readme directory should force scaffold rollback");
+
+        assert!(error.contains("write scaffold readme"));
+        assert!(
+            !manifest_path.exists(),
+            "manifest should be removed after readme write failure"
+        );
+        assert!(
+            readme_path.is_dir(),
+            "readme test fixture directory should remain in place"
+        );
     }
 
     #[tokio::test]

--- a/crates/daemon/src/plugins_cli.rs
+++ b/crates/daemon/src/plugins_cli.rs
@@ -3,10 +3,15 @@ use std::fs;
 use std::path::Path;
 
 use clap::{Args, Subcommand, ValueEnum};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::kernel::{Capability, ExecutionRoute, HarnessKind, VerticalPackManifest};
+use crate::kernel::{
+    CURRENT_PLUGIN_HOST_API, CURRENT_PLUGIN_MANIFEST_API_VERSION, Capability, ExecutionRoute,
+    HarnessKind, PACKAGE_MANIFEST_FILE_NAME, PluginBridgeKind, PluginCompatibility, PluginManifest,
+    VerticalPackManifest, plugin_runtime_scaffold_defaults,
+};
 use crate::{
     BridgeSupportSpec, CliResult, HumanApprovalMode, HumanApprovalSpec, JsonSchemaDescriptor,
     MaterializedBridgeSupportDeltaArtifact, OperationSpec,
@@ -22,6 +27,7 @@ pub const PLUGINS_BRIDGE_PROFILES_SCHEMA_PURPOSE: &str = "bridge_profiles_catalo
 pub const PLUGINS_BRIDGE_TEMPLATE_SCHEMA_PURPOSE: &str = "bridge_support_materialization";
 pub const PLUGINS_PREFLIGHT_SCHEMA_PURPOSE: &str = "ecosystem_preflight_evaluation";
 pub const PLUGINS_ACTIONS_SCHEMA_PURPOSE: &str = "operator_action_plan";
+pub const PLUGINS_INIT_SCHEMA_PURPOSE: &str = "package_scaffold";
 
 fn plugins_command_schema(purpose: &str) -> JsonSchemaDescriptor {
     let version = PLUGINS_COMMAND_SCHEMA_VERSION;
@@ -32,6 +38,8 @@ fn plugins_command_schema(purpose: &str) -> JsonSchemaDescriptor {
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum PluginsCommands {
+    /// Scaffold a new manifest-first plugin package root for external authors
+    Init(PluginInitCommand),
     /// List bundled bridge support profiles for controlled ecosystem compatibility
     BridgeProfiles(PluginBridgeProfilesCommand),
     /// Emit the effective recommended bridge support profile template for the scanned ecosystem
@@ -165,6 +173,64 @@ pub struct PluginActionsCommand {
     /// Restrict returned actions by reload requirement
     #[arg(long)]
     pub requires_reload: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "snake_case")]
+pub enum PluginInitBridgeKindArg {
+    HttpJson,
+    ProcessStdio,
+    NativeFfi,
+    WasmComponent,
+    McpServer,
+    AcpBridge,
+    AcpRuntime,
+}
+
+impl PluginInitBridgeKindArg {
+    fn as_bridge_kind(self) -> PluginBridgeKind {
+        match self {
+            Self::HttpJson => PluginBridgeKind::HttpJson,
+            Self::ProcessStdio => PluginBridgeKind::ProcessStdio,
+            Self::NativeFfi => PluginBridgeKind::NativeFfi,
+            Self::WasmComponent => PluginBridgeKind::WasmComponent,
+            Self::McpServer => PluginBridgeKind::McpServer,
+            Self::AcpBridge => PluginBridgeKind::AcpBridge,
+            Self::AcpRuntime => PluginBridgeKind::AcpRuntime,
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+#[command(
+    about = "Scaffold a manifest-first plugin package root for external authors",
+    long_about = "Scaffold a manifest-first plugin package root for external authors.\n\nThe generated package contains a canonical `loongclaw.plugin.json` plus a README that points authors to `loongclaw plugins preflight` and `loongclaw plugins actions` for governance validation. This command scaffolds package metadata only; it does not generate runtime code or widen trust policy."
+)]
+pub struct PluginInitCommand {
+    /// Target package root to create or reuse when the directory is empty
+    #[arg(value_name = "PACKAGE_ROOT")]
+    pub package_root: String,
+    /// Stable plugin identity used by governance, inventory, and audit surfaces
+    #[arg(long)]
+    pub plugin_id: String,
+    /// Optional provider id override; defaults to plugin_id
+    #[arg(long)]
+    pub provider_id: Option<String>,
+    /// Optional connector name override; defaults to plugin_id
+    #[arg(long)]
+    pub connector_name: Option<String>,
+    /// Runtime bridge surface declared by the plugin package
+    #[arg(long, value_enum)]
+    pub bridge_kind: PluginInitBridgeKindArg,
+    /// Source language for language-specific bridges such as process_stdio or native_ffi
+    #[arg(long)]
+    pub source_language: Option<String>,
+    /// Initial package version written to the manifest
+    #[arg(long, default_value = "0.1.0")]
+    pub version: String,
+    /// Optional one-line summary written to the manifest
+    #[arg(long)]
+    pub summary: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -486,9 +552,28 @@ pub struct PluginsBridgeTemplateExecution {
     pub template: BridgeSupportSpec,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PluginsInitExecution {
+    pub schema_version: u32,
+    pub schema: JsonSchemaDescriptor,
+    pub package_root: String,
+    pub manifest_path: String,
+    pub readme_path: String,
+    pub plugin_id: String,
+    pub provider_id: String,
+    pub connector_name: String,
+    pub version: String,
+    pub bridge_kind: String,
+    pub source_language: Option<String>,
+    pub adapter_family: String,
+    pub entrypoint: String,
+    pub files_written: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
 pub enum PluginsCommandExecution {
+    Init(Box<PluginsInitExecution>),
     BridgeProfiles(Box<PluginsBridgeProfilesExecution>),
     BridgeTemplate(Box<PluginsBridgeTemplateExecution>),
     Preflight(Box<PluginsPreflightExecution>),
@@ -513,6 +598,10 @@ pub async fn execute_plugins_command(
     options: PluginsCommandOptions,
 ) -> CliResult<PluginsCommandExecution> {
     match options.command {
+        PluginsCommands::Init(command) => {
+            let execution = execute_plugins_init(command)?;
+            Ok(PluginsCommandExecution::Init(Box::new(execution)))
+        }
         PluginsCommands::BridgeProfiles(command) => {
             let profiles = load_bridge_profile_views(&command.profiles)?;
             Ok(PluginsCommandExecution::BridgeProfiles(Box::new(
@@ -716,8 +805,291 @@ pub async fn execute_plugins_command(
     }
 }
 
+const PLUGINS_INIT_README_FILE_NAME: &str = "README.md";
+
+#[derive(Debug, Serialize)]
+struct PluginPackageScaffoldManifestDocument {
+    api_version: String,
+    version: String,
+    plugin_id: String,
+    provider_id: String,
+    connector_name: String,
+    capabilities: BTreeSet<Capability>,
+    metadata: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<String>,
+    compatibility: PluginCompatibility,
+}
+
+fn execute_plugins_init(command: PluginInitCommand) -> CliResult<PluginsInitExecution> {
+    let package_root = normalize_required_cli_value("package root", &command.package_root)?;
+    let plugin_id = normalize_required_cli_value("--plugin-id", &command.plugin_id)?;
+    let provider_id = normalize_optional_cli_value(command.provider_id.as_deref())
+        .unwrap_or_else(|| plugin_id.clone());
+    let connector_name = normalize_optional_cli_value(command.connector_name.as_deref())
+        .unwrap_or_else(|| plugin_id.clone());
+    let version = normalize_required_cli_value("--version", &command.version)?;
+    let summary = normalize_optional_cli_value(command.summary.as_deref());
+    let bridge_kind = command.bridge_kind.as_bridge_kind();
+
+    validate_plugin_scaffold_version(&version)?;
+
+    let scaffold_defaults =
+        plugin_runtime_scaffold_defaults(bridge_kind, command.source_language.as_deref())
+            .map_err(|error| format!("plugins init failed: {error}; use --source-language when required by the selected bridge"))?;
+
+    let manifest = build_plugin_scaffold_manifest(
+        &plugin_id,
+        &provider_id,
+        &connector_name,
+        &version,
+        summary,
+        &scaffold_defaults,
+    );
+
+    let package_root_path = Path::new(package_root.as_str());
+    ensure_empty_plugin_scaffold_root(package_root_path)?;
+
+    let manifest_path = package_root_path.join(PACKAGE_MANIFEST_FILE_NAME);
+    let readme_path = package_root_path.join(PLUGINS_INIT_README_FILE_NAME);
+
+    let manifest_document = plugin_scaffold_manifest_document(&manifest)?;
+    let rendered_manifest = serde_json::to_string_pretty(&manifest_document)
+        .map_err(|error| format!("serialize scaffold manifest failed: {error}"))?;
+    let rendered_readme = render_plugin_scaffold_readme(
+        package_root.as_str(),
+        plugin_id.as_str(),
+        bridge_kind.as_str(),
+    );
+
+    fs::write(&manifest_path, rendered_manifest).map_err(|error| {
+        format!(
+            "write scaffold manifest `{}` failed: {error}",
+            manifest_path.display()
+        )
+    })?;
+    fs::write(&readme_path, rendered_readme).map_err(|error| {
+        format!(
+            "write scaffold readme `{}` failed: {error}",
+            readme_path.display()
+        )
+    })?;
+
+    let manifest_path_string = manifest_path.display().to_string();
+    let readme_path_string = readme_path.display().to_string();
+    let files_written = vec![manifest_path_string.clone(), readme_path_string.clone()];
+
+    Ok(PluginsInitExecution {
+        schema_version: PLUGINS_COMMAND_SCHEMA_VERSION,
+        schema: plugins_command_schema(PLUGINS_INIT_SCHEMA_PURPOSE),
+        package_root,
+        manifest_path: manifest_path_string,
+        readme_path: readme_path_string,
+        plugin_id,
+        provider_id,
+        connector_name,
+        version,
+        bridge_kind: bridge_kind.as_str().to_owned(),
+        source_language: scaffold_defaults.source_language,
+        adapter_family: scaffold_defaults.adapter_family,
+        entrypoint: scaffold_defaults.entrypoint_hint,
+        files_written,
+    })
+}
+
+fn normalize_required_cli_value(field_name: &str, raw: &str) -> CliResult<String> {
+    let trimmed = raw.trim();
+
+    if trimmed.is_empty() {
+        return Err(format!("plugins init requires a non-empty {field_name}"));
+    }
+
+    Ok(trimmed.to_owned())
+}
+
+fn normalize_optional_cli_value(raw: Option<&str>) -> Option<String> {
+    raw.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        Some(trimmed.to_owned())
+    })
+}
+
+fn validate_plugin_scaffold_version(version: &str) -> CliResult<()> {
+    Version::parse(version)
+        .map(|_| ())
+        .map_err(|error| format!("plugins init requires --version to be valid semver: {error}"))
+}
+
+fn ensure_empty_plugin_scaffold_root(package_root: &Path) -> CliResult<()> {
+    if package_root.exists() {
+        let root_is_directory = package_root.is_dir();
+        if !root_is_directory {
+            return Err(format!(
+                "plugins init requires package root `{}` to be a directory",
+                package_root.display()
+            ));
+        }
+
+        let mut entries = fs::read_dir(package_root).map_err(|error| {
+            format!(
+                "inspect scaffold package root `{}` failed: {error}",
+                package_root.display()
+            )
+        })?;
+        let first_entry = entries.next().transpose().map_err(|error| {
+            format!(
+                "inspect scaffold package root `{}` failed: {error}",
+                package_root.display()
+            )
+        })?;
+        if first_entry.is_some() {
+            return Err(format!(
+                "plugins init requires an empty package root; `{}` already contains files",
+                package_root.display()
+            ));
+        }
+
+        return Ok(());
+    }
+
+    fs::create_dir_all(package_root).map_err(|error| {
+        format!(
+            "create scaffold package root `{}` failed: {error}",
+            package_root.display()
+        )
+    })
+}
+
+fn build_plugin_scaffold_manifest(
+    plugin_id: &str,
+    provider_id: &str,
+    connector_name: &str,
+    version: &str,
+    summary: Option<String>,
+    scaffold_defaults: &crate::kernel::PluginRuntimeScaffoldDefaults,
+) -> PluginManifest {
+    let mut capabilities = BTreeSet::new();
+    capabilities.insert(Capability::InvokeConnector);
+
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "bridge_kind".to_owned(),
+        scaffold_defaults.bridge_kind.as_str().to_owned(),
+    );
+    metadata.insert(
+        "adapter_family".to_owned(),
+        scaffold_defaults.adapter_family.clone(),
+    );
+    metadata.insert(
+        "entrypoint".to_owned(),
+        scaffold_defaults.entrypoint_hint.clone(),
+    );
+    if let Some(source_language) = scaffold_defaults.source_language.as_ref() {
+        metadata.insert("source_language".to_owned(), source_language.clone());
+    }
+
+    let host_version_req = format!(">={}", env!("CARGO_PKG_VERSION"));
+    let compatibility = PluginCompatibility {
+        host_api: Some(CURRENT_PLUGIN_HOST_API.to_owned()),
+        host_version_req: Some(host_version_req),
+    };
+
+    PluginManifest {
+        api_version: Some(CURRENT_PLUGIN_MANIFEST_API_VERSION.to_owned()),
+        version: Some(version.to_owned()),
+        plugin_id: plugin_id.to_owned(),
+        provider_id: provider_id.to_owned(),
+        connector_name: connector_name.to_owned(),
+        channel_id: None,
+        endpoint: None,
+        capabilities,
+        trust_tier: Default::default(),
+        metadata,
+        summary,
+        tags: Vec::new(),
+        input_examples: Vec::new(),
+        output_examples: Vec::new(),
+        defer_loading: false,
+        setup: None,
+        slot_claims: Vec::new(),
+        compatibility: Some(compatibility),
+    }
+}
+
+fn plugin_scaffold_manifest_document(
+    manifest: &PluginManifest,
+) -> CliResult<PluginPackageScaffoldManifestDocument> {
+    let api_version = manifest
+        .api_version
+        .clone()
+        .ok_or_else(|| "scaffold manifest is missing api_version".to_owned())?;
+    let version = manifest
+        .version
+        .clone()
+        .ok_or_else(|| "scaffold manifest is missing version".to_owned())?;
+    let compatibility = manifest
+        .compatibility
+        .clone()
+        .ok_or_else(|| "scaffold manifest is missing compatibility".to_owned())?;
+
+    Ok(PluginPackageScaffoldManifestDocument {
+        api_version,
+        version,
+        plugin_id: manifest.plugin_id.clone(),
+        provider_id: manifest.provider_id.clone(),
+        connector_name: manifest.connector_name.clone(),
+        capabilities: manifest.capabilities.clone(),
+        metadata: manifest.metadata.clone(),
+        summary: manifest.summary.clone(),
+        compatibility,
+    })
+}
+
+fn render_plugin_scaffold_readme(package_root: &str, plugin_id: &str, bridge_kind: &str) -> String {
+    let preflight_command =
+        format!("loongclaw plugins preflight --root \"{package_root}\" --profile sdk-release");
+    let actions_command =
+        format!("loongclaw plugins actions --root \"{package_root}\" --profile sdk-release");
+
+    [
+        format!("# {plugin_id}"),
+        String::new(),
+        "This package was scaffolded by `loongclaw plugins init`.".to_owned(),
+        String::new(),
+        format!("- Bridge kind: `{bridge_kind}`"),
+        format!("- Manifest: `{PACKAGE_MANIFEST_FILE_NAME}`"),
+        "- Trust default: `unverified`".to_owned(),
+        String::new(),
+        "## Next Steps".to_owned(),
+        String::new(),
+        format!(
+            "1. Replace the scaffolded bridge entrypoint in `{PACKAGE_MANIFEST_FILE_NAME}` with the real runtime entry for your package."
+        ),
+        format!(
+            "2. Fill in `summary`, `setup`, `slot_claims`, `tags`, and examples in `{PACKAGE_MANIFEST_FILE_NAME}` as your package contract becomes concrete."
+        ),
+        "3. Validate the package contract through the shared governance surface:".to_owned(),
+        String::new(),
+        "```bash".to_owned(),
+        preflight_command,
+        "```".to_owned(),
+        String::new(),
+        "4. Review the deduplicated operator action plan before release or marketplace handoff:"
+            .to_owned(),
+        String::new(),
+        "```bash".to_owned(),
+        actions_command,
+        "```".to_owned(),
+    ]
+    .join("\n")
+}
+
 fn render_plugins_cli_text(execution: &PluginsCommandExecution) -> String {
     match execution {
+        PluginsCommandExecution::Init(execution) => render_plugins_init_text(execution),
         PluginsCommandExecution::BridgeProfiles(execution) => {
             render_plugins_bridge_profiles_text(execution)
         }
@@ -727,6 +1099,32 @@ fn render_plugins_cli_text(execution: &PluginsCommandExecution) -> String {
         PluginsCommandExecution::Preflight(execution) => render_plugins_preflight_text(execution),
         PluginsCommandExecution::Actions(execution) => render_plugins_actions_text(execution),
     }
+}
+
+fn render_plugins_init_text(execution: &PluginsInitExecution) -> String {
+    let source_language = execution.source_language.as_deref().unwrap_or("-");
+    let mut lines = vec![format!(
+        "plugins init package_root={} plugin_id={} provider_id={} connector_name={}",
+        execution.package_root,
+        execution.plugin_id,
+        execution.provider_id,
+        execution.connector_name
+    )];
+    lines.push(format!(
+        "- bridge_kind={} source_language={} adapter_family={} entrypoint={}",
+        execution.bridge_kind, source_language, execution.adapter_family, execution.entrypoint
+    ));
+    lines.push(format!("- manifest={}", execution.manifest_path));
+    lines.push(format!("- readme={}", execution.readme_path));
+    lines.push(format!(
+        "- next_steps=loongclaw plugins preflight --root \"{}\" --profile sdk-release",
+        execution.package_root
+    ));
+    lines.push(format!(
+        "- operator_actions=loongclaw plugins actions --root \"{}\" --profile sdk-release",
+        execution.package_root
+    ));
+    lines.join("\n")
 }
 
 fn render_plugins_bridge_profiles_text(execution: &PluginsBridgeProfilesExecution) -> String {
@@ -2583,5 +2981,263 @@ mod tests {
             delta_artifact.delta.shim_profile_additions[0].supported_source_languages,
             vec!["python".to_owned()]
         );
+    }
+
+    #[tokio::test]
+    async fn execute_plugins_init_scaffolds_http_json_package_manifest() {
+        let temp_root = unique_temp_dir("loongclaw-plugins-cli-init-http");
+        let package_root = format!("{temp_root}/tavily-search");
+
+        let execution = execute_plugins_command(PluginsCommandOptions {
+            json: false,
+            command: PluginsCommands::Init(PluginInitCommand {
+                package_root: package_root.clone(),
+                plugin_id: "tavily-search".to_owned(),
+                provider_id: None,
+                connector_name: None,
+                bridge_kind: PluginInitBridgeKindArg::HttpJson,
+                source_language: None,
+                version: "0.1.0".to_owned(),
+                summary: Some("Tavily-backed search package".to_owned()),
+            }),
+        })
+        .await
+        .expect("plugins init should scaffold an http json package");
+
+        let PluginsCommandExecution::Init(execution) = execution else {
+            panic!("expected init execution");
+        };
+
+        assert_eq!(execution.schema_version, PLUGINS_COMMAND_SCHEMA_VERSION);
+        assert_eq!(execution.schema.version, PLUGINS_COMMAND_SCHEMA_VERSION);
+        assert_eq!(execution.schema.surface, PLUGINS_COMMAND_SCHEMA_SURFACE);
+        assert_eq!(execution.schema.purpose, PLUGINS_INIT_SCHEMA_PURPOSE);
+        assert_eq!(execution.package_root, package_root);
+        assert_eq!(execution.plugin_id, "tavily-search");
+        assert_eq!(execution.provider_id, "tavily-search");
+        assert_eq!(execution.connector_name, "tavily-search");
+        assert_eq!(execution.bridge_kind, "http_json");
+        assert_eq!(execution.source_language, None);
+        assert_eq!(execution.adapter_family, "http-adapter");
+        assert_eq!(execution.entrypoint, "https://localhost/invoke");
+        assert_eq!(execution.version, "0.1.0");
+        assert_eq!(execution.files_written.len(), 2);
+
+        let manifest_path = execution.manifest_path.clone();
+        let readme_path = execution.readme_path.clone();
+
+        let rendered_manifest =
+            fs::read_to_string(&manifest_path).expect("scaffold manifest should exist");
+        let manifest: crate::kernel::PluginManifest =
+            serde_json::from_str(&rendered_manifest).expect("scaffold manifest should decode");
+
+        assert_eq!(
+            manifest.api_version.as_deref(),
+            Some(crate::kernel::CURRENT_PLUGIN_MANIFEST_API_VERSION)
+        );
+        assert_eq!(manifest.version.as_deref(), Some("0.1.0"));
+        assert_eq!(manifest.plugin_id, "tavily-search");
+        assert_eq!(manifest.provider_id, "tavily-search");
+        assert_eq!(manifest.connector_name, "tavily-search");
+        assert_eq!(
+            manifest.summary.as_deref(),
+            Some("Tavily-backed search package")
+        );
+        assert!(
+            manifest.capabilities.contains(&Capability::InvokeConnector),
+            "scaffold manifest should include invoke_connector"
+        );
+        assert_eq!(
+            manifest.metadata.get("bridge_kind").map(String::as_str),
+            Some("http_json")
+        );
+        assert_eq!(
+            manifest.metadata.get("adapter_family").map(String::as_str),
+            Some("http-adapter")
+        );
+        assert_eq!(
+            manifest.metadata.get("entrypoint").map(String::as_str),
+            Some("https://localhost/invoke")
+        );
+        assert_eq!(
+            manifest
+                .compatibility
+                .as_ref()
+                .and_then(|compatibility| compatibility.host_api.as_deref()),
+            Some(crate::kernel::CURRENT_PLUGIN_HOST_API)
+        );
+        assert_eq!(
+            manifest
+                .compatibility
+                .as_ref()
+                .and_then(|compatibility| compatibility.host_version_req.as_deref()),
+            Some(">=0.1.0-alpha.2")
+        );
+
+        let rendered_readme =
+            fs::read_to_string(&readme_path).expect("scaffold readme should exist");
+        assert!(
+            rendered_readme.contains("loongclaw plugins preflight --root"),
+            "README should point authors to preflight: {rendered_readme}"
+        );
+        assert!(
+            rendered_readme.contains("loongclaw plugins actions --root"),
+            "README should point authors to actions: {rendered_readme}"
+        );
+
+        let scanner = crate::kernel::PluginScanner::new();
+        let scan_report = scanner
+            .scan_path(&execution.package_root)
+            .expect("scaffold package should scan cleanly");
+        let translator = crate::kernel::PluginTranslator::new();
+        let translation_report = translator.translate_scan_report(&scan_report);
+        let ir = &translation_report.entries[0];
+
+        assert_eq!(translation_report.translated_plugins, 1);
+        assert_eq!(
+            ir.runtime.bridge_kind,
+            crate::kernel::PluginBridgeKind::HttpJson
+        );
+        assert_eq!(ir.runtime.adapter_family, "http-adapter");
+        assert_eq!(ir.runtime.entrypoint_hint, "https://localhost/invoke");
+    }
+
+    #[tokio::test]
+    async fn execute_plugins_init_requires_source_language_for_process_stdio() {
+        let temp_root = unique_temp_dir("loongclaw-plugins-cli-init-process-language");
+        let package_root = format!("{temp_root}/tavily-search");
+
+        let error = execute_plugins_command(PluginsCommandOptions {
+            json: false,
+            command: PluginsCommands::Init(PluginInitCommand {
+                package_root,
+                plugin_id: "tavily-search".to_owned(),
+                provider_id: None,
+                connector_name: None,
+                bridge_kind: PluginInitBridgeKindArg::ProcessStdio,
+                source_language: None,
+                version: "0.1.0".to_owned(),
+                summary: None,
+            }),
+        })
+        .await
+        .expect_err("process stdio scaffold should require source language");
+
+        assert!(error.contains("--source-language"));
+        assert!(error.contains("process_stdio"));
+    }
+
+    #[tokio::test]
+    async fn execute_plugins_init_rejects_invalid_semver_version() {
+        let temp_root = unique_temp_dir("loongclaw-plugins-cli-init-invalid-version");
+        let package_root = format!("{temp_root}/tavily-search");
+
+        let error = execute_plugins_command(PluginsCommandOptions {
+            json: false,
+            command: PluginsCommands::Init(PluginInitCommand {
+                package_root,
+                plugin_id: "tavily-search".to_owned(),
+                provider_id: None,
+                connector_name: None,
+                bridge_kind: PluginInitBridgeKindArg::HttpJson,
+                source_language: None,
+                version: "not-semver".to_owned(),
+                summary: None,
+            }),
+        })
+        .await
+        .expect_err("plugins init should reject invalid semver");
+
+        assert!(error.contains("--version"));
+        assert!(error.contains("semver"));
+    }
+
+    #[tokio::test]
+    async fn execute_plugins_init_process_stdio_scaffold_retains_source_language() {
+        let temp_root = unique_temp_dir("loongclaw-plugins-cli-init-process");
+        let package_root = format!("{temp_root}/weather-python");
+
+        let execution = execute_plugins_command(PluginsCommandOptions {
+            json: false,
+            command: PluginsCommands::Init(PluginInitCommand {
+                package_root,
+                plugin_id: "weather-python".to_owned(),
+                provider_id: Some("weather".to_owned()),
+                connector_name: Some("weather-stdio".to_owned()),
+                bridge_kind: PluginInitBridgeKindArg::ProcessStdio,
+                source_language: Some("py".to_owned()),
+                version: "0.2.0".to_owned(),
+                summary: Some("Python weather bridge".to_owned()),
+            }),
+        })
+        .await
+        .expect("process stdio scaffold should succeed");
+
+        let PluginsCommandExecution::Init(execution) = execution else {
+            panic!("expected init execution");
+        };
+
+        assert_eq!(execution.bridge_kind, "process_stdio");
+        assert_eq!(execution.source_language.as_deref(), Some("python"));
+        assert_eq!(execution.adapter_family, "python-stdio-adapter");
+        assert_eq!(execution.entrypoint, "stdin/stdout::invoke");
+
+        let rendered_manifest =
+            fs::read_to_string(&execution.manifest_path).expect("manifest should exist");
+        let manifest: crate::kernel::PluginManifest =
+            serde_json::from_str(&rendered_manifest).expect("manifest should decode");
+
+        assert_eq!(
+            manifest.metadata.get("source_language").map(String::as_str),
+            Some("python")
+        );
+        assert_eq!(
+            manifest.metadata.get("adapter_family").map(String::as_str),
+            Some("python-stdio-adapter")
+        );
+
+        let scanner = crate::kernel::PluginScanner::new();
+        let scan_report = scanner
+            .scan_path(&execution.package_root)
+            .expect("scaffold package should scan cleanly");
+        let translator = crate::kernel::PluginTranslator::new();
+        let translation_report = translator.translate_scan_report(&scan_report);
+        let ir = &translation_report.entries[0];
+
+        assert_eq!(ir.runtime.source_language, "python");
+        assert_eq!(
+            ir.runtime.bridge_kind,
+            crate::kernel::PluginBridgeKind::ProcessStdio
+        );
+        assert_eq!(ir.runtime.adapter_family, "python-stdio-adapter");
+        assert_eq!(ir.runtime.entrypoint_hint, "stdin/stdout::invoke");
+    }
+
+    #[tokio::test]
+    async fn execute_plugins_init_rejects_non_empty_package_root() {
+        let temp_root = unique_temp_dir("loongclaw-plugins-cli-init-non-empty");
+        let package_root = format!("{temp_root}/existing");
+
+        fs::create_dir_all(&package_root).expect("create package root");
+        fs::write(format!("{package_root}/README.md"), "occupied").expect("write occupied file");
+
+        let error = execute_plugins_command(PluginsCommandOptions {
+            json: false,
+            command: PluginsCommands::Init(PluginInitCommand {
+                package_root: package_root.clone(),
+                plugin_id: "occupied".to_owned(),
+                provider_id: None,
+                connector_name: None,
+                bridge_kind: PluginInitBridgeKindArg::HttpJson,
+                source_language: None,
+                version: "0.1.0".to_owned(),
+                summary: None,
+            }),
+        })
+        .await
+        .expect_err("non-empty package root should be rejected");
+
+        assert!(error.contains("empty"));
+        assert!(error.contains(&package_root));
     }
 }

--- a/crates/daemon/src/plugins_cli.rs
+++ b/crates/daemon/src/plugins_cli.rs
@@ -15,9 +15,9 @@ use crate::kernel::{
 use crate::{
     BridgeSupportSpec, CliResult, HumanApprovalMode, HumanApprovalSpec, JsonSchemaDescriptor,
     MaterializedBridgeSupportDeltaArtifact, OperationSpec, PluginInventoryResult,
-    PluginPreflightBridgeProfileRecommendation, PluginPreflightProfile, PluginScanSpec,
-    ResolvedBridgeSupportSelection, RunnerSpec, SecurityProfileSignatureSpec, SpecRunReport,
-    default_plugin_inventory_limit, default_plugin_preflight_limit, execute_spec,
+    PluginPreflightBridgeProfileRecommendation, PluginPreflightProfile, PluginPreflightResult,
+    PluginScanSpec, ResolvedBridgeSupportSelection, RunnerSpec, SecurityProfileSignatureSpec,
+    SpecRunReport, default_plugin_inventory_limit, default_plugin_preflight_limit, execute_spec,
     json_schema_descriptor, materialize_bridge_support_delta_artifact,
     materialize_bridge_support_template, resolve_bridge_support_policy,
     resolve_bridge_support_selection,
@@ -26,6 +26,7 @@ use crate::{
 pub const PLUGINS_COMMAND_SCHEMA_VERSION: u32 = 1;
 pub const PLUGINS_COMMAND_SCHEMA_SURFACE: &str = "plugin_governance";
 pub const PLUGINS_INVENTORY_SCHEMA_PURPOSE: &str = "package_inventory";
+pub const PLUGINS_DOCTOR_SCHEMA_PURPOSE: &str = "package_doctor";
 pub const PLUGINS_BRIDGE_PROFILES_SCHEMA_PURPOSE: &str = "bridge_profiles_catalog";
 pub const PLUGINS_BRIDGE_TEMPLATE_SCHEMA_PURPOSE: &str = "bridge_support_materialization";
 pub const PLUGINS_PREFLIGHT_SCHEMA_PURPOSE: &str = "ecosystem_preflight_evaluation";
@@ -45,6 +46,8 @@ pub enum PluginsCommands {
     Init(PluginInitCommand),
     /// Inspect manifest-first package truth across one or more plugin roots
     Inventory(PluginInventoryCommand),
+    /// Diagnose manifest-first plugin packages with author-facing remediation
+    Doctor(PluginDoctorCommand),
     /// List bundled bridge support profiles for controlled ecosystem compatibility
     BridgeProfiles(PluginBridgeProfilesCommand),
     /// Emit the effective recommended bridge support profile template for the scanned ecosystem
@@ -123,6 +126,52 @@ pub struct PluginInventoryCommand {
     /// Include input/output examples in inventory result rows
     #[arg(long, default_value_t = false)]
     pub include_examples: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct PluginDoctorSourceArgs {
+    #[command(flatten)]
+    pub scan: PluginScanSourceArgs,
+    /// Author-facing governance profile to evaluate
+    #[arg(long, value_enum, default_value_t = PluginPreflightProfileArg::SdkRelease)]
+    pub profile: PluginPreflightProfileArg,
+    /// Optional plugin preflight policy JSON file
+    #[arg(long)]
+    pub policy_path: Option<String>,
+    /// Optional sha256 pin for the plugin preflight policy file
+    #[arg(long)]
+    pub policy_sha256: Option<String>,
+    /// Optional base64-encoded public key for plugin preflight policy signature verification
+    #[arg(long)]
+    pub policy_signature_public_key_base64: Option<String>,
+    /// Optional base64-encoded signature for plugin preflight policy verification
+    #[arg(long)]
+    pub policy_signature_base64: Option<String>,
+    /// Signature algorithm for the provided policy signature
+    #[arg(long, default_value = "ed25519")]
+    pub policy_signature_algorithm: String,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+#[command(
+    about = "Diagnose manifest-first plugin packages and show author-facing remediation",
+    long_about = "Diagnose manifest-first plugin packages and show author-facing remediation.\n\nThis command reuses the shared spec `plugin_preflight` surface, but defaults to the `sdk_release` profile and renders package-author truth first: setup contract, activation status, diagnostics, remediation classes, and required operator actions. Use `--profile runtime-activation` or `--profile marketplace-submission` when you need host-specific or stricter ecosystem review."
+)]
+pub struct PluginDoctorCommand {
+    #[command(flatten)]
+    pub source: PluginDoctorSourceArgs,
+    /// Include plugins that pass the selected governance profile
+    #[arg(long, default_value_t = true)]
+    pub include_passed: bool,
+    /// Include plugins that warn under the selected governance profile
+    #[arg(long, default_value_t = true)]
+    pub include_warned: bool,
+    /// Include plugins that block under the selected governance profile
+    #[arg(long, default_value_t = true)]
+    pub include_blocked: bool,
+    /// Include deferred plugins in the doctor scan
+    #[arg(long, default_value_t = true)]
+    pub include_deferred: bool,
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -233,7 +282,7 @@ impl PluginInitBridgeKindArg {
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 #[command(
     about = "Scaffold a manifest-first plugin package root for external authors",
-    long_about = "Scaffold a manifest-first plugin package root for external authors.\n\nThe generated package contains a canonical `loongclaw.plugin.json` plus a README that points authors to `loongclaw plugins preflight` and `loongclaw plugins actions` for governance validation. This command scaffolds package metadata only; it does not generate runtime code or widen trust policy."
+    long_about = "Scaffold a manifest-first plugin package root for external authors.\n\nThe generated package contains a canonical `loongclaw.plugin.json` plus a README that points authors to `loongclaw plugins doctor` and `loongclaw plugins actions` for shared governance validation. This command scaffolds package metadata only; it does not generate runtime code or widen trust policy."
 )]
 pub struct PluginInitCommand {
     /// Target package root to create or reuse when the directory is empty
@@ -459,6 +508,48 @@ pub struct PluginsInventoryExecution {
     pub results: Vec<PluginInventoryResult>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PluginsDoctorSummaryView {
+    pub matched_plugins: usize,
+    pub returned_plugins: usize,
+    pub passed_plugins: usize,
+    pub warned_plugins: usize,
+    pub blocked_plugins: usize,
+    pub activation_ready_plugins: usize,
+    pub setup_incomplete_plugins: usize,
+    pub deferred_plugins: usize,
+    pub loaded_plugins: usize,
+    pub packages_requiring_author_attention: usize,
+    pub packages_with_operator_actions: usize,
+    pub total_recommended_actions: usize,
+    pub total_operator_actions: usize,
+    pub remediation_counts: BTreeMap<String, usize>,
+    pub bridge_kind_distribution: BTreeMap<String, usize>,
+    pub source_language_distribution: BTreeMap<String, usize>,
+    pub setup_surface_distribution: BTreeMap<String, usize>,
+    pub activation_status_distribution: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PluginsDoctorExecution {
+    pub schema_version: u32,
+    pub schema: JsonSchemaDescriptor,
+    pub scan_roots: Vec<String>,
+    pub query: String,
+    pub limit: usize,
+    pub profile: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_support_provenance: Option<PluginsBridgeSupportProvenanceView>,
+    pub bridge_support_source: Option<String>,
+    pub bridge_support_sha256: Option<String>,
+    pub bridge_support_delta_source: Option<String>,
+    pub bridge_support_delta_sha256: Option<String>,
+    pub summary: PluginsDoctorSummaryView,
+    pub preflight_summary: PluginsPreflightSummaryView,
+    pub returned_results: usize,
+    pub results: Vec<PluginPreflightResult>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PluginsPreflightSummaryView {
     pub schema_version: u32,
@@ -479,6 +570,7 @@ pub struct PluginsPreflightSummaryView {
     pub error_diagnostics: usize,
     pub warning_diagnostics: usize,
     pub info_diagnostics: usize,
+    pub remediation_counts: BTreeMap<String, usize>,
     pub source_kind_distribution: BTreeMap<String, usize>,
     pub dialect_distribution: BTreeMap<String, usize>,
     pub compatibility_mode_distribution: BTreeMap<String, usize>,
@@ -523,7 +615,7 @@ pub struct PluginsPreflightExecution {
     pub bridge_support_delta_sha256: Option<String>,
     pub summary: PluginsPreflightSummaryView,
     pub returned_results: usize,
-    pub results: Vec<Value>,
+    pub results: Vec<PluginPreflightResult>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -637,6 +729,7 @@ pub struct PluginsInitExecution {
 pub enum PluginsCommandExecution {
     Init(Box<PluginsInitExecution>),
     Inventory(Box<PluginsInventoryExecution>),
+    Doctor(Box<PluginsDoctorExecution>),
     BridgeProfiles(Box<PluginsBridgeProfilesExecution>),
     BridgeTemplate(Box<PluginsBridgeTemplateExecution>),
     Preflight(Box<PluginsPreflightExecution>),
@@ -695,6 +788,44 @@ pub async fn execute_plugins_command(
                     bridge_support_delta_sha256: context.bridge_support_delta_sha256,
                     returned_results: results.len(),
                     summary,
+                    results,
+                },
+            )))
+        }
+        PluginsCommands::Doctor(command) => {
+            let context = build_plugin_doctor_context(
+                &command.source,
+                command.include_passed,
+                command.include_warned,
+                command.include_blocked,
+                command.include_deferred,
+            )?;
+            let report = execute_spec(&context.spec, false).await;
+            if let Some(reason) = report.blocked_reason.as_deref() {
+                return Err(format!("plugin doctor blocked: {reason}"));
+            }
+            let bridge_support_provenance = context.bridge_support_provenance();
+            let preflight_summary =
+                decode_preflight_summary(&report, bridge_support_provenance.clone())?;
+            let results = decode_preflight_results(&report)?;
+            let summary = summarize_plugin_doctor_results(&results, &preflight_summary);
+
+            Ok(PluginsCommandExecution::Doctor(Box::new(
+                PluginsDoctorExecution {
+                    schema_version: PLUGINS_COMMAND_SCHEMA_VERSION,
+                    schema: plugins_command_schema(PLUGINS_DOCTOR_SCHEMA_PURPOSE),
+                    scan_roots: context.scan_roots,
+                    query: context.query,
+                    limit: context.limit,
+                    profile: context.profile,
+                    bridge_support_provenance,
+                    bridge_support_source: context.bridge_support_source,
+                    bridge_support_sha256: context.bridge_support_sha256,
+                    bridge_support_delta_source: context.bridge_support_delta_source,
+                    bridge_support_delta_sha256: context.bridge_support_delta_sha256,
+                    summary,
+                    preflight_summary,
+                    returned_results: results.len(),
                     results,
                 },
             )))
@@ -1146,8 +1277,8 @@ fn plugin_scaffold_manifest_document(
 }
 
 fn render_plugin_scaffold_readme(package_root: &str, plugin_id: &str, bridge_kind: &str) -> String {
-    let preflight_command =
-        format!("loongclaw plugins preflight --root \"{package_root}\" --profile sdk-release");
+    let doctor_command =
+        format!("loongclaw plugins doctor --root \"{package_root}\" --profile sdk-release");
     let actions_command =
         format!("loongclaw plugins actions --root \"{package_root}\" --profile sdk-release");
 
@@ -1168,10 +1299,11 @@ fn render_plugin_scaffold_readme(package_root: &str, plugin_id: &str, bridge_kin
         format!(
             "2. Fill in `summary`, `setup`, `slot_claims`, `tags`, and examples in `{PACKAGE_MANIFEST_FILE_NAME}` as your package contract becomes concrete."
         ),
-        "3. Validate the package contract through the shared governance surface:".to_owned(),
+        "3. Diagnose the package contract through the shared author-facing governance surface:"
+            .to_owned(),
         String::new(),
         "```bash".to_owned(),
-        preflight_command,
+        doctor_command,
         "```".to_owned(),
         String::new(),
         "4. Review the deduplicated operator action plan before release or marketplace handoff:"
@@ -1188,6 +1320,7 @@ fn render_plugins_cli_text(execution: &PluginsCommandExecution) -> String {
     match execution {
         PluginsCommandExecution::Init(execution) => render_plugins_init_text(execution),
         PluginsCommandExecution::Inventory(execution) => render_plugins_inventory_text(execution),
+        PluginsCommandExecution::Doctor(execution) => render_plugins_doctor_text(execution),
         PluginsCommandExecution::BridgeProfiles(execution) => {
             render_plugins_bridge_profiles_text(execution)
         }
@@ -1215,7 +1348,7 @@ fn render_plugins_init_text(execution: &PluginsInitExecution) -> String {
     lines.push(format!("- manifest={}", execution.manifest_path));
     lines.push(format!("- readme={}", execution.readme_path));
     lines.push(format!(
-        "- next_steps=loongclaw plugins preflight --root \"{}\" --profile sdk-release",
+        "- next_steps=loongclaw plugins doctor --root \"{}\" --profile sdk-release",
         execution.package_root
     ));
     lines.push(format!(
@@ -1310,6 +1443,66 @@ fn render_plugins_inventory_text(execution: &PluginsInventoryExecution) -> Strin
         if let Some(reason) = result.activation_reason.as_deref() {
             lines.push(format!("  activation_reason={reason}"));
         }
+    }
+    lines.join("\n")
+}
+
+fn render_plugins_doctor_text(execution: &PluginsDoctorExecution) -> String {
+    let preflight_summary = &execution.preflight_summary;
+    let mut lines = vec![format!(
+        "plugins doctor profile={} query={} roots={} matched_plugins={} returned_plugins={} passed={} warned={} blocked={}",
+        execution.profile,
+        display_text_or_dash(Some(execution.query.as_str())),
+        execution.scan_roots.join(","),
+        execution.summary.matched_plugins,
+        execution.returned_results,
+        execution.summary.passed_plugins,
+        execution.summary.warned_plugins,
+        execution.summary.blocked_plugins
+    )];
+    lines.push(format!(
+        "policy source={} version={} checksum={} sha256={}",
+        preflight_summary.policy_source,
+        display_text_or_dash(preflight_summary.policy_version.as_deref()),
+        preflight_summary.policy_checksum,
+        preflight_summary.policy_sha256
+    ));
+    lines.push(format!(
+        "bridge_support source={} sha256={}",
+        display_text_or_dash(execution.bridge_support_source.as_deref()),
+        display_text_or_dash(execution.bridge_support_sha256.as_deref())
+    ));
+    lines.push(format!(
+        "bridge_support_delta source={} sha256={}",
+        display_text_or_dash(execution.bridge_support_delta_source.as_deref()),
+        display_text_or_dash(execution.bridge_support_delta_sha256.as_deref())
+    ));
+    lines.push(format!(
+        "ecosystem bridge={} language={} setup_surface={} activation_status={}",
+        format_rollup_map(&execution.summary.bridge_kind_distribution),
+        format_rollup_map(&execution.summary.source_language_distribution),
+        format_rollup_map(&execution.summary.setup_surface_distribution),
+        format_rollup_map(&execution.summary.activation_status_distribution)
+    ));
+    lines.push(format!(
+        "doctor_attention activation_ready={} setup_incomplete={} deferred={} loaded={} attention={} remediation_counts={}",
+        execution.summary.activation_ready_plugins,
+        execution.summary.setup_incomplete_plugins,
+        execution.summary.deferred_plugins,
+        execution.summary.loaded_plugins,
+        execution.summary.packages_requiring_author_attention,
+        format_rollup_map(&execution.summary.remediation_counts)
+    ));
+    lines.push(format!(
+        "doctor_actions recommended={} operator_actions={} packages_with_operator_actions={} operator_plan_by_kind={}",
+        execution.summary.total_recommended_actions,
+        execution.summary.total_operator_actions,
+        execution.summary.packages_with_operator_actions,
+        format_rollup_map(&preflight_summary.operator_action_counts_by_kind)
+    ));
+    lines.extend(render_bridge_profile_fit_lines(preflight_summary));
+    for result in &execution.results {
+        lines.extend(render_plugin_doctor_result_lines(result));
     }
     lines.join("\n")
 }
@@ -1487,52 +1680,141 @@ fn render_plugins_preflight_text(execution: &PluginsPreflightExecution) -> Strin
     ));
     lines.extend(render_bridge_profile_fit_lines(&execution.summary));
     for result in &execution.results {
-        let plugin = result.get("plugin");
-        let plugin_id = plugin
-            .and_then(|plugin| plugin.get("plugin_id"))
-            .and_then(Value::as_str);
-        let provider_id = plugin
-            .and_then(|plugin| plugin.get("provider_id"))
-            .and_then(Value::as_str);
-        let verdict = result.get("verdict").and_then(Value::as_str);
-        let baseline_verdict = result.get("baseline_verdict").and_then(Value::as_str);
-        let activation_ready = result
-            .get("activation_ready")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let loaded = plugin
-            .and_then(|plugin| plugin.get("loaded"))
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let action_kinds = result
-            .get("recommended_actions")
-            .and_then(Value::as_array)
-            .map(|actions| {
-                let kinds = actions
-                    .iter()
-                    .filter_map(|action| action.get("operator_action"))
-                    .filter_map(|action| action.get("kind"))
-                    .filter_map(Value::as_str)
-                    .collect::<BTreeSet<_>>();
-                if kinds.is_empty() {
-                    "-".to_owned()
-                } else {
-                    kinds.into_iter().collect::<Vec<_>>().join(",")
-                }
-            })
-            .unwrap_or_else(|| "-".to_owned());
+        let plugin = &result.plugin;
+        let action_kinds =
+            format_preflight_result_operator_action_kinds(&result.recommended_actions);
         lines.push(format!(
             "- plugin={} provider={} verdict={} baseline={} activation_ready={} loaded={} actions={}",
-            display_text_or_dash(plugin_id),
-            display_text_or_dash(provider_id),
-            display_text_or_dash(verdict),
-            display_text_or_dash(baseline_verdict),
-            activation_ready,
-            loaded,
+            plugin.plugin_id,
+            plugin.provider_id,
+            result.verdict,
+            result.baseline_verdict,
+            result.activation_ready,
+            plugin.loaded,
             action_kinds
         ));
     }
     lines.join("\n")
+}
+
+fn render_plugin_doctor_result_lines(result: &PluginPreflightResult) -> Vec<String> {
+    let plugin = &result.plugin;
+    let activation_status = inventory_result_status_label(plugin);
+    let setup_surface = inventory_result_setup_surface_label(plugin);
+    let source_language = plugin.source_language.as_deref().unwrap_or("-");
+    let manifest_path = display_text_or_dash(plugin.package_manifest_path.as_deref());
+    let setup_mode = display_text_or_dash(plugin.setup_mode.as_deref());
+    let required_env_vars = format_csv_or_dash(&plugin.setup_required_env_vars);
+    let required_config_keys = format_csv_or_dash(&plugin.setup_required_config_keys);
+    let setup_remediation = display_text_or_dash(plugin.setup_remediation.as_deref());
+    let runtime_health = plugin
+        .runtime_health
+        .as_ref()
+        .map(|health| health.status.as_str());
+    let attestation = plugin
+        .activation_attestation
+        .as_ref()
+        .map(|value| value.integrity.as_str());
+    let effective_flags = format_csv_or_dash(&result.effective_policy_flags);
+    let remediation_classes = format_preflight_remediation_classes(&result.remediation_classes);
+    let operator_action_kinds =
+        format_preflight_result_operator_action_kinds(&result.recommended_actions);
+    let blocking_diagnostics = format_csv_or_dash(&result.blocking_diagnostic_codes);
+    let advisory_diagnostics = format_csv_or_dash(&result.advisory_diagnostic_codes);
+    let recommended_actions =
+        format_preflight_result_recommended_actions(&result.recommended_actions);
+
+    let mut lines = vec![format!(
+        "- plugin={} provider={} verdict={} activation_status={} loaded={} deferred={} bridge={} language={} setup_surface={}",
+        plugin.plugin_id,
+        plugin.provider_id,
+        result.verdict,
+        activation_status,
+        plugin.loaded,
+        plugin.deferred,
+        plugin.bridge_kind,
+        source_language,
+        setup_surface
+    )];
+    lines.push(format!(
+        "  manifest={} setup_mode={} required_env={} required_config={} setup_remediation={}",
+        manifest_path, setup_mode, required_env_vars, required_config_keys, setup_remediation
+    ));
+    lines.push(format!(
+        "  source={} activation_ready={} runtime_health={} attestation={} summary={}",
+        plugin.source_path,
+        result.activation_ready,
+        display_text_or_dash(runtime_health),
+        display_text_or_dash(attestation),
+        display_text_or_dash(plugin.summary.as_deref())
+    ));
+    lines.push(format!(
+        "  policy_summary={} effective_flags={} remediation_classes={} operator_actions={}",
+        result.policy_summary, effective_flags, remediation_classes, operator_action_kinds
+    ));
+    lines.push(format!(
+        "  blocking_diagnostics={} advisory_diagnostics={}",
+        blocking_diagnostics, advisory_diagnostics
+    ));
+    if let Some(reason) = plugin.activation_reason.as_deref() {
+        lines.push(format!("  activation_reason={reason}"));
+    }
+    if recommended_actions != "-" {
+        lines.push(format!("  recommended_actions={recommended_actions}"));
+    }
+    lines
+}
+
+fn format_preflight_remediation_classes(
+    values: &[crate::PluginPreflightRemediationClass],
+) -> String {
+    if values.is_empty() {
+        return "-".to_owned();
+    }
+
+    let mut classes = values
+        .iter()
+        .map(|value| value.as_str().to_owned())
+        .collect::<Vec<_>>();
+    classes.sort();
+    classes.dedup();
+    classes.join(",")
+}
+
+fn format_preflight_result_operator_action_kinds(
+    values: &[crate::PluginPreflightRecommendedAction],
+) -> String {
+    let kinds = values
+        .iter()
+        .filter_map(|value| value.operator_action.as_ref())
+        .map(|value| value.kind.as_str().to_owned())
+        .collect::<BTreeSet<_>>();
+
+    if kinds.is_empty() {
+        return "-".to_owned();
+    }
+
+    kinds.into_iter().collect::<Vec<_>>().join(",")
+}
+
+fn format_preflight_result_recommended_actions(
+    values: &[crate::PluginPreflightRecommendedAction],
+) -> String {
+    if values.is_empty() {
+        return "-".to_owned();
+    }
+
+    let mut rendered = Vec::new();
+    for value in values {
+        let remediation_class = value.remediation_class.as_str();
+        let mut parts = vec![remediation_class.to_owned(), value.summary.clone()];
+        if let Some(action) = value.operator_action.as_ref() {
+            let kind = action.kind.as_str();
+            parts.push(format!("action={kind}"));
+        }
+        rendered.push(parts.join("|"));
+    }
+    rendered.join("; ")
 }
 
 fn render_plugins_actions_text(execution: &PluginsActionsExecution) -> String {
@@ -1714,6 +1996,14 @@ impl PluginPreflightContext {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct PluginGovernanceSurfaceContextSpec {
+    pack_id: &'static str,
+    agent_id: &'static str,
+    operator_surface: &'static str,
+    surface_label: &'static str,
+}
+
 fn build_plugin_inventory_context(
     source: &PluginScanSourceArgs,
     include_ready: bool,
@@ -1781,6 +2071,41 @@ fn build_plugin_inventory_context(
     })
 }
 
+fn build_plugin_doctor_context(
+    source: &PluginDoctorSourceArgs,
+    include_passed: bool,
+    include_warned: bool,
+    include_blocked: bool,
+    include_deferred: bool,
+) -> CliResult<PluginPreflightContext> {
+    let policy_signature = build_policy_signature_spec(
+        source.policy_signature_algorithm.as_str(),
+        source.policy_signature_public_key_base64.as_deref(),
+        source.policy_signature_base64.as_deref(),
+    )?;
+    let profile = source.profile.as_profile();
+    let surface_spec = PluginGovernanceSurfaceContextSpec {
+        pack_id: "plugin-doctor",
+        agent_id: "agent-plugin-doctor",
+        operator_surface: "plugin_doctor",
+        surface_label: "plugins doctor",
+    };
+
+    build_plugin_preflight_context_from_parts(
+        &source.scan,
+        profile,
+        source.policy_path.clone(),
+        source.policy_sha256.clone(),
+        policy_signature,
+        include_passed,
+        include_warned,
+        include_blocked,
+        include_deferred,
+        false,
+        surface_spec,
+    )
+}
+
 fn build_plugin_preflight_context(
     source: &PluginGovernanceSourceArgs,
     include_passed: bool,
@@ -1789,18 +2114,54 @@ fn build_plugin_preflight_context(
     include_deferred: bool,
     include_examples: bool,
 ) -> CliResult<PluginPreflightContext> {
-    let default_limit = default_plugin_preflight_limit();
-    let resolved =
-        resolve_plugin_scan_source(&source.scan, default_limit, 500, "plugins governance")?;
     let policy_signature = build_policy_signature_spec(
         source.policy_signature_algorithm.as_str(),
         source.policy_signature_public_key_base64.as_deref(),
         source.policy_signature_base64.as_deref(),
     )?;
+    let profile = source.profile.as_profile();
+    let surface_spec = PluginGovernanceSurfaceContextSpec {
+        pack_id: "plugin-governance",
+        agent_id: "agent-plugin-governance",
+        operator_surface: "plugin_governance",
+        surface_label: "plugins governance",
+    };
+
+    build_plugin_preflight_context_from_parts(
+        &source.scan,
+        profile,
+        source.policy_path.clone(),
+        source.policy_sha256.clone(),
+        policy_signature,
+        include_passed,
+        include_warned,
+        include_blocked,
+        include_deferred,
+        include_examples,
+        surface_spec,
+    )
+}
+
+fn build_plugin_preflight_context_from_parts(
+    scan: &PluginScanSourceArgs,
+    profile: PluginPreflightProfile,
+    policy_path: Option<String>,
+    policy_sha256: Option<String>,
+    policy_signature: Option<SecurityProfileSignatureSpec>,
+    include_passed: bool,
+    include_warned: bool,
+    include_blocked: bool,
+    include_deferred: bool,
+    include_examples: bool,
+    surface_spec: PluginGovernanceSurfaceContextSpec,
+) -> CliResult<PluginPreflightContext> {
+    let default_limit = default_plugin_preflight_limit();
+    let resolved =
+        resolve_plugin_scan_source(scan, default_limit, 500, surface_spec.surface_label)?;
 
     let mut spec = RunnerSpec::template();
     spec.pack = VerticalPackManifest {
-        pack_id: "plugin-governance".to_owned(),
+        pack_id: surface_spec.pack_id.to_owned(),
         domain: "ops".to_owned(),
         version: "0.1.0".to_owned(),
         default_route: ExecutionRoute {
@@ -1811,10 +2172,10 @@ fn build_plugin_preflight_context(
         granted_capabilities: BTreeSet::from([Capability::ObserveTelemetry]),
         metadata: BTreeMap::from([(
             "operator_surface".to_owned(),
-            "plugin_governance".to_owned(),
+            surface_spec.operator_surface.to_owned(),
         )]),
     };
-    spec.agent_id = "agent-plugin-governance".to_owned();
+    spec.agent_id = surface_spec.agent_id.to_owned();
     spec.ttl_s = 120;
     spec.approval = Some(HumanApprovalSpec {
         mode: HumanApprovalMode::Disabled,
@@ -1833,13 +2194,12 @@ fn build_plugin_preflight_context(
     spec.bootstrap = None;
     spec.auto_provision = None;
     spec.hotfixes = Vec::new();
-    let profile = source.profile.as_profile();
     spec.operation = OperationSpec::PluginPreflight {
         query: resolved.query.clone(),
         limit: resolved.limit,
         profile,
-        policy_path: source.policy_path.clone(),
-        policy_sha256: source.policy_sha256.clone(),
+        policy_path,
+        policy_sha256,
         policy_signature,
         include_passed,
         include_warned,
@@ -2244,13 +2604,109 @@ fn decode_preflight_summary(
     Ok(summary)
 }
 
-fn decode_preflight_results(report: &SpecRunReport) -> CliResult<Vec<Value>> {
-    report
+fn decode_preflight_results(report: &SpecRunReport) -> CliResult<Vec<PluginPreflightResult>> {
+    let results_value = report
         .outcome
         .get("results")
-        .and_then(Value::as_array)
         .cloned()
-        .ok_or_else(|| "decode plugin preflight results failed: results is not an array".to_owned())
+        .unwrap_or(Value::Null);
+
+    serde_json::from_value(results_value)
+        .map_err(|error| format!("decode plugin preflight results failed: {error}"))
+}
+
+fn summarize_plugin_doctor_results(
+    results: &[PluginPreflightResult],
+    preflight_summary: &PluginsPreflightSummaryView,
+) -> PluginsDoctorSummaryView {
+    let mut activation_ready_plugins: usize = 0;
+    let mut setup_incomplete_plugins: usize = 0;
+    let mut deferred_plugins: usize = 0;
+    let mut loaded_plugins: usize = 0;
+    let mut packages_with_operator_actions: usize = 0;
+    let mut total_recommended_actions: usize = 0;
+    let mut total_operator_actions: usize = 0;
+    let mut bridge_kind_distribution = BTreeMap::new();
+    let mut source_language_distribution = BTreeMap::new();
+    let mut setup_surface_distribution = BTreeMap::new();
+    let mut activation_status_distribution = BTreeMap::new();
+
+    for result in results {
+        let plugin = &result.plugin;
+
+        if result.activation_ready {
+            activation_ready_plugins = activation_ready_plugins.saturating_add(1);
+        }
+
+        if plugin.activation_status.as_deref() == Some("setup_incomplete") {
+            setup_incomplete_plugins = setup_incomplete_plugins.saturating_add(1);
+        }
+
+        if plugin.deferred {
+            deferred_plugins = deferred_plugins.saturating_add(1);
+        }
+
+        if plugin.loaded {
+            loaded_plugins = loaded_plugins.saturating_add(1);
+        }
+
+        let recommended_action_count = result.recommended_actions.len();
+        total_recommended_actions =
+            total_recommended_actions.saturating_add(recommended_action_count);
+
+        let operator_action_count = count_preflight_result_operator_actions(result);
+        total_operator_actions = total_operator_actions.saturating_add(operator_action_count);
+
+        if operator_action_count > 0 {
+            packages_with_operator_actions = packages_with_operator_actions.saturating_add(1);
+        }
+
+        increment_rollup_count(&mut bridge_kind_distribution, plugin.bridge_kind.as_str());
+
+        let source_language = plugin.source_language.as_deref().unwrap_or("unknown");
+        increment_rollup_count(&mut source_language_distribution, source_language);
+
+        let setup_surface = inventory_result_setup_surface_label(plugin);
+        increment_rollup_count(&mut setup_surface_distribution, setup_surface);
+
+        let activation_status = inventory_result_status_label(plugin);
+        increment_rollup_count(&mut activation_status_distribution, activation_status);
+    }
+
+    let packages_requiring_author_attention = preflight_summary
+        .warned_plugins
+        .saturating_add(preflight_summary.blocked_plugins);
+
+    PluginsDoctorSummaryView {
+        matched_plugins: preflight_summary.matched_plugins,
+        returned_plugins: results.len(),
+        passed_plugins: preflight_summary.passed_plugins,
+        warned_plugins: preflight_summary.warned_plugins,
+        blocked_plugins: preflight_summary.blocked_plugins,
+        activation_ready_plugins,
+        setup_incomplete_plugins,
+        deferred_plugins,
+        loaded_plugins,
+        packages_requiring_author_attention,
+        packages_with_operator_actions,
+        total_recommended_actions,
+        total_operator_actions,
+        remediation_counts: preflight_summary.remediation_counts.clone(),
+        bridge_kind_distribution,
+        source_language_distribution,
+        setup_surface_distribution,
+        activation_status_distribution,
+    }
+}
+
+fn count_preflight_result_operator_actions(result: &PluginPreflightResult) -> usize {
+    let mut count = 0_usize;
+    for action in &result.recommended_actions {
+        if action.operator_action.is_some() {
+            count = count.saturating_add(1);
+        }
+    }
+    count
 }
 
 fn action_matches_filters(
@@ -2597,6 +3053,18 @@ mod tests {
         }
     }
 
+    fn plugin_doctor_source(plugin_root: &str, query: &str) -> PluginDoctorSourceArgs {
+        PluginDoctorSourceArgs {
+            scan: plugin_scan_source(plugin_root, query),
+            profile: PluginPreflightProfileArg::SdkRelease,
+            policy_path: None,
+            policy_sha256: None,
+            policy_signature_public_key_base64: None,
+            policy_signature_base64: None,
+            policy_signature_algorithm: "ed25519".to_owned(),
+        }
+    }
+
     #[test]
     fn build_policy_signature_spec_requires_complete_pair() {
         let error = build_policy_signature_spec("ed25519", Some("pub"), None)
@@ -2795,6 +3263,104 @@ mod tests {
                 .setup_required_config_keys
                 .iter()
                 .any(|key| key == "plugins.entries.weather-sdk")
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_plugins_doctor_defaults_to_sdk_release_and_surfaces_author_actions() {
+        let plugin_root = unique_temp_dir("loongclaw-plugins-cli-doctor-openclaw");
+        write_openclaw_weather_sdk_package(&plugin_root);
+
+        let mut source = plugin_doctor_source(&plugin_root, "weather-sdk");
+        source.scan.bridge_profile = Some(PluginBridgeProfileArg::OpenclawEcosystemBalanced);
+
+        let execution = execute_plugins_command(PluginsCommandOptions {
+            json: false,
+            command: PluginsCommands::Doctor(PluginDoctorCommand {
+                source,
+                include_passed: true,
+                include_warned: true,
+                include_blocked: true,
+                include_deferred: true,
+            }),
+        })
+        .await
+        .expect("plugins doctor should execute");
+
+        let PluginsCommandExecution::Doctor(execution) = execution else {
+            panic!("expected doctor execution");
+        };
+        assert_eq!(execution.schema_version, PLUGINS_COMMAND_SCHEMA_VERSION);
+        assert_eq!(execution.schema.version, PLUGINS_COMMAND_SCHEMA_VERSION);
+        assert_eq!(execution.schema.surface, PLUGINS_COMMAND_SCHEMA_SURFACE);
+        assert_eq!(execution.schema.purpose, PLUGINS_DOCTOR_SCHEMA_PURPOSE);
+        assert_eq!(execution.profile, "sdk_release");
+        assert_eq!(execution.returned_results, 1);
+        assert_eq!(execution.summary.matched_plugins, 1);
+        assert_eq!(execution.summary.returned_plugins, 1);
+        assert_eq!(execution.summary.passed_plugins, 0);
+        assert_eq!(execution.summary.warned_plugins, 0);
+        assert_eq!(execution.summary.blocked_plugins, 1);
+        assert_eq!(execution.summary.activation_ready_plugins, 0);
+        assert_eq!(execution.summary.setup_incomplete_plugins, 1);
+        assert_eq!(execution.summary.deferred_plugins, 1);
+        assert_eq!(execution.summary.loaded_plugins, 0);
+        assert_eq!(execution.summary.packages_requiring_author_attention, 1);
+        assert_eq!(
+            execution.summary.packages_with_operator_actions, 1,
+            "doctor should surface at least one actionable operator follow-up"
+        );
+        assert!(
+            execution.summary.total_recommended_actions > 0,
+            "doctor should expose recommended actions"
+        );
+        assert!(
+            execution.summary.total_operator_actions > 0,
+            "doctor should expose operator actions"
+        );
+        assert_eq!(
+            execution
+                .summary
+                .setup_surface_distribution
+                .get("channel")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            execution
+                .summary
+                .activation_status_distribution
+                .get("setup_incomplete")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            execution
+                .summary
+                .remediation_counts
+                .get("resolve_activation_blockers")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            execution
+                .preflight_summary
+                .operator_action_counts_by_kind
+                .get("review_diagnostics")
+                .copied(),
+            Some(1)
+        );
+        let result = &execution.results[0];
+        assert_eq!(result.profile, "sdk_release");
+        assert_eq!(result.verdict, "block");
+        assert_eq!(result.plugin.plugin_id, "weather-sdk");
+        assert_eq!(result.plugin.setup_mode.as_deref(), Some("governed_entry"));
+        assert_eq!(result.plugin.setup_surface.as_deref(), Some("channel"));
+        assert!(
+            result
+                .recommended_actions
+                .iter()
+                .any(|action| action.operator_action.is_some())
         );
     }
 
@@ -3031,32 +3597,22 @@ mod tests {
         );
         assert_eq!(execution.results.len(), 1);
         let first_result = &execution.results[0];
-        let plugin = first_result
-            .get("plugin")
-            .and_then(Value::as_object)
-            .unwrap_or_else(|| panic!("expected plugin object in first result"));
-        let activation_status = plugin
-            .get("activation_status")
-            .and_then(Value::as_str)
-            .unwrap_or_else(|| panic!("expected plugin.activation_status string"));
-        let verdict = first_result
-            .get("verdict")
-            .and_then(Value::as_str)
-            .unwrap_or_else(|| panic!("expected verdict string"));
-
+        let plugin = &first_result.plugin;
+        let activation_status = plugin.activation_status.as_deref();
         let activation_reason = plugin
-            .get("activation_reason")
-            .and_then(Value::as_str)
-            .unwrap_or_else(|| panic!("expected plugin.activation_reason string"));
-        let policy_flags = first_result
-            .get("policy_flags")
-            .and_then(Value::as_array)
-            .unwrap_or_else(|| panic!("expected policy_flags array"));
+            .activation_reason
+            .as_deref()
+            .expect("expected plugin activation reason");
 
-        assert_eq!(activation_status, "setup_incomplete");
-        assert_eq!(verdict, "block");
+        assert_eq!(activation_status, Some("setup_incomplete"));
+        assert_eq!(first_result.verdict, "block");
         assert!(activation_reason.contains("plugins.entries.weather-sdk"));
-        assert!(policy_flags.iter().any(|flag| flag == "activation_blocked"));
+        assert!(
+            first_result
+                .policy_flags
+                .iter()
+                .any(|flag| flag == "activation_blocked")
+        );
     }
 
     #[tokio::test]
@@ -3569,8 +4125,8 @@ mod tests {
         let rendered_readme =
             fs::read_to_string(&readme_path).expect("scaffold readme should exist");
         assert!(
-            rendered_readme.contains("loongclaw plugins preflight --root"),
-            "README should point authors to preflight: {rendered_readme}"
+            rendered_readme.contains("loongclaw plugins doctor --root"),
+            "README should point authors to doctor: {rendered_readme}"
         );
         assert!(
             rendered_readme.contains("loongclaw plugins actions --root"),

--- a/crates/daemon/src/plugins_cli.rs
+++ b/crates/daemon/src/plugins_cli.rs
@@ -14,15 +14,18 @@ use crate::kernel::{
 };
 use crate::{
     BridgeSupportSpec, CliResult, HumanApprovalMode, HumanApprovalSpec, JsonSchemaDescriptor,
-    MaterializedBridgeSupportDeltaArtifact, OperationSpec,
-    PluginPreflightBridgeProfileRecommendation, PluginPreflightProfile, PluginScanSpec, RunnerSpec,
-    SecurityProfileSignatureSpec, SpecRunReport, execute_spec, json_schema_descriptor,
-    materialize_bridge_support_delta_artifact, materialize_bridge_support_template,
-    resolve_bridge_support_policy, resolve_bridge_support_selection,
+    MaterializedBridgeSupportDeltaArtifact, OperationSpec, PluginInventoryResult,
+    PluginPreflightBridgeProfileRecommendation, PluginPreflightProfile, PluginScanSpec,
+    ResolvedBridgeSupportSelection, RunnerSpec, SecurityProfileSignatureSpec, SpecRunReport,
+    default_plugin_inventory_limit, default_plugin_preflight_limit, execute_spec,
+    json_schema_descriptor, materialize_bridge_support_delta_artifact,
+    materialize_bridge_support_template, resolve_bridge_support_policy,
+    resolve_bridge_support_selection,
 };
 
 pub const PLUGINS_COMMAND_SCHEMA_VERSION: u32 = 1;
 pub const PLUGINS_COMMAND_SCHEMA_SURFACE: &str = "plugin_governance";
+pub const PLUGINS_INVENTORY_SCHEMA_PURPOSE: &str = "package_inventory";
 pub const PLUGINS_BRIDGE_PROFILES_SCHEMA_PURPOSE: &str = "bridge_profiles_catalog";
 pub const PLUGINS_BRIDGE_TEMPLATE_SCHEMA_PURPOSE: &str = "bridge_support_materialization";
 pub const PLUGINS_PREFLIGHT_SCHEMA_PURPOSE: &str = "ecosystem_preflight_evaluation";
@@ -40,6 +43,8 @@ fn plugins_command_schema(purpose: &str) -> JsonSchemaDescriptor {
 pub enum PluginsCommands {
     /// Scaffold a new manifest-first plugin package root for external authors
     Init(PluginInitCommand),
+    /// Inspect manifest-first package truth across one or more plugin roots
+    Inventory(PluginInventoryCommand),
     /// List bundled bridge support profiles for controlled ecosystem compatibility
     BridgeProfiles(PluginBridgeProfilesCommand),
     /// Emit the effective recommended bridge support profile template for the scanned ecosystem
@@ -51,19 +56,16 @@ pub enum PluginsCommands {
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
-pub struct PluginGovernanceSourceArgs {
+pub struct PluginScanSourceArgs {
     /// Scan root to inspect for plugins. Repeat the flag for multiple roots.
     #[arg(long = "root", required = true, value_name = "ROOT")]
     pub roots: Vec<String>,
     /// Filter plugins by query before evaluating preflight
     #[arg(long, default_value = "")]
     pub query: String,
-    /// Maximum number of preflight results to return
-    #[arg(long, default_value_t = 200)]
-    pub limit: usize,
-    /// Active governance profile to evaluate
-    #[arg(long, value_enum, default_value_t = PluginPreflightProfileArg::RuntimeActivation)]
-    pub profile: PluginPreflightProfileArg,
+    /// Maximum number of plugins to return
+    #[arg(long)]
+    pub limit: Option<usize>,
     /// Optional JSON file containing a bridge support policy
     #[arg(long, conflicts_with = "bridge_profile")]
     pub bridge_support: Option<String>,
@@ -79,6 +81,15 @@ pub struct PluginGovernanceSourceArgs {
     /// Optional sha256 pin for the bridge support delta artifact
     #[arg(long)]
     pub bridge_support_delta_sha256: Option<String>,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct PluginGovernanceSourceArgs {
+    #[command(flatten)]
+    pub scan: PluginScanSourceArgs,
+    /// Active governance profile to evaluate
+    #[arg(long, value_enum, default_value_t = PluginPreflightProfileArg::RuntimeActivation)]
+    pub profile: PluginPreflightProfileArg,
     /// Optional plugin preflight policy JSON file
     #[arg(long)]
     pub policy_path: Option<String>,
@@ -94,6 +105,24 @@ pub struct PluginGovernanceSourceArgs {
     /// Signature algorithm for the provided policy signature
     #[arg(long, default_value = "ed25519")]
     pub policy_signature_algorithm: String,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct PluginInventoryCommand {
+    #[command(flatten)]
+    pub source: PluginScanSourceArgs,
+    /// Include ready or setup-incomplete plugins in the inventory results
+    #[arg(long, default_value_t = true)]
+    pub include_ready: bool,
+    /// Include blocked plugins in the inventory results
+    #[arg(long, default_value_t = true)]
+    pub include_blocked: bool,
+    /// Include deferred plugins in the inventory results
+    #[arg(long, default_value_t = true)]
+    pub include_deferred: bool,
+    /// Include input/output examples in inventory result rows
+    #[arg(long, default_value_t = false)]
+    pub include_examples: bool,
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -397,6 +426,39 @@ pub struct PluginsBridgeSupportProvenanceView {
     pub delta_sha256: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PluginsInventorySummaryView {
+    pub returned_plugins: usize,
+    pub ready_plugins: usize,
+    pub setup_incomplete_plugins: usize,
+    pub blocked_plugins: usize,
+    pub deferred_plugins: usize,
+    pub loaded_plugins: usize,
+    pub source_kind_distribution: BTreeMap<String, usize>,
+    pub bridge_kind_distribution: BTreeMap<String, usize>,
+    pub source_language_distribution: BTreeMap<String, usize>,
+    pub setup_surface_distribution: BTreeMap<String, usize>,
+    pub activation_status_distribution: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PluginsInventoryExecution {
+    pub schema_version: u32,
+    pub schema: JsonSchemaDescriptor,
+    pub scan_roots: Vec<String>,
+    pub query: String,
+    pub limit: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_support_provenance: Option<PluginsBridgeSupportProvenanceView>,
+    pub bridge_support_source: Option<String>,
+    pub bridge_support_sha256: Option<String>,
+    pub bridge_support_delta_source: Option<String>,
+    pub bridge_support_delta_sha256: Option<String>,
+    pub summary: PluginsInventorySummaryView,
+    pub returned_results: usize,
+    pub results: Vec<PluginInventoryResult>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PluginsPreflightSummaryView {
     pub schema_version: u32,
@@ -574,6 +636,7 @@ pub struct PluginsInitExecution {
 #[serde(tag = "command", rename_all = "snake_case")]
 pub enum PluginsCommandExecution {
     Init(Box<PluginsInitExecution>),
+    Inventory(Box<PluginsInventoryExecution>),
     BridgeProfiles(Box<PluginsBridgeProfilesExecution>),
     BridgeTemplate(Box<PluginsBridgeTemplateExecution>),
     Preflight(Box<PluginsPreflightExecution>),
@@ -601,6 +664,40 @@ pub async fn execute_plugins_command(
         PluginsCommands::Init(command) => {
             let execution = execute_plugins_init(command)?;
             Ok(PluginsCommandExecution::Init(Box::new(execution)))
+        }
+        PluginsCommands::Inventory(command) => {
+            let context = build_plugin_inventory_context(
+                &command.source,
+                command.include_ready,
+                command.include_blocked,
+                command.include_deferred,
+                command.include_examples,
+            )?;
+            let report = execute_spec(&context.spec, false).await;
+            if let Some(reason) = report.blocked_reason.as_deref() {
+                return Err(format!("plugin inventory blocked: {reason}"));
+            }
+            let bridge_support_provenance = context.bridge_support_provenance();
+            let results = decode_plugin_inventory_results(&report)?;
+            let summary = summarize_plugin_inventory_results(&results);
+
+            Ok(PluginsCommandExecution::Inventory(Box::new(
+                PluginsInventoryExecution {
+                    schema_version: PLUGINS_COMMAND_SCHEMA_VERSION,
+                    schema: plugins_command_schema(PLUGINS_INVENTORY_SCHEMA_PURPOSE),
+                    scan_roots: context.scan_roots,
+                    query: context.query,
+                    limit: context.limit,
+                    bridge_support_provenance,
+                    bridge_support_source: context.bridge_support_source,
+                    bridge_support_sha256: context.bridge_support_sha256,
+                    bridge_support_delta_source: context.bridge_support_delta_source,
+                    bridge_support_delta_sha256: context.bridge_support_delta_sha256,
+                    returned_results: results.len(),
+                    summary,
+                    results,
+                },
+            )))
         }
         PluginsCommands::BridgeProfiles(command) => {
             let profiles = load_bridge_profile_views(&command.profiles)?;
@@ -1090,6 +1187,7 @@ fn render_plugin_scaffold_readme(package_root: &str, plugin_id: &str, bridge_kin
 fn render_plugins_cli_text(execution: &PluginsCommandExecution) -> String {
     match execution {
         PluginsCommandExecution::Init(execution) => render_plugins_init_text(execution),
+        PluginsCommandExecution::Inventory(execution) => render_plugins_inventory_text(execution),
         PluginsCommandExecution::BridgeProfiles(execution) => {
             render_plugins_bridge_profiles_text(execution)
         }
@@ -1124,6 +1222,95 @@ fn render_plugins_init_text(execution: &PluginsInitExecution) -> String {
         "- operator_actions=loongclaw plugins actions --root \"{}\" --profile sdk-release",
         execution.package_root
     ));
+    lines.join("\n")
+}
+
+fn render_plugins_inventory_text(execution: &PluginsInventoryExecution) -> String {
+    let mut lines = vec![format!(
+        "plugins inventory query={} roots={} returned_plugins={} ready={} setup_incomplete={} blocked={} deferred={} loaded={}",
+        display_text_or_dash(Some(execution.query.as_str())),
+        execution.scan_roots.join(","),
+        execution.returned_results,
+        execution.summary.ready_plugins,
+        execution.summary.setup_incomplete_plugins,
+        execution.summary.blocked_plugins,
+        execution.summary.deferred_plugins,
+        execution.summary.loaded_plugins
+    )];
+    lines.push(format!(
+        "bridge_support source={} sha256={}",
+        display_text_or_dash(execution.bridge_support_source.as_deref()),
+        display_text_or_dash(execution.bridge_support_sha256.as_deref())
+    ));
+    lines.push(format!(
+        "bridge_support_delta source={} sha256={}",
+        display_text_or_dash(execution.bridge_support_delta_source.as_deref()),
+        display_text_or_dash(execution.bridge_support_delta_sha256.as_deref())
+    ));
+    lines.push(format!(
+        "ecosystem source_kind={} bridge={} language={} setup_surface={} activation_status={}",
+        format_rollup_map(&execution.summary.source_kind_distribution),
+        format_rollup_map(&execution.summary.bridge_kind_distribution),
+        format_rollup_map(&execution.summary.source_language_distribution),
+        format_rollup_map(&execution.summary.setup_surface_distribution),
+        format_rollup_map(&execution.summary.activation_status_distribution)
+    ));
+    for result in &execution.results {
+        let activation_status = inventory_result_status_label(result);
+        let setup_surface = inventory_result_setup_surface_label(result);
+        let source_language = result.source_language.as_deref().unwrap_or("-");
+        let manifest_path = display_text_or_dash(result.package_manifest_path.as_deref());
+        let setup_mode = display_text_or_dash(result.setup_mode.as_deref());
+        let host_api = result
+            .compatibility
+            .as_ref()
+            .and_then(|compatibility| compatibility.host_api.as_deref());
+        let host_version_req = result
+            .compatibility
+            .as_ref()
+            .and_then(|compatibility| compatibility.host_version_req.as_deref());
+        let required_env_vars = format_csv_or_dash(&result.setup_required_env_vars);
+        let required_config_keys = format_csv_or_dash(&result.setup_required_config_keys);
+        let runtime_health = result
+            .runtime_health
+            .as_ref()
+            .map(|health| health.status.as_str());
+        let attestation = result
+            .activation_attestation
+            .as_ref()
+            .map(|attestation| attestation.integrity.as_str());
+        lines.push(format!(
+            "- plugin={} provider={} status={} loaded={} deferred={} bridge={} language={} setup_surface={}",
+            result.plugin_id,
+            result.provider_id,
+            activation_status,
+            result.loaded,
+            result.deferred,
+            result.bridge_kind,
+            source_language,
+            setup_surface
+        ));
+        lines.push(format!(
+            "  manifest={} setup_mode={} required_env={} required_config={} host_api={} host_version_req={}",
+            manifest_path,
+            setup_mode,
+            required_env_vars,
+            required_config_keys,
+            display_text_or_dash(host_api),
+            display_text_or_dash(host_version_req)
+        ));
+        lines.push(format!(
+            "  source={} bootstrap_hint={} runtime_health={} attestation={} summary={}",
+            result.source_path,
+            display_text_or_dash(result.bootstrap_hint.as_deref()),
+            display_text_or_dash(runtime_health),
+            display_text_or_dash(attestation),
+            display_text_or_dash(result.summary.as_deref())
+        ));
+        if let Some(reason) = result.activation_reason.as_deref() {
+            lines.push(format!("  activation_reason={reason}"));
+        }
+    }
     lines.join("\n")
 }
 
@@ -1444,6 +1631,66 @@ fn render_plugins_actions_text(execution: &PluginsActionsExecution) -> String {
 }
 
 #[derive(Debug, Clone)]
+struct ResolvedPluginScanSource {
+    scan_roots: Vec<String>,
+    query: String,
+    limit: usize,
+    bridge_support: Option<ResolvedBridgeSupportSelection>,
+}
+
+impl ResolvedPluginScanSource {
+    fn bridge_support_source(&self) -> Option<String> {
+        self.bridge_support
+            .as_ref()
+            .map(|selection| selection.policy.source.clone())
+    }
+
+    fn bridge_support_sha256(&self) -> Option<String> {
+        self.bridge_support
+            .as_ref()
+            .map(|selection| selection.policy.sha256.clone())
+    }
+
+    fn bridge_support_delta_source(&self) -> Option<String> {
+        self.bridge_support
+            .as_ref()
+            .and_then(|selection| selection.delta_source.clone())
+    }
+
+    fn bridge_support_delta_sha256(&self) -> Option<String> {
+        self.bridge_support.as_ref().and_then(|selection| {
+            selection
+                .delta_artifact
+                .as_ref()
+                .map(|artifact| artifact.sha256.clone())
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PluginInventoryContext {
+    scan_roots: Vec<String>,
+    query: String,
+    limit: usize,
+    bridge_support_source: Option<String>,
+    bridge_support_sha256: Option<String>,
+    bridge_support_delta_source: Option<String>,
+    bridge_support_delta_sha256: Option<String>,
+    spec: RunnerSpec,
+}
+
+impl PluginInventoryContext {
+    fn bridge_support_provenance(&self) -> Option<PluginsBridgeSupportProvenanceView> {
+        PluginsBridgeSupportProvenanceView::from_fields(
+            self.bridge_support_source.as_deref(),
+            self.bridge_support_sha256.as_deref(),
+            self.bridge_support_delta_source.as_deref(),
+            self.bridge_support_delta_sha256.as_deref(),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
 struct PluginPreflightContext {
     scan_roots: Vec<String>,
     query: String,
@@ -1467,6 +1714,73 @@ impl PluginPreflightContext {
     }
 }
 
+fn build_plugin_inventory_context(
+    source: &PluginScanSourceArgs,
+    include_ready: bool,
+    include_blocked: bool,
+    include_deferred: bool,
+    include_examples: bool,
+) -> CliResult<PluginInventoryContext> {
+    let default_limit = default_plugin_inventory_limit();
+    let resolved = resolve_plugin_scan_source(source, default_limit, 100, "plugins inventory")?;
+
+    let mut spec = RunnerSpec::template();
+    spec.pack = VerticalPackManifest {
+        pack_id: "plugin-inventory".to_owned(),
+        domain: "ops".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: Some("pi-local".to_owned()),
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::ObserveTelemetry]),
+        metadata: BTreeMap::from([("operator_surface".to_owned(), "plugin_inventory".to_owned())]),
+    };
+    spec.agent_id = "agent-plugin-inventory".to_owned();
+    spec.ttl_s = 120;
+    spec.approval = Some(HumanApprovalSpec {
+        mode: HumanApprovalMode::Disabled,
+        ..HumanApprovalSpec::default()
+    });
+    spec.defaults = None;
+    spec.self_awareness = None;
+    spec.plugin_scan = Some(PluginScanSpec {
+        enabled: true,
+        roots: resolved.scan_roots.clone(),
+    });
+    spec.bridge_support = resolved
+        .bridge_support
+        .as_ref()
+        .map(|selection| selection.policy.profile.clone());
+    spec.bootstrap = None;
+    spec.auto_provision = None;
+    spec.hotfixes = Vec::new();
+    spec.operation = OperationSpec::PluginInventory {
+        query: resolved.query.clone(),
+        limit: resolved.limit,
+        include_ready,
+        include_blocked,
+        include_deferred,
+        include_examples,
+    };
+    let bridge_support_source = resolved.bridge_support_source();
+    let bridge_support_sha256 = resolved.bridge_support_sha256();
+    let bridge_support_delta_source = resolved.bridge_support_delta_source();
+    let bridge_support_delta_sha256 = resolved.bridge_support_delta_sha256();
+
+    Ok(PluginInventoryContext {
+        scan_roots: resolved.scan_roots,
+        query: resolved.query,
+        limit: resolved.limit,
+        bridge_support_source,
+        bridge_support_sha256,
+        bridge_support_delta_source,
+        bridge_support_delta_sha256,
+        spec,
+    })
+}
+
 fn build_plugin_preflight_context(
     source: &PluginGovernanceSourceArgs,
     include_passed: bool,
@@ -1475,15 +1789,9 @@ fn build_plugin_preflight_context(
     include_deferred: bool,
     include_examples: bool,
 ) -> CliResult<PluginPreflightContext> {
-    let roots = normalize_scan_roots(&source.roots)?;
-    let limit = validate_plugin_limit(source.limit)?;
-    let bridge_support = resolve_bridge_support_selection(
-        source.bridge_support.as_deref(),
-        source.bridge_profile.map(PluginBridgeProfileArg::as_str),
-        source.bridge_support_delta.as_deref(),
-        source.bridge_support_sha256.as_deref(),
-        source.bridge_support_delta_sha256.as_deref(),
-    )?;
+    let default_limit = default_plugin_preflight_limit();
+    let resolved =
+        resolve_plugin_scan_source(&source.scan, default_limit, 500, "plugins governance")?;
     let policy_signature = build_policy_signature_spec(
         source.policy_signature_algorithm.as_str(),
         source.policy_signature_public_key_base64.as_deref(),
@@ -1516,9 +1824,10 @@ fn build_plugin_preflight_context(
     spec.self_awareness = None;
     spec.plugin_scan = Some(PluginScanSpec {
         enabled: true,
-        roots: roots.clone(),
+        roots: resolved.scan_roots.clone(),
     });
-    spec.bridge_support = bridge_support
+    spec.bridge_support = resolved
+        .bridge_support
         .as_ref()
         .map(|selection| selection.policy.profile.clone());
     spec.bootstrap = None;
@@ -1526,8 +1835,8 @@ fn build_plugin_preflight_context(
     spec.hotfixes = Vec::new();
     let profile = source.profile.as_profile();
     spec.operation = OperationSpec::PluginPreflight {
-        query: source.query.clone(),
-        limit,
+        query: resolved.query.clone(),
+        limit: resolved.limit,
         profile,
         policy_path: source.policy_path.clone(),
         policy_sha256: source.policy_sha256.clone(),
@@ -1538,28 +1847,46 @@ fn build_plugin_preflight_context(
         include_deferred,
         include_examples,
     };
+    let bridge_support_source = resolved.bridge_support_source();
+    let bridge_support_sha256 = resolved.bridge_support_sha256();
+    let bridge_support_delta_source = resolved.bridge_support_delta_source();
+    let bridge_support_delta_sha256 = resolved.bridge_support_delta_sha256();
 
     Ok(PluginPreflightContext {
+        scan_roots: resolved.scan_roots,
+        query: resolved.query,
+        limit: resolved.limit,
+        profile: profile.as_str().to_owned(),
+        bridge_support_source,
+        bridge_support_sha256,
+        bridge_support_delta_source,
+        bridge_support_delta_sha256,
+        spec,
+    })
+}
+
+fn resolve_plugin_scan_source(
+    source: &PluginScanSourceArgs,
+    default_limit: usize,
+    max_limit: usize,
+    surface_label: &str,
+) -> CliResult<ResolvedPluginScanSource> {
+    let roots = normalize_scan_roots(&source.roots, surface_label)?;
+    let requested_limit = source.limit.unwrap_or(default_limit);
+    let limit = validate_plugin_limit(requested_limit, max_limit, surface_label)?;
+    let bridge_support = resolve_bridge_support_selection(
+        source.bridge_support.as_deref(),
+        source.bridge_profile.map(PluginBridgeProfileArg::as_str),
+        source.bridge_support_delta.as_deref(),
+        source.bridge_support_sha256.as_deref(),
+        source.bridge_support_delta_sha256.as_deref(),
+    )?;
+
+    Ok(ResolvedPluginScanSource {
         scan_roots: roots,
         query: source.query.clone(),
         limit,
-        profile: profile.as_str().to_owned(),
-        bridge_support_source: bridge_support
-            .as_ref()
-            .map(|selection| selection.policy.source.clone()),
-        bridge_support_sha256: bridge_support
-            .as_ref()
-            .map(|selection| selection.policy.sha256.clone()),
-        bridge_support_delta_source: bridge_support
-            .as_ref()
-            .and_then(|selection| selection.delta_source.clone()),
-        bridge_support_delta_sha256: bridge_support.as_ref().and_then(|selection| {
-            selection
-                .delta_artifact
-                .as_ref()
-                .map(|artifact| artifact.sha256.clone())
-        }),
-        spec,
+        bridge_support,
     })
 }
 
@@ -1687,7 +2014,7 @@ fn load_bridge_profile_views(
     Ok(views)
 }
 
-fn normalize_scan_roots(roots: &[String]) -> CliResult<Vec<String>> {
+fn normalize_scan_roots(roots: &[String], surface_label: &str) -> CliResult<Vec<String>> {
     let mut normalized = Vec::new();
     let mut seen = BTreeSet::new();
     for root in roots {
@@ -1700,14 +2027,18 @@ fn normalize_scan_roots(roots: &[String]) -> CliResult<Vec<String>> {
         }
     }
     if normalized.is_empty() {
-        return Err("plugins governance requires at least one non-empty --root".to_owned());
+        return Err(format!(
+            "{surface_label} requires at least one non-empty --root"
+        ));
     }
     Ok(normalized)
 }
 
-fn validate_plugin_limit(limit: usize) -> CliResult<usize> {
-    if !(1..=500).contains(&limit) {
-        return Err("plugins governance limit must be between 1 and 500".to_owned());
+fn validate_plugin_limit(limit: usize, max_limit: usize, surface_label: &str) -> CliResult<usize> {
+    if !(1..=max_limit).contains(&limit) {
+        return Err(format!(
+            "{surface_label} limit must be between 1 and {max_limit}"
+        ));
     }
     Ok(limit)
 }
@@ -1749,6 +2080,132 @@ fn decode_preflight_bridge_profile_recommendation(
     serde_json::from_value(recommendation_value).map_err(|error| {
         format!("decode plugin preflight bridge profile recommendation failed: {error}")
     })
+}
+
+fn decode_plugin_inventory_results(
+    report: &SpecRunReport,
+) -> CliResult<Vec<PluginInventoryResult>> {
+    let results_value = report
+        .outcome
+        .get("results")
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    serde_json::from_value(results_value)
+        .map_err(|error| format!("decode plugin inventory results failed: {error}"))
+}
+
+fn summarize_plugin_inventory_results(
+    results: &[PluginInventoryResult],
+) -> PluginsInventorySummaryView {
+    let returned_plugins = results.len();
+    let mut ready_plugins = 0;
+    let mut setup_incomplete_plugins = 0;
+    let mut blocked_plugins = 0;
+    let mut deferred_plugins = 0;
+    let mut loaded_plugins = 0;
+    let mut source_kind_distribution = BTreeMap::new();
+    let mut bridge_kind_distribution = BTreeMap::new();
+    let mut source_language_distribution = BTreeMap::new();
+    let mut setup_surface_distribution = BTreeMap::new();
+    let mut activation_status_distribution = BTreeMap::new();
+
+    for result in results {
+        let activation_status = result.activation_status.as_deref();
+
+        if activation_status == Some("ready") {
+            ready_plugins += 1;
+        }
+        if activation_status == Some("setup_incomplete") {
+            setup_incomplete_plugins += 1;
+        }
+        if activation_status.is_some_and(plugin_inventory_status_is_blocked) {
+            blocked_plugins += 1;
+        }
+        if result.deferred {
+            deferred_plugins += 1;
+        }
+        if result.loaded {
+            loaded_plugins += 1;
+        }
+
+        increment_rollup_count(&mut source_kind_distribution, result.source_kind.as_str());
+        increment_rollup_count(&mut bridge_kind_distribution, result.bridge_kind.as_str());
+
+        let source_language = result.source_language.as_deref().unwrap_or("unknown");
+        increment_rollup_count(&mut source_language_distribution, source_language);
+
+        let setup_surface = inventory_result_setup_surface_label(result);
+        increment_rollup_count(&mut setup_surface_distribution, setup_surface);
+
+        let status_label = inventory_result_status_label(result);
+        increment_rollup_count(&mut activation_status_distribution, status_label);
+    }
+
+    PluginsInventorySummaryView {
+        returned_plugins,
+        ready_plugins,
+        setup_incomplete_plugins,
+        blocked_plugins,
+        deferred_plugins,
+        loaded_plugins,
+        source_kind_distribution,
+        bridge_kind_distribution,
+        source_language_distribution,
+        setup_surface_distribution,
+        activation_status_distribution,
+    }
+}
+
+fn plugin_inventory_status_is_blocked(status: &str) -> bool {
+    if status == "ready" {
+        return false;
+    }
+
+    if status == "setup_incomplete" {
+        return false;
+    }
+
+    true
+}
+
+fn inventory_result_status_label(result: &PluginInventoryResult) -> &str {
+    let activation_status = result.activation_status.as_deref();
+    let has_activation_status = activation_status.is_some_and(|status| !status.is_empty());
+
+    if has_activation_status {
+        return activation_status.unwrap_or("unknown");
+    }
+
+    if result.deferred {
+        return "deferred";
+    }
+
+    "unknown"
+}
+
+fn inventory_result_setup_surface_label(result: &PluginInventoryResult) -> &str {
+    let setup_surface = result.setup_surface.as_deref();
+    let has_setup_surface = setup_surface.is_some_and(|value| !value.is_empty());
+
+    if has_setup_surface {
+        return setup_surface.unwrap_or("none");
+    }
+
+    let setup_mode = result.setup_mode.as_deref();
+    let has_setup_mode = setup_mode.is_some_and(|value| !value.is_empty());
+
+    if has_setup_mode {
+        return "unspecified";
+    }
+
+    "none"
+}
+
+fn increment_rollup_count(values: &mut BTreeMap<String, usize>, key: &str) {
+    let entry = values.entry(key.to_owned()).or_default();
+    let next_value = entry.saturating_add(1);
+    *entry = next_value;
 }
 
 impl PluginsBridgeSupportProvenanceView {
@@ -2115,6 +2572,31 @@ mod tests {
         .expect("write setup entry");
     }
 
+    fn plugin_scan_source(plugin_root: &str, query: &str) -> PluginScanSourceArgs {
+        PluginScanSourceArgs {
+            roots: vec![plugin_root.to_owned()],
+            query: query.to_owned(),
+            limit: Some(10),
+            bridge_support: None,
+            bridge_profile: None,
+            bridge_support_delta: None,
+            bridge_support_sha256: None,
+            bridge_support_delta_sha256: None,
+        }
+    }
+
+    fn plugin_governance_source(plugin_root: &str, query: &str) -> PluginGovernanceSourceArgs {
+        PluginGovernanceSourceArgs {
+            scan: plugin_scan_source(plugin_root, query),
+            profile: PluginPreflightProfileArg::RuntimeActivation,
+            policy_path: None,
+            policy_sha256: None,
+            policy_signature_public_key_base64: None,
+            policy_signature_base64: None,
+            policy_signature_algorithm: "ed25519".to_owned(),
+        }
+    }
+
     #[test]
     fn build_policy_signature_spec_requires_complete_pair() {
         let error = build_policy_signature_spec("ed25519", Some("pub"), None)
@@ -2128,16 +2610,20 @@ mod tests {
 
     #[test]
     fn normalize_scan_roots_deduplicates_and_rejects_empty_input() {
-        let roots = normalize_scan_roots(&[
-            " /tmp/a ".to_owned(),
-            "/tmp/a".to_owned(),
-            "  ".to_owned(),
-            "/tmp/b".to_owned(),
-        ])
+        let roots = normalize_scan_roots(
+            &[
+                " /tmp/a ".to_owned(),
+                "/tmp/a".to_owned(),
+                "  ".to_owned(),
+                "/tmp/b".to_owned(),
+            ],
+            "plugins inventory",
+        )
         .expect("roots should normalize");
         assert_eq!(roots, vec!["/tmp/a".to_owned(), "/tmp/b".to_owned()]);
 
-        let error = normalize_scan_roots(&["   ".to_owned()]).expect_err("empty roots should fail");
+        let error = normalize_scan_roots(&["   ".to_owned()], "plugins inventory")
+            .expect_err("empty roots should fail");
         assert!(error.contains("--root"));
     }
 
@@ -2220,6 +2706,99 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_plugins_inventory_surfaces_manifest_first_openclaw_package_truth() {
+        let plugin_root = unique_temp_dir("loongclaw-plugins-cli-inventory-openclaw");
+        write_openclaw_weather_sdk_package(&plugin_root);
+
+        let mut source = plugin_scan_source(&plugin_root, "weather-sdk");
+        source.limit = None;
+        source.bridge_profile = Some(PluginBridgeProfileArg::OpenclawEcosystemBalanced);
+
+        let execution = execute_plugins_command(PluginsCommandOptions {
+            json: false,
+            command: PluginsCommands::Inventory(PluginInventoryCommand {
+                source,
+                include_ready: true,
+                include_blocked: true,
+                include_deferred: true,
+                include_examples: false,
+            }),
+        })
+        .await
+        .expect("plugins inventory should execute");
+
+        let PluginsCommandExecution::Inventory(execution) = execution else {
+            panic!("expected inventory execution");
+        };
+        assert_eq!(execution.schema_version, PLUGINS_COMMAND_SCHEMA_VERSION);
+        assert_eq!(execution.schema.version, PLUGINS_COMMAND_SCHEMA_VERSION);
+        assert_eq!(execution.schema.surface, PLUGINS_COMMAND_SCHEMA_SURFACE);
+        assert_eq!(execution.schema.purpose, PLUGINS_INVENTORY_SCHEMA_PURPOSE);
+        assert_eq!(execution.limit, default_plugin_inventory_limit());
+        assert_eq!(execution.returned_results, 1);
+        assert_eq!(execution.summary.returned_plugins, 1);
+        assert_eq!(execution.summary.ready_plugins, 0);
+        assert_eq!(execution.summary.setup_incomplete_plugins, 1);
+        assert_eq!(execution.summary.blocked_plugins, 0);
+        assert_eq!(execution.summary.deferred_plugins, 1);
+        assert_eq!(execution.summary.loaded_plugins, 0);
+        assert_eq!(
+            execution
+                .summary
+                .bridge_kind_distribution
+                .get("process_stdio")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            execution
+                .summary
+                .source_language_distribution
+                .get("javascript")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            execution
+                .summary
+                .setup_surface_distribution
+                .get("channel")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            execution
+                .summary
+                .activation_status_distribution
+                .get("setup_incomplete")
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            execution.bridge_support_source.as_deref(),
+            Some("bundled:bridge-support-openclaw-ecosystem-balanced.json")
+        );
+        let result = &execution.results[0];
+        assert_eq!(result.plugin_id, "weather-sdk");
+        assert_eq!(result.provider_id, "weather-sdk");
+        assert_eq!(result.bridge_kind, "process_stdio");
+        assert_eq!(result.source_language.as_deref(), Some("javascript"));
+        assert_eq!(result.setup_mode.as_deref(), Some("governed_entry"));
+        assert_eq!(result.setup_surface.as_deref(), Some("channel"));
+        assert_eq!(
+            result.activation_status.as_deref(),
+            Some("setup_incomplete")
+        );
+        assert!(result.deferred);
+        assert!(
+            result
+                .setup_required_config_keys
+                .iter()
+                .any(|key| key == "plugins.entries.weather-sdk")
+        );
+    }
+
+    #[tokio::test]
     async fn execute_plugins_actions_filters_operator_action_plan() {
         let plugin_root = unique_temp_dir("loongclaw-plugins-cli-actions");
         fs::create_dir_all(&plugin_root).expect("create plugin root");
@@ -2264,25 +2843,12 @@ mod tests {
         )
         .expect("write plugin b");
 
+        let source = plugin_governance_source(&plugin_root, "");
+
         let execution = execute_plugins_command(PluginsCommandOptions {
             json: false,
             command: PluginsCommands::Actions(PluginActionsCommand {
-                source: PluginGovernanceSourceArgs {
-                    roots: vec![plugin_root.clone()],
-                    query: String::new(),
-                    limit: 10,
-                    profile: PluginPreflightProfileArg::RuntimeActivation,
-                    bridge_support: None,
-                    bridge_profile: None,
-                    bridge_support_delta: None,
-                    bridge_support_sha256: None,
-                    bridge_support_delta_sha256: None,
-                    policy_path: None,
-                    policy_sha256: None,
-                    policy_signature_public_key_base64: None,
-                    policy_signature_base64: None,
-                    policy_signature_algorithm: "ed25519".to_owned(),
-                },
+                source,
                 include_passed: false,
                 include_warned: true,
                 include_blocked: true,
@@ -2341,25 +2907,13 @@ mod tests {
         let plugin_root = unique_temp_dir("loongclaw-plugins-cli-openclaw");
         write_openclaw_weather_sdk_package(&plugin_root);
 
+        let mut source = plugin_governance_source(&plugin_root, "weather-sdk");
+        source.scan.bridge_profile = Some(PluginBridgeProfileArg::OpenclawEcosystemBalanced);
+
         let execution = execute_plugins_command(PluginsCommandOptions {
             json: false,
             command: PluginsCommands::Preflight(PluginPreflightCommand {
-                source: PluginGovernanceSourceArgs {
-                    roots: vec![plugin_root.clone()],
-                    query: "weather-sdk".to_owned(),
-                    limit: 10,
-                    profile: PluginPreflightProfileArg::RuntimeActivation,
-                    bridge_support: None,
-                    bridge_profile: Some(PluginBridgeProfileArg::OpenclawEcosystemBalanced),
-                    bridge_support_delta: None,
-                    bridge_support_sha256: None,
-                    bridge_support_delta_sha256: None,
-                    policy_path: None,
-                    policy_sha256: None,
-                    policy_signature_public_key_base64: None,
-                    policy_signature_base64: None,
-                    policy_signature_algorithm: "ed25519".to_owned(),
-                },
+                source,
                 include_passed: true,
                 include_warned: true,
                 include_blocked: true,
@@ -2510,25 +3064,12 @@ mod tests {
         let plugin_root = unique_temp_dir("loongclaw-plugins-cli-openclaw-recommend");
         write_openclaw_weather_sdk_package(&plugin_root);
 
+        let source = plugin_governance_source(&plugin_root, "weather-sdk");
+
         let execution = execute_plugins_command(PluginsCommandOptions {
             json: false,
             command: PluginsCommands::Preflight(PluginPreflightCommand {
-                source: PluginGovernanceSourceArgs {
-                    roots: vec![plugin_root.clone()],
-                    query: "weather-sdk".to_owned(),
-                    limit: 10,
-                    profile: PluginPreflightProfileArg::RuntimeActivation,
-                    bridge_support: None,
-                    bridge_profile: None,
-                    bridge_support_delta: None,
-                    bridge_support_sha256: None,
-                    bridge_support_delta_sha256: None,
-                    policy_path: None,
-                    policy_sha256: None,
-                    policy_signature_public_key_base64: None,
-                    policy_signature_base64: None,
-                    policy_signature_algorithm: "ed25519".to_owned(),
-                },
+                source,
                 include_passed: true,
                 include_warned: true,
                 include_blocked: true,
@@ -2606,25 +3147,12 @@ mod tests {
         let plugin_root = unique_temp_dir("loongclaw-plugins-cli-openclaw-python-delta");
         write_openclaw_weather_sdk_python_package(&plugin_root);
 
+        let source = plugin_governance_source(&plugin_root, "weather-sdk");
+
         let execution = execute_plugins_command(PluginsCommandOptions {
             json: false,
             command: PluginsCommands::Preflight(PluginPreflightCommand {
-                source: PluginGovernanceSourceArgs {
-                    roots: vec![plugin_root.clone()],
-                    query: "weather-sdk".to_owned(),
-                    limit: 10,
-                    profile: PluginPreflightProfileArg::RuntimeActivation,
-                    bridge_support: None,
-                    bridge_profile: None,
-                    bridge_support_delta: None,
-                    bridge_support_sha256: None,
-                    bridge_support_delta_sha256: None,
-                    policy_path: None,
-                    policy_sha256: None,
-                    policy_signature_public_key_base64: None,
-                    policy_signature_base64: None,
-                    policy_signature_algorithm: "ed25519".to_owned(),
-                },
+                source,
                 include_passed: true,
                 include_warned: true,
                 include_blocked: true,
@@ -2697,25 +3225,14 @@ mod tests {
         )
         .expect("write delta artifact");
 
+        let mut source = plugin_governance_source(&plugin_root, "weather-sdk");
+        source.scan.bridge_support_delta = Some(delta_path.clone());
+        source.scan.bridge_support_delta_sha256 = Some(artifact.sha256.clone());
+
         let execution = execute_plugins_command(PluginsCommandOptions {
             json: false,
             command: PluginsCommands::Preflight(PluginPreflightCommand {
-                source: PluginGovernanceSourceArgs {
-                    roots: vec![plugin_root.clone()],
-                    query: "weather-sdk".to_owned(),
-                    limit: 10,
-                    profile: PluginPreflightProfileArg::RuntimeActivation,
-                    bridge_support: None,
-                    bridge_profile: None,
-                    bridge_support_delta: Some(delta_path.clone()),
-                    bridge_support_sha256: None,
-                    bridge_support_delta_sha256: Some(artifact.sha256.clone()),
-                    policy_path: None,
-                    policy_sha256: None,
-                    policy_signature_public_key_base64: None,
-                    policy_signature_base64: None,
-                    policy_signature_algorithm: "ed25519".to_owned(),
-                },
+                source,
                 include_passed: true,
                 include_warned: true,
                 include_blocked: true,
@@ -2795,25 +3312,13 @@ mod tests {
         let plugin_root = unique_temp_dir("loongclaw-plugins-cli-bridge-template-aligned");
         write_openclaw_weather_sdk_package(&plugin_root);
 
+        let mut source = plugin_governance_source(&plugin_root, "weather-sdk");
+        source.scan.bridge_profile = Some(PluginBridgeProfileArg::OpenclawEcosystemBalanced);
+
         let execution = execute_plugins_command(PluginsCommandOptions {
             json: false,
             command: PluginsCommands::BridgeTemplate(PluginBridgeTemplateCommand {
-                source: PluginGovernanceSourceArgs {
-                    roots: vec![plugin_root.clone()],
-                    query: "weather-sdk".to_owned(),
-                    limit: 10,
-                    profile: PluginPreflightProfileArg::RuntimeActivation,
-                    bridge_support: None,
-                    bridge_profile: Some(PluginBridgeProfileArg::OpenclawEcosystemBalanced),
-                    bridge_support_delta: None,
-                    bridge_support_sha256: None,
-                    bridge_support_delta_sha256: None,
-                    policy_path: None,
-                    policy_sha256: None,
-                    policy_signature_public_key_base64: None,
-                    policy_signature_base64: None,
-                    policy_signature_algorithm: "ed25519".to_owned(),
-                },
+                source,
                 include_passed: true,
                 include_warned: true,
                 include_blocked: true,
@@ -2888,25 +3393,12 @@ mod tests {
         let output_path = format!("{plugin_root}/generated/bridge-support.json");
         let delta_output_path = format!("{plugin_root}/generated/bridge-support.delta.json");
 
+        let source = plugin_governance_source(&plugin_root, "weather-sdk");
+
         let execution = execute_plugins_command(PluginsCommandOptions {
             json: false,
             command: PluginsCommands::BridgeTemplate(PluginBridgeTemplateCommand {
-                source: PluginGovernanceSourceArgs {
-                    roots: vec![plugin_root.clone()],
-                    query: "weather-sdk".to_owned(),
-                    limit: 10,
-                    profile: PluginPreflightProfileArg::RuntimeActivation,
-                    bridge_support: None,
-                    bridge_profile: None,
-                    bridge_support_delta: None,
-                    bridge_support_sha256: None,
-                    bridge_support_delta_sha256: None,
-                    policy_path: None,
-                    policy_sha256: None,
-                    policy_signature_public_key_base64: None,
-                    policy_signature_base64: None,
-                    policy_signature_algorithm: "ed25519".to_owned(),
-                },
+                source,
                 include_passed: true,
                 include_warned: true,
                 include_blocked: true,

--- a/crates/daemon/tests/integration/plugins_cli.rs
+++ b/crates/daemon/tests/integration/plugins_cli.rs
@@ -361,10 +361,15 @@ fn plugins_init_cli_parses_manifest_scaffold_request() {
 #[test]
 fn plugins_help_mentions_preflight_and_action_plan() {
     let help = render_cli_help(["plugins"]);
+    let help_lists_init_subcommand = help.lines().any(|line| {
+        let trimmed_line = line.trim();
+        let first_token = trimmed_line.split_whitespace().next();
+        first_token == Some("init")
+    });
 
     assert!(help.contains("plugin preflight"), "help: {help}");
     assert!(help.contains("doctor"), "help: {help}");
-    assert!(help.contains("init"), "help: {help}");
+    assert!(help_lists_init_subcommand, "help: {help}");
     assert!(help.contains("inventory"), "help: {help}");
     assert!(help.contains("bridge-profiles"), "help: {help}");
     assert!(help.contains("bridge-template"), "help: {help}");

--- a/crates/daemon/tests/integration/plugins_cli.rs
+++ b/crates/daemon/tests/integration/plugins_cli.rs
@@ -24,7 +24,8 @@ fn plugins_bridge_profiles_cli_parses_selected_profile_and_json_flag() {
                         ]
                     );
                 }
-                other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
+                other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
                     panic!("unexpected plugins subcommand parsed: {other:?}");
@@ -88,7 +89,8 @@ fn plugins_actions_cli_parses_filters_and_global_json_after_subcommand() {
                     );
                     assert_eq!(command.requires_reload, Some(true));
                 }
-                other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
+                other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_) => {
                     panic!("unexpected plugins subcommand parsed: {other:?}");
@@ -135,7 +137,8 @@ fn plugins_bridge_template_cli_parses_output_and_bridge_profile() {
                         Some("/tmp/bridge-support.delta.json")
                     );
                 }
-                other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
+                other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
                     panic!("unexpected plugins subcommand parsed: {other:?}");
@@ -176,8 +179,63 @@ fn plugins_preflight_cli_parses_bridge_support_delta_selector() {
                         Some("abc123")
                     );
                 }
+                other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
+                    panic!("unexpected plugins subcommand parsed: {other:?}");
+                }
+            }
+        }
+        other => panic!("unexpected parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn plugins_init_cli_parses_manifest_scaffold_request() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "plugins",
+        "init",
+        "/tmp/tavily-search",
+        "--plugin-id",
+        "tavily-search",
+        "--provider-id",
+        "tavily",
+        "--connector-name",
+        "tavily-http",
+        "--bridge-kind",
+        "process_stdio",
+        "--source-language",
+        "python",
+        "--summary",
+        "Tavily-backed search package",
+        "--json",
+    ])
+    .expect("plugins init CLI should parse");
+
+    match cli.command {
+        Some(Commands::Plugins { json, command }) => {
+            assert!(json);
+            match command {
+                loongclaw_daemon::plugins_cli::PluginsCommands::Init(command) => {
+                    assert_eq!(command.package_root, "/tmp/tavily-search");
+                    assert_eq!(command.plugin_id, "tavily-search");
+                    assert_eq!(command.provider_id.as_deref(), Some("tavily"));
+                    assert_eq!(command.connector_name.as_deref(), Some("tavily-http"));
+                    assert_eq!(
+                        command.bridge_kind,
+                        loongclaw_daemon::plugins_cli::PluginInitBridgeKindArg::ProcessStdio
+                    );
+                    assert_eq!(command.source_language.as_deref(), Some("python"));
+                    assert_eq!(
+                        command.summary.as_deref(),
+                        Some("Tavily-backed search package")
+                    );
+                }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
                     panic!("unexpected plugins subcommand parsed: {other:?}");
                 }
@@ -192,6 +250,7 @@ fn plugins_help_mentions_preflight_and_action_plan() {
     let help = render_cli_help(["plugins"]);
 
     assert!(help.contains("plugin preflight"), "help: {help}");
+    assert!(help.contains("init"), "help: {help}");
     assert!(help.contains("bridge-profiles"), "help: {help}");
     assert!(help.contains("bridge-template"), "help: {help}");
     assert!(help.contains("actions"), "help: {help}");
@@ -205,6 +264,24 @@ fn plugins_bridge_profiles_help_mentions_profile_filter() {
     assert!(help.contains("--profile <PROFILE>"), "help: {help}");
     assert!(help.contains("native-balanced"), "help: {help}");
     assert!(help.contains("openclaw-ecosystem-balanced"), "help: {help}");
+}
+
+#[test]
+fn plugins_init_help_mentions_bridge_contract_flags() {
+    let help = render_cli_help(["plugins", "init"]);
+
+    assert!(help.contains("<PACKAGE_ROOT>"), "help: {help}");
+    assert!(help.contains("--plugin-id <PLUGIN_ID>"), "help: {help}");
+    assert!(help.contains("--bridge-kind <BRIDGE_KIND>"), "help: {help}");
+    assert!(
+        help.contains("--source-language <SOURCE_LANGUAGE>"),
+        "help: {help}"
+    );
+    assert!(help.contains("--provider-id <PROVIDER_ID>"), "help: {help}");
+    assert!(
+        help.contains("--connector-name <CONNECTOR_NAME>"),
+        "help: {help}"
+    );
 }
 
 #[test]

--- a/crates/daemon/tests/integration/plugins_cli.rs
+++ b/crates/daemon/tests/integration/plugins_cli.rs
@@ -25,6 +25,7 @@ fn plugins_bridge_profiles_cli_parses_selected_profile_and_json_flag() {
                     );
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Doctor(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
@@ -74,6 +75,60 @@ fn plugins_inventory_cli_parses_bridge_profile_and_examples_flag() {
                     assert!(command.include_examples);
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Doctor(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
+                    panic!("unexpected plugins subcommand parsed: {other:?}");
+                }
+            }
+        }
+        other => panic!("unexpected parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn plugins_doctor_cli_defaults_to_sdk_release_profile() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "plugins",
+        "doctor",
+        "--root",
+        "/tmp/plugins",
+        "--query",
+        "weather-sdk",
+        "--bridge-profile",
+        "openclaw-ecosystem-balanced",
+        "--json",
+    ])
+    .expect("plugins doctor CLI should parse");
+
+    match cli.command {
+        Some(Commands::Plugins { json, command }) => {
+            assert!(json);
+            match command {
+                loongclaw_daemon::plugins_cli::PluginsCommands::Doctor(command) => {
+                    assert_eq!(command.source.scan.roots, vec!["/tmp/plugins".to_owned()]);
+                    assert_eq!(command.source.scan.query, "weather-sdk");
+                    assert_eq!(command.source.scan.limit, None);
+                    assert_eq!(
+                        command.source.scan.bridge_profile,
+                        Some(
+                            loongclaw_daemon::plugins_cli::PluginBridgeProfileArg::OpenclawEcosystemBalanced
+                        )
+                    );
+                    assert_eq!(
+                        command.source.profile,
+                        loongclaw_daemon::plugins_cli::PluginPreflightProfileArg::SdkRelease
+                    );
+                    assert!(command.include_passed);
+                    assert!(command.include_warned);
+                    assert!(command.include_blocked);
+                    assert!(command.include_deferred);
+                }
+                other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
@@ -140,6 +195,7 @@ fn plugins_actions_cli_parses_filters_and_global_json_after_subcommand() {
                     assert_eq!(command.requires_reload, Some(true));
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Doctor(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
@@ -189,6 +245,7 @@ fn plugins_bridge_template_cli_parses_output_and_bridge_profile() {
                     );
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Doctor(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
@@ -232,6 +289,7 @@ fn plugins_preflight_cli_parses_bridge_support_delta_selector() {
                     );
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Doctor(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
@@ -286,7 +344,8 @@ fn plugins_init_cli_parses_manifest_scaffold_request() {
                         Some("Tavily-backed search package")
                     );
                 }
-                other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
+                other @ loongclaw_daemon::plugins_cli::PluginsCommands::Doctor(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
@@ -304,6 +363,7 @@ fn plugins_help_mentions_preflight_and_action_plan() {
     let help = render_cli_help(["plugins"]);
 
     assert!(help.contains("plugin preflight"), "help: {help}");
+    assert!(help.contains("doctor"), "help: {help}");
     assert!(help.contains("init"), "help: {help}");
     assert!(help.contains("inventory"), "help: {help}");
     assert!(help.contains("bridge-profiles"), "help: {help}");
@@ -329,6 +389,25 @@ fn plugins_inventory_help_mentions_scan_and_bridge_flags_without_governance_prof
     );
     assert!(help.contains("--include-examples"), "help: {help}");
     assert!(!help.contains("--profile <PROFILE>"), "help: {help}");
+}
+
+#[test]
+fn plugins_doctor_help_mentions_sdk_release_profile_and_scan_flags() {
+    let help = render_cli_help(["plugins", "doctor"]);
+
+    assert!(help.contains("--root <ROOT>"), "help: {help}");
+    assert!(help.contains("--query <QUERY>"), "help: {help}");
+    assert!(help.contains("--limit <LIMIT>"), "help: {help}");
+    assert!(help.contains("--profile <PROFILE>"), "help: {help}");
+    assert!(help.contains("sdk-release"), "help: {help}");
+    assert!(
+        help.contains("--bridge-profile <BRIDGE_PROFILE>"),
+        "help: {help}"
+    );
+    assert!(
+        help.contains("--bridge-support-delta <BRIDGE_SUPPORT_DELTA>"),
+        "help: {help}"
+    );
 }
 
 #[test]

--- a/crates/daemon/tests/integration/plugins_cli.rs
+++ b/crates/daemon/tests/integration/plugins_cli.rs
@@ -25,6 +25,56 @@ fn plugins_bridge_profiles_cli_parses_selected_profile_and_json_flag() {
                     );
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
+                    panic!("unexpected plugins subcommand parsed: {other:?}");
+                }
+            }
+        }
+        other => panic!("unexpected parse result: {other:?}"),
+    }
+}
+
+#[test]
+fn plugins_inventory_cli_parses_bridge_profile_and_examples_flag() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "plugins",
+        "inventory",
+        "--root",
+        "/tmp/plugins",
+        "--query",
+        "weather-sdk",
+        "--bridge-profile",
+        "openclaw-ecosystem-balanced",
+        "--include-examples",
+        "--json",
+    ])
+    .expect("plugins inventory CLI should parse");
+
+    match cli.command {
+        Some(Commands::Plugins { json, command }) => {
+            assert!(json);
+            match command {
+                loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(command) => {
+                    assert_eq!(command.source.roots, vec!["/tmp/plugins".to_owned()]);
+                    assert_eq!(command.source.query, "weather-sdk");
+                    assert_eq!(command.source.limit, None);
+                    assert_eq!(
+                        command.source.bridge_profile,
+                        Some(
+                            loongclaw_daemon::plugins_cli::PluginBridgeProfileArg::OpenclawEcosystemBalanced
+                        )
+                    );
+                    assert!(command.include_ready);
+                    assert!(command.include_blocked);
+                    assert!(command.include_deferred);
+                    assert!(command.include_examples);
+                }
+                other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
@@ -66,7 +116,7 @@ fn plugins_actions_cli_parses_filters_and_global_json_after_subcommand() {
             match command {
                 loongclaw_daemon::plugins_cli::PluginsCommands::Actions(command) => {
                     assert_eq!(
-                        command.source.roots,
+                        command.source.scan.roots,
                         vec!["/tmp/plugins-a".to_owned(), "/tmp/plugins-b".to_owned()]
                     );
                     assert_eq!(
@@ -74,7 +124,7 @@ fn plugins_actions_cli_parses_filters_and_global_json_after_subcommand() {
                         loongclaw_daemon::plugins_cli::PluginPreflightProfileArg::RuntimeActivation
                     );
                     assert_eq!(
-                        command.source.bridge_profile,
+                        command.source.scan.bridge_profile,
                         Some(
                             loongclaw_daemon::plugins_cli::PluginBridgeProfileArg::OpenclawEcosystemBalanced
                         )
@@ -90,6 +140,7 @@ fn plugins_actions_cli_parses_filters_and_global_json_after_subcommand() {
                     assert_eq!(command.requires_reload, Some(true));
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_) => {
@@ -124,9 +175,9 @@ fn plugins_bridge_template_cli_parses_output_and_bridge_profile() {
             assert!(json);
             match command {
                 loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(command) => {
-                    assert_eq!(command.source.roots, vec!["/tmp/plugins".to_owned()]);
+                    assert_eq!(command.source.scan.roots, vec!["/tmp/plugins".to_owned()]);
                     assert_eq!(
-                        command.source.bridge_profile,
+                        command.source.scan.bridge_profile,
                         Some(
                             loongclaw_daemon::plugins_cli::PluginBridgeProfileArg::OpenclawEcosystemBalanced
                         )
@@ -138,6 +189,7 @@ fn plugins_bridge_template_cli_parses_output_and_bridge_profile() {
                     );
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
@@ -171,15 +223,16 @@ fn plugins_preflight_cli_parses_bridge_support_delta_selector() {
             match command {
                 loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(command) => {
                     assert_eq!(
-                        command.source.bridge_support_delta.as_deref(),
+                        command.source.scan.bridge_support_delta.as_deref(),
                         Some("/tmp/bridge-support.delta.json")
                     );
                     assert_eq!(
-                        command.source.bridge_support_delta_sha256.as_deref(),
+                        command.source.scan.bridge_support_delta_sha256.as_deref(),
                         Some("abc123")
                     );
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::Init(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
@@ -234,6 +287,7 @@ fn plugins_init_cli_parses_manifest_scaffold_request() {
                     );
                 }
                 other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeProfiles(_)
+                | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Inventory(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::BridgeTemplate(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Preflight(_)
                 | other @ loongclaw_daemon::plugins_cli::PluginsCommands::Actions(_) => {
@@ -251,10 +305,30 @@ fn plugins_help_mentions_preflight_and_action_plan() {
 
     assert!(help.contains("plugin preflight"), "help: {help}");
     assert!(help.contains("init"), "help: {help}");
+    assert!(help.contains("inventory"), "help: {help}");
     assert!(help.contains("bridge-profiles"), "help: {help}");
     assert!(help.contains("bridge-template"), "help: {help}");
     assert!(help.contains("actions"), "help: {help}");
     assert!(help.contains("operator action plan"), "help: {help}");
+}
+
+#[test]
+fn plugins_inventory_help_mentions_scan_and_bridge_flags_without_governance_profile() {
+    let help = render_cli_help(["plugins", "inventory"]);
+
+    assert!(help.contains("--root <ROOT>"), "help: {help}");
+    assert!(help.contains("--query <QUERY>"), "help: {help}");
+    assert!(help.contains("--limit <LIMIT>"), "help: {help}");
+    assert!(
+        help.contains("--bridge-profile <BRIDGE_PROFILE>"),
+        "help: {help}"
+    );
+    assert!(
+        help.contains("--bridge-support-delta <BRIDGE_SUPPORT_DELTA>"),
+        "help: {help}"
+    );
+    assert!(help.contains("--include-examples"), "help: {help}");
+    assert!(!help.contains("--profile <PROFILE>"), "help: {help}");
 }
 
 #[test]

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -58,18 +58,19 @@ pub use memory::{
 };
 pub use pack::VerticalPackManifest;
 pub use plugin::{
-    CURRENT_PLUGIN_HOST_API, CURRENT_PLUGIN_MANIFEST_API_VERSION, PluginAbsorbReport,
-    PluginCompatibility, PluginCompatibilityMode, PluginCompatibilityShim, PluginContractDialect,
-    PluginDescriptor, PluginDiagnosticCode, PluginDiagnosticFinding, PluginDiagnosticPhase,
-    PluginDiagnosticSeverity, PluginManifest, PluginScanReport, PluginScanner, PluginSetup,
-    PluginSetupMode, PluginSlotClaim, PluginSlotMode, PluginSourceKind, PluginTrustTier,
-    format_plugin_provenance_summary, plugin_provenance_summary_for_descriptor,
+    CURRENT_PLUGIN_HOST_API, CURRENT_PLUGIN_MANIFEST_API_VERSION, PACKAGE_MANIFEST_FILE_NAME,
+    PluginAbsorbReport, PluginCompatibility, PluginCompatibilityMode, PluginCompatibilityShim,
+    PluginContractDialect, PluginDescriptor, PluginDiagnosticCode, PluginDiagnosticFinding,
+    PluginDiagnosticPhase, PluginDiagnosticSeverity, PluginManifest, PluginScanReport,
+    PluginScanner, PluginSetup, PluginSetupMode, PluginSlotClaim, PluginSlotMode, PluginSourceKind,
+    PluginTrustTier, format_plugin_provenance_summary, plugin_provenance_summary_for_descriptor,
 };
 pub use plugin_ir::{
     BridgeSupportMatrix, PluginActivationCandidate, PluginActivationInventoryEntry,
     PluginActivationPlan, PluginActivationStatus, PluginBridgeKind, PluginCompatibilityShimSupport,
-    PluginIR, PluginRuntimeProfile, PluginSetupReadiness, PluginSetupReadinessContext,
-    PluginTranslationReport, PluginTranslator, evaluate_plugin_setup_requirements,
+    PluginIR, PluginRuntimeProfile, PluginRuntimeScaffoldDefaults, PluginSetupReadiness,
+    PluginSetupReadinessContext, PluginTranslationReport, PluginTranslator,
+    evaluate_plugin_setup_requirements, plugin_runtime_scaffold_defaults,
 };
 pub use policy::{PolicyContext, PolicyDecision, PolicyEngine, PolicyRequest, StaticPolicyEngine};
 pub use policy_ext::{PolicyExtension, PolicyExtensionChain, PolicyExtensionContext};

--- a/crates/kernel/src/plugin.rs
+++ b/crates/kernel/src/plugin.rs
@@ -15,7 +15,7 @@ use crate::{
     pack::VerticalPackManifest,
 };
 
-const PACKAGE_MANIFEST_FILE_NAME: &str = "loongclaw.plugin.json";
+pub const PACKAGE_MANIFEST_FILE_NAME: &str = "loongclaw.plugin.json";
 const OPENCLAW_PACKAGE_MANIFEST_FILE_NAME: &str = "openclaw.plugin.json";
 const PACKAGE_JSON_FILE_NAME: &str = "package.json";
 const OPENCLAW_MODERN_COMPATIBILITY_ADAPTER_FAMILY: &str = "openclaw-modern-compat";

--- a/crates/kernel/src/plugin_ir.rs
+++ b/crates/kernel/src/plugin_ir.rs
@@ -56,6 +56,14 @@ pub struct PluginRuntimeProfile {
     pub entrypoint_hint: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginRuntimeScaffoldDefaults {
+    pub source_language: Option<String>,
+    pub bridge_kind: PluginBridgeKind,
+    pub adapter_family: String,
+    pub entrypoint_hint: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PluginIR {
     pub manifest_api_version: Option<String>,
@@ -1146,7 +1154,11 @@ fn infer_runtime_profile_from_parts(
     metadata: &BTreeMap<String, String>,
     endpoint: Option<&str>,
 ) -> PluginRuntimeProfile {
-    let source_language = normalize_language(language);
+    let source_language = metadata
+        .get("source_language")
+        .map(|value| normalize_language(value))
+        .filter(|value| value != "unknown")
+        .unwrap_or_else(|| normalize_language(language));
 
     let bridge_kind = metadata
         .get("bridge_kind")
@@ -1176,6 +1188,43 @@ fn infer_runtime_profile_from_parts(
         adapter_family,
         entrypoint_hint,
     }
+}
+
+pub fn plugin_runtime_scaffold_defaults(
+    bridge_kind: PluginBridgeKind,
+    source_language: Option<&str>,
+) -> Result<PluginRuntimeScaffoldDefaults, String> {
+    if matches!(bridge_kind, PluginBridgeKind::Unknown) {
+        return Err("plugin scaffold does not support bridge_kind `unknown`".to_owned());
+    }
+
+    let normalized_source_language = source_language
+        .map(normalize_language)
+        .filter(|value| value != "unknown" && value != "manifest");
+
+    let source_language_is_required = matches!(
+        bridge_kind,
+        PluginBridgeKind::ProcessStdio | PluginBridgeKind::NativeFfi
+    );
+
+    if source_language_is_required && normalized_source_language.is_none() {
+        return Err(format!(
+            "plugin scaffold requires an explicit source language for bridge_kind `{}`",
+            bridge_kind.as_str()
+        ));
+    }
+
+    let adapter_language = normalized_source_language.as_deref().unwrap_or("unknown");
+    let adapter_family = default_adapter_family(adapter_language, bridge_kind);
+    let entrypoint_hint =
+        default_entrypoint_hint(bridge_kind, None).unwrap_or_else(|| "invoke".to_owned());
+
+    Ok(PluginRuntimeScaffoldDefaults {
+        source_language: normalized_source_language,
+        bridge_kind,
+        adapter_family,
+        entrypoint_hint,
+    })
 }
 
 fn legacy_plugin_ir_dialect(source_kind: PluginSourceKind) -> PluginContractDialect {
@@ -1470,6 +1519,25 @@ mod tests {
     }
 
     #[test]
+    fn translator_honors_metadata_source_language_for_package_manifests() {
+        let descriptor = descriptor(
+            "manifest",
+            BTreeMap::from([
+                ("bridge_kind".to_owned(), "process_stdio".to_owned()),
+                ("source_language".to_owned(), "py".to_owned()),
+            ]),
+        );
+
+        let translator = PluginTranslator::new();
+        let ir = translator.translate_descriptor(&descriptor);
+
+        assert_eq!(ir.runtime.source_language, "python");
+        assert_eq!(ir.runtime.bridge_kind, PluginBridgeKind::ProcessStdio);
+        assert_eq!(ir.runtime.adapter_family, "python-stdio-adapter");
+        assert_eq!(ir.runtime.entrypoint_hint, "stdin/stdout::invoke");
+    }
+
+    #[test]
     fn translator_defaults_manifest_descriptor_with_endpoint_to_http_json() {
         let descriptor = descriptor("manifest", BTreeMap::new());
 
@@ -1490,6 +1558,35 @@ mod tests {
             ir.package_manifest_path,
             Some("/tmp/loongclaw.plugin.json".to_owned())
         );
+    }
+
+    #[test]
+    fn plugin_runtime_scaffold_defaults_require_source_language_for_process_stdio() {
+        let error = plugin_runtime_scaffold_defaults(PluginBridgeKind::ProcessStdio, None)
+            .expect_err("process bridge scaffold should require source language");
+
+        assert!(error.contains("source language"));
+        assert!(error.contains("process_stdio"));
+    }
+
+    #[test]
+    fn plugin_runtime_scaffold_defaults_require_source_language_for_native_ffi() {
+        let error = plugin_runtime_scaffold_defaults(PluginBridgeKind::NativeFfi, None)
+            .expect_err("native ffi scaffold should require source language");
+
+        assert!(error.contains("source language"));
+        assert!(error.contains("native_ffi"));
+    }
+
+    #[test]
+    fn plugin_runtime_scaffold_defaults_normalize_python_process_bridge() {
+        let defaults = plugin_runtime_scaffold_defaults(PluginBridgeKind::ProcessStdio, Some("py"))
+            .expect("python process bridge scaffold defaults should resolve");
+
+        assert_eq!(defaults.source_language.as_deref(), Some("python"));
+        assert_eq!(defaults.bridge_kind, PluginBridgeKind::ProcessStdio);
+        assert_eq!(defaults.adapter_family, "python-stdio-adapter");
+        assert_eq!(defaults.entrypoint_hint, "stdin/stdout::invoke");
     }
 
     #[test]

--- a/crates/spec/src/spec_runtime/plugin_contract_types.rs
+++ b/crates/spec/src/spec_runtime/plugin_contract_types.rs
@@ -1035,7 +1035,7 @@ pub struct PluginPreflightBridgeShimProfileDelta {
     pub supported_source_languages: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginPreflightResult {
     pub profile: String,
     pub baseline_verdict: String,

--- a/crates/spec/src/spec_runtime/plugin_contract_types.rs
+++ b/crates/spec/src/spec_runtime/plugin_contract_types.rs
@@ -866,7 +866,7 @@ pub struct PluginInventoryEntry {
     pub loaded: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginInventoryResult {
     pub manifest_api_version: Option<String>,
     pub plugin_version: Option<String>,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -284,6 +284,16 @@ Acceptance criteria:
 Status: planned
 Focus: open ecosystem without sacrificing trust boundaries.
 
+Delivered in current baseline:
+
+- `loongclaw plugins init <package_root>` scaffolds a manifest-first plugin
+  package root with a canonical `loongclaw.plugin.json`, current host
+  compatibility defaults, and a README that routes authors into shared
+  governance validation instead of internal crate spelunking
+- package-manifest runtime projection now also honors explicit
+  `metadata.source_language`, so language-specific scaffolded packages keep
+  canonical bridge, adapter-family, and preflight language semantics
+
 Planned deliverables:
 
 - multi-language plugin intake pipeline:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -289,7 +289,11 @@ Delivered in current baseline:
 - `loongclaw plugins init <package_root>` scaffolds a manifest-first plugin
   package root with a canonical `loongclaw.plugin.json`, current host
   compatibility defaults, and a README that routes authors into shared
-  governance validation instead of internal crate spelunking
+  package diagnosis instead of internal crate spelunking
+- `loongclaw plugins doctor --root <package_root>` reuses the shared
+  `plugin_preflight` contract for author-facing package diagnosis, defaulting
+  to the `sdk_release` profile while surfacing setup truth, remediation
+  classes, and required operator follow-up actions
 - package-manifest runtime projection now also honors explicit
   `metadata.source_language`, so language-specific scaffolded packages keep
   canonical bridge, adapter-family, and preflight language semantics

--- a/docs/design-docs/plugin-package-manifest-contract.md
+++ b/docs/design-docs/plugin-package-manifest-contract.md
@@ -205,6 +205,17 @@ contract:
   operators can see whether their plugin surface is drifting toward foreign
   dialect, shim-heavy, or bridge-constrained mixes before those mixes become
   delivery or marketplace problems
+- the daemon now also exposes `loongclaw plugins init <package_root>` as a
+  bounded authoring bootstrap that writes a canonical
+  `loongclaw.plugin.json` plus a README for external authors instead of asking
+  them to reverse-engineer package shape from kernel internals or tests
+- scaffolded manifests pin `api_version` and `compatibility.host_api` to the
+  current host contract and reuse kernel-owned bridge defaults for
+  `bridge_kind`, `adapter_family`, and `entrypoint`
+- package-manifest runtime projection now also honors explicit
+  `metadata.source_language`, so language-specific scaffolds do not collapse
+  into a fake `manifest` language during preflight, bridge-profile fit
+  analysis, or activation planning
 
 This is intentionally not the full Stage 4 ecosystem model yet. It closes the
 most important ownership ambiguity first: plugin packages can now express and
@@ -232,6 +243,27 @@ Every distributable plugin package should have one package-level manifest file.
 Recommended filename:
 
 - `loongclaw.plugin.json`
+
+The repo now also ships a bounded first-mile authoring command for that file
+contract:
+
+```bash
+loongclaw plugins init ./plugins/tavily-search \
+  --plugin-id tavily-search \
+  --provider-id tavily \
+  --connector-name tavily-http \
+  --bridge-kind http_json \
+  --summary "Tavily-backed search package"
+```
+
+The scaffold is intentionally narrow:
+
+- it creates an empty package root only
+- it writes a canonical `loongclaw.plugin.json`
+- it writes a README that points authors to `plugins preflight` and
+  `plugins actions`
+- it does not generate runtime code, widen trust policy, or guess setup/slot
+  ownership
 
 The manifest is the source of truth for:
 
@@ -460,6 +492,11 @@ Example:
   "tags": ["search", "provider", "web"]
 }
 ```
+
+For language-specific bridges such as `process_stdio` or `native_ffi`, the
+manifest should also carry `metadata.source_language`. The scaffold command adds
+that field when `--source-language` is provided so bridge policy, preflight
+summary, and activation planning all stay aligned on one runtime projection.
 
 Important design constraints:
 

--- a/docs/design-docs/plugin-package-manifest-contract.md
+++ b/docs/design-docs/plugin-package-manifest-contract.md
@@ -209,6 +209,9 @@ contract:
   bounded authoring bootstrap that writes a canonical
   `loongclaw.plugin.json` plus a README for external authors instead of asking
   them to reverse-engineer package shape from kernel internals or tests
+- the daemon now also exposes `loongclaw plugins doctor --root <package_root>`
+  as the author-facing diagnosis surface, reusing shared preflight truth to
+  surface setup contracts, remediation classes, and operator follow-up actions
 - scaffolded manifests pin `api_version` and `compatibility.host_api` to the
   current host contract and reuse kernel-owned bridge defaults for
   `bridge_kind`, `adapter_family`, and `entrypoint`
@@ -260,7 +263,7 @@ The scaffold is intentionally narrow:
 
 - it creates an empty package root only
 - it writes a canonical `loongclaw.plugin.json`
-- it writes a README that points authors to `plugins preflight` and
+- it writes a README that points authors to `plugins doctor` and
   `plugins actions`
 - it does not generate runtime code, widen trust policy, or guess setup/slot
   ownership


### PR DESCRIPTION
## Summary

- Problem:
  External plugin authors still had to hand-author `loongclaw.plugin.json`, reverse-engineer package shape from kernel internals or tests, and drop to raw preflight/spec surfaces to understand why a package was not activation-ready.
- Why it matters:
  That gap slows internal product-mode iteration today and leaves the future community co-creation path without a stable author-facing contract surface. Authoring, inspection, diagnosis, docs, and runtime projection need to stay aligned on the same kernel/spec truth.
- What changed:
  Added `loongclaw plugins init <package_root>` as a manifest-first authoring bootstrap.
  The command writes a canonical `loongclaw.plugin.json` and `README.md`, validates package-root emptiness and semver, defaults provider and connector identity to `plugin_id`, and reuses kernel-owned bridge defaults for `bridge_kind`, `adapter_family`, and `entrypoint`.
  Added `loongclaw plugins inventory` as a thin daemon surface over `OperationSpec::PluginInventory`, including CLI rendering, JSON decoding, result summaries, and regression coverage.
  Added `loongclaw plugins doctor` as a thin author-facing daemon surface over `OperationSpec::PluginPreflight`, defaulting to the `sdk_release` profile while surfacing setup truth, activation state, remediation classes, recommended actions, and required operator follow-up actions.
  Shared daemon-side preflight result decoding now uses typed `PluginPreflightResult` values instead of raw `serde_json::Value`, so both `plugins preflight` and `plugins doctor` render stable contract fields with regression coverage.
  Shared plugin scan resolution keeps scan `limit` optional and resolves per-surface defaults from the spec contract, so inventory keeps its own default cap instead of inheriting governance-oriented limits.
  Package-manifest runtime projection now honors explicit `metadata.source_language`, so language-specific package scaffolds keep the correct runtime semantics during scan, inventory, preflight, doctor, and bridge-profile fit analysis.
  Updated plugin namespace help, design docs, roadmap, scaffolded README guidance, and CLI/spec regression coverage for the scaffold, inventory surface, doctor surface, and source-language projection fix.
- What did not change (scope boundary):
  No SDK crate.
  No runtime code generator.
  No marketplace, registry, or publish flow.
  No trust-policy widening.
  No second policy engine.

## Linked Issues

- Closes #693
- Related #426

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  passed

cargo clippy --workspace --all-targets --all-features -- -D warnings
  passed

cargo test -p loongclaw-daemon plugins_cli -- --nocapture
  passed

cargo test --workspace --locked
  passed

cargo test --workspace --all-features --locked
  passed

LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
  passed

scripts/check_dep_graph.sh
  passed

scripts/check-docs.sh
  passed with existing non-blocking release-artifact warnings only

python3 scripts/sync_github_labels.py --check
  passed

bash scripts/test_sync_github_labels.sh
  passed

diff CLAUDE.md AGENTS.md
  passed

cargo deny check advisories bans licenses sources
  not clean because of existing repository baseline license policy failures:
  - 0BSD via quoted_printable
  - CC0-1.0 via secp256k1 / secp256k1-sys
  advisories, bans, and sources were otherwise OK

command -v task
  not installed in this environment, so task-based verify wrappers were not runnable here

test -f "$HOME/.claude/skills/convention-engineering/scripts/main.go"
  missing, so the repository's convention-wrapper check could not run in this environment
```

Before/after behavior for the new default-sensitive path:

- Before:
  There was no daemon `plugins doctor` surface, scaffolded package guidance pointed authors to raw preflight, and daemon-side preflight rendering decoded result rows as untyped JSON blobs.
- After:
  `plugins doctor` defaults to `sdk_release`, gives package authors an explicit diagnosis surface over shared preflight truth, scaffolded package guidance points there by default, and daemon-side preflight rendering now consumes typed `PluginPreflightResult` values.
  Regression coverage asserts the doctor parse/help shape, default profile behavior, author-facing remediation/operator-action rendering inputs, and continued inventory default-limit isolation from governance defaults.

## User-visible / Operator-visible Changes

- `loongclaw plugins init <package_root>` bootstraps a manifest-first plugin package root for external authors.
- `loongclaw plugins inventory` exposes a first-class daemon inspection surface for package-first plugin scans, with summary rollups for activation status, setup surface, source language, and bridge kind.
- `loongclaw plugins doctor --root <package_root>` exposes an author-facing diagnosis surface that defaults to `sdk_release` and reuses shared preflight truth instead of inventing a second governance engine.
- Generated packages now preserve explicit `source_language` semantics for language-specific bridge profiles instead of collapsing to manifest-only defaults during runtime projection.

## Failure Recovery

- Fast rollback or disable path:
  Revert commits `0e338674`, `1d263a33`, and `63185c0d`, or avoid invoking `loongclaw plugins init`, `loongclaw plugins inventory`, and `loongclaw plugins doctor`.
- Observable failure symptoms reviewers should watch for:
  Scaffolded package manifests missing compatibility or runtime metadata defaults.
  `process_stdio` or `native_ffi` scaffolds translating back to manifest-only source language during scan or preflight.
  `plugins inventory` unexpectedly exposing governance-only knobs, truncating results with the wrong default limit, or misclassifying package setup status.
  `plugins doctor` rendering the wrong default profile, hiding operator follow-up actions, or drifting from shared preflight verdict/remediation truth.

## Reviewer Focus

- Review the scaffold, inventory, and doctor surfaces in `crates/daemon/src/plugins_cli.rs`, especially scope discipline, per-surface default selection, typed preflight rendering, and the thin-wrapper reuse of shared spec truth.
- Review the runtime-projection root-cause fix in `crates/kernel/src/plugin_ir.rs` to confirm `metadata.source_language` now overrides manifest-path fallback semantics.
- Review the contract alignment in `crates/spec/src/spec_runtime/plugin_contract_types.rs` and the CLI/help/docs updates to confirm this remains a bounded manifest-first authoring slice rather than silently expanding into publish, marketplace, or separate-SDK territory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `plugins init` to scaffold a manifest-first plugin package (writes canonical manifest + README) and `plugins inventory` to summarize installed plugins with JSON/text output and rollout counts.
  * `plugins doctor` updated to be author-facing and use shared preflight semantics.

* **Behavior Changes**
  * Scaffold preserves/validates explicit package source-language; some bridge kinds require `--source-language`. `--version` must be valid semver.

* **Documentation**
  * Updated roadmap and design docs for manifest-first authoring and runtime projection.

* **Tests**
  * Expanded integration/unit tests for new CLI behaviors and validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
