### PR TITLE
fix(feishu): complete bitable app/table/record/field/view support and harden   CLI contracts

### DIFF
--- a/crates/app/src/channel/feishu/api/resources/bitable.rs
+++ b/crates/app/src/channel/feishu/api/resources/bitable.rs
@@ -709,7 +709,6 @@ pub fn ensure_bitable_batch_limit(tool_name: &str, actual: usize) -> CliResult<(
     ))
 }
 
-#[allow(dead_code)]
 fn omit_field_property_for_unsupported_types(
     field_type: i64,
     property: Option<Value>,

--- a/crates/app/src/channel/feishu/api/resources/bitable.rs
+++ b/crates/app/src/channel/feishu/api/resources/bitable.rs
@@ -3,7 +3,12 @@ use serde_json::{Value, json};
 use crate::CliResult;
 
 use super::super::client::FeishuClient;
-use super::types::{FeishuBitableRecord, FeishuBitableRecordPage, FeishuBitableTableListPage};
+use super::types::{
+    FeishuBitableApp, FeishuBitableAppListPage, FeishuBitableDeletedField,
+    FeishuBitableDeletedRecord, FeishuBitableField, FeishuBitableFieldListPage,
+    FeishuBitableRecord, FeishuBitableRecordPage, FeishuBitableTableListPage, FeishuBitableView,
+    FeishuBitableViewListPage,
+};
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct BitableRecordSearchQuery {
@@ -45,6 +50,158 @@ impl BitableRecordSearchQuery {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct BitableAppListQuery {
+    pub folder_token: Option<String>,
+    pub page_size: Option<usize>,
+    pub page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct BitableFieldListQuery {
+    pub view_id: Option<String>,
+    pub page_size: Option<usize>,
+    pub page_token: Option<String>,
+}
+
+impl BitableFieldListQuery {
+    fn query_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs = Vec::new();
+        if let Some(value) = self.view_id.as_ref() {
+            pairs.push(("view_id".to_owned(), value.clone()));
+        }
+        if let Some(value) = self.page_size {
+            pairs.push(("page_size".to_owned(), value.to_string()));
+        }
+        if let Some(value) = self.page_token.as_ref() {
+            pairs.push(("page_token".to_owned(), value.clone()));
+        }
+        pairs
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct BitableViewListQuery {
+    pub page_size: Option<usize>,
+    pub page_token: Option<String>,
+}
+
+impl BitableViewListQuery {
+    fn query_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs = Vec::new();
+        if let Some(value) = self.page_size {
+            pairs.push(("page_size".to_owned(), value.to_string()));
+        }
+        if let Some(value) = self.page_token.as_ref() {
+            pairs.push(("page_token".to_owned(), value.clone()));
+        }
+        pairs
+    }
+}
+
+impl BitableAppListQuery {
+    fn query_pairs(&self) -> Vec<(String, String)> {
+        let mut pairs = Vec::new();
+        if let Some(value) = self.folder_token.as_ref() {
+            pairs.push(("folder_token".to_owned(), value.clone()));
+        }
+        if let Some(value) = self.page_size {
+            pairs.push(("page_size".to_owned(), value.to_string()));
+        }
+        if let Some(value) = self.page_token.as_ref() {
+            pairs.push(("page_token".to_owned(), value.clone()));
+        }
+        pairs
+    }
+}
+
+pub async fn create_bitable_app(
+    client: &FeishuClient,
+    access_token: &str,
+    name: &str,
+    folder_token: Option<&str>,
+) -> CliResult<FeishuBitableApp> {
+    let mut body = serde_json::Map::new();
+    body.insert("name".to_owned(), json!(name));
+    if let Some(value) = folder_token {
+        body.insert("folder_token".to_owned(), json!(value));
+    }
+    let payload = client
+        .post_json(
+            "/open-apis/bitable/v1/apps",
+            Some(access_token),
+            &[],
+            &Value::Object(body),
+        )
+        .await?;
+    parse_bitable_app_response(&payload, "bitable app create")
+}
+
+pub async fn get_bitable_app(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+) -> CliResult<FeishuBitableApp> {
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}");
+    let payload = client.get_json(&path, Some(access_token), &[]).await?;
+    parse_bitable_app_response(&payload, "bitable app get")
+}
+
+pub async fn list_bitable_apps(
+    client: &FeishuClient,
+    access_token: &str,
+    query: &BitableAppListQuery,
+) -> CliResult<FeishuBitableAppListPage> {
+    let payload = client
+        .get_json(
+            "/open-apis/drive/v1/files",
+            Some(access_token),
+            &query.query_pairs(),
+        )
+        .await?;
+    parse_bitable_app_list_response(&payload)
+}
+
+pub async fn patch_bitable_app(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    name: Option<&str>,
+    is_advanced: Option<bool>,
+) -> CliResult<FeishuBitableApp> {
+    let mut body = serde_json::Map::new();
+    if let Some(value) = name {
+        body.insert("name".to_owned(), json!(value));
+    }
+    if let Some(value) = is_advanced {
+        body.insert("is_advanced".to_owned(), json!(value));
+    }
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}");
+    let payload = client
+        .patch_json(&path, Some(access_token), &[], &Value::Object(body))
+        .await?;
+    parse_bitable_app_response(&payload, "bitable app patch")
+}
+
+pub async fn copy_bitable_app(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    name: &str,
+    folder_token: Option<&str>,
+) -> CliResult<FeishuBitableApp> {
+    let mut body = serde_json::Map::new();
+    body.insert("name".to_owned(), json!(name));
+    if let Some(value) = folder_token {
+        body.insert("folder_token".to_owned(), json!(value));
+    }
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/copy");
+    let payload = client
+        .post_json(&path, Some(access_token), &[], &Value::Object(body))
+        .await?;
+    parse_bitable_app_response(&payload, "bitable app copy")
+}
+
 pub async fn list_bitable_tables(
     client: &FeishuClient,
     access_token: &str,
@@ -64,6 +221,73 @@ pub async fn list_bitable_tables(
     parse_bitable_table_list_response(&payload)
 }
 
+pub async fn create_bitable_table(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    name: &str,
+    default_view_name: Option<&str>,
+    fields: Option<Vec<Value>>,
+) -> CliResult<Value> {
+    let mut table = serde_json::Map::new();
+    table.insert("name".to_owned(), json!(name));
+    if let Some(value) = default_view_name {
+        table.insert("default_view_name".to_owned(), json!(value));
+    }
+    if let Some(value) = fields {
+        table.insert(
+            "fields".to_owned(),
+            Value::Array(sanitize_table_fields(value)),
+        );
+    }
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables");
+    let payload = client
+        .post_json(
+            &path,
+            Some(access_token),
+            &[],
+            &json!({ "table": Value::Object(table) }),
+        )
+        .await?;
+    parse_bitable_data_response(&payload, "bitable table create")
+}
+
+pub async fn patch_bitable_table(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    name: &str,
+) -> CliResult<Value> {
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}");
+    let payload = client
+        .patch_json(&path, Some(access_token), &[], &json!({ "name": name }))
+        .await?;
+    parse_bitable_data_response(&payload, "bitable table patch")
+}
+
+pub async fn batch_create_bitable_tables(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    tables: Vec<Value>,
+) -> CliResult<Value> {
+    let tables = tables
+        .into_iter()
+        .map(|table| {
+            let name = table.get("name").and_then(Value::as_str).ok_or_else(|| {
+                "bitable table batch create: each table requires `name`".to_owned()
+            })?;
+            Ok(json!({ "name": name }))
+        })
+        .collect::<CliResult<Vec<_>>>()?;
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables/batch_create");
+    let payload = client
+        .post_json(&path, Some(access_token), &[], &json!({ "tables": tables }))
+        .await?;
+    parse_bitable_data_response(&payload, "bitable table batch create")
+}
+
 pub async fn create_bitable_record(
     client: &FeishuClient,
     access_token: &str,
@@ -81,6 +305,237 @@ pub async fn create_bitable_record(
         )
         .await?;
     parse_bitable_record_response(&payload)
+}
+
+pub async fn update_bitable_record(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    record_id: &str,
+    fields: Value,
+) -> CliResult<FeishuBitableRecord> {
+    let path =
+        format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}");
+    let payload = client
+        .put_json(
+            &path,
+            Some(access_token),
+            &create_record_query_pairs(),
+            &json!({ "fields": fields }),
+        )
+        .await?;
+    parse_bitable_record_response(&payload)
+}
+
+pub async fn delete_bitable_record(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    record_id: &str,
+) -> CliResult<FeishuBitableDeletedRecord> {
+    let path =
+        format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}");
+    let payload = client.delete_json(&path, Some(access_token), &[]).await?;
+    parse_bitable_deleted_record_response(&payload)
+}
+
+pub async fn batch_create_bitable_records(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    records: Vec<Value>,
+) -> CliResult<Value> {
+    let path =
+        format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_create");
+    let payload = client
+        .post_json(
+            &path,
+            Some(access_token),
+            &create_record_query_pairs(),
+            &json!({ "records": records }),
+        )
+        .await?;
+    parse_bitable_data_response(&payload, "bitable record batch create")
+}
+
+pub async fn batch_update_bitable_records(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    records: Vec<Value>,
+) -> CliResult<Value> {
+    let path =
+        format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_update");
+    let payload = client
+        .post_json(
+            &path,
+            Some(access_token),
+            &create_record_query_pairs(),
+            &json!({ "records": records }),
+        )
+        .await?;
+    parse_bitable_data_response(&payload, "bitable record batch update")
+}
+
+pub async fn batch_delete_bitable_records(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    records: Vec<String>,
+) -> CliResult<Value> {
+    let path =
+        format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_delete");
+    let payload = client
+        .post_json(
+            &path,
+            Some(access_token),
+            &[],
+            &json!({ "records": records }),
+        )
+        .await?;
+    parse_bitable_data_response(&payload, "bitable record batch delete")
+}
+
+pub async fn create_bitable_field(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    field_name: &str,
+    field_type: i64,
+    property: Option<Value>,
+) -> CliResult<FeishuBitableField> {
+    let mut body = serde_json::Map::new();
+    body.insert("field_name".to_owned(), json!(field_name));
+    body.insert("type".to_owned(), json!(field_type));
+    if let Some(property) = omit_field_property_for_unsupported_types(field_type, property) {
+        body.insert("property".to_owned(), property);
+    }
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields");
+    let payload = client
+        .post_json(&path, Some(access_token), &[], &Value::Object(body))
+        .await?;
+    parse_bitable_field_response(&payload, "bitable field create")
+}
+
+pub async fn list_bitable_fields(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    query: &BitableFieldListQuery,
+) -> CliResult<FeishuBitableFieldListPage> {
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields");
+    let payload = client
+        .get_json(&path, Some(access_token), &query.query_pairs())
+        .await?;
+    parse_bitable_field_page_response(&payload)
+}
+
+pub async fn update_bitable_field(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    field_id: &str,
+    field_name: &str,
+    field_type: i64,
+    property: Option<Value>,
+) -> CliResult<FeishuBitableField> {
+    let mut body = serde_json::Map::new();
+    body.insert("field_name".to_owned(), json!(field_name));
+    body.insert("type".to_owned(), json!(field_type));
+    if let Some(property) = omit_field_property_for_unsupported_types(field_type, property) {
+        body.insert("property".to_owned(), property);
+    }
+    let path =
+        format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields/{field_id}");
+    let payload = client
+        .put_json(&path, Some(access_token), &[], &Value::Object(body))
+        .await?;
+    parse_bitable_field_response(&payload, "bitable field update")
+}
+
+pub async fn delete_bitable_field(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    field_id: &str,
+) -> CliResult<FeishuBitableDeletedField> {
+    let path =
+        format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields/{field_id}");
+    let payload = client.delete_json(&path, Some(access_token), &[]).await?;
+    parse_bitable_deleted_field_response(&payload)
+}
+
+pub async fn create_bitable_view(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    view_name: &str,
+    view_type: Option<&str>,
+) -> CliResult<FeishuBitableView> {
+    let mut body = serde_json::Map::new();
+    body.insert("view_name".to_owned(), json!(view_name));
+    body.insert("view_type".to_owned(), json!(view_type.unwrap_or("grid")));
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views");
+    let payload = client
+        .post_json(&path, Some(access_token), &[], &Value::Object(body))
+        .await?;
+    parse_bitable_view_response(&payload, "bitable view create")
+}
+
+pub async fn get_bitable_view(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    view_id: &str,
+) -> CliResult<FeishuBitableView> {
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}");
+    let payload = client.get_json(&path, Some(access_token), &[]).await?;
+    parse_bitable_view_response(&payload, "bitable view get")
+}
+
+pub async fn list_bitable_views(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    query: &BitableViewListQuery,
+) -> CliResult<FeishuBitableViewListPage> {
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views");
+    let payload = client
+        .get_json(&path, Some(access_token), &query.query_pairs())
+        .await?;
+    parse_bitable_view_page_response(&payload)
+}
+
+pub async fn patch_bitable_view(
+    client: &FeishuClient,
+    access_token: &str,
+    app_token: &str,
+    table_id: &str,
+    view_id: &str,
+    view_name: &str,
+) -> CliResult<FeishuBitableView> {
+    let path = format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}");
+    let payload = client
+        .patch_json(
+            &path,
+            Some(access_token),
+            &[],
+            &json!({ "view_name": view_name }),
+        )
+        .await?;
+    parse_bitable_view_response(&payload, "bitable view patch")
 }
 
 pub async fn search_bitable_records(
@@ -129,8 +584,146 @@ pub fn parse_bitable_record_page_response(payload: &Value) -> CliResult<FeishuBi
         .map_err(|error| format!("bitable record search: failed to parse response: {error}"))
 }
 
+pub fn parse_bitable_app_response(payload: &Value, action: &str) -> CliResult<FeishuBitableApp> {
+    let data = payload
+        .get("data")
+        .ok_or_else(|| format!("{action}: missing `data` in response"))?;
+    let app = data
+        .get("app")
+        .ok_or_else(|| format!("{action}: missing `data.app` in response"))?;
+    serde_json::from_value(app.clone())
+        .map_err(|error| format!("{action}: failed to parse app: {error}"))
+}
+
+pub fn parse_bitable_app_list_response(payload: &Value) -> CliResult<FeishuBitableAppListPage> {
+    let data = payload
+        .get("data")
+        .ok_or_else(|| "bitable app list: missing `data` in response".to_owned())?;
+    let files = data
+        .get("files")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "bitable app list: missing `data.files` in response".to_owned())?;
+    let apps = files
+        .iter()
+        .filter(|file| file.get("type").and_then(Value::as_str) == Some("bitable"))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    Ok(FeishuBitableAppListPage {
+        apps,
+        has_more: data.get("has_more").and_then(Value::as_bool),
+        page_token: data
+            .get("page_token")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+    })
+}
+
+pub fn parse_bitable_deleted_record_response(
+    payload: &Value,
+) -> CliResult<FeishuBitableDeletedRecord> {
+    let data = payload
+        .get("data")
+        .ok_or_else(|| "bitable record delete: missing `data` in response".to_owned())?;
+    serde_json::from_value(data.clone())
+        .map_err(|error| format!("bitable record delete: failed to parse response: {error}"))
+}
+
+pub fn parse_bitable_field_response(
+    payload: &Value,
+    action: &str,
+) -> CliResult<FeishuBitableField> {
+    let data = payload
+        .get("data")
+        .ok_or_else(|| format!("{action}: missing `data` in response"))?;
+    let field = data
+        .get("field")
+        .ok_or_else(|| format!("{action}: missing `data.field` in response"))?;
+    serde_json::from_value(field.clone())
+        .map_err(|error| format!("{action}: failed to parse field: {error}"))
+}
+
+pub fn parse_bitable_field_page_response(payload: &Value) -> CliResult<FeishuBitableFieldListPage> {
+    let data = payload
+        .get("data")
+        .ok_or_else(|| "bitable field list: missing `data` in response".to_owned())?;
+    serde_json::from_value(data.clone())
+        .map_err(|error| format!("bitable field list: failed to parse response: {error}"))
+}
+
+pub fn parse_bitable_deleted_field_response(
+    payload: &Value,
+) -> CliResult<FeishuBitableDeletedField> {
+    let data = payload
+        .get("data")
+        .ok_or_else(|| "bitable field delete: missing `data` in response".to_owned())?;
+    serde_json::from_value(data.clone())
+        .map_err(|error| format!("bitable field delete: failed to parse response: {error}"))
+}
+
+pub fn parse_bitable_view_response(payload: &Value, action: &str) -> CliResult<FeishuBitableView> {
+    let data = payload
+        .get("data")
+        .ok_or_else(|| format!("{action}: missing `data` in response"))?;
+    let view = data
+        .get("view")
+        .ok_or_else(|| format!("{action}: missing `data.view` in response"))?;
+    serde_json::from_value(view.clone())
+        .map_err(|error| format!("{action}: failed to parse view: {error}"))
+}
+
+pub fn parse_bitable_view_page_response(payload: &Value) -> CliResult<FeishuBitableViewListPage> {
+    let data = payload
+        .get("data")
+        .ok_or_else(|| "bitable view list: missing `data` in response".to_owned())?;
+    serde_json::from_value(data.clone())
+        .map_err(|error| format!("bitable view list: failed to parse response: {error}"))
+}
+
+pub fn parse_bitable_data_response(payload: &Value, action: &str) -> CliResult<Value> {
+    payload
+        .get("data")
+        .cloned()
+        .ok_or_else(|| format!("{action}: missing `data` in response"))
+}
+
 fn create_record_query_pairs() -> Vec<(String, String)> {
     vec![("user_id_type".to_owned(), "open_id".to_owned())]
+}
+
+#[allow(dead_code)]
+fn omit_field_property_for_unsupported_types(
+    field_type: i64,
+    property: Option<Value>,
+) -> Option<Value> {
+    if matches!(field_type, 7 | 15) {
+        None
+    } else {
+        property
+    }
+}
+
+fn sanitize_table_fields(fields: Vec<Value>) -> Vec<Value> {
+    fields
+        .into_iter()
+        .map(|field| {
+            let Some(mut field_object) = field.as_object().cloned() else {
+                return field;
+            };
+            let field_type = field_object.get("type").and_then(Value::as_i64);
+            let property = field_object.remove("property");
+            if let Some(field_type) = field_type {
+                if let Some(property) =
+                    omit_field_property_for_unsupported_types(field_type, property)
+                {
+                    field_object.insert("property".to_owned(), property);
+                }
+            } else if let Some(property) = property {
+                field_object.insert("property".to_owned(), property);
+            }
+            Value::Object(field_object)
+        })
+        .collect()
 }
 
 fn normalize_bitable_filter(value: &Value) -> Value {
@@ -261,5 +854,40 @@ mod tests {
 
         let body = query.request_body();
         assert_eq!(body["filter"]["conditions"][0]["value"], json!([]));
+    }
+
+    #[test]
+    fn omit_field_property_for_unsupported_types_drops_checkbox_and_url_property() {
+        assert_eq!(
+            omit_field_property_for_unsupported_types(7, Some(json!({"color": "green"}))),
+            None
+        );
+        assert_eq!(
+            omit_field_property_for_unsupported_types(
+                15,
+                Some(json!({"link": "https://example.com"}))
+            ),
+            None
+        );
+        assert_eq!(
+            omit_field_property_for_unsupported_types(3, Some(json!({"options": []}))),
+            Some(json!({"options": []}))
+        );
+    }
+
+    #[test]
+    fn parse_bitable_delete_record_response_extracts_deleted_status() {
+        let payload = json!({
+            "code": 0,
+            "data": {
+                "deleted": true,
+                "record_id": "rec_123"
+            }
+        });
+
+        let result =
+            parse_bitable_deleted_record_response(&payload).expect("delete response should parse");
+        assert!(result.deleted);
+        assert_eq!(result.record_id, "rec_123");
     }
 }

--- a/crates/app/src/channel/feishu/api/resources/bitable.rs
+++ b/crates/app/src/channel/feishu/api/resources/bitable.rs
@@ -621,6 +621,7 @@ pub fn parse_bitable_app_list_response(payload: &Value) -> CliResult<FeishuBitab
         has_more: data.get("has_more").and_then(Value::as_bool),
         page_token: data
             .get("page_token")
+            .or_else(|| data.get("next_page_token"))
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
     })
@@ -883,6 +884,30 @@ mod tests {
 
         let body = query.request_body();
         assert_eq!(body["automatic_fields"], json!(true));
+    }
+
+    #[test]
+    fn parse_bitable_app_list_response_accepts_next_page_token() {
+        let payload = json!({
+            "code": 0,
+            "data": {
+                "files": [
+                    {
+                        "token": "app_123",
+                        "name": "Roadmap",
+                        "type": "bitable"
+                    }
+                ],
+                "has_more": true,
+                "next_page_token": "next_drive_page"
+            }
+        });
+
+        let result =
+            parse_bitable_app_list_response(&payload).expect("app list response should parse");
+        assert_eq!(result.apps.len(), 1);
+        assert_eq!(result.page_token.as_deref(), Some("next_drive_page"));
+        assert_eq!(result.has_more, Some(true));
     }
 
     #[test]

--- a/crates/app/src/channel/feishu/api/resources/bitable.rs
+++ b/crates/app/src/channel/feishu/api/resources/bitable.rs
@@ -18,6 +18,7 @@ pub struct BitableRecordSearchQuery {
     pub filter: Option<Value>,
     pub sort: Option<Value>,
     pub field_names: Option<Vec<String>>,
+    pub automatic_fields: Option<bool>,
 }
 
 impl BitableRecordSearchQuery {
@@ -45,6 +46,9 @@ impl BitableRecordSearchQuery {
         }
         if let Some(value) = self.field_names.as_ref() {
             body.insert("field_names".to_owned(), json!(value));
+        }
+        if let Some(value) = self.automatic_fields {
+            body.insert("automatic_fields".to_owned(), json!(value));
         }
         Value::Object(body)
     }
