### PR TITLE
fix: preserve discovery-shaped tool follow-up semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,6 +2009,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2164,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite",
  "toml",
+ "tracing",
  "unicode-normalization",
  "unicode-segmentation",
  "wait-timeout",
@@ -2219,6 +2226,8 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tower",
+ "tracing",
+ "tracing-subscriber",
  "wat",
 ]
 
@@ -2297,6 +2306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2385,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3338,6 +3365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3845,6 +3881,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3979,6 +4058,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ wasmtime = { version = "43.0.0", default-features = false, features = ["std", "r
 rusqlite = { version = "0.39", features = ["bundled"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 which = "8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 [profile.release]
 lto = "thin"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -95,6 +95,7 @@ secp256k1.workspace = true
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"], optional = true }
 tokio-rustls = { version = "0.26.4", optional = true }
 libc = "0.2"
+tracing.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/app/src/acp/manager.rs
+++ b/crates/app/src/acp/manager.rs
@@ -117,11 +117,10 @@ impl AcpSessionManager {
         let selection = resolve_acp_backend_selection(config);
         tracing::debug!(
             target: "loongclaw.acp",
-            session_key = %bootstrap.session_key,
             backend_id = %selection.id,
-            conversation_id = ?bootstrap.conversation_id.as_deref(),
             mode = ?bootstrap.mode,
             binding = ?AcpSessionBindingScope::from_bootstrap(bootstrap),
+            has_conversation_id = bootstrap.conversation_id.is_some(),
             "ensuring ACP session"
         );
         if let Some(existing) =
@@ -129,7 +128,6 @@ impl AcpSessionManager {
         {
             tracing::debug!(
                 target: "loongclaw.acp",
-                session_key = %existing.session_key,
                 backend_id = %existing.backend_id,
                 state = ?existing.state,
                 "reused ACP session"
@@ -154,7 +152,6 @@ impl AcpSessionManager {
         self.store.upsert(metadata.clone())?;
         tracing::debug!(
             target: "loongclaw.acp",
-            session_key = %metadata.session_key,
             backend_id = %metadata.backend_id,
             activation_origin = ?metadata.activation_origin.map(AcpRoutingOrigin::as_str),
             "created ACP session"
@@ -191,11 +188,10 @@ impl AcpSessionManager {
             .map(String::as_str);
         tracing::debug!(
             target: "loongclaw.acp",
-            session_key = %bootstrap.session_key,
             backend_id = %metadata.backend_id,
-            trace_id = ?trace_id,
             input_len = request.input.chars().count(),
             sink_enabled = sink.is_some(),
+            has_trace_id = trace_id.is_some(),
             "starting ACP turn"
         );
         let backend = resolve_acp_backend(Some(metadata.backend_id.as_str()))?;
@@ -256,15 +252,14 @@ impl AcpSessionManager {
                 self.store.upsert(metadata)?;
                 tracing::debug!(
                     target: "loongclaw.acp",
-                    session_key = %bootstrap.session_key,
                     backend_id = %handle.backend_id,
-                    trace_id = ?trace_id,
                     state = ?result.state,
                     stop_reason = ?result.stop_reason,
                     reported_event_count,
                     streamed_event_count,
                     merged_event_count = result.events.len(),
                     duration_ms,
+                    has_trace_id = trace_id.is_some(),
                     "ACP turn completed"
                 );
                 Ok(result)
@@ -277,11 +272,10 @@ impl AcpSessionManager {
                 self.store.upsert(metadata)?;
                 tracing::warn!(
                     target: "loongclaw.acp",
-                    session_key = %bootstrap.session_key,
                     backend_id = %handle.backend_id,
-                    trace_id = ?trace_id,
                     duration_ms = started_at.elapsed().as_millis(),
                     error = %crate::observability::summarize_error(error.as_str()),
+                    has_trace_id = trace_id.is_some(),
                     "ACP turn failed"
                 );
                 Err(error)

--- a/crates/app/src/acp/manager.rs
+++ b/crates/app/src/acp/manager.rs
@@ -7,10 +7,10 @@ use crate::CliResult;
 use crate::config::LoongClawConfig;
 
 use super::backend::{
-    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, AcpAbortController, AcpConfigPatch, AcpDoctorReport,
-    AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle, AcpSessionMetadata, AcpSessionMode,
-    AcpSessionState, AcpSessionStatus, AcpTurnEventSink, AcpTurnRequest, AcpTurnResult,
-    BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
+    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, ACP_TURN_METADATA_TRACE_ID, AcpAbortController,
+    AcpConfigPatch, AcpDoctorReport, AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle,
+    AcpSessionMetadata, AcpSessionMode, AcpSessionState, AcpSessionStatus, AcpTurnEventSink,
+    AcpTurnRequest, AcpTurnResult, BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
 };
 use super::binding::AcpSessionBindingScope;
 use super::merge_turn_events;
@@ -115,9 +115,25 @@ impl AcpSessionManager {
         self.cleanup_idle_sessions(config).await?;
 
         let selection = resolve_acp_backend_selection(config);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %selection.id,
+            conversation_id = ?bootstrap.conversation_id.as_deref(),
+            mode = ?bootstrap.mode,
+            binding = ?AcpSessionBindingScope::from_bootstrap(bootstrap),
+            "ensuring ACP session"
+        );
         if let Some(existing) =
             self.resolve_existing_session(config, selection.id.as_str(), bootstrap)?
         {
+            tracing::debug!(
+                target: "loongclaw.acp",
+                session_key = %existing.session_key,
+                backend_id = %existing.backend_id,
+                state = ?existing.state,
+                "reused ACP session"
+            );
             return Ok(existing);
         }
 
@@ -136,6 +152,13 @@ impl AcpSessionManager {
             .get(ACP_SESSION_METADATA_ACTIVATION_ORIGIN)
             .and_then(|value| AcpRoutingOrigin::parse(value));
         self.store.upsert(metadata.clone())?;
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %metadata.session_key,
+            backend_id = %metadata.backend_id,
+            activation_origin = ?metadata.activation_origin.map(AcpRoutingOrigin::as_str),
+            "created ACP session"
+        );
         Ok(metadata)
     }
 
@@ -156,11 +179,25 @@ impl AcpSessionManager {
         request: &AcpTurnRequest,
         sink: Option<&dyn AcpTurnEventSink>,
     ) -> CliResult<AcpTurnResult> {
+        let started_at = std::time::Instant::now();
         let actor_key = actor_key_for_bootstrap(bootstrap);
         let _turn_queue_guard = self.acquire_turn_queue_guard(actor_key.clone()).await?;
         self.cleanup_idle_sessions(config).await?;
 
         let mut metadata = self.ensure_session(config, bootstrap).await?;
+        let trace_id = request
+            .metadata
+            .get(ACP_TURN_METADATA_TRACE_ID)
+            .map(String::as_str);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %metadata.backend_id,
+            trace_id = ?trace_id,
+            input_len = request.input.chars().count(),
+            sink_enabled = sink.is_some(),
+            "starting ACP turn"
+        );
         let backend = resolve_acp_backend(Some(metadata.backend_id.as_str()))?;
         metadata.state = AcpSessionState::Busy;
         metadata.clear_error();
@@ -209,11 +246,27 @@ impl AcpSessionManager {
             Ok(mut result) => {
                 self.record_turn_completion(turn_started_ms, true)?;
                 let streamed_events = buffered_sink.snapshot()?;
+                let duration_ms = started_at.elapsed().as_millis();
+                let reported_event_count = result.events.len();
+                let streamed_event_count = streamed_events.len();
                 result.events = merge_turn_events(&result.events, &streamed_events);
                 metadata.state = result.state;
                 metadata.clear_error();
                 metadata.touch();
                 self.store.upsert(metadata)?;
+                tracing::debug!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    state = ?result.state,
+                    stop_reason = ?result.stop_reason,
+                    reported_event_count,
+                    streamed_event_count,
+                    merged_event_count = result.events.len(),
+                    duration_ms,
+                    "ACP turn completed"
+                );
                 Ok(result)
             }
             Err(error) => {
@@ -222,6 +275,15 @@ impl AcpSessionManager {
                 metadata.state = AcpSessionState::Error;
                 metadata.set_error(error.clone());
                 self.store.upsert(metadata)?;
+                tracing::warn!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    duration_ms = started_at.elapsed().as_millis(),
+                    error = %crate::observability::summarize_error(error.as_str()),
+                    "ACP turn failed"
+                );
                 Err(error)
             }
         }

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -4417,16 +4417,51 @@ pub(super) async fn process_inbound_with_provider(
     kernel_ctx: &KernelContext,
     feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<String> {
+    let started_at = std::time::Instant::now();
     let turn_config = reload_channel_turn_config(config, resolved_path)?;
     let runtime = DefaultConversationRuntime::from_config_or_env(&turn_config)?;
-    process_inbound_with_runtime_and_feedback(
+    let result = process_inbound_with_runtime_and_feedback(
         &turn_config,
         &runtime,
         message,
         ConversationRuntimeBinding::kernel(kernel_ctx),
         feedback_policy,
     )
-    .await
+    .await;
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(reply) => {
+            tracing::debug!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                reply_len = reply.chars().count(),
+                duration_ms,
+                "channel inbound processed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "channel inbound failed"
+            );
+        }
+    }
+    result
 }
 
 #[cfg(any(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -11171,6 +11171,140 @@ async fn turn_engine_truncates_oversized_tool_payload_summary() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_engine_keeps_discovery_shaped_payloads_intact_for_followup_compaction() {
+    use crate::conversation::turn_engine::{ProviderTurn, TurnEngine, TurnResult};
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
+    use loongclaw_kernel::CoreToolAdapter;
+
+    struct LargeToolSearchAdapter;
+
+    #[async_trait]
+    impl CoreToolAdapter for LargeToolSearchAdapter {
+        fn name(&self) -> &str {
+            "large-discovery-result-adapter"
+        }
+
+        async fn execute_core_tool(
+            &self,
+            request: ToolCoreRequest,
+        ) -> Result<ToolCoreOutcome, ToolPlaneError> {
+            let (tool_name, _arguments) = effective_tool_request(&request);
+            let repeated_summary = "news result".repeat(600);
+
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "query": "latest ai news",
+                    "returned": 12,
+                    "results": (0..12)
+                        .map(|index| json!({
+                            "tool_id": format!("tool-{index}"),
+                            "summary": format!("{} {}", repeated_summary.as_str(), index),
+                            "argument_hint": "query:string",
+                            "required_fields": ["query"],
+                            "required_field_groups": [["query"]],
+                            "lease": format!("lease-{index}")
+                        }))
+                        .collect::<Vec<_>>(),
+                    "tool": tool_name
+                }),
+            })
+        }
+    }
+
+    let audit = Arc::new(InMemoryAuditSink::default());
+    let clock = Arc::new(FixedClock::new(1_700_000_000));
+    let mut kernel = LoongClawKernel::with_runtime(StaticPolicyEngine::default(), clock, audit);
+
+    let pack = VerticalPackManifest {
+        pack_id: "test-pack".to_owned(),
+        domain: "testing".to_owned(),
+        version: "0.1.0".to_owned(),
+        default_route: ExecutionRoute {
+            harness_kind: HarnessKind::EmbeddedPi,
+            adapter: None,
+        },
+        allowed_connectors: BTreeSet::new(),
+        granted_capabilities: BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead]),
+        metadata: BTreeMap::new(),
+    };
+    kernel.register_pack(pack).expect("register pack");
+    kernel.register_core_tool_adapter(LargeToolSearchAdapter);
+    kernel
+        .set_default_core_tool_adapter("large-discovery-result-adapter")
+        .expect("set default");
+
+    let token = kernel
+        .issue_token("test-pack", "test-agent", 3600)
+        .expect("issue token");
+
+    let ctx = KernelContext {
+        kernel: Arc::new(kernel),
+        token,
+    };
+
+    let engine = TurnEngine::new(5);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![provider_tool_intent(
+            "file.read",
+            json!({"path": "README.md"}),
+            "s1",
+            "t1",
+            "c-search-large",
+        )],
+        raw_meta: serde_json::Value::Null,
+    };
+
+    let result = engine.execute_turn(&turn, &ctx).await;
+    match result {
+        TurnResult::FinalText(text) => {
+            let line = text.lines().next().expect("tool result line should exist");
+            let payload = line
+                .strip_prefix("[ok] ")
+                .expect("tool result line should keep [ok] prefix");
+            let envelope: Value =
+                serde_json::from_str(payload).expect("tool result envelope should be json");
+
+            assert_eq!(envelope["tool"], "file.read");
+            assert_eq!(envelope["tool_call_id"], "c-search-large");
+            assert_eq!(envelope["payload_semantics"], json!("discovery_result"));
+            assert_eq!(envelope["payload_truncated"], false);
+            assert!(
+                envelope["payload_chars"]
+                    .as_u64()
+                    .expect("payload chars should exist")
+                    > 64_000
+            );
+            let payload_summary = envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should be string");
+            assert!(payload_summary.contains("\"tool_id\""));
+            assert!(payload_summary.contains("\"lease\""));
+            assert!(payload_summary.chars().count() > 64_000);
+        }
+        TurnResult::StreamingText(other) => {
+            panic!("expected FinalText, got StreamingText({other:?})")
+        }
+        TurnResult::StreamingDone(other) => {
+            panic!("expected FinalText, got StreamingDone({other:?})")
+        }
+        TurnResult::NeedsApproval(other) => {
+            panic!("expected FinalText, got NeedsApproval({other:?})")
+        }
+        TurnResult::ToolDenied(other) => {
+            panic!("expected FinalText, got ToolDenied({other:?})")
+        }
+        TurnResult::ToolError(other) => {
+            panic!("expected FinalText, got ToolError({other:?})")
+        }
+        TurnResult::ProviderError(other) => {
+            panic!("expected FinalText, got ProviderError({other:?})")
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(feature = "memory-sqlite")]
 async fn autonomy_policy_turn_engine_discovery_only_denies_capability_install() {
     use crate::conversation::turn_engine::{
@@ -11962,11 +12096,15 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
             request: ToolCoreRequest,
         ) -> Result<ToolCoreOutcome, ToolPlaneError> {
             let (tool_name, _arguments) = effective_tool_request(&request);
+            let instructions = "Follow the managed skill instruction. ".repeat(2_500);
+
             Ok(ToolCoreOutcome {
                 status: "ok".to_owned(),
                 payload: json!({
+                    "skill_id": "demo-skill",
+                    "display_name": "Demo Skill",
                     "tool": tool_name,
-                    "instructions": "Follow the managed skill instruction. ".repeat(200),
+                    "instructions": instructions,
                     "invocation_summary": "Loaded managed external skill instructions."
                 }),
             })
@@ -12049,14 +12187,25 @@ async fn turn_engine_keeps_external_skill_invoke_payloads_intact() {
             let envelope: Value =
                 serde_json::from_str(payload).expect("tool result envelope should be valid json");
             assert_eq!(envelope["tool"], "external_skills.invoke");
+            assert_eq!(
+                envelope["payload_semantics"],
+                json!("external_skill_context")
+            );
             assert_eq!(envelope["payload_truncated"], json!(false));
             assert!(
-                envelope["payload_summary"]
-                    .as_str()
-                    .expect("payload summary should be text")
-                    .contains("Follow the managed skill instruction."),
+                envelope["payload_chars"]
+                    .as_u64()
+                    .expect("payload chars should be present")
+                    > 64_000
+            );
+            let payload_summary = envelope["payload_summary"]
+                .as_str()
+                .expect("payload summary should be text");
+            assert!(
+                payload_summary.contains("Follow the managed skill instruction."),
                 "payload summary should keep invoke instructions intact: {envelope:?}"
             );
+            assert!(payload_summary.chars().count() > 64_000);
         }
         other @ TurnResult::ToolDenied(_)
         | other @ TurnResult::NeedsApproval(_)

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1165,16 +1165,14 @@ fn build_tool_result_envelope(
 ) -> ToolResultEnvelope {
     let effective_tool_name = effective_result_tool_name(intent);
     let payload_semantics = detect_tool_result_payload_semantics(&outcome.payload);
-    let effective_limit =
-        effective_payload_summary_limit(payload_semantics, payload_summary_limit_chars);
-    let normalized_limit = effective_limit.clamp(
+    let normalized_limit = payload_summary_limit_chars.clamp(
         MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
         MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
     );
     let payload_text = serde_json::to_string(&outcome.payload)
         .unwrap_or_else(|_| "[tool_payload_unserializable]".to_owned());
     let (payload_summary, payload_chars, payload_truncated) =
-        truncate_by_chars(payload_text.as_str(), normalized_limit);
+        summarize_tool_result_payload(payload_text.as_str(), payload_semantics, normalized_limit);
 
     ToolResultEnvelope {
         status: outcome.status.clone(),
@@ -1187,14 +1185,18 @@ fn build_tool_result_envelope(
     }
 }
 
-fn effective_payload_summary_limit(
+fn summarize_tool_result_payload(
+    payload_text: &str,
     payload_semantics: Option<ToolResultPayloadSemantics>,
-    default_limit: usize,
-) -> usize {
+    payload_summary_limit_chars: usize,
+) -> (String, usize, bool) {
     if payload_semantics.is_some() {
-        return MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS;
+        let payload_chars = payload_text.chars().count();
+        let payload_summary = payload_text.to_owned();
+        return (payload_summary, payload_chars, false);
     }
-    default_limit
+
+    truncate_by_chars(payload_text, payload_summary_limit_chars)
 }
 
 fn detect_tool_result_payload_semantics(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -119,9 +119,18 @@ pub struct ToolResultEnvelope {
     pub status: String,
     pub tool: String,
     pub tool_call_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_semantics: Option<ToolResultPayloadSemantics>,
     pub payload_summary: String,
     pub payload_chars: usize,
     pub payload_truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolResultPayloadSemantics {
+    DiscoveryResult,
+    ExternalSkillContext,
 }
 
 const TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS: usize = 2048;
@@ -1155,11 +1164,13 @@ fn build_tool_result_envelope(
     payload_summary_limit_chars: usize,
 ) -> ToolResultEnvelope {
     let effective_tool_name = effective_result_tool_name(intent);
-    let normalized_limit = effective_payload_summary_limit(intent, payload_summary_limit_chars)
-        .clamp(
-            MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-            MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
-        );
+    let payload_semantics = detect_tool_result_payload_semantics(&outcome.payload);
+    let effective_limit =
+        effective_payload_summary_limit(payload_semantics, payload_summary_limit_chars);
+    let normalized_limit = effective_limit.clamp(
+        MIN_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+        MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS,
+    );
     let payload_text = serde_json::to_string(&outcome.payload)
         .unwrap_or_else(|_| "[tool_payload_unserializable]".to_owned());
     let (payload_summary, payload_chars, payload_truncated) =
@@ -1169,17 +1180,85 @@ fn build_tool_result_envelope(
         status: outcome.status.clone(),
         tool: effective_tool_name,
         tool_call_id: intent.tool_call_id.clone(),
+        payload_semantics,
         payload_summary,
         payload_chars,
         payload_truncated,
     }
 }
 
-fn effective_payload_summary_limit(intent: &ToolIntent, default_limit: usize) -> usize {
-    if effective_result_tool_name(intent) == "external_skills.invoke" {
+fn effective_payload_summary_limit(
+    payload_semantics: Option<ToolResultPayloadSemantics>,
+    default_limit: usize,
+) -> usize {
+    if payload_semantics.is_some() {
         return MAX_TOOL_RESULT_PAYLOAD_SUMMARY_LIMIT_CHARS;
     }
     default_limit
+}
+
+fn detect_tool_result_payload_semantics(
+    payload: &serde_json::Value,
+) -> Option<ToolResultPayloadSemantics> {
+    let looks_like_discovery_result = payload_looks_like_discovery_result(payload);
+    if looks_like_discovery_result {
+        return Some(ToolResultPayloadSemantics::DiscoveryResult);
+    }
+
+    let looks_like_external_skill_context = payload_looks_like_external_skill_context(payload);
+    if looks_like_external_skill_context {
+        return Some(ToolResultPayloadSemantics::ExternalSkillContext);
+    }
+
+    None
+}
+
+fn payload_looks_like_discovery_result(payload: &serde_json::Value) -> bool {
+    let Some(payload_object) = payload.as_object() else {
+        return false;
+    };
+    let Some(results) = payload_object
+        .get("results")
+        .and_then(serde_json::Value::as_array)
+    else {
+        return false;
+    };
+
+    if results.is_empty() {
+        return payload_object.contains_key("query");
+    }
+
+    results.iter().any(|result| {
+        let Some(result_object) = result.as_object() else {
+            return false;
+        };
+        result_object
+            .get("tool_id")
+            .and_then(serde_json::Value::as_str)
+            .is_some()
+            && result_object
+                .get("lease")
+                .and_then(serde_json::Value::as_str)
+                .is_some()
+    })
+}
+
+fn payload_looks_like_external_skill_context(payload: &serde_json::Value) -> bool {
+    let Some(payload_object) = payload.as_object() else {
+        return false;
+    };
+    payload_object
+        .get("skill_id")
+        .and_then(serde_json::Value::as_str)
+        .is_some()
+        && payload_object
+            .get("display_name")
+            .and_then(serde_json::Value::as_str)
+            .is_some()
+        && payload_object
+            .get("instructions")
+            .and_then(serde_json::Value::as_str)
+            .is_some()
 }
 
 pub(crate) fn effective_result_tool_name(intent: &ToolIntent) -> String {

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -2520,14 +2520,14 @@ mod tests {
         );
 
         let prompt = build_tool_followup_user_prompt(
-            "查询 AI 新闻，聚合返回",
+            "find the latest ai news and summarize it",
             None,
             Some(tool_result.as_str()),
             None,
         );
 
         assert!(prompt.contains(DISCOVERY_RESULT_FOLLOWUP_PROMPT));
-        assert!(prompt.contains("Original request:\n查询 AI 新闻，聚合返回"));
+        assert!(prompt.contains("Original request:\nfind the latest ai news and summarize it"));
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -3,7 +3,10 @@ use super::ProviderErrorMode;
 use super::persistence::format_provider_error_reply;
 use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
-use super::turn_engine::{ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, TurnResult};
+use super::turn_engine::{
+    ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, ToolResultPayloadSemantics,
+    TurnResult,
+};
 use serde::Serialize;
 use serde_json::{Map, Value};
 use std::borrow::Cow;
@@ -14,6 +17,7 @@ use unicode_normalization::UnicodeNormalization;
 use crate::CliResult;
 
 pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
+pub const DISCOVERY_RESULT_FOLLOWUP_PROMPT: &str = "The tool result above is a discovery result, not the final evidence. Choose the best matching discovered tool, reuse its lease when invoking it, continue with the next tool call needed to satisfy the original user request, and only answer directly if the discovery results already contain the final user-facing information.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "An external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
@@ -946,9 +950,19 @@ pub fn tool_result_contains_truncation_signal(tool_result_text: &str) -> bool {
 }
 
 fn line_contains_structured_truncation_signal(line: &str) -> bool {
+    let Some(envelope) = parse_tool_result_envelope(line) else {
+        return false;
+    };
+    envelope
+        .get("payload_truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn parse_tool_result_envelope(line: &str) -> Option<Value> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
-        return false;
+        return None;
     }
     let candidate = if trimmed.starts_with('[') {
         trimmed
@@ -959,16 +973,9 @@ fn line_contains_structured_truncation_signal(line: &str) -> bool {
         trimmed
     };
     if !(candidate.starts_with('{') || candidate.starts_with('[')) {
-        return false;
+        return None;
     }
-    let envelope = match serde_json::from_str::<Value>(candidate) {
-        Ok(value) => value,
-        Err(_) => return false,
-    };
-    envelope
-        .get("payload_truncated")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+    serde_json::from_str::<Value>(candidate).ok()
 }
 
 pub fn build_tool_followup_user_prompt(
@@ -977,7 +984,14 @@ pub fn build_tool_followup_user_prompt(
     tool_result_text: Option<&str>,
     rendered_tool_result_text: Option<&str>,
 ) -> String {
-    let mut sections = vec![TOOL_FOLLOWUP_PROMPT.to_owned()];
+    let prompt =
+        if followup_prompt_uses_discovery_guidance(tool_result_text, rendered_tool_result_text) {
+            DISCOVERY_RESULT_FOLLOWUP_PROMPT
+        } else {
+            TOOL_FOLLOWUP_PROMPT
+        };
+
+    let mut sections = vec![prompt.to_owned()];
     if let Some(reason) = loop_warning_reason {
         sections.push(format!(
             "Loop warning:\n{reason}\nAvoid repeating the same tool call with unchanged results. Try a different tool, adjust arguments, or provide a best-effort final answer if evidence is sufficient."
@@ -999,6 +1013,18 @@ fn followup_prompt_needs_truncation_hint(
         .unwrap_or(false)
         || rendered_tool_result_text
             .map(tool_result_contains_truncation_signal)
+            .unwrap_or(false)
+}
+
+fn followup_prompt_uses_discovery_guidance(
+    tool_result_text: Option<&str>,
+    rendered_tool_result_text: Option<&str>,
+) -> bool {
+    tool_result_text
+        .map(tool_result_contains_discovery_payload)
+        .unwrap_or(false)
+        || rendered_tool_result_text
+            .map(tool_result_contains_discovery_payload)
             .unwrap_or(false)
 }
 
@@ -1044,6 +1070,84 @@ fn reduce_tool_result_text_for_model(text: &str) -> Option<String> {
     Some(reduced)
 }
 
+fn tool_result_contains_discovery_payload(tool_result_text: &str) -> bool {
+    tool_result_text
+        .lines()
+        .filter_map(parse_tool_result_envelope)
+        .any(|envelope| envelope_uses_discovery_semantics(&envelope))
+}
+
+fn envelope_uses_discovery_semantics(envelope: &Value) -> bool {
+    let uses_explicit_semantics =
+        envelope_has_payload_semantics(envelope, ToolResultPayloadSemantics::DiscoveryResult);
+    if uses_explicit_semantics {
+        return true;
+    }
+    envelope_contains_discovery_payload(envelope)
+}
+
+fn envelope_uses_external_skill_context(envelope: &Value) -> bool {
+    let uses_explicit_semantics =
+        envelope_has_payload_semantics(envelope, ToolResultPayloadSemantics::ExternalSkillContext);
+    if uses_explicit_semantics {
+        return true;
+    }
+
+    envelope_uses_legacy_external_skill_tool(envelope)
+}
+
+fn envelope_uses_legacy_external_skill_tool(envelope: &Value) -> bool {
+    let tool_name = envelope.get("tool").and_then(Value::as_str);
+    tool_name == Some("external_skills.invoke")
+}
+
+fn envelope_contains_discovery_payload(envelope: &Value) -> bool {
+    let Some(payload_summary) = envelope.get("payload_summary").and_then(Value::as_str) else {
+        return false;
+    };
+    let Ok(payload_json) = serde_json::from_str::<Value>(payload_summary) else {
+        return false;
+    };
+    payload_summary_looks_like_discovery_result(&payload_json)
+}
+
+fn payload_summary_looks_like_discovery_result(payload: &Value) -> bool {
+    let Some(payload_object) = payload.as_object() else {
+        return false;
+    };
+    let Some(results) = payload_object.get("results").and_then(Value::as_array) else {
+        return false;
+    };
+
+    if results.is_empty() {
+        return payload_object.contains_key("query");
+    }
+
+    results.iter().any(|result| {
+        let Some(result_object) = result.as_object() else {
+            return false;
+        };
+        result_object
+            .get("tool_id")
+            .and_then(Value::as_str)
+            .is_some()
+            && result_object.get("lease").and_then(Value::as_str).is_some()
+    })
+}
+
+fn envelope_payload_semantics(envelope: &Value) -> Option<ToolResultPayloadSemantics> {
+    let payload_semantics_value = envelope.get("payload_semantics")?;
+    serde_json::from_value(payload_semantics_value.clone()).ok()
+}
+
+fn envelope_has_payload_semantics(
+    envelope: &Value,
+    expected_semantics: ToolResultPayloadSemantics,
+) -> bool {
+    let payload_semantics = envelope_payload_semantics(envelope);
+    payload_semantics == Some(expected_semantics)
+}
+
 fn reduce_tool_result_line_for_model(line: &str) -> String {
     let trimmed = line.trim();
     if trimmed.is_empty() {
@@ -1058,10 +1162,6 @@ fn reduce_tool_result_line_for_model(line: &str) -> String {
     let Ok(mut envelope) = serde_json::from_str::<Value>(payload) else {
         return line.to_owned();
     };
-    let Some(tool) = envelope.get("tool").and_then(Value::as_str) else {
-        return line.to_owned();
-    };
-
     let payload_truncated = envelope
         .get("payload_truncated")
         .and_then(Value::as_bool)
@@ -1070,21 +1170,23 @@ fn reduce_tool_result_line_for_model(line: &str) -> String {
         return line.to_owned();
     };
 
-    let reduction = match tool {
-        "file.read" => {
+    let reduction = match envelope.get("tool").and_then(Value::as_str) {
+        Some("file.read") => {
             let Ok(payload_json) = serde_json::from_str::<Value>(payload_summary) else {
                 return line.to_owned();
             };
             reduce_file_read_payload_summary(&payload_json).map(|summary| (summary, true))
         }
-        "shell.exec" => {
+        Some("shell.exec") => {
             let Ok(mut payload_json) = serde_json::from_str::<Value>(payload_summary) else {
                 return line.to_owned();
             };
             reduce_shell_payload_summary(&mut payload_json).map(|summary| (summary, true))
         }
-        "tool.search" if !payload_truncated => {
-            compact_tool_search_payload_summary_str(payload_summary).map(|summary| (summary, false))
+        _ if !payload_truncated => {
+            let payload_semantics = envelope_payload_semantics(&envelope);
+            compact_discovery_payload_summary_str(payload_summary, payload_semantics)
+                .map(|summary| (summary, false))
         }
         _ => None,
     };
@@ -1229,14 +1331,26 @@ pub fn build_external_skill_followup_user_prompt(
     sections.join("\n\n")
 }
 
-fn compact_tool_search_payload_summary_str(payload_summary: &str) -> Option<String> {
+fn compact_discovery_payload_summary_str(
+    payload_summary: &str,
+    payload_semantics: Option<ToolResultPayloadSemantics>,
+) -> Option<String> {
     let payload_json = serde_json::from_str::<Value>(payload_summary).ok()?;
-    let compacted_summary = compact_tool_search_payload_summary(&payload_json)?;
+    let compacted_summary = compact_discovery_payload_summary(&payload_json, payload_semantics)?;
     let compacted_summary_str = serde_json::to_string(&compacted_summary).ok()?;
     (compacted_summary_str.len() < payload_summary.len()).then_some(compacted_summary_str)
 }
 
-fn compact_tool_search_payload_summary(payload: &Value) -> Option<Value> {
+fn compact_discovery_payload_summary(
+    payload: &Value,
+    payload_semantics: Option<ToolResultPayloadSemantics>,
+) -> Option<Value> {
+    let use_discovery_compaction = payload_semantics
+        == Some(ToolResultPayloadSemantics::DiscoveryResult)
+        || payload_summary_looks_like_discovery_result(payload);
+    if !use_discovery_compaction {
+        return None;
+    }
     let payload_object = payload.as_object()?;
     let results = payload_object.get("results")?.as_array()?;
 
@@ -1249,7 +1363,7 @@ fn compact_tool_search_payload_summary(payload: &Value) -> Option<Value> {
         Value::Array(
             results
                 .iter()
-                .map(compact_tool_search_payload_result)
+                .map(compact_discovery_payload_result)
                 .collect(),
         ),
     );
@@ -1257,7 +1371,7 @@ fn compact_tool_search_payload_summary(payload: &Value) -> Option<Value> {
     Some(Value::Object(compacted))
 }
 
-fn compact_tool_search_payload_result(result: &Value) -> Value {
+fn compact_discovery_payload_result(result: &Value) -> Value {
     let Some(result_object) = result.as_object() else {
         return result.clone();
     };
@@ -1504,7 +1618,8 @@ fn parse_external_skill_invoke_context_line(line: &str) -> Option<ExternalSkillI
     }
     let payload = trimmed.strip_prefix("[ok] ")?;
     let envelope: Value = serde_json::from_str(payload).ok()?;
-    if envelope.get("tool")?.as_str()? != "external_skills.invoke" {
+    let uses_external_skill_context = envelope_uses_external_skill_context(&envelope);
+    if !uses_external_skill_context {
         return None;
     }
     if envelope
@@ -2092,6 +2207,33 @@ mod tests {
     }
 
     #[test]
+    fn tool_result_followup_tail_promotes_external_skill_from_semantic_envelope() {
+        let tail = build_tool_result_followup_tail(
+            "preface",
+            r#"[ok] {"status":"ok","tool":"file.read","tool_call_id":"call-1","payload_semantics":"external_skill_context","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#,
+            "summarize note.md",
+            Some("warning"),
+            |_, _| panic!("external skill payload should bypass payload mapper"),
+        );
+
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("system".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| {
+                        content.contains("Follow the managed skill instruction before answering.")
+                    })
+                    .unwrap_or(false)
+        }));
+        assert!(
+            tail.iter()
+                .filter_map(|message| message.get("content").and_then(Value::as_str))
+                .all(|content| !content.contains("[tool_result]\n[ok]"))
+        );
+    }
+
+    #[test]
     fn tool_result_followup_tail_uses_payload_mapper_and_keeps_truncation_hint() {
         let tail = build_tool_result_followup_tail(
             "preface",
@@ -2354,6 +2496,41 @@ mod tests {
     }
 
     #[test]
+    fn followup_prompt_uses_discovery_guidance_for_discovery_shaped_results() {
+        let payload_summary = json!({
+            "query": "latest ai news",
+            "results": [
+                {
+                    "tool_id": "web.search",
+                    "lease": "lease-web-search"
+                }
+            ]
+        })
+        .to_string();
+        let tool_result = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "file.read",
+                "tool_call_id": "call-search",
+                "payload_summary": payload_summary,
+                "payload_chars": 512,
+                "payload_truncated": false
+            })
+        );
+
+        let prompt = build_tool_followup_user_prompt(
+            "查询 AI 新闻，聚合返回",
+            None,
+            Some(tool_result.as_str()),
+            None,
+        );
+
+        assert!(prompt.contains(DISCOVERY_RESULT_FOLLOWUP_PROMPT));
+        assert!(prompt.contains("Original request:\n查询 AI 新闻，聚合返回"));
+    }
+
+    #[test]
     fn reduce_followup_payload_for_model_preserves_shell_payload_metadata() {
         let payload = json!({
             "adapter": "core-tools",
@@ -2516,7 +2693,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_external_skill_invoke_context_extracts_full_instructions() {
+    fn parse_external_skill_invoke_context_extracts_full_instructions_from_semantic_envelope() {
         let instructions = format!("prefix {}\nsuffix-marker", "x".repeat(256));
         let payload = json!({
             "skill_id": "demo-skill",
@@ -2527,8 +2704,9 @@ mod tests {
             "[ok] {}",
             json!({
                 "status": "ok",
-                "tool": "external_skills.invoke",
+                "tool": "file.read",
                 "tool_call_id": "call-1",
+                "payload_semantics": "external_skill_context",
                 "payload_summary": serde_json::to_string(&payload).expect("encode payload"),
                 "payload_chars": 512,
                 "payload_truncated": false
@@ -2540,6 +2718,31 @@ mod tests {
         assert_eq!(parsed.skill_id, "demo-skill");
         assert_eq!(parsed.display_name, "Demo Skill");
         assert!(parsed.instructions.contains("suffix-marker"));
+    }
+
+    #[test]
+    fn parse_external_skill_invoke_context_requires_semantics_or_legacy_tool_name() {
+        let payload = json!({
+            "skill_id": "demo-skill",
+            "display_name": "Demo Skill",
+            "instructions": "Follow the managed skill instruction before answering.",
+        });
+        let line = format!(
+            "[ok] {}",
+            json!({
+                "status": "ok",
+                "tool": "file.read",
+                "tool_call_id": "call-1",
+                "payload_summary": serde_json::to_string(&payload).expect("encode payload"),
+                "payload_chars": 512,
+                "payload_truncated": false
+            })
+        );
+
+        assert!(
+            parse_external_skill_invoke_context(line.as_str()).is_none(),
+            "skill-shaped payloads should not activate managed skill context without semantics or the legacy tool name"
+        );
     }
 
     #[test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -8,6 +8,7 @@ pub mod conversation;
 pub mod crypto;
 pub mod memory;
 pub mod migration;
+pub(crate) mod observability;
 pub mod presentation;
 pub mod prompt;
 pub mod provider;

--- a/crates/app/src/observability.rs
+++ b/crates/app/src/observability.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 const MAX_LOGGED_JSON_KEYS: usize = 8;
+const MAX_LOGGED_JSON_KEY_CHARS: usize = 48;
 const MAX_ERROR_CHARS: usize = 240;
 
 pub(crate) fn json_value_kind(value: &Value) -> &'static str {
@@ -22,12 +23,23 @@ pub(crate) fn top_level_json_keys(value: &Value) -> Vec<String> {
     let mut keys = map
         .keys()
         .take(MAX_LOGGED_JSON_KEYS)
-        .cloned()
+        .map(|key| truncate_logged_json_key(key))
         .collect::<Vec<_>>();
     if map.len() > MAX_LOGGED_JSON_KEYS {
         keys.push(format!("+{}", map.len() - MAX_LOGGED_JSON_KEYS));
     }
     keys
+}
+
+fn truncate_logged_json_key(key: &str) -> String {
+    let key_chars = key.chars().count();
+    if key_chars <= MAX_LOGGED_JSON_KEY_CHARS {
+        return key.to_owned();
+    }
+
+    let visible_chars = MAX_LOGGED_JSON_KEY_CHARS.saturating_sub(3);
+    let truncated = key.chars().take(visible_chars).collect::<String>();
+    format!("{truncated}...")
 }
 
 pub(crate) fn summarize_error(error: &str) -> String {
@@ -45,7 +57,7 @@ pub(crate) fn summarize_error(error: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use serde_json::{Map, Value, json};
 
     use super::{json_value_kind, summarize_error, top_level_json_keys};
 
@@ -87,6 +99,20 @@ mod tests {
                 "+1".to_owned()
             ]
         );
+    }
+
+    #[test]
+    fn top_level_json_keys_truncates_individual_key_length() {
+        let mut map = Map::new();
+        let long_key = "k".repeat(80);
+
+        map.insert(long_key, json!(1));
+
+        let value = Value::Object(map);
+        let keys = top_level_json_keys(&value);
+        let first_key = keys.first().expect("first key should exist");
+
+        assert!(first_key.chars().count() <= 48);
     }
 
     #[test]

--- a/crates/app/src/observability.rs
+++ b/crates/app/src/observability.rs
@@ -1,0 +1,102 @@
+use serde_json::Value;
+
+const MAX_LOGGED_JSON_KEYS: usize = 8;
+const MAX_ERROR_CHARS: usize = 240;
+
+pub(crate) fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+pub(crate) fn top_level_json_keys(value: &Value) -> Vec<String> {
+    let Value::Object(map) = value else {
+        return Vec::new();
+    };
+
+    let mut keys = map
+        .keys()
+        .take(MAX_LOGGED_JSON_KEYS)
+        .cloned()
+        .collect::<Vec<_>>();
+    if map.len() > MAX_LOGGED_JSON_KEYS {
+        keys.push(format!("+{}", map.len() - MAX_LOGGED_JSON_KEYS));
+    }
+    keys
+}
+
+pub(crate) fn summarize_error(error: &str) -> String {
+    let compact = error.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= MAX_ERROR_CHARS {
+        return compact;
+    }
+
+    let truncated = compact
+        .chars()
+        .take(MAX_ERROR_CHARS.saturating_sub(3))
+        .collect::<String>();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{json_value_kind, summarize_error, top_level_json_keys};
+
+    #[test]
+    fn json_value_kind_labels_common_shapes() {
+        assert_eq!(json_value_kind(&json!(null)), "null");
+        assert_eq!(json_value_kind(&json!(true)), "bool");
+        assert_eq!(json_value_kind(&json!(1)), "number");
+        assert_eq!(json_value_kind(&json!("hello")), "string");
+        assert_eq!(json_value_kind(&json!([1, 2, 3])), "array");
+        assert_eq!(json_value_kind(&json!({"command": "pwd"})), "object");
+    }
+
+    #[test]
+    fn top_level_json_keys_limits_output() {
+        let value = json!({
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+            "e": 5,
+            "f": 6,
+            "g": 7,
+            "h": 8,
+            "i": 9
+        });
+
+        assert_eq!(
+            top_level_json_keys(&value),
+            vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned(),
+                "e".to_owned(),
+                "f".to_owned(),
+                "g".to_owned(),
+                "h".to_owned(),
+                "+1".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn summarize_error_collapses_whitespace_and_truncates() {
+        let repeated = "detail ".repeat(64);
+        let summary = summarize_error(&format!("line one\nline two\t{repeated}"));
+
+        assert!(!summary.contains('\n'));
+        assert!(!summary.contains('\t'));
+        assert!(summary.ends_with("..."));
+        assert!(summary.chars().count() <= 240);
+    }
+}

--- a/crates/app/src/provider/request_failover_runtime.rs
+++ b/crates/app/src/provider/request_failover_runtime.rs
@@ -34,6 +34,15 @@ where
 
     let ordered_profiles =
         prioritize_provider_auth_profiles_by_health(auth_profiles, profile_state_policy);
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %provider.kind.profile().id,
+        binding = %binding.as_str(),
+        model_candidate_count = model_candidates.len(),
+        auth_profile_count = ordered_profiles.len(),
+        auto_model_mode,
+        "dispatching provider request across model candidates"
+    );
     let mut last_error = None;
     let mut last_error_snapshot = None;
     for (model_index, model) in model_candidates.iter().enumerate() {
@@ -44,6 +53,18 @@ where
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_success(policy, profile);
                     }
+                    tracing::debug!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %model,
+                        auth_profile_id = %profile.id,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        "provider request succeeded"
+                    );
                     return Ok(value);
                 }
                 Err(model_error) => {
@@ -54,6 +75,8 @@ where
                         snapshot,
                         ..
                     } = model_error;
+                    let exhausted = profile_index + 1 >= ordered_profiles.len()
+                        && model_index + 1 >= model_candidates.len();
                     record_provider_failover_audit_event(
                         binding,
                         provider,
@@ -62,12 +85,31 @@ where
                         auto_model_mode,
                         model_index,
                         model_candidates.len(),
-                        profile_index + 1 >= ordered_profiles.len()
-                            && model_index + 1 >= model_candidates.len(),
+                        exhausted,
                     );
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_failure(policy, profile, reason);
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %snapshot.model,
+                        auth_profile_id = %profile.id,
+                        reason = %snapshot.reason.as_str(),
+                        stage = %snapshot.stage.as_str(),
+                        attempt = snapshot.attempt,
+                        max_attempts = snapshot.max_attempts,
+                        status_code = ?snapshot.status_code,
+                        try_next_model,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        exhausted,
+                        error = %crate::observability::summarize_error(message.as_str()),
+                        "provider request attempt failed"
+                    );
                     last_error = Some(message);
                     last_error_snapshot = Some(snapshot);
 

--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -87,6 +87,14 @@ pub(super) async fn prepare_provider_request_session(
                             classify_profile_failure_reason_from_message(error.as_str()),
                         );
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %config.provider.kind.profile().id,
+                        auth_profile_id = %profile.id,
+                        auto_model_mode,
+                        error = %crate::observability::summarize_error(error.as_str()),
+                        "provider model catalog resolution failed for auth profile"
+                    );
                     last_error = Some(error);
                 }
             }
@@ -108,7 +116,7 @@ pub(super) async fn prepare_provider_request_session(
         .await?
     };
 
-    Ok(ProviderRequestSession {
+    let session = ProviderRequestSession {
         endpoint,
         headers,
         request_policy,
@@ -119,7 +127,16 @@ pub(super) async fn prepare_provider_request_session(
         auto_model_mode,
         model_candidate_cooldown_policy,
         auth_context,
-    })
+    };
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %config.provider.kind.profile().id,
+        auth_profile_count = session.auth_profiles.len(),
+        model_candidate_count = session.model_candidates.len(),
+        auto_model_mode = session.auto_model_mode,
+        "prepared provider request session"
+    );
+    Ok(session)
 }
 
 fn build_model_candidate_cooldown_policy(

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -23,7 +23,24 @@ impl<'a> ProviderRuntimeBinding<'a> {
         }
     }
 
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Kernel(_) => "kernel",
+            Self::Direct => "direct",
+        }
+    }
+
     pub const fn is_kernel_bound(self) -> bool {
         matches!(self, Self::Kernel(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProviderRuntimeBinding;
+
+    #[test]
+    fn provider_runtime_binding_labels_are_stable() {
+        assert_eq!(ProviderRuntimeBinding::direct().as_str(), "direct");
     }
 }

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -41,6 +41,12 @@ mod tests {
 
     #[test]
     fn provider_runtime_binding_labels_are_stable() {
+        let kernel_context =
+            crate::context::bootstrap_test_kernel_context("runtime-binding-test", 60)
+                .expect("kernel context should bootstrap");
+        let binding = ProviderRuntimeBinding::kernel(&kernel_context);
+
         assert_eq!(ProviderRuntimeBinding::direct().as_str(), "direct");
+        assert_eq!(binding.as_str(), "kernel");
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -660,6 +660,17 @@ pub fn execute_tool_core_with_config(
         &request.payload,
         "payload",
     )?;
+    let requested_tool_name = request.tool_name.clone();
+    let payload_kind = crate::observability::json_value_kind(&request.payload);
+    let payload_keys = crate::observability::top_level_json_keys(&request.payload);
+    if !trusted_internal_tool_payload_enabled()
+        && payload_uses_reserved_internal_tool_context(&request.payload)
+    {
+        return Err(format!(
+            "tool `{}` payload.{LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY} is reserved for trusted internal tool context; retry without that field",
+            request.tool_name
+        ));
+    }
     let canonical_name = canonical_tool_name(request.tool_name.as_str());
     let request = ToolCoreRequest {
         tool_name: canonical_name.to_owned(),
@@ -668,11 +679,40 @@ pub fn execute_tool_core_with_config(
     let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)?
         .map(|narrowing| config.narrowed(&narrowing));
     let config = effective_config.as_ref().unwrap_or(config);
-    match canonical_name {
+    let started_at = std::time::Instant::now();
+    let result = match canonical_name {
         "tool.search" => execute_tool_search_tool_with_config(request, config),
         "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
         _ => execute_discoverable_tool_core_with_config(request, config),
+    };
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(outcome) => {
+            tracing::debug!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                status = %outcome.status,
+                duration_ms,
+                "tool execution completed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "tool execution failed"
+            );
+        }
     }
+    result
 }
 
 fn trusted_runtime_narrowing_from_payload(

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -78,6 +78,8 @@ semver.workspace = true
 ed25519-dalek.workspace = true
 dunce = "1"
 tokio-stream = { version = "0.1", features = ["sync"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [[bin]]
 name = "loong"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -120,9 +120,9 @@ pub use gateway::read_models::{ChannelsCliJsonPayload, ChannelsCliJsonSchema};
 pub use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,
 };
+pub use observability::{debug_variant_name, init_tracing, summarize_error};
 pub use tlon_cli::TLON_SEND_CLI_SPEC;
 use tlon_cli::{default_tlon_send_target_kind, parse_tlon_send_target_kind};
-pub use observability::init_tracing;
 
 #[allow(
     clippy::expect_used,

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -94,6 +94,7 @@ mod memory_context_benchmark;
 pub mod migrate_cli;
 pub mod migration;
 pub mod next_actions;
+mod observability;
 pub mod onboard_cli;
 mod onboard_finalize;
 mod onboard_preflight;
@@ -121,6 +122,7 @@ pub use loongclaw_spec::programmatic::{
 };
 pub use tlon_cli::TLON_SEND_CLI_SPEC;
 use tlon_cli::{default_tlon_send_target_kind, parse_tlon_send_target_kind};
+pub use observability::init_tracing;
 
 #[allow(
     clippy::expect_used,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -39,8 +39,14 @@ async fn main() {
     init_tracing();
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
     let cli = parse_cli();
-    tracing::debug!(target: "loongclaw.daemon", command = ?cli.command, "parsed CLI command");
-    let result = match cli.command.unwrap_or_else(resolve_default_entry_command) {
+    let command = cli.command.unwrap_or_else(resolve_default_entry_command);
+    let command_name = debug_variant_name(&command);
+    tracing::debug!(
+        target: "loongclaw.daemon",
+        command = %command_name,
+        "parsed CLI command"
+    );
+    let result = match command {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
         Commands::RunTask { objective, payload } => run_task_cli(&objective, &payload).await,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -36,8 +36,10 @@ impl Drop for StdinGuard {
 #[tokio::main]
 async fn main() {
     let _stdin_guard = StdinGuard;
+    init_tracing();
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
     let cli = parse_cli();
+    tracing::debug!(target: "loongclaw.daemon", command = ?cli.command, "parsed CLI command");
     let result = match cli.command.unwrap_or_else(resolve_default_entry_command) {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
@@ -952,6 +954,11 @@ async fn main() {
         }
     };
     if let Err(error) = result {
+        tracing::error!(
+            target: "loongclaw.daemon",
+            error = %error,
+            "CLI command failed"
+        );
         #[allow(clippy::print_stderr)]
         {
             eprintln!("error: {error}");

--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -1,0 +1,99 @@
+use std::io::{self, IsTerminal};
+
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+
+const DEFAULT_LOG_FILTER: &str = "warn";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogFormat {
+    Compact,
+    Pretty,
+    Json,
+}
+
+impl LogFormat {
+    fn parse(raw: Option<&str>) -> Self {
+        match raw
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("compact")
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "pretty" => Self::Pretty,
+            "json" => Self::Json,
+            _ => Self::Compact,
+        }
+    }
+}
+
+fn resolved_log_directive(loongclaw_log: Option<&str>, rust_log: Option<&str>) -> String {
+    loongclaw_log
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| rust_log.map(str::trim).filter(|value| !value.is_empty()))
+        .unwrap_or(DEFAULT_LOG_FILTER)
+        .to_owned()
+}
+
+fn build_env_filter(raw: &str) -> EnvFilter {
+    EnvFilter::try_new(raw).unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER))
+}
+
+pub fn init_tracing() {
+    let log_format = LogFormat::parse(std::env::var("LOONGCLAW_LOG_FORMAT").ok().as_deref());
+    let directive = resolved_log_directive(
+        std::env::var("LOONGCLAW_LOG").ok().as_deref(),
+        std::env::var("RUST_LOG").ok().as_deref(),
+    );
+    let env_filter = build_env_filter(directive.as_str());
+    let use_ansi = log_format != LogFormat::Json && io::stderr().is_terminal();
+    let base = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(io::stderr)
+        .with_target(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_ansi(use_ansi);
+
+    let _ = match log_format {
+        LogFormat::Compact => base.compact().finish().try_init(),
+        LogFormat::Pretty => base.pretty().finish().try_init(),
+        LogFormat::Json => base.json().flatten_event(true).finish().try_init(),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogFormat, build_env_filter, resolved_log_directive};
+
+    #[test]
+    fn resolved_log_directive_prefers_loongclaw_log() {
+        assert_eq!(
+            resolved_log_directive(Some("loongclaw_app=debug"), Some("warn")),
+            "loongclaw_app=debug"
+        );
+    }
+
+    #[test]
+    fn resolved_log_directive_falls_back_to_rust_log_then_default() {
+        assert_eq!(resolved_log_directive(None, Some("info")), "info");
+        assert_eq!(resolved_log_directive(None, None), "warn");
+    }
+
+    #[test]
+    fn parse_log_format_accepts_known_variants() {
+        assert_eq!(LogFormat::parse(Some("pretty")), LogFormat::Pretty);
+        assert_eq!(LogFormat::parse(Some("json")), LogFormat::Json);
+        assert_eq!(LogFormat::parse(Some("compact")), LogFormat::Compact);
+        assert_eq!(LogFormat::parse(Some("unknown")), LogFormat::Compact);
+    }
+
+    #[test]
+    fn build_env_filter_falls_back_on_invalid_directive() {
+        let filter = build_env_filter("[broken");
+        let rendered = filter.to_string();
+        assert_eq!(rendered, "warn");
+    }
+}

--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::io::{self, IsTerminal};
 
 use tracing_subscriber::EnvFilter;
@@ -5,6 +6,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 
 const DEFAULT_LOG_FILTER: &str = "warn";
+const MAX_ERROR_CHARS: usize = 240;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LogFormat {
@@ -42,6 +44,26 @@ fn build_env_filter(raw: &str) -> EnvFilter {
     EnvFilter::try_new(raw).unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER))
 }
 
+pub fn summarize_error(error: &str) -> String {
+    let compact = error.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= MAX_ERROR_CHARS {
+        return compact;
+    }
+
+    let visible_chars = MAX_ERROR_CHARS.saturating_sub(3);
+    let truncated = compact.chars().take(visible_chars).collect::<String>();
+    format!("{truncated}...")
+}
+
+pub fn debug_variant_name(value: &impl Debug) -> String {
+    let rendered = format!("{value:?}");
+    let variant_end = rendered
+        .find(|character: char| character.is_ascii_whitespace() || character == '{')
+        .or_else(|| rendered.find('('))
+        .unwrap_or(rendered.len());
+    rendered[..variant_end].to_owned()
+}
+
 pub fn init_tracing() {
     let log_format = LogFormat::parse(std::env::var("LOONGCLAW_LOG_FORMAT").ok().as_deref());
     let directive = resolved_log_directive(
@@ -66,7 +88,10 @@ pub fn init_tracing() {
 
 #[cfg(test)]
 mod tests {
-    use super::{LogFormat, build_env_filter, resolved_log_directive};
+    use super::{
+        LogFormat, build_env_filter, debug_variant_name, resolved_log_directive, summarize_error,
+    };
+    use crate::Commands;
 
     #[test]
     fn resolved_log_directive_prefers_loongclaw_log() {
@@ -95,5 +120,28 @@ mod tests {
         let filter = build_env_filter("[broken");
         let rendered = filter.to_string();
         assert_eq!(rendered, "warn");
+    }
+
+    #[test]
+    fn summarize_error_collapses_whitespace_and_truncates() {
+        let repeated = "detail ".repeat(64);
+        let summary = summarize_error(&format!("line one\nline two\t{repeated}"));
+
+        assert!(!summary.contains('\n'));
+        assert!(!summary.contains('\t'));
+        assert!(summary.ends_with("..."));
+        assert!(summary.chars().count() <= 240);
+    }
+
+    #[test]
+    fn debug_variant_name_keeps_only_variant_identity() {
+        let welcome = debug_variant_name(&Commands::Welcome);
+        let run_task = debug_variant_name(&Commands::RunTask {
+            objective: "ship".to_owned(),
+            payload: "{\"mode\":\"safe\"}".to_owned(),
+        });
+
+        assert_eq!(welcome, "Welcome");
+        assert_eq!(run_task, "RunTask");
     }
 }


### PR DESCRIPTION
## Summary

- Problem:
  Discovery-shaped tool results could be truncated before follow-up compaction and then framed as final evidence in the provider follow-up turn, so the model could answer directly instead of invoking the discovered tool.
- Why it matters:
  This breaks multi-step tool workflows even when discovery already found the correct next tool and lease, which makes discovery-heavy requests look non-operational.
- What changed:
  Added explicit payload semantics to tool result envelopes, preserved full payload summaries for semantics-sensitive results, switched discovery follow-up prompting and compaction to semantics-first handling with shape fallback, and updated external skill follow-up parsing to prefer explicit semantics while keeping a narrow legacy compatibility path.
- What did not change (scope boundary):
  This does not introduce broader autonomous tool expansion beyond the discovered-next-tool flow, and it does not change approval policy, tool search ranking, or unrelated routing logic.

## Linked Issues

- Closes #717
- Related #570

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
cargo test -p loongclaw-app followup_prompt_uses_discovery_guidance_for_discovery_shaped_results -- --nocapture
cargo test -p loongclaw-app turn_engine_keeps_discovery_shaped_payloads_intact_for_followup_compaction -- --nocapture
cargo test -p loongclaw-app turn_engine_keeps_external_skill_invoke_payloads_intact -- --nocapture
cargo test -p loongclaw-app tool_result_followup_tail_promotes_external_skill_from_semantic_envelope -- --nocapture
cargo test -p loongclaw-app parse_external_skill_invoke_context_requires_semantics_or_legacy_tool_name -- --nocapture

All commands above passed.

Attempted but unavailable in this local environment:
- task check:architecture
- task check:conventions
The local shell does not have the `task` command installed.
```

## User-visible / Operator-visible Changes

- Discovery-heavy requests now keep large discovery results actionable through the follow-up turn instead of prematurely collapsing into a direct answer path.
- Managed external skill follow-up keeps using the promoted skill context through explicit payload semantics, without reintroducing broad tool-name hardcoding.

## Failure Recovery

- Fast rollback or disable path:
  Revert `fce30baf` to restore the previous envelope and follow-up handling.
- Observable failure symptoms reviewers should watch for:
  Discovery results are answered directly without a second tool call, or managed external skill context stops being promoted into the follow-up system message.

## Reviewer Focus

- Review `crates/app/src/conversation/turn_engine.rs` for the payload-semantics classification and envelope summary-limit behavior.
- Review `crates/app/src/conversation/turn_shared.rs` for discovery follow-up prompting, discovery payload compaction, and the conservative external-skill compatibility fallback.
- Review `crates/app/src/conversation/tests.rs` for the non-name-coupled regressions that prove the fix works by payload semantics rather than query or tool-name hardcoding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace-wide structured logging/observability and CLI tracing initialization for improved runtime diagnostics.
  * Enhanced payload handling with semantic detection for discovery results and external-skill contexts, preserved large payloads, and discovery-specific follow-up prompts.

* **Bug Fixes / Improvements**
  * Added timing and outcome-aware logging around key runtime paths and tool execution to aid troubleshooting.

* **Tests**
  * Added/expanded tests validating preservation and handling of large discovery-shaped and external-skill payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->