### PR TITLE
feat(channel): implement DocumentsApi for FeishuAdapter (Step 4)

### DIFF
--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -640,12 +640,17 @@ impl DocumentsApi for FeishuAdapter {
             create_feishu_document(&self.client, &token, Some(title), parent_id).await,
         )?;
 
-        let document = convert_feishu_document_metadata_to_document(metadata)?;
+        let mut document = convert_feishu_document_metadata_to_document(metadata);
 
         // If content is provided, append it to the document
         if let Some(content) = content {
-            self.append_document_content_with_token(&token, &document.id, content)
+            let document_id = document.id.clone();
+            let initial_content = content.clone();
+
+            self.append_document_content_with_token(&token, &document_id, content)
                 .await?;
+
+            document.content = Some(initial_content);
         }
 
         Ok(document)
@@ -807,8 +812,8 @@ impl DocumentsApi for FeishuAdapter {
 /// owner_id, created_at, updated_at are not available from Feishu API.
 fn convert_feishu_document_metadata_to_document(
     metadata: crate::channel::feishu::api::resources::types::FeishuDocumentMetadata,
-) -> ApiResult<Document> {
-    Ok(Document {
+) -> Document {
+    Document {
         id: metadata.document_id,
         title: metadata.title,
         owner_id: None,   // Feishu doesn't return owner
@@ -820,7 +825,7 @@ fn convert_feishu_document_metadata_to_document(
             "revision_id": metadata.revision_id,
             "url": metadata.url,
         })),
-    })
+    }
 }
 
 /// Convert FeishuDocumentContent to generic Document
