### PR TITLE
feat: add governed runtime-capability apply executor

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -619,7 +619,7 @@ pub enum Commands {
         #[command(subcommand)]
         command: runtime_experiment_cli::RuntimeExperimentCommands,
     },
-    /// Manage run-derived capability candidates, family readiness, and dry-run promotion plans
+    /// Manage run-derived capability candidates, family readiness, promotion plans, and governed apply outputs
     RuntimeCapability {
         #[command(subcommand)]
         command: runtime_capability_cli::RuntimeCapabilityCommands,

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
+    io::{ErrorKind, Write},
     path::{Path, PathBuf},
 };
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
@@ -1525,19 +1526,25 @@ fn persist_runtime_capability_apply_artifact(
     output_path: &Path,
     artifact: &RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument,
 ) -> CliResult<RuntimeCapabilityApplyOutcome> {
-    if output_path.exists() {
-        let existing_artifact = load_runtime_capability_apply_artifact(output_path)?;
-        if existing_artifact == *artifact {
-            return Ok(RuntimeCapabilityApplyOutcome::AlreadyApplied);
+    match write_pretty_json_file_create_new(output_path, artifact) {
+        Ok(()) => Ok(RuntimeCapabilityApplyOutcome::Applied),
+        Err(error) if error.contains("already exists") => {
+            let existing_artifact = load_runtime_capability_apply_artifact(output_path)?;
+            if existing_artifact == *artifact {
+                Ok(RuntimeCapabilityApplyOutcome::AlreadyApplied)
+            } else {
+                Err(format!(
+                    "runtime capability apply output {} already exists with different content",
+                    output_path.display()
+                ))
+            }
         }
-
-        return Err(format!(
-            "runtime capability apply output {} already exists with different content",
-            output_path.display()
-        ));
+        Err(error) => Err(error),
     }
+}
 
-    if let Some(parent) = output_path.parent()
+fn write_pretty_json_file_create_new(path: &Path, value: &impl Serialize) -> CliResult<()> {
+    if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
         fs::create_dir_all(parent).map_err(|error| {
@@ -1547,15 +1554,33 @@ fn persist_runtime_capability_apply_artifact(
             )
         })?;
     }
-    let encoded = serde_json::to_string_pretty(artifact)
+
+    let encoded = serde_json::to_vec_pretty(value)
         .map_err(|error| format!("serialize runtime capability apply artifact failed: {error}"))?;
-    fs::write(output_path, encoded).map_err(|error| {
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| {
+            if error.kind() == ErrorKind::AlreadyExists {
+                format!(
+                    "runtime capability apply artifact {} already exists",
+                    path.display()
+                )
+            } else {
+                format!(
+                    "write runtime capability apply artifact {} failed: {error}",
+                    path.display()
+                )
+            }
+        })?;
+    file.write_all(&encoded).map_err(|error| {
         format!(
             "write runtime capability apply artifact {} failed: {error}",
-            output_path.display()
+            path.display()
         )
     })?;
-    Ok(RuntimeCapabilityApplyOutcome::Applied)
+    Ok(())
 }
 
 fn canonicalize_existing_path(path: &Path) -> CliResult<String> {
@@ -2163,5 +2188,44 @@ fn render_family_readiness_checks(checks: &[RuntimeCapabilityFamilyReadinessChec
             .map(render_family_readiness_check)
             .collect::<Vec<_>>()
             .join(" | ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    }
+
+    #[test]
+    fn write_pretty_json_file_create_new_rejects_existing_path() {
+        let root = unique_temp_dir("loongclaw-runtime-capability-atomic-create");
+        fs::create_dir_all(&root).expect("create temp dir");
+        let output_path = root.join("memory_stage_profiles/profile.json");
+        fs::create_dir_all(output_path.parent().expect("parent directory"))
+            .expect("create output parent");
+        fs::write(&output_path, "{\"existing\":true}\n").expect("write existing file");
+
+        let error = write_pretty_json_file_create_new(&output_path, &json!({"new": true}))
+            .expect_err("atomic create should reject an existing path");
+
+        assert!(
+            error.contains("already exists"),
+            "expected already-exists error, got: {error}"
+        );
+
+        fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/daemon/src/runtime_capability_cli.rs
+++ b/crates/daemon/src/runtime_capability_cli.rs
@@ -19,6 +19,10 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 pub const RUNTIME_CAPABILITY_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
 pub const RUNTIME_CAPABILITY_ARTIFACT_SURFACE: &str = "runtime_capability";
 pub const RUNTIME_CAPABILITY_ARTIFACT_PURPOSE: &str = "promotion_candidate_record";
+pub const RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_JSON_SCHEMA_VERSION: u32 = 1;
+pub const RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_SURFACE: &str = "memory_stage_profile";
+pub const RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_PURPOSE: &str =
+    "runtime_capability_apply_output";
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeCapabilityCommands {
@@ -32,6 +36,8 @@ pub enum RuntimeCapabilityCommands {
     Index(RuntimeCapabilityIndexCommandOptions),
     /// Derive one dry-run promotion plan from one indexed capability family
     Plan(RuntimeCapabilityPlanCommandOptions),
+    /// Materialize one governed memory-stage-profile artifact from one promotable capability family
+    Apply(RuntimeCapabilityApplyCommandOptions),
 }
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
@@ -88,6 +94,16 @@ pub struct RuntimeCapabilityIndexCommandOptions {
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCapabilityPlanCommandOptions {
+    #[arg(long)]
+    pub root: String,
+    #[arg(long)]
+    pub family_id: String,
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCapabilityApplyCommandOptions {
     #[arg(long)]
     pub root: String,
     #[arg(long)]
@@ -280,12 +296,12 @@ pub struct RuntimeCapabilityPromotionProvenance {
     pub latest_reviewed_at: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeCapabilityPromotionPlannedPayload {
     pub memory_stage_profile: RuntimeCapabilityMemoryStageProfileDryRunPayload,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeCapabilityMemoryStageProfileDryRunPayload {
     pub schema_version: u32,
     pub artifact_kind: String,
@@ -293,7 +309,7 @@ pub struct RuntimeCapabilityMemoryStageProfileDryRunPayload {
     pub provenance: RuntimeCapabilityMemoryStageProfileDryRunProvenance,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeCapabilityMemoryStageProfileDryRunProfile {
     pub id: String,
     pub summary: String,
@@ -302,14 +318,14 @@ pub struct RuntimeCapabilityMemoryStageProfileDryRunProfile {
     pub tags: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeCapabilityMemoryStageProfileDryRunProvenance {
     pub family_id: String,
     pub accepted_candidate_ids: Vec<String>,
     pub evidence_digest: RuntimeCapabilityMemoryStageProfileDryRunEvidenceDigest,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeCapabilityMemoryStageProfileDryRunEvidenceDigest {
     pub changed_surfaces: Vec<String>,
 }
@@ -329,6 +345,34 @@ pub struct RuntimeCapabilityPromotionPlanReport {
     pub rollback_hints: Vec<String>,
     pub provenance: RuntimeCapabilityPromotionProvenance,
     pub planned_payload: Option<RuntimeCapabilityPromotionPlannedPayload>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument {
+    pub schema: RuntimeCapabilityArtifactSchema,
+    pub artifact_kind: String,
+    pub artifact_id: String,
+    pub delivery_surface: String,
+    pub profile: RuntimeCapabilityMemoryStageProfileDryRunProfile,
+    pub provenance: RuntimeCapabilityMemoryStageProfileDryRunProvenance,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityApplyOutcome {
+    Applied,
+    AlreadyApplied,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityApplyReport {
+    pub generated_at: String,
+    pub root: String,
+    pub family_id: String,
+    pub output_path: String,
+    pub outcome: RuntimeCapabilityApplyOutcome,
+    pub planned_artifact: RuntimeCapabilityPromotionArtifactPlan,
+    pub materialized_artifact: RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument,
 }
 
 pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResult<()> {
@@ -357,6 +401,11 @@ pub fn run_runtime_capability_cli(command: RuntimeCapabilityCommands) -> CliResu
             let as_json = options.json;
             let report = execute_runtime_capability_plan_command(options)?;
             emit_runtime_capability_promotion_plan(&report, as_json)
+        }
+        RuntimeCapabilityCommands::Apply(options) => {
+            let as_json = options.json;
+            let report = execute_runtime_capability_apply_command(options)?;
+            emit_runtime_capability_apply_report(&report, as_json)
         }
     }
 }
@@ -521,6 +570,37 @@ pub fn execute_runtime_capability_plan_command(
     })
 }
 
+pub fn execute_runtime_capability_apply_command(
+    options: RuntimeCapabilityApplyCommandOptions,
+) -> CliResult<RuntimeCapabilityApplyReport> {
+    let plan_options = RuntimeCapabilityPlanCommandOptions {
+        root: options.root,
+        family_id: options.family_id,
+        json: false,
+    };
+    let plan = execute_runtime_capability_plan_command(plan_options)?;
+    validate_runtime_capability_apply_plan(&plan)?;
+
+    let planned_artifact = plan.planned_artifact.clone();
+    let root = plan.root.clone();
+    let family_id = plan.family_id.clone();
+    let root_path = PathBuf::from(&root);
+    let output_path = resolve_runtime_capability_apply_output_path(&root_path, &planned_artifact);
+    let materialized_artifact = build_runtime_capability_apply_artifact(&plan)?;
+    let outcome = persist_runtime_capability_apply_artifact(&output_path, &materialized_artifact)?;
+    let output_path = canonicalize_existing_path(&output_path)?;
+
+    Ok(RuntimeCapabilityApplyReport {
+        generated_at: now_rfc3339()?,
+        root,
+        family_id,
+        output_path,
+        outcome,
+        planned_artifact,
+        materialized_artifact,
+    })
+}
+
 fn emit_runtime_capability_artifact(
     artifact: &RuntimeCapabilityArtifactDocument,
     as_json: bool,
@@ -565,6 +645,22 @@ fn emit_runtime_capability_promotion_plan(
     }
 
     println!("{}", render_runtime_capability_promotion_plan_text(report));
+    Ok(())
+}
+
+fn emit_runtime_capability_apply_report(
+    report: &RuntimeCapabilityApplyReport,
+    as_json: bool,
+) -> CliResult<()> {
+    if as_json {
+        let pretty = serde_json::to_string_pretty(report).map_err(|error| {
+            format!("serialize runtime capability apply report failed: {error}")
+        })?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    println!("{}", render_runtime_capability_apply_text(report));
     Ok(())
 }
 
@@ -1264,6 +1360,204 @@ fn persist_runtime_capability_artifact(
     Ok(())
 }
 
+fn validate_runtime_capability_apply_plan(
+    plan: &RuntimeCapabilityPromotionPlanReport,
+) -> CliResult<()> {
+    if !plan.promotable {
+        let readiness = render_family_readiness_status(plan.readiness.status);
+        let blockers = render_family_readiness_checks(&plan.blockers);
+        return Err(format!(
+            "runtime capability family `{}` is not promotable for apply; readiness={} blockers={}",
+            plan.family_id, readiness, blockers
+        ));
+    }
+
+    let target = plan.planned_artifact.target_kind;
+    if target != RuntimeCapabilityTarget::MemoryStageProfile {
+        let rendered_target = render_target(target);
+        return Err(format!(
+            "runtime capability apply currently supports only memory_stage_profile families; family `{}` resolves to target `{}`",
+            plan.family_id, rendered_target
+        ));
+    }
+
+    Ok(())
+}
+
+fn resolve_runtime_capability_apply_output_path(
+    root: &Path,
+    planned_artifact: &RuntimeCapabilityPromotionArtifactPlan,
+) -> PathBuf {
+    let delivery_surface = &planned_artifact.delivery_surface;
+    let artifact_file_name = format!("{}.json", planned_artifact.artifact_id);
+    root.join(delivery_surface).join(artifact_file_name)
+}
+
+fn build_runtime_capability_apply_artifact(
+    plan: &RuntimeCapabilityPromotionPlanReport,
+) -> CliResult<RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument> {
+    let planned_payload = plan.planned_payload.as_ref().ok_or_else(|| {
+        format!(
+            "runtime capability apply requires a planned payload for family `{}`",
+            plan.family_id
+        )
+    })?;
+    let memory_payload = &planned_payload.memory_stage_profile;
+    let expected_schema_version =
+        RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_JSON_SCHEMA_VERSION;
+    if memory_payload.schema_version != expected_schema_version {
+        return Err(format!(
+            "runtime capability apply expected memory-stage-profile payload schema version {}; found {}",
+            expected_schema_version, memory_payload.schema_version
+        ));
+    }
+
+    let expected_artifact_kind = &plan.planned_artifact.artifact_kind;
+    if memory_payload.artifact_kind != *expected_artifact_kind {
+        return Err(format!(
+            "runtime capability apply payload artifact kind {} does not match planned artifact kind {}",
+            memory_payload.artifact_kind, expected_artifact_kind
+        ));
+    }
+
+    let expected_artifact_id = &plan.planned_artifact.artifact_id;
+    if memory_payload.profile.id != *expected_artifact_id {
+        return Err(format!(
+            "runtime capability apply payload profile id {} does not match planned artifact id {}",
+            memory_payload.profile.id, expected_artifact_id
+        ));
+    }
+
+    Ok(RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument {
+        schema: RuntimeCapabilityArtifactSchema {
+            version: RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_JSON_SCHEMA_VERSION,
+            surface: RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_SURFACE.to_owned(),
+            purpose: RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_PURPOSE.to_owned(),
+        },
+        artifact_kind: memory_payload.artifact_kind.clone(),
+        artifact_id: memory_payload.profile.id.clone(),
+        delivery_surface: plan.planned_artifact.delivery_surface.clone(),
+        profile: memory_payload.profile.clone(),
+        provenance: memory_payload.provenance.clone(),
+    })
+}
+
+fn load_runtime_capability_apply_artifact(
+    path: &Path,
+) -> CliResult<RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "read runtime capability apply artifact {} failed: {error}",
+            path.display()
+        )
+    })?;
+    let artifact =
+        serde_json::from_str::<RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument>(&raw)
+            .map_err(|error| {
+                format!(
+                    "decode runtime capability apply artifact {} failed: {error}",
+                    path.display()
+                )
+            })?;
+    validate_runtime_capability_apply_artifact_schema(&artifact, path)?;
+    Ok(artifact)
+}
+
+fn validate_runtime_capability_apply_artifact_schema(
+    artifact: &RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument,
+    path: &Path,
+) -> CliResult<()> {
+    let schema = &artifact.schema;
+    if schema.version != RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_JSON_SCHEMA_VERSION {
+        return Err(format!(
+            "runtime capability apply artifact {} uses unsupported schema version {}; expected {}",
+            path.display(),
+            schema.version,
+            RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_JSON_SCHEMA_VERSION
+        ));
+    }
+    if schema.surface != RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_SURFACE {
+        return Err(format!(
+            "runtime capability apply artifact {} uses unsupported schema surface {}; expected {}",
+            path.display(),
+            schema.surface,
+            RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_SURFACE
+        ));
+    }
+    if schema.purpose != RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_PURPOSE {
+        return Err(format!(
+            "runtime capability apply artifact {} uses unsupported schema purpose {}; expected {}",
+            path.display(),
+            schema.purpose,
+            RUNTIME_CAPABILITY_MEMORY_STAGE_PROFILE_ARTIFACT_PURPOSE
+        ));
+    }
+
+    let (expected_artifact_kind, expected_delivery_surface, _) =
+        runtime_capability_promotion_target_contract(RuntimeCapabilityTarget::MemoryStageProfile);
+    if artifact.artifact_kind != expected_artifact_kind {
+        return Err(format!(
+            "runtime capability apply artifact {} uses unsupported artifact kind {}; expected {}",
+            path.display(),
+            artifact.artifact_kind,
+            expected_artifact_kind
+        ));
+    }
+    if artifact.delivery_surface != expected_delivery_surface {
+        return Err(format!(
+            "runtime capability apply artifact {} uses unsupported delivery surface {}; expected {}",
+            path.display(),
+            artifact.delivery_surface,
+            expected_delivery_surface
+        ));
+    }
+    if artifact.artifact_id != artifact.profile.id {
+        return Err(format!(
+            "runtime capability apply artifact {} has inconsistent artifact_id and profile.id fields",
+            path.display()
+        ));
+    }
+
+    Ok(())
+}
+
+fn persist_runtime_capability_apply_artifact(
+    output_path: &Path,
+    artifact: &RuntimeCapabilityAppliedMemoryStageProfileArtifactDocument,
+) -> CliResult<RuntimeCapabilityApplyOutcome> {
+    if output_path.exists() {
+        let existing_artifact = load_runtime_capability_apply_artifact(output_path)?;
+        if existing_artifact == *artifact {
+            return Ok(RuntimeCapabilityApplyOutcome::AlreadyApplied);
+        }
+
+        return Err(format!(
+            "runtime capability apply output {} already exists with different content",
+            output_path.display()
+        ));
+    }
+
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "create runtime capability apply artifact directory {} failed: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let encoded = serde_json::to_string_pretty(artifact)
+        .map_err(|error| format!("serialize runtime capability apply artifact failed: {error}"))?;
+    fs::write(output_path, encoded).map_err(|error| {
+        format!(
+            "write runtime capability apply artifact {} failed: {error}",
+            output_path.display()
+        )
+    })?;
+    Ok(RuntimeCapabilityApplyOutcome::Applied)
+}
+
 fn canonicalize_existing_path(path: &Path) -> CliResult<String> {
     dunce::canonicalize(path)
         .map(|resolved| resolved.display().to_string())
@@ -1339,6 +1633,39 @@ pub fn render_runtime_capability_text(artifact: &RuntimeCapabilityArtifactDocume
                 .as_ref()
                 .map(|review| render_string_values_with_separator(&review.warnings, " | "))
                 .unwrap_or_else(|| "-".to_owned())
+        ),
+    ]
+    .join("\n")
+}
+
+pub fn render_runtime_capability_apply_text(report: &RuntimeCapabilityApplyReport) -> String {
+    let artifact = &report.materialized_artifact;
+
+    [
+        format!("family_id={}", report.family_id),
+        format!(
+            "outcome={}",
+            render_runtime_capability_apply_outcome(report.outcome)
+        ),
+        format!("artifact_kind={}", artifact.artifact_kind),
+        format!("artifact_id={}", artifact.artifact_id),
+        format!("delivery_surface={}", artifact.delivery_surface),
+        format!("output_path={}", report.output_path),
+        format!("profile_summary={}", artifact.profile.summary),
+        format!("review_scope={}", artifact.profile.review_scope),
+        format!(
+            "required_capabilities={}",
+            render_string_values(&artifact.profile.required_capabilities)
+        ),
+        format!("tags={}", render_string_values(&artifact.profile.tags)),
+        format!("provenance_family_id={}", artifact.provenance.family_id),
+        format!(
+            "accepted_candidate_ids={}",
+            render_string_values(&artifact.provenance.accepted_candidate_ids)
+        ),
+        format!(
+            "changed_surfaces={}",
+            render_string_values(&artifact.provenance.evidence_digest.changed_surfaces)
         ),
     ]
     .join("\n")
@@ -1482,6 +1809,13 @@ fn render_capability_decision(decision: RuntimeCapabilityDecision) -> &'static s
         RuntimeCapabilityDecision::Undecided => "undecided",
         RuntimeCapabilityDecision::Accepted => "accepted",
         RuntimeCapabilityDecision::Rejected => "rejected",
+    }
+}
+
+fn render_runtime_capability_apply_outcome(outcome: RuntimeCapabilityApplyOutcome) -> &'static str {
+    match outcome {
+        RuntimeCapabilityApplyOutcome::Applied => "applied",
+        RuntimeCapabilityApplyOutcome::AlreadyApplied => "already_applied",
     }
 }
 

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -997,7 +997,8 @@ fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Apply(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -1045,7 +1046,8 @@ fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Apply(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -1075,7 +1077,8 @@ fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
                 _,
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Apply(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -1103,7 +1106,8 @@ fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Apply(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -1134,7 +1138,42 @@ fn runtime_capability_cli_parses_propose_review_show_index_and_plan() {
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Apply(_)) => {
+                panic!("unexpected runtime-capability subcommand parsed: {other:?}")
+            }
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+
+    let apply = try_parse_cli([
+        "loongclaw",
+        "runtime-capability",
+        "apply",
+        "--root",
+        "/tmp/runtime-capability",
+        "--family-id",
+        "family-123",
+        "--json",
+    ])
+    .expect("`runtime-capability apply` should parse");
+
+    match apply.command {
+        Some(Commands::RuntimeCapability { command }) => match command {
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Apply(
+                options,
+            ) => {
+                assert_eq!(options.root, "/tmp/runtime-capability");
+                assert_eq!(options.family_id, "family-123");
+                assert!(options.json);
+            }
+            other @ (loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Propose(
+                _,
+            )
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Review(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -1191,7 +1230,8 @@ fn runtime_capability_cli_parses_memory_stage_profile_target() {
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Apply(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },
@@ -1239,7 +1279,8 @@ fn runtime_capability_cli_parses_memory_stage_profile_canonical_spelling() {
             )
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Show(_)
             | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Index(_)
-            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)) => {
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Plan(_)
+            | loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityCommands::Apply(_)) => {
                 panic!("unexpected runtime-capability subcommand parsed: {other:?}")
             }
         },

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -3083,6 +3083,574 @@ fn runtime_capability_plan_rejects_unknown_family_id() {
 }
 
 #[test]
+fn runtime_capability_apply_materializes_memory_stage_profile_artifact() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-apply-memory-stage-profile");
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-apply-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-apply-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-apply-a.json");
+    let candidate_b_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-apply-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-apply-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-apply-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-apply-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-apply-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_apply_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                family_id: family.family_id.clone(),
+                json: false,
+            },
+        )
+        .expect("runtime capability apply should succeed");
+
+    assert_eq!(
+        report.outcome,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyOutcome::Applied
+    );
+    assert_eq!(
+        report.planned_artifact.target_kind,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile
+    );
+    assert!(
+        report.output_path.ends_with(&format!(
+            "memory_stage_profiles/{}.json",
+            report.planned_artifact.artifact_id
+        )),
+        "apply should materialize the memory-stage-profile artifact under the delivery surface"
+    );
+
+    let output_path = PathBuf::from(&report.output_path);
+    assert!(
+        output_path.exists(),
+        "apply should persist the output artifact"
+    );
+
+    let persisted_payload = serde_json::from_str::<Value>(
+        &fs::read_to_string(&output_path).expect("read apply output artifact"),
+    )
+    .expect("decode apply output artifact");
+
+    assert_eq!(
+        persisted_payload
+            .pointer("/schema/surface")
+            .and_then(Value::as_str),
+        Some("memory_stage_profile")
+    );
+    assert_eq!(
+        persisted_payload
+            .pointer("/schema/purpose")
+            .and_then(Value::as_str),
+        Some("runtime_capability_apply_output")
+    );
+    assert_eq!(
+        persisted_payload
+            .pointer("/artifact_id")
+            .and_then(Value::as_str),
+        Some(report.planned_artifact.artifact_id.as_str())
+    );
+    assert_eq!(
+        persisted_payload
+            .pointer("/delivery_surface")
+            .and_then(Value::as_str),
+        Some("memory_stage_profiles")
+    );
+    assert_eq!(
+        persisted_payload
+            .pointer("/profile/summary")
+            .and_then(Value::as_str),
+        Some("Promote governed memory pipeline intent into a reusable profile")
+    );
+
+    let reindexed_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability re-index should still succeed");
+
+    assert_eq!(
+        reindexed_report.total_candidate_count, 2,
+        "materialized apply outputs should not be mistaken for runtime-capability candidates"
+    );
+    assert_eq!(
+        reindexed_report.family_count, 1,
+        "materialized apply outputs should stay outside capability-family aggregation"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_apply_rejects_unknown_family_id() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-apply-missing-family");
+    let config_path = write_runtime_capability_config(&root);
+    let (run_path, _) = finish_runtime_experiment(&root, &config_path);
+    propose_runtime_capability_variant(&root, &run_path, "missing");
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_apply_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: "missing-family".to_owned(),
+            json: false,
+        },
+    )
+    .expect_err("unknown family id should be rejected during apply");
+
+    assert!(
+        error.contains("missing-family"),
+        "error should name the requested family id: {error}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_apply_rejects_non_promotable_memory_stage_profile_family() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-apply-memory-stage-profile-blocked");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-blocked-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "memory-stage-profile-blocked-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-blocked-a.json");
+    let candidate_b_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-blocked-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-blocked-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-blocked-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-blocked-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-blocked-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_apply_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect_err("non-promotable memory-stage-profile family should be rejected");
+
+    assert!(
+        error.contains("not promotable"),
+        "apply should explain why materialization was refused: {error}"
+    );
+    assert!(
+        error.contains("memory_delta_evidence"),
+        "apply should surface the missing readiness dimension: {error}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_apply_rejects_unsupported_target_kind() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-apply-unsupported-target");
+    let config_path = write_runtime_capability_config(&root);
+
+    let (run_a_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "managed-skill-apply-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant(
+        &root,
+        &config_path,
+        "managed-skill-apply-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path = root.join("artifacts/runtime-capability-managed-skill-apply-a.json");
+    let candidate_b_path = root.join("artifacts/runtime-capability-managed-skill-apply-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "managed-skill-apply-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "managed-skill-apply-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::ManagedSkill,
+        "Codify browser preview onboarding as a reusable managed skill",
+        "Browser preview onboarding and companion readiness checks only",
+        &["invoke_tool", "memory_read"],
+        &["browser", "onboarding"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "managed-skill-apply-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "managed-skill-apply-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_apply_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect_err("unsupported target kinds should be rejected");
+
+    assert!(
+        error.contains("memory_stage_profile"),
+        "apply should state the only supported target kind: {error}"
+    );
+    assert!(
+        error.contains("managed_skill"),
+        "apply should name the unsupported planned target: {error}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_apply_is_idempotent_when_existing_output_matches() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-apply-idempotent");
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-idempotent-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-idempotent-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-idempotent-a.json");
+    let candidate_b_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-idempotent-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-idempotent-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-idempotent-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-idempotent-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-idempotent-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let first_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_apply_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                family_id: family.family_id.clone(),
+                json: false,
+            },
+        )
+        .expect("first runtime capability apply should succeed");
+
+    let first_output = fs::read_to_string(&first_report.output_path)
+        .expect("read first apply output artifact for idempotence check");
+
+    let second_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_apply_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                family_id: family.family_id.clone(),
+                json: false,
+            },
+        )
+        .expect("second runtime capability apply should be idempotent");
+
+    let second_output = fs::read_to_string(&second_report.output_path)
+        .expect("read second apply output artifact for idempotence check");
+
+    assert_eq!(
+        second_report.outcome,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyOutcome::AlreadyApplied
+    );
+    assert_eq!(
+        first_report.output_path, second_report.output_path,
+        "idempotent apply should reuse the same output path"
+    );
+    assert_eq!(
+        first_output, second_output,
+        "idempotent apply should not rewrite matching output content"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn runtime_capability_apply_rejects_conflicting_existing_output() {
+    let root = unique_temp_dir("loongclaw-runtime-capability-apply-conflict");
+    let (run_a_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-conflict-a",
+        -0.2,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+    let (run_b_path, _) = finish_runtime_experiment_variant_with_memory_compare_delta(
+        &root,
+        "memory-stage-profile-conflict-b",
+        -0.4,
+        &[],
+        loongclaw_daemon::runtime_experiment_cli::RuntimeExperimentDecision::Promoted,
+    );
+
+    let candidate_a_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-conflict-a.json");
+    let candidate_b_path =
+        root.join("artifacts/runtime-capability-memory-stage-profile-conflict-b.json");
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_a_path,
+        "memory-stage-profile-conflict-a",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    propose_runtime_capability_variant_with_target(
+        &root,
+        &run_b_path,
+        "memory-stage-profile-conflict-b",
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile,
+        "Promote governed memory pipeline intent into a reusable profile",
+        "Governed memory pipeline promotion intent only",
+        &["memory_read"],
+        &["memory", "pipeline"],
+    );
+    review_runtime_capability_variant(
+        &candidate_a_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-conflict-a",
+    );
+    review_runtime_capability_variant(
+        &candidate_b_path,
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityReviewDecision::Accepted,
+        "memory-stage-profile-conflict-b",
+    );
+
+    let index_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_index_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityIndexCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                json: false,
+            },
+        )
+        .expect("runtime capability index should succeed");
+    let family = index_report
+        .families
+        .first()
+        .expect("one capability family should be reported");
+
+    let first_report =
+        loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_apply_command(
+            loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyCommandOptions {
+                root: root.join("artifacts").display().to_string(),
+                family_id: family.family_id.clone(),
+                json: false,
+            },
+        )
+        .expect("first runtime capability apply should succeed");
+
+    let output_path = PathBuf::from(&first_report.output_path);
+    rewrite_json_file(&output_path, |payload| {
+        let profile_summary = payload
+            .pointer_mut("/profile/summary")
+            .expect("apply output should include profile.summary");
+        *profile_summary = Value::String("conflicting manual edit".to_owned());
+    });
+
+    let error = loongclaw_daemon::runtime_capability_cli::execute_runtime_capability_apply_command(
+        loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityApplyCommandOptions {
+            root: root.join("artifacts").display().to_string(),
+            family_id: family.family_id.clone(),
+            json: false,
+        },
+    )
+    .expect_err("conflicting existing output should be rejected");
+
+    assert!(
+        error.contains("different content"),
+        "apply should reject conflicting materialized output: {error}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
 fn runtime_capability_show_text_renders_snapshot_delta_summary() {
     let root = unique_temp_dir("loongclaw-runtime-capability-show-text-delta-summary");
     let config_path = write_runtime_capability_config(&root);

--- a/crates/daemon/tests/integration/runtime_capability_cli.rs
+++ b/crates/daemon/tests/integration/runtime_capability_cli.rs
@@ -3166,15 +3166,16 @@ fn runtime_capability_apply_materializes_memory_stage_profile_artifact() {
         report.planned_artifact.target_kind,
         loongclaw_daemon::runtime_capability_cli::RuntimeCapabilityTarget::MemoryStageProfile
     );
+    let output_path = PathBuf::from(&report.output_path);
+    let actual_output_path_suffix = artifact_path_suffix(&output_path);
+    let expected_output_path_suffix = format!(
+        "memory_stage_profiles/{}.json",
+        report.planned_artifact.artifact_id
+    );
     assert!(
-        report.output_path.ends_with(&format!(
-            "memory_stage_profiles/{}.json",
-            report.planned_artifact.artifact_id
-        )),
+        actual_output_path_suffix == expected_output_path_suffix,
         "apply should materialize the memory-stage-profile artifact under the delivery surface"
     );
-
-    let output_path = PathBuf::from(&report.output_path);
     assert!(
         output_path.exists(),
         "apply should persist the output artifact"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -358,6 +358,7 @@ Delivered in current baseline:
   - `runtime-capability propose|review|show` records one run-derived capability candidate, bounded scope, required capabilities, explicit operator review, and any recorded snapshot-backed delta evidence without mutating live runtime state
   - `runtime-capability index` groups matching candidate records into deterministic capability families, emits compact evidence digests including delta-evidence coverage and changed runtime surfaces, and evaluates readiness as `ready`, `not_ready`, or `blocked`
   - `runtime-capability plan` resolves one indexed capability family into a deterministic dry-run promotion plan with artifact identity, blockers, approval checklist, rollback hints, provenance, and the same family-level delta evidence digest
+  - `runtime-capability apply` materializes one deterministic governed `memory_stage_profile` artifact from a promotable capability family, keeps the output idempotent, and rejects conflicting or unsupported apply paths instead of mutating live runtime state directly
 - modular channel/provider architecture for extension-safe evolution:
   - `app/channel/feishu/*` split into adapter/payload/webhook layers
   - Feishu encrypted webhook payload decrypt lane with signature verification
@@ -377,15 +378,15 @@ Remaining deliverables:
   - expand beyond installer scripts into package-manager distribution only after release adoption is stable
 - experiment-state operator surface follow-through:
   - use the shipped snapshot/restore/experiment/capability record layer as the prerequisite for later evaluator pipelines and automated skill-optimization loops
-  - keep the new dry-run promotion planner read-only and use it as the contract for any future promotion executor instead of jumping directly to automatic mutation
+  - keep the new promotion planner as the contract for governed executors; only the explicit `memory_stage_profile` apply lane is shipped today, and other promotion targets stay read-only until their executor contracts exist
 - runtime productization over already-shipped substrate:
   - background task UX on top of session runtime:
     - expose task-shaped create, inspect, wait, follow, cancel, and recover flows over the current async delegate child-session substrate
     - surface approval-pending and tool-narrowing state as task diagnostics instead of raw session-runtime detail only
     - keep cron, heartbeat, and service-owned scheduling out of the first slice
-  - discovery-first managed skills UX:
-    - add search and recommendation over the current managed, user, and project skill inventory
-    - explain eligibility, visibility, shadowing, and first-use guidance rather than requiring operators to know a `skill_id` up front
+  - product-mode managed skills UX:
+    - add search, recommendation, and explicit acquisition guidance over the current managed, user, and project skill inventory
+    - explain eligibility, visibility, shadowing, first-use guidance, and product-mode fit rather than requiring operators to know a `skill_id` up front
     - keep install and invoke explicit and governed instead of drifting into blind auto-install
   - scoped memory retrieval productization:
     - add query-aware retrieval and broaden beyond session-summary-only hydration

--- a/docs/product-specs/runtime-capability.md
+++ b/docs/product-specs/runtime-capability.md
@@ -9,7 +9,7 @@ experiment should be crystallized into a reusable lower-layer capability.
 ## Acceptance Criteria
 
 - [ ] LoongClaw exposes a `runtime-capability` command family with `propose`,
-      `review`, `show`, `index`, and `plan` subcommands.
+      `review`, `show`, `index`, `plan`, and `apply` subcommands.
 - [ ] `runtime-capability propose` creates a persisted capability-candidate
       artifact from one finished `runtime-experiment` run.
 - [ ] The candidate artifact records one explicit target type:
@@ -43,16 +43,30 @@ experiment should be crystallized into a reusable lower-layer capability.
       artifact id, blockers, approval checklist, rollback hints, provenance
       references, and the aggregated delta-evidence digest without mutating
       runtime state.
+- [ ] `runtime-capability apply` reuses the existing `plan` contract and
+      materializes one deterministic lower-layer artifact only when the chosen
+      family is currently promotable.
+- [ ] In v1, `runtime-capability apply` supports only the
+      `memory_stage_profile` target kind and persists one governed artifact
+      under the family root's `memory_stage_profiles/` delivery surface.
+- [ ] Re-applying the same promotable `memory_stage_profile` family is
+      idempotent when the existing materialized artifact already matches the
+      deterministic expected content.
+- [ ] `runtime-capability apply` fails closed for unknown family ids,
+      non-promotable families, unsupported target kinds, or conflicting
+      existing materialized output.
 - [ ] Product docs describe `runtime-capability` as the governed review layer
       above `runtime-experiment`, with `index`/readiness and `plan` forming the
-      dry-run planning ladder below any future promotion executor or automated
-      promotion loop.
+      planning ladder below explicit promotion executors or any future
+      automated promotion loop.
 
 ## Out of Scope
 
 - Automatically generating or applying managed skills
 - Automatically generating or applying programmatic flows
 - Automatically mutating `profile_note` or runtime config
+- `runtime-capability apply` support for targets other than
+  `memory_stage_profile`
 - Automatic promotion, rollback, or optimizer orchestration
 - Persisted capability-family state or background indexing daemons
 - Persisted promotion-plan artifacts or plan caches
@@ -124,3 +138,54 @@ That compact digest is narrower than the broader family-level plan evidence.
 Rejected-only or undecided-only delta surfaces may still appear under the main
 report `evidence.changed_surfaces`, but they are excluded from
 `planned_payload.memory_stage_profile.provenance.evidence_digest.changed_surfaces`.
+
+## Apply v1 Materialization
+
+`runtime-capability apply` is the first explicit governed promotion executor.
+It does not mutate live runtime configuration. Instead, it materializes one
+runtime-owned `memory_stage_profile` artifact from the existing dry-run plan
+contract.
+
+For v1:
+
+- `apply` calls the same indexed-family planner internally instead of building a
+  second planning path.
+- The persisted artifact content is deterministic and excludes volatile
+  execution-time timestamps.
+- Execution-time details such as whether the file was newly written or already
+  matched are reported in the apply result, not baked into the artifact body.
+- The materialized artifact uses the non-`runtime_capability` schema surface
+  `memory_stage_profile`, so future capability scans ignore it safely even when
+  it lives under the same root.
+
+The persisted JSON shape is:
+
+```json
+{
+  "schema": {
+    "version": 1,
+    "surface": "memory_stage_profile",
+    "purpose": "runtime_capability_apply_output"
+  },
+  "artifact_kind": "memory_stage_profile",
+  "artifact_id": "memory-stage-profile-...",
+  "delivery_surface": "memory_stage_profiles",
+  "profile": {
+    "id": "memory-stage-profile-...",
+    "summary": "Promote governed memory pipeline intent into a reusable profile",
+    "review_scope": "Governed memory pipeline promotion intent only",
+    "required_capabilities": ["memory_read"],
+    "tags": ["memory", "pipeline"]
+  },
+  "provenance": {
+    "family_id": "8f5c2d1a4b7e...",
+    "accepted_candidate_ids": ["capability-candidate-..."],
+    "evidence_digest": {
+      "changed_surfaces": [
+        "context_engine_compaction",
+        "memory_policy"
+      ]
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary

- Problem:
  `runtime-capability` stopped at dry-run `plan`, so promotable capability families still had no governed executor that could materialize a lower-layer artifact.
- Why it matters:
  Product-mode and self-evolution work need an explicit, deterministic promotion lane before any broader automation can be trusted.
- What changed:
  Added `runtime-capability apply`, reused the existing `plan` contract, materialized deterministic `memory_stage_profile` artifacts under `memory_stage_profiles/`, enforced idempotent re-apply behavior, rejected conflicting or unsupported apply paths, and documented the new governed executor.
- What did not change (scope boundary):
  No live runtime config mutation, no managed-skill/programmatic-flow/profile-note apply executor, and no autonomous promotion loop.

## Linked Issues

- Closes #702
- Related #596

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-daemon --test integration runtime_capability_
cargo test --workspace --locked
cargo test --workspace --all-features --locked
LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
diff CLAUDE.md AGENTS.md
scripts/check-docs.sh
python3 scripts/sync_github_labels.py --check
bash scripts/test_sync_github_labels.sh
cargo deny check advisories bans licenses sources

Results:
- All cargo, runtime-capability targeted, architecture, dep-graph, docs, label, and mirror checks passed.
- `scripts/check-docs.sh` passed with existing non-blocking local release-artifact warnings.
- `cargo deny check advisories bans licenses sources` still fails on pre-existing license allowlist rejections for transitive crates using `0BSD` and `CC0-1.0`; this PR does not introduce those dependencies.
- The convention-engineering task could not be run locally because `$HOME/.claude/skills/convention-engineering/scripts/main.go` is not present in this environment.
- Not applicable: this PR does not change config/env fallback behavior and does not add new process-global env mutation coverage requirements.
```

## User-visible / Operator-visible Changes

- `runtime-capability apply --root ... --family-id ...` now materializes a governed `memory_stage_profile` artifact for a promotable capability family.
- Re-running the same apply is a no-op when the persisted artifact already matches.
- Conflicting existing output, unsupported target kinds, and non-promotable families now fail closed with explicit operator-facing errors.

## Failure Recovery

- Fast rollback or disable path:
  Remove the generated `memory_stage_profiles/<artifact_id>.json` artifact and fall back to the existing `runtime-capability plan` dry-run lane.
- Observable failure symptoms reviewers should watch for:
  Apply unexpectedly treating a non-`runtime_capability` artifact as an index candidate, non-idempotent re-apply behavior, or accepting unsupported target kinds.

## Reviewer Focus

- Review `crates/daemon/src/runtime_capability_cli.rs` for the plan-to-apply contract reuse, deterministic output path/content rules, and fail-closed handling.
- Review `crates/daemon/tests/integration/runtime_capability_cli.rs` for the new apply success/idempotence/conflict coverage and the guarantee that materialized artifacts stay invisible to capability indexing.
- Review `docs/product-specs/runtime-capability.md` and `docs/ROADMAP.md` for the updated product-mode positioning and explicit scope boundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `runtime-capability apply` subcommand to deterministically materialize governed capability artifacts from promotable families; idempotent and currently limited to MemoryStageProfile targets.

* **Documentation**
  * Updated product spec and roadmap to describe apply behavior, constraints, delivery surface, idempotency, and failure conditions.

* **Tests**
  * Added integration tests covering happy path, error cases, idempotency, and conflict detection for apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->