### PR TITLE
fix(provider): align StepPlan region endpoint guidance

### DIFF
--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -3583,7 +3583,7 @@ const PROVIDER_PROFILES: [ProviderProfile; 41] = [
         kind: ProviderKind::StepPlan,
         id: "step_plan",
         aliases: &["stepfun_step_plan"],
-        base_url: "https://api.stepfun.ai",
+        base_url: "https://api.stepfun.com",
         chat_completions_path: "/step_plan/v1/chat/completions",
         models_path: Some("/step_plan/v1/models"),
         protocol_family: ProviderProtocolFamily::OpenAiChatCompletions,

--- a/crates/app/src/config/provider.rs
+++ b/crates/app/src/config/provider.rs
@@ -2810,11 +2810,11 @@ impl ProviderKind {
                     base_url: "https://api.z.ai",
                 },
             }),
-            ProviderKind::Stepfun => Some(ProviderRegionEndpointGuide {
+            ProviderKind::Stepfun | ProviderKind::StepPlan => Some(ProviderRegionEndpointGuide {
                 family_label: "Stepfun",
                 default_variant: ProviderRegionEndpointVariant {
                     label: "CN",
-                    base_url: "https://api.stepfun.com",
+                    base_url: profile.base_url,
                 },
                 alternate_variant: ProviderRegionEndpointVariant {
                     label: "Global",
@@ -2849,7 +2849,6 @@ impl ProviderKind {
             | ProviderKind::Sambanova
             | ProviderKind::Sglang
             | ProviderKind::Siliconflow
-            | ProviderKind::StepPlan
             | ProviderKind::Together
             | ProviderKind::Venice
             | ProviderKind::VercelAiGateway
@@ -4384,6 +4383,34 @@ mod tests {
     }
 
     #[test]
+    fn step_plan_provider_support_facts_expose_region_endpoint_variants() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::StepPlan,
+            ..ProviderConfig::default()
+        };
+
+        let support_facts = provider.support_facts();
+        let region_endpoint_support = support_facts.region_endpoint;
+        let note = region_endpoint_support
+            .note
+            .expect("step plan should expose a region endpoint note");
+        let catalog_failure_hint = region_endpoint_support
+            .catalog_failure_hint
+            .expect("step plan should expose a catalog failure hint");
+        let request_failure_hint = region_endpoint_support
+            .request_failure_hint
+            .expect("step plan should expose a request failure hint");
+
+        assert!(note.contains("Stepfun"));
+        assert!(note.contains("https://api.stepfun.com"));
+        assert!(note.contains("https://api.stepfun.ai"));
+        assert!(catalog_failure_hint.contains("https://api.stepfun.com"));
+        assert!(catalog_failure_hint.contains("https://api.stepfun.ai"));
+        assert!(request_failure_hint.contains("https://api.stepfun.com"));
+        assert!(request_failure_hint.contains("https://api.stepfun.ai"));
+    }
+
+    #[test]
     fn provider_descriptor_document_preserves_x_api_key_contract_facts() {
         let provider = ProviderConfig {
             kind: ProviderKind::Anthropic,
@@ -4506,6 +4533,50 @@ mod tests {
         assert!(catalog_failure_hint.contains("https://api.minimax.io"));
         assert!(request_failure_hint.contains("https://api.minimaxi.com"));
         assert!(request_failure_hint.contains("https://api.minimax.io"));
+    }
+
+    #[test]
+    fn step_plan_descriptor_document_preserves_region_endpoint_variants_and_hints() {
+        let provider = ProviderConfig {
+            kind: ProviderKind::StepPlan,
+            ..ProviderConfig::default()
+        };
+
+        let descriptor = provider.descriptor_document();
+        let encoded = encode_provider_descriptor(&descriptor);
+        let note = encoded["region_endpoint"]["note"]
+            .as_str()
+            .expect("step plan descriptor should expose a region note");
+        let catalog_failure_hint = encoded["region_endpoint"]["catalog_failure_hint"]
+            .as_str()
+            .expect("step plan descriptor should expose a catalog failure hint");
+        let request_failure_hint = encoded["region_endpoint"]["request_failure_hint"]
+            .as_str()
+            .expect("step plan descriptor should expose a request failure hint");
+
+        assert_eq!(encoded["region_endpoint"]["family_label"], json!("Stepfun"));
+        assert_eq!(
+            encoded["region_endpoint"]["variants"][0]["label"],
+            json!("CN")
+        );
+        assert_eq!(
+            encoded["region_endpoint"]["variants"][0]["base_url"],
+            json!("https://api.stepfun.com")
+        );
+        assert_eq!(
+            encoded["region_endpoint"]["variants"][1]["label"],
+            json!("Global")
+        );
+        assert_eq!(
+            encoded["region_endpoint"]["variants"][1]["base_url"],
+            json!("https://api.stepfun.ai")
+        );
+        assert!(note.contains("https://api.stepfun.com"));
+        assert!(note.contains("https://api.stepfun.ai"));
+        assert!(catalog_failure_hint.contains("https://api.stepfun.com"));
+        assert!(catalog_failure_hint.contains("https://api.stepfun.ai"));
+        assert!(request_failure_hint.contains("https://api.stepfun.com"));
+        assert!(request_failure_hint.contains("https://api.stepfun.ai"));
     }
 
     #[test]

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -8146,6 +8146,31 @@ mod tests {
     }
 
     #[test]
+    fn resolve_provider_selection_allows_switching_step_plan_region_endpoint() {
+        let mut config = mvp::config::LoongClawConfig::default();
+        let options = interactive_onboard_options();
+        let provider_selection = crate::migration::ProviderSelectionPlan::default();
+        let context = onboard_test_context();
+        let mut ui = TestOnboardUi::with_inputs(["", "", "2"]);
+
+        config.provider =
+            mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::StepPlan);
+
+        let selected = resolve_provider_selection(
+            &options,
+            &config,
+            &provider_selection,
+            GuidedPromptPath::NativePromptPack,
+            &mut ui,
+            &context,
+        )
+        .expect("step plan region selection should accept the global endpoint");
+
+        assert_eq!(selected.kind, mvp::config::ProviderKind::StepPlan);
+        assert_eq!(selected.base_url, "https://api.stepfun.ai");
+    }
+
+    #[test]
     fn resolve_model_selection_prefills_minimax_recommended_model_interactively() {
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.kind = mvp::config::ProviderKind::Minimax;

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-31T04:53:20Z
+- Generated at: 2026-03-31T08:05:51Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -25,11 +25,11 @@
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10773 | 11200 | 427 | 97 | 120 | 23 | 96.2% | TIGHT |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14256 | 15000 | 744 | 54 | 70 | 16 | 95.0% | TIGHT |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6295 | 6500 | 205 | 209 | 210 | 1 | 99.5% | TIGHT |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9494 | 9800 | 306 | 228 | 250 | 22 | 96.9% | TIGHT |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.2%), tools_mod (95.0%), daemon_lib (99.5%), onboard_cli (96.9%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_execution (95.8%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.2%), tools_mod (95.0%), daemon_lib (99.5%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): spec_runtime (90.8%), memory_mod (87.5%), acp_manager (94.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -70,7 +70,7 @@
 <!-- arch-hotspot key=turn_coordinator lines=10773 functions=97 -->
 <!-- arch-hotspot key=tools_mod lines=14256 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6295 functions=209 -->
-<!-- arch-hotspot key=onboard_cli lines=9494 functions=228 -->
+<!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
Summary

Problem:
StepPlan was updated to the CN `api.stepfun.com` default, but the provider still behaved like a single hardcoded region. That left onboarding and provider support metadata out of sync with Stepfun's existing CN/global region model.

What changed:
- kept StepPlan's default base URL on the CN endpoint `https://api.stepfun.com`
- reused the existing Stepfun region endpoint guidance for `StepPlan`, with `https://api.stepfun.ai` exposed as the global alternative
- added regression coverage for provider support facts, provider descriptor export, and interactive onboarding region switching
- refreshed the March architecture drift report required by the governance freshness check

Why this shape:
- matches the repo's existing multi-region provider pattern instead of hardcoding a single-endpoint assumption
- keeps the contributor's intended bug fix while preserving a supported global path for users outside CN
- limits the change to provider metadata and onboarding guidance without introducing new config knobs or provider-specific branching

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test --workspace --all-features --locked`
- `bash scripts/check_architecture_boundaries.sh`
- `bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md`
- `scripts/check_dep_graph.sh`

Linked context:
- follow-up to #532