@@ -1370,6 +1375,10 @@ mod tests {
         assert_eq!(document.id, "doxcnCreated");
         assert_eq!(document.title.as_deref(), Some("Release Plan"));
         assert_eq!(document.doc_type, DocumentType::Docx);
+        assert_eq!(
+            document.content,
+            Some(DocumentContent::Markdown("# Release Plan".to_owned()))
+        );
 
         let requests = requests.lock().await.clone();
         assert_eq!(requests.len(), 4);

--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -7,6 +7,10 @@ use crate::channel::feishu::api::messaging_api::{
     convert_cli_result, convert_feishu_message_to_generic, convert_message_content_to_feishu,
     convert_string_error_to_api_error, extract_receive_params, generate_idempotency_key,
 };
+use crate::channel::feishu::api::resources::docs::{
+    convert_content_to_blocks, create_document as create_feishu_document, create_nested_blocks,
+    fetch_document_content,
+};
 use crate::channel::feishu::api::resources::messages::{
     self, FeishuMessageHistoryQuery, FeishuOutboundMessageBody, fetch_message_detail,
     fetch_message_history, reply_outbound_message, send_outbound_message, update_card,
@@ -14,6 +18,7 @@ use crate::channel::feishu::api::resources::messages::{
 use crate::channel::feishu::api::{
     FeishuOperatorOutboundMessageInput, resolve_operator_outbound_message_body,
 };
+use crate::channel::traits::documents::{Document, DocumentContent, DocumentType, DocumentsApi};
 use crate::channel::traits::error::{ApiError, ApiResult};
 use crate::channel::traits::messaging::{
     Message, MessageContent, MessagingApi, PaginatedResult, Pagination, SendOptions,
@@ -560,6 +565,256 @@ impl MessagingApi for FeishuAdapter {
         let token = convert_cli_result(self.client.get_tenant_access_token().await)?;
 
         convert_cli_result(messages::delete_message(&self.client, &token, message_id).await)
+    }
+}
+
+#[async_trait]
+impl DocumentsApi for FeishuAdapter {
+    /// Creates a new Feishu document.
+    ///
+    /// If content is provided, it will be appended to the document after creation.
+    async fn create_document(
+        &self,
+        title: &str,
+        content: Option<&DocumentContent>,
+        parent_id: Option<&str>,
+    ) -> ApiResult<Document> {
+        let token = convert_cli_result(self.client.get_tenant_access_token().await)?;
+
+        // Create empty document
+        let metadata = convert_cli_result(
+            create_feishu_document(&self.client, &token, Some(title), parent_id).await,
+        )?;
+
+        let document = convert_feishu_document_metadata_to_document(metadata)?;
+
+        // If content is provided, append it to the document
+        if let Some(content) = content {
+            self.append_to_document(&document.id, content).await?;
+        }
+
+        Ok(document)
+    }
+
+    /// Gets a Feishu document by ID.
+    ///
+    /// Returns the document with available fields. Some fields may be None
+    /// if not returned by Feishu API (e.g., owner_id, timestamps).
+    async fn get_document(&self, id: &str) -> ApiResult<Option<Document>> {
+        let document_id = id.trim();
+        if document_id.is_empty() {
+            return Err(ApiError::InvalidRequest(
+                "Document ID cannot be empty".to_owned(),
+            ));
+        }
+
+        let token = convert_cli_result(self.client.get_tenant_access_token().await)?;
+
+        let metadata_result = fetch_document_content(&self.client, &token, document_id, None).await;
+
+        match metadata_result {
+            Ok(content) => {
+                let doc = convert_feishu_document_content_to_document(content);
+                Ok(Some(doc))
+            }
+            Err(err) => {
+                let api_err = convert_string_error_to_api_error(&err);
+                match api_err {
+                    ApiError::NotFound(_) => Ok(None),
+                    ApiError::Auth(_)
+                    | ApiError::RateLimited { .. }
+                    | ApiError::InvalidRequest(_)
+                    | ApiError::Network(_)
+                    | ApiError::Server(_)
+                    | ApiError::NotSupported(_)
+                    | ApiError::Platform { .. }
+                    | ApiError::Other(_) => Err(api_err),
+                }
+            }
+        }
+    }
+
+    /// Gets the content of a Feishu document.
+    async fn get_document_content(&self, id: &str) -> ApiResult<Option<DocumentContent>> {
+        let document_id = id.trim();
+        if document_id.is_empty() {
+            return Err(ApiError::InvalidRequest(
+                "Document ID cannot be empty".to_owned(),
+            ));
+        }
+
+        let token = convert_cli_result(self.client.get_tenant_access_token().await)?;
+
+        match fetch_document_content(&self.client, &token, document_id, None).await {
+            Ok(content) => Ok(Some(DocumentContent::Text(content.content))),
+            Err(err) => {
+                let api_err = convert_string_error_to_api_error(&err);
+                match api_err {
+                    ApiError::NotFound(_) => Ok(None),
+                    ApiError::Auth(_)
+                    | ApiError::RateLimited { .. }
+                    | ApiError::InvalidRequest(_)
+                    | ApiError::Network(_)
+                    | ApiError::Server(_)
+                    | ApiError::NotSupported(_)
+                    | ApiError::Platform { .. }
+                    | ApiError::Other(_) => Err(api_err),
+                }
+            }
+        }
+    }
+
+    /// Updates document content.
+    ///
+    /// Not supported by Feishu; use append_to_document instead.
+    async fn update_document(&self, _id: &str, _content: &DocumentContent) -> ApiResult<()> {
+        // Feishu doesn't support updating entire document content
+        // Recommend using append_to_document instead
+        Err(ApiError::NotSupported(
+            "update_document not supported by Feishu; use append_to_document instead".to_owned(),
+        ))
+    }
+
+    /// Appends content blocks to a Feishu document.
+    ///
+    /// Converts the content to Feishu blocks and inserts them.
+    /// Supports Text and Markdown content types.
+    async fn append_to_document(&self, id: &str, content: &DocumentContent) -> ApiResult<()> {
+        let document_id = id.trim();
+        if document_id.is_empty() {
+            return Err(ApiError::InvalidRequest(
+                "Document ID cannot be empty".to_owned(),
+            ));
+        }
+
+        // Validate content is not empty
+        let (content_type, content_str) = match content {
+            DocumentContent::Text(text) => {
+                if text.trim().is_empty() {
+                    return Err(ApiError::InvalidRequest(
+                        "Document content cannot be empty".to_owned(),
+                    ));
+                }
+                ("markdown", text.as_str())
+            }
+            DocumentContent::Markdown(text) => {
+                if text.trim().is_empty() {
+                    return Err(ApiError::InvalidRequest(
+                        "Document content cannot be empty".to_owned(),
+                    ));
+                }
+                ("markdown", text.as_str())
+            }
+            DocumentContent::Binary(_) => {
+                return Err(ApiError::NotSupported(
+                    "Binary content not supported by Feishu documents".to_owned(),
+                ));
+            }
+            DocumentContent::Json(_) => {
+                return Err(ApiError::NotSupported(
+                    "JSON content not supported by Feishu documents".to_owned(),
+                ));
+            }
+        };
+
+        let token = convert_cli_result(self.client.get_tenant_access_token().await)?;
+
+        // Convert content to Feishu blocks
+        let blocks = convert_cli_result(
+            convert_content_to_blocks(&self.client, &token, content_type, content_str).await,
+        )?;
+
+        // Insert blocks into document
+        let _insert_result = convert_cli_result(
+            create_nested_blocks(&self.client, &token, document_id, &blocks).await,
+        )?;
+
+        Ok(())
+    }
+
+    /// Lists documents in a container.
+    ///
+    /// Not supported by Feishu.
+    async fn list_documents(
+        &self,
+        _parent_id: Option<&str>,
+        _pagination: Option<Pagination>,
+    ) -> ApiResult<Vec<Document>> {
+        Err(ApiError::NotSupported(
+            "list_documents not supported by Feishu".to_owned(),
+        ))
+    }
+
+    /// Searches documents.
+    ///
+    /// Not supported by Feishu.
+    async fn search_documents(
+        &self,
+        _query: &str,
+        _pagination: Option<Pagination>,
+    ) -> ApiResult<Vec<Document>> {
+        Err(ApiError::NotSupported(
+            "search_documents not supported by Feishu".to_owned(),
+        ))
+    }
+
+    /// Deletes a document.
+    ///
+    /// Not supported by Feishu.
+    async fn delete_document(&self, _id: &str) -> ApiResult<()> {
+        Err(ApiError::NotSupported(
+            "delete_document not supported by Feishu".to_owned(),
+        ))
+    }
+
+    /// Moves a document to a different parent.
+    ///
+    /// Not supported by Feishu.
+    async fn move_document(&self, _id: &str, _new_parent_id: &str) -> ApiResult<Document> {
+        Err(ApiError::NotSupported(
+            "move_document not supported by Feishu".to_owned(),
+        ))
+    }
+}
+
+/// Convert FeishuDocumentMetadata to generic Document
+///
+/// Note: Feishu's create API returns limited metadata (id, title, revision_id, url).
+/// owner_id, created_at, updated_at are not available from Feishu API.
+fn convert_feishu_document_metadata_to_document(
+    metadata: crate::channel::feishu::api::resources::types::FeishuDocumentMetadata,
+) -> ApiResult<Document> {
+    Ok(Document {
+        id: metadata.document_id,
+        title: metadata.title,
+        owner_id: None,   // Feishu doesn't return owner
+        created_at: None, // Feishu doesn't return create time
+        updated_at: None, // Feishu doesn't return update time
+        content: None,
+        doc_type: DocumentType::Docx,
+        metadata: Some(serde_json::json!({
+            "revision_id": metadata.revision_id,
+            "url": metadata.url,
+        })),
+    })
+}
+
+/// Convert FeishuDocumentContent to generic Document
+///
+/// Note: Feishu's raw_content API returns only content, document_id, and url.
+/// title, owner_id, timestamps are not available.
+fn convert_feishu_document_content_to_document(
+    content: crate::channel::feishu::api::resources::types::FeishuDocumentContent,
+) -> Document {
+    Document {
+        id: content.document_id,
+        title: None, // Raw content doesn't include title
+        owner_id: None,
+        created_at: None,
+        updated_at: None,
+        content: Some(DocumentContent::Text(content.content)),
+        doc_type: DocumentType::Docx,
+        metadata: content.url.map(|url| serde_json::json!({ "url": url })),
     }
 }
 

--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -9,7 +9,7 @@ use crate::channel::feishu::api::messaging_api::{
 };
 use crate::channel::feishu::api::resources::docs::{
     convert_content_to_blocks, create_document as create_feishu_document, create_nested_blocks,
-    fetch_document_content,
+    fetch_document_content, fetch_document_metadata,
 };
 use crate::channel::feishu::api::resources::messages::{
     self, FeishuMessageHistoryQuery, FeishuOutboundMessageBody, fetch_message_detail,
@@ -199,6 +199,60 @@ impl FeishuAdapter {
                 Err("feishu adapter only supports message_reply or receive_id targets".to_owned())
             }
         }
+    }
+
+    async fn append_document_content_with_token(
+        &self,
+        token: &str,
+        document_id: &str,
+        content: &DocumentContent,
+    ) -> ApiResult<()> {
+        let trimmed_document_id = document_id.trim();
+        if trimmed_document_id.is_empty() {
+            return Err(ApiError::InvalidRequest(
+                "Document ID cannot be empty".to_owned(),
+            ));
+        }
+
+        let content_str = match content {
+            DocumentContent::Text(text) => {
+                if text.trim().is_empty() {
+                    return Err(ApiError::InvalidRequest(
+                        "Document content cannot be empty".to_owned(),
+                    ));
+                }
+                text.as_str()
+            }
+            DocumentContent::Markdown(text) => {
+                if text.trim().is_empty() {
+                    return Err(ApiError::InvalidRequest(
+                        "Document content cannot be empty".to_owned(),
+                    ));
+                }
+                text.as_str()
+            }
+            DocumentContent::Binary(_) => {
+                return Err(ApiError::NotSupported(
+                    "Binary content not supported by Feishu documents".to_owned(),
+                ));
+            }
+            DocumentContent::Json(_) => {
+                return Err(ApiError::NotSupported(
+                    "JSON content not supported by Feishu documents".to_owned(),
+                ));
+            }
+        };
+
+        let blocks = convert_cli_result(
+            convert_content_to_blocks(&self.client, token, "markdown", content_str).await,
+        )?;
+
+        let insert_summary = convert_cli_result(
+            create_nested_blocks(&self.client, token, trimmed_document_id, &blocks).await,
+        )?;
+
+        let _ = insert_summary;
+        Ok(())
     }
 }
 
@@ -590,7 +644,8 @@ impl DocumentsApi for FeishuAdapter {
 
         // If content is provided, append it to the document
         if let Some(content) = content {
-            self.append_to_document(&document.id, content).await?;
+            self.append_document_content_with_token(&token, &document.id, content)
+                .await?;
         }
 
         Ok(document)
@@ -598,8 +653,8 @@ impl DocumentsApi for FeishuAdapter {
 
     /// Gets a Feishu document by ID.
     ///
-    /// Returns the document with available fields. Some fields may be None
-    /// if not returned by Feishu API (e.g., owner_id, timestamps).
+    /// Returns the document metadata together with plain text content.
+    /// Some fields may be None if not returned by Feishu API.
     async fn get_document(&self, id: &str) -> ApiResult<Option<Document>> {
         let document_id = id.trim();
         if document_id.is_empty() {
@@ -610,17 +665,12 @@ impl DocumentsApi for FeishuAdapter {
 
         let token = convert_cli_result(self.client.get_tenant_access_token().await)?;
 
-        let metadata_result = fetch_document_content(&self.client, &token, document_id, None).await;
-
-        match metadata_result {
-            Ok(content) => {
-                let doc = convert_feishu_document_content_to_document(content);
-                Ok(Some(doc))
-            }
+        let metadata = match fetch_document_metadata(&self.client, &token, document_id).await {
+            Ok(metadata) => metadata,
             Err(err) => {
                 let api_err = convert_string_error_to_api_error(&err);
                 match api_err {
-                    ApiError::NotFound(_) => Ok(None),
+                    ApiError::NotFound(_) => return Ok(None),
                     ApiError::Auth(_)
                     | ApiError::RateLimited { .. }
                     | ApiError::InvalidRequest(_)
@@ -628,10 +678,31 @@ impl DocumentsApi for FeishuAdapter {
                     | ApiError::Server(_)
                     | ApiError::NotSupported(_)
                     | ApiError::Platform { .. }
-                    | ApiError::Other(_) => Err(api_err),
+                    | ApiError::Other(_) => return Err(api_err),
                 }
             }
-        }
+        };
+
+        let content = match fetch_document_content(&self.client, &token, document_id, None).await {
+            Ok(content) => content,
+            Err(err) => {
+                let api_err = convert_string_error_to_api_error(&err);
+                match api_err {
+                    ApiError::NotFound(_) => return Ok(None),
+                    ApiError::Auth(_)
+                    | ApiError::RateLimited { .. }
+                    | ApiError::InvalidRequest(_)
+                    | ApiError::Network(_)
+                    | ApiError::Server(_)
+                    | ApiError::NotSupported(_)
+                    | ApiError::Platform { .. }
+                    | ApiError::Other(_) => return Err(api_err),
+                }
+            }
+        };
+
+        let document = convert_feishu_document_snapshot_to_document(metadata, content);
+        Ok(Some(document))
     }
 
     /// Gets the content of a Feishu document.
@@ -680,56 +751,9 @@ impl DocumentsApi for FeishuAdapter {
     /// Converts the content to Feishu blocks and inserts them.
     /// Supports Text and Markdown content types.
     async fn append_to_document(&self, id: &str, content: &DocumentContent) -> ApiResult<()> {
-        let document_id = id.trim();
-        if document_id.is_empty() {
-            return Err(ApiError::InvalidRequest(
-                "Document ID cannot be empty".to_owned(),
-            ));
-        }
-
-        // Validate content is not empty
-        let (content_type, content_str) = match content {
-            DocumentContent::Text(text) => {
-                if text.trim().is_empty() {
-                    return Err(ApiError::InvalidRequest(
-                        "Document content cannot be empty".to_owned(),
-                    ));
-                }
-                ("markdown", text.as_str())
-            }
-            DocumentContent::Markdown(text) => {
-                if text.trim().is_empty() {
-                    return Err(ApiError::InvalidRequest(
-                        "Document content cannot be empty".to_owned(),
-                    ));
-                }
-                ("markdown", text.as_str())
-            }
-            DocumentContent::Binary(_) => {
-                return Err(ApiError::NotSupported(
-                    "Binary content not supported by Feishu documents".to_owned(),
-                ));
-            }
-            DocumentContent::Json(_) => {
-                return Err(ApiError::NotSupported(
-                    "JSON content not supported by Feishu documents".to_owned(),
-                ));
-            }
-        };
-
         let token = convert_cli_result(self.client.get_tenant_access_token().await)?;
-
-        // Convert content to Feishu blocks
-        let blocks = convert_cli_result(
-            convert_content_to_blocks(&self.client, &token, content_type, content_str).await,
-        )?;
-
-        // Insert blocks into document
-        let _insert_result = convert_cli_result(
-            create_nested_blocks(&self.client, &token, document_id, &blocks).await,
-        )?;
-
-        Ok(())
+        self.append_document_content_with_token(&token, id, content)
+            .await
     }
 
     /// Lists documents in a container.
@@ -801,20 +825,26 @@ fn convert_feishu_document_metadata_to_document(
 
 /// Convert FeishuDocumentContent to generic Document
 ///
-/// Note: Feishu's raw_content API returns only content, document_id, and url.
-/// title, owner_id, timestamps are not available.
-fn convert_feishu_document_content_to_document(
+/// Note: Feishu's get and raw_content APIs expose different parts of the snapshot.
+fn convert_feishu_document_snapshot_to_document(
+    metadata: crate::channel::feishu::api::resources::types::FeishuDocumentMetadata,
     content: crate::channel::feishu::api::resources::types::FeishuDocumentContent,
 ) -> Document {
+    let document_url = metadata.url.or(content.url);
+    let document_metadata = serde_json::json!({
+        "revision_id": metadata.revision_id,
+        "url": document_url,
+    });
+
     Document {
-        id: content.document_id,
-        title: None, // Raw content doesn't include title
+        id: metadata.document_id,
+        title: metadata.title,
         owner_id: None,
         created_at: None,
         updated_at: None,
         content: Some(DocumentContent::Text(content.content)),
         doc_type: DocumentType::Docx,
-        metadata: content.url.map(|url| serde_json::json!({ "url": url })),
+        metadata: Some(document_metadata),
     }
 }
 
@@ -826,7 +856,7 @@ mod tests {
         Json, Router,
         body::to_bytes,
         extract::{Request, State},
-        routing::post,
+        routing::{get, post},
     };
     use serde_json::json;
     use std::sync::Arc;
@@ -1218,6 +1248,327 @@ mod tests {
             requests[1]
                 .body
                 .contains("\\\"text\\\":\\\"threaded reply\\\"")
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn feishu_adapter_create_document_supports_initial_markdown_content() {
+        let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let state = MockServerState {
+            requests: requests.clone(),
+        };
+        let router = Router::new()
+            .route(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "tenant_access_token": "t-token-doc-create"
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/docx/v1/documents",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "document": {
+                                        "document_id": "doxcnCreated",
+                                        "revision_id": 7,
+                                        "title": "Release Plan"
+                                    }
+                                }
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/docx/v1/documents/blocks/convert",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "first_level_block_ids": ["tmp-heading"],
+                                    "blocks": [
+                                        {
+                                            "block_id": "tmp-heading",
+                                            "block_type": 3,
+                                            "heading1": {
+                                                "elements": [
+                                                    {
+                                                        "text_run": {
+                                                            "content": "Release Plan"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "children": []
+                                        }
+                                    ]
+                                }
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/docx/v1/documents/doxcnCreated/blocks/doxcnCreated/descendant",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "block_id_relations": [
+                                        {
+                                            "block_id": "blk_real_heading",
+                                            "temporary_block_id": "tmp-heading"
+                                        }
+                                    ]
+                                }
+                            }))
+                        }
+                    }
+                }),
+            );
+        let (base_url, server) = spawn_mock_feishu_server(router).await;
+        let adapter = FeishuAdapter::new(&resolved_config(&base_url)).expect("build adapter");
+
+        let document = DocumentsApi::create_document(
+            &adapter,
+            "Release Plan",
+            Some(&DocumentContent::Markdown("# Release Plan".to_owned())),
+            None,
+        )
+        .await
+        .expect("create document");
+
+        assert_eq!(document.id, "doxcnCreated");
+        assert_eq!(document.title.as_deref(), Some("Release Plan"));
+        assert_eq!(document.doc_type, DocumentType::Docx);
+
+        let requests = requests.lock().await.clone();
+        assert_eq!(requests.len(), 4);
+        assert_eq!(requests[1].path, "/open-apis/docx/v1/documents");
+        assert_eq!(
+            requests[1].authorization.as_deref(),
+            Some("Bearer t-token-doc-create")
+        );
+        assert!(requests[1].body.contains("\"title\":\"Release Plan\""));
+        assert_eq!(
+            requests[2].path,
+            "/open-apis/docx/v1/documents/blocks/convert"
+        );
+        assert!(requests[2].body.contains("\"content_type\":\"markdown\""));
+        assert!(requests[2].body.contains("# Release Plan"));
+        assert_eq!(
+            requests[3].path,
+            "/open-apis/docx/v1/documents/doxcnCreated/blocks/doxcnCreated/descendant"
+        );
+        assert!(
+            requests[3]
+                .query
+                .as_deref()
+                .is_some_and(|query| query.contains("document_revision_id=-1"))
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn feishu_adapter_get_document_reads_metadata_and_raw_content() {
+        let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let state = MockServerState {
+            requests: requests.clone(),
+        };
+        let router = Router::new()
+            .route(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "tenant_access_token": "t-token-doc-get"
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/docx/v1/documents/doxcnCreated",
+                get({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "document": {
+                                        "document_id": "doxcnCreated",
+                                        "revision_id": 9,
+                                        "title": "Release Plan"
+                                    }
+                                }
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/docx/v1/documents/doxcnCreated/raw_content",
+                get({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "content": "hello from docs"
+                                }
+                            }))
+                        }
+                    }
+                }),
+            );
+        let (base_url, server) = spawn_mock_feishu_server(router).await;
+        let adapter = FeishuAdapter::new(&resolved_config(&base_url)).expect("build adapter");
+
+        let document = DocumentsApi::get_document(&adapter, "doxcnCreated")
+            .await
+            .expect("get document should succeed")
+            .expect("document should exist");
+
+        assert_eq!(document.id, "doxcnCreated");
+        assert_eq!(document.title.as_deref(), Some("Release Plan"));
+        assert_eq!(
+            document.content,
+            Some(DocumentContent::Text("hello from docs".to_owned()))
+        );
+        assert_eq!(document.doc_type, DocumentType::Docx);
+        assert_eq!(
+            document
+                .metadata
+                .as_ref()
+                .and_then(|value| value.get("revision_id"))
+                .and_then(|value| value.as_i64()),
+            Some(9)
+        );
+        assert_eq!(
+            document
+                .metadata
+                .as_ref()
+                .and_then(|value| value.get("url"))
+                .and_then(|value| value.as_str()),
+            Some("https://open.feishu.cn/docx/doxcnCreated")
+        );
+
+        let requests = requests.lock().await.clone();
+        assert_eq!(requests.len(), 3);
+        assert_eq!(
+            requests[1].path,
+            "/open-apis/docx/v1/documents/doxcnCreated"
+        );
+        assert_eq!(
+            requests[1].authorization.as_deref(),
+            Some("Bearer t-token-doc-get")
+        );
+        assert_eq!(
+            requests[2].path,
+            "/open-apis/docx/v1/documents/doxcnCreated/raw_content"
+        );
+        assert_eq!(
+            requests[2].authorization.as_deref(),
+            Some("Bearer t-token-doc-get")
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn feishu_adapter_get_document_returns_none_when_metadata_is_missing() {
+        let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let state = MockServerState {
+            requests: requests.clone(),
+        };
+        let router = Router::new()
+            .route(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "tenant_access_token": "t-token-doc-missing"
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/docx/v1/documents/doxcnMissing",
+                get({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 1770002,
+                                "msg": "not found"
+                            }))
+                        }
+                    }
+                }),
+            );
+        let (base_url, server) = spawn_mock_feishu_server(router).await;
+        let adapter = FeishuAdapter::new(&resolved_config(&base_url)).expect("build adapter");
+
+        let document = DocumentsApi::get_document(&adapter, "doxcnMissing")
+            .await
+            .expect("get document should not fail");
+
+        assert_eq!(document, None);
+
+        let requests = requests.lock().await.clone();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[1].path,
+            "/open-apis/docx/v1/documents/doxcnMissing"
         );
 
         server.abort();

