### PR TITLE
build: allow current cargo-deny license set

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,8 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "0BSD",
+    "CC0-1.0",
     "ISC",
     "MPL-2.0",
     "Unicode-3.0",


### PR DESCRIPTION
## Why This PR Exists
- `task verify` on the current `dev` line was failing at `cargo deny` because the allowlist no longer covered two licenses now present in transitive dependencies.
- This PR fixes that blocker and keeps the change small enough to review on its own.

## What Changed
- Added `0BSD` to the cargo-deny allowlist for `quoted_printable`.
- Added `CC0-1.0` to the cargo-deny allowlist for `secp256k1` and `secp256k1-sys`.

## What This PR Does Not Do
- It does not bump the project version.
- It does not add stable `v0.1.0` changelog or release-doc metadata.
- It does not change the branch/release strategy.

## Why The Scope Is Narrow
- I originally prepared a broader stable-release prep branch, then closed that PR after review because stable `0.1.0` metadata should stay off normal `dev` until the actual freeze/promotion point.
- This PR keeps only the always-needed verification fix so reviewers can approve or reject it independently.

## Validation
- `cargo deny check licenses`
- `task verify`

## Reviewer Focus
- Are `0BSD` and `CC0-1.0` acceptable additions to LoongClaw's cargo-deny license policy?
- Is there any better dependency/governance fix than explicitly allowing these current transitive licenses?
