### PR TITLE
release: freeze stable v0.1.0 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,23 @@ The format follows Keep a Changelog and semantic versioning intent.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-03-29
+
+### Added
+
+- Added the first stable LoongClaw baseline after the `0.1.0-alpha.*` prerelease line, carrying forward the frozen `dev` slice for promotion into `main`.
+- Added Feishu channel delivery follow-through including Messaging API integration plus bitable list, create, and search support.
+- Added background task CLI flows, discovery-first external skills guidance, doctor security audit coverage, session-scoped tool consent handling, manifest-first plugin packaging, and plugin inventory plus doctor CLI surfaces.
+
+### Changed
+
+- Changed the default CLI command path to `loong`, expanded channel send surfaces and trust enforcement, and added governed runtime-capability apply execution for promotion readiness.
+- Refined release governance, architecture drift evidence, and cargo-deny policy coverage so the stable line can be promoted from `dev` into `main` with the same strict local gates used in prerelease validation.
+
 ### Fixed
 
 - Restored provider-side tool execution when OpenAI-compatible responses emit standalone JSON tool blocks or Ollama-style `<tool_call>...</tool_call>` fallbacks instead of native `tool_calls`.
+- Hardened plugin scaffold file writes before freezing the first stable slice.
 
 ## [0.1.0-alpha.2] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format follows Keep a Changelog and semantic versioning intent.
 ### Added
 
 - Added the first stable LoongClaw baseline after the `0.1.0-alpha.*` prerelease line, carrying forward the frozen `dev` slice for promotion into `main`.
-- Added Feishu channel delivery follow-through including Messaging API integration plus bitable list, create, and search support.
+- Expanded Feishu channel delivery follow-through including Messaging API integration plus bitable list, create, and search support.
 - Added background task CLI flows, discovery-first external skills guidance, doctor security audit coverage, session-scoped tool consent handling, manifest-first plugin packaging, and plugin inventory plus doctor CLI surfaces.
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,7 +2112,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loongclaw-app"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-bench"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "loongclaw-kernel",
  "loongclaw-spec",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-contracts"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "semver",
  "serde",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-daemon"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "axum",
  "base64",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-kernel"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-protocol"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-spec"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.0-alpha.2"
+version = "0.1.0"
 authors = ["chumyin"]
 
 [workspace.dependencies]

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -23,20 +23,23 @@
 - Operator note: the explicit `--source-ref main` override is required for the stable publish because release-gate docs still show the stale prerelease-oriented default source ref.
 
 ## Artifacts
+
 | Asset | Size (bytes) | SHA256 | Download |
 |---|---:|---|---|