@@ -348,6 +352,7 @@ pub async fn batch_create_bitable_records(
     table_id: &str,
     records: Vec<Value>,
 ) -> CliResult<Value> {
+    ensure_bitable_batch_limit("feishu.bitable.record.batch_create", records.len())?;
     let path =
         format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_create");
     let payload = client
@@ -368,6 +373,7 @@ pub async fn batch_update_bitable_records(
     table_id: &str,
     records: Vec<Value>,
 ) -> CliResult<Value> {
+    ensure_bitable_batch_limit("feishu.bitable.record.batch_update", records.len())?;
     let path =
         format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_update");
     let payload = client
@@ -388,6 +394,7 @@ pub async fn batch_delete_bitable_records(
     table_id: &str,
     records: Vec<String>,
 ) -> CliResult<Value> {
+    ensure_bitable_batch_limit("feishu.bitable.record.batch_delete", records.len())?;
     let path =
         format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_delete");
     let payload = client
@@ -691,6 +698,16 @@ fn create_record_query_pairs() -> Vec<(String, String)> {
     vec![("user_id_type".to_owned(), "open_id".to_owned())]
 }
 
+pub fn ensure_bitable_batch_limit(tool_name: &str, actual: usize) -> CliResult<()> {
+    if actual <= 500 {
+        return Ok(());
+    }
+
+    Err(format!(
+        "{tool_name}: batch size must be <= 500, got {actual}"
+    ))
+}
+
 #[allow(dead_code)]
 fn omit_field_property_for_unsupported_types(
     field_type: i64,
@@ -824,6 +841,7 @@ mod tests {
             filter: None,
             sort: None,
             field_names: None,
+            automatic_fields: None,
         };
 
         assert_eq!(
@@ -854,6 +872,24 @@ mod tests {
 
         let body = query.request_body();
         assert_eq!(body["filter"]["conditions"][0]["value"], json!([]));
+    }
+
+    #[test]
+    fn search_request_body_includes_automatic_fields_when_requested() {
+        let query = BitableRecordSearchQuery {
+            automatic_fields: Some(true),
+            ..BitableRecordSearchQuery::default()
+        };
+
+        let body = query.request_body();
+        assert_eq!(body["automatic_fields"], json!(true));
+    }
+
+    #[test]
+    fn ensure_bitable_batch_limit_rejects_more_than_500_items() {
+        let error = ensure_bitable_batch_limit("feishu.bitable.record.batch_create", 501)
+            .expect_err("batch limit should reject values above 500");
+        assert!(error.contains("batch size must be <= 500"), "error={error}");
     }
 
     #[test]

--- a/crates/app/src/channel/feishu/api/resources/types.rs
+++ b/crates/app/src/channel/feishu/api/resources/types.rs
@@ -172,6 +172,29 @@ pub struct FeishuBitableTable {
     pub revision: Option<i64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeishuBitableApp {
+    pub app_token: Option<String>,
+    pub name: Option<String>,
+    pub revision: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeishuBitableField {
+    pub field_id: Option<String>,
+    pub field_name: Option<String>,
+    #[serde(rename = "type")]
+    pub r#type: Option<i64>,
+    pub property: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeishuBitableView {
+    pub view_id: Option<String>,
+    pub view_name: Option<String>,
+    pub view_type: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FeishuBitableTableListPage {
     pub items: Vec<FeishuBitableTable>,
@@ -194,9 +217,45 @@ pub struct FeishuBitableRecordPage {
     pub total: Option<i64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeishuBitableAppListPage {
+    pub apps: Vec<Value>,
+    pub page_token: Option<String>,
+    pub has_more: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeishuBitableFieldListPage {
+    pub items: Vec<FeishuBitableField>,
+    pub page_token: Option<String>,
+    pub has_more: Option<bool>,
+    pub total: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeishuBitableViewListPage {
+    pub items: Vec<FeishuBitableView>,
+    pub page_token: Option<String>,
+    pub has_more: Option<bool>,
+    pub total: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeishuBitableDeletedRecord {
+    pub deleted: bool,
+    pub record_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeishuBitableDeletedField {
+    pub deleted: bool,
+    pub field_id: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn feishu_message_resource_type_accepts_audio_and_media_aliases() {
@@ -218,5 +277,45 @@ mod tests {
                 .expect("image should parse"),
             FeishuMessageResourceType::Image
         );
+    }
+
+    #[test]
+    fn feishu_bitable_field_deserializes_type_and_property() {
+        let field: FeishuBitableField = serde_json::from_value(json!({
+            "field_id": "fld_123",
+            "field_name": "Status",
+            "type": 3,
+            "property": {
+                "options": [{"name": "Open"}]
+            }
+        }))
+        .expect("field should deserialize");
+
+        assert_eq!(field.field_id.as_deref(), Some("fld_123"));
+        assert_eq!(field.field_name.as_deref(), Some("Status"));
+        assert_eq!(field.r#type, Some(3));
+        assert_eq!(field.property, Some(json!({"options": [{"name": "Open"}]})));
+    }
+
+    #[test]
+    fn feishu_bitable_view_list_page_deserializes_items() {
+        let page: FeishuBitableViewListPage = serde_json::from_value(json!({
+            "items": [
+                {
+                    "view_id": "vew_123",
+                    "view_name": "All Tasks",
+                    "view_type": "grid"
+                }
+            ],
+            "has_more": false,
+            "page_token": "page_1",
+            "total": 1
+        }))
+        .expect("view page should deserialize");
+
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].view_id.as_deref(), Some("vew_123"));
+        assert_eq!(page.items[0].view_type.as_deref(), Some("grid"));
+        assert_eq!(page.total, Some(1));
     }
 }

--- a/crates/app/src/channel/feishu/api/resources/types.rs
+++ b/crates/app/src/channel/feishu/api/resources/types.rs
@@ -185,6 +185,7 @@ pub struct FeishuBitableField {
     pub field_name: Option<String>,
     #[serde(rename = "type")]
     pub r#type: Option<i64>,
+    pub ui_type: Option<String>,
     pub property: Option<Value>,
 }
 
@@ -285,6 +286,7 @@ mod tests {
             "field_id": "fld_123",
             "field_name": "Status",
             "type": 3,
+            "ui_type": "SingleSelect",
             "property": {
                 "options": [{"name": "Open"}]
             }
@@ -294,6 +296,7 @@ mod tests {
         assert_eq!(field.field_id.as_deref(), Some("fld_123"));
         assert_eq!(field.field_name.as_deref(), Some("Status"));
         assert_eq!(field.r#type, Some(3));
+        assert_eq!(field.ui_type.as_deref(), Some("SingleSelect"));
         assert_eq!(field.property, Some(json!({"options": [{"name": "Open"}]})));
     }
 

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -793,6 +793,41 @@ fn build_tool_catalog() -> ToolCatalog {
     {
         push_feishu_tool_descriptor(
             &mut descriptors,
+            "feishu.bitable.app.create",
+            "feishu_bitable_app_create",
+            "Create a Feishu Bitable app with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.app.get",
+            "feishu_bitable_app_get",
+            "Fetch Feishu Bitable app metadata with the selected account grant",
+            DEFAULT_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.app.list",
+            "feishu_bitable_app_list",
+            "List Feishu Bitable apps through the Drive API with the selected account grant",
+            DEFAULT_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.app.patch",
+            "feishu_bitable_app_patch",
+            "Update Feishu Bitable app metadata with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.app.copy",
+            "feishu_bitable_app_copy",
+            "Copy a Feishu Bitable app with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
             "feishu.bitable.list",
             "feishu_bitable_list",
             "List data tables in a Feishu Bitable app with the selected account grant",
@@ -800,9 +835,121 @@ fn build_tool_catalog() -> ToolCatalog {
         );
         push_feishu_tool_descriptor(
             &mut descriptors,
+            "feishu.bitable.table.create",
+            "feishu_bitable_table_create",
+            "Create a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.table.patch",
+            "feishu_bitable_table_patch",
+            "Rename a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.table.batch_create",
+            "feishu_bitable_table_batch_create",
+            "Batch create Feishu Bitable tables with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
             "feishu.bitable.record.create",
             "feishu_bitable_record_create",
             "Create a record in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.record.update",
+            "feishu_bitable_record_update",
+            "Update a record in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.record.delete",
+            "feishu_bitable_record_delete",
+            "Delete a record in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.record.batch_create",
+            "feishu_bitable_record_batch_create",
+            "Batch create records in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.record.batch_update",
+            "feishu_bitable_record_batch_update",
+            "Batch update records in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.record.batch_delete",
+            "feishu_bitable_record_batch_delete",
+            "Batch delete records in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.field.create",
+            "feishu_bitable_field_create",
+            "Create a field in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.field.list",
+            "feishu_bitable_field_list",
+            "List fields in a Feishu Bitable table with the selected account grant",
+            DEFAULT_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.field.update",
+            "feishu_bitable_field_update",
+            "Update a field in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.field.delete",
+            "feishu_bitable_field_delete",
+            "Delete a field in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.view.create",
+            "feishu_bitable_view_create",
+            "Create a view in a Feishu Bitable table with the selected account grant",
+            ELEVATED_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.view.get",
+            "feishu_bitable_view_get",
+            "Fetch a view in a Feishu Bitable table with the selected account grant",
+            DEFAULT_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.view.list",
+            "feishu_bitable_view_list",
+            "List views in a Feishu Bitable table with the selected account grant",
+            DEFAULT_TOOL_POLICY_DESCRIPTOR,
+        );
+        push_feishu_tool_descriptor(
+            &mut descriptors,
+            "feishu.bitable.view.patch",
+            "feishu_bitable_view_patch",
+            "Patch a view in a Feishu Bitable table with the selected account grant",
             ELEVATED_TOOL_POLICY_DESCRIPTOR,
         );
         push_feishu_tool_descriptor(
@@ -2932,11 +3079,72 @@ fn feishu_definition(descriptor: &ToolDescriptor) -> Value {
 
 fn tool_argument_hint(name: &str) -> &'static str {
     match name {
+        "feishu.bitable.app.create" => {
+            "account_id?:string,open_id?:string,name:string,folder_token?:string"
+        }
+        "feishu.bitable.app.get" => "account_id?:string,open_id?:string,app_token:string",
+        "feishu.bitable.app.list" => {
+            "account_id?:string,open_id?:string,folder_token?:string,page_size?:integer,page_token?:string"
+        }
+        "feishu.bitable.app.patch" => {
+            "account_id?:string,open_id?:string,app_token:string,name?:string,is_advanced?:boolean"
+        }
+        "feishu.bitable.app.copy" => {
+            "account_id?:string,open_id?:string,app_token:string,name:string,folder_token?:string"
+        }
         "feishu.bitable.list" => {
             "account_id?:string,open_id?:string,app_token:string,page_size?:integer,page_token?:string"
         }
+        "feishu.bitable.table.create" => {
+            "account_id?:string,open_id?:string,app_token:string,name:string,default_view_name?:string,fields?:array"
+        }
+        "feishu.bitable.table.patch" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,name:string"
+        }
+        "feishu.bitable.table.batch_create" => {
+            "account_id?:string,open_id?:string,app_token:string,tables:array"
+        }
         "feishu.bitable.record.create" => {
             "account_id?:string,open_id?:string,app_token:string,table_id:string,fields:object"
+        }
+        "feishu.bitable.record.update" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,record_id:string,fields:object"
+        }
+        "feishu.bitable.record.delete" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,record_id:string"
+        }
+        "feishu.bitable.record.batch_create" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,records:array"
+        }
+        "feishu.bitable.record.batch_update" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,records:array"
+        }
+        "feishu.bitable.record.batch_delete" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,records:array"
+        }
+        "feishu.bitable.field.create" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,field_name:string,type:integer,property?:object"
+        }
+        "feishu.bitable.field.list" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,view_id?:string,page_size?:integer,page_token?:string"
+        }
+        "feishu.bitable.field.update" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,field_id:string,field_name:string,type:integer,property?:object"
+        }
+        "feishu.bitable.field.delete" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,field_id:string"
+        }
+        "feishu.bitable.view.create" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,view_name:string,view_type?:string"
+        }
+        "feishu.bitable.view.get" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,view_id:string"
+        }
+        "feishu.bitable.view.list" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,page_size?:integer,page_token?:string"
+        }
+        "feishu.bitable.view.patch" => {
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,view_id:string,view_name:string"
         }
         "feishu.bitable.record.search" => {
             "account_id?:string,open_id?:string,app_token:string,table_id:string,view_id?:string,filter?:object,sort?:array,field_names?:string[],page_size?:integer,page_token?:string"
@@ -3021,6 +3229,38 @@ fn tool_argument_hint(name: &str) -> &'static str {
 
 fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
     match name {
+        "feishu.bitable.app.create" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("name", "string"),
+            ("folder_token", "string"),
+        ],
+        "feishu.bitable.app.get" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+        ],
+        "feishu.bitable.app.list" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("folder_token", "string"),
+            ("page_size", "integer"),
+            ("page_token", "string"),
+        ],
+        "feishu.bitable.app.patch" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("name", "string"),
+            ("is_advanced", "boolean"),
+        ],
+        "feishu.bitable.app.copy" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("name", "string"),
+            ("folder_token", "string"),
+        ],
         "feishu.bitable.list" => &[
             ("account_id", "string"),
             ("open_id", "string"),
@@ -3028,12 +3268,135 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
             ("page_size", "integer"),
             ("page_token", "string"),
         ],
+        "feishu.bitable.table.create" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("name", "string"),
+            ("default_view_name", "string"),
+            ("fields", "array"),
+        ],
+        "feishu.bitable.table.patch" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("name", "string"),
+        ],
+        "feishu.bitable.table.batch_create" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("tables", "array"),
+        ],
         "feishu.bitable.record.create" => &[
             ("account_id", "string"),
             ("open_id", "string"),
             ("app_token", "string"),
             ("table_id", "string"),
             ("fields", "object"),
+        ],
+        "feishu.bitable.record.update" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("record_id", "string"),
+            ("fields", "object"),
+        ],
+        "feishu.bitable.record.delete" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("record_id", "string"),
+        ],
+        "feishu.bitable.record.batch_create" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("records", "array"),
+        ],
+        "feishu.bitable.record.batch_update" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("records", "array"),
+        ],
+        "feishu.bitable.record.batch_delete" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("records", "array"),
+        ],
+        "feishu.bitable.field.create" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("field_name", "string"),
+            ("type", "integer"),
+            ("property", "object"),
+        ],
+        "feishu.bitable.field.list" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("view_id", "string"),
+            ("page_size", "integer"),
+            ("page_token", "string"),
+        ],
+        "feishu.bitable.field.update" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("field_id", "string"),
+            ("field_name", "string"),
+            ("type", "integer"),
+            ("property", "object"),
+        ],
+        "feishu.bitable.field.delete" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("field_id", "string"),
+        ],
+        "feishu.bitable.view.create" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("view_name", "string"),
+            ("view_type", "string"),
+        ],
+        "feishu.bitable.view.get" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("view_id", "string"),
+        ],
+        "feishu.bitable.view.list" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("page_size", "integer"),
+            ("page_token", "string"),
+        ],
+        "feishu.bitable.view.patch" => &[
+            ("account_id", "string"),
+            ("open_id", "string"),
+            ("app_token", "string"),
+            ("table_id", "string"),
+            ("view_id", "string"),
+            ("view_name", "string"),
         ],
         "feishu.bitable.record.search" => &[
             ("account_id", "string"),
@@ -3246,8 +3609,31 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
 
 fn tool_required_fields(name: &str) -> &'static [&'static str] {
     match name {
+        "feishu.bitable.app.create" => &["name"],
+        "feishu.bitable.app.get" => &["app_token"],
+        "feishu.bitable.app.list" => &[],
+        "feishu.bitable.app.patch" => &["app_token"],
+        "feishu.bitable.app.copy" => &["app_token", "name"],
         "feishu.bitable.list" => &["app_token"],
+        "feishu.bitable.table.create" => &["app_token", "name"],
+        "feishu.bitable.table.patch" => &["app_token", "table_id", "name"],
+        "feishu.bitable.table.batch_create" => &["app_token", "tables"],
         "feishu.bitable.record.create" => &["app_token", "table_id", "fields"],
+        "feishu.bitable.record.update" => &["app_token", "table_id", "record_id", "fields"],
+        "feishu.bitable.record.delete" => &["app_token", "table_id", "record_id"],
+        "feishu.bitable.record.batch_create"
+        | "feishu.bitable.record.batch_update"
+        | "feishu.bitable.record.batch_delete" => &["app_token", "table_id", "records"],
+        "feishu.bitable.field.create" => &["app_token", "table_id", "field_name", "type"],
+        "feishu.bitable.field.list" => &["app_token", "table_id"],
+        "feishu.bitable.field.update" => {
+            &["app_token", "table_id", "field_id", "field_name", "type"]
+        }
+        "feishu.bitable.field.delete" => &["app_token", "table_id", "field_id"],
+        "feishu.bitable.view.create" => &["app_token", "table_id", "view_name"],
+        "feishu.bitable.view.get" => &["app_token", "table_id", "view_id"],
+        "feishu.bitable.view.list" => &["app_token", "table_id"],
+        "feishu.bitable.view.patch" => &["app_token", "table_id", "view_id", "view_name"],
         "feishu.bitable.record.search" => &["app_token", "table_id"],
         "feishu.calendar.freebusy" => &["time_min", "time_max"],
         "feishu.doc.append" | "feishu.doc.read" => &["url"],
@@ -3289,8 +3675,32 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
 
 fn tool_tags(name: &str) -> &'static [&'static str] {
     match name {
+        "feishu.bitable.app.get" | "feishu.bitable.app.list" => {
+            &["feishu", "bitable", "app", "read"]
+        }
+        "feishu.bitable.app.create" | "feishu.bitable.app.patch" | "feishu.bitable.app.copy" => {
+            &["feishu", "bitable", "app", "write"]
+        }
         "feishu.bitable.list" | "feishu.bitable.record.search" => &["feishu", "bitable", "read"],
-        "feishu.bitable.record.create" => &["feishu", "bitable", "write"],
+        "feishu.bitable.table.create"
+        | "feishu.bitable.table.patch"
+        | "feishu.bitable.table.batch_create" => &["feishu", "bitable", "table", "write"],
+        "feishu.bitable.record.create"
+        | "feishu.bitable.record.update"
+        | "feishu.bitable.record.delete"
+        | "feishu.bitable.record.batch_create"
+        | "feishu.bitable.record.batch_update"
+        | "feishu.bitable.record.batch_delete" => &["feishu", "bitable", "write"],
+        "feishu.bitable.field.list" => &["feishu", "bitable", "field", "read"],
+        "feishu.bitable.field.create"
+        | "feishu.bitable.field.update"
+        | "feishu.bitable.field.delete" => &["feishu", "bitable", "field", "write"],
+        "feishu.bitable.view.get" | "feishu.bitable.view.list" => {
+            &["feishu", "bitable", "view", "read"]
+        }
+        "feishu.bitable.view.create" | "feishu.bitable.view.patch" => {
+            &["feishu", "bitable", "view", "write"]
+        }
         "feishu.calendar.freebusy" | "feishu.calendar.list" => &["feishu", "calendar", "read"],
         "feishu.card.update" => &["feishu", "card", "update", "callback"],
         "feishu.doc.read" => &["feishu", "docs", "read"],

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -3147,7 +3147,7 @@ fn tool_argument_hint(name: &str) -> &'static str {
             "account_id?:string,open_id?:string,app_token:string,table_id:string,view_id:string,view_name:string"
         }
         "feishu.bitable.record.search" => {
-            "account_id?:string,open_id?:string,app_token:string,table_id:string,view_id?:string,filter?:object,sort?:array,field_names?:string[],page_size?:integer,page_token?:string"
+            "account_id?:string,open_id?:string,app_token:string,table_id:string,view_id?:string,filter?:object,sort?:array,field_names?:string[],automatic_fields?:boolean,page_size?:integer,page_token?:string"
         }
         "feishu.calendar.freebusy" => {
             "account_id?:string,open_id?:string,time_min:string,time_max:string,user_id?:string,room_id?:string"
@@ -3407,6 +3407,7 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
             ("filter", "object"),
             ("sort", "array"),
             ("field_names", "array"),
+            ("automatic_fields", "boolean"),
             ("page_size", "integer"),
             ("page_token", "string"),
         ],
@@ -4228,5 +4229,19 @@ mod tests {
 
         assert!(description.contains("channel-backed"));
         assert!(description.contains("Matrix"));
+    }
+
+    #[test]
+    fn feishu_bitable_record_search_catalog_metadata_includes_automatic_fields() {
+        let descriptor = tool_catalog()
+            .descriptor("feishu.bitable.record.search")
+            .expect("feishu bitable record search descriptor");
+
+        assert!(descriptor.argument_hint().contains("automatic_fields?:boolean"));
+        assert!(
+            descriptor
+                .parameter_types()
+                .contains(&("automatic_fields", "boolean"))
+        );
     }
 }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -4231,6 +4231,7 @@ mod tests {
         assert!(description.contains("Matrix"));
     }
 
+    #[cfg(feature = "feishu-integration")]
     #[test]
     fn feishu_bitable_record_search_catalog_metadata_includes_automatic_fields() {
         let descriptor = tool_catalog()

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -4237,7 +4237,11 @@ mod tests {
             .descriptor("feishu.bitable.record.search")
             .expect("feishu bitable record search descriptor");
 
-        assert!(descriptor.argument_hint().contains("automatic_fields?:boolean"));
+        assert!(
+            descriptor
+                .argument_hint()
+                .contains("automatic_fields?:boolean")
+        );
         assert!(
             descriptor
                 .parameter_types()

--- a/crates/app/src/tools/feishu.rs
+++ b/crates/app/src/tools/feishu.rs
@@ -2913,11 +2913,7 @@ fn execute_feishu_bitable_app_list_tool_with_config(
             &grant,
         )
         .await?;
-        ensure_any_required_scope(
-            &grant,
-            &["drive:drive:readonly", "bitable:app"],
-            tool_name.as_str(),
-        )?;
+        ensure_required_scopes(&grant, &["drive:drive:readonly"], tool_name.as_str())?;
         let result =
             bitable::list_bitable_apps(&context.client, &grant.access_token, &query).await?;
 
@@ -2926,7 +2922,11 @@ fn execute_feishu_bitable_app_list_tool_with_config(
             context.configured_account_label.as_str(),
             context.account_id.as_str(),
             &grant.principal,
-            json!({ "result": result }),
+            json!({
+                "apps": result.apps,
+                "page_token": result.page_token,
+                "has_more": result.has_more,
+            }),
         ))
     })
 }