--- a/crates/app/src/channel/feishu/api/resources/docs.rs
+++ b/crates/app/src/channel/feishu/api/resources/docs.rs
@@ -56,6 +56,20 @@ pub async fn fetch_document_content(
     parse_raw_content_response(document_id.as_str(), &payload)
 }
 
+pub async fn fetch_document_metadata(
+    client: &FeishuClient,
+    user_access_token: &str,
+    document_id_or_url: &str,
+) -> CliResult<FeishuDocumentMetadata> {
+    let document_id = extract_document_id(document_id_or_url)
+        .ok_or_else(|| "failed to resolve Feishu document id".to_owned())?;
+    let path = format!("/open-apis/docx/v1/documents/{document_id}");
+    let payload = client
+        .get_json(path.as_str(), Some(user_access_token), &[])
+        .await?;
+    parse_document_metadata_response(&payload)
+}
+
 pub async fn create_document(
     client: &FeishuClient,
     user_access_token: &str,
@@ -80,7 +94,7 @@ pub async fn create_document(
             &Value::Object(body),
         )
         .await?;
-    parse_document_create_response(&payload)
+    parse_document_metadata_response(&payload)
 }
 
 pub async fn convert_content_to_blocks(
@@ -183,7 +197,7 @@ pub fn parse_raw_content_response(
     })
 }
 
