### PR TITLE
ci: restore dev baseline checks blocking dependency PRs

### DIFF
--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2755,7 +2755,8 @@ impl TurnEngine {
             }
             Err(reason) if reason.starts_with("app_tool_denied:") => {
                 let human_reason = render_app_tool_denied_reason(reason.as_str());
-                let turn_result = TurnResult::policy_denied("app_tool_denied", human_reason.clone());
+                let turn_result =
+                    TurnResult::policy_denied("app_tool_denied", human_reason.clone());
                 let decision = ToolDecisionTelemetry::deny(
                     effective_tool_name.as_str(),
                     human_reason,

--- a/docs/releases/architecture-drift-2026-03.md
+++ b/docs/releases/architecture-drift-2026-03.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-03
 
 ## Summary
-- Generated at: 2026-03-31T08:52:22Z
+- Generated at: 2026-03-31T13:47:49Z
 - Report month: `2026-03`
 - Baseline report: none
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9796 | 9800 | 4 | 90 | 90 | 0 | 100.0% | TIGHT |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6936 | 7300 | 364 | 146 | 160 | 14 | 95.0% | TIGHT |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10773 | 11200 | 427 | 97 | 120 | 23 | 96.2% | TIGHT |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14256 | 15000 | 744 | 54 | 70 | 16 | 95.0% | TIGHT |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6324 | 6500 | 176 | 210 | 210 | 0 | 100.0% | TIGHT |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (95.9%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.2%), tools_mod (95.0%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (95.9%), acpx_runtime (96.4%), channel_registry (97.8%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.7%), tools_mod (95.0%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -67,7 +67,7 @@
 <!-- arch-hotspot key=channel_config lines=9796 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6936 functions=146 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10773 functions=97 -->
+<!-- arch-hotspot key=turn_coordinator lines=10831 functions=98 -->
 <!-- arch-hotspot key=tools_mod lines=14256 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6324 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->


### PR DESCRIPTION
Closes #741

## Summary
- reformat the existing `turn_engine.rs` drift so `cargo fmt --all -- --check` passes on `dev`
- refresh `docs/releases/architecture-drift-2026-03.md` so the tracked March architecture drift report is current again
- unblock the Dependabot PR batch from inherited baseline failures before handling the dependency-specific breakages

## Validation
- `cargo fmt --all -- --check`
- `bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-03.md`
- `git diff --check`
