### PR TITLE
feat(app): persist structured autonomy policy telemetry

### DIFF
--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use serde_json::{Value, json};
 
 use crate::CliResult;
@@ -10,7 +11,6 @@ use crate::memory::{
 
 use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
-use super::turn_engine::{ToolDecision, ToolOutcome};
 use super::turn_shared::ReplyPersistenceMode;
 
 pub(super) fn format_provider_error_reply(error: &str) -> String {
@@ -53,14 +53,18 @@ pub(super) async fn persist_reply_turns_with_mode<R: ConversationRuntime + ?Size
 /// The content is a single JSON line with `"type": "tool_decision"` plus
 /// correlation identifiers (`session_id`, `turn_id`, `tool_call_id`).
 #[allow(dead_code)] // Will be wired into TurnEngine in a follow-up task
-pub(super) async fn persist_tool_decision<R: ConversationRuntime + ?Sized>(
+pub(super) async fn persist_tool_decision<R, D>(
     runtime: &R,
     session_id: &str,
     turn_id: &str,
     tool_call_id: &str,
-    decision: &ToolDecision,
+    decision: &D,
     binding: ConversationRuntimeBinding<'_>,
-) -> CliResult<()> {
+) -> CliResult<()>
+where
+    R: ConversationRuntime + ?Sized,
+    D: Serialize + ?Sized,
+{
     let content = build_tool_decision_content(
         turn_id,
         tool_call_id,
@@ -75,14 +79,18 @@ pub(super) async fn persist_tool_decision<R: ConversationRuntime + ?Sized>(
 /// The content is a single JSON line with `"type": "tool_outcome"` plus
 /// correlation identifiers (`session_id`, `turn_id`, `tool_call_id`).
 #[allow(dead_code)] // Will be wired into TurnEngine in a follow-up task
-pub(super) async fn persist_tool_outcome<R: ConversationRuntime + ?Sized>(
+pub(super) async fn persist_tool_outcome<R, O>(
     runtime: &R,
     session_id: &str,
     turn_id: &str,
     tool_call_id: &str,
-    outcome: &ToolOutcome,
+    outcome: &O,
     binding: ConversationRuntimeBinding<'_>,
-) -> CliResult<()> {
+) -> CliResult<()>
+where
+    R: ConversationRuntime + ?Sized,
+    O: Serialize + ?Sized,
+{
     let content = build_tool_outcome_content(
         turn_id,
         tool_call_id,

--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -52,7 +52,6 @@ pub(super) async fn persist_reply_turns_with_mode<R: ConversationRuntime + ?Size
 /// Uses the existing `persist_turn` mechanism so the DB schema stays unchanged.
 /// The content is a single JSON line with `"type": "tool_decision"` plus
 /// correlation identifiers (`session_id`, `turn_id`, `tool_call_id`).
-#[allow(dead_code)] // Will be wired into TurnEngine in a follow-up task
 pub(super) async fn persist_tool_decision<R, D>(
     runtime: &R,
     session_id: &str,
@@ -78,7 +77,6 @@ where
 /// Uses the existing `persist_turn` mechanism so the DB schema stays unchanged.
 /// The content is a single JSON line with `"type": "tool_outcome"` plus
 /// correlation identifiers (`session_id`, `turn_id`, `tool_call_id`).
-#[allow(dead_code)] // Will be wired into TurnEngine in a follow-up task
 pub(super) async fn persist_tool_outcome<R, O>(
     runtime: &R,
     session_id: &str,

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -994,6 +994,25 @@ fn persisted_conversation_event_payloads_by_name(
         .collect()
 }
 
+fn persisted_internal_records_by_type(
+    persisted: &[(String, String, String)],
+    record_type: &str,
+) -> Vec<Value> {
+    persisted
+        .iter()
+        .filter_map(|(_, role, content)| {
+            if role != "assistant" {
+                return None;
+            }
+            let parsed = serde_json::from_str::<Value>(content).ok()?;
+            if parsed.get("type")?.as_str()? != record_type {
+                return None;
+            }
+            Some(parsed)
+        })
+        .collect()
+}
+
 fn assert_discovery_first_followup_summary(
     persisted: &[(String, String, String)],
     raw_tool_output_requested: bool,
@@ -12075,6 +12094,274 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_se
         governance_snapshot["reason_code"],
         "autonomy_policy_session_mutation_requires_approval"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_telemetry_handle_turn_persists_approval_required_tool_decision() {
+    let workspace_root_name =
+        unique_acp_test_id("conversation-autonomy-telemetry", "guided-install-approval");
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let _skill_root = write_test_external_skill(&workspace_root, "source/demo-skill");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-telemetry-guided-approval");
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.external_skills.enabled = true;
+    config.tools.autonomy_profile = AutonomyProfile::GuidedAcquisition;
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Install the demo skill.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "external_skills.install",
+                json!({
+                    "path": "source/demo-skill"
+                }),
+                "session-autonomy-telemetry-guided",
+                "turn-autonomy-telemetry-guided",
+                "call-autonomy-telemetry-guided",
+            )],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-telemetry-guided",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-autonomy-telemetry-guided",
+            "install the demo skill",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("guided autonomy turn should complete");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let decisions = persisted_internal_records_by_type(&persisted, "tool_decision");
+    let outcomes = persisted_internal_records_by_type(&persisted, "tool_outcome");
+
+    assert_eq!(decisions.len(), 1);
+    assert_eq!(outcomes.len(), 0);
+
+    let decision = &decisions[0]["decision"];
+    assert!(
+        decisions[0]["turn_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+    assert_eq!(
+        decisions[0]["tool_call_id"],
+        "call-autonomy-telemetry-guided"
+    );
+    assert_eq!(decision["tool_name"], "external_skills.install");
+    assert_eq!(decision["decision_kind"], "approval_required");
+    assert_eq!(decision["allow"], false);
+    assert_eq!(decision["deny"], false);
+    assert_eq!(decision["policy_source"], "autonomy_policy");
+    assert_eq!(decision["autonomy_profile"], "guided_acquisition");
+    assert_eq!(decision["capability_action_class"], "capability_install");
+    assert_eq!(
+        decision["rule_id"],
+        "autonomy_policy_capability_acquisition_requires_approval"
+    );
+    assert_eq!(
+        decision["reason_code"],
+        "autonomy_policy_capability_acquisition_requires_approval"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_telemetry_handle_turn_persists_denied_tool_decision() {
+    let workspace_root_name = unique_acp_test_id(
+        "conversation-autonomy-telemetry",
+        "discovery-install-denied",
+    );
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let _skill_root = write_test_external_skill(&workspace_root, "source/demo-skill");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-telemetry-discovery-denied");
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.external_skills.enabled = true;
+    config.tools.autonomy_profile = AutonomyProfile::DiscoveryOnly;
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Install the demo skill.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "external_skills.install",
+                json!({
+                    "path": "source/demo-skill"
+                }),
+                "session-autonomy-telemetry-discovery",
+                "turn-autonomy-telemetry-discovery",
+                "call-autonomy-telemetry-discovery",
+            )],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-telemetry-discovery",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-autonomy-telemetry-discovery",
+            "install the demo skill",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("discovery autonomy turn should complete");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let decisions = persisted_internal_records_by_type(&persisted, "tool_decision");
+    let outcomes = persisted_internal_records_by_type(&persisted, "tool_outcome");
+
+    assert_eq!(decisions.len(), 1);
+    assert_eq!(outcomes.len(), 0);
+
+    let decision = &decisions[0]["decision"];
+    assert!(
+        decisions[0]["turn_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+    assert_eq!(
+        decisions[0]["tool_call_id"],
+        "call-autonomy-telemetry-discovery"
+    );
+    assert_eq!(decision["tool_name"], "external_skills.install");
+    assert_eq!(decision["decision_kind"], "deny");
+    assert_eq!(decision["allow"], false);
+    assert_eq!(decision["deny"], true);
+    assert_eq!(decision["policy_source"], "autonomy_policy");
+    assert_eq!(decision["autonomy_profile"], "discovery_only");
+    assert_eq!(decision["capability_action_class"], "capability_install");
+    assert_eq!(
+        decision["rule_id"],
+        "autonomy_policy_capability_acquisition_disallowed"
+    );
+    assert_eq!(
+        decision["reason_code"],
+        "autonomy_policy_capability_acquisition_disallowed"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_telemetry_handle_turn_persists_allow_decision_and_tool_outcome() {
+    let workspace_root_name =
+        unique_acp_test_id("conversation-autonomy-telemetry", "bounded-install-allow");
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let _skill_root = write_test_external_skill(&workspace_root, "source/demo-skill");
+
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("autonomy-telemetry-bounded-allow");
+    config.tools.file_root = Some(workspace_root.display().to_string());
+    config.external_skills.enabled = true;
+    config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Install the demo skill.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "external_skills.install",
+                json!({
+                    "path": "source/demo-skill"
+                }),
+                "session-autonomy-telemetry-bounded",
+                "turn-autonomy-telemetry-bounded",
+                "call-autonomy-telemetry-bounded",
+            )],
+            raw_meta: Value::Null,
+        }),
+        Ok("unused".to_owned()),
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = crate::context::bootstrap_kernel_context_with_config(
+        "autonomy-telemetry-bounded",
+        60,
+        &config,
+    )
+    .expect("bootstrap kernel context");
+
+    let _reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-autonomy-telemetry-bounded",
+            "install the demo skill and show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("bounded autonomy turn should complete");
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let decisions = persisted_internal_records_by_type(&persisted, "tool_decision");
+    let outcomes = persisted_internal_records_by_type(&persisted, "tool_outcome");
+
+    assert_eq!(decisions.len(), 1);
+    assert_eq!(outcomes.len(), 1);
+
+    let decision = &decisions[0]["decision"];
+    assert!(
+        decisions[0]["turn_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+    assert_eq!(
+        decisions[0]["tool_call_id"],
+        "call-autonomy-telemetry-bounded"
+    );
+    assert_eq!(decision["tool_name"], "external_skills.install");
+    assert_eq!(decision["decision_kind"], "allow");
+    assert_eq!(decision["allow"], true);
+    assert_eq!(decision["deny"], false);
+    assert_eq!(decision["policy_source"], "autonomy_policy");
+    assert_eq!(decision["autonomy_profile"], "bounded_autonomous");
+    assert_eq!(decision["capability_action_class"], "capability_install");
+
+    let outcome = &outcomes[0]["outcome"];
+    assert!(
+        outcomes[0]["turn_id"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+    assert_eq!(
+        outcomes[0]["tool_call_id"],
+        "call-autonomy-telemetry-bounded"
+    );
+    assert_eq!(outcome["tool_name"], "external_skills.install");
+    assert_eq!(outcome["status"], "ok");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -43,7 +43,8 @@ use super::ingress::ConversationIngressContext;
 use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
 use super::persistence::{
     format_provider_error_reply, persist_acp_runtime_events, persist_conversation_event,
-    persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode,
+    persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode, persist_tool_decision,
+    persist_tool_outcome,
 };
 use super::plan_executor::{
     PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure,
@@ -5004,24 +5005,46 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         }
     };
 
-    if let Some(trace) = fast_lane_tool_batch_trace.as_ref()
-        && emit_fast_lane_tool_batch_event(runtime, session_id, trace, binding)
-            .await
-            .is_err()
-        && let Some(ctx) = binding.kernel_context()
-    {
-        let _ = ctx.kernel.record_audit_event(
-            Some(ctx.agent_id()),
-            AuditEventKind::PlaneInvoked {
-                pack_id: ctx.pack_id().to_owned(),
-                plane: ExecutionPlane::Runtime,
-                tier: PlaneTier::Core,
-                primary_adapter: "conversation.fast_lane".to_owned(),
-                delegated_core_adapter: None,
-                operation: "conversation.fast_lane.fast_lane_tool_batch_persist_failed".to_owned(),
-                required_capabilities: Vec::new(),
-            },
-        );
+    if let Some(trace) = fast_lane_tool_batch_trace.as_ref() {
+        let trace_persist_failed =
+            persist_fast_lane_tool_trace(runtime, session_id, trace, binding)
+                .await
+                .is_err();
+        if trace_persist_failed && let Some(ctx) = binding.kernel_context() {
+            let _ = ctx.kernel.record_audit_event(
+                Some(ctx.agent_id()),
+                AuditEventKind::PlaneInvoked {
+                    pack_id: ctx.pack_id().to_owned(),
+                    plane: ExecutionPlane::Runtime,
+                    tier: PlaneTier::Core,
+                    primary_adapter: "conversation.fast_lane".to_owned(),
+                    delegated_core_adapter: None,
+                    operation: "conversation.fast_lane.tool_trace_persist_failed".to_owned(),
+                    required_capabilities: Vec::new(),
+                },
+            );
+        }
+
+        let should_emit_batch_event = trace.has_execution_segments();
+        let batch_event_failed = should_emit_batch_event
+            && emit_fast_lane_tool_batch_event(runtime, session_id, trace, binding)
+                .await
+                .is_err();
+        if batch_event_failed && let Some(ctx) = binding.kernel_context() {
+            let _ = ctx.kernel.record_audit_event(
+                Some(ctx.agent_id()),
+                AuditEventKind::PlaneInvoked {
+                    pack_id: ctx.pack_id().to_owned(),
+                    plane: ExecutionPlane::Runtime,
+                    tier: PlaneTier::Core,
+                    primary_adapter: "conversation.fast_lane".to_owned(),
+                    delegated_core_adapter: None,
+                    operation: "conversation.fast_lane.fast_lane_tool_batch_persist_failed"
+                        .to_owned(),
+                    required_capabilities: Vec::new(),
+                },
+            );
+        }
     }
 
     let tool_events = build_provider_turn_tool_terminal_events(
@@ -5527,6 +5550,39 @@ async fn emit_fast_lane_tool_batch_event<R: ConversationRuntime + ?Sized>(
         binding,
     )
     .await
+}
+
+async fn persist_fast_lane_tool_trace<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    trace: &ToolBatchExecutionTrace,
+    binding: ConversationRuntimeBinding<'_>,
+) -> CliResult<()> {
+    for record in &trace.decision_records {
+        persist_tool_decision(
+            runtime,
+            session_id,
+            &record.turn_id,
+            &record.tool_call_id,
+            &record.decision,
+            binding,
+        )
+        .await?;
+    }
+
+    for record in &trace.outcome_records {
+        persist_tool_outcome(
+            runtime,
+            session_id,
+            &record.turn_id,
+            &record.tool_call_id,
+            &record.outcome,
+            binding,
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 async fn emit_turn_ingress_event<R: ConversationRuntime + ?Sized>(
@@ -7634,6 +7690,8 @@ mod tests {
             observed_peak_in_flight: 1,
             observed_wall_time_ms: 10,
             segments: Vec::new(),
+            decision_records: Vec::new(),
+            outcome_records: Vec::new(),
             intent_outcomes: vec![
                 ToolBatchExecutionIntentTrace {
                     tool_call_id: "call-1".to_owned(),

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1601,7 +1601,7 @@ fn build_success_tool_outcome_trace_record(
     let outcome = ToolOutcomeTelemetry {
         tool_name,
         status: outcome.status.clone(),
-        payload: outcome.payload.clone(),
+        payload: build_bounded_tool_outcome_payload(intent, outcome),
         error_code: None,
         human_reason: None,
         audit_event_id: None,
@@ -1611,6 +1611,31 @@ fn build_success_tool_outcome_trace_record(
         tool_call_id: intent.tool_call_id.clone(),
         outcome,
     }
+}
+
+fn build_bounded_tool_outcome_payload(
+    intent: &ToolIntent,
+    outcome: &ToolCoreOutcome,
+) -> serde_json::Value {
+    let normalized_limit =
+        effective_payload_summary_limit(intent, TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS).clamp(
+            MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+            MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+        );
+    let payload_text = serde_json::to_string(&outcome.payload)
+        .unwrap_or_else(|_| "[tool_payload_unserializable]".to_owned());
+    let (payload_summary, payload_chars, payload_truncated) =
+        truncate_by_chars(payload_text.as_str(), normalized_limit);
+
+    if !payload_truncated {
+        return outcome.payload.clone();
+    }
+
+    json!({
+        "payload_summary": payload_summary,
+        "payload_chars": payload_chars,
+        "payload_truncated": true,
+    })
 }
 
 fn build_failure_tool_outcome_trace_record(
@@ -2245,7 +2270,6 @@ impl TurnEngine {
                     binding,
                     &autonomy_budget_state,
                     ingress,
-                    &mut trace,
                 )
                 .await
             {
@@ -2589,7 +2613,6 @@ impl TurnEngine {
         binding: ConversationRuntimeBinding<'_>,
         budget_state: &AutonomyTurnBudgetState,
         ingress: Option<&ConversationIngressContext>,
-        _trace: &mut ToolBatchExecutionTrace,
     ) -> Result<PreparedToolIntent, PreparedToolIntentFailure> {
         let Some(resolved_tool) = crate::tools::resolve_tool_execution(&intent.tool_name) else {
             let reason = format!("tool_not_found: {}", intent.tool_name);
@@ -4480,6 +4503,48 @@ mod tests {
                 .is_some_and(|detail| detail.contains("simulated observed tool failure")),
             "expected failure detail in trace, got {:?}",
             trace.intent_outcomes[1].detail
+        );
+    }
+
+    #[test]
+    fn success_outcome_trace_record_bounds_large_payloads() {
+        let intent = provider_app_tool_intent(
+            "file.read",
+            json!({"path": "note.md"}),
+            "session-bounded-payload",
+            "turn-bounded-payload",
+            "call-bounded-payload",
+        );
+        let large_payload = json!({
+            "contents": "x".repeat(TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS + 128),
+        });
+        let outcome = ToolCoreOutcome {
+            status: "ok".to_owned(),
+            payload: large_payload,
+        };
+
+        let record = build_success_tool_outcome_trace_record(&intent, &outcome);
+
+        assert_eq!(record.outcome.tool_name, "file.read");
+        assert_eq!(record.outcome.status, "ok");
+        assert_eq!(record.turn_id, "turn-bounded-payload");
+        assert_eq!(record.tool_call_id, "call-bounded-payload");
+        assert_eq!(record.outcome.payload["payload_truncated"], json!(true));
+        let payload_summary = record.outcome.payload["payload_summary"]
+            .as_str()
+            .expect("expected truncated payload summary");
+        let payload_chars = record.outcome.payload["payload_chars"]
+            .as_u64()
+            .expect("expected original payload char count");
+        assert!(
+            payload_summary.len() < payload_chars as usize,
+            "expected bounded payload summary, got {:?}",
+            record.outcome.payload
+        );
+        assert!(
+            payload_chars > TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS as u64,
+            "expected original payload char count, got {:?}",
+            record.outcome.payload
         );
     }
 

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1263,6 +1263,13 @@ fn classify_tool_execution_reason(reason: &str) -> KernelFailureClass {
     }
 }
 
+fn render_app_tool_denied_reason(reason: &str) -> String {
+    reason
+        .strip_prefix("app_tool_denied: ")
+        .unwrap_or(reason)
+        .to_owned()
+}
+
 fn with_runtime_ready_browser_companion_tools(
     base_view: ToolView,
     session_tool_view: &ToolView,
@@ -1614,18 +1621,18 @@ fn build_success_tool_outcome_trace_record(
 }
 
 fn build_bounded_tool_outcome_payload(
-    intent: &ToolIntent,
+    _intent: &ToolIntent,
     outcome: &ToolCoreOutcome,
 ) -> serde_json::Value {
-    let normalized_limit =
-        effective_payload_summary_limit(intent, TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS).clamp(
-            MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-            MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-        );
+    let payload_semantics = detect_tool_result_payload_semantics(&outcome.payload);
+    let normalized_limit = TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS.clamp(
+        MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+        MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+    );
     let payload_text = serde_json::to_string(&outcome.payload)
         .unwrap_or_else(|_| "[tool_payload_unserializable]".to_owned());
     let (payload_summary, payload_chars, payload_truncated) =
-        truncate_by_chars(payload_text.as_str(), normalized_limit);
+        summarize_tool_result_payload(payload_text.as_str(), payload_semantics, normalized_limit);
 
     if !payload_truncated {
         return outcome.payload.clone();
@@ -2747,10 +2754,11 @@ impl TurnEngine {
                 });
             }
             Err(reason) if reason.starts_with("app_tool_denied:") => {
-                let turn_result = TurnResult::policy_denied("app_tool_denied", reason.clone());
+                let human_reason = render_app_tool_denied_reason(reason.as_str());
+                let turn_result = TurnResult::policy_denied("app_tool_denied", human_reason.clone());
                 let decision = ToolDecisionTelemetry::deny(
                     effective_tool_name.as_str(),
-                    reason,
+                    human_reason,
                     "app_tool_denied",
                 );
                 return Err(PreparedToolIntentFailure {
@@ -2849,7 +2857,8 @@ impl TurnEngine {
                     Err(TurnResult::policy_denied("app_tool_disabled", reason))
                 }
                 Err(reason) if reason.starts_with("app_tool_denied:") => {
-                    Err(TurnResult::policy_denied("app_tool_denied", reason))
+                    let human_reason = render_app_tool_denied_reason(reason.as_str());
+                    Err(TurnResult::policy_denied("app_tool_denied", human_reason))
                 }
                 Err(reason) => Err(TurnResult::non_retryable_tool_error(
                     "app_tool_execution_failed",
@@ -4050,6 +4059,80 @@ mod tests {
             stored.request_payload_json["args_json"]["selector"],
             "#submit"
         );
+    }
+
+    #[tokio::test]
+    async fn governed_tool_predenied_reason_omits_internal_prefix() {
+        let memory_config = isolated_memory_config("browser-companion-click-predenied");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        tool_config.browser_companion.enabled = true;
+        tool_config.browser_companion.command = Some("browser-companion".to_owned());
+        tool_config
+            .approval
+            .denied_calls
+            .push("tool:browser.companion.click".to_owned());
+
+        let mut runtime_config = crate::tools::runtime_config::ToolRuntimeConfig::default();
+        runtime_config.browser_companion.enabled = true;
+        runtime_config.browser_companion.ready = true;
+        runtime_config.browser_companion.command = Some("browser-companion".to_owned());
+
+        let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &browser_companion_click_turn(
+                    "root-session",
+                    "turn-browser-companion-predenied",
+                    "call-browser-companion-predenied",
+                    "browser-companion-123",
+                ),
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::direct(),
+                None,
+            )
+            .await;
+
+        let failure = match result {
+            TurnResult::ToolDenied(failure) => failure,
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::NeedsApproval(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_)
+            | other @ TurnResult::StreamingText(_)
+            | other @ TurnResult::StreamingDone(_) => {
+                panic!("expected ToolDenied, got {other:?}")
+            }
+        };
+
+        assert_eq!(failure.code, "app_tool_denied");
+        assert!(
+            !failure.reason.starts_with("app_tool_denied:"),
+            "human-facing denial reason should not expose the transport prefix: {failure:?}"
+        );
+        assert!(
+            failure.reason.contains("tool:browser.companion.click"),
+            "denial should still identify the governed tool: {failure:?}"
+        );
+
+        let requests = repo
+            .list_approval_requests_for_session("root-session", None)
+            .expect("list approval requests");
+        assert!(requests.is_empty());
     }
 
     #[tokio::test]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -73,6 +73,121 @@ pub struct ToolOutcome {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum ToolDecisionKind {
+    Allow,
+    ApprovalRequired,
+    Deny,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolDecisionTelemetry {
+    pub tool_name: String,
+    pub decision_kind: ToolDecisionKind,
+    pub allow: bool,
+    pub deny: bool,
+    pub reason: String,
+    pub rule_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autonomy_profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capability_action_class: Option<String>,
+}
+
+impl ToolDecisionTelemetry {
+    fn allow(
+        tool_name: impl Into<String>,
+        reason: impl Into<String>,
+        rule_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool_name: tool_name.into(),
+            decision_kind: ToolDecisionKind::Allow,
+            allow: true,
+            deny: false,
+            reason: reason.into(),
+            rule_id: rule_id.into(),
+            reason_code: None,
+            policy_source: None,
+            autonomy_profile: None,
+            capability_action_class: None,
+        }
+    }
+
+    fn approval_required(
+        tool_name: impl Into<String>,
+        reason: impl Into<String>,
+        rule_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool_name: tool_name.into(),
+            decision_kind: ToolDecisionKind::ApprovalRequired,
+            allow: false,
+            deny: false,
+            reason: reason.into(),
+            rule_id: rule_id.into(),
+            reason_code: None,
+            policy_source: None,
+            autonomy_profile: None,
+            capability_action_class: None,
+        }
+    }
+
+    fn deny(
+        tool_name: impl Into<String>,
+        reason: impl Into<String>,
+        rule_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            tool_name: tool_name.into(),
+            decision_kind: ToolDecisionKind::Deny,
+            allow: false,
+            deny: true,
+            reason: reason.into(),
+            rule_id: rule_id.into(),
+            reason_code: None,
+            policy_source: None,
+            autonomy_profile: None,
+            capability_action_class: None,
+        }
+    }
+
+    fn with_reason_code(mut self, reason_code: impl Into<String>) -> Self {
+        self.reason_code = Some(reason_code.into());
+        self
+    }
+
+    fn with_policy_source(mut self, policy_source: impl Into<String>) -> Self {
+        self.policy_source = Some(policy_source.into());
+        self
+    }
+
+    fn with_autonomy_profile(mut self, autonomy_profile: impl Into<String>) -> Self {
+        self.autonomy_profile = Some(autonomy_profile.into());
+        self
+    }
+
+    fn with_capability_action_class(mut self, capability_action_class: impl Into<String>) -> Self {
+        self.capability_action_class = Some(capability_action_class.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ToolOutcomeTelemetry {
+    pub tool_name: String,
+    pub status: String,
+    pub payload: serde_json::Value,
+    pub error_code: Option<String>,
+    pub human_reason: Option<String>,
+    pub audit_event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ApprovalRequirementKind {
     KernelContextRequired,
     GovernedTool,
@@ -109,9 +224,15 @@ impl ApprovalRequirement {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolPreflightOutcome {
-    Allow,
-    NeedsApproval(ApprovalRequirement),
-    Denied(TurnFailure),
+    Allow(ToolDecisionTelemetry),
+    NeedsApproval {
+        requirement: ApprovalRequirement,
+        decision: ToolDecisionTelemetry,
+    },
+    Denied {
+        failure: TurnFailure,
+        decision: ToolDecisionTelemetry,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -136,6 +257,9 @@ pub enum ToolResultPayloadSemantics {
 const TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 2048;
 const MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 256;
 const MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 64_000;
+const TOOL_PREFLIGHT_ALLOW_RULE_ID: &str = "tool_preflight_allowed";
+const AUTONOMY_POLICY_ALLOW_RULE_ID: &str = "autonomy_policy_allow";
+const AUTONOMY_POLICY_ALLOW_REASON_CODE: &str = "autonomy_policy_allow";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -278,6 +402,26 @@ pub(crate) fn classify_kernel_error(error: &KernelError) -> KernelFailureClass {
     }
 }
 
+fn generic_allow_tool_decision(tool_name: &str) -> ToolDecisionTelemetry {
+    let reason = format!("tool preflight allowed `{tool_name}`");
+    ToolDecisionTelemetry::allow(tool_name, reason, TOOL_PREFLIGHT_ALLOW_RULE_ID)
+}
+
+fn approval_required_tool_decision(
+    tool_name: &str,
+    requirement: &ApprovalRequirement,
+) -> ToolDecisionTelemetry {
+    let reason = requirement.reason.clone();
+    let rule_id = requirement.rule_id.clone();
+    ToolDecisionTelemetry::approval_required(tool_name, reason, rule_id)
+}
+
+fn denied_tool_decision(tool_name: &str, failure: &TurnFailure) -> ToolDecisionTelemetry {
+    let reason = failure.reason.clone();
+    let rule_id = failure.code.clone();
+    ToolDecisionTelemetry::deny(tool_name, reason, rule_id)
+}
+
 #[async_trait]
 pub trait AppToolDispatcher: Send + Sync {
     async fn preflight_tool_intent_with_binding(
@@ -292,8 +436,17 @@ pub trait AppToolDispatcher: Send + Sync {
             .maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
             .await
         {
-            Ok(Some(requirement)) => Ok(ToolPreflightOutcome::NeedsApproval(requirement)),
-            Ok(None) => Ok(ToolPreflightOutcome::Allow),
+            Ok(Some(requirement)) => {
+                let decision = approval_required_tool_decision(descriptor.name, &requirement);
+                Ok(ToolPreflightOutcome::NeedsApproval {
+                    requirement,
+                    decision,
+                })
+            }
+            Ok(None) => {
+                let decision = generic_allow_tool_decision(descriptor.name);
+                Ok(ToolPreflightOutcome::Allow(decision))
+            }
             Err(reason) => Err(reason),
         }
     }
@@ -371,6 +524,79 @@ impl DefaultAppToolDispatcher {
             crate::memory::runtime_config::get_memory_runtime_config().clone(),
             ToolConfig::default(),
         )
+    }
+
+    fn autonomy_policy_decision_base(
+        tool_name: &str,
+        policy_snapshot: &crate::tools::runtime_config::AutonomyPolicySnapshot,
+        action_class: crate::tools::CapabilityActionClass,
+    ) -> ToolDecisionTelemetry {
+        let profile = policy_snapshot.profile.as_str();
+        let action_class_name = action_class.as_str();
+        let base = ToolDecisionTelemetry::allow(tool_name, "", AUTONOMY_POLICY_ALLOW_RULE_ID);
+        let with_source = base.with_policy_source(AUTONOMY_POLICY_SOURCE);
+        let with_profile = with_source.with_autonomy_profile(profile);
+        let with_action_class = with_profile.with_capability_action_class(action_class_name);
+        with_action_class.with_reason_code(AUTONOMY_POLICY_ALLOW_REASON_CODE)
+    }
+
+    fn autonomy_policy_allow_decision(
+        tool_name: &str,
+        policy_snapshot: &crate::tools::runtime_config::AutonomyPolicySnapshot,
+        action_class: crate::tools::CapabilityActionClass,
+    ) -> ToolDecisionTelemetry {
+        let profile = policy_snapshot.profile.as_str();
+        let reason =
+            format!("autonomy policy allowed `{tool_name}` under `{profile}` product mode");
+        let base = Self::autonomy_policy_decision_base(tool_name, policy_snapshot, action_class);
+        ToolDecisionTelemetry { reason, ..base }
+    }
+
+    fn autonomy_policy_grant_satisfied_decision(
+        tool_name: &str,
+        policy_snapshot: &crate::tools::runtime_config::AutonomyPolicySnapshot,
+        action_class: crate::tools::CapabilityActionClass,
+        rule_id: &str,
+        reason_code: &str,
+        reason: String,
+    ) -> ToolDecisionTelemetry {
+        let base = Self::autonomy_policy_decision_base(tool_name, policy_snapshot, action_class);
+        let decision = ToolDecisionTelemetry {
+            reason,
+            rule_id: rule_id.to_owned(),
+            ..base
+        };
+        decision.with_reason_code(reason_code)
+    }
+
+    fn autonomy_policy_approval_required_decision(
+        tool_name: &str,
+        policy_snapshot: &crate::tools::runtime_config::AutonomyPolicySnapshot,
+        action_class: crate::tools::CapabilityActionClass,
+        rule_id: &str,
+        reason_code: &str,
+        reason: String,
+    ) -> ToolDecisionTelemetry {
+        let base = ToolDecisionTelemetry::approval_required(tool_name, reason, rule_id);
+        let with_source = base.with_policy_source(AUTONOMY_POLICY_SOURCE);
+        let with_profile = with_source.with_autonomy_profile(policy_snapshot.profile.as_str());
+        let with_action_class = with_profile.with_capability_action_class(action_class.as_str());
+        with_action_class.with_reason_code(reason_code)
+    }
+
+    fn autonomy_policy_denied_decision(
+        tool_name: &str,
+        policy_snapshot: &crate::tools::runtime_config::AutonomyPolicySnapshot,
+        action_class: crate::tools::CapabilityActionClass,
+        rule_id: &str,
+        reason_code: &str,
+        reason: String,
+    ) -> ToolDecisionTelemetry {
+        let base = ToolDecisionTelemetry::deny(tool_name, reason, rule_id);
+        let with_source = base.with_policy_source(AUTONOMY_POLICY_SOURCE);
+        let with_profile = with_source.with_autonomy_profile(policy_snapshot.profile.as_str());
+        let with_action_class = with_profile.with_capability_action_class(action_class.as_str());
+        with_action_class.with_reason_code(reason_code)
     }
 
     fn effective_tool_config_for_session(&self, session_context: &SessionContext) -> ToolConfig {
@@ -717,9 +943,21 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
             binding,
             budget: budget_state,
         };
+        let autonomy_policy_applies =
+            super::autonomy_policy::action_mode(&policy_snapshot, action_class).is_some();
         let policy_decision = evaluate_policy(policy_input);
+        let mut autonomy_allow_decision = None;
         match policy_decision {
-            PolicyDecision::Allow => {}
+            PolicyDecision::Allow => {
+                if autonomy_policy_applies {
+                    let decision = Self::autonomy_policy_allow_decision(
+                        descriptor.name,
+                        &policy_snapshot,
+                        action_class,
+                    );
+                    autonomy_allow_decision = Some(decision);
+                }
+            }
             PolicyDecision::ApprovalRequired {
                 rule_id,
                 reason_code,
@@ -733,9 +971,17 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                     let _ = (session_context, intent, approval_key);
                     let failure = TurnFailure::policy_denied(
                         "autonomy_policy_approval_support_missing",
+                        reason.clone(),
+                    );
+                    let decision = Self::autonomy_policy_denied_decision(
+                        descriptor.name,
+                        &policy_snapshot,
+                        action_class,
+                        rule_id,
+                        reason_code,
                         reason,
                     );
-                    return Ok(ToolPreflightOutcome::Denied(failure));
+                    return Ok(ToolPreflightOutcome::Denied { failure, decision });
                 }
 
                 #[cfg(feature = "memory-sqlite")]
@@ -743,9 +989,11 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                     let is_preapproved = self.is_tool_call_preapproved(&approval_key);
                     let is_predenied = self.is_tool_call_predenied(&approval_key);
                     if is_predenied {
-                        return Err(format!(
-                            "app_tool_denied: governed tool `{approval_key}` is denied by approval policy"
-                        ));
+                        let reason =
+                            format!("governed tool `{approval_key}` is denied by approval policy");
+                        let failure = TurnFailure::policy_denied("app_tool_denied", reason);
+                        let decision = denied_tool_decision(descriptor.name, &failure);
+                        return Ok(ToolPreflightOutcome::Denied { failure, decision });
                     }
 
                     let has_approval_grant =
@@ -754,6 +1002,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                     if !autonomy_approval_is_satisfied {
                         let governance_snapshot_json = json!({
                             "policy_source": AUTONOMY_POLICY_SOURCE,
+                            "decision_kind": ToolDecisionKind::ApprovalRequired,
                             "autonomy_profile": policy_snapshot.profile.as_str(),
                             "capability_action_class": action_class.as_str(),
                             "rule_id": rule_id,
@@ -769,18 +1018,60 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                             rule_id,
                             governance_snapshot_json,
                         )?;
-                        return Ok(ToolPreflightOutcome::NeedsApproval(requirement));
+                        let decision = Self::autonomy_policy_approval_required_decision(
+                            descriptor.name,
+                            &policy_snapshot,
+                            action_class,
+                            rule_id,
+                            reason_code,
+                            reason,
+                        );
+                        return Ok(ToolPreflightOutcome::NeedsApproval {
+                            requirement,
+                            decision,
+                        });
                     }
+
+                    let satisfied_reason = if is_preapproved {
+                        format!(
+                            "configured approval policy already allows `{}` under `{}` product mode",
+                            descriptor.name,
+                            policy_snapshot.profile.as_str()
+                        )
+                    } else {
+                        format!(
+                            "stored approval grant satisfied `{}` under `{}` product mode",
+                            descriptor.name,
+                            policy_snapshot.profile.as_str()
+                        )
+                    };
+                    let decision = Self::autonomy_policy_grant_satisfied_decision(
+                        descriptor.name,
+                        &policy_snapshot,
+                        action_class,
+                        rule_id,
+                        reason_code,
+                        satisfied_reason,
+                    );
+                    autonomy_allow_decision = Some(decision);
                 }
             }
             PolicyDecision::Deny {
-                rule_id: _rule_id,
+                rule_id,
                 reason_code,
             } => {
                 let reason =
                     render_reason(&policy_snapshot, action_class, descriptor.name, reason_code);
-                let failure = TurnFailure::policy_denied(reason_code, reason);
-                return Ok(ToolPreflightOutcome::Denied(failure));
+                let failure = TurnFailure::policy_denied(reason_code, reason.clone());
+                let decision = Self::autonomy_policy_denied_decision(
+                    descriptor.name,
+                    &policy_snapshot,
+                    action_class,
+                    rule_id,
+                    reason_code,
+                    reason,
+                );
+                return Ok(ToolPreflightOutcome::Denied { failure, decision });
             }
         }
 
@@ -788,8 +1079,18 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
             .maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
             .await
         {
-            Ok(Some(requirement)) => Ok(ToolPreflightOutcome::NeedsApproval(requirement)),
-            Ok(None) => Ok(ToolPreflightOutcome::Allow),
+            Ok(Some(requirement)) => {
+                let decision = approval_required_tool_decision(descriptor.name, &requirement);
+                Ok(ToolPreflightOutcome::NeedsApproval {
+                    requirement,
+                    decision,
+                })
+            }
+            Ok(None) => {
+                let decision = autonomy_allow_decision
+                    .unwrap_or_else(|| generic_allow_tool_decision(descriptor.name));
+                Ok(ToolPreflightOutcome::Allow(decision))
+            }
             Err(reason) => Err(reason),
         }
     }
@@ -1281,6 +1582,58 @@ pub(crate) fn effective_result_tool_name(intent: &ToolIntent) -> String {
         .to_owned()
 }
 
+fn build_tool_decision_trace_record(
+    intent: &ToolIntent,
+    decision: ToolDecisionTelemetry,
+) -> ToolDecisionTraceRecord {
+    ToolDecisionTraceRecord {
+        turn_id: intent.turn_id.clone(),
+        tool_call_id: intent.tool_call_id.clone(),
+        decision,
+    }
+}
+
+fn build_success_tool_outcome_trace_record(
+    intent: &ToolIntent,
+    outcome: &ToolCoreOutcome,
+) -> ToolOutcomeTraceRecord {
+    let tool_name = effective_result_tool_name(intent);
+    let outcome = ToolOutcomeTelemetry {
+        tool_name,
+        status: outcome.status.clone(),
+        payload: outcome.payload.clone(),
+        error_code: None,
+        human_reason: None,
+        audit_event_id: None,
+    };
+    ToolOutcomeTraceRecord {
+        turn_id: intent.turn_id.clone(),
+        tool_call_id: intent.tool_call_id.clone(),
+        outcome,
+    }
+}
+
+fn build_failure_tool_outcome_trace_record(
+    intent: &ToolIntent,
+    turn_result: &TurnResult,
+) -> Option<ToolOutcomeTraceRecord> {
+    let failure = turn_result.failure()?;
+    let tool_name = effective_result_tool_name(intent);
+    let outcome = ToolOutcomeTelemetry {
+        tool_name,
+        status: "error".to_owned(),
+        payload: serde_json::Value::Null,
+        error_code: Some(failure.code.clone()),
+        human_reason: Some(failure.reason.clone()),
+        audit_event_id: None,
+    };
+    Some(ToolOutcomeTraceRecord {
+        turn_id: intent.turn_id.clone(),
+        tool_call_id: intent.tool_call_id.clone(),
+        outcome,
+    })
+}
+
 fn build_tool_intent_completed_trace(
     intent: &ToolIntent,
     outcome: &ToolCoreOutcome,
@@ -1511,6 +1864,20 @@ pub(crate) struct ToolBatchExecutionIntentTrace {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolDecisionTraceRecord {
+    pub turn_id: String,
+    pub tool_call_id: String,
+    pub decision: ToolDecisionTelemetry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolOutcomeTraceRecord {
+    pub turn_id: String,
+    pub tool_call_id: String,
+    pub outcome: ToolOutcomeTelemetry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ToolBatchExecutionTrace {
     pub total_intents: usize,
     pub parallel_execution_enabled: bool,
@@ -1518,6 +1885,8 @@ pub(crate) struct ToolBatchExecutionTrace {
     pub observed_peak_in_flight: usize,
     pub observed_wall_time_ms: u64,
     pub segments: Vec<ToolBatchExecutionSegmentTrace>,
+    pub decision_records: Vec<ToolDecisionTraceRecord>,
+    pub outcome_records: Vec<ToolOutcomeTraceRecord>,
     pub intent_outcomes: Vec<ToolBatchExecutionIntentTrace>,
 }
 
@@ -1529,6 +1898,10 @@ impl ToolBatchExecutionSegmentTrace {
 }
 
 impl ToolBatchExecutionTrace {
+    pub(crate) fn has_execution_segments(&self) -> bool {
+        !self.segments.is_empty()
+    }
+
     fn finish_observation(&mut self, observed_wall_time_ms: u64) {
         self.observed_wall_time_ms = observed_wall_time_ms;
         self.observed_peak_in_flight = self
@@ -1614,6 +1987,14 @@ struct PreparedToolIntent {
     capability_action_class: crate::tools::CapabilityActionClass,
     scheduling_class: ToolSchedulingClass,
     trusted_internal_context: bool,
+    decision: ToolDecisionTelemetry,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedToolIntentFailure {
+    intent: ToolIntent,
+    turn_result: TurnResult,
+    decision: ToolDecisionTelemetry,
 }
 
 impl TurnEngine {
@@ -1852,6 +2233,7 @@ impl TurnEngine {
             Ok(TurnValidation::ToolExecutionRequired) => {}
         }
 
+        let mut trace = self.trace_empty_batch(turn.tool_intents.len());
         let mut prepared = Vec::new();
         let mut autonomy_budget_state = AutonomyTurnBudgetState::default();
         for intent in &turn.tool_intents {
@@ -1863,18 +2245,34 @@ impl TurnEngine {
                     binding,
                     &autonomy_budget_state,
                     ingress,
+                    &mut trace,
                 )
                 .await
             {
                 Ok(prepared_intent) => {
+                    let decision_record = build_tool_decision_trace_record(
+                        &prepared_intent.intent,
+                        prepared_intent.decision.clone(),
+                    );
+                    trace.decision_records.push(decision_record);
                     autonomy_budget_state.record_action(prepared_intent.capability_action_class);
                     prepared.push(prepared_intent);
                 }
-                Err(result) => return (result, None),
+                Err(failure) => {
+                    let decision_record =
+                        build_tool_decision_trace_record(&failure.intent, failure.decision);
+                    trace.decision_records.push(decision_record);
+                    let intent_outcome =
+                        build_tool_intent_failure_trace(&failure.intent, &failure.turn_result);
+                    if let Some(intent_outcome) = intent_outcome {
+                        trace.intent_outcomes.push(intent_outcome);
+                    }
+                    return (failure.turn_result, Some(trace));
+                }
             }
         }
         let batch_segments = self.prepared_batch_segments(&prepared);
-        let mut trace = self.trace_prepared_batch(&prepared, &batch_segments);
+        self.populate_trace_segments(&mut trace, &batch_segments);
 
         let outputs = match self
             .execute_prepared_batch(
@@ -1922,6 +2320,7 @@ impl TurnEngine {
                             app_dispatcher,
                             binding,
                             &mut trace.intent_outcomes,
+                            &mut trace.outcome_records,
                             trace_segment,
                         )
                         .await?
@@ -1933,6 +2332,7 @@ impl TurnEngine {
                             app_dispatcher,
                             binding,
                             &mut trace.intent_outcomes,
+                            &mut trace.outcome_records,
                             trace_segment,
                         )
                         .await?
@@ -1949,31 +2349,39 @@ impl TurnEngine {
         result
     }
 
-    fn trace_prepared_batch(
-        &self,
-        prepared: &[PreparedToolIntent],
-        batch_segments: &[PreparedBatchSegment],
-    ) -> ToolBatchExecutionTrace {
+    fn trace_empty_batch(&self, total_intents: usize) -> ToolBatchExecutionTrace {
         ToolBatchExecutionTrace {
-            total_intents: prepared.len(),
+            total_intents,
             parallel_execution_enabled: self.parallel_tool_execution_enabled,
             parallel_execution_max_in_flight: self.parallel_tool_execution_max_in_flight,
             observed_peak_in_flight: 0,
             observed_wall_time_ms: 0,
-            segments: batch_segments
-                .iter()
-                .enumerate()
-                .map(|(segment_index, segment)| ToolBatchExecutionSegmentTrace {
-                    segment_index,
-                    scheduling_class: segment.scheduling_class,
-                    execution_mode: segment.execution_mode,
-                    intent_count: segment.len,
-                    observed_peak_in_flight: None,
-                    observed_wall_time_ms: None,
-                })
-                .collect(),
+            segments: Vec::new(),
+            decision_records: Vec::new(),
+            outcome_records: Vec::new(),
             intent_outcomes: Vec::new(),
         }
+    }
+
+    fn populate_trace_segments(
+        &self,
+        trace: &mut ToolBatchExecutionTrace,
+        batch_segments: &[PreparedBatchSegment],
+    ) {
+        trace.parallel_execution_enabled = self.parallel_tool_execution_enabled;
+        trace.parallel_execution_max_in_flight = self.parallel_tool_execution_max_in_flight;
+        trace.segments = batch_segments
+            .iter()
+            .enumerate()
+            .map(|(segment_index, segment)| ToolBatchExecutionSegmentTrace {
+                segment_index,
+                scheduling_class: segment.scheduling_class,
+                execution_mode: segment.execution_mode,
+                intent_count: segment.len,
+                observed_peak_in_flight: None,
+                observed_wall_time_ms: None,
+            })
+            .collect();
     }
 
     fn prepared_batch_segments(
@@ -2022,6 +2430,7 @@ impl TurnEngine {
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
         intent_outcomes: &mut Vec<ToolBatchExecutionIntentTrace>,
+        outcome_records: &mut Vec<ToolOutcomeTraceRecord>,
         trace_segment: &mut ToolBatchExecutionSegmentTrace,
     ) -> Result<Vec<String>, TurnResult> {
         let started_at = Instant::now();
@@ -2039,6 +2448,13 @@ impl TurnEngine {
                 {
                     Ok(outcome) => outcome,
                     Err(turn_result) => {
+                        let outcome_record = build_failure_tool_outcome_trace_record(
+                            &prepared_intent.intent,
+                            &turn_result,
+                        );
+                        if let Some(outcome_record) = outcome_record {
+                            outcome_records.push(outcome_record);
+                        }
                         let intent_outcome =
                             build_tool_intent_failure_trace(&prepared_intent.intent, &turn_result);
                         if let Some(intent_outcome) = intent_outcome {
@@ -2047,6 +2463,9 @@ impl TurnEngine {
                         return Err(turn_result);
                     }
                 };
+                let outcome_record =
+                    build_success_tool_outcome_trace_record(&prepared_intent.intent, &outcome);
+                outcome_records.push(outcome_record);
                 let intent_outcome =
                     build_tool_intent_completed_trace(&prepared_intent.intent, &outcome);
                 intent_outcomes.push(intent_outcome);
@@ -2073,6 +2492,7 @@ impl TurnEngine {
         app_dispatcher: &D,
         binding: ConversationRuntimeBinding<'_>,
         intent_outcomes: &mut Vec<ToolBatchExecutionIntentTrace>,
+        outcome_records: &mut Vec<ToolOutcomeTraceRecord>,
         trace_segment: &mut ToolBatchExecutionSegmentTrace,
     ) -> Result<Vec<String>, TurnResult> {
         let started_at = Instant::now();
@@ -2101,18 +2521,26 @@ impl TurnEngine {
                                 &outcome,
                                 payload_summary_limit_chars,
                             );
+                            let outcome_record = build_success_tool_outcome_trace_record(
+                                &prepared_intent.intent,
+                                &outcome,
+                            );
                             let intent_outcome = build_tool_intent_completed_trace(
                                 &prepared_intent.intent,
                                 &outcome,
                             );
-                            (output, intent_outcome)
+                            (output, intent_outcome, outcome_record)
                         })
                         .map_err(|turn_result| {
                             let intent_outcome = build_tool_intent_failure_trace(
                                 &prepared_intent.intent,
                                 &turn_result,
                             );
-                            (turn_result, intent_outcome)
+                            let outcome_record = build_failure_tool_outcome_trace_record(
+                                &prepared_intent.intent,
+                                &turn_result,
+                            );
+                            (turn_result, intent_outcome, outcome_record)
                         });
                     in_flight.fetch_sub(1, Ordering::Relaxed);
                     (index, result)
@@ -2124,13 +2552,17 @@ impl TurnEngine {
         let result = async {
             while let Some((index, result)) = executions.next().await {
                 match result {
-                    Ok((output, intent_outcome)) => {
+                    Ok((output, intent_outcome, outcome_record)) => {
                         intent_outcomes.push(intent_outcome);
+                        outcome_records.push(outcome_record);
                         results.push((index, output));
                     }
-                    Err((turn_result, intent_outcome)) => {
+                    Err((turn_result, intent_outcome, outcome_record)) => {
                         if let Some(intent_outcome) = intent_outcome {
                             intent_outcomes.push(intent_outcome);
+                        }
+                        if let Some(outcome_record) = outcome_record {
+                            outcome_records.push(outcome_record);
                         }
                         return Err(turn_result);
                     }
@@ -2157,10 +2589,18 @@ impl TurnEngine {
         binding: ConversationRuntimeBinding<'_>,
         budget_state: &AutonomyTurnBudgetState,
         ingress: Option<&ConversationIngressContext>,
-    ) -> Result<PreparedToolIntent, TurnResult> {
+        _trace: &mut ToolBatchExecutionTrace,
+    ) -> Result<PreparedToolIntent, PreparedToolIntentFailure> {
         let Some(resolved_tool) = crate::tools::resolve_tool_execution(&intent.tool_name) else {
             let reason = format!("tool_not_found: {}", intent.tool_name);
-            return Err(TurnResult::policy_denied("tool_not_found", reason));
+            let turn_result = TurnResult::policy_denied("tool_not_found", reason.clone());
+            let decision =
+                ToolDecisionTelemetry::deny(intent.tool_name.as_str(), reason, "tool_not_found");
+            return Err(PreparedToolIntentFailure {
+                intent: intent.clone(),
+                turn_result,
+                decision,
+            });
         };
         let injected = inject_internal_tool_ingress(
             resolved_tool.canonical_name,
@@ -2237,15 +2677,23 @@ impl TurnEngine {
         });
         let Some(descriptor) = descriptor else {
             let reason = format!("tool_descriptor_missing: {}", effective_tool_name);
-            return Err(TurnResult::non_retryable_tool_error(
-                "tool_descriptor_missing",
+            let turn_result =
+                TurnResult::non_retryable_tool_error("tool_descriptor_missing", reason.clone());
+            let decision = ToolDecisionTelemetry::deny(
+                effective_tool_name.as_str(),
                 reason,
-            ));
+                "tool_descriptor_missing",
+            );
+            return Err(PreparedToolIntentFailure {
+                intent: effective_intent,
+                turn_result,
+                decision,
+            });
         };
         let capability_action_class = descriptor.capability_action_class();
         let scheduling_class = descriptor.scheduling_class();
 
-        match app_dispatcher
+        let decision = match app_dispatcher
             .preflight_tool_intent_with_binding(
                 session_context,
                 &effective_intent,
@@ -2255,38 +2703,77 @@ impl TurnEngine {
             )
             .await
         {
-            Ok(ToolPreflightOutcome::Allow) => {}
-            Ok(ToolPreflightOutcome::NeedsApproval(requirement)) => {
-                return Err(TurnResult::NeedsApproval(requirement));
+            Ok(ToolPreflightOutcome::Allow(decision)) => decision,
+            Ok(ToolPreflightOutcome::NeedsApproval {
+                requirement,
+                decision,
+            }) => {
+                let turn_result = TurnResult::NeedsApproval(requirement);
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision,
+                });
             }
-            Ok(ToolPreflightOutcome::Denied(failure)) => {
-                return Err(TurnResult::ToolDenied(failure));
+            Ok(ToolPreflightOutcome::Denied { failure, decision }) => {
+                let turn_result = TurnResult::ToolDenied(failure);
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision,
+                });
             }
             Err(reason) if reason.starts_with("app_tool_denied:") => {
-                return Err(TurnResult::policy_denied("app_tool_denied", reason));
+                let turn_result = TurnResult::policy_denied("app_tool_denied", reason.clone());
+                let decision = ToolDecisionTelemetry::deny(
+                    effective_tool_name.as_str(),
+                    reason,
+                    "app_tool_denied",
+                );
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision,
+                });
             }
             Err(reason) => {
-                return Err(TurnResult::non_retryable_tool_error(
-                    "tool_preflight_failed",
+                let turn_result =
+                    TurnResult::non_retryable_tool_error("tool_preflight_failed", reason.clone());
+                let decision = ToolDecisionTelemetry::deny(
+                    effective_tool_name.as_str(),
                     reason,
-                ));
+                    "tool_preflight_failed",
+                );
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision,
+                });
             }
-        }
+        };
 
         match effective_execution_kind {
             ToolExecutionKind::Core => {
                 if binding.kernel_context().is_none() {
-                    return Err(TurnResult::policy_denied(
+                    let turn_result =
+                        TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
+                    let decision = ToolDecisionTelemetry::deny(
+                        effective_tool_name.as_str(),
                         "no_kernel_context",
                         "no_kernel_context",
-                    ));
+                    );
+                    return Err(PreparedToolIntentFailure {
+                        intent: effective_intent,
+                        turn_result,
+                        decision,
+                    });
                 }
             }
             ToolExecutionKind::App => {}
         }
 
         Ok(PreparedToolIntent {
-            intent: intent.clone(),
+            intent: effective_intent,
             request: effective_request,
             execution_kind: effective_execution_kind,
             capability_action_class,
@@ -2294,6 +2781,7 @@ impl TurnEngine {
             trusted_internal_context: injected.trusted_internal_context
                 || (!injected_payload_uses_reserved_internal_context
                     && augmented_payload_uses_reserved_internal_context),
+            decision,
         })
     }
 

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -730,6 +730,7 @@ fn approval_attention_summary_json(requests: &[ApprovalRequestView]) -> Value {
 #[cfg(feature = "memory-sqlite")]
 fn approval_request_summary_json(view: &ApprovalRequestView) -> Value {
     let record = &view.record;
+    let snapshot = &record.governance_snapshot_json;
     json!({
         "approval_request_id": record.approval_request_id,
         "session_id": record.session_id,
@@ -748,10 +749,14 @@ fn approval_request_summary_json(view: &ApprovalRequestView) -> Value {
             .governance_snapshot_json
             .get("reason")
             .and_then(Value::as_str),
-        "rule_id": record
-            .governance_snapshot_json
-            .get("rule_id")
+        "policy_source": snapshot.get("policy_source").and_then(Value::as_str),
+        "autonomy_profile": snapshot.get("autonomy_profile").and_then(Value::as_str),
+        "capability_action_class": snapshot
+            .get("capability_action_class")
             .and_then(Value::as_str),
+        "decision_kind": snapshot.get("decision_kind").and_then(Value::as_str),
+        "rule_id": snapshot.get("rule_id").and_then(Value::as_str),
+        "reason_code": snapshot.get("reason_code").and_then(Value::as_str),
         "execution_integrity": view.attention.execution_integrity_json(),
         "grant_review": view.attention.grant_review_json(),
         "grant_attention": view.attention.grant_attention_json(),
@@ -1524,6 +1529,74 @@ mod tests {
         assert!(
             error.contains("unknown grant_attention `unknown`"),
             "expected invalid grant attention error, got: {error}"
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_tool_query_list_surfaces_autonomy_fields_in_summary() {
+        let config = isolated_memory_config("approval-summary-autonomy-fields");
+        let repo = SessionRepository::new(&config).expect("repository");
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: "apr-autonomy-summary".to_owned(),
+            session_id: "root-session".to_owned(),
+            turn_id: "turn-autonomy-summary".to_owned(),
+            tool_call_id: "call-autonomy-summary".to_owned(),
+            tool_name: "external_skills.install".to_owned(),
+            approval_key: "tool:external_skills.install".to_owned(),
+            request_payload_json: json!({
+                "session_id": "root-session",
+                "tool_name": "external_skills.install",
+                "args_json": {
+                    "path": "source/demo-skill"
+                },
+            }),
+            governance_snapshot_json: json!({
+                "policy_source": "autonomy_policy",
+                "autonomy_profile": "guided_acquisition",
+                "capability_action_class": "capability_install",
+                "decision_kind": "approval_required",
+                "rule_id": "autonomy_policy_capability_acquisition_requires_approval",
+                "reason_code": "autonomy_policy_capability_acquisition_requires_approval",
+                "reason": "operator approval required before running `external_skills.install` under `guided_acquisition` product mode",
+            }),
+        })
+        .expect("seed approval request");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_requests_list".to_owned(),
+                payload: json!({}),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_requests_list outcome");
+
+        let requests = outcome.payload["requests"]
+            .as_array()
+            .expect("requests array");
+        assert_eq!(requests.len(), 1);
+
+        let request = &requests[0];
+        assert_eq!(request["policy_source"], "autonomy_policy");
+        assert_eq!(request["autonomy_profile"], "guided_acquisition");
+        assert_eq!(request["capability_action_class"], "capability_install");
+        assert_eq!(request["decision_kind"], "approval_required");
+        assert_eq!(
+            request["rule_id"],
+            "autonomy_policy_capability_acquisition_requires_approval"
+        );
+        assert_eq!(
+            request["reason_code"],
+            "autonomy_policy_capability_acquisition_requires_approval"
+        );
+        assert_eq!(
+            request["reason"],
+            "operator approval required before running `external_skills.install` under `guided_acquisition` product mode"
         );
     }
 


### PR DESCRIPTION
## Summary

- Problem: product-mode turns only persisted execution-batch telemetry, so preflight allow, approval-required, and deny decisions could disappear on early-return paths.
- Why it matters: operators could not reliably audit why a governed tool was allowed, blocked, or sent to approval, and approval request summaries lacked the structured autonomy context needed for review.
- What changed: persisted structured tool_decision and tool_outcome records from the fast-lane trace, carried decision telemetry through blocked and executed intents, and surfaced autonomy policy fields in approval request summaries.
- What did not change (scope boundary): no new storage table, no parallel telemetry pipeline, no web UI work, and no change to the existing fast_lane_tool_batch execution event beyond skipping empty non-execution batches.

## Linked Issues

- Closes #694
- Related #687 (stacked base PR)

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this changes the product-mode preflight trace path, decision persistence, and approval summary projection. The main failure mode would be duplicate, missing, or mis-correlated decision records.
- Rollout / guardrails: the existing fast_lane_tool_batch event remains in place for execution telemetry, and new regression coverage exercises allow, approval-required, deny, and approval summary projection paths.
- Rollback path: revert this commit to fall back to the previous execution-only telemetry behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked

Focused regression coverage also passed for:
- cargo test -p loongclaw-app autonomy_policy_telemetry_ -- --test-threads=1
- cargo test -p loongclaw-app --lib approval_request_tool_query_list_surfaces_autonomy_fields_in_summary -- --test-threads=1
- cargo test -p loongclaw-app autonomy_policy_turn_engine_ -- --test-threads=1
- cargo test -p loongclaw-app handle_turn_with_runtime_persists_fast_lane_tool_batch_event_for_mixed_segments -- --test-threads=1
- cargo test -p loongclaw-app observed_fast_lane_execution_trace_records_partial_tool_failure_outcomes -- --test-threads=1

All commands completed successfully with no test failures.
```

## User-visible / Operator-visible Changes

- Product-mode turns now persist structured tool_decision records for allow, approval-required, and deny outcomes even when execution never starts.
- Executed product-mode tools now persist structured tool_outcome records alongside the existing batch event.
- approval_requests_list now surfaces autonomy policy source, profile, action class, decision kind, rule id, reason code, and reason in its summary payload.

## Failure Recovery

- Fast rollback or disable path: revert `feat(app): persist autonomy policy telemetry` to restore the prior behavior.
- Observable failure symptoms reviewers should watch for: missing tool_decision records on blocked turns, missing tool_outcome records on allowed executions, or approval request summaries that omit autonomy policy fields.

## Reviewer Focus

- Review the preflight decision trace flow in `crates/app/src/conversation/turn_engine.rs`, especially the blocked-turn path that now returns a trace instead of dropping it.
- Review the trace persistence wiring in `crates/app/src/conversation/turn_coordinator.rs` and confirm empty non-execution traces do not emit misleading batch events.
- Review the approval summary projection in `crates/app/src/tools/approval.rs` and the new regression coverage in `crates/app/src/conversation/tests.rs`.
- This PR is stacked on `feat/autonomy-turn-policy-gate-v2` / #687, so the intended review surface is the delta from that base.