-pub fn parse_document_create_response(payload: &Value) -> CliResult<FeishuDocumentMetadata> {
+pub fn parse_document_metadata_response(payload: &Value) -> CliResult<FeishuDocumentMetadata> {
     let document = payload
         .get("data")
         .and_then(|value| value.get("document"))
@@ -1221,7 +1235,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_document_create_response_reads_document_metadata() {
+    fn parse_document_metadata_response_reads_document_metadata() {
         let payload = serde_json::json!({
             "code": 0,
             "msg": "success",
@@ -1234,7 +1248,7 @@ mod tests {
             }
         });
 
-        let document = parse_document_create_response(&payload).expect("parse document create");
+        let document = parse_document_metadata_response(&payload).expect("parse document metadata");
 
         assert_eq!(document.document_id, "doxcnCreated");
         assert_eq!(document.revision_id, Some(1));

--- a/crates/app/src/channel/feishu/api/resources/docs.rs
+++ b/crates/app/src/channel/feishu/api/resources/docs.rs
@@ -202,9 +202,9 @@ pub fn parse_document_metadata_response(payload: &Value) -> CliResult<FeishuDocu
         .get("data")
         .and_then(|value| value.get("document"))
         .and_then(Value::as_object)
-        .ok_or_else(|| "feishu document create payload missing data.document".to_owned())?;
+        .ok_or_else(|| "feishu document metadata payload missing data.document".to_owned())?;
     let document_id = object_string(document, "document_id").ok_or_else(|| {
-        "feishu document create payload missing data.document.document_id".to_owned()
+        "feishu document metadata payload missing data.document.document_id".to_owned()
     })?;
 
     Ok(FeishuDocumentMetadata {

--- a/crates/app/src/channel/traits/documents.rs
+++ b/crates/app/src/channel/traits/documents.rs
@@ -17,23 +17,30 @@ pub enum DocumentContent {
     Json(serde_json::Value),
 }
 
+/// Document type enumeration
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DocumentType {
+    /// Docx document (Feishu, Office 365, etc.)
+    Docx,
+}
+
 /// Document metadata
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Document {
     /// Platform-specific document ID
     pub id: String,
     /// Document title/name
-    pub title: String,
-    /// Document owner/creator ID
-    pub owner_id: String,
-    /// Creation timestamp
-    pub created_at: DateTime<Utc>,
-    /// Last modification timestamp
-    pub updated_at: DateTime<Utc>,
+    pub title: Option<String>,
+    /// Document owner/creator ID (None if not available)
+    pub owner_id: Option<String>,
+    /// Creation timestamp (None if not available)
+    pub created_at: Option<DateTime<Utc>>,
+    /// Last modification timestamp (None if not available)
+    pub updated_at: Option<DateTime<Utc>>,
     /// Document content (optional, for list operations)
     pub content: Option<DocumentContent>,
     /// Document type/format
-    pub doc_type: String,
+    pub doc_type: DocumentType,
     /// Platform-specific metadata
     pub metadata: Option<serde_json::Value>,
 }
@@ -64,10 +71,10 @@ pub trait DocumentsApi: Send + Sync {
     async fn get_document_content(&self, id: &str) -> ApiResult<Option<DocumentContent>>;
 
     /// Update document content
-    async fn update_document(&self, id: &str, content: &DocumentContent) -> ApiResult<Document>;
+    async fn update_document(&self, id: &str, content: &DocumentContent) -> ApiResult<()>;
 
     /// Append content to an existing document
-    async fn append_to_document(&self, id: &str, content: &DocumentContent) -> ApiResult<Document>;
+    async fn append_to_document(&self, id: &str, content: &DocumentContent) -> ApiResult<()>;
 
     /// List documents in a container
     async fn list_documents(

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T05:52:20Z
+- Generated at: 2026-04-01T06:21:52Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T06:21:52Z
+- Generated at: 2026-04-01T06:33:24Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -18,8 +18,8 @@
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 0.0% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3383 | 3600 | 217 | 8 | 12 | 4 | 94.0% | WATCH | 3383 | 0.0% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2698 | 2800 | 102 | 56 | 65 | 9 | 96.4% | TIGHT | 2698 | 0.0% | PASS | 56 |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9922 | 10500 | 578 | 88 | 90 | 2 | 97.8% | TIGHT | 9922 | 0.0% | PASS | 88 |
-| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9796 | 9800 | 4 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10378 | 10500 | 122 | 89 | 90 | 1 | 98.9% | TIGHT | 9922 | 4.6% | PASS | 88 |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9798 | 9800 | 2 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6936 | 7300 | 364 | 146 | 160 | 14 | 95.0% | TIGHT | 6936 | 0.0% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.7%), tools_mod (96.5%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.7%), tools_mod (96.5%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -63,8 +63,8 @@
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3383 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2698 functions=56 -->
-<!-- arch-hotspot key=channel_registry lines=9922 functions=88 -->
-<!-- arch-hotspot key=channel_config lines=9796 functions=90 -->
+<!-- arch-hotspot key=channel_registry lines=10378 functions=89 -->
+<!-- arch-hotspot key=channel_config lines=9798 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6936 functions=146 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10831 functions=98 -->


### PR DESCRIPTION
## Summary
- Implement `DocumentsApi` trait for `FeishuAdapter` (Step 4 of #404)
- Refactor `Document` struct: `title`, `owner_id`, timestamps → `Option` types
- Add `DocumentType` enum (`Docx`) for type safety
- Unsupported methods (`update`, `list`, `search`, `delete`, `move`) return `NotSupported`

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] All workspace tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feishu integration: create documents, fetch documents and their textual content, and append text/markdown; missing docs return None and unsupported operations are reported.

* **Refactor**
  * Document type now explicit Docx; title/owner/timestamps are optional. Update/append now acknowledge success without returning the document payload.

* **Tests**
  * Added async tests covering creation with initial content, retrieval, and not-found behavior.

* **Documentation**
  * Added monthly architecture drift report and related freshness check scripts/tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->