-| `install.ps1` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/install.ps1) |
-| `install.sh` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/install.sh) |
-| `loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz) |
-| `loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz.sha256) |
-| `loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz) |
-| `loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz.sha256) |
-| `loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip) |
-| `loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip.sha256) |
-| `loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz) |
-| `loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256) |
+| `install.ps1` | pending | pending | [Download install.ps1](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/install.ps1) |
+| `install.sh` | pending | pending | [Download install.sh](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/install.sh) |
+| `loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz` | pending | pending | [Download aarch64 Apple archive](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz.sha256` | pending | pending | [SHA256 for aarch64 Apple archive](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz` | pending | pending | [Download x86_64 Apple archive](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz.sha256` | pending | pending | [SHA256 for x86_64 Apple archive](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip` | pending | pending | [Download Windows zip](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip) |
+| `loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip.sha256` | pending | pending | [SHA256 for Windows zip](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip.sha256) |
+| `loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz` | pending | pending | [Download x86_64 Linux archive](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz) |
+| `loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256` | pending | pending | [SHA256 for x86_64 Linux archive](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256) |
+
 
 ## Verification
+
 | Check | Result | Evidence |
 |---|---|---|
 | Stable metadata matches target tag | PASS | `release-gate check --repo <worktree> --tag v0.1.0` validates `Cargo.toml`, `CHANGELOG.md`, and `docs/releases/v0.1.0.md` |

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,65 @@
+# Release v0.1.0
+
+## Summary
+- Generated at: 2026-03-30T05:08:11Z
+- Release status: freeze prep staged locally; not yet published (pending `dev -> main` promotion and `release-gate release --execute` from `main`)
+- Target commitish: frozen `dev` commit `8e677a363fd0e7e6124703a7736a4bcafb8948db`, to be promoted unchanged into `main`
+- Artifact count: pending publish
+- Trace ID: `b1aeda65`
+- Trace path: `.docs/traces/20260330T050811Z-post-release-v0.1.0-b1aeda65`
+
+## Highlights
+- Promotes the current `dev` line from prerelease validation toward the first stable `v0.1.0` baseline on `main`.
+- Carries forward the post-`v0.1.0-alpha.2` channel, runtime, and plugin expansion work, including Feishu Messaging API and bitable support, background tasks CLI flows, session-scoped tool consent, plugin package scaffolding, and plugin inventory plus doctor surfaces.
+- Folds in the governed runtime-capability apply executor, the provider tool-call fallback repair, and the cargo-deny policy coverage required for the canonical local verification gate to pass.
+
+## Process
+- Date: 2026-03-29
+- Owner: local freeze-prep staging
+- Scope summary: prepare stable `v0.1.0` metadata from the frozen `upstream/dev` tip so maintainers can promote the slice into `main` and publish from the stable branch.
+- Gates run: local artifact bootstrap, strict release-doc checks, and `release-gate check --repo <worktree> --tag v0.1.0` before any publish attempt.
+- Refactor budget item: no separate refactor-budget paydown was attached to this stable freeze prep.
+- Publish command after promotion: `release-gate release --repo <clean-main-worktree> --tag v0.1.0 --source-remote upstream --source-ref main --push-remote upstream --execute`
+- Operator note: the explicit `--source-ref main` override is required for the stable publish because release-gate docs still show the stale prerelease-oriented default source ref.
+
+## Artifacts
+| Asset | Size (bytes) | SHA256 | Download |
+|---|---:|---|---|
+| `install.ps1` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/install.ps1) |
+| `install.sh` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/install.sh) |
+| `loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-aarch64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz) |
+| `loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-apple-darwin.tar.gz.sha256) |
+| `loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip) |
+| `loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-pc-windows-msvc.zip.sha256) |
+| `loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz) |
+| `loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256` | pending | pending | [link](https://github.com/loongclaw-ai/loongclaw/releases/download/v0.1.0/loongclaw-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256) |
+
+## Verification
+| Check | Result | Evidence |
+|---|---|---|
+| Stable metadata matches target tag | PASS | `release-gate check --repo <worktree> --tag v0.1.0` validates `Cargo.toml`, `CHANGELOG.md`, and `docs/releases/v0.1.0.md` |
+| Canonical local verification gate passes | PASS | `release-gate check` reruns `task verify` and `task verify:full` successfully on the freeze-prep worktree |
+| Stable publish command is pinned to `main` | PASS | future publish step is recorded here as `release-gate release --repo <clean-main-worktree> --tag v0.1.0 --source-remote upstream --source-ref main --push-remote upstream --execute` |
+
+## Refactor Budget
+- Hotspot metric paid down: none recorded as a dedicated release-budget item.
+- Evidence: stable freeze prep focused on branch promotion readiness, doc governance, and verification parity for the frozen `dev` slice.
+- If no paydown shipped, rationale: this prep packages already-landed runtime, channel, plugin, and governance work from `dev` into the first stable baseline.
+
+## Known Issues
+- `upstream/main` is still the initial commit on 2026-03-29, so publish cannot proceed until maintainers merge the frozen `dev` slice into `main`.
+- The tracked trace identity is a local bootstrap artifact for the strict release-doc contract; final workflow URLs, asset hashes, and publish evidence remain pending until the real release from `main`.
+
+## Rollback
+- If the frozen `dev -> main` promotion is rejected, discard this staged `v0.1.0` metadata and regenerate it against the next reviewed freeze point.
+- If publish from `main` produces bad assets, supersede with a patch release and update this document with final release evidence.
+
+## Detail Links
+- [Changelog entry](../../CHANGELOG.md)
+- [Release workflow definition](../../.github/workflows/release.yml)
+- [Branch collaboration policy](../references/github-collaboration.md)
+- [Planned GitHub release page](https://github.com/loongclaw-ai/loongclaw/releases/tag/v0.1.0)
+- Trace directory: `.docs/traces/20260330T050811Z-post-release-v0.1.0-b1aeda65`
+- Local debug log: `.docs/releases/v0.1.0-debug.md`


### PR DESCRIPTION
## Summary
- freeze the first stable `v0.1.0` metadata slice from current `upstream/dev` commit `8e677a363fd0e7e6124703a7736a4bcafb8948db`
- bump workspace release metadata from `0.1.0-alpha.2` to `0.1.0`
- add the stable changelog entry and canonical `docs/releases/v0.1.0.md`
- record the exact later publish command from `main`, including the required `--source-ref main` override

## What This Does Not Do
- does not publish `v0.1.0`
- does not promote `dev` into `main`
- does not change runtime behavior outside release metadata

## Validation
- `./scripts/bootstrap_release_local_artifacts.sh`
- `LOONGCLAW_RELEASE_DOCS_STRICT=1 ./scripts/check-docs.sh`
- `tools/release-gate/bin/release-gate check --repo /Users/xj/github/loongclaw/loongclaw/.worktrees/freeze-v0.1.0-20260329 --tag v0.1.0`
- check trace: `.docs/traces/20260330T051024Z-check-v0.1.0-5a04bbf5`

## Reviewer Focus
- is this the right frozen `dev` slice for the first stable `v0.1.0` promotion?
- are the changelog and release-doc summaries accurate enough for the stable baseline?
- does the explicit `--source-ref main` publish note make the eventual operator path unambiguous?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feishu channel delivery (messaging + data list/create/search)
  * CLI background task flows, external-skill guidance, plugin inventory/doctor surfaces
  * Session-scoped tool consent and manifest-first plugin packaging

* **Changed**
  * Default CLI command path updated
  * Expanded channel send surfaces with trust enforcement
  * Strengthened release governance and promotion readiness

* **Fixed**
  * Hardened plugin scaffold/file writes and tool-execution recovery

* **Chores**
  * Bumped version to 0.1.0

* **Documentation**
  * Added release notes and promotion/process documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->