--- a/crates/app/src/tools/feishu.rs
+++ b/crates/app/src/tools/feishu.rs
@@ -3601,7 +3601,8 @@ fn execute_feishu_bitable_field_create_tool_with_config(
         "field_name",
         &payload.field_name,
     )?;
-    let field_type = payload.field_type;
+    let field_type =
+        require_positive_i64("feishu.bitable.field.create", "type", payload.field_type)?;
     let property = payload.property;
     let tool_name = request.tool_name;
 
@@ -3714,7 +3715,8 @@ fn execute_feishu_bitable_field_update_tool_with_config(
         "field_name",
         &payload.field_name,
     )?;
-    let field_type = payload.field_type;
+    let field_type =
+        require_positive_i64("feishu.bitable.field.update", "type", payload.field_type)?;
     let property = payload.property;
     let tool_name = request.tool_name;
 
@@ -5024,6 +5026,16 @@ fn require_non_empty(tool_name: &str, field: &str, value: &str) -> CliResult<Str
         return Err(format!("{tool_name} requires payload.{field}"));
     }
     Ok(trimmed.to_owned())
+}
+
+fn require_positive_i64(tool_name: &str, field: &str, value: i64) -> CliResult<i64> {
+    if value > 0 {
+        return Ok(value);
+    }
+
+    Err(format!(
+        "{tool_name} invalid payload.{field}: expected positive integer, got {value}"
+    ))
 }
 
 fn resolve_feishu_doc_content_type(

--- a/crates/app/src/tools/feishu.rs
+++ b/crates/app/src/tools/feishu.rs
@@ -87,11 +87,50 @@ pub(crate) fn drain_deferred_feishu_card_updates(
 #[cfg(all(test, feature = "tool-file"))]
 const FEISHU_TOOL_ALIAS_PAIRS: &[(&str, &str)] = &[
     ("feishu_whoami", "feishu.whoami"),
+    ("feishu_bitable_app_create", "feishu.bitable.app.create"),
+    ("feishu_bitable_app_get", "feishu.bitable.app.get"),
+    ("feishu_bitable_app_list", "feishu.bitable.app.list"),
+    ("feishu_bitable_app_patch", "feishu.bitable.app.patch"),
+    ("feishu_bitable_app_copy", "feishu.bitable.app.copy"),
     ("feishu_bitable_list", "feishu.bitable.list"),
+    ("feishu_bitable_table_create", "feishu.bitable.table.create"),
+    ("feishu_bitable_table_patch", "feishu.bitable.table.patch"),
+    (
+        "feishu_bitable_table_batch_create",
+        "feishu.bitable.table.batch_create",
+    ),
     (
         "feishu_bitable_record_create",
         "feishu.bitable.record.create",
     ),
+    (
+        "feishu_bitable_record_update",
+        "feishu.bitable.record.update",
+    ),
+    (
+        "feishu_bitable_record_delete",
+        "feishu.bitable.record.delete",
+    ),
+    (
+        "feishu_bitable_record_batch_create",
+        "feishu.bitable.record.batch_create",
+    ),
+    (
+        "feishu_bitable_record_batch_update",
+        "feishu.bitable.record.batch_update",
+    ),
+    (
+        "feishu_bitable_record_batch_delete",
+        "feishu.bitable.record.batch_delete",
+    ),
+    ("feishu_bitable_field_create", "feishu.bitable.field.create"),
+    ("feishu_bitable_field_list", "feishu.bitable.field.list"),
+    ("feishu_bitable_field_update", "feishu.bitable.field.update"),
+    ("feishu_bitable_field_delete", "feishu.bitable.field.delete"),
+    ("feishu_bitable_view_create", "feishu.bitable.view.create"),
+    ("feishu_bitable_view_get", "feishu.bitable.view.get"),
+    ("feishu_bitable_view_list", "feishu.bitable.view.list"),
+    ("feishu_bitable_view_patch", "feishu.bitable.view.patch"),
     (
         "feishu_bitable_record_search",
         "feishu.bitable.record.search",
@@ -116,11 +155,50 @@ const FEISHU_TOOL_ALIAS_PAIRS: &[(&str, &str)] = &[
 #[cfg(all(test, not(feature = "tool-file")))]
 const FEISHU_TOOL_ALIAS_PAIRS: &[(&str, &str)] = &[
     ("feishu_whoami", "feishu.whoami"),
+    ("feishu_bitable_app_create", "feishu.bitable.app.create"),
+    ("feishu_bitable_app_get", "feishu.bitable.app.get"),
+    ("feishu_bitable_app_list", "feishu.bitable.app.list"),
+    ("feishu_bitable_app_patch", "feishu.bitable.app.patch"),
+    ("feishu_bitable_app_copy", "feishu.bitable.app.copy"),
     ("feishu_bitable_list", "feishu.bitable.list"),
+    ("feishu_bitable_table_create", "feishu.bitable.table.create"),
+    ("feishu_bitable_table_patch", "feishu.bitable.table.patch"),
+    (
+        "feishu_bitable_table_batch_create",
+        "feishu.bitable.table.batch_create",
+    ),
     (
         "feishu_bitable_record_create",
         "feishu.bitable.record.create",
     ),
+    (
+        "feishu_bitable_record_update",
+        "feishu.bitable.record.update",
+    ),
+    (
+        "feishu_bitable_record_delete",
+        "feishu.bitable.record.delete",
+    ),
+    (
+        "feishu_bitable_record_batch_create",
+        "feishu.bitable.record.batch_create",
+    ),
+    (
+        "feishu_bitable_record_batch_update",
+        "feishu.bitable.record.batch_update",
+    ),
+    (
+        "feishu_bitable_record_batch_delete",
+        "feishu.bitable.record.batch_delete",
+    ),
+    ("feishu_bitable_field_create", "feishu.bitable.field.create"),
+    ("feishu_bitable_field_list", "feishu.bitable.field.list"),
+    ("feishu_bitable_field_update", "feishu.bitable.field.update"),
+    ("feishu_bitable_field_delete", "feishu.bitable.field.delete"),
+    ("feishu_bitable_view_create", "feishu.bitable.view.create"),
+    ("feishu_bitable_view_get", "feishu.bitable.view.get"),
+    ("feishu_bitable_view_list", "feishu.bitable.view.list"),
+    ("feishu_bitable_view_patch", "feishu.bitable.view.patch"),
     (
         "feishu_bitable_record_search",
         "feishu.bitable.record.search",
@@ -703,12 +781,274 @@ struct FeishuBitableListPayload {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
+struct FeishuBitableAppCreatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    name: String,
+    folder_token: Option<String>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableAppGetPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableAppListPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    folder_token: Option<String>,
+    page_token: Option<String>,
+    page_size: Option<usize>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableAppPatchPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    name: Option<String>,
+    is_advanced: Option<bool>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableAppCopyPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    name: String,
+    folder_token: Option<String>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
 struct FeishuBitableRecordCreatePayload {
     #[serde(flatten)]
     selector: GrantSelectorPayload,
     app_token: String,
     table_id: String,
     fields: Value,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableRecordUpdatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    record_id: String,
+    fields: Value,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableRecordDeletePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    record_id: String,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableRecordBatchCreatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    records: Vec<Value>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableRecordBatchUpdatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    records: Vec<Value>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableRecordBatchDeletePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    records: Vec<String>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableFieldCreatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    field_name: String,
+    #[serde(rename = "type")]
+    field_type: i64,
+    property: Option<Value>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableFieldListPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    view_id: Option<String>,
+    page_size: Option<usize>,
+    page_token: Option<String>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableFieldUpdatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    field_id: String,
+    field_name: String,
+    #[serde(rename = "type")]
+    field_type: i64,
+    property: Option<Value>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableFieldDeletePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    field_id: String,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableViewCreatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    view_name: String,
+    view_type: Option<String>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableViewGetPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    view_id: String,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableViewListPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    page_size: Option<usize>,
+    page_token: Option<String>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableViewPatchPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    view_id: String,
+    view_name: String,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableTableCreatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    name: String,
+    default_view_name: Option<String>,
+    fields: Option<Vec<Value>>,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableTablePatchPayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    table_id: String,
+    name: String,
+    #[serde(default, rename = "_loongclaw")]
+    internal: LoongclawInternalToolPayload,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct FeishuBitableTableBatchCreatePayload {
+    #[serde(flatten)]
+    selector: GrantSelectorPayload,
+    app_token: String,
+    tables: Vec<Value>,
     #[serde(default, rename = "_loongclaw")]
     internal: LoongclawInternalToolPayload,
 }
@@ -755,9 +1095,60 @@ pub(super) fn feishu_tool_alias_pairs() -> &'static [(&'static str, &'static str
 pub(super) fn canonical_feishu_tool_name(raw: &str) -> Option<&'static str> {
     match raw {
         "feishu.whoami" | "feishu_whoami" => Some("feishu.whoami"),
+        "feishu.bitable.app.create" | "feishu_bitable_app_create" => {
+            Some("feishu.bitable.app.create")
+        }
+        "feishu.bitable.app.get" | "feishu_bitable_app_get" => Some("feishu.bitable.app.get"),
+        "feishu.bitable.app.list" | "feishu_bitable_app_list" => Some("feishu.bitable.app.list"),
+        "feishu.bitable.app.patch" | "feishu_bitable_app_patch" => Some("feishu.bitable.app.patch"),
+        "feishu.bitable.app.copy" | "feishu_bitable_app_copy" => Some("feishu.bitable.app.copy"),
         "feishu.bitable.list" | "feishu_bitable_list" => Some("feishu.bitable.list"),
+        "feishu.bitable.table.create" | "feishu_bitable_table_create" => {
+            Some("feishu.bitable.table.create")
+        }
+        "feishu.bitable.table.patch" | "feishu_bitable_table_patch" => {
+            Some("feishu.bitable.table.patch")
+        }
+        "feishu.bitable.table.batch_create" | "feishu_bitable_table_batch_create" => {
+            Some("feishu.bitable.table.batch_create")
+        }
         "feishu.bitable.record.create" | "feishu_bitable_record_create" => {
             Some("feishu.bitable.record.create")
+        }
+        "feishu.bitable.record.update" | "feishu_bitable_record_update" => {
+            Some("feishu.bitable.record.update")
+        }
+        "feishu.bitable.record.delete" | "feishu_bitable_record_delete" => {
+            Some("feishu.bitable.record.delete")
+        }
+        "feishu.bitable.record.batch_create" | "feishu_bitable_record_batch_create" => {
+            Some("feishu.bitable.record.batch_create")
+        }
+        "feishu.bitable.record.batch_update" | "feishu_bitable_record_batch_update" => {
+            Some("feishu.bitable.record.batch_update")
+        }
+        "feishu.bitable.record.batch_delete" | "feishu_bitable_record_batch_delete" => {
+            Some("feishu.bitable.record.batch_delete")
+        }
+        "feishu.bitable.field.create" | "feishu_bitable_field_create" => {
+            Some("feishu.bitable.field.create")
+        }
+        "feishu.bitable.field.list" | "feishu_bitable_field_list" => {
+            Some("feishu.bitable.field.list")
+        }
+        "feishu.bitable.field.update" | "feishu_bitable_field_update" => {
+            Some("feishu.bitable.field.update")
+        }
+        "feishu.bitable.field.delete" | "feishu_bitable_field_delete" => {
+            Some("feishu.bitable.field.delete")
+        }
+        "feishu.bitable.view.create" | "feishu_bitable_view_create" => {
+            Some("feishu.bitable.view.create")
+        }
+        "feishu.bitable.view.get" | "feishu_bitable_view_get" => Some("feishu.bitable.view.get"),
+        "feishu.bitable.view.list" | "feishu_bitable_view_list" => Some("feishu.bitable.view.list"),
+        "feishu.bitable.view.patch" | "feishu_bitable_view_patch" => {
+            Some("feishu.bitable.view.patch")
         }
         "feishu.bitable.record.search" | "feishu_bitable_record_search" => {
             Some("feishu.bitable.record.search")
@@ -790,13 +1181,118 @@ pub(super) fn feishu_tool_registry_entries() -> Vec<super::ToolRegistryEntry> {
     let mut entries = Vec::new();
     push_feishu_registry_entry(
         &mut entries,
+        "feishu.bitable.app.create",
+        "Create a Feishu Bitable app with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.app.get",
+        "Fetch Feishu Bitable app metadata with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.app.list",
+        "List Feishu Bitable apps through the Drive API with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.app.patch",
+        "Update Feishu Bitable app metadata with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.app.copy",
+        "Copy a Feishu Bitable app with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
         "feishu.bitable.list",
         "List data tables in a Feishu Bitable app with the selected account grant",
     );
     push_feishu_registry_entry(
         &mut entries,
+        "feishu.bitable.table.create",
+        "Create a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.table.patch",
+        "Rename a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.table.batch_create",
+        "Batch create Feishu Bitable tables with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
         "feishu.bitable.record.create",
         "Create a record in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.record.update",
+        "Update a record in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.record.delete",
+        "Delete a record in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.record.batch_create",
+        "Batch create records in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.record.batch_update",
+        "Batch update records in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.record.batch_delete",
+        "Batch delete records in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.field.create",
+        "Create a field in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.field.list",
+        "List fields in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.field.update",
+        "Update a field in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.field.delete",
+        "Delete a field in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.view.create",
+        "Create a view in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.view.get",
+        "Fetch a view in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.view.list",
+        "List views in a Feishu Bitable table with the selected account grant",
+    );
+    push_feishu_registry_entry(
+        &mut entries,
+        "feishu.bitable.view.patch",
+        "Patch a view in a Feishu Bitable table with the selected account grant",
     );
     push_feishu_registry_entry(
         &mut entries,
@@ -877,6 +1373,88 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     let mut tools = Vec::new();
     push_feishu_provider_tool_definition(
         &mut tools,
+        "feishu_bitable_app_create",
+        "Create a Feishu Bitable app with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "name": { "type": "string", "description": "Bitable app name." },
+                "folder_token": { "type": "string", "description": "Optional Drive folder token." }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_app_get",
+        "Fetch Feishu Bitable app metadata with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "app_token": { "type": "string", "description": "Feishu Bitable app token." }
+            },
+            "required": ["app_token"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_app_list",
+        "List Feishu Bitable apps through the Drive API with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "folder_token": { "type": "string", "description": "Optional Drive folder token." },
+                "page_size": { "type": "integer", "minimum": 1, "maximum": 200 },
+                "page_token": { "type": "string" }
+            },
+            "required": [],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_app_patch",
+        "Update Feishu Bitable app metadata with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "app_token": { "type": "string", "description": "Feishu Bitable app token." },
+                "name": { "type": "string", "description": "Optional new app name." },
+                "is_advanced": { "type": "boolean", "description": "Optional advanced permission toggle." }
+            },
+            "required": ["app_token"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_app_copy",
+        "Copy a Feishu Bitable app with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "app_token": { "type": "string", "description": "Source Bitable app token." },
+                "name": { "type": "string", "description": "Copied app name." },
+                "folder_token": { "type": "string", "description": "Optional target Drive folder token." }
+            },
+            "required": ["app_token", "name"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
         "feishu_bitable_list",
         "List data tables in a Feishu Bitable app with the selected account grant.",
         json!({
@@ -909,6 +1487,57 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
     );
     push_feishu_provider_tool_definition(
         &mut tools,
+        "feishu_bitable_table_create",
+        "Create a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "app_token": { "type": "string", "description": "Feishu Bitable app token." },
+                "name": { "type": "string", "description": "Bitable table name." },
+                "default_view_name": { "type": "string", "description": "Optional default view name." },
+                "fields": { "type": "array", "items": { "type": "object" }, "description": "Optional table field definitions." }
+            },
+            "required": ["app_token", "name"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_table_patch",
+        "Rename a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "app_token": { "type": "string", "description": "Feishu Bitable app token." },
+                "table_id": { "type": "string", "description": "Feishu Bitable table id." },
+                "name": { "type": "string", "description": "New table name." }
+            },
+            "required": ["app_token", "table_id", "name"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_table_batch_create",
+        "Batch create Feishu Bitable tables with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "app_token": { "type": "string", "description": "Feishu Bitable app token." },
+                "tables": { "type": "array", "items": { "type": "object" }, "description": "Tables to create; only `name` is sent upstream." }
+            },
+            "required": ["app_token", "tables"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
         "feishu_bitable_record_create",
         "Create a record in a Feishu Bitable table with the selected account grant.",
         json!({
@@ -936,6 +1565,238 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
                 }
             },
             "required": ["app_token", "table_id", "fields"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_record_update",
+        "Update a record in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "app_token": { "type": "string", "description": "Feishu Bitable app token." },
+                "table_id": { "type": "string", "description": "Feishu Bitable table id." },
+                "record_id": { "type": "string", "description": "Feishu Bitable record id." },
+                "fields": { "type": "object", "description": "Record field values keyed by field name." }
+            },
+            "required": ["app_token", "table_id", "record_id", "fields"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_record_delete",
+        "Delete a record in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string", "description": "Optional Feishu configured account id to route through." },
+                "open_id": { "type": "string", "description": "Optional explicit Feishu user open_id grant selector." },
+                "app_token": { "type": "string", "description": "Feishu Bitable app token." },
+                "table_id": { "type": "string", "description": "Feishu Bitable table id." },
+                "record_id": { "type": "string", "description": "Feishu Bitable record id." }
+            },
+            "required": ["app_token", "table_id", "record_id"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_record_batch_create",
+        "Batch create records in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "records": { "type": "array", "items": { "type": "object" } }
+            },
+            "required": ["app_token", "table_id", "records"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_record_batch_update",
+        "Batch update records in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "records": { "type": "array", "items": { "type": "object" } }
+            },
+            "required": ["app_token", "table_id", "records"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_record_batch_delete",
+        "Batch delete records in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "records": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["app_token", "table_id", "records"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_field_create",
+        "Create a field in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "field_name": { "type": "string" },
+                "type": { "type": "integer" },
+                "property": {}
+            },
+            "required": ["app_token", "table_id", "field_name", "type"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_field_list",
+        "List fields in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "view_id": { "type": "string" },
+                "page_size": { "type": "integer" },
+                "page_token": { "type": "string" }
+            },
+            "required": ["app_token", "table_id"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_field_update",
+        "Update a field in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "field_id": { "type": "string" },
+                "field_name": { "type": "string" },
+                "type": { "type": "integer" },
+                "property": {}
+            },
+            "required": ["app_token", "table_id", "field_id", "field_name", "type"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_field_delete",
+        "Delete a field in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "field_id": { "type": "string" }
+            },
+            "required": ["app_token", "table_id", "field_id"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_view_create",
+        "Create a view in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "view_name": { "type": "string" },
+                "view_type": { "type": "string" }
+            },
+            "required": ["app_token", "table_id", "view_name"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_view_get",
+        "Fetch a view in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "view_id": { "type": "string" }
+            },
+            "required": ["app_token", "table_id", "view_id"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_view_list",
+        "List views in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "page_size": { "type": "integer" },
+                "page_token": { "type": "string" }
+            },
+            "required": ["app_token", "table_id"],
+            "additionalProperties": false
+        }),
+    );
+    push_feishu_provider_tool_definition(
+        &mut tools,
+        "feishu_bitable_view_patch",
+        "Patch a view in a Feishu Bitable table with the selected account grant.",
+        json!({
+            "type": "object",
+            "properties": {
+                "account_id": { "type": "string" },
+                "open_id": { "type": "string" },
+                "app_token": { "type": "string" },
+                "table_id": { "type": "string" },
+                "view_id": { "type": "string" },
+                "view_name": { "type": "string" }
+            },
+            "required": ["app_token", "table_id", "view_id", "view_name"],
             "additionalProperties": false
         }),
     );
@@ -1772,9 +2633,72 @@ pub(super) fn execute_feishu_tool_with_config(
 ) -> Result<ToolCoreOutcome, String> {
     match request.tool_name.as_str() {
         "feishu.whoami" => execute_feishu_whoami_tool_with_config(request, config),
+        "feishu.bitable.app.create" => {
+            execute_feishu_bitable_app_create_tool_with_config(request, config)
+        }
+        "feishu.bitable.app.get" => {
+            execute_feishu_bitable_app_get_tool_with_config(request, config)
+        }
+        "feishu.bitable.app.list" => {
+            execute_feishu_bitable_app_list_tool_with_config(request, config)
+        }
+        "feishu.bitable.app.patch" => {
+            execute_feishu_bitable_app_patch_tool_with_config(request, config)
+        }
+        "feishu.bitable.app.copy" => {
+            execute_feishu_bitable_app_copy_tool_with_config(request, config)
+        }
         "feishu.bitable.list" => execute_feishu_bitable_list_tool_with_config(request, config),
+        "feishu.bitable.table.create" => {
+            execute_feishu_bitable_table_create_tool_with_config(request, config)
+        }
+        "feishu.bitable.table.patch" => {
+            execute_feishu_bitable_table_patch_tool_with_config(request, config)
+        }
+        "feishu.bitable.table.batch_create" => {
+            execute_feishu_bitable_table_batch_create_tool_with_config(request, config)
+        }
         "feishu.bitable.record.create" => {
             execute_feishu_bitable_record_create_tool_with_config(request, config)
+        }
+        "feishu.bitable.record.update" => {
+            execute_feishu_bitable_record_update_tool_with_config(request, config)
+        }
+        "feishu.bitable.record.delete" => {
+            execute_feishu_bitable_record_delete_tool_with_config(request, config)
+        }
+        "feishu.bitable.record.batch_create" => {
+            execute_feishu_bitable_record_batch_create_tool_with_config(request, config)
+        }
+        "feishu.bitable.record.batch_update" => {
+            execute_feishu_bitable_record_batch_update_tool_with_config(request, config)
+        }
+        "feishu.bitable.record.batch_delete" => {
+            execute_feishu_bitable_record_batch_delete_tool_with_config(request, config)
+        }
+        "feishu.bitable.field.create" => {
+            execute_feishu_bitable_field_create_tool_with_config(request, config)
+        }
+        "feishu.bitable.field.list" => {
+            execute_feishu_bitable_field_list_tool_with_config(request, config)
+        }
+        "feishu.bitable.field.update" => {
+            execute_feishu_bitable_field_update_tool_with_config(request, config)
+        }
+        "feishu.bitable.field.delete" => {
+            execute_feishu_bitable_field_delete_tool_with_config(request, config)
+        }
+        "feishu.bitable.view.create" => {
+            execute_feishu_bitable_view_create_tool_with_config(request, config)
+        }
+        "feishu.bitable.view.get" => {
+            execute_feishu_bitable_view_get_tool_with_config(request, config)
+        }
+        "feishu.bitable.view.list" => {
+            execute_feishu_bitable_view_list_tool_with_config(request, config)
+        }
+        "feishu.bitable.view.patch" => {
+            execute_feishu_bitable_view_patch_tool_with_config(request, config)
         }
         "feishu.bitable.record.search" => {
             execute_feishu_bitable_record_search_tool_with_config(request, config)
@@ -1881,6 +2805,213 @@ fn execute_feishu_bitable_list_tool_with_config(
     })
 }
 
+fn execute_feishu_bitable_app_create_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableAppCreatePayload>(
+        "feishu.bitable.app.create",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let name = require_non_empty("feishu.bitable.app.create", "name", &payload.name)?;
+    let folder_token = payload.folder_token;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let app = bitable::create_bitable_app(
+            &context.client,
+            &grant.access_token,
+            &name,
+            folder_token.as_deref(),
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "app": app }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_app_get_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload =
+        parse_payload::<FeishuBitableAppGetPayload>("feishu.bitable.app.get", request.payload)?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty("feishu.bitable.app.get", "app_token", &payload.app_token)?;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let app =
+            bitable::get_bitable_app(&context.client, &grant.access_token, &app_token).await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "app": app }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_app_list_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload =
+        parse_payload::<FeishuBitableAppListPayload>("feishu.bitable.app.list", request.payload)?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let query = bitable::BitableAppListQuery {
+        folder_token: payload.folder_token,
+        page_token: payload.page_token,
+        page_size: payload.page_size,
+    };
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(
+            &grant,
+            &["drive:drive:readonly", "bitable:app"],
+            tool_name.as_str(),
+        )?;
+        let result =
+            bitable::list_bitable_apps(&context.client, &grant.access_token, &query).await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_app_patch_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload =
+        parse_payload::<FeishuBitableAppPatchPayload>("feishu.bitable.app.patch", request.payload)?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty("feishu.bitable.app.patch", "app_token", &payload.app_token)?;
+    let name = payload.name;
+    let is_advanced = payload.is_advanced;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let app = bitable::patch_bitable_app(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            name.as_deref(),
+            is_advanced,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "app": app }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_app_copy_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload =
+        parse_payload::<FeishuBitableAppCopyPayload>("feishu.bitable.app.copy", request.payload)?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty("feishu.bitable.app.copy", "app_token", &payload.app_token)?;
+    let name = require_non_empty("feishu.bitable.app.copy", "name", &payload.name)?;
+    let folder_token = payload.folder_token;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let app = bitable::copy_bitable_app(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &name,
+            folder_token.as_deref(),
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "app": app }),
+        ))
+    })
+}
+
 fn execute_feishu_bitable_record_create_tool_with_config(
     request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
@@ -1938,6 +3069,153 @@ fn execute_feishu_bitable_record_create_tool_with_config(
             json!({
                 "record": record,
             }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_table_create_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableTableCreatePayload>(
+        "feishu.bitable.table.create",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.table.create",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let name = require_non_empty("feishu.bitable.table.create", "name", &payload.name)?;
+    let default_view_name = payload.default_view_name;
+    let fields = payload.fields;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let result = bitable::create_bitable_table(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &name,
+            default_view_name.as_deref(),
+            fields,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_table_patch_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableTablePatchPayload>(
+        "feishu.bitable.table.patch",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.table.patch",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty("feishu.bitable.table.patch", "table_id", &payload.table_id)?;
+    let name = require_non_empty("feishu.bitable.table.patch", "name", &payload.name)?;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let result = bitable::patch_bitable_table(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &name,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_table_batch_create_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableTableBatchCreatePayload>(
+        "feishu.bitable.table.batch_create",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.table.batch_create",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let tables = payload.tables;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let result = bitable::batch_create_bitable_tables(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            tables,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
         ))
     })
 }
@@ -2000,6 +3278,701 @@ fn execute_feishu_bitable_record_search_tool_with_config(
             json!({
                 "result": result,
             }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_record_update_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableRecordUpdatePayload>(
+        "feishu.bitable.record.update",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.record.update",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty(
+        "feishu.bitable.record.update",
+        "table_id",
+        &payload.table_id,
+    )?;
+    let record_id = require_non_empty(
+        "feishu.bitable.record.update",
+        "record_id",
+        &payload.record_id,
+    )?;
+    if !payload.fields.is_object() {
+        return Err(format!(
+            "feishu.bitable.record.update: `fields` must be a JSON object, got {}",
+            payload.fields
+        ));
+    }
+    let fields = payload.fields;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["base:record:write"], tool_name.as_str())?;
+        let record = bitable::update_bitable_record(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &record_id,
+            fields,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "record": record }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_record_delete_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableRecordDeletePayload>(
+        "feishu.bitable.record.delete",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.record.delete",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty(
+        "feishu.bitable.record.delete",
+        "table_id",
+        &payload.table_id,
+    )?;
+    let record_id = require_non_empty(
+        "feishu.bitable.record.delete",
+        "record_id",
+        &payload.record_id,
+    )?;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["base:record:write"], tool_name.as_str())?;
+        let result = bitable::delete_bitable_record(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &record_id,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({
+                "deleted": result.deleted,
+                "record_id": result.record_id,
+            }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_record_batch_create_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableRecordBatchCreatePayload>(
+        "feishu.bitable.record.batch_create",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.record.batch_create",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty(
+        "feishu.bitable.record.batch_create",
+        "table_id",
+        &payload.table_id,
+    )?;
+    let records = payload.records;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["base:record:write"], tool_name.as_str())?;
+        let result = bitable::batch_create_bitable_records(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            records,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_record_batch_update_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableRecordBatchUpdatePayload>(
+        "feishu.bitable.record.batch_update",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.record.batch_update",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty(
+        "feishu.bitable.record.batch_update",
+        "table_id",
+        &payload.table_id,
+    )?;
+    let records = payload.records;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["base:record:write"], tool_name.as_str())?;
+        let result = bitable::batch_update_bitable_records(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            records,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_record_batch_delete_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableRecordBatchDeletePayload>(
+        "feishu.bitable.record.batch_delete",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.record.batch_delete",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty(
+        "feishu.bitable.record.batch_delete",
+        "table_id",
+        &payload.table_id,
+    )?;
+    let records = payload.records;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["base:record:write"], tool_name.as_str())?;
+        let result = bitable::batch_delete_bitable_records(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            records,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_field_create_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableFieldCreatePayload>(
+        "feishu.bitable.field.create",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.field.create",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty("feishu.bitable.field.create", "table_id", &payload.table_id)?;
+    let field_name = require_non_empty(
+        "feishu.bitable.field.create",
+        "field_name",
+        &payload.field_name,
+    )?;
+    let field_type = payload.field_type;
+    let property = payload.property;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let field = bitable::create_bitable_field(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &field_name,
+            field_type,
+            property,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "field": field }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_field_list_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableFieldListPayload>(
+        "feishu.bitable.field.list",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token =
+        require_non_empty("feishu.bitable.field.list", "app_token", &payload.app_token)?;
+    let table_id = require_non_empty("feishu.bitable.field.list", "table_id", &payload.table_id)?;
+    let query = bitable::BitableFieldListQuery {
+        view_id: payload.view_id,
+        page_size: payload.page_size,
+        page_token: payload.page_token,
+    };
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let result = bitable::list_bitable_fields(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &query,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_field_update_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableFieldUpdatePayload>(
+        "feishu.bitable.field.update",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.field.update",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty("feishu.bitable.field.update", "table_id", &payload.table_id)?;
+    let field_id = require_non_empty("feishu.bitable.field.update", "field_id", &payload.field_id)?;
+    let field_name = require_non_empty(
+        "feishu.bitable.field.update",
+        "field_name",
+        &payload.field_name,
+    )?;
+    let field_type = payload.field_type;
+    let property = payload.property;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let field = bitable::update_bitable_field(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &field_id,
+            &field_name,
+            field_type,
+            property,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "field": field }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_field_delete_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableFieldDeletePayload>(
+        "feishu.bitable.field.delete",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.field.delete",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty("feishu.bitable.field.delete", "table_id", &payload.table_id)?;
+    let field_id = require_non_empty("feishu.bitable.field.delete", "field_id", &payload.field_id)?;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let result = bitable::delete_bitable_field(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &field_id,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({
+                "deleted": result.deleted,
+                "field_id": result.field_id,
+            }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_view_create_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableViewCreatePayload>(
+        "feishu.bitable.view.create",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty(
+        "feishu.bitable.view.create",
+        "app_token",
+        &payload.app_token,
+    )?;
+    let table_id = require_non_empty("feishu.bitable.view.create", "table_id", &payload.table_id)?;
+    let view_name = require_non_empty(
+        "feishu.bitable.view.create",
+        "view_name",
+        &payload.view_name,
+    )?;
+    let view_type = payload.view_type;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let view = bitable::create_bitable_view(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &view_name,
+            view_type.as_deref(),
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "view": view }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_view_get_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload =
+        parse_payload::<FeishuBitableViewGetPayload>("feishu.bitable.view.get", request.payload)?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty("feishu.bitable.view.get", "app_token", &payload.app_token)?;
+    let table_id = require_non_empty("feishu.bitable.view.get", "table_id", &payload.table_id)?;
+    let view_id = require_non_empty("feishu.bitable.view.get", "view_id", &payload.view_id)?;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let view = bitable::get_bitable_view(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &view_id,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "view": view }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_view_list_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload =
+        parse_payload::<FeishuBitableViewListPayload>("feishu.bitable.view.list", request.payload)?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token = require_non_empty("feishu.bitable.view.list", "app_token", &payload.app_token)?;
+    let table_id = require_non_empty("feishu.bitable.view.list", "table_id", &payload.table_id)?;
+    let query = bitable::BitableViewListQuery {
+        page_size: payload.page_size,
+        page_token: payload.page_token,
+    };
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let result = bitable::list_bitable_views(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &query,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "result": result }),
+        ))
+    })
+}
+
+fn execute_feishu_bitable_view_patch_tool_with_config(
+    request: ToolCoreRequest,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let payload = parse_payload::<FeishuBitableViewPatchPayload>(
+        "feishu.bitable.view.patch",
+        request.payload,
+    )?;
+    let context = load_feishu_tool_context(
+        config,
+        requested_account_id(payload.selector.account_id.as_deref(), &payload.internal),
+    )?;
+    let grant = require_selected_grant(&context, payload.selector.open_id.as_deref())?;
+    let app_token =
+        require_non_empty("feishu.bitable.view.patch", "app_token", &payload.app_token)?;
+    let table_id = require_non_empty("feishu.bitable.view.patch", "table_id", &payload.table_id)?;
+    let view_id = require_non_empty("feishu.bitable.view.patch", "view_id", &payload.view_id)?;
+    let view_name =
+        require_non_empty("feishu.bitable.view.patch", "view_name", &payload.view_name)?;
+    let tool_name = request.tool_name;
+
+    run_feishu_future(async move {
+        let grant = crate::channel::feishu::api::ensure_fresh_user_grant(
+            &context.client,
+            &context.store,
+            &grant,
+        )
+        .await?;
+        ensure_any_required_scope(&grant, &["bitable:app"], tool_name.as_str())?;
+        let view = bitable::patch_bitable_view(
+            &context.client,
+            &grant.access_token,
+            &app_token,
+            &table_id,
+            &view_id,
+            &view_name,
+        )
+        .await?;
+
+        Ok(ok_outcome(
+            tool_name.as_str(),
+            context.configured_account_label.as_str(),
+            context.account_id.as_str(),
+            &grant.principal,
+            json!({ "view": view }),
         ))
     })
 }

--- a/crates/app/src/tools/feishu.rs
+++ b/crates/app/src/tools/feishu.rs
@@ -1066,6 +1066,7 @@ struct FeishuBitableRecordSearchPayload {
     filter: Option<Value>,
     sort: Option<Value>,
     field_names: Option<Vec<String>>,
+    automatic_fields: Option<bool>,
     #[serde(default, rename = "_loongclaw")]
     internal: LoongclawInternalToolPayload,
 }
@@ -1854,6 +1855,10 @@ pub(super) fn feishu_provider_tool_definitions() -> Vec<Value> {
                         "type": "string"
                     },
                     "description": "Optional subset of field names to return."
+                },
+                "automatic_fields": {
+                    "type": "boolean",
+                    "description": "Whether to return automatic fields such as created_time and last_modified_time."
                 },
                 "page_size": {
                     "type": "integer",
@@ -3250,6 +3255,7 @@ fn execute_feishu_bitable_record_search_tool_with_config(
         filter: payload.filter,
         sort: payload.sort,
         field_names: payload.field_names,
+        automatic_fields: payload.automatic_fields,
     };
     let tool_name = request.tool_name;
 
@@ -3431,6 +3437,7 @@ fn execute_feishu_bitable_record_batch_create_tool_with_config(
         &payload.table_id,
     )?;
     let records = payload.records;
+    bitable::ensure_bitable_batch_limit("feishu.bitable.record.batch_create", records.len())?;
     let tool_name = request.tool_name;
 
     run_feishu_future(async move {
@@ -3484,6 +3491,7 @@ fn execute_feishu_bitable_record_batch_update_tool_with_config(
         &payload.table_id,
     )?;
     let records = payload.records;
+    bitable::ensure_bitable_batch_limit("feishu.bitable.record.batch_update", records.len())?;
     let tool_name = request.tool_name;
 
     run_feishu_future(async move {
@@ -3537,6 +3545,7 @@ fn execute_feishu_bitable_record_batch_delete_tool_with_config(
         &payload.table_id,
     )?;
     let records = payload.records;
+    bitable::ensure_bitable_batch_limit("feishu.bitable.record.batch_delete", records.len())?;
     let tool_name = request.tool_name;
 
     run_feishu_future(async move {
@@ -3668,7 +3677,12 @@ fn execute_feishu_bitable_field_list_tool_with_config(
             context.configured_account_label.as_str(),
             context.account_id.as_str(),
             &grant.principal,
-            json!({ "result": result }),
+            json!({
+                "fields": result.items,
+                "page_token": result.page_token,
+                "has_more": result.has_more,
+                "total": result.total,
+            }),
         ))
     })
 }
@@ -3923,7 +3937,12 @@ fn execute_feishu_bitable_view_list_tool_with_config(
             context.configured_account_label.as_str(),
             context.account_id.as_str(),
             &grant.principal,
-            json!({ "result": result }),
+            json!({
+                "views": result.items,
+                "page_token": result.page_token,
+                "has_more": result.has_more,
+                "total": result.total,
+            }),
         ))
     })
 }

--- a/crates/app/src/tools/feishu.rs
+++ b/crates/app/src/tools/feishu.rs
@@ -2804,7 +2804,9 @@ fn execute_feishu_bitable_list_tool_with_config(
             context.account_id.as_str(),
             &grant.principal,
             json!({
-                "result": result,
+                "tables": result.items,
+                "has_more": result.has_more,
+                "page_token": result.page_token,
             }),
         ))
     })

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -5034,6 +5034,58 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "feishu-integration", feature = "channel-feishu"))]
+    #[test]
+    fn feishu_bitable_field_tools_require_positive_type() {
+        let temp_dir = unique_feishu_tool_temp_dir("bitable-field-type");
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let sqlite_path = temp_dir.join("feishu.sqlite3");
+        let _store = seed_feishu_tool_grant(
+            &sqlite_path,
+            "u-token-field-type",
+            &["offline_access", "bitable:app"],
+        );
+        let config =
+            build_feishu_tool_runtime_config("http://127.0.0.1:9".to_owned(), &sqlite_path);
+
+        let create_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "feishu.bitable.field.create".to_owned(),
+                payload: json!({
+                    "app_token": "app_demo",
+                    "table_id": "tbl_demo",
+                    "field_name": "Amount",
+                    "type": 0
+                }),
+            },
+            &config,
+        )
+        .expect_err("field create should reject non-positive type");
+        assert!(
+            create_error.contains("feishu.bitable.field.create invalid payload.type"),
+            "error={create_error}"
+        );
+
+        let update_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "feishu.bitable.field.update".to_owned(),
+                payload: json!({
+                    "app_token": "app_demo",
+                    "table_id": "tbl_demo",
+                    "field_id": "fld_demo",
+                    "field_name": "Amount",
+                    "type": 0
+                }),
+            },
+            &config,
+        )
+        .expect_err("field update should reject non-positive type");
+        assert!(
+            update_error.contains("feishu.bitable.field.update invalid payload.type"),
+            "error={update_error}"
+        );
+    }
+
     #[cfg(feature = "feishu-integration")]
     #[test]
     fn provider_tool_definitions_with_config_caps_bitable_list_page_size_at_100() {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -4951,6 +4951,78 @@ mod tests {
             search["function"]["parameters"]["properties"]["sort"]["items"]["type"],
             "object"
         );
+        assert_eq!(
+            search["function"]["parameters"]["properties"]["automatic_fields"]["type"],
+            "boolean"
+        );
+    }
+
+    #[cfg(all(feature = "feishu-integration", feature = "channel-feishu"))]
+    #[test]
+    fn feishu_bitable_batch_record_tools_reject_more_than_500_items_before_network() {
+        let temp_dir = unique_feishu_tool_temp_dir("bitable-batch-limit");
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let sqlite_path = temp_dir.join("feishu.sqlite3");
+        let _store = seed_feishu_tool_grant(
+            &sqlite_path,
+            "u-token-batch-limit",
+            &["offline_access", "base:record:write"],
+        );
+        let config =
+            build_feishu_tool_runtime_config("http://127.0.0.1:9".to_owned(), &sqlite_path);
+
+        let create_records = (0..501)
+            .map(|index| json!({ "fields": { "Name": format!("row-{index}") } }))
+            .collect::<Vec<_>>();
+        let create_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "feishu.bitable.record.batch_create".to_owned(),
+                payload: json!({
+                    "app_token": "app_demo",
+                    "table_id": "tbl_demo",
+                    "records": create_records,
+                }),
+            },
+            &config,
+        )
+        .expect_err("tool should reject >500 batch create items");
+        assert!(create_error.contains("batch size must be <= 500"), "error={create_error}");
+
+        let update_records = (0..501)
+            .map(|index| {
+                json!({ "record_id": format!("rec_{index}"), "fields": { "Name": format!("row-{index}") } })
+            })
+            .collect::<Vec<_>>();
+        let update_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "feishu.bitable.record.batch_update".to_owned(),
+                payload: json!({
+                    "app_token": "app_demo",
+                    "table_id": "tbl_demo",
+                    "records": update_records,
+                }),
+            },
+            &config,
+        )
+        .expect_err("tool should reject >500 batch update items");
+        assert!(update_error.contains("batch size must be <= 500"), "error={update_error}");
+
+        let delete_records = (0..501)
+            .map(|index| format!("rec_{index}"))
+            .collect::<Vec<_>>();
+        let delete_error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "feishu.bitable.record.batch_delete".to_owned(),
+                payload: json!({
+                    "app_token": "app_demo",
+                    "table_id": "tbl_demo",
+                    "records": delete_records,
+                }),
+            },
+            &config,
+        )
+        .expect_err("tool should reject >500 batch delete items");
+        assert!(delete_error.contains("batch size must be <= 500"), "error={delete_error}");
     }
 
     #[cfg(feature = "feishu-integration")]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -9576,6 +9576,86 @@ mod tests {
 
     #[cfg(all(feature = "feishu-integration", feature = "channel-feishu"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn feishu_bitable_list_tool_returns_top_level_tables_page() {
