### PR TITLE
feat: add allowlisted wasm guest config reads

### DIFF
--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -3223,6 +3223,7 @@ fn run_wasm_bridge_sample(wasm_artifact: &Path) -> CliResult<WasmBridgeSample> {
         allowed_process_commands: BTreeSet::new(),
         bridge_circuit_breaker: ConnectorCircuitBreakerPolicy::default(),
         wasm_allowed_path_prefixes: vec![artifact_parent.to_path_buf()],
+        wasm_guest_readable_config_keys: BTreeSet::new(),
         wasm_max_component_bytes: Some(8 * 1024 * 1024),
         wasm_max_output_bytes: None,
         wasm_fuel_limit: Some(2_000_000),

--- a/crates/daemon/tests/integration/spec_runtime.rs
+++ b/crates/daemon/tests/integration/spec_runtime.rs
@@ -2946,6 +2946,7 @@ async fn execute_spec_wasm_component_bridge_exchanges_request_output_when_runtim
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: Some(200_000),
@@ -3130,6 +3131,211 @@ async fn execute_spec_wasm_component_bridge_exchanges_request_output_when_runtim
 }
 
 #[tokio::test]
+async fn execute_spec_wasm_component_bridge_reads_allowlisted_guest_config_when_runtime_enabled() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    let plugin_root =
+        std::env::temp_dir().join(format!("loongclaw-wasm-runtime-config-read-{unique}"));
+    fs::create_dir_all(&plugin_root).expect("create plugin root");
+
+    let config_key = "provider.region";
+    let config_key_len = config_key.len();
+    let wat_source = format!(
+        r#"
+            (module
+              (import "loongclaw" "config_len" (func $config_len (param i32 i32) (result i32)))
+              (import "loongclaw" "read_config" (func $read_config (param i32 i32 i32 i32) (result i32)))
+              (import "loongclaw" "write_output" (func $write_output (param i32 i32) (result i32)))
+              (func (export "run") (result i32)
+                (local $value_len i32)
+                i32.const 0
+                i32.const {config_key_len}
+                call $config_len
+                local.tee $value_len
+                i32.const 0
+                i32.lt_s
+                if
+                  i32.const 1
+                  return
+                end
+                i32.const 63
+                i32.const 34
+                i32.store8
+                i32.const 0
+                i32.const {config_key_len}
+                i32.const 64
+                local.get $value_len
+                call $read_config
+                local.get $value_len
+                i32.ne
+                if
+                  i32.const 2
+                  return
+                end
+                i32.const 64
+                local.get $value_len
+                i32.add
+                i32.const 34
+                i32.store8
+                i32.const 63
+                local.get $value_len
+                i32.const 2
+                i32.add
+                call $write_output
+                local.get $value_len
+                i32.const 2
+                i32.add
+                i32.ne
+                if
+                  i32.const 3
+                  return
+                end
+                i32.const 0)
+              (memory (export "memory") 1)
+              (data (i32.const 0) "{config_key}"))
+        "#
+    );
+    let wasm_bytes = wat::parse_str(wat_source.as_str()).expect("compile wasm");
+    let digest = Sha256::digest(&wasm_bytes);
+    let digest_hex = hex_lower(&digest);
+
+    let plugin_manifest = r#"
+// LOONGCLAW_PLUGIN_START
+// {
+//   "plugin_id": "wasm-runtime-config-read",
+//   "provider_id": "wasm-runtime-config-provider",
+//   "connector_name": "wasm-runtime-config-provider",
+//   "channel_id": "primary",
+//   "endpoint": "local://wasm-runtime-config-provider/invoke",
+//   "capabilities": ["InvokeConnector"],
+//   "metadata": {
+//     "bridge_kind":"wasm_component",
+//     "component":"plugin.wasm",
+//     "component_sha256":"__COMPONENT_SHA256__",
+//     "entrypoint":"run",
+//     "region":"us-east-1",
+//     "version":"1.0.0"
+//   }
+// }
+// LOONGCLAW_PLUGIN_END
+"#
+    .replace("__COMPONENT_SHA256__", digest_hex.as_str());
+    fs::write(plugin_root.join("plugin.rs"), plugin_manifest).expect("write wasm plugin manifest");
+    fs::write(plugin_root.join("plugin.wasm"), wasm_bytes).expect("write wasm module");
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-wasm-runtime-config-read".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::new(),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-wasm-runtime-config-read".to_owned(),
+        ttl_s: 120,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: Some(PluginScanSpec {
+            enabled: true,
+            roots: vec![plugin_root.display().to_string()],
+        }),
+        bridge_support: Some(BridgeSupportSpec {
+            enabled: true,
+            supported_bridges: vec![PluginBridgeKind::WasmComponent],
+            supported_adapter_families: Vec::new(),
+            supported_compatibility_modes: vec![PluginCompatibilityMode::Native],
+            supported_compatibility_shims: Vec::new(),
+            supported_compatibility_shim_profiles: Vec::new(),
+            enforce_supported: true,
+            policy_version: None,
+            expected_checksum: None,
+            expected_sha256: None,
+            execute_process_stdio: false,
+            execute_http_json: false,
+            allowed_process_commands: Vec::new(),
+            enforce_execution_success: true,
+            security_scan: Some(SecurityScanSpec {
+                enabled: true,
+                block_on_high: true,
+                profile_path: None,
+                profile_sha256: None,
+                profile_signature: None,
+                siem_export: None,
+                runtime: SecurityRuntimeExecutionSpec {
+                    execute_wasm_component: true,
+                    allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: vec![config_key.to_owned()],
+                    max_component_bytes: Some(128 * 1024),
+                    max_output_bytes: None,
+                    fuel_limit: Some(200_000),
+                    bridge_circuit_breaker: ConnectorCircuitBreakerPolicy::default(),
+                    timeout_ms: None,
+                },
+                high_risk_metadata_keywords: Vec::new(),
+                wasm: WasmSecurityScanSpec {
+                    enabled: true,
+                    max_module_bytes: 128 * 1024,
+                    allow_wasi: false,
+                    blocked_import_prefixes: vec!["wasi".to_owned()],
+                    allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    require_hash_pin: false,
+                    required_sha256_by_plugin: BTreeMap::new(),
+                },
+            }),
+        }),
+        bootstrap: Some(BootstrapSpec {
+            enabled: true,
+            allow_http_json_auto_apply: Some(false),
+            allow_process_stdio_auto_apply: Some(false),
+            allow_native_ffi_auto_apply: Some(false),
+            allow_wasm_component_auto_apply: Some(true),
+            allow_mcp_server_auto_apply: Some(false),
+            allow_acp_bridge_auto_apply: Some(false),
+            allow_acp_runtime_auto_apply: Some(false),
+            block_unverified_high_risk_auto_apply: None,
+            enforce_ready_execution: Some(true),
+            max_tasks: Some(5),
+        }),
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
+        operation: OperationSpec::ConnectorLegacy {
+            connector_name: "wasm-runtime-config-provider".to_owned(),
+            operation: "invoke".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeConnector]),
+            payload: json!({"input":"ping"}),
+        },
+    };
+
+    let report = execute_spec(&spec, true).await;
+
+    assert_eq!(report.operation_kind, "connector_legacy");
+    assert_eq!(report.outcome["outcome"]["status"], "ok");
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["bridge_execution"]["status"],
+        "executed"
+    );
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"]["host_abi_enabled"],
+        true
+    );
+    assert_eq!(
+        report.outcome["outcome"]["payload"]["bridge_execution"]["runtime"]["output_json"],
+        json!("us-east-1")
+    );
+}
+
+#[tokio::test]
 async fn execute_spec_wasm_component_bridge_executes_with_timeout_guard_and_no_cache() {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -3213,6 +3419,7 @@ async fn execute_spec_wasm_component_bridge_executes_with_timeout_guard_and_no_c
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: Some(50_000),
@@ -3405,6 +3612,7 @@ async fn execute_spec_wasm_component_bridge_times_out_and_reports_timeout_eviden
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: None,
@@ -3568,6 +3776,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_component_sha256_mismatc
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: Some(200_000),
@@ -3711,6 +3920,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_metadata_pin_conflicts_w
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: Some(200_000),
@@ -3856,6 +4066,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_hash_pin_required_but_mi
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: Some(200_000),
@@ -4003,6 +4214,7 @@ async fn execute_spec_wasm_component_bridge_blocks_artifact_outside_runtime_pref
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![disallowed_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: Some(100_000),
@@ -4154,6 +4366,7 @@ async fn execute_spec_wasm_component_bridge_blocks_symlink_escape_under_allowed_
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: Some(100_000),
@@ -4296,6 +4509,7 @@ async fn execute_spec_wasm_component_bridge_blocks_non_regular_artifact_path() {
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(128 * 1024),
                     max_output_bytes: None,
                     fuel_limit: Some(100_000),
@@ -4439,6 +4653,7 @@ async fn execute_spec_wasm_component_bridge_blocks_when_module_size_exceeds_runt
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: vec![plugin_root.display().to_string()],
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(8),
                     max_output_bytes: None,
                     fuel_limit: Some(100_000),
@@ -4550,6 +4765,7 @@ async fn execute_spec_blocks_when_wasm_runtime_enabled_without_allowed_prefixes(
                 runtime: SecurityRuntimeExecutionSpec {
                     execute_wasm_component: true,
                     allowed_path_prefixes: Vec::new(),
+                    guest_readable_config_keys: Vec::new(),
                     max_component_bytes: Some(1024),
                     max_output_bytes: None,
                     fuel_limit: Some(10_000),

--- a/crates/spec/src/spec_execution.rs
+++ b/crates/spec/src/spec_execution.rs
@@ -244,6 +244,37 @@ async fn execute_spec_internal(
         );
     }
 
+    let bridge_runtime_policy = match bridge_runtime_policy(spec, security_scan_policy.as_ref()) {
+        Ok(policy) => policy,
+        Err(error) => {
+            let reason = format!("bridge runtime policy is invalid: {error}");
+            return build_blocked_spec_run_report(
+                pack.pack_id.clone(),
+                spec.agent_id.clone(),
+                reason,
+                approval_guard,
+                bridge_support_source.clone(),
+                bridge_support_checksum,
+                bridge_support_sha256,
+                bridge_support_delta_source.clone(),
+                bridge_support_delta_sha256.clone(),
+                self_awareness,
+                architecture_guard,
+                plugin_scan_reports,
+                plugin_translation_reports,
+                plugin_activation_plans,
+                plugin_bootstrap_reports,
+                plugin_bootstrap_queue,
+                plugin_absorb_reports,
+                security_scan_report,
+                auto_provision_plan,
+                integration_catalog,
+                include_audit,
+                &audit_sink,
+            );
+        }
+    };
+
     if let Some(plugin_scan) = &spec.plugin_scan
         && plugin_scan.enabled
     {
@@ -522,36 +553,6 @@ async fn execute_spec_internal(
     }
 
     let shared_catalog = Arc::new(Mutex::new(integration_catalog.clone()));
-    let bridge_runtime_policy = match bridge_runtime_policy(spec, security_scan_policy.as_ref()) {
-        Ok(policy) => policy,
-        Err(error) => {
-            let reason = format!("bridge runtime policy is invalid: {error}");
-            return build_blocked_spec_run_report(
-                pack.pack_id.clone(),
-                spec.agent_id.clone(),
-                reason,
-                approval_guard,
-                bridge_support_source.clone(),
-                bridge_support_checksum,
-                bridge_support_sha256,
-                bridge_support_delta_source.clone(),
-                bridge_support_delta_sha256.clone(),
-                self_awareness,
-                architecture_guard,
-                plugin_scan_reports,
-                plugin_translation_reports,
-                plugin_activation_plans,
-                plugin_bootstrap_reports,
-                plugin_bootstrap_queue,
-                plugin_absorb_reports,
-                security_scan_report,
-                auto_provision_plan,
-                integration_catalog,
-                include_audit,
-                &audit_sink,
-            );
-        }
-    };
     register_dynamic_catalog_connectors(&mut kernel, shared_catalog.clone(), bridge_runtime_policy);
 
     if let Err(error) = kernel.register_pack(pack.clone()) {
@@ -1302,6 +1303,21 @@ fn normalize_allowed_path_prefixes(prefixes: &[String]) -> Vec<PathBuf> {
         .collect()
 }
 
+fn validate_wasm_guest_readable_config_keys(keys: &BTreeSet<String>) -> CliResult<()> {
+    for key in keys {
+        let key_is_supported = wasm_guest_config_key_is_supported(key.as_str());
+        if key_is_supported {
+            continue;
+        }
+
+        return Err(format!(
+            "invalid security scan runtime.guest_readable_config_keys entry `{key}`: entries must use `{WASM_GUEST_CONFIG_PROVIDER_PREFIX}<metadata_key>` or `{WASM_GUEST_CONFIG_CHANNEL_PREFIX}<metadata_key>`"
+        ));
+    }
+
+    Ok(())
+}
+
 pub fn normalize_path_for_policy(path: &Path) -> PathBuf {
     if let Ok(canonical) = fs::canonicalize(path) {
         return canonical;
@@ -1515,6 +1531,9 @@ fn bridge_runtime_policy(
         .map(PathBuf::from)
         .map(|path| normalize_path_for_policy(&path))
         .collect();
+    let wasm_guest_readable_config_keys =
+        collect_verified_name_list(&runtime.guest_readable_config_keys);
+    validate_wasm_guest_readable_config_keys(&wasm_guest_readable_config_keys)?;
 
     Ok(BridgeRuntimePolicy {
         execute_process_stdio: bridge.execute_process_stdio,
@@ -1529,6 +1548,7 @@ fn bridge_runtime_policy(
             .collect(),
         bridge_circuit_breaker,
         wasm_allowed_path_prefixes,
+        wasm_guest_readable_config_keys,
         wasm_max_component_bytes: runtime.max_component_bytes,
         wasm_max_output_bytes: runtime.max_output_bytes,
         wasm_fuel_limit: runtime.fuel_limit,
@@ -2748,6 +2768,118 @@ mod bridge_runtime_policy_tests {
             .expect_err("invalid bridge circuit breaker policy should fail");
 
         assert!(error.contains("failure_threshold"));
+    }
+
+    #[test]
+    fn bridge_runtime_policy_normalizes_guest_readable_config_keys() {
+        let mut spec = RunnerSpec::template();
+        let (mut bridge, _source) =
+            load_bundled_bridge_support_policy("openclaw-ecosystem-balanced")
+                .expect("bundled bridge support should resolve");
+        let mut security_scan = SecurityScanSpec {
+            enabled: true,
+            ..SecurityScanSpec::default()
+        };
+        security_scan.runtime.guest_readable_config_keys = vec![
+            " provider.region ".to_owned(),
+            "channel.mode".to_owned(),
+            "provider.region".to_owned(),
+        ];
+        bridge.security_scan = Some(security_scan);
+        spec.bridge_support = Some(bridge);
+        let security_scan = spec
+            .bridge_support
+            .as_ref()
+            .and_then(|bridge| bridge.security_scan.as_ref());
+
+        let policy = bridge_runtime_policy(&spec, security_scan)
+            .expect("bridge runtime policy should build");
+
+        assert_eq!(
+            policy.wasm_guest_readable_config_keys,
+            BTreeSet::from(["channel.mode".to_owned(), "provider.region".to_owned(),])
+        );
+    }
+
+    #[test]
+    fn bridge_runtime_policy_rejects_invalid_guest_readable_config_key_namespace() {
+        let mut spec = RunnerSpec::template();
+        let (mut bridge, _source) =
+            load_bundled_bridge_support_policy("openclaw-ecosystem-balanced")
+                .expect("bundled bridge support should resolve");
+        let mut security_scan = SecurityScanSpec {
+            enabled: true,
+            ..SecurityScanSpec::default()
+        };
+        security_scan.runtime.guest_readable_config_keys = vec!["region".to_owned()];
+        bridge.security_scan = Some(security_scan);
+        spec.bridge_support = Some(bridge);
+        let security_scan = spec
+            .bridge_support
+            .as_ref()
+            .and_then(|bridge| bridge.security_scan.as_ref());
+
+        let error = bridge_runtime_policy(&spec, security_scan)
+            .expect_err("invalid guest-readable config key should fail");
+
+        assert!(error.contains("guest_readable_config_keys"));
+        assert!(error.contains("region"));
+        assert!(error.contains(WASM_GUEST_CONFIG_PROVIDER_PREFIX));
+        assert!(error.contains(WASM_GUEST_CONFIG_CHANNEL_PREFIX));
+    }
+
+    #[test]
+    fn bridge_runtime_policy_rejects_guest_readable_config_key_with_inner_whitespace() {
+        let mut spec = RunnerSpec::template();
+        let (mut bridge, _source) =
+            load_bundled_bridge_support_policy("openclaw-ecosystem-balanced")
+                .expect("bundled bridge support should resolve");
+        let mut security_scan = SecurityScanSpec {
+            enabled: true,
+            ..SecurityScanSpec::default()
+        };
+        security_scan.runtime.guest_readable_config_keys = vec!["provider.region name".to_owned()];
+        bridge.security_scan = Some(security_scan);
+        spec.bridge_support = Some(bridge);
+        let security_scan = spec
+            .bridge_support
+            .as_ref()
+            .and_then(|bridge| bridge.security_scan.as_ref());
+
+        let error = bridge_runtime_policy(&spec, security_scan)
+            .expect_err("guest-readable config key with inner whitespace should fail");
+
+        assert!(error.contains("provider.region name"));
+        assert!(error.contains("guest_readable_config_keys"));
+    }
+
+    #[tokio::test]
+    async fn execute_spec_rejects_invalid_guest_readable_config_keys_before_plugin_scan() {
+        let mut spec = RunnerSpec::template();
+        let (mut bridge, _source) =
+            load_bundled_bridge_support_policy("openclaw-ecosystem-balanced")
+                .expect("bundled bridge support should resolve");
+        let mut security_scan = SecurityScanSpec {
+            enabled: true,
+            ..SecurityScanSpec::default()
+        };
+        security_scan.runtime.guest_readable_config_keys = vec!["region".to_owned()];
+        bridge.security_scan = Some(security_scan);
+        spec.bridge_support = Some(bridge);
+        spec.plugin_scan = Some(PluginScanSpec {
+            enabled: true,
+            roots: vec!["/definitely/missing/loongclaw-plugin-root".to_owned()],
+        });
+
+        let report = execute_spec(&spec, false).await;
+        let blocked_reason = report
+            .blocked_reason
+            .expect("invalid bridge runtime policy should block the spec");
+
+        assert_eq!(report.operation_kind, "blocked");
+        assert!(blocked_reason.contains("bridge runtime policy is invalid"));
+        assert!(blocked_reason.contains("guest_readable_config_keys"));
+        assert!(!blocked_reason.contains("plugin scan failed"));
     }
 }
 

--- a/crates/spec/src/spec_execution/bridge_support_policy.rs
+++ b/crates/spec/src/spec_execution/bridge_support_policy.rs
@@ -916,6 +916,8 @@ fn canonical_security_scan_siem_export_value(export: Option<&SecuritySiemExportS
 fn canonical_security_scan_runtime_value(runtime: &SecurityRuntimeExecutionSpec) -> Value {
     let mut allowed_path_prefixes = runtime.allowed_path_prefixes.clone();
     allowed_path_prefixes.sort();
+    let mut guest_readable_config_keys = runtime.guest_readable_config_keys.clone();
+    guest_readable_config_keys.sort();
     let bridge_circuit_breaker = json!({
         "enabled": runtime.bridge_circuit_breaker.enabled,
         "failure_threshold": runtime.bridge_circuit_breaker.failure_threshold,
@@ -927,6 +929,7 @@ fn canonical_security_scan_runtime_value(runtime: &SecurityRuntimeExecutionSpec)
     json!({
         "execute_wasm_component": runtime.execute_wasm_component,
         "allowed_path_prefixes": allowed_path_prefixes,
+        "guest_readable_config_keys": guest_readable_config_keys,
         "max_component_bytes": runtime.max_component_bytes,
         "max_output_bytes": runtime.max_output_bytes,
         "fuel_limit": runtime.fuel_limit,

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -73,8 +73,12 @@ use wasm_cache::{
     insert_cached_wasm_module, lookup_cached_wasm_module, modified_unix_nanos,
     wasm_artifact_file_identity, wasm_module_cache_capacity, wasm_module_cache_max_bytes,
 };
+pub(crate) use wasm_host_abi::{
+    WASM_GUEST_CONFIG_CHANNEL_PREFIX, WASM_GUEST_CONFIG_PROVIDER_PREFIX,
+    wasm_guest_config_key_is_supported,
+};
 use wasm_host_abi::{
-    WasmHostAbiSnapshot, WasmHostAbiStoreData, link_wasm_host_abi,
+    WasmHostAbiSnapshot, WasmHostAbiStoreData, build_wasm_guest_config, link_wasm_host_abi,
     module_requires_wasm_host_abi_memory, module_uses_wasm_host_abi,
 };
 use wasm_runtime_policy::wasm_signals_based_traps_enabled_from_env;
@@ -1003,6 +1007,7 @@ pub struct BridgeRuntimePolicy {
     pub allowed_process_commands: BTreeSet<String>,
     pub bridge_circuit_breaker: ConnectorCircuitBreakerPolicy,
     pub wasm_allowed_path_prefixes: Vec<PathBuf>,
+    pub wasm_guest_readable_config_keys: BTreeSet<String>,
     pub wasm_max_component_bytes: Option<usize>,
     pub wasm_max_output_bytes: Option<usize>,
     pub wasm_fuel_limit: Option<u64>,
@@ -1540,6 +1545,8 @@ pub struct SecurityRuntimeExecutionSpec {
     pub execute_wasm_component: bool,
     #[serde(default)]
     pub allowed_path_prefixes: Vec<String>,
+    #[serde(default)]
+    pub guest_readable_config_keys: Vec<String>,
     #[serde(default)]
     pub max_component_bytes: Option<usize>,
     #[serde(default)]
@@ -2698,11 +2705,19 @@ pub fn execute_wasm_component_bridge(
                 WasmRunEvidence::default(),
             )
         })?;
-        let store_data =
-            WasmHostAbiStoreData::try_new(input_bytes, runtime_policy.wasm_max_output_bytes)
-                .map_err(|reason| {
-                    boxed_wasm_run_failure(reason, false, None, WasmRunEvidence::default())
-                })?;
+        let guest_config = build_wasm_guest_config(
+            provider,
+            channel,
+            &runtime_policy.wasm_guest_readable_config_keys,
+        );
+        let store_data = WasmHostAbiStoreData::try_new(
+            input_bytes,
+            guest_config,
+            runtime_policy.wasm_max_output_bytes,
+        )
+        .map_err(|reason| {
+            boxed_wasm_run_failure(reason, false, None, WasmRunEvidence::default())
+        })?;
         let mut store = WasmtimeStore::new(&cached_module.engine, store_data);
         if let Some(limit) = runtime_policy.wasm_fuel_limit {
             store.set_fuel(limit).map_err(|error| {

--- a/crates/spec/src/spec_runtime/wasm_host_abi.rs
+++ b/crates/spec/src/spec_runtime/wasm_host_abi.rs
@@ -1,5 +1,9 @@
-use std::ops::Range;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Range,
+};
 
+use kernel::{ChannelConfig, ProviderConfig};
 use serde_json::Value;
 use wasmtime::{
     Caller, Extern, Linker as WasmtimeLinker, Module as WasmtimeModule, Result as WasmtimeResult,
@@ -8,15 +12,23 @@ use wasmtime::{
 const WASM_HOST_ABI_IMPORT_MODULE: &str = "loongclaw";
 const WASM_HOST_ABI_IMPORT_INPUT_LEN: &str = "input_len";
 const WASM_HOST_ABI_IMPORT_READ_INPUT: &str = "read_input";
+const WASM_HOST_ABI_IMPORT_CONFIG_LEN: &str = "config_len";
+const WASM_HOST_ABI_IMPORT_READ_CONFIG: &str = "read_config";
 const WASM_HOST_ABI_IMPORT_WRITE_OUTPUT: &str = "write_output";
 const WASM_HOST_ABI_IMPORT_LOG: &str = "log";
 const WASM_HOST_ABI_IMPORT_ABORT: &str = "abort";
 const WASM_HOST_ABI_ERROR_CODE: i32 = -1;
 const WASM_HOST_ABI_LOG_DROPPED_CODE: i32 = 0;
+const WASM_HOST_ABI_CONFIG_UNAVAILABLE_CODE: i32 = -2;
+const WASM_HOST_ABI_BUFFER_TOO_SMALL_CODE: i32 = -3;
 const DEFAULT_WASM_HOST_ABI_MAX_OUTPUT_BYTES: usize = 256 * 1024;
+const WASM_HOST_ABI_MAX_CONFIG_KEY_BYTES: usize = 1024;
 const WASM_HOST_ABI_MAX_LOG_ENTRY_BYTES: usize = 4 * 1024;
 const WASM_HOST_ABI_MAX_LOG_TOTAL_BYTES: usize = 16 * 1024;
 const WASM_HOST_ABI_MAX_LOG_ENTRIES: usize = 64;
+
+pub(crate) const WASM_GUEST_CONFIG_PROVIDER_PREFIX: &str = "provider.";
+pub(crate) const WASM_GUEST_CONFIG_CHANNEL_PREFIX: &str = "channel.";
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct WasmHostAbiSnapshot {
@@ -31,6 +43,7 @@ pub(super) struct WasmHostAbiSnapshot {
 #[derive(Debug, Clone)]
 pub(super) struct WasmHostAbiStoreData {
     input_bytes: Vec<u8>,
+    guest_config: BTreeMap<String, Vec<u8>>,
     guest_logs: Vec<String>,
     guest_logs_bytes: usize,
     guest_logs_truncated: bool,
@@ -43,6 +56,7 @@ pub(super) struct WasmHostAbiStoreData {
 impl WasmHostAbiStoreData {
     pub(super) fn try_new(
         input_bytes: Vec<u8>,
+        guest_config: BTreeMap<String, Vec<u8>>,
         max_output_bytes: Option<usize>,
     ) -> Result<Self, String> {
         let input_len = input_bytes.len();
@@ -53,10 +67,20 @@ impl WasmHostAbiStoreData {
             ));
         }
 
+        for (key, value_bytes) in &guest_config {
+            let value_len = value_bytes.len();
+            if value_len > max_len {
+                return Err(format!(
+                    "wasm guest config value exceeds supported length for key `{key}`: {value_len} bytes"
+                ));
+            }
+        }
+
         let resolved_max_output_bytes = resolve_wasm_host_abi_max_output_bytes(max_output_bytes)?;
 
         Ok(Self {
             input_bytes,
+            guest_config,
             guest_logs: Vec::new(),
             guest_logs_bytes: 0,
             guest_logs_truncated: false,
@@ -141,6 +165,20 @@ pub(super) fn link_wasm_host_abi(
     linker
         .func_wrap(
             WASM_HOST_ABI_IMPORT_MODULE,
+            WASM_HOST_ABI_IMPORT_CONFIG_LEN,
+            wasm_host_config_len,
+        )
+        .map_err(|error| format!("failed to define wasm host function config_len: {error}"))?;
+    linker
+        .func_wrap(
+            WASM_HOST_ABI_IMPORT_MODULE,
+            WASM_HOST_ABI_IMPORT_READ_CONFIG,
+            wasm_host_read_config,
+        )
+        .map_err(|error| format!("failed to define wasm host function read_config: {error}"))?;
+    linker
+        .func_wrap(
+            WASM_HOST_ABI_IMPORT_MODULE,
             WASM_HOST_ABI_IMPORT_WRITE_OUTPUT,
             wasm_host_write_output,
         )
@@ -167,6 +205,8 @@ fn wasm_host_abi_import_uses_guest_memory(import_name: &str) -> bool {
     matches!(
         import_name,
         WASM_HOST_ABI_IMPORT_READ_INPUT
+            | WASM_HOST_ABI_IMPORT_CONFIG_LEN
+            | WASM_HOST_ABI_IMPORT_READ_CONFIG
             | WASM_HOST_ABI_IMPORT_WRITE_OUTPUT
             | WASM_HOST_ABI_IMPORT_LOG
     )
@@ -223,6 +263,72 @@ fn wasm_host_read_input(mut caller: Caller<'_, WasmHostAbiStoreData>, ptr: i32, 
     };
     target_slice.copy_from_slice(input_slice);
     input_len as i32
+}
+
+fn wasm_host_config_len(
+    mut caller: Caller<'_, WasmHostAbiStoreData>,
+    key_ptr: i32,
+    key_len: i32,
+) -> i32 {
+    let config_key = match copy_guest_config_key(&mut caller, key_ptr, key_len) {
+        Ok(key) => key,
+        Err(_) => {
+            return WASM_HOST_ABI_ERROR_CODE;
+        }
+    };
+
+    let config_value = caller.data().guest_config.get(config_key.as_str());
+    let Some(config_value) = config_value else {
+        return WASM_HOST_ABI_CONFIG_UNAVAILABLE_CODE;
+    };
+
+    let config_len = config_value.len();
+    config_len as i32
+}
+
+fn wasm_host_read_config(
+    mut caller: Caller<'_, WasmHostAbiStoreData>,
+    key_ptr: i32,
+    key_len: i32,
+    ptr: i32,
+    len: i32,
+) -> i32 {
+    let config_key = match copy_guest_config_key(&mut caller, key_ptr, key_len) {
+        Ok(key) => key,
+        Err(_) => {
+            return WASM_HOST_ABI_ERROR_CODE;
+        }
+    };
+
+    let Some(requested_len) = checked_len(len) else {
+        return WASM_HOST_ABI_ERROR_CODE;
+    };
+
+    let Ok(memory) = guest_memory(&mut caller) else {
+        return WASM_HOST_ABI_ERROR_CODE;
+    };
+
+    let (memory_bytes, store_data) = memory.data_and_store_mut(caller);
+    let config_value = store_data.guest_config.get(config_key.as_str());
+    let Some(config_value) = config_value else {
+        return WASM_HOST_ABI_CONFIG_UNAVAILABLE_CODE;
+    };
+
+    let config_len = config_value.len();
+    if requested_len < config_len {
+        return WASM_HOST_ABI_BUFFER_TOO_SMALL_CODE;
+    }
+
+    let Some(memory_range) = checked_memory_range(memory_bytes.len(), ptr, config_len) else {
+        return WASM_HOST_ABI_ERROR_CODE;
+    };
+
+    let Some(target_slice) = memory_bytes.get_mut(memory_range) else {
+        return WASM_HOST_ABI_ERROR_CODE;
+    };
+
+    target_slice.copy_from_slice(config_value.as_slice());
+    config_len as i32
 }
 
 fn wasm_host_write_output(mut caller: Caller<'_, WasmHostAbiStoreData>, ptr: i32, len: i32) -> i32 {
@@ -317,6 +423,23 @@ fn guest_memory(caller: &mut Caller<'_, WasmHostAbiStoreData>) -> Result<wasmtim
     Ok(memory)
 }
 
+fn copy_guest_config_key(
+    caller: &mut Caller<'_, WasmHostAbiStoreData>,
+    ptr: i32,
+    len: i32,
+) -> Result<String, String> {
+    let key_bytes = copy_guest_bytes_with_limit(
+        caller,
+        ptr,
+        len,
+        WASM_HOST_ABI_MAX_CONFIG_KEY_BYTES,
+        "wasm guest config key exceeds host ABI limit of",
+    )?;
+
+    String::from_utf8(key_bytes)
+        .map_err(|_error| "wasm guest config key must be valid UTF-8".to_owned())
+}
+
 fn copy_guest_bytes(
     caller: &mut Caller<'_, WasmHostAbiStoreData>,
     ptr: i32,
@@ -370,4 +493,72 @@ fn checked_memory_range(memory_len: usize, ptr: i32, len: usize) -> Option<Range
     }
 
     Some(offset..end)
+}
+
+pub(crate) fn wasm_guest_config_key_is_supported(raw_key: &str) -> bool {
+    let provider_key =
+        prefixed_wasm_guest_config_metadata_key(raw_key, WASM_GUEST_CONFIG_PROVIDER_PREFIX);
+    if provider_key.is_some() {
+        return true;
+    }
+
+    let channel_key =
+        prefixed_wasm_guest_config_metadata_key(raw_key, WASM_GUEST_CONFIG_CHANNEL_PREFIX);
+    channel_key.is_some()
+}
+
+pub(super) fn build_wasm_guest_config(
+    provider: &ProviderConfig,
+    channel: &ChannelConfig,
+    guest_readable_config_keys: &BTreeSet<String>,
+) -> BTreeMap<String, Vec<u8>> {
+    let mut guest_config = BTreeMap::new();
+
+    for key in guest_readable_config_keys {
+        let resolved_value = resolve_wasm_guest_config_value(provider, channel, key.as_str());
+        let Some(resolved_value) = resolved_value else {
+            continue;
+        };
+
+        let value_bytes = resolved_value.as_bytes().to_vec();
+        guest_config.insert(key.clone(), value_bytes);
+    }
+
+    guest_config
+}
+
+fn resolve_wasm_guest_config_value<'a>(
+    provider: &'a ProviderConfig,
+    channel: &'a ChannelConfig,
+    raw_key: &str,
+) -> Option<&'a str> {
+    let provider_key =
+        prefixed_wasm_guest_config_metadata_key(raw_key, WASM_GUEST_CONFIG_PROVIDER_PREFIX);
+    if let Some(provider_key) = provider_key {
+        let value = provider.metadata.get(provider_key)?;
+        return Some(value.as_str());
+    }
+
+    let channel_key =
+        prefixed_wasm_guest_config_metadata_key(raw_key, WASM_GUEST_CONFIG_CHANNEL_PREFIX);
+    if let Some(channel_key) = channel_key {
+        let value = channel.metadata.get(channel_key)?;
+        return Some(value.as_str());
+    }
+
+    None
+}
+
+fn prefixed_wasm_guest_config_metadata_key<'a>(raw_key: &'a str, prefix: &str) -> Option<&'a str> {
+    let metadata_key = raw_key.strip_prefix(prefix)?;
+    let trimmed_key = metadata_key.trim();
+    let has_outer_whitespace = trimmed_key.len() != metadata_key.len();
+    let has_inner_whitespace = trimmed_key
+        .chars()
+        .any(|character| character.is_whitespace());
+    if trimmed_key.is_empty() || has_outer_whitespace || has_inner_whitespace {
+        return None;
+    }
+
+    Some(trimmed_key)
 }

--- a/crates/spec/src/spec_runtime/wasm_runtime_tests.rs
+++ b/crates/spec/src/spec_runtime/wasm_runtime_tests.rs
@@ -203,6 +203,289 @@ fn test_wasm_runtime_policy(root: &Path) -> BridgeRuntimePolicy {
 }
 
 #[test]
+fn build_wasm_guest_config_includes_allowlisted_provider_and_channel_values() {
+    let provider = provider_with_metadata(BTreeMap::from([
+        ("region".to_owned(), "ap-southeast-1".to_owned()),
+        ("secret".to_owned(), "hidden".to_owned()),
+    ]));
+    let mut channel = test_wasm_channel(&provider);
+    channel
+        .metadata
+        .insert("mode".to_owned(), "strict".to_owned());
+    let guest_readable_config_keys = BTreeSet::from([
+        "channel.mode".to_owned(),
+        "provider.missing".to_owned(),
+        "provider.region".to_owned(),
+    ]);
+
+    let guest_config =
+        super::build_wasm_guest_config(&provider, &channel, &guest_readable_config_keys);
+
+    assert_eq!(
+        guest_config,
+        BTreeMap::from([
+            ("channel.mode".to_owned(), b"strict".to_vec()),
+            ("provider.region".to_owned(), b"ap-southeast-1".to_vec()),
+        ])
+    );
+}
+
+#[test]
+fn execute_wasm_component_bridge_reads_allowlisted_guest_config_value() {
+    let config_key = "provider.region";
+    let config_key_len = config_key.len();
+    let wat_source = format!(
+        r#"
+            (module
+              (import "loongclaw" "config_len" (func $config_len (param i32 i32) (result i32)))
+              (import "loongclaw" "read_config" (func $read_config (param i32 i32 i32 i32) (result i32)))
+              (import "loongclaw" "write_output" (func $write_output (param i32 i32) (result i32)))
+              (func (export "run") (result i32)
+                (local $value_len i32)
+                i32.const 0
+                i32.const {config_key_len}
+                call $config_len
+                local.tee $value_len
+                i32.const 0
+                i32.lt_s
+                if
+                  i32.const 1
+                  return
+                end
+                i32.const 63
+                i32.const 34
+                i32.store8
+                i32.const 0
+                i32.const {config_key_len}
+                i32.const 64
+                local.get $value_len
+                call $read_config
+                local.get $value_len
+                i32.ne
+                if
+                  i32.const 2
+                  return
+                end
+                i32.const 64
+                local.get $value_len
+                i32.add
+                i32.const 34
+                i32.store8
+                i32.const 63
+                local.get $value_len
+                i32.const 2
+                i32.add
+                call $write_output
+                local.get $value_len
+                i32.const 2
+                i32.add
+                i32.ne
+                if
+                  i32.const 3
+                  return
+                end
+                i32.const 0)
+              (memory (export "memory") 1)
+              (data (i32.const 0) "{config_key}"))
+        "#
+    );
+    let (root, wasm_path) = temp_wasm_fixture(
+        "loongclaw-wasm-host-abi-config-allowed",
+        wat_source.as_str(),
+    );
+    let component_path = wasm_path.display().to_string();
+    let provider = provider_with_metadata(BTreeMap::from([
+        ("component".to_owned(), component_path),
+        ("region".to_owned(), "us-east-1".to_owned()),
+    ]));
+    let channel = test_wasm_channel(&provider);
+    let command = test_wasm_command(json!({"input":"ping"}));
+    let root_path = root.path();
+    let mut runtime_policy = test_wasm_runtime_policy(root_path);
+    runtime_policy
+        .wasm_guest_readable_config_keys
+        .insert(config_key.to_owned());
+
+    let execution = super::execute_wasm_component_bridge(
+        json!({"status": "planned"}),
+        &provider,
+        &channel,
+        &command,
+        &runtime_policy,
+    );
+
+    assert_eq!(execution["status"], json!("executed"));
+    assert_eq!(execution["runtime"]["host_abi_enabled"], json!(true));
+    assert_eq!(execution["runtime"]["output_json"], json!("us-east-1"));
+}
+
+#[test]
+fn execute_wasm_component_bridge_fails_closed_for_missing_guest_config_key() {
+    let config_key = "provider.missing";
+    let config_key_len = config_key.len();
+    let wat_source = format!(
+        r#"
+            (module
+              (import "loongclaw" "config_len" (func $config_len (param i32 i32) (result i32)))
+              (func (export "run") (result i32)
+                i32.const 0
+                i32.const {config_key_len}
+                call $config_len
+                i32.const -2
+                i32.eq
+                if (result i32)
+                  i32.const 0
+                else
+                  i32.const 1
+                end)
+              (memory (export "memory") 1)
+              (data (i32.const 0) "{config_key}"))
+        "#
+    );
+    let (root, wasm_path) = temp_wasm_fixture(
+        "loongclaw-wasm-host-abi-config-missing",
+        wat_source.as_str(),
+    );
+    let component_path = wasm_path.display().to_string();
+    let provider = provider_with_metadata(BTreeMap::from([
+        ("component".to_owned(), component_path),
+        ("region".to_owned(), "us-east-1".to_owned()),
+    ]));
+    let channel = test_wasm_channel(&provider);
+    let command = test_wasm_command(json!({"input":"ping"}));
+    let root_path = root.path();
+    let mut runtime_policy = test_wasm_runtime_policy(root_path);
+    runtime_policy
+        .wasm_guest_readable_config_keys
+        .insert(config_key.to_owned());
+
+    let execution = super::execute_wasm_component_bridge(
+        json!({"status": "planned"}),
+        &provider,
+        &channel,
+        &command,
+        &runtime_policy,
+    );
+
+    assert_eq!(execution["status"], json!("executed"));
+    assert_eq!(execution["runtime"]["guest_exit_code"], json!(0));
+    assert_eq!(execution["runtime"]["output_json"], Value::Null);
+}
+
+#[test]
+fn execute_wasm_component_bridge_fails_closed_for_disallowed_guest_config_key() {
+    let config_key = "provider.region";
+    let config_key_len = config_key.len();
+    let wat_source = format!(
+        r#"
+            (module
+              (import "loongclaw" "config_len" (func $config_len (param i32 i32) (result i32)))
+              (func (export "run") (result i32)
+                i32.const 0
+                i32.const {config_key_len}
+                call $config_len
+                i32.const -2
+                i32.eq
+                if (result i32)
+                  i32.const 0
+                else
+                  i32.const 1
+                end)
+              (memory (export "memory") 1)
+              (data (i32.const 0) "{config_key}"))
+        "#
+    );
+    let (root, wasm_path) = temp_wasm_fixture(
+        "loongclaw-wasm-host-abi-config-disallowed",
+        wat_source.as_str(),
+    );
+    let component_path = wasm_path.display().to_string();
+    let provider = provider_with_metadata(BTreeMap::from([
+        ("component".to_owned(), component_path),
+        ("region".to_owned(), "us-east-1".to_owned()),
+    ]));
+    let channel = test_wasm_channel(&provider);
+    let command = test_wasm_command(json!({"input":"ping"}));
+    let root_path = root.path();
+    let runtime_policy = test_wasm_runtime_policy(root_path);
+
+    let execution = super::execute_wasm_component_bridge(
+        json!({"status": "planned"}),
+        &provider,
+        &channel,
+        &command,
+        &runtime_policy,
+    );
+
+    assert_eq!(execution["status"], json!("executed"));
+    assert_eq!(execution["runtime"]["guest_exit_code"], json!(0));
+    assert_eq!(execution["runtime"]["output_json"], Value::Null);
+}
+
+#[test]
+fn execute_wasm_component_bridge_reports_buffer_too_small_for_guest_config_read() {
+    let config_key = "provider.region";
+    let config_key_len = config_key.len();
+    let wat_source = format!(
+        r#"
+            (module
+              (import "loongclaw" "config_len" (func $config_len (param i32 i32) (result i32)))
+              (import "loongclaw" "read_config" (func $read_config (param i32 i32 i32 i32) (result i32)))
+              (func (export "run") (result i32)
+                (local $value_len i32)
+                i32.const 0
+                i32.const {config_key_len}
+                call $config_len
+                local.set $value_len
+                i32.const 0
+                i32.const {config_key_len}
+                i32.const 64
+                local.get $value_len
+                i32.const 1
+                i32.sub
+                call $read_config
+                i32.const -3
+                i32.eq
+                if (result i32)
+                  i32.const 0
+                else
+                  i32.const 1
+                end)
+              (memory (export "memory") 1)
+              (data (i32.const 0) "{config_key}"))
+        "#
+    );
+    let (root, wasm_path) = temp_wasm_fixture(
+        "loongclaw-wasm-host-abi-config-buffer-small",
+        wat_source.as_str(),
+    );
+    let component_path = wasm_path.display().to_string();
+    let provider = provider_with_metadata(BTreeMap::from([
+        ("component".to_owned(), component_path),
+        ("region".to_owned(), "us-east-1".to_owned()),
+    ]));
+    let channel = test_wasm_channel(&provider);
+    let command = test_wasm_command(json!({"input":"ping"}));
+    let root_path = root.path();
+    let mut runtime_policy = test_wasm_runtime_policy(root_path);
+    runtime_policy
+        .wasm_guest_readable_config_keys
+        .insert(config_key.to_owned());
+
+    let execution = super::execute_wasm_component_bridge(
+        json!({"status": "planned"}),
+        &provider,
+        &channel,
+        &command,
+        &runtime_policy,
+    );
+
+    assert_eq!(execution["status"], json!("executed"));
+    assert_eq!(execution["runtime"]["guest_exit_code"], json!(0));
+    assert_eq!(execution["runtime"]["output_json"], Value::Null);
+}
+
+#[test]
 fn execute_wasm_component_bridge_exchanges_request_output_and_logs() {
     let wat_source = r#"
             (module

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,11 +93,13 @@ Delivered in current baseline:
 - Core-module WASM host ABI v0 for plugin data exchange:
   - request payload delivery into guest memory
   - structured JSON output capture from guest memory
+  - allowlisted guest-readable config access via namespaced `provider.` / `channel.` keys
   - bounded guest logging surfaced in runtime evidence
   - explicit guest abort propagation
   - backward-compatible fallback to legacy `run() -> ()`
 - Policy-driven runtime guardrails in `bridge_support.security_scan.runtime`:
   - required `allowed_path_prefixes` when `execute_wasm_component=true` (fail closed)
+  - optional `guest_readable_config_keys` allowlist for WASM guest config reads
   - `max_component_bytes`
   - optional `max_output_bytes` for host ABI output capture
   - optional `fuel_limit`

--- a/docs/design-docs/layered-kernel-design.md
+++ b/docs/design-docs/layered-kernel-design.md
@@ -231,9 +231,12 @@ Rules:
   (`acp_bridge`) and a session-aware ACP runtime backend (`acp_runtime`), so runtime backends such
   as ACPX do not collapse into the same abstraction bucket as bridge/gateway entrypoints.
 - WASM runtime execution is policy-driven through `security_scan.runtime` with fail-closed
-  guards (`execute_wasm_component`, `allowed_path_prefixes`, `max_component_bytes`,
-  `max_output_bytes`, `fuel_limit`) so enabling execution never requires hardcoded kernel
-  branches.
+  guards (`execute_wasm_component`, `allowed_path_prefixes`, `guest_readable_config_keys`,
+  `max_component_bytes`, `max_output_bytes`, `fuel_limit`) so enabling execution never requires
+  hardcoded kernel branches.
+- Guest-readable WASM config is an explicit host view, not raw metadata passthrough:
+  `guest_readable_config_keys` must use namespaced `provider.<metadata_key>` or
+  `channel.<metadata_key>` entries, and missing or non-allowlisted keys fail closed.
 
 ### L8. Self-Awareness and Architecture Guard Plane
 

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,35 +1,35 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T05:31:59Z
+- Generated at: 2026-04-01T05:52:20Z
 - Report month: `2026-04`
-- Baseline report: none
+- Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
 - Boundary checks tracked: 4
 - SLO status: PASS
 
 ## Hotspot Metrics
 
-| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|
-| spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3455 | 3600 | 145 | 65 | 65 | 0 | 100.0% | TIGHT |
-| spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3547 | 3700 | 153 | 43 | 80 | 37 | 95.9% | TIGHT |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH |
-| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3383 | 3600 | 217 | 8 | 12 | 4 | 94.0% | WATCH |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2698 | 2800 | 102 | 56 | 65 | 9 | 96.4% | TIGHT |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9922 | 10500 | 578 | 88 | 90 | 2 | 97.8% | TIGHT |
-| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9796 | 9800 | 4 | 90 | 90 | 0 | 100.0% | TIGHT |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6936 | 7300 | 364 | 146 | 160 | 14 | 95.0% | TIGHT |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14472 | 15000 | 528 | 54 | 70 | 16 | 96.5% | TIGHT |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6324 | 6500 | 176 | 210 | 210 | 0 | 100.0% | TIGHT |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT |
+| Key | Classes | File | Lines | Max Lines | Line Headroom | Functions | Max Functions | Fn Headroom | Peak Usage | Pressure | Prev Lines | Line Growth | Growth SLO | Prev Functions |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
+| spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3470 | 3600 | 130 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 0.4% | PASS | 65 |
+| spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3679 | 3700 | 21 | 44 | 80 | 36 | 99.4% | TIGHT | 3547 | 3.7% | PASS | 43 |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.0% | PASS | 10 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 0.0% | PASS | 14 |
+| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3383 | 3600 | 217 | 8 | 12 | 4 | 94.0% | WATCH | 3383 | 0.0% | PASS | 8 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2698 | 2800 | 102 | 56 | 65 | 9 | 96.4% | TIGHT | 2698 | 0.0% | PASS | 56 |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 9922 | 10500 | 578 | 88 | 90 | 2 | 97.8% | TIGHT | 9922 | 0.0% | PASS | 88 |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9796 | 9800 | 4 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6936 | 7300 | 364 | 146 | 160 | 14 | 95.0% | TIGHT | 6936 | 0.0% | PASS | 146 |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14472 | 15000 | 528 | 54 | 70 | 16 | 96.5% | TIGHT | 14472 | 0.0% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6324 | 6500 | 176 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.0% | PASS | 210 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (95.9%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.7%), tools_mod (96.5%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.7%), tools_mod (96.5%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -37,10 +37,10 @@
 
 | Check | Status | Previous Status | Detail |
 |---|---|---|---|
-| memory_literals | PASS | n/a | memory operation literals are centralized in crates/app/src/memory/* |
-| provider_mod_helper_definitions | PASS | n/a | provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module |
-| conversation_provider_optional_binding_roundtrip | PASS | n/a | conversation/runtime.rs translates explicit conversation bindings into provider bindings without optional-kernel roundtrips |
-| spec_app_dependency | PASS | n/a | spec crate remains detached from app crate at the Cargo dependency boundary |
+| memory_literals | PASS | PASS | memory operation literals are centralized in crates/app/src/memory/* |
+| provider_mod_helper_definitions | PASS | PASS | provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module |
+| conversation_provider_optional_binding_roundtrip | PASS | PASS | conversation/runtime.rs translates explicit conversation bindings into provider bindings without optional-kernel roundtrips |
+| spec_app_dependency | PASS | PASS | spec crate remains detached from app crate at the Cargo dependency boundary |
 
 ## SLO Assessment
 - Hotspot growth SLO (>10% month-over-month): PASS
@@ -57,8 +57,8 @@
 - [Release template](TEMPLATE.md)
 - [CI workflow](../../.github/workflows/ci.yml)
 
-<!-- arch-hotspot key=spec_runtime lines=3455 functions=65 -->
-<!-- arch-hotspot key=spec_execution lines=3547 functions=43 -->
+<!-- arch-hotspot key=spec_runtime lines=3470 functions=65 -->
+<!-- arch-hotspot key=spec_execution lines=3679 functions=44 -->
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3383 functions=8 -->

--- a/scripts/check_architecture_drift_freshness.sh
+++ b/scripts/check_architecture_drift_freshness.sh
@@ -12,6 +12,30 @@ NORMALIZED_GENERATED="$(mktemp)"
 DIFF_OUTPUT="$(mktemp)"
 trap 'rm -f "$TEMP_REPORT" "$NORMALIZED_TRACKED" "$NORMALIZED_GENERATED" "$DIFF_OUTPUT"' EXIT
 
+derive_previous_month() {
+  local label="$1"
+  local year="${label%-*}"
+  local month="${label#*-}"
+  month=$((10#$month))
+  if (( month == 1 )); then
+    year=$((year - 1))
+    month=12
+  else
+    month=$((month - 1))
+  fi
+  printf '%04d-%02d' "$year" "$month"
+}
+
+resolve_adjacent_baseline_report() {
+  local report_path="$1"
+  local report_month="$2"
+  local report_dir
+  report_dir="$(dirname "$report_path")"
+  local previous_month
+  previous_month="$(derive_previous_month "$report_month")"
+  printf '%s/architecture-drift-%s.md\n' "$report_dir" "$previous_month"
+}
+
 normalize_architecture_drift_report() {
   local input_path="${1:?input_path is required}"
   sed '/^- Generated at: /d' "$input_path"
@@ -22,7 +46,24 @@ if ! git ls-files --error-unmatch "$REPORT_PATH" >/dev/null 2>&1; then
   exit 1
 fi
 
-LOONGCLAW_ARCH_REPORT_MONTH="$REPORT_MONTH" scripts/generate_architecture_drift_report.sh "$TEMP_REPORT"
+GENERATE_ENV=(
+  "LOONGCLAW_ARCH_REPORT_MONTH=${REPORT_MONTH}"
+)
+
+if [[ -n "${LOONGCLAW_ARCH_DRIFT_BASELINE_REPORT:-}" ]]; then
+  GENERATE_ENV+=(
+    "LOONGCLAW_ARCH_DRIFT_BASELINE_REPORT=${LOONGCLAW_ARCH_DRIFT_BASELINE_REPORT}"
+  )
+else
+  DEFAULT_BASELINE_REPORT="$(resolve_adjacent_baseline_report "$REPORT_PATH" "$REPORT_MONTH")"
+  if [[ -f "$DEFAULT_BASELINE_REPORT" ]]; then
+    GENERATE_ENV+=(
+      "LOONGCLAW_ARCH_DRIFT_BASELINE_REPORT=${DEFAULT_BASELINE_REPORT}"
+    )
+  fi
+fi
+
+env "${GENERATE_ENV[@]}" scripts/generate_architecture_drift_report.sh "$TEMP_REPORT"
 normalize_architecture_drift_report "$REPORT_PATH" >"$NORMALIZED_TRACKED"
 normalize_architecture_drift_report "$TEMP_REPORT" >"$NORMALIZED_GENERATED"
 

--- a/scripts/test_check_architecture_drift_freshness.sh
+++ b/scripts/test_check_architecture_drift_freshness.sh
@@ -107,6 +107,35 @@ run_fresh_report_passes_test() {
   assert_contains "$output_file" "tracked architecture drift report is fresh"
 }
 
+run_fresh_report_with_adjacent_baseline_passes_test() {
+  local fixture
+  fixture="$(make_fixture_repo)"
+  trap 'rm -rf "$fixture"' RETURN
+
+  local baseline_file="$fixture/docs/releases/architecture-drift-2098-12.md"
+  local report_file="$fixture/docs/releases/architecture-drift-2099-01.md"
+
+  (
+    cd "$fixture"
+    LOONGCLAW_ARCH_REPORT_MONTH="2098-12" \
+      scripts/generate_architecture_drift_report.sh "$baseline_file"
+    LOONGCLAW_ARCH_REPORT_MONTH="2099-01" \
+      scripts/generate_architecture_drift_report.sh "$report_file"
+    git add "$baseline_file"
+    git add "$report_file"
+    git commit -qm "seed fresh architecture drift reports with baseline"
+  )
+
+  local output_file="$fixture/fresh-with-baseline.out"
+  (
+    cd "$fixture"
+    LOONGCLAW_ARCH_REPORT_MONTH="2099-01" \
+      scripts/check_architecture_drift_freshness.sh "$report_file" >"$output_file" 2>&1
+  )
+
+  assert_contains "$output_file" "tracked architecture drift report is fresh"
+}
+
 run_stale_report_fails_test() {
   local fixture
   fixture="$(make_fixture_repo)"
@@ -163,6 +192,7 @@ run_untracked_report_fails_test() {
 }
 
 run_fresh_report_passes_test
+run_fresh_report_with_adjacent_baseline_passes_test
 run_stale_report_fails_test
 run_untracked_report_fails_test
 


### PR DESCRIPTION
## Summary

- Problem: WASM host ABI v0 could exchange request payloads, logs, and JSON output, but guest code still had no safe, bounded way to read host-provided runtime configuration.
- Why it matters: plugin authors need stable host-provided config without copying it into every request, while runtime policy must stay fail-closed and avoid exposing raw provider or channel metadata.
- What changed:
  - added `security_scan.runtime.guest_readable_config_keys` and normalized it into `BridgeRuntimePolicy`
  - added `config_len` and `read_config` host ABI imports backed by an explicit guest config snapshot derived from allowlisted `provider.` / `channel.` metadata keys
  - kept missing and disallowed keys fail-closed behind the same unavailable result and added regression coverage for allowed, missing, disallowed, and buffer-too-small paths
  - updated roadmap and architecture docs to describe the new runtime boundary
- What did not change (scope boundary):
  - no raw provider or channel metadata passthrough
  - no writable host config surface
  - no ad-hoc hardcoded key exceptions
  - no new config storage mechanism

## Linked Issues

- Closes #729
- Related #425

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this adds a new WASM host ABI read surface, so mistakes in allowlist normalization or metadata resolution could either overexpose host state or incorrectly block guest access.
- Rollout / guardrails: the surface is opt-in through `guest_readable_config_keys`; unsupported namespaces are rejected during policy construction; runtime reads stay fail-closed for missing or non-allowlisted keys.
- Rollback path: remove `guest_readable_config_keys` from affected specs, disable `execute_wasm_component`, or revert this PR to remove the config-read ABI surface.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all -- --check
cargo test -p loongclaw-spec --lib guest_config -- --nocapture
cargo test -p loongclaw-spec --lib bridge_runtime_policy_ -- --nocapture
cargo test -p loongclaw-daemon --test integration execute_spec_wasm_component_bridge_reads_allowlisted_guest_config_when_runtime_enabled -- --nocapture
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --locked
cargo test --workspace --all-features --locked
./scripts/check_dep_graph.sh
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
scripts/check-docs.sh
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
git diff --check

Results:
- All compile, lint, unit, integration, workspace, all-features, dep-graph, architecture, and default doc checks passed.
- `LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh` fails on the current `origin/dev` baseline because release-governance artifacts under `.docs/` are missing for existing releases; this PR does not touch those artifacts.
- Before: WASM guests had no policy-backed host config read path.
- After explicit path: allowlisted `provider.<metadata_key>` / `channel.<metadata_key>` reads succeed through `config_len` + `read_config`.
- After fallback path: missing or non-allowlisted keys return the same unavailable result and do not expose metadata presence.
- Boundary coverage: invalid namespaces fail policy construction; undersized read buffers return the buffer-too-small code.
```

## User-visible / Operator-visible Changes

- WASM bridge specs can now declare `security_scan.runtime.guest_readable_config_keys`.
- Guests can read only allowlisted config values through `config_len` and `read_config`.

## Failure Recovery

- Fast rollback or disable path: clear `guest_readable_config_keys`, disable WASM runtime execution for the affected spec, or revert this PR.
- Observable failure symptoms reviewers should watch for: policy construction errors for invalid namespaces, or guests receiving unavailable / buffer-too-small codes when config access is misconfigured.

## Reviewer Focus

- `crates/spec/src/spec_runtime/wasm_host_abi.rs` for fail-closed ABI behavior and the derived guest config snapshot.
- `crates/spec/src/spec_execution.rs` and `crates/spec/src/spec_execution/bridge_support_policy.rs` for policy normalization, namespace validation, and canonical hashing.
- `crates/spec/src/spec_runtime/wasm_runtime_tests.rs` and `crates/daemon/tests/integration/spec_runtime.rs` for regression coverage of allowed, missing, disallowed, and bounded-read scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WASM components can now read allowlisted configuration values from provider and channel metadata using namespaced `provider.` and `channel.` keys.
  * Configuration access is governed by an allowlist and fails closed when keys are missing or not authorized.

* **Documentation**
  * Updated roadmap and design documentation to reflect WASM host configuration capabilities and guardrails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->