### PR TITLE
release: prepare stable v0.1.0 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows Keep a Changelog and semantic versioning intent.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-03-29
+
+### Added
+
+- Added the first stable LoongClaw baseline after the `0.1.0-alpha.*` prerelease line, carrying forward the current `dev` slice for promotion into `main`.
+- Added Feishu channel delivery follow-through including Messaging API integration plus bitable list, create, and search support.
+- Added background task CLI flows, discovery-first external skills guidance, doctor security audit coverage, and session-scoped tool consent handling for the daemon/runtime surface.
+
+### Changed
+
+- Changed the default CLI command path to `loong`, expanded channel send surfaces and trust enforcement, and continued hardening browser, approval, consent, plugin, and outbound HTTP governance boundaries.
+- Refined release governance, architecture drift evidence, and promotion-readiness checks so the stable line can be promoted from `dev` into `main` with the same strict local gates used in prerelease validation.
+
 ### Fixed
 
 - Restored provider-side tool execution when OpenAI-compatible responses emit standalone JSON tool blocks or Ollama-style `<tool_call>...</tool_call>` fallbacks instead of native `tool_calls`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,7 +2112,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loongclaw-app"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-bench"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "loongclaw-kernel",
  "loongclaw-spec",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-contracts"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "semver",
  "serde",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-daemon"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "axum",
  "base64",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-kernel"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-protocol"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-spec"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 authors = ["chumyin"]
 
 [workspace.dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,8 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "0BSD",
+    "CC0-1.0",
     "ISC",
     "MPL-2.0",
     "Unicode-3.0",

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,64 @@
+# Release v0.1.0
+
+## Summary
+- Generated at: 2026-03-30T03:33:42Z
+- Release status: prepared locally; not yet published (pending `dev -> main` promotion and `release-gate release --execute`)
+- Target commitish: planned `main` promotion point from `dev` commit `633bffa8258e75d609401633139264f5fd7efa91`
+- Artifact count: pending publish
+- Trace ID: `0f1000aa`
+- Trace path: `.docs/traces/20260330T033342Z-post-release-v0.1.0-0f1000aa`
+
+## Highlights
+- Promotes the current `dev` line from prerelease validation toward the first stable `v0.1.0` baseline on `main`.
+- Carries forward the recent channel/runtime expansion work, including Feishu messaging and bitable support, background tasks CLI flows, and session-scoped tool consent handling.
+- Folds in the current provider execution fallback repair and the cargo-deny policy update required for the canonical local verification gate to pass.
+
+## Process
+- Date: 2026-03-29
+- Owner: local release-prep staging
+- Scope summary: prepared stable `v0.1.0` metadata from the current `upstream/dev` tip so maintainers can promote the slice into `main` and publish from the stable branch.
+- Gates run: local `task verify`, strict release-doc bootstrap, and release-gate metadata validation are required before publish.
+- Refactor budget item: no separate refactor-budget paydown was attached to this stable release prep.
+- Prepared against branch-policy guidance that only reviewed `dev` changes should move into `main` before tagging.
+
+## Artifacts
+| Asset | Size (bytes) | SHA256 | Download |
+|---|---:|---|---|
+| `install.ps1` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/install.ps1) |
+| `install.sh` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/install.sh) |
+| `loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip) |
+| `loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip.sha256) |
+| `loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz) |
+| `loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256) |
+
+## Verification
+| Check | Result | Evidence |
+|---|---|---|
+| Stable metadata matches target tag | PASS | `release-gate check --repo <worktree> --tag v0.1.0` validated `Cargo.toml`, `CHANGELOG.md`, and `docs/releases/v0.1.0.md` |
+| Canonical local verification gate passes | PASS | `release-gate check` reran `task verify` and `task verify:full` successfully on the release-prep worktree |
+| Release-gate metadata contract passes before publish | PASS | check trace `.docs/traces/20260330T033539Z-check-v0.1.0-cb0a7612` |
+
+## Refactor Budget
+- Hotspot metric paid down: none recorded as a dedicated release-budget item.
+- Evidence: stable release prep focused on branch promotion readiness, doc governance, and verification parity.
+- If no paydown shipped, rationale: this prep packages already-landed runtime and governance work from `dev` into the first stable baseline.
+
+## Known Issues
+- `upstream/main` is still the initial commit on 2026-03-29, so publish cannot proceed until maintainers merge the reviewed `dev` slice into `main`.
+- Final asset hashes, workflow run URLs, and release-page evidence remain pending until the actual publish from `main`.
+
+## Rollback
+- If the `dev -> main` promotion is rejected, discard this staged `v0.1.0` metadata and regenerate it against the next reviewed promotion point.
+- If publish from `main` produces bad assets, supersede with a patch release and update this document with final release evidence.
+
+## Detail Links
+- [Changelog entry](../../CHANGELOG.md)
+- [Release workflow definition](../../.github/workflows/release.yml)
+- [Branch collaboration policy](../references/github-collaboration.md)
+- [Planned GitHub release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0)
+- Trace directory: `.docs/traces/20260330T033342Z-post-release-v0.1.0-0f1000aa`
+- Local debug log: `.docs/releases/v0.1.0-debug.md`


### PR DESCRIPTION
## Summary
- add the stable `0.1.0` workspace/changelog/release-doc metadata needed before a real `dev -> main` promotion
- include the cargo-deny allowlist update for `0BSD` and `CC0-1.0` so the canonical local gate stays green
- carry the expected `Cargo.lock` workspace-version churn produced by the stable version bump

## Validation
- `./scripts/bootstrap_release_local_artifacts.sh`
- `LOONGCLAW_RELEASE_DOCS_STRICT=1 ./scripts/check-docs.sh`
- `../loongclaw-release-gate/tools/release-gate/bin/release-gate check --repo /Users/xj/github/loongclaw/loongclaw/.worktrees/fix-deny-license-policy-20260329 --tag v0.1.0`
- `../loongclaw-release-gate/tools/release-gate/bin/release-gate check --repo /Users/xj/github/loongclaw/loongclaw/.worktrees/fix-deny-license-policy-20260329 --tag v0.1.0 --skip-gates`

## Notes
- This PR should merge into `dev`, not `main`.
- After merge, maintainers can open the real promotion PR from `dev` to `main`, then publish from `main` with `release-gate release --source-ref main --execute`.
- Full non-publish release-gate trace: `.docs/traces/20260330T033539Z-check-v0.1.0-cb0a7612`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stable v0.1.0 release with Feishu channel integration, background task CLI workflows, and enhanced security features.

* **Documentation**
  * Added comprehensive release documentation and updated changelog with new features, improvements, and security enhancements.

* **Chores**
  * Updated version metadata and license policies for release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->