+        use std::fs;
+
+        use axum::{
+            Json, Router,
+            extract::{Request, State},
+            routing::get,
+        };
+
+        let temp_dir = unique_feishu_tool_temp_dir("bitable-list-tables");
+        fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let sqlite_path = temp_dir.join("feishu.sqlite3");
+        let requests =
+            std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<FeishuToolMockRequest>::new()));
+        let state = FeishuToolMockServerState {
+            requests: requests.clone(),
+        };
+        let router = Router::new().route(
+            "/open-apis/bitable/v1/apps/app_demo/tables",
+            get({
+                let state = state.clone();
+                move |request: Request| {
+                    let state = state.clone();
+                    async move {
+                        record_feishu_tool_request(State(state), request).await;
+                        Json(serde_json::json!({
+                            "code": 0,
+                            "data": {
+                                "items": [{
+                                    "table_id": "tbl_1",
+                                    "name": "Tasks",
+                                    "revision": 3
+                                }],
+                                "page_token": "page_next",
+                                "has_more": true
+                            }
+                        }))
+                    }
+                }
+            }),
+        );
+        let (base_url, server) = spawn_feishu_tool_mock_server(router).await;
+        let _store = seed_feishu_tool_grant(
+            &sqlite_path,
+            "u-token-bitable-list",
+            &["offline_access", "base:table:read"],
+        );
+        let config = build_feishu_tool_runtime_config(base_url, &sqlite_path);
+
+        let outcome = execute_tool_core_with_config(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "feishu.bitable.list".to_owned(),
+                payload: serde_json::json!({
+                    "app_token": "app_demo",
+                    "page_size": 20,
+                    "page_token": "page_current"
+                }),
+            },
+            &config,
+        )
+        .expect("feishu bitable list tool should succeed");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["tables"][0]["table_id"], "tbl_1");
+        assert_eq!(outcome.payload["has_more"], true);
+        assert_eq!(outcome.payload["page_token"], "page_next");
+        assert!(outcome.payload.get("result").is_none());
+
+        let requests = requests.lock().await.clone();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/tables");
+        assert!(requests[0].query.as_deref().is_some_and(|query| {
+            query.contains("page_size=20") && query.contains("page_token=page_current")
+        }));
+
+        server.abort();
+    }
+
+    #[cfg(all(feature = "feishu-integration", feature = "channel-feishu"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn feishu_messages_search_tool_defaults_chat_scope_and_account_from_internal_ingress() {
         use std::collections::BTreeMap;
         use std::fs;

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -4986,7 +4986,10 @@ mod tests {
             &config,
         )
         .expect_err("tool should reject >500 batch create items");
