### PR TITLE
fix(feishu): upgrade card schema to v2 and remove spurious card wrapper

### DIFF
--- a/crates/app/src/channel/feishu/api/resources/cards.rs
+++ b/crates/app/src/channel/feishu/api/resources/cards.rs
@@ -11,13 +11,16 @@ use super::types::FeishuCardUpdateReceipt;
 pub fn build_markdown_card(text: &str) -> Value {
     let content = text.trim();
     serde_json::json!({
+        "schema": "2.0",
         "config": {
             "wide_screen_mode": true
         },
-        "elements": [{
-            "tag": "markdown",
-            "content": content
-        }]
+        "body": {
+            "elements": [{
+                "tag": "markdown",
+                "content": content
+            }]
+        }
     })
 }
 
@@ -108,13 +111,16 @@ mod tests {
         assert_eq!(
             build_markdown_card("  approved  "),
             json!({
+                "schema": "2.0",
                 "config": {
                     "wide_screen_mode": true
                 },
-                "elements": [{
-                    "tag": "markdown",
-                    "content": "approved"
-                }]
+                "body": {
+                    "elements": [{
+                        "tag": "markdown",
+                        "content": "approved"
+                    }]
+                }
             })
         );
     }

--- a/crates/app/src/channel/feishu/api/resources/messages.rs
+++ b/crates/app/src/channel/feishu/api/resources/messages.rs
@@ -209,11 +209,9 @@ pub async fn send_markdown_card_message(
         receive_id_type,
         receive_id,
         "interactive",
-        serde_json::json!({
-            "card": cards::build_markdown_card(
-                require_non_empty("feishu message send", "text", text)?.as_str()
-            )
-        }),
+        cards::build_markdown_card(
+            require_non_empty("feishu message send", "text", text)?.as_str(),
+        ),
         uuid,
     )
     .await
@@ -322,11 +320,9 @@ pub async fn reply_markdown_card_message(
         tenant_access_token,
         message_id,
         "interactive",
-        serde_json::json!({
-            "card": cards::build_markdown_card(
-                require_non_empty("feishu message reply", "text", text)?.as_str()
-            )
-        }),
+        cards::build_markdown_card(
+            require_non_empty("feishu message reply", "text", text)?.as_str(),
+        ),
         reply_in_thread,
         uuid,
     )

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -2186,15 +2186,18 @@ mod tests {
             response.body(),
             &json!({
                 "card": {
+                    "schema": "2.0",
                     "config": {
                         "wide_screen_mode": true
                     },
-                    "elements": [
-                        {
-                            "tag": "markdown",
-                            "content": "Approved inline"
-                        }
-                    ]
+                    "body": {
+                        "elements": [
+                            {
+                                "tag": "markdown",
+                                "content": "Approved inline"
+                            }
+                        ]
+                    }
                 }
             })
         );
@@ -2386,15 +2389,18 @@ mod tests {
                     "content": "Approved"
                 },
                 "card": {
+                    "schema": "2.0",
                     "config": {
                         "wide_screen_mode": true
                     },
-                    "elements": [
-                        {
-                            "tag": "markdown",
-                            "content": "Approved inline"
-                        }
-                    ]
+                    "body": {
+                        "elements": [
+                            {
+                                "tag": "markdown",
+                                "content": "Approved inline"
+                            }
+                        ]
+                    }
                 }
             })
         );


### PR DESCRIPTION
## Summary

- Problem: Feishu interactive card messages (`msg_type = "interactive"`) fail with ErrCode 230099 / inner 200621 on all send and reply paths.
- Why it matters: Every agent response routed through the Feishu channel that produces a markdown card is silently dropped — the bot appears unresponsive to users.
- What changed: Upgraded `build_markdown_card` to Card v2 schema (`"schema": "2.0"`, elements nested under `body`); removed the spurious `{"card": ...}` wrapper in `send_markdown_card_message` and `reply_markdown_card_message` so the card JSON is passed directly as the `content` string.
- What did not change (scope boundary): No changes to text messages, post messages, image messages, or any other message type. No changes to tools, kernel, or CLI.

## Linked Issues

- Related # (card schema regression introduced in channel restructure refactor)

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-app --all-features cards -- --nocapture
# result: 8 passed; 0 failed
```

## User-visible / Operator-visible Changes

- Feishu interactive card messages (send and reply) now succeed instead of returning ErrCode 230099 / 200621.

## Failure Recovery

- Fast rollback or disable path: revert this commit; no runtime state or config is affected.
- Observable failure symptoms reviewers should watch for: if the card schema regresses, Feishu API returns `{"code": 230099, "error": {"field_violations": [{"field": "content", "code": 200621}]}}` on any interactive card send or reply.

## Changed Files

**Modified:**
- `crates/app/src/channel/feishu/api/resources/cards.rs` — upgrade `build_markdown_card` to Card v2 schema; update unit test assertion
- `crates/app/src/channel/feishu/api/resources/messages.rs` — remove `{"card": ...}` wrapper in `send_markdown_card_message` and `reply_markdown_card_message`

## Reviewer Focus

- `cards.rs:11-24` — verify v2 schema shape (`schema`, `config`, `body.elements`) matches Feishu Card v2 spec.
- `messages.rs` (`send_markdown_card_message` / `reply_markdown_card_message`) — confirm card value is now passed directly to `send_message` / `reply_message` without any outer wrapper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Feishu markdown cards now use schema 2.0 and a nested body structure for markdown elements, ensuring correct payload format.
* **Tests**
  * Updated callbacks and unit tests to validate the new card JSON shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->