-        assert!(create_error.contains("batch size must be <= 500"), "error={create_error}");
+        assert!(
+            create_error.contains("batch size must be <= 500"),
+            "error={create_error}"
+        );
 
         let update_records = (0..501)
             .map(|index| {
@@ -5005,7 +5008,10 @@ mod tests {
             &config,
         )
         .expect_err("tool should reject >500 batch update items");
-        assert!(update_error.contains("batch size must be <= 500"), "error={update_error}");
+        assert!(
+            update_error.contains("batch size must be <= 500"),
+            "error={update_error}"
+        );
 
         let delete_records = (0..501)
             .map(|index| format!("rec_{index}"))
@@ -5022,7 +5028,10 @@ mod tests {
             &config,
         )
         .expect_err("tool should reject >500 batch delete items");
-        assert!(delete_error.contains("batch size must be <= 500"), "error={delete_error}");
+        assert!(
+            delete_error.contains("batch size must be <= 500"),
+            "error={delete_error}"
+        );
     }
 
     #[cfg(feature = "feishu-integration")]
@@ -9646,7 +9655,10 @@ mod tests {
 
         let requests = requests.lock().await.clone();
         assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/tables");
+        assert_eq!(
+            requests[0].path,
+            "/open-apis/bitable/v1/apps/app_demo/tables"
+        );
         assert!(requests[0].query.as_deref().is_some_and(|query| {
             query.contains("page_size=20") && query.contains("page_token=page_current")
         }));

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -122,10 +122,52 @@ pub enum FeishuCalendarCommand {
 
 #[derive(Subcommand, Debug)]
 pub enum FeishuBitableCommand {
+    /// Create a Bitable app
+    AppCreate(FeishuBitableAppCreateArgs),
+    /// Fetch Bitable app metadata
+    AppGet(FeishuBitableAppGetArgs),
+    /// List Bitable apps through the Drive API
+    AppList(FeishuBitableAppListArgs),
+    /// Update Bitable app metadata
+    AppPatch(FeishuBitableAppPatchArgs),
+    /// Copy a Bitable app
+    AppCopy(FeishuBitableAppCopyArgs),
     /// List data tables in a Bitable app
     ListTables(FeishuBitableListTablesArgs),
+    /// Create a data table in a Bitable app
+    CreateTable(FeishuBitableCreateTableArgs),
+    /// Rename a data table in a Bitable app
+    PatchTable(FeishuBitablePatchTableArgs),
+    /// Batch create data tables in a Bitable app
+    BatchCreateTables(FeishuBitableBatchCreateTablesArgs),
     /// Create a record in a Bitable table
     CreateRecord(FeishuBitableCreateRecordArgs),
+    /// Update a record in a Bitable table
+    UpdateRecord(FeishuBitableUpdateRecordArgs),
+    /// Delete a record in a Bitable table
+    DeleteRecord(FeishuBitableDeleteRecordArgs),
+    /// Batch create records in a Bitable table
+    BatchCreateRecords(FeishuBitableBatchCreateRecordsArgs),
+    /// Batch update records in a Bitable table
+    BatchUpdateRecords(FeishuBitableBatchUpdateRecordsArgs),
+    /// Batch delete records in a Bitable table
+    BatchDeleteRecords(FeishuBitableBatchDeleteRecordsArgs),
+    /// Create a field in a Bitable table
+    CreateField(FeishuBitableCreateFieldArgs),
+    /// List fields in a Bitable table
+    ListFields(FeishuBitableListFieldsArgs),
+    /// Update a field in a Bitable table
+    UpdateField(FeishuBitableUpdateFieldArgs),
+    /// Delete a field in a Bitable table
+    DeleteField(FeishuBitableDeleteFieldArgs),
+    /// Create a view in a Bitable table
+    CreateView(FeishuBitableCreateViewArgs),
+    /// Get a view in a Bitable table
+    GetView(FeishuBitableGetViewArgs),
+    /// List views in a Bitable table
+    ListViews(FeishuBitableListViewsArgs),
+    /// Patch a view in a Bitable table
+    PatchView(FeishuBitablePatchViewArgs),
     /// Search records in a Bitable table
     SearchRecords(FeishuBitableSearchRecordsArgs),
 }
@@ -371,6 +413,60 @@ pub struct FeishuBitableListTablesArgs {
 }
 
 #[derive(Args, Debug, Clone)]
+pub struct FeishuBitableAppCreateArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub folder_token: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableAppGetArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableAppListArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub folder_token: Option<String>,
+    #[arg(long)]
+    pub page_size: Option<usize>,
+    #[arg(long)]
+    pub page_token: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableAppPatchArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub name: Option<String>,
+    #[arg(long)]
+    pub is_advanced: Option<bool>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableAppCopyArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub folder_token: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
 pub struct FeishuBitableCreateRecordArgs {
     #[command(flatten)]
     pub grant: FeishuGrantArgs,
@@ -380,6 +476,42 @@ pub struct FeishuBitableCreateRecordArgs {
     pub table_id: String,
     #[arg(long)]
     pub fields: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableCreateTableArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub default_view_name: Option<String>,
+    #[arg(long)]
+    pub fields: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitablePatchTableArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub name: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableBatchCreateTablesArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub tables: String,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -402,6 +534,184 @@ pub struct FeishuBitableSearchRecordsArgs {
     pub page_size: Option<usize>,
     #[arg(long)]
     pub page_token: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableUpdateRecordArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub record_id: String,
+    #[arg(long)]
+    pub fields: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableDeleteRecordArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub record_id: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableBatchCreateRecordsArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub records: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableBatchUpdateRecordsArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub records: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableBatchDeleteRecordsArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub records: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableCreateFieldArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub field_name: String,
+    #[arg(long = "type")]
+    pub field_type: i64,
+    #[arg(long)]
+    pub property: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableListFieldsArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub view_id: Option<String>,
+    #[arg(long)]
+    pub page_size: Option<usize>,
+    #[arg(long)]
+    pub page_token: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableUpdateFieldArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub field_id: String,
+    #[arg(long)]
+    pub field_name: Option<String>,
+    #[arg(long = "type")]
+    pub field_type: Option<i64>,
+    #[arg(long)]
+    pub property: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableDeleteFieldArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub field_id: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableCreateViewArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub view_name: String,
+    #[arg(long)]
+    pub view_type: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableGetViewArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub view_id: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitableListViewsArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub page_size: Option<usize>,
+    #[arg(long)]
+    pub page_token: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct FeishuBitablePatchViewArgs {
+    #[command(flatten)]
+    pub grant: FeishuGrantArgs,
+    #[arg(long)]
+    pub app_token: String,
+    #[arg(long)]
+    pub table_id: String,
+    #[arg(long)]
+    pub view_id: String,
+    #[arg(long)]
+    pub view_name: String,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -565,12 +875,52 @@ pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
             }
         },
         FeishuCommand::Bitable { command } => match command {
+            FeishuBitableCommand::AppCreate(args) => {
+                let payload = execute_feishu_bitable_app_create(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_app_text)?;
+            }
+            FeishuBitableCommand::AppGet(args) => {
+                let payload = execute_feishu_bitable_app_get(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_app_text)?;
+            }
+            FeishuBitableCommand::AppList(args) => {
+                let payload = execute_feishu_bitable_app_list(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_app_list_text,
+                )?;
+            }
+            FeishuBitableCommand::AppPatch(args) => {
+                let payload = execute_feishu_bitable_app_patch(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_app_text)?;
+            }
+            FeishuBitableCommand::AppCopy(args) => {
+                let payload = execute_feishu_bitable_app_copy(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_app_text)?;
+            }
             FeishuBitableCommand::ListTables(args) => {
                 let payload = execute_feishu_bitable_list_tables(&args).await?;
                 print_feishu_payload(
                     &payload,
                     args.grant.common.json,
                     render_bitable_list_tables_text,
+                )?;
+            }
+            FeishuBitableCommand::CreateTable(args) => {
+                let payload = execute_feishu_bitable_create_table(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_table_text)?;
+            }
+            FeishuBitableCommand::PatchTable(args) => {
+                let payload = execute_feishu_bitable_patch_table(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_table_text)?;
+            }
+            FeishuBitableCommand::BatchCreateTables(args) => {
+                let payload = execute_feishu_bitable_batch_create_tables(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_table_batch_create_text,
                 )?;
             }
             FeishuBitableCommand::CreateRecord(args) => {
@@ -580,6 +930,90 @@ pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
                     args.grant.common.json,
                     render_bitable_create_record_text,
                 )?;
+            }
+            FeishuBitableCommand::UpdateRecord(args) => {
+                let payload = execute_feishu_bitable_update_record(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_create_record_text,
+                )?;
+            }
+            FeishuBitableCommand::DeleteRecord(args) => {
+                let payload = execute_feishu_bitable_delete_record(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_delete_record_text,
+                )?;
+            }
+            FeishuBitableCommand::BatchCreateRecords(args) => {
+                let payload = execute_feishu_bitable_batch_create_records(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_batch_records_text,
+                )?;
+            }
+            FeishuBitableCommand::BatchUpdateRecords(args) => {
+                let payload = execute_feishu_bitable_batch_update_records(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_batch_records_text,
+                )?;
+            }
+            FeishuBitableCommand::BatchDeleteRecords(args) => {
+                let payload = execute_feishu_bitable_batch_delete_records(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_batch_records_text,
+                )?;
+            }
+            FeishuBitableCommand::CreateField(args) => {
+                let payload = execute_feishu_bitable_create_field(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_field_text)?;
+            }
+            FeishuBitableCommand::ListFields(args) => {
+                let payload = execute_feishu_bitable_list_fields(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_field_list_text,
+                )?;
+            }
+            FeishuBitableCommand::UpdateField(args) => {
+                let payload = execute_feishu_bitable_update_field(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_field_text)?;
+            }
+            FeishuBitableCommand::DeleteField(args) => {
+                let payload = execute_feishu_bitable_delete_field(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_delete_field_text,
+                )?;
+            }
+            FeishuBitableCommand::CreateView(args) => {
+                let payload = execute_feishu_bitable_create_view(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_view_text)?;
+            }
+            FeishuBitableCommand::GetView(args) => {
+                let payload = execute_feishu_bitable_get_view(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_view_text)?;
+            }
+            FeishuBitableCommand::ListViews(args) => {
+                let payload = execute_feishu_bitable_list_views(&args).await?;
+                print_feishu_payload(
+                    &payload,
+                    args.grant.common.json,
+                    render_bitable_view_list_text,
+                )?;
+            }
+            FeishuBitableCommand::PatchView(args) => {
+                let payload = execute_feishu_bitable_patch_view(&args).await?;
+                print_feishu_payload(&payload, args.grant.common.json, render_bitable_view_text)?;
             }
             FeishuBitableCommand::SearchRecords(args) => {
                 let payload = execute_feishu_bitable_search_records(&args).await?;
@@ -1367,6 +1801,139 @@ pub async fn execute_feishu_bitable_list_tables(
     }))
 }
 
+pub async fn execute_feishu_bitable_app_create(
+    args: &FeishuBitableAppCreateArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable app-create",
+    )?;
+    let client = context.build_client()?;
+    let app = mvp::channel::feishu::api::resources::bitable::create_bitable_app(
+        &client,
+        &grant.access_token,
+        &args.name,
+        args.folder_token.as_deref(),
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "app": app,
+    }))
+}
+
+pub async fn execute_feishu_bitable_app_get(args: &FeishuBitableAppGetArgs) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable app-get",
+    )?;
+    let client = context.build_client()?;
+    let app = mvp::channel::feishu::api::resources::bitable::get_bitable_app(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "app": app,
+    }))
+}
+
+pub async fn execute_feishu_bitable_app_list(args: &FeishuBitableAppListArgs) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["drive:drive:readonly", "bitable:app"],
+        "loongclaw feishu bitable app-list",
+    )?;
+    let client = context.build_client()?;
+    let result = mvp::channel::feishu::api::resources::bitable::list_bitable_apps(
+        &client,
+        &grant.access_token,
+        &mvp::channel::feishu::api::resources::bitable::BitableAppListQuery {
+            folder_token: args.folder_token.clone(),
+            page_size: args.page_size,
+            page_token: args.page_token.clone(),
+        },
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_app_patch(
+    args: &FeishuBitableAppPatchArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable app-patch",
+    )?;
+    let client = context.build_client()?;
+    let app = mvp::channel::feishu::api::resources::bitable::patch_bitable_app(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        args.name.as_deref(),
+        args.is_advanced,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "app": app,
+    }))
+}
+
+pub async fn execute_feishu_bitable_app_copy(args: &FeishuBitableAppCopyArgs) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable app-copy",
+    )?;
+    let client = context.build_client()?;
+    let app = mvp::channel::feishu::api::resources::bitable::copy_bitable_app(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.name,
+        args.folder_token.as_deref(),
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "app": app,
+    }))
+}
+
 pub async fn execute_feishu_bitable_create_record(
     args: &FeishuBitableCreateRecordArgs,
 ) -> CliResult<Value> {
@@ -1397,6 +1964,109 @@ pub async fn execute_feishu_bitable_create_record(
         "configured_account": context.resolved.configured_account_label,
         "principal": grant.principal,
         "record": record,
+    }))
+}
+
+pub async fn execute_feishu_bitable_create_table(
+    args: &FeishuBitableCreateTableArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable create-table",
+    )?;
+    let client = context.build_client()?;
+    let fields = args
+        .fields
+        .as_deref()
+        .map(serde_json::from_str::<Value>)
+        .transpose()
+        .map_err(|error| format!("invalid --fields JSON: {error}"))?;
+    let fields = match fields {
+        Some(Value::Array(items)) => Some(items),
+        Some(_) => return Err("--fields must be a JSON array".to_owned()),
+        None => None,
+    };
+    let result = mvp::channel::feishu::api::resources::bitable::create_bitable_table(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.name,
+        args.default_view_name.as_deref(),
+        fields,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_patch_table(
+    args: &FeishuBitablePatchTableArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable patch-table",
+    )?;
+    let client = context.build_client()?;
+    let result = mvp::channel::feishu::api::resources::bitable::patch_bitable_table(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.name,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_batch_create_tables(
+    args: &FeishuBitableBatchCreateTablesArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable batch-create-tables",
+    )?;
+    let client = context.build_client()?;
+    let tables = serde_json::from_str::<Value>(&args.tables)
+        .map_err(|error| format!("invalid --tables JSON: {error}"))?;
+    let tables = match tables {
+        Value::Array(items) => items,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => {
+            return Err("--tables must be a JSON array".to_owned());
+        }
+    };
+    let result = mvp::channel::feishu::api::resources::bitable::batch_create_bitable_tables(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        tables,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
     }))
 }
 
@@ -1438,6 +2108,459 @@ pub async fn execute_feishu_bitable_search_records(
         "configured_account": context.resolved.configured_account_label,
         "principal": grant.principal,
         "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_update_record(
+    args: &FeishuBitableUpdateRecordArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["base:record:write"],
+        "loongclaw feishu bitable update-record",
+    )?;
+    let client = context.build_client()?;
+    let fields = serde_json::from_str::<Value>(&args.fields)
+        .map_err(|error| format!("invalid --fields JSON: {error}"))?;
+    if !fields.is_object() {
+        return Err("--fields must be a JSON object (e.g. '{\"Name\": \"value\"}')".to_owned());
+    }
+    let record = mvp::channel::feishu::api::resources::bitable::update_bitable_record(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.record_id,
+        fields,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "record": record,
+    }))
+}
+
+pub async fn execute_feishu_bitable_delete_record(
+    args: &FeishuBitableDeleteRecordArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["base:record:write"],
+        "loongclaw feishu bitable delete-record",
+    )?;
+    let client = context.build_client()?;
+    let result = mvp::channel::feishu::api::resources::bitable::delete_bitable_record(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.record_id,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "deleted": result.deleted,
+        "record_id": result.record_id,
+    }))
+}
+
+pub async fn execute_feishu_bitable_batch_create_records(
+    args: &FeishuBitableBatchCreateRecordsArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["base:record:write"],
+        "loongclaw feishu bitable batch-create-records",
+    )?;
+    let client = context.build_client()?;
+    let records = serde_json::from_str::<Value>(&args.records)
+        .map_err(|error| format!("invalid --records JSON: {error}"))?;
+    let records = match records {
+        Value::Array(items) => items,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => {
+            return Err("--records must be a JSON array".to_owned());
+        }
+    };
+    if records.len() > 500 {
+        return Err(format!(
+            "feishu.bitable.record.batch_create: batch size must be <= 500, got {}",
+            records.len()
+        ));
+    }
+    let result = mvp::channel::feishu::api::resources::bitable::batch_create_bitable_records(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        records,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_batch_update_records(
+    args: &FeishuBitableBatchUpdateRecordsArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["base:record:write"],
+        "loongclaw feishu bitable batch-update-records",
+    )?;
+    let client = context.build_client()?;
+    let records = serde_json::from_str::<Value>(&args.records)
+        .map_err(|error| format!("invalid --records JSON: {error}"))?;
+    let records = match records {
+        Value::Array(items) => items,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => {
+            return Err("--records must be a JSON array".to_owned());
+        }
+    };
+    if records.len() > 500 {
+        return Err(format!(
+            "feishu.bitable.record.batch_update: batch size must be <= 500, got {}",
+            records.len()
+        ));
+    }
+    let result = mvp::channel::feishu::api::resources::bitable::batch_update_bitable_records(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        records,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_batch_delete_records(
+    args: &FeishuBitableBatchDeleteRecordsArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["base:record:write"],
+        "loongclaw feishu bitable batch-delete-records",
+    )?;
+    let client = context.build_client()?;
+    let records = serde_json::from_str::<Value>(&args.records)
+        .map_err(|error| format!("invalid --records JSON: {error}"))?;
+    let records = match records {
+        Value::Array(items) => items
+            .into_iter()
+            .map(|item| {
+                item.as_str()
+                    .map(ToOwned::to_owned)
+                    .ok_or_else(|| "--records must be a JSON array of strings".to_owned())
+            })
+            .collect::<CliResult<Vec<_>>>()?,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => {
+            return Err("--records must be a JSON array".to_owned());
+        }
+    };
+    if records.len() > 500 {
+        return Err(format!(
+            "feishu.bitable.record.batch_delete: batch size must be <= 500, got {}",
+            records.len()
+        ));
+    }
+    let result = mvp::channel::feishu::api::resources::bitable::batch_delete_bitable_records(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        records,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_create_field(
+    args: &FeishuBitableCreateFieldArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable create-field",
+    )?;
+    let client = context.build_client()?;
+    let property = args
+        .property
+        .as_deref()
+        .map(serde_json::from_str::<Value>)
+        .transpose()
+        .map_err(|error| format!("invalid --property JSON: {error}"))?;
+    let field = mvp::channel::feishu::api::resources::bitable::create_bitable_field(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.field_name,
+        args.field_type,
+        property,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "field": field,
+    }))
+}
+
+pub async fn execute_feishu_bitable_list_fields(
+    args: &FeishuBitableListFieldsArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable list-fields",
+    )?;
+    let client = context.build_client()?;
+    let result = mvp::channel::feishu::api::resources::bitable::list_bitable_fields(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &mvp::channel::feishu::api::resources::bitable::BitableFieldListQuery {
+            view_id: args.view_id.clone(),
+            page_size: args.page_size,
+            page_token: args.page_token.clone(),
+        },
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_update_field(
+    args: &FeishuBitableUpdateFieldArgs,
+) -> CliResult<Value> {
+    let field_name = args
+        .field_name
+        .as_deref()
+        .ok_or_else(|| "--field-name and --type are required for field update".to_owned())?;
+    let field_type = args
+        .field_type
+        .ok_or_else(|| "--field-name and --type are required for field update".to_owned())?;
+
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable update-field",
+    )?;
+    let client = context.build_client()?;
+    let property = args
+        .property
+        .as_deref()
+        .map(serde_json::from_str::<Value>)
+        .transpose()
+        .map_err(|error| format!("invalid --property JSON: {error}"))?;
+    let field = mvp::channel::feishu::api::resources::bitable::update_bitable_field(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.field_id,
+        field_name,
+        field_type,
+        property,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "field": field,
+    }))
+}
+
+pub async fn execute_feishu_bitable_delete_field(
+    args: &FeishuBitableDeleteFieldArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable delete-field",
+    )?;
+    let client = context.build_client()?;
+    let result = mvp::channel::feishu::api::resources::bitable::delete_bitable_field(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.field_id,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "deleted": result.deleted,
+        "field_id": result.field_id,
+    }))
+}
+
+pub async fn execute_feishu_bitable_create_view(
+    args: &FeishuBitableCreateViewArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable create-view",
+    )?;
+    let client = context.build_client()?;
+    let view = mvp::channel::feishu::api::resources::bitable::create_bitable_view(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.view_name,
+        args.view_type.as_deref(),
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "view": view,
+    }))
+}
+
+pub async fn execute_feishu_bitable_get_view(args: &FeishuBitableGetViewArgs) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable get-view",
+    )?;
+    let client = context.build_client()?;
+    let view = mvp::channel::feishu::api::resources::bitable::get_bitable_view(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.view_id,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "view": view,
+    }))
+}
+
+pub async fn execute_feishu_bitable_list_views(
+    args: &FeishuBitableListViewsArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable list-views",
+    )?;
+    let client = context.build_client()?;
+    let result = mvp::channel::feishu::api::resources::bitable::list_bitable_views(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &mvp::channel::feishu::api::resources::bitable::BitableViewListQuery {
+            page_size: args.page_size,
+            page_token: args.page_token.clone(),
+        },
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "result": result,
+    }))
+}
+
+pub async fn execute_feishu_bitable_patch_view(
+    args: &FeishuBitablePatchViewArgs,
+) -> CliResult<Value> {
+    let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["bitable:app"],
+        "loongclaw feishu bitable patch-view",
+    )?;
+    let client = context.build_client()?;
+    let view = mvp::channel::feishu::api::resources::bitable::patch_bitable_view(
+        &client,
+        &grant.access_token,
+        &args.app_token,
+        &args.table_id,
+        &args.view_id,
+        &args.view_name,
+    )
+    .await?;
+
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "principal": grant.principal,
+        "view": view,
     }))
 }
 
@@ -2879,6 +4002,67 @@ fn render_bitable_list_tables_text(payload: &Value) -> CliResult<String> {
     Ok(lines.join("\n"))
 }
 
+fn render_bitable_app_text(payload: &Value) -> CliResult<String> {
+    let app = payload
+        .get("app")
+        .ok_or_else(|| "feishu bitable app payload missing app".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable app".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!(
+            "app_token: {}",
+            app.get("app_token").and_then(Value::as_str).unwrap_or("-")
+        ),
+        format!(
+            "name: {}",
+            app.get("name").and_then(Value::as_str).unwrap_or("-")
+        ),
+    ]);
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_app_list_text(payload: &Value) -> CliResult<String> {
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "feishu bitable app list payload missing result".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable app-list".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!(
+            "apps: {}",
+            result
+                .get("apps")
+                .and_then(Value::as_array)
+                .map_or(0, std::vec::Vec::len)
+        ),
+        format!(
+            "has_more: {}",
+            result
+                .get("has_more")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        ),
+        format!(
+            "page_token: {}",
+            result
+                .get("page_token")
+                .and_then(Value::as_str)
+                .unwrap_or("-")
+        ),
+    ]);
+    Ok(lines.join("\n"))
+}
+
 fn render_bitable_create_record_text(payload: &Value) -> CliResult<String> {
     let record = payload
         .get("record")
@@ -2906,6 +4090,54 @@ fn render_bitable_create_record_text(payload: &Value) -> CliResult<String> {
                 .map_or(0, serde_json::Map::len)
         ),
     ]);
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_table_text(payload: &Value) -> CliResult<String> {
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "feishu bitable table payload missing result".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable table".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!(
+            "table_id: {}",
+            result
+                .get("table_id")
+                .and_then(Value::as_str)
+                .unwrap_or("-")
+        ),
+        format!(
+            "name: {}",
+            result.get("name").and_then(Value::as_str).unwrap_or("-")
+        ),
+    ]);
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_table_batch_create_text(payload: &Value) -> CliResult<String> {
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "feishu bitable batch create tables payload missing result".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable batch-create-tables".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.push(format!(
+        "table_ids: {}",
+        result
+            .get("table_ids")
+            .and_then(Value::as_array)
+            .map_or(0, std::vec::Vec::len)
+    ));
     Ok(lines.join("\n"))
 }
 
@@ -2943,6 +4175,173 @@ fn render_bitable_search_records_text(payload: &Value) -> CliResult<String> {
                 .unwrap_or("-")
         ),
     ]);
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_delete_record_text(payload: &Value) -> CliResult<String> {
+    let mut lines = vec![
+        "feishu bitable delete-record".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!(
+            "record_id: {}",
+            payload
+                .get("record_id")
+                .and_then(Value::as_str)
+                .unwrap_or("-")
+        ),
+        format!(
+            "deleted: {}",
+            payload
+                .get("deleted")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        ),
+    ]);
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_batch_records_text(payload: &Value) -> CliResult<String> {
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "feishu bitable batch payload missing result".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable batch-records".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    if let Some(records) = result.get("records").and_then(Value::as_array) {
+        lines.push(format!("records: {}", records.len()));
+    }
+    if let Some(success) = result.get("success").and_then(Value::as_bool) {
+        lines.push(format!("success: {success}"));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_field_text(payload: &Value) -> CliResult<String> {
+    let field = payload
+        .get("field")
+        .ok_or_else(|| "feishu bitable field payload missing field".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable field".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!(
+            "field_id: {}",
+            field.get("field_id").and_then(Value::as_str).unwrap_or("-")
+        ),
+        format!(
+            "field_name: {}",
+            field
+                .get("field_name")
+                .and_then(Value::as_str)
+                .unwrap_or("-")
+        ),
+    ]);
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_field_list_text(payload: &Value) -> CliResult<String> {
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "feishu bitable field list payload missing result".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable list-fields".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.push(format!(
+        "fields: {}",
+        result
+            .get("items")
+            .and_then(Value::as_array)
+            .map_or(0, std::vec::Vec::len)
+    ));
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_delete_field_text(payload: &Value) -> CliResult<String> {
+    let mut lines = vec![
+        "feishu bitable delete-field".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!(
+            "field_id: {}",
+            payload
+                .get("field_id")
+                .and_then(Value::as_str)
+                .unwrap_or("-")
+        ),
+        format!(
+            "deleted: {}",
+            payload
+                .get("deleted")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        ),
+    ]);
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_view_text(payload: &Value) -> CliResult<String> {
+    let view = payload
+        .get("view")
+        .ok_or_else(|| "feishu bitable view payload missing view".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable view".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.extend([
+        format!(
+            "view_id: {}",
+            view.get("view_id").and_then(Value::as_str).unwrap_or("-")
+        ),
+        format!(
+            "view_name: {}",
+            view.get("view_name").and_then(Value::as_str).unwrap_or("-")
+        ),
+    ]);
+    Ok(lines.join("\n"))
+}
+
+fn render_bitable_view_list_text(payload: &Value) -> CliResult<String> {
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "feishu bitable view list payload missing result".to_owned())?;
+    let mut lines = vec![
+        "feishu bitable list-views".to_owned(),
+        format!("account: {}", required_json_string(payload, "account_id")?),
+    ];
+    if let Some(configured_account) = payload.get("configured_account").and_then(Value::as_str) {
+        lines.push(format!("configured_account: {configured_account}"));
+    }
+    lines.push(format!(
+        "views: {}",
+        result
+            .get("items")
+            .and_then(Value::as_array)
+            .map_or(0, std::vec::Vec::len)
+    ));
     Ok(lines.join("\n"))
 }
 

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -1859,7 +1859,7 @@ pub async fn execute_feishu_bitable_app_list(args: &FeishuBitableAppListArgs) ->
     ensure_grant_has_any_scope(
         &grant,
         context.resolved.configured_account_id.as_str(),
-        &["drive:drive:readonly", "bitable:app"],
+        &["drive:drive:readonly"],
         "loongclaw feishu bitable app-list",
     )?;
     let client = context.build_client()?;
@@ -1878,7 +1878,9 @@ pub async fn execute_feishu_bitable_app_list(args: &FeishuBitableAppListArgs) ->
         "account_id": context.account_id(),
         "configured_account": context.resolved.configured_account_label,
         "principal": grant.principal,
-        "result": result,
+        "apps": result.apps,
+        "page_token": result.page_token,
+        "has_more": result.has_more,
     }))
 }
 
@@ -4042,9 +4044,6 @@ fn render_bitable_app_text(payload: &Value) -> CliResult<String> {
 }
 
 fn render_bitable_app_list_text(payload: &Value) -> CliResult<String> {
-    let result = payload
-        .get("result")
-        .ok_or_else(|| "feishu bitable app list payload missing result".to_owned())?;
     let mut lines = vec![
         "feishu bitable app-list".to_owned(),
         format!("account: {}", required_json_string(payload, "account_id")?),
@@ -4055,21 +4054,21 @@ fn render_bitable_app_list_text(payload: &Value) -> CliResult<String> {
     lines.extend([
         format!(
             "apps: {}",
-            result
+            payload
                 .get("apps")
                 .and_then(Value::as_array)
                 .map_or(0, std::vec::Vec::len)
         ),
         format!(
             "has_more: {}",
-            result
+            payload
                 .get("has_more")
                 .and_then(Value::as_bool)
                 .unwrap_or(false)
         ),
         format!(
             "page_token: {}",
-            result
+            payload
                 .get("page_token")
                 .and_then(Value::as_str)
                 .unwrap_or("-")

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -1785,6 +1785,12 @@ pub async fn execute_feishu_bitable_list_tables(
     args: &FeishuBitableListTablesArgs,
 ) -> CliResult<Value> {
     let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["base:table:read"],
+        "loongclaw feishu bitable list-tables",
+    )?;
     let client = context.build_client()?;
     let result = mvp::channel::feishu::api::resources::bitable::list_bitable_tables(
         &client,

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -531,6 +531,8 @@ pub struct FeishuBitableSearchRecordsArgs {
     #[arg(long)]
     pub sort: Option<String>,
     #[arg(long)]
+    pub automatic_fields: bool,
+    #[arg(long)]
     pub page_size: Option<usize>,
     #[arg(long)]
     pub page_token: Option<String>,
@@ -2074,6 +2076,12 @@ pub async fn execute_feishu_bitable_search_records(
     args: &FeishuBitableSearchRecordsArgs,
 ) -> CliResult<Value> {
     let (context, grant) = load_context_and_fresh_grant(&args.grant).await?;
+    ensure_grant_has_any_scope(
+        &grant,
+        context.resolved.configured_account_id.as_str(),
+        &["base:record:retrieve"],
+        "loongclaw feishu bitable search-records",
+    )?;
     let client = context.build_client()?;
     let filter = args
         .filter
@@ -2099,6 +2107,7 @@ pub async fn execute_feishu_bitable_search_records(
             filter,
             sort,
             field_names: (!args.field_names.is_empty()).then(|| args.field_names.clone()),
+            automatic_fields: args.automatic_fields.then_some(true),
         },
     )
     .await?;
@@ -2371,7 +2380,10 @@ pub async fn execute_feishu_bitable_list_fields(
         "account_id": context.account_id(),
         "configured_account": context.resolved.configured_account_label,
         "principal": grant.principal,
-        "result": result,
+        "fields": result.items,
+        "page_token": result.page_token,
+        "has_more": result.has_more,
+        "total": result.total,
     }))
 }
 
@@ -2531,7 +2543,10 @@ pub async fn execute_feishu_bitable_list_views(
         "account_id": context.account_id(),
         "configured_account": context.resolved.configured_account_label,
         "principal": grant.principal,
-        "result": result,
+        "views": result.items,
+        "page_token": result.page_token,
+        "has_more": result.has_more,
+        "total": result.total,
     }))
 }
 
@@ -4253,9 +4268,6 @@ fn render_bitable_field_text(payload: &Value) -> CliResult<String> {
 }
 
 fn render_bitable_field_list_text(payload: &Value) -> CliResult<String> {
-    let result = payload
-        .get("result")
-        .ok_or_else(|| "feishu bitable field list payload missing result".to_owned())?;
     let mut lines = vec![
         "feishu bitable list-fields".to_owned(),
         format!("account: {}", required_json_string(payload, "account_id")?),
@@ -4265,8 +4277,8 @@ fn render_bitable_field_list_text(payload: &Value) -> CliResult<String> {
     }
     lines.push(format!(
         "fields: {}",
-        result
-            .get("items")
+        payload
+            .get("fields")
             .and_then(Value::as_array)
             .map_or(0, std::vec::Vec::len)
     ));
@@ -4325,9 +4337,6 @@ fn render_bitable_view_text(payload: &Value) -> CliResult<String> {
 }
 
 fn render_bitable_view_list_text(payload: &Value) -> CliResult<String> {
-    let result = payload
-        .get("result")
-        .ok_or_else(|| "feishu bitable view list payload missing result".to_owned())?;
     let mut lines = vec![
         "feishu bitable list-views".to_owned(),
         format!("account: {}", required_json_string(payload, "account_id")?),
@@ -4337,8 +4346,8 @@ fn render_bitable_view_list_text(payload: &Value) -> CliResult<String> {
     }
     lines.push(format!(
         "views: {}",
-        result
-            .get("items")
+        payload
+            .get("views")
             .and_then(Value::as_array)
             .map_or(0, std::vec::Vec::len)
     ));

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -1805,7 +1805,9 @@ pub async fn execute_feishu_bitable_list_tables(
         "account_id": context.account_id(),
         "configured_account": context.resolved.configured_account_label,
         "principal": grant.principal,
-        "result": result,
+        "tables": result.items,
+        "has_more": result.has_more,
+        "page_token": result.page_token,
     }))
 }
 
@@ -3989,9 +3991,6 @@ fn render_calendar_freebusy_text(payload: &Value) -> CliResult<String> {
 }
 
 fn render_bitable_list_tables_text(payload: &Value) -> CliResult<String> {
-    let result = payload
-        .get("result")
-        .ok_or_else(|| "feishu bitable list payload missing result".to_owned())?;
     let mut lines = vec![
         "feishu bitable list-tables".to_owned(),
         format!("account: {}", required_json_string(payload, "account_id")?),
@@ -4002,21 +4001,21 @@ fn render_bitable_list_tables_text(payload: &Value) -> CliResult<String> {
     lines.extend([
         format!(
             "tables: {}",
-            result
-                .get("items")
+            payload
+                .get("tables")
                 .and_then(Value::as_array)
                 .map_or(0, std::vec::Vec::len)
         ),
         format!(
             "has_more: {}",
-            result
+            payload
                 .get("has_more")
                 .and_then(Value::as_bool)
                 .unwrap_or(false)
         ),
         format!(
             "page_token: {}",
-            result
+            payload
                 .get("page_token")
                 .and_then(Value::as_str)
                 .unwrap_or("-")

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -1592,7 +1592,7 @@ async fn feishu_bitable_app_patch_sends_patch_body() {
     };
     let router = Router::new().route(
         "/open-apis/bitable/v1/apps/app_demo",
-        put({
+        patch({
             let state = state.clone();
             move |request| {
                 let state = state.clone();
@@ -1640,7 +1640,7 @@ async fn feishu_bitable_app_patch_sends_patch_body() {
     assert_eq!(payload["app"]["name"], "Renamed");
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].method, "PUT");
+    assert_eq!(requests[0].method, "PATCH");
     assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo");
     assert!(requests[0].body.contains("\"name\":\"Renamed\""));
     assert!(requests[0].body.contains("\"is_advanced\":true"));
@@ -1873,7 +1873,7 @@ async fn feishu_bitable_patch_table_sends_patch_request() {
     };
     let router = Router::new().route(
         "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo",
-        put({
+        patch({
             let state = state.clone();
             move |request| {
                 let state = state.clone();
@@ -1916,7 +1916,7 @@ async fn feishu_bitable_patch_table_sends_patch_request() {
     assert_eq!(payload["result"]["name"], "Renamed Table");
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].method, "PUT");
+    assert_eq!(requests[0].method, "PATCH");
     assert_eq!(
         requests[0].path,
         "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo"

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -3,7 +3,7 @@ use axum::{
     Json, Router,
     body::to_bytes,
     extract::{Request, State},
-    routing::{get, post},
+    routing::{delete, get, patch, post},
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -1148,9 +1148,9 @@ async fn feishu_bitable_app_list_filters_drive_files_to_bitable() {
     .await
     .expect("execute bitable app list");
 
-    assert_eq!(payload["result"]["apps"].as_array().map(Vec::len), Some(1));
-    assert_eq!(payload["result"]["apps"][0]["token"], "app_1");
-    assert_eq!(payload["result"]["has_more"], true);
+    assert_eq!(payload["apps"].as_array().map(Vec::len), Some(1));
+    assert_eq!(payload["apps"][0]["token"], "app_1");
+    assert_eq!(payload["has_more"], true);
 
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
@@ -1161,6 +1161,253 @@ async fn feishu_bitable_app_list_filters_drive_files_to_bitable() {
             && query.contains("page_size=20")
             && query.contains("page_token=page_current")
     ));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_app_list_requires_drive_readonly_scope() {
+    let temp_dir = temp_feishu_cli_dir("bitable-app-list-scope");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/drive/v1/files",
+        get({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {"files": [], "has_more": false}
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed app list scope grant");
+    store
+        .set_selected_grant("feishu_main", "ou_123", now_s + 1)
+        .expect("select app list scope grant");
+
+    let error = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_list(
+        &loongclaw_daemon::feishu_cli::FeishuBitableAppListArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: None,
+            },
+            folder_token: None,
+            page_size: None,
+            page_token: None,
+        },
+    )
+    .await
+    .expect_err("app list should reject missing drive readonly scope");
+
+    assert!(
+        error.contains("loongclaw feishu bitable app-list requires at least one Feishu scope [drive:drive:readonly]"),
+        "error={error}"
+    );
+    assert!(requests.lock().await.is_empty());
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_app_get_fetches_expected_path() {
+    let temp_dir = temp_feishu_cli_dir("bitable-app-get");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo",
+        get({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "app": {"app_token": "app_demo", "name": "Demo", "revision": 2}
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed app get grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_get(
+        &loongclaw_daemon::feishu_cli::FeishuBitableAppGetArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+        },
+    )
+    .await
+    .expect("execute app get");
+
+    assert_eq!(payload["app"]["app_token"], "app_demo");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_app_patch_sends_patch_body() {
+    let temp_dir = temp_feishu_cli_dir("bitable-app-patch");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo",
+        patch({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "app": {"app_token": "app_demo", "name": "Renamed", "revision": 3}
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed app patch grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_patch(
+        &loongclaw_daemon::feishu_cli::FeishuBitableAppPatchArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            name: Some("Renamed".to_owned()),
+            is_advanced: Some(true),
+        },
+    )
+    .await
+    .expect("execute app patch");
+
+    assert_eq!(payload["app"]["name"], "Renamed");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "PATCH");
+    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo");
+    assert!(requests[0].body.contains("\"name\":\"Renamed\""));
+    assert!(requests[0].body.contains("\"is_advanced\":true"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_app_copy_posts_copy_body() {
+    let temp_dir = temp_feishu_cli_dir("bitable-app-copy");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/copy",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "app": {"app_token": "app_copy", "name": "Copy", "revision": 1}
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed app copy grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_copy(
+        &loongclaw_daemon::feishu_cli::FeishuBitableAppCopyArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            name: "Copy".to_owned(),
+            folder_token: Some("fld_demo".to_owned()),
+        },
+    )
+    .await
+    .expect("execute app copy");
+
+    assert_eq!(payload["app"]["app_token"], "app_copy");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "POST");
+    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/copy");
+    assert!(requests[0].body.contains("\"name\":\"Copy\""));
+    assert!(requests[0].body.contains("\"folder_token\":\"fld_demo\""));
 
     server.abort();
 }
@@ -1312,6 +1559,63 @@ async fn feishu_bitable_batch_create_tables_posts_name_only_items() {
             .body
             .contains(r#""tables":[{"name":"Tasks"},{"name":"Archive"}]"#)
     );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_patch_table_sends_patch_request() {
+    let temp_dir = temp_feishu_cli_dir("bitable-table-patch");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo",
+        patch({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({"code": 0, "data": {"name": "Renamed Table"}}))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed patch table grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_patch_table(
+        &loongclaw_daemon::feishu_cli::FeishuBitablePatchTableArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            name: "Renamed Table".to_owned(),
+        },
+    )
+    .await
+    .expect("execute patch table");
+
+    assert_eq!(payload["result"]["name"], "Renamed Table");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "PATCH");
+    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo");
+    assert!(requests[0].body.contains("\"name\":\"Renamed Table\""));
 
     server.abort();
 }
@@ -1616,6 +1920,78 @@ async fn feishu_bitable_batch_delete_records_uses_records_body_key() {
 }
 
 #[tokio::test]
+async fn feishu_bitable_batch_update_records_sends_open_id_query() {
+    let temp_dir = temp_feishu_cli_dir("bitable-record-batch-update");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/batch_update",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "records": [{"record_id": "rec_1", "fields": {"Name": "Updated"}}]
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:write",
+    ]);
+    store.save_grant(&grant).expect("seed batch update grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_batch_update_records(
+        &loongclaw_daemon::feishu_cli::FeishuBitableBatchUpdateRecordsArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            records: r#"[{"record_id":"rec_1","fields":{"Name":"Updated"}}]"#.to_owned(),
+        },
+    )
+    .await
+    .expect("execute batch update");
+
+    assert_eq!(payload["result"]["records"][0]["record_id"], "rec_1");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/batch_update"
+    );
+    assert!(
+        requests[0]
+            .query
+            .as_deref()
+            .is_some_and(|query| query.contains("user_id_type=open_id"))
+    );
+    assert!(requests[0].body.contains("\"record_id\":\"rec_1\""));
+
+    server.abort();
+}
+
+#[tokio::test]
 async fn feishu_bitable_batch_create_records_rejects_more_than_500_items() {
     let temp_dir = temp_feishu_cli_dir("bitable-record-batch-limit");
     let config_path = write_sample_feishu_config(&temp_dir);
@@ -1852,6 +2228,68 @@ async fn feishu_bitable_update_field_requires_field_name_and_type() {
 }
 
 #[tokio::test]
+async fn feishu_bitable_delete_field_sends_delete_request() {
+    let temp_dir = temp_feishu_cli_dir("bitable-field-delete");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields/fld_demo",
+        delete({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {"deleted": true, "field_id": "fld_demo"}
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed delete field grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_delete_field(
+        &loongclaw_daemon::feishu_cli::FeishuBitableDeleteFieldArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            field_id: "fld_demo".to_owned(),
+        },
+    )
+    .await
+    .expect("execute delete field");
+
+    assert_eq!(payload["field_id"], "fld_demo");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "DELETE");
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields/fld_demo"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
 async fn feishu_bitable_view_create_posts_expected_body() {
     let temp_dir = temp_feishu_cli_dir("bitable-view-create");
     let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
@@ -2066,6 +2504,136 @@ async fn feishu_bitable_search_records_supports_automatic_fields() {
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
     assert!(requests[0].body.contains("\"automatic_fields\":true"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_get_view_fetches_expected_path() {
+    let temp_dir = temp_feishu_cli_dir("bitable-view-get");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/views/vew_demo",
+        get({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "view": {"view_id": "vew_demo", "view_name": "Grid", "view_type": "grid"}
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed get view grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_get_view(
+        &loongclaw_daemon::feishu_cli::FeishuBitableGetViewArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            view_id: "vew_demo".to_owned(),
+        },
+    )
+    .await
+    .expect("execute get view");
+
+    assert_eq!(payload["view"]["view_id"], "vew_demo");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/views/vew_demo"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_patch_view_sends_patch_request() {
+    let temp_dir = temp_feishu_cli_dir("bitable-view-patch");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/views/vew_demo",
+        patch({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "view": {"view_id": "vew_demo", "view_name": "Board", "view_type": "kanban"}
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed patch view grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_patch_view(
+        &loongclaw_daemon::feishu_cli::FeishuBitablePatchViewArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            view_id: "vew_demo".to_owned(),
+            view_name: "Board".to_owned(),
+        },
+    )
+    .await
+    .expect("execute patch view");
+
+    assert_eq!(payload["view"]["view_name"], "Board");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "PATCH");
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/views/vew_demo"
+    );
+    assert!(requests[0].body.contains("\"view_name\":\"Board\""));
 
     server.abort();
 }

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -298,6 +298,296 @@ fn feishu_resource_subcommands_parse() {
         "loongclaw",
         "feishu",
         "bitable",
+        "create-view",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--view-name",
+        "Board",
+        "--view-type",
+        "kanban",
+    ])
+    .expect("bitable create view command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "get-view",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--view-id",
+        "vew_demo",
+    ])
+    .expect("bitable get view command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "list-views",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+    ])
+    .expect("bitable list views command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "patch-view",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--view-id",
+        "vew_demo",
+        "--view-name",
+        "Board Renamed",
+    ])
+    .expect("bitable patch view command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "create-field",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--field-name",
+        "Link",
+        "--type",
+        "15",
+        "--property",
+        r#"{"formatter":"url"}"#,
+    ])
+    .expect("bitable create field command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "list-fields",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+    ])
+    .expect("bitable list fields command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "update-field",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--field-id",
+        "fld_demo",
+        "--field-name",
+        "Status",
+        "--type",
+        "3",
+    ])
+    .expect("bitable update field command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "delete-field",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--field-id",
+        "fld_demo",
+    ])
+    .expect("bitable delete field command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "batch-create-records",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--records",
+        r#"[{"fields":{"Name":"one"}},{"fields":{"Name":"two"}}]"#,
+    ])
+    .expect("bitable batch create records command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "batch-update-records",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--records",
+        r#"[{"record_id":"rec1","fields":{"Name":"one"}}]"#,
+    ])
+    .expect("bitable batch update records command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "batch-delete-records",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--records",
+        r#"["rec1","rec2"]"#,
+    ])
+    .expect("bitable batch delete records command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "update-record",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--record-id",
+        "rec_demo",
+        "--fields",
+        r#"{"Name":"updated"}"#,
+    ])
+    .expect("bitable update record command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "delete-record",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--record-id",
+        "rec_demo",
+    ])
+    .expect("bitable delete record command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "create-table",
+        "--app-token",
+        "app_demo",
+        "--name",
+        "Tasks",
+        "--default-view-name",
+        "All Tasks",
+    ])
+    .expect("bitable create table command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "patch-table",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--name",
+        "Tasks Renamed",
+    ])
+    .expect("bitable patch table command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "batch-create-tables",
+        "--app-token",
+        "app_demo",
+        "--tables",
+        r#"[{"name":"Tasks"},{"name":"Archive"}]"#,
+    ])
+    .expect("bitable batch create tables command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "app-get",
+        "--app-token",
+        "app_demo",
+    ])
+    .expect("bitable app get command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "app-patch",
+        "--app-token",
+        "app_demo",
+        "--name",
+        "Renamed App",
+        "--is-advanced",
+        "true",
+    ])
+    .expect("bitable app patch command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "app-copy",
+        "--app-token",
+        "app_demo",
+        "--name",
+        "Copied App",
+    ])
+    .expect("bitable app copy command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "app-create",
+        "--name",
+        "Demo App",
+    ])
+    .expect("bitable app create command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "app-list",
+        "--folder-token",
+        "fld_demo",
+        "--page-size",
+        "20",
+    ])
+    .expect("bitable app list command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
         "search-records",
         "--app-token",
         "bascnDemoAppToken",
@@ -650,6 +940,902 @@ async fn feishu_bitable_create_record_requires_confirmed_write_scope() {
         "error={error}"
     );
     assert!(requests.lock().await.is_empty());
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_app_create_posts_expected_body() {
+    let temp_dir = temp_feishu_cli_dir("bitable-app-create");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "app": {
+                                "app_token": "app_new_123",
+                                "name": "Demo App",
+                                "revision": 1
+                            }
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store.save_grant(&grant).expect("seed app create grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_create(
+        &loongclaw_daemon::feishu_cli::FeishuBitableAppCreateArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            name: "Demo App".to_owned(),
+            folder_token: Some("fld_demo".to_owned()),
+        },
+    )
+    .await
+    .expect("execute bitable app create");
+
+    assert_eq!(payload["app"]["app_token"], "app_new_123");
+    assert_eq!(payload["app"]["name"], "Demo App");
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps");
+    assert_eq!(requests[0].authorization.as_deref(), Some("Bearer u-token"));
+    assert!(requests[0].body.contains("\"name\":\"Demo App\""));
+    assert!(requests[0].body.contains("\"folder_token\":\"fld_demo\""));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_app_list_filters_drive_files_to_bitable() {
+    let temp_dir = temp_feishu_cli_dir("bitable-app-list");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/drive/v1/files",
+        get({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "files": [
+                                {"token": "app_1", "name": "Bitable One", "type": "bitable"},
+                                {"token": "doc_1", "name": "Doc One", "type": "docx"}
+                            ],
+                            "has_more": true,
+                            "page_token": "page_next"
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "drive:drive:readonly",
+    ]);
+    store.save_grant(&grant).expect("seed app list grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_list(
+        &loongclaw_daemon::feishu_cli::FeishuBitableAppListArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            folder_token: Some("fld_demo".to_owned()),
+            page_size: Some(20),
+            page_token: Some("page_current".to_owned()),
+        },
+    )
+    .await
+    .expect("execute bitable app list");
+
+    assert_eq!(payload["result"]["apps"].as_array().map(Vec::len), Some(1));
+    assert_eq!(payload["result"]["apps"][0]["token"], "app_1");
+    assert_eq!(payload["result"]["has_more"], true);
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/open-apis/drive/v1/files");
+    assert_eq!(requests[0].authorization.as_deref(), Some("Bearer u-token"));
+    assert!(requests[0].query.as_deref().is_some_and(
+        |query| query.contains("folder_token=fld_demo")
+            && query.contains("page_size=20")
+            && query.contains("page_token=page_current")
+    ));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_create_table_omits_property_for_checkbox_and_url_fields() {
+    let temp_dir = temp_feishu_cli_dir("bitable-table-create");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "table_id": "tbl_new",
+                            "default_view_id": "vew_default",
+                            "field_id_list": ["fld_checkbox", "fld_link"]
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store.save_grant(&grant).expect("seed table create grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_create_table(
+        &loongclaw_daemon::feishu_cli::FeishuBitableCreateTableArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            name: "Tasks".to_owned(),
+            default_view_name: Some("All Tasks".to_owned()),
+            fields: Some(
+                r#"[{"field_name":"Done","type":7,"property":{"color":"green"}},{"field_name":"Link","type":15,"property":{"formatter":"url"}}]"#
+                    .to_owned(),
+            ),
+        },
+    )
+    .await
+    .expect("execute create table");
+
+    assert_eq!(payload["result"]["table_id"], "tbl_new");
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables"
+    );
+    assert!(
+        requests[0]
+            .body
+            .contains("\"default_view_name\":\"All Tasks\"")
+    );
+    assert!(!requests[0].body.contains("\"color\":\"green\""));
+    assert!(!requests[0].body.contains("\"formatter\":\"url\""));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_batch_create_tables_posts_name_only_items() {
+    let temp_dir = temp_feishu_cli_dir("bitable-table-batch-create");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/batch_create",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "table_ids": ["tbl_1", "tbl_2"]
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store
+        .save_grant(&grant)
+        .expect("seed table batch create grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_batch_create_tables(
+        &loongclaw_daemon::feishu_cli::FeishuBitableBatchCreateTablesArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            tables: r#"[{"name":"Tasks"},{"name":"Archive"}]"#.to_owned(),
+        },
+    )
+    .await
+    .expect("execute batch create tables");
+
+    assert_eq!(payload["result"]["table_ids"][0], "tbl_1");
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/batch_create"
+    );
+    assert!(
+        requests[0]
+            .body
+            .contains(r#""tables":[{"name":"Tasks"},{"name":"Archive"}]"#)
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_update_record_sends_put_with_open_id_query() {
+    let temp_dir = temp_feishu_cli_dir("bitable-record-update");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/rec_demo",
+        axum::routing::put({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "record": {
+                                "record_id": "rec_demo",
+                                "fields": {
+                                    "Name": "updated"
+                                }
+                            }
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:write",
+    ]);
+    store.save_grant(&grant).expect("seed record update grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_update_record(
+        &loongclaw_daemon::feishu_cli::FeishuBitableUpdateRecordArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            record_id: "rec_demo".to_owned(),
+            fields: r#"{"Name":"updated"}"#.to_owned(),
+        },
+    )
+    .await
+    .expect("execute update record");
+
+    assert_eq!(payload["record"]["record_id"], "rec_demo");
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/rec_demo"
+    );
+    assert!(
+        requests[0]
+            .query
+            .as_deref()
+            .is_some_and(|query| query.contains("user_id_type=open_id"))
+    );
+    assert!(requests[0].body.contains("\"Name\":\"updated\""));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_delete_record_sends_delete_to_record_path() {
+    let temp_dir = temp_feishu_cli_dir("bitable-record-delete");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/rec_demo",
+        axum::routing::delete({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "deleted": true,
+                            "record_id": "rec_demo"
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:write",
+    ]);
+    store.save_grant(&grant).expect("seed record delete grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_delete_record(
+        &loongclaw_daemon::feishu_cli::FeishuBitableDeleteRecordArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            record_id: "rec_demo".to_owned(),
+        },
+    )
+    .await
+    .expect("execute delete record");
+
+    assert_eq!(payload["record_id"], "rec_demo");
+    assert_eq!(payload["deleted"], true);
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/rec_demo"
+    );
+    assert_eq!(requests[0].method, "DELETE");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_batch_create_records_sends_open_id_query() {
+    let temp_dir = temp_feishu_cli_dir("bitable-record-batch-create");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/batch_create",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "records": [
+                                {"record_id": "rec1", "fields": {"Name": "one"}},
+                                {"record_id": "rec2", "fields": {"Name": "two"}}
+                            ]
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:write",
+    ]);
+    store
+        .save_grant(&grant)
+        .expect("seed record batch create grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_batch_create_records(
+        &loongclaw_daemon::feishu_cli::FeishuBitableBatchCreateRecordsArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            records: r#"[{"fields":{"Name":"one"}},{"fields":{"Name":"two"}}]"#.to_owned(),
+        },
+    )
+    .await
+    .expect("execute batch create records");
+
+    assert_eq!(
+        payload["result"]["records"].as_array().map(Vec::len),
+        Some(2)
+    );
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/batch_create"
+    );
+    assert!(
+        requests[0]
+            .query
+            .as_deref()
+            .is_some_and(|query| query.contains("user_id_type=open_id"))
+    );
+    assert!(requests[0].body.contains("\"records\":["));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_batch_delete_records_uses_records_body_key() {
+    let temp_dir = temp_feishu_cli_dir("bitable-record-batch-delete");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/batch_delete",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "success": true
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:write",
+    ]);
+    store
+        .save_grant(&grant)
+        .expect("seed record batch delete grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_batch_delete_records(
+        &loongclaw_daemon::feishu_cli::FeishuBitableBatchDeleteRecordsArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            records: r#"["rec1","rec2"]"#.to_owned(),
+        },
+    )
+    .await
+    .expect("execute batch delete records");
+
+    assert_eq!(payload["result"]["success"], true);
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/batch_delete"
+    );
+    assert!(requests[0].body.contains(r#""records":["rec1","rec2"]"#));
+    assert!(!requests[0].body.contains("record_ids"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_batch_create_records_rejects_more_than_500_items() {
+    let temp_dir = temp_feishu_cli_dir("bitable-record-batch-limit");
+    let config_path = write_sample_feishu_config(&temp_dir);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:write",
+    ]);
+    store
+        .save_grant(&grant)
+        .expect("seed record batch limit grant");
+
+    let records = (0..501)
+        .map(|index| json!({ "fields": { "Name": format!("row-{index}") } }))
+        .collect::<Vec<_>>();
+
+    let error = loongclaw_daemon::feishu_cli::execute_feishu_bitable_batch_create_records(
+        &loongclaw_daemon::feishu_cli::FeishuBitableBatchCreateRecordsArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            records: serde_json::to_string(&records).expect("serialize records"),
+        },
+    )
+    .await
+    .expect_err("batch create should reject >500 items");
+
+    assert!(error.contains("batch size must be <= 500"), "error={error}");
+}
+
+#[tokio::test]
+async fn feishu_bitable_create_field_omits_property_for_url_field() {
+    let temp_dir = temp_feishu_cli_dir("bitable-field-create");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "field": {
+                                "field_id": "fld_link",
+                                "field_name": "Link",
+                                "type": 15
+                            }
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store.save_grant(&grant).expect("seed field create grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_create_field(
+        &loongclaw_daemon::feishu_cli::FeishuBitableCreateFieldArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            field_name: "Link".to_owned(),
+            field_type: 15,
+            property: Some(r#"{"formatter":"url"}"#.to_owned()),
+        },
+    )
+    .await
+    .expect("execute create field");
+
+    assert_eq!(payload["field"]["field_id"], "fld_link");
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields"
+    );
+    assert!(!requests[0].body.contains("formatter"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_update_field_requires_field_name_and_type() {
+    let temp_dir = temp_feishu_cli_dir("bitable-field-update-validation");
+    let config_path = write_sample_feishu_config(&temp_dir);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store.save_grant(&grant).expect("seed field update grant");
+
+    let error = loongclaw_daemon::feishu_cli::execute_feishu_bitable_update_field(
+        &loongclaw_daemon::feishu_cli::FeishuBitableUpdateFieldArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            field_id: "fld_demo".to_owned(),
+            field_name: None,
+            field_type: None,
+            property: None,
+        },
+    )
+    .await
+    .expect_err("update field should require field_name and type");
+
+    assert!(
+        error.contains("--field-name and --type are required for field update"),
+        "error={error}"
+    );
+}
+
+#[tokio::test]
+async fn feishu_bitable_view_create_posts_expected_body() {
+    let temp_dir = temp_feishu_cli_dir("bitable-view-create");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/views",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "view": {
+                                "view_id": "vew_kanban",
+                                "view_name": "Board",
+                                "view_type": "kanban"
+                            }
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store.save_grant(&grant).expect("seed view create grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_create_view(
+        &loongclaw_daemon::feishu_cli::FeishuBitableCreateViewArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            view_name: "Board".to_owned(),
+            view_type: Some("kanban".to_owned()),
+        },
+    )
+    .await
+    .expect("execute create view");
+
+    assert_eq!(payload["view"]["view_id"], "vew_kanban");
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/views"
+    );
+    assert!(requests[0].body.contains("\"view_name\":\"Board\""));
+    assert!(requests[0].body.contains("\"view_type\":\"kanban\""));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_view_list_parses_paginated_items() {
+    let temp_dir = temp_feishu_cli_dir("bitable-view-list");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/views",
+        get({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "items": [
+                                {"view_id": "vew_1", "view_name": "Grid", "view_type": "grid"},
+                                {"view_id": "vew_2", "view_name": "Board", "view_type": "kanban"}
+                            ],
+                            "has_more": true,
+                            "page_token": "page_next",
+                            "total": 2
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store.save_grant(&grant).expect("seed view list grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_list_views(
+        &loongclaw_daemon::feishu_cli::FeishuBitableListViewsArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            page_size: Some(20),
+            page_token: Some("page_current".to_owned()),
+        },
+    )
+    .await
+    .expect("execute list views");
+
+    assert_eq!(payload["result"]["items"].as_array().map(Vec::len), Some(2));
+    assert_eq!(payload["result"]["page_token"], "page_next");
+    assert_eq!(payload["result"]["has_more"], true);
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].query.as_deref().is_some_and(
+        |query| query.contains("page_size=20") && query.contains("page_token=page_current")
+    ));
 
     server.abort();
 }

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -3,7 +3,7 @@ use axum::{
     Json, Router,
     body::to_bytes,
     extract::{Request, State},
-    routing::{delete, get, patch, post},
+    routing::{delete, get, patch, post, put},
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -413,6 +413,20 @@ fn feishu_resource_subcommands_parse() {
         "fld_demo",
     ])
     .expect("bitable delete field command should parse");
+
+    try_parse_cli([
+        "loongclaw",
+        "feishu",
+        "bitable",
+        "create-record",
+        "--app-token",
+        "app_demo",
+        "--table-id",
+        "tbl_demo",
+        "--fields",
+        r#"{"Name":"one"}"#,
+    ])
+    .expect("bitable create record command should parse");
 
     try_parse_cli([
         "loongclaw",
@@ -946,6 +960,137 @@ async fn feishu_bitable_create_record_requires_confirmed_write_scope() {
 }
 
 #[tokio::test]
+async fn feishu_bitable_create_record_sends_post_with_open_id_query() {
+    let temp_dir = temp_feishu_cli_dir("bitable-create-record");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "record": {
+                                "record_id": "rec_demo",
+                                "fields": {"Name": "one"}
+                            }
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:create",
+    ]);
+    store.save_grant(&grant).expect("seed create record grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_create_record(
+        &loongclaw_daemon::feishu_cli::FeishuBitableCreateRecordArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            fields: r#"{"Name":"one"}"#.to_owned(),
+        },
+    )
+    .await
+    .expect("execute create record");
+
+    assert_eq!(payload["record"]["record_id"], "rec_demo");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "POST");
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records"
+    );
+    assert_eq!(requests[0].query.as_deref(), Some("user_id_type=open_id"));
+    assert!(requests[0].body.contains("\"Name\":\"one\""));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_create_record_surfaces_invalid_response_body() {
+    let temp_dir = temp_feishu_cli_dir("bitable-create-record-invalid-body");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {}
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:create",
+    ]);
+    store
+        .save_grant(&grant)
+        .expect("seed invalid create record grant");
+
+    let error = loongclaw_daemon::feishu_cli::execute_feishu_bitable_create_record(
+        &loongclaw_daemon::feishu_cli::FeishuBitableCreateRecordArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            fields: r#"{"Name":"one"}"#.to_owned(),
+        },
+    )
+    .await
+    .expect_err("invalid create record response should fail");
+
+    assert!(error.contains("bitable record create: missing `data.record` in response"));
+    assert_eq!(requests.lock().await.len(), 1);
+
+    server.abort();
+}
+
+#[tokio::test]
 async fn feishu_bitable_search_records_requires_confirmed_retrieve_scope() {
     let temp_dir = temp_feishu_cli_dir("bitable-search-scope");
     let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
@@ -1447,7 +1592,7 @@ async fn feishu_bitable_app_patch_sends_patch_body() {
     };
     let router = Router::new().route(
         "/open-apis/bitable/v1/apps/app_demo",
-        patch({
+        put({
             let state = state.clone();
             move |request| {
                 let state = state.clone();
@@ -1495,7 +1640,7 @@ async fn feishu_bitable_app_patch_sends_patch_body() {
     assert_eq!(payload["app"]["name"], "Renamed");
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].method, "PATCH");
+    assert_eq!(requests[0].method, "PUT");
     assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo");
     assert!(requests[0].body.contains("\"name\":\"Renamed\""));
     assert!(requests[0].body.contains("\"is_advanced\":true"));
@@ -1728,7 +1873,7 @@ async fn feishu_bitable_patch_table_sends_patch_request() {
     };
     let router = Router::new().route(
         "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo",
-        patch({
+        put({
             let state = state.clone();
             move |request| {
                 let state = state.clone();
@@ -1771,7 +1916,7 @@ async fn feishu_bitable_patch_table_sends_patch_request() {
     assert_eq!(payload["result"]["name"], "Renamed Table");
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].method, "PATCH");
+    assert_eq!(requests[0].method, "PUT");
     assert_eq!(
         requests[0].path,
         "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo"
@@ -2389,6 +2534,71 @@ async fn feishu_bitable_update_field_requires_field_name_and_type() {
         error.contains("--field-name and --type are required for field update"),
         "error={error}"
     );
+
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields/fld_demo",
+        put({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "field": {
+                                "field_id": "fld_demo",
+                                "field_name": "Amount",
+                                "type": 2,
+                                "property": {"formatter": "currency"}
+                            }
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_update_field(
+        &loongclaw_daemon::feishu_cli::FeishuBitableUpdateFieldArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            field_id: "fld_demo".to_owned(),
+            field_name: Some("Amount".to_owned()),
+            field_type: Some(2),
+            property: Some(r#"{"formatter":"currency"}"#.to_owned()),
+        },
+    )
+    .await
+    .expect("update field happy path should succeed");
+
+    assert_eq!(payload["field"]["field_id"], "fld_demo");
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "PUT");
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields/fld_demo"
+    );
+    assert!(requests[0].body.contains("\"field_name\":\"Amount\""));
+    assert!(requests[0].body.contains("\"type\":2"));
+    assert!(requests[0].body.contains("\"formatter\":\"currency\""));
+
+    server.abort();
 }
 
 #[tokio::test]

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -1228,6 +1228,68 @@ async fn feishu_bitable_app_list_requires_drive_readonly_scope() {
 }
 
 #[tokio::test]
+async fn feishu_bitable_list_tables_requires_table_read_scope() {
+    let temp_dir = temp_feishu_cli_dir("bitable-list-tables-scope");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables",
+        get({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {"items": [], "has_more": false}
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes =
+        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    store.save_grant(&grant).expect("seed list tables scope grant");
+    store
+        .set_selected_grant("feishu_main", "ou_123", now_s + 1)
+        .expect("select list tables scope grant");
+
+    let error = loongclaw_daemon::feishu_cli::execute_feishu_bitable_list_tables(
+        &loongclaw_daemon::feishu_cli::FeishuBitableListTablesArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: None,
+            },
+            app_token: "app_demo".to_owned(),
+            page_size: None,
+            page_token: None,
+        },
+    )
+    .await
+    .expect_err("list tables should reject missing base table read scope");
+
+    assert!(
+        error.contains("loongclaw feishu bitable list-tables requires at least one Feishu scope [base:table:read]"),
+        "error={error}"
+    );
+    assert!(requests.lock().await.is_empty());
+
+    server.abort();
+}
+
+#[tokio::test]
 async fn feishu_bitable_app_get_fetches_expected_path() {
     let temp_dir = temp_feishu_cli_dir("bitable-app-get");
     let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -601,6 +601,7 @@ fn feishu_resource_subcommands_parse() {
         r#"[{"field_name":"Name","desc":true}]"#,
         "--filter",
         r#"{"conjunction":"and","conditions":[{"field_name":"Name","operator":"is","value":["demo"]}]}"#,
+        "--automatic-fields",
     ])
     .expect("bitable search records command should parse");
 
@@ -933,6 +934,80 @@ async fn feishu_bitable_create_record_requires_confirmed_write_scope() {
 
     assert!(
         error.contains("loongclaw feishu bitable create-record requires at least one Feishu scope [base:record:create]"),
+        "error={error}"
+    );
+    assert!(
+        error.contains("loong feishu auth start --account feishu_main"),
+        "error={error}"
+    );
+    assert!(requests.lock().await.is_empty());
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_search_records_requires_confirmed_retrieve_scope() {
+    let temp_dir = temp_feishu_cli_dir("bitable-search-scope");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/bascn_demo/tables/tbl_demo/records/search",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "items": [],
+                            "has_more": false
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token-1", "r-token-1", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access"]);
+    store.save_grant(&grant).expect("seed bitable search grant");
+    store
+        .set_selected_grant("feishu_main", "ou_123", now_s + 1)
+        .expect("select bitable search grant");
+
+    let error = loongclaw_daemon::feishu_cli::execute_feishu_bitable_search_records(
+        &loongclaw_daemon::feishu_cli::FeishuBitableSearchRecordsArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: None,
+            },
+            app_token: "bascn_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            view_id: None,
+            page_size: None,
+            page_token: None,
+            filter: None,
+            sort: None,
+            automatic_fields: false,
+            field_names: Vec::new(),
+        },
+    )
+    .await
+    .expect_err("bitable search should reject grants without retrieve scope");
+
+    assert!(
+        error.contains("loongclaw feishu bitable search-records requires at least one Feishu scope [base:record:retrieve]"),
         "error={error}"
     );
     assert!(
@@ -1654,6 +1729,89 @@ async fn feishu_bitable_create_field_omits_property_for_url_field() {
 }
 
 #[tokio::test]
+async fn feishu_bitable_list_fields_preserves_ui_type() {
+    let temp_dir = temp_feishu_cli_dir("bitable-field-list-ui-type");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields",
+        get({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "items": [
+                                {
+                                    "field_id": "fld_amount",
+                                    "field_name": "Amount",
+                                    "type": 2,
+                                    "ui_type": "Currency",
+                                    "property": {
+                                        "formatter": "0.00"
+                                    }
+                                }
+                            ],
+                            "has_more": false,
+                            "page_token": "page_1",
+                            "total": 1
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store.save_grant(&grant).expect("seed field list grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_list_fields(
+        &loongclaw_daemon::feishu_cli::FeishuBitableListFieldsArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            view_id: None,
+            page_size: Some(50),
+            page_token: None,
+        },
+    )
+    .await
+    .expect("execute list fields");
+
+    assert_eq!(payload["fields"][0]["field_id"], "fld_amount");
+    assert_eq!(payload["fields"][0]["ui_type"], "Currency");
+    assert_eq!(payload["fields"][0]["type"], 2);
+    assert_eq!(payload["has_more"], false);
+    assert_eq!(payload["page_token"], "page_1");
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields");
+    assert_eq!(requests[0].query.as_deref(), Some("page_size=50"));
+
+    server.abort();
+}
+
+#[tokio::test]
 async fn feishu_bitable_update_field_requires_field_name_and_type() {
     let temp_dir = temp_feishu_cli_dir("bitable-field-update-validation");
     let config_path = write_sample_feishu_config(&temp_dir);
@@ -1827,15 +1985,87 @@ async fn feishu_bitable_view_list_parses_paginated_items() {
     .await
     .expect("execute list views");
 
-    assert_eq!(payload["result"]["items"].as_array().map(Vec::len), Some(2));
-    assert_eq!(payload["result"]["page_token"], "page_next");
-    assert_eq!(payload["result"]["has_more"], true);
+    assert_eq!(payload["views"].as_array().map(Vec::len), Some(2));
+    assert_eq!(payload["page_token"], "page_next");
+    assert_eq!(payload["has_more"], true);
 
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
     assert!(requests[0].query.as_deref().is_some_and(
         |query| query.contains("page_size=20") && query.contains("page_token=page_current")
     ));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn feishu_bitable_search_records_supports_automatic_fields() {
+    let temp_dir = temp_feishu_cli_dir("bitable-search-automatic-fields");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/records/search",
+        post({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "items": [{"record_id": "rec_1", "fields": {}}],
+                            "has_more": false
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:record:retrieve",
+    ]);
+    store
+        .save_grant(&grant)
+        .expect("seed search automatic_fields grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_search_records(
+        &loongclaw_daemon::feishu_cli::FeishuBitableSearchRecordsArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            table_id: "tbl_demo".to_owned(),
+            view_id: None,
+            field_names: Vec::new(),
+            filter: None,
+            sort: None,
+            automatic_fields: true,
+            page_size: Some(10),
+            page_token: None,
+        },
+    )
+    .await
+    .expect("execute search records");
+
+    assert_eq!(payload["result"]["items"].as_array().map(Vec::len), Some(1));
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].body.contains("\"automatic_fields\":true"));
 
     server.abort();
 }

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -1290,6 +1290,85 @@ async fn feishu_bitable_list_tables_requires_table_read_scope() {
 }
 
 #[tokio::test]
+async fn feishu_bitable_list_tables_returns_top_level_tables_page() {
+    let temp_dir = temp_feishu_cli_dir("bitable-list-tables-page");
+    let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+    let state = MockServerState {
+        requests: requests.clone(),
+    };
+    let router = Router::new().route(
+        "/open-apis/bitable/v1/apps/app_demo/tables",
+        get({
+            let state = state.clone();
+            move |request| {
+                let state = state.clone();
+                async move {
+                    record_request(State(state), request).await;
+                    Json(json!({
+                        "code": 0,
+                        "data": {
+                            "items": [
+                                {
+                                    "table_id": "tbl_1",
+                                    "name": "Tasks",
+                                    "revision": 3
+                                }
+                            ],
+                            "has_more": true,
+                            "page_token": "page_next"
+                        }
+                    }))
+                }
+            }
+        }),
+    );
+    let (base_url, server) = spawn_mock_feishu_server(router).await;
+    let config_path = write_sample_feishu_config_with_base_url(&temp_dir, &base_url);
+    let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
+    let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
+    let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "base:table:read",
+    ]);
+    store.save_grant(&grant).expect("seed list tables grant");
+
+    let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_list_tables(
+        &loongclaw_daemon::feishu_cli::FeishuBitableListTablesArgs {
+            grant: loongclaw_daemon::feishu_cli::FeishuGrantArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: true,
+                },
+                open_id: Some("ou_123".to_owned()),
+            },
+            app_token: "app_demo".to_owned(),
+            page_size: Some(20),
+            page_token: Some("page_current".to_owned()),
+        },
+    )
+    .await
+    .expect("execute list tables");
+
+    assert_eq!(payload["tables"].as_array().map(Vec::len), Some(1));
+    assert_eq!(payload["tables"][0]["table_id"], "tbl_1");
+    assert_eq!(payload["has_more"], true);
+    assert_eq!(payload["page_token"], "page_next");
+    assert!(payload.get("result").is_none());
+
+    let requests = requests.lock().await.clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/tables");
+    assert!(requests[0].query.as_deref().is_some_and(
+        |query| query.contains("page_size=20") && query.contains("page_token=page_current")
+    ));
+
+    server.abort();
+}
+
+#[tokio::test]
 async fn feishu_bitable_app_get_fetches_expected_path() {
     let temp_dir = temp_feishu_cli_dir("bitable-app-get");
     let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -1193,8 +1193,10 @@ async fn feishu_bitable_app_list_requires_drive_readonly_scope() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
     store.save_grant(&grant).expect("seed app list scope grant");
     store
         .set_selected_grant("feishu_main", "ou_123", now_s + 1)
@@ -1255,9 +1257,13 @@ async fn feishu_bitable_list_tables_requires_table_read_scope() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
-    store.save_grant(&grant).expect("seed list tables scope grant");
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
+    store
+        .save_grant(&grant)
+        .expect("seed list tables scope grant");
     store
         .set_selected_grant("feishu_main", "ou_123", now_s + 1)
         .expect("select list tables scope grant");
@@ -1360,7 +1366,10 @@ async fn feishu_bitable_list_tables_returns_top_level_tables_page() {
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].method, "GET");
-    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/tables");
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables"
+    );
     assert!(requests[0].query.as_deref().is_some_and(
         |query| query.contains("page_size=20") && query.contains("page_token=page_current")
     ));
@@ -1398,8 +1407,10 @@ async fn feishu_bitable_app_get_fetches_expected_path() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
     store.save_grant(&grant).expect("seed app get grant");
 
     let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_get(
@@ -1457,8 +1468,10 @@ async fn feishu_bitable_app_patch_sends_patch_body() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
     store.save_grant(&grant).expect("seed app patch grant");
 
     let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_patch(
@@ -1520,8 +1533,10 @@ async fn feishu_bitable_app_copy_posts_copy_body() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
     store.save_grant(&grant).expect("seed app copy grant");
 
     let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_app_copy(
@@ -1729,8 +1744,10 @@ async fn feishu_bitable_patch_table_sends_patch_request() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
     store.save_grant(&grant).expect("seed patch table grant");
 
     let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_patch_table(
@@ -1755,7 +1772,10 @@ async fn feishu_bitable_patch_table_sends_patch_request() {
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].method, "PATCH");
-    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo");
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo"
+    );
     assert!(requests[0].body.contains("\"name\":\"Renamed Table\""));
 
     server.abort();
@@ -2322,7 +2342,10 @@ async fn feishu_bitable_list_fields_preserves_ui_type() {
 
     let requests = requests.lock().await.clone();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].path, "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields");
+    assert_eq!(
+        requests[0].path,
+        "/open-apis/bitable/v1/apps/app_demo/tables/tbl_demo/fields"
+    );
     assert_eq!(requests[0].query.as_deref(), Some("page_size=50"));
 
     server.abort();
@@ -2396,8 +2419,10 @@ async fn feishu_bitable_delete_field_sends_delete_request() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
     store.save_grant(&grant).expect("seed delete field grant");
 
     let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_delete_field(
@@ -2679,8 +2704,10 @@ async fn feishu_bitable_get_view_fetches_expected_path() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
     store.save_grant(&grant).expect("seed get view grant");
 
     let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_get_view(
@@ -2743,8 +2770,10 @@ async fn feishu_bitable_patch_view_sends_patch_request() {
     let now_s = loongclaw_daemon::feishu_support::unix_ts_now();
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let mut grant = sample_grant("feishu_main", "ou_123", "u-token", "r-token", now_s);
-    grant.scopes =
-        mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes(["offline_access", "bitable:app"]);
+    grant.scopes = mvp::channel::feishu::api::FeishuGrantScopeSet::from_scopes([
+        "offline_access",
+        "bitable:app",
+    ]);
     store.save_grant(&grant).expect("seed patch view grant");
 
     let payload = loongclaw_daemon::feishu_cli::execute_feishu_bitable_patch_view(

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-31T13:47:49Z
+- Generated at: 2026-04-01T05:09:36Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6936 | 7300 | 364 | 146 | 160 | 14 | 95.0% | TIGHT |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14256 | 15000 | 744 | 54 | 70 | 16 | 95.0% | TIGHT |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14472 | 15000 | 528 | 54 | 70 | 16 | 96.5% | TIGHT |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6324 | 6500 | 176 | 210 | 210 | 0 | 100.0% | TIGHT |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (95.9%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.7%), tools_mod (95.0%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (95.9%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.7%), tools_mod (96.5%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6936 functions=146 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10831 functions=98 -->
-<!-- arch-hotspot key=tools_mod lines=14256 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14472 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6324 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  Feishu Bitable support was incomplete across the `resource -> tool -> catalog -> cli -> integration test` path. Several app / table / record / field / view capabilities were missing, and follow-up reviews uncovered multiple gaps in local scope enforcement, response contract consistency, pagination compatibility, and execution-level regression coverage.
- Why it matters:
  These gaps made parts of the Bitable surface unavailable or inconsistent. In practice, that meant CLI and tool permission boundaries could diverge, some list endpoints required caller-specific response adaptation, batch limits were enforced only at one entry point, and regressions in critical paths could slip through without targeted tests.
- What changed:
  This branch completes the main Feishu Bitable app / table / record / field / view flows and closes the review findings discovered during implementation:
  - Added or completed `app.create/get/list/patch/copy`
  - Added or completed `table.create/list/patch/batch_create`
  - Added or completed `record.search/create/update/delete/batch_create/batch_update/batch_delete`
  - Added or completed `field.create/list/update/delete`
  - Added or completed `view.create/get/list/patch`
  - Added missing CLI-local scope gates to match tool-layer contracts
  - Normalized multiple list responses to top-level paging shapes
  - Preserved `ui_type`, added `automatic_fields`, enforced batch `<= 500`, and accepted `next_page_token` for app listing
  - Added targeted unit tests and execution-level integration tests for the above paths
- What did not change (scope boundary):
  - No behavior outside Feishu Bitable was changed
  - No kernel, protocol, provider-routing, or architecture-boundary work was included
  - The pre-existing `crates/app/src/channel/mod.rs` architecture pressure issue was not addressed in this branch
  - No new crate/module layering or broad refactor was introduced

## Linked Issues

- Closes #722
- Related bug(feishu): assistant says create-record tool is unavailable after PR #692 #722

## Change Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [ ] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo build -p loongclaw-app --all-features
cargo build -p loongclaw-daemon --all-features
cargo test --workspace --all-features
cargo test -p loongclaw-app --lib --all-features
cargo test -p loongclaw-app feishu_tool --lib --all-features
cargo test -p loongclaw-app parse_bitable_app_list_response_accepts_next_page_token --lib --all-features
cargo test -p loongclaw-app feishu_bitable_list_tool_returns_top_level_tables_page --lib --all-features
cargo test -p loongclaw-app ensure_bitable_batch_limit_rejects_more_than_500_items --lib --all-features
cargo test -p loongclaw-app search_request_body_includes_automatic_fields_when_requested --lib --all-features
cargo test -p loongclaw-app feishu_bitable_batch_record_tools_reject_more_than_500_items_before_network --lib --all-features
cargo test -p loongclaw-app provider_tool_definitions_with_config_exposes_bitable_search_sort_as_array --lib --all-features
cargo test -p loongclaw-app feishu_bitable_record_search_catalog_metadata_includes_automatic_fields --lib --all-features
cargo test -p loongclaw-daemon --test integration feishu_resource_subcommands_parse -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_app_list_filters_drive_files_to_bitable -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_app_list_requires_drive_readonly_scope -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_list_tables_requires_table_read_scope -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_list_tables_returns_top_level_tables_page -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_app_get_fetches_expected_path -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_app_patch_sends_patch_body -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_app_copy_posts_copy_body -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_create_table_omits_property_for_checkbox_and_url_fields -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_patch_table_sends_patch_request -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_search_records_requires_confirmed_retrieve_scope -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_search_records_supports_automatic_fields -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_batch_create_records_sends_open_id_query -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_batch_update_records_sends_open_id_query -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_batch_delete_records_uses_records_body_key -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_batch_create_records_rejects_more_than_500_items -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_create_field_omits_property_for_url_field -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_list_fields_preserves_ui_type -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_update_field_requires_field_name_and_type -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_delete_field_sends_delete_request -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_view_create_posts_expected_body -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_view_list_parses_paginated_items -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_get_view_fetches_expected_path -- --nocapture
cargo test -p loongclaw-daemon --test integration feishu_bitable_patch_view_sends_patch_request -- --nocapture
cargo clippy --workspace --all-targets --all-features -- -D warnings

Result summary:
- Feishu Bitable app / table / record / field / view paths compile and pass targeted unit/integration coverage.
- Full workspace all-feature tests passed.
- Clippy passed.
- `task verify` was not fully clean because of a pre-existing architecture pressure breach in `crates/app/src/channel/mod.rs`, not because of this branch.
- Temp sqlite/config state in tests is isolated under per-test temp directories; mock servers are aborted at the end of each async integration test.
```

## User-visible / Operator-visible Changes

- Feishu Bitable commands and tools now cover the main app / table / record / field / view operations.
- Multiple list endpoints now return consistent top-level paging fields, reducing caller-specific adaptation.
- CLI-local permission checks are stricter and fail earlier when required scopes are missing instead of deferring the error to the upstream API.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR. The change set is concentrated in Feishu Bitable resource, tool, catalog, CLI, and test files, with no cross-module data migration.
- Observable failure symptoms reviewers should watch for:
  - `feishu.bitable.*` commands returning JSON field names that do not match caller expectations
  - Missing local scope failures when required permissions are absent
  - Lost list/search paging tokens
  - Missing local rejection for batch record operations above 500 items

## Reviewer Focus

- Verify permission boundaries are aligned in both `tool` and `CLI` layers, especially:
  - `crates/app/src/tools/feishu.rs`
  - `crates/daemon/src/feishu_cli.rs`
- Verify list/search response contracts match the documented and reference shapes, especially:
  - `app.list`
  - `table.list`
  - `field.list`
  - `view.list`
- Verify resource-layer compatibility and edge handling, especially:
  - `crates/app/src/channel/feishu/api/resources/bitable.rs`
  - `ui_type`
  - `automatic_fields`
  - `next_page_token`
  - batch `<= 500`
- Verify regression coverage for permissions, request shapes, paging, and output contracts, especially:
  - `crates/app/src/tools/mod.rs`
  - `crates/daemon/tests/integration/feishu_cli.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Feishu Bitable support: manage apps, tables, records, fields, and views (create/get/list/patch/copy/delete) via CLI and provider tools.
  * Batch operations for tables and records; record search adds optional automatic_fields and pagination.

* **Bug Fixes / Validation**
  * Enforced batch-size limit (<= 500) for bulk record ops.
  * Omit unsupported field properties in schema payloads; list-tables now returns top-level paging keys (tables, has_more, page_token).

* **Tests**
  * Extensive unit and integration tests for API handling, pagination, validation, and CLI/tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->