### PR TITLE
Add workflow-aware daemon sessions shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,16 @@ loong completions elvish >> ~/.config/elvish/rc.elv
    loong audit token-trail --token-id token-abc
    ```
 
+When delegated work outlives one foreground turn, use the session shell to
+inspect the retained session lineage directly:
+
+```bash
+loong sessions list --session default
+loong sessions status --session default delegate:child-1
+loong sessions history --session default delegate:child-1
+loong sessions wait --session default delegate:child-1 --timeout-ms 1000
+```
+
 Channel setup comes after the base CLI path is healthy.
 
 ### Repository Observability

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -216,6 +216,16 @@ cargo install --path crates/daemon
    loong doctor --fix
    ```
 
+当委派出来的后台工作超出单次前台交互后，可以直接用 session shell
+检查保留下来的 session lineage：
+
+```bash
+loong sessions list --session default
+loong sessions status --session default delegate:child-1
+loong sessions history --session default delegate:child-1
+loong sessions wait --session default delegate:child-1 --timeout-ms 1000
+```
+
 先把 CLI 这条基础路径走通，再继续配置其他通道。
 
 ### 仓库可观测性

--- a/crates/app/src/channel/http.rs
+++ b/crates/app/src/channel/http.rs
@@ -120,8 +120,10 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::time::Duration;
 
-    fn read_test_http_request(stream: &mut TcpStream) -> Result<(), String> {
-        let read_timeout = Duration::from_millis(250);
+    fn read_test_http_request(
+        stream: &mut TcpStream,
+        read_timeout: Duration,
+    ) -> Result<(), String> {
         stream
             .set_read_timeout(Some(read_timeout))
             .map_err(|error| format!("set test server read timeout: {error}"))?;
@@ -179,11 +181,13 @@ mod tests {
 
         let handle = std::thread::spawn(move || -> Result<bool, String> {
             let deadline = std::time::Instant::now() + accept_timeout;
+            let minimum_request_read_timeout = Duration::from_secs(1);
+            let request_read_timeout = accept_timeout.max(minimum_request_read_timeout);
 
             loop {
                 match listener.accept() {
                     Ok((mut stream, _peer)) => {
-                        read_test_http_request(&mut stream)?;
+                        read_test_http_request(&mut stream, request_read_timeout)?;
                         stream
                             .write_all(response.as_bytes())
                             .map_err(|error| format!("write test server response: {error}"))?;

--- a/crates/app/src/runtime_self_continuity.rs
+++ b/crates/app/src/runtime_self_continuity.rs
@@ -7,7 +7,7 @@ use crate::config::LoongClawConfig;
 use crate::runtime_identity::{self, ResolvedRuntimeIdentity};
 use crate::runtime_self::{self, RuntimeSelfModel};
 #[cfg(feature = "memory-sqlite")]
-use crate::session::repository::SessionRepository;
+use crate::session::repository::{SessionEventRecord, SessionRepository};
 use crate::tools::runtime_config::ToolRuntimeConfig;
 
 const DURABLE_RECALL_INTRO: &str = concat!(
@@ -101,22 +101,34 @@ pub(crate) fn load_persisted_runtime_self_continuity(
     repo: &SessionRepository,
     session_id: &str,
 ) -> Result<Option<RuntimeSelfContinuity>, String> {
-    let recent_events = repo.list_recent_events(session_id, 64)?;
-    let recent_continuity = recent_events.into_iter().rev().find_map(|event| {
-        let is_continuity_event = event.event_kind == RUNTIME_SELF_CONTINUITY_EVENT_KIND;
-        if !is_continuity_event {
-            return None;
-        }
+    load_persisted_runtime_self_continuity_with_delegate_events(repo, session_id, None)
+}
 
-        runtime_self_continuity_from_event_payload(&event.payload_json)
-    });
-    if recent_continuity.is_some() {
-        return Ok(recent_continuity);
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn load_persisted_runtime_self_continuity_with_delegate_events(
+    repo: &SessionRepository,
+    session_id: &str,
+    delegate_events: Option<&[SessionEventRecord]>,
+) -> Result<Option<RuntimeSelfContinuity>, String> {
+    let latest_event =
+        repo.load_latest_event_by_kind(session_id, RUNTIME_SELF_CONTINUITY_EVENT_KIND)?;
+    let latest_continuity = latest_event
+        .as_ref()
+        .and_then(|event| runtime_self_continuity_from_event_payload(&event.payload_json));
+    if latest_continuity.is_some() {
+        return Ok(latest_continuity);
     }
 
-    let delegate_events = repo.list_delegate_lifecycle_events(session_id)?;
+    let loaded_delegate_events = match delegate_events {
+        Some(_) => None,
+        None => Some(repo.list_delegate_lifecycle_events(session_id)?),
+    };
+    let delegate_events = match delegate_events {
+        Some(events) => events,
+        None => loaded_delegate_events.as_deref().unwrap_or(&[]),
+    };
     let delegate_continuity = delegate_events
-        .into_iter()
+        .iter()
         .rev()
         .find_map(|event| runtime_self_continuity_from_event_payload(&event.payload_json));
     Ok(delegate_continuity)

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -890,6 +890,17 @@ impl SessionRepository {
         Self::list_recent_events_with_conn(&conn, &session_id, limit)
     }
 
+    pub fn load_latest_event_by_kind(
+        &self,
+        session_id: &str,
+        event_kind: &str,
+    ) -> Result<Option<SessionEventRecord>, String> {
+        let session_id = normalize_required_text(session_id, "session_id")?;
+        let event_kind = normalize_required_text(event_kind, "event_kind")?;
+        let conn = self.open_connection()?;
+        Self::load_latest_event_by_kind_with_conn(&conn, &session_id, &event_kind)
+    }
+
     pub fn list_events_after(
         &self,
         session_id: &str,
@@ -2033,6 +2044,41 @@ impl SessionRepository {
         }
         events.reverse();
         Ok(events)
+    }
+
+    fn load_latest_event_by_kind_with_conn(
+        conn: &Connection,
+        session_id: &str,
+        event_kind: &str,
+    ) -> Result<Option<SessionEventRecord>, String> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, event_kind, actor_session_id, payload_json, ts
+                 FROM session_events
+                 WHERE session_id = ?1 AND event_kind = ?2
+                 ORDER BY id DESC
+                 LIMIT 1",
+            )
+            .map_err(|error| format!("prepare latest session event query failed: {error}"))?;
+        let raw = stmt
+            .query_row(params![session_id, event_kind], |row| {
+                Ok(RawSessionEventRecord {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    event_kind: row.get(2)?,
+                    actor_session_id: row.get(3)?,
+                    payload_json: row.get(4)?,
+                    ts: row.get(5)?,
+                })
+            })
+            .optional()
+            .map_err(|error| format!("query latest session event failed: {error}"))?;
+        let raw = match raw {
+            Some(raw) => raw,
+            None => return Ok(None),
+        };
+        let event = SessionEventRecord::try_from_raw(raw)?;
+        Ok(Some(event))
     }
 
     fn list_events_after_with_conn(

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -1466,11 +1466,9 @@ fn load_session_workflow_record(
     session: &SessionSummaryRecord,
     delegate_events: Option<&[SessionEventRecord]>,
 ) -> Result<SessionWorkflowRecord, String> {
-    let lineage_root_session_id = repo
-        .lineage_root_session_id(&session.session_id)
-        .ok()
-        .flatten();
-    let lineage_depth = repo.session_lineage_depth(&session.session_id).ok();
+    let lineage_root_session_id =
+        optional_lineage_lookup(repo.lineage_root_session_id(&session.session_id))?.flatten();
+    let lineage_depth = optional_lineage_lookup(repo.session_lineage_depth(&session.session_id))?;
 
     let loaded_delegate_events = match delegate_events {
         Some(_) => None,
@@ -1508,30 +1506,34 @@ fn session_workflow_task_from_event(event: &SessionEventRecord) -> Option<String
 }
 
 #[cfg(feature = "memory-sqlite")]
+fn optional_lineage_lookup<T>(result: Result<T, String>) -> Result<Option<T>, String> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(error) if is_expected_lineage_gap_error(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn is_expected_lineage_gap_error(error: &str) -> bool {
+    let is_broken = error.starts_with("session_lineage_broken:");
+    let is_cycle = error.starts_with("session_lineage_cycle_detected:");
+    is_broken || is_cycle
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn load_session_runtime_self_continuity_record(
     repo: &SessionRepository,
     session: &SessionSummaryRecord,
     delegate_events: &[SessionEventRecord],
 ) -> Result<Option<SessionRuntimeSelfContinuityRecord>, String> {
-    let recent_events = repo.list_recent_events(&session.session_id, 64)?;
-    let recent_continuity = recent_events
-        .iter()
-        .rev()
-        .filter(|event| {
-            event.event_kind == runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND
-        })
-        .find_map(|event| {
-            runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
-        });
-    if let Some(continuity) = recent_continuity {
-        let record = session_runtime_self_continuity_record_from_continuity(&continuity);
-        return Ok(Some(record));
-    }
-
-    let delegate_continuity = delegate_events.iter().rev().find_map(|event| {
-        runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
-    });
-    let record = delegate_continuity
+    let continuity =
+        runtime_self_continuity::load_persisted_runtime_self_continuity_with_delegate_events(
+            repo,
+            &session.session_id,
+            Some(delegate_events),
+        )?;
+    let record = continuity
         .as_ref()
         .map(session_runtime_self_continuity_record_from_continuity);
     Ok(record)
@@ -4210,6 +4212,137 @@ mod tests {
             outcome.payload["workflow"]["runtime_self_continuity"]["session_profile_projection_present"],
             true
         );
+    }
+
+    #[test]
+    fn session_status_keeps_runtime_self_continuity_after_more_than_64_newer_events() {
+        let config = isolated_memory_config("session-status-refresh-continuity-stale-window");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.append_event(NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: crate::runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND
+                .to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "source": "compaction",
+                "runtime_self_continuity": {
+                    "runtime_self": {
+                        "standing_instructions": ["Stay concise."],
+                        "tool_usage_policy": ["Prefer visible evidence."],
+                        "soul_guidance": ["Keep continuity explicit."],
+                        "identity_context": ["# Identity\n- Name: Root"],
+                        "user_context": ["Operator prefers concise technical summaries."]
+                    },
+                    "resolved_identity": {
+                        "source": "workspace_self",
+                        "content": "# Identity\n- Name: Root"
+                    },
+                    "session_profile_projection": "## Session Profile\nOperator prefers concise technical summaries."
+                }
+            }),
+        })
+        .expect("append runtime self continuity refresh");
+
+        for index in 0..70 {
+            let event_kind = format!("noise_event_{index}");
+            let payload = json!({ "index": index });
+            let event = NewSessionEvent {
+                session_id: "root-session".to_owned(),
+                event_kind,
+                actor_session_id: Some("root-session".to_owned()),
+                payload_json: payload,
+            };
+            repo.append_event(event).expect("append noise event");
+        }
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "root-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["present"],
+            true
+        );
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["resolved_identity_present"],
+            true
+        );
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["session_profile_projection_present"],
+            true
+        );
+    }
+
+    #[test]
+    fn load_session_workflow_record_propagates_unexpected_lineage_lookup_failures() {
+        let config = isolated_memory_config("session-workflow-lineage-errors");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+
+        let session = repo
+            .load_session_summary_with_legacy_fallback("root-session")
+            .expect("load session summary")
+            .expect("root session summary");
+
+        let db_path = config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path for session tools test");
+        let conn = rusqlite::Connection::open(db_path).expect("open sqlite db");
+        conn.execute("DROP TABLE sessions", [])
+            .expect("drop sessions table");
+
+        let error = super::load_session_workflow_record(&repo, &session, None)
+            .expect_err("unexpected lineage lookup failures should surface");
+
+        assert!(
+            error.contains("no such table: sessions"),
+            "expected sqlite lineage lookup failure, got: {error}"
+        );
+    }
+
+    #[test]
+    fn optional_lineage_lookup_only_degrades_expected_gap_errors() {
+        let broken = super::optional_lineage_lookup::<usize>(Err(
+            "session_lineage_broken: missing parent row for `child-session`".to_owned(),
+        ))
+        .expect("broken lineage should degrade to missing");
+        assert_eq!(broken, None);
+
+        let cycle = super::optional_lineage_lookup::<usize>(Err(
+            "session_lineage_cycle_detected: `child-session` reappeared".to_owned(),
+        ))
+        .expect("cycle lineage should degrade to missing");
+        assert_eq!(cycle, None);
+
+        let error = super::optional_lineage_lookup::<usize>(Err(
+            "query sessions failed: database is locked".to_owned(),
+        ))
+        .expect_err("unexpected lineage lookup failures should not be swallowed");
+        assert_eq!(error, "query sessions failed: database is locked");
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -20,6 +20,8 @@ use crate::conversation::ConstrainedSubagentExecution;
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
+use crate::runtime_self_continuity;
+#[cfg(feature = "memory-sqlite")]
 use crate::session::recovery::{
     RECOVERY_EVENT_KIND, RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
     RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED, SessionRecoveryRecord,
@@ -417,9 +419,15 @@ fn execute_sessions_list(
 
     let mut listed_sessions = Vec::new();
     for session in sessions {
+        let delegate_events = if session.kind == SessionKind::DelegateChild {
+            Some(load_delegate_lifecycle_events(&repo, &session)?)
+        } else {
+            None
+        };
         let delegate_lifecycle = if include_delegate_lifecycle {
-            let delegate_events = load_delegate_lifecycle_events(&repo, &session)?;
-            session_delegate_lifecycle_at(&session, delegate_events.as_slice(), now_ts)
+            delegate_events
+                .as_deref()
+                .and_then(|events| session_delegate_lifecycle_at(&session, events, now_ts))
         } else {
             None
         };
@@ -432,7 +440,7 @@ fn execute_sessions_list(
         {
             continue;
         }
-        listed_sessions.push((session, delegate_lifecycle));
+        listed_sessions.push((session, delegate_events, delegate_lifecycle));
     }
 
     let matched_count = listed_sessions.len();
@@ -448,8 +456,8 @@ fn execute_sessions_list(
     }
     let returned_count = listed_sessions.len();
     let mut session_payloads = Vec::with_capacity(returned_count);
-    for (session, delegate_lifecycle) in listed_sessions {
-        let workflow = load_session_workflow_record(&repo, &session, None)?;
+    for (session, delegate_events, delegate_lifecycle) in listed_sessions {
+        let workflow = load_session_workflow_record(&repo, &session, delegate_events.as_deref())?;
         let payload = session_summary_json_with_delegate_lifecycle(
             session,
             workflow,
@@ -1479,10 +1487,8 @@ fn load_session_workflow_record(
         .iter()
         .rev()
         .find_map(session_workflow_task_from_event);
-    let runtime_self_continuity = delegate_events
-        .iter()
-        .rev()
-        .find_map(session_runtime_self_continuity_from_event);
+    let runtime_self_continuity =
+        load_session_runtime_self_continuity_record(repo, session, delegate_events)?;
 
     Ok(SessionWorkflowRecord {
         task,
@@ -1502,21 +1508,48 @@ fn session_workflow_task_from_event(event: &SessionEventRecord) -> Option<String
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn session_runtime_self_continuity_from_event(
-    event: &SessionEventRecord,
-) -> Option<SessionRuntimeSelfContinuityRecord> {
-    let continuity = event.payload_json.get("runtime_self_continuity")?;
-    let resolved_identity = continuity.get("resolved_identity");
-    let session_profile_projection = continuity.get("session_profile_projection");
-    let resolved_identity_present = resolved_identity.is_some_and(Value::is_object);
-    let session_profile_projection_present =
-        session_profile_projection.and_then(Value::as_str).is_some();
+fn load_session_runtime_self_continuity_record(
+    repo: &SessionRepository,
+    session: &SessionSummaryRecord,
+    delegate_events: &[SessionEventRecord],
+) -> Result<Option<SessionRuntimeSelfContinuityRecord>, String> {
+    let recent_events = repo.list_recent_events(&session.session_id, 64)?;
+    let recent_continuity = recent_events
+        .iter()
+        .rev()
+        .filter(|event| {
+            event.event_kind == runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND
+        })
+        .find_map(|event| {
+            runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
+        });
+    if let Some(continuity) = recent_continuity {
+        let record = session_runtime_self_continuity_record_from_continuity(&continuity);
+        return Ok(Some(record));
+    }
 
-    Some(SessionRuntimeSelfContinuityRecord {
-        present: true,
-        resolved_identity_present,
+    let delegate_continuity = delegate_events.iter().rev().find_map(|event| {
+        runtime_self_continuity::runtime_self_continuity_from_event_payload(&event.payload_json)
+    });
+    let record = delegate_continuity
+        .as_ref()
+        .map(session_runtime_self_continuity_record_from_continuity);
+    Ok(record)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_runtime_self_continuity_record_from_continuity(
+    continuity: &runtime_self_continuity::RuntimeSelfContinuity,
+) -> SessionRuntimeSelfContinuityRecord {
+    let session_profile_projection_present = continuity
+        .session_profile_projection
+        .as_deref()
+        .is_some_and(|projection| !projection.trim().is_empty());
+    SessionRuntimeSelfContinuityRecord {
+        present: continuity.has_prompt_projection(),
+        resolved_identity_present: continuity.resolved_identity.is_some(),
         session_profile_projection_present,
-    })
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -4114,6 +4147,69 @@ mod tests {
         );
         assert_eq!(outcome.payload["session"]["turn_count"], 2);
         assert!(outcome.payload["session"]["last_turn_at"].is_number());
+    }
+
+    #[test]
+    fn session_status_includes_runtime_self_continuity_from_refresh_events() {
+        let config = isolated_memory_config("session-status-refresh-continuity");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.append_event(NewSessionEvent {
+            session_id: "root-session".to_owned(),
+            event_kind: crate::runtime_self_continuity::RUNTIME_SELF_CONTINUITY_EVENT_KIND
+                .to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "source": "compaction",
+                "runtime_self_continuity": {
+                    "runtime_self": {
+                        "standing_instructions": ["Stay concise."],
+                        "tool_usage_policy": ["Prefer visible evidence."],
+                        "soul_guidance": ["Keep continuity explicit."],
+                        "identity_context": ["# Identity\n- Name: Root"],
+                        "user_context": ["Operator prefers concise technical summaries."]
+                    },
+                    "resolved_identity": {
+                        "source": "workspace_self",
+                        "content": "# Identity\n- Name: Root"
+                    },
+                    "session_profile_projection": "## Session Profile\nOperator prefers concise technical summaries."
+                }
+            }),
+        })
+        .expect("append runtime self continuity refresh");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "root-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["present"],
+            true
+        );
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["resolved_identity_present"],
+            true
+        );
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["session_profile_projection_present"],
+            true
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -68,6 +68,7 @@ pub(super) struct SessionInspectionSnapshot {
     pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
     pub recent_events: Vec<SessionEventRecord>,
     pub delegate_events: Vec<SessionEventRecord>,
+    pub workflow: SessionWorkflowRecord,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -107,6 +108,23 @@ struct SessionDelegateCancellationRecord {
     reference: String,
     requested_at: i64,
     reason: String,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SessionWorkflowRecord {
+    task: Option<String>,
+    lineage_root_session_id: Option<String>,
+    lineage_depth: Option<usize>,
+    runtime_self_continuity: Option<SessionRuntimeSelfContinuityRecord>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionRuntimeSelfContinuityRecord {
+    present: bool,
+    resolved_identity_present: bool,
+    session_profile_projection_present: bool,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -429,6 +447,17 @@ fn execute_sessions_list(
         let _ = listed_sessions.pop();
     }
     let returned_count = listed_sessions.len();
+    let mut session_payloads = Vec::with_capacity(returned_count);
+    for (session, delegate_lifecycle) in listed_sessions {
+        let workflow = load_session_workflow_record(&repo, &session, None)?;
+        let payload = session_summary_json_with_delegate_lifecycle(
+            session,
+            workflow,
+            delegate_lifecycle,
+            include_delegate_lifecycle,
+        );
+        session_payloads.push(payload);
+    }
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
@@ -437,16 +466,7 @@ fn execute_sessions_list(
             "matched_count": matched_count,
             "returned_count": returned_count,
             "has_more": has_more,
-            "sessions": listed_sessions
-                .into_iter()
-                .map(|(session, delegate_lifecycle)| {
-                    session_summary_json_with_delegate_lifecycle(
-                        session,
-                        delegate_lifecycle,
-                        include_delegate_lifecycle,
-                    )
-                })
-                .collect::<Vec<_>>(),
+            "sessions": session_payloads,
         }),
     })
 }
@@ -1407,6 +1427,7 @@ pub(super) fn observe_visible_session_with_policies(
         )?
         .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
     let delegate_events = load_delegate_lifecycle_events(&repo, &session)?;
+    let workflow = load_session_workflow_record(&repo, &session, Some(delegate_events.as_slice()))?;
 
     Ok(SessionObservationSnapshot {
         inspection: SessionInspectionSnapshot {
@@ -1414,6 +1435,7 @@ pub(super) fn observe_visible_session_with_policies(
             terminal_outcome,
             recent_events,
             delegate_events,
+            workflow,
         },
         tail_events,
     })
@@ -1428,6 +1450,73 @@ fn load_delegate_lifecycle_events(
         return Ok(Vec::new());
     }
     repo.list_delegate_lifecycle_events(&session.session_id)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_session_workflow_record(
+    repo: &SessionRepository,
+    session: &SessionSummaryRecord,
+    delegate_events: Option<&[SessionEventRecord]>,
+) -> Result<SessionWorkflowRecord, String> {
+    let lineage_root_session_id = repo
+        .lineage_root_session_id(&session.session_id)
+        .ok()
+        .flatten();
+    let lineage_depth = repo.session_lineage_depth(&session.session_id).ok();
+
+    let loaded_delegate_events = match delegate_events {
+        Some(_) => None,
+        None if session.kind == SessionKind::DelegateChild => {
+            Some(repo.list_delegate_lifecycle_events(&session.session_id)?)
+        }
+        None => None,
+    };
+    let delegate_events = match delegate_events {
+        Some(events) => events,
+        None => loaded_delegate_events.as_deref().unwrap_or(&[]),
+    };
+    let task = delegate_events
+        .iter()
+        .rev()
+        .find_map(session_workflow_task_from_event);
+    let runtime_self_continuity = delegate_events
+        .iter()
+        .rev()
+        .find_map(session_runtime_self_continuity_from_event);
+
+    Ok(SessionWorkflowRecord {
+        task,
+        lineage_root_session_id,
+        lineage_depth,
+        runtime_self_continuity,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_workflow_task_from_event(event: &SessionEventRecord) -> Option<String> {
+    event
+        .payload_json
+        .get("task")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_runtime_self_continuity_from_event(
+    event: &SessionEventRecord,
+) -> Option<SessionRuntimeSelfContinuityRecord> {
+    let continuity = event.payload_json.get("runtime_self_continuity")?;
+    let resolved_identity = continuity.get("resolved_identity");
+    let session_profile_projection = continuity.get("session_profile_projection");
+    let resolved_identity_present = resolved_identity.is_some_and(Value::is_object);
+    let session_profile_projection_present =
+        session_profile_projection.and_then(Value::as_str).is_some();
+
+    Some(SessionRuntimeSelfContinuityRecord {
+        present: true,
+        resolved_identity_present,
+        session_profile_projection_present,
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1469,8 +1558,11 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
             "updated_at": snapshot.session.updated_at,
             "archived": snapshot.session.archived_at.is_some(),
             "archived_at": snapshot.session.archived_at,
+            "turn_count": snapshot.session.turn_count,
+            "last_turn_at": snapshot.session.last_turn_at,
             "last_error": snapshot.session.last_error,
         },
+        "workflow": session_workflow_json(snapshot.workflow),
         "terminal_outcome_state": terminal_outcome_state,
         "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
         "delegate_lifecycle": delegate_lifecycle.map(session_delegate_lifecycle_json),
@@ -3034,7 +3126,7 @@ fn sessions_list_filters_json(request: &SessionsListRequest) -> Value {
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn session_summary_json(session: SessionSummaryRecord) -> Value {
+fn session_summary_json(session: SessionSummaryRecord, workflow: SessionWorkflowRecord) -> Value {
     json!({
         "session_id": session.session_id,
         "kind": session.kind.as_str(),
@@ -3048,16 +3140,18 @@ fn session_summary_json(session: SessionSummaryRecord) -> Value {
         "turn_count": session.turn_count,
         "last_turn_at": session.last_turn_at,
         "last_error": session.last_error,
+        "workflow": session_workflow_json(workflow),
     })
 }
 
 #[cfg(feature = "memory-sqlite")]
 fn session_summary_json_with_delegate_lifecycle(
     session: SessionSummaryRecord,
+    workflow: SessionWorkflowRecord,
     delegate_lifecycle: Option<SessionDelegateLifecycleRecord>,
     include_delegate_lifecycle: bool,
 ) -> Value {
-    let mut payload = session_summary_json(session);
+    let mut payload = session_summary_json(session, workflow);
     if include_delegate_lifecycle && let Some(object) = payload.as_object_mut() {
         object.insert(
             "delegate_lifecycle".to_owned(),
@@ -3067,6 +3161,30 @@ fn session_summary_json_with_delegate_lifecycle(
         );
     }
     payload
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_workflow_json(workflow: SessionWorkflowRecord) -> Value {
+    json!({
+        "task": workflow.task,
+        "lineage_root_session_id": workflow.lineage_root_session_id,
+        "lineage_depth": workflow.lineage_depth,
+        "runtime_self_continuity": workflow
+            .runtime_self_continuity
+            .map(session_runtime_self_continuity_json),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_runtime_self_continuity_json(
+    runtime_self_continuity: SessionRuntimeSelfContinuityRecord,
+) -> Value {
+    json!({
+        "present": runtime_self_continuity.present,
+        "resolved_identity_present": runtime_self_continuity.resolved_identity_present,
+        "session_profile_projection_present": runtime_self_continuity
+            .session_profile_projection_present,
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -3713,6 +3831,72 @@ mod tests {
     }
 
     #[test]
+    fn sessions_list_includes_workflow_metadata_for_delegate_children() {
+        let config = isolated_memory_config("sessions-list-workflow");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Research Child".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_queued".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research release readiness",
+                "label": "Research Child",
+                "execution": {
+                    "mode": "async",
+                    "depth": 1,
+                    "max_depth": 3,
+                    "active_children": 0,
+                    "max_active_children": 2,
+                    "timeout_seconds": 120,
+                    "allow_shell_in_child": false,
+                    "child_tool_allowlist": ["file.read"],
+                    "kernel_bound": false,
+                    "runtime_narrowing": {}
+                }
+            }),
+        })
+        .expect("append queued");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({
+                    "kind": "delegate_child"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_list outcome");
+
+        let child = outcome.payload["sessions"]
+            .as_array()
+            .expect("sessions array")
+            .iter()
+            .find(|item| item["session_id"] == "child-session")
+            .expect("child session");
+        assert_eq!(child["workflow"]["task"], "research release readiness");
+        assert_eq!(child["workflow"]["lineage_root_session_id"], "root-session");
+        assert_eq!(child["workflow"]["lineage_depth"], 1);
+    }
+
+    #[test]
     fn sessions_history_returns_transcript_without_control_events() {
         let config = isolated_memory_config("sessions-history");
         let repo = SessionRepository::new(&config).expect("repository");
@@ -3836,6 +4020,100 @@ mod tests {
             .expect("recent_events array");
         assert_eq!(recent_events.len(), 1);
         assert_eq!(recent_events[0]["event_kind"], "delegate_failed");
+    }
+
+    #[test]
+    fn session_status_includes_workflow_metadata_for_delegate_child() {
+        let config = isolated_memory_config("session-status-workflow");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Continuity Child".to_owned()),
+            state: SessionState::Running,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "child-session".to_owned(),
+            event_kind: "delegate_started".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({
+                "task": "research continuity",
+                "label": "Continuity Child",
+                "execution": {
+                    "mode": "async",
+                    "depth": 1,
+                    "max_depth": 3,
+                    "active_children": 0,
+                    "max_active_children": 2,
+                    "timeout_seconds": 90,
+                    "allow_shell_in_child": false,
+                    "child_tool_allowlist": ["file.read"],
+                    "kernel_bound": false,
+                    "runtime_narrowing": {}
+                },
+                "runtime_self_continuity": {
+                    "runtime_self": {
+                        "standing_instructions": ["Stay concise."],
+                        "tool_usage_policy": ["Prefer visible evidence."],
+                        "soul_guidance": ["Keep continuity explicit."],
+                        "identity_context": ["# Identity\n- Name: Child"],
+                        "user_context": ["Operator prefers concise technical summaries."]
+                    },
+                    "resolved_identity": {
+                        "source": "workspace_self",
+                        "content": "# Identity\n- Name: Child"
+                    },
+                    "session_profile_projection": "## Session Profile\nOperator prefers concise technical summaries."
+                }
+            }),
+        })
+        .expect("append delegate_started");
+        append_turn_direct("child-session", "user", "hello", &config).expect("append user turn");
+        append_turn_direct("child-session", "assistant", "world", &config)
+            .expect("append assistant turn");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "session_status".to_owned(),
+                payload: json!({
+                    "session_id": "child-session"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("session_status outcome");
+
+        assert_eq!(outcome.payload["workflow"]["task"], "research continuity");
+        assert_eq!(
+            outcome.payload["workflow"]["lineage_root_session_id"],
+            "root-session"
+        );
+        assert_eq!(outcome.payload["workflow"]["lineage_depth"], 1);
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["present"],
+            true
+        );
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["resolved_identity_present"],
+            true
+        );
+        assert_eq!(
+            outcome.payload["workflow"]["runtime_self_continuity"]["session_profile_projection_present"],
+            true
+        );
+        assert_eq!(outcome.payload["session"]["turn_count"], 2);
+        assert!(outcome.payload["session"]["last_turn_at"].is_number());
     }
 
     #[test]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -110,6 +110,7 @@ mod provider_route_diagnostics;
 pub mod runtime_capability_cli;
 pub mod runtime_experiment_cli;
 pub mod runtime_restore_cli;
+pub mod sessions_cli;
 pub mod skills_cli;
 pub mod source_presentation;
 pub mod supervisor;
@@ -611,6 +612,20 @@ pub enum Commands {
         session: String,
         #[command(subcommand)]
         command: tasks_cli::TasksCommands,
+    },
+    #[command(
+        about = "Inspect and manage persisted runtime sessions through an operator-facing session shell",
+        long_about = "Bounded operator-facing session shell for persisted runtime sessions.\n\nUse this surface to list visible sessions, inspect one session's workflow metadata, review lifecycle events, inspect transcript history, and apply bounded recover, cancel, or archive actions without inventing a second session model."
+    )]
+    Sessions {
+        #[arg(long, global = true)]
+        config: Option<String>,
+        #[arg(long, global = true, default_value_t = false)]
+        json: bool,
+        #[arg(long, global = true, default_value = "default")]
+        session: String,
+        #[command(subcommand)]
+        command: sessions_cli::SessionsCommands,
     },
     #[command(
         visible_alias = "plugin",

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -277,6 +277,20 @@ async fn main() {
             })
             .await
         }
+        Commands::Sessions {
+            config,
+            json,
+            session,
+            command,
+        } => {
+            sessions_cli::run_sessions_cli(sessions_cli::SessionsCommandOptions {
+                config,
+                json,
+                session,
+                command,
+            })
+            .await
+        }
         Commands::Plugins { json, command } => {
             plugins_cli::run_plugins_cli(plugins_cli::PluginsCommandOptions { json, command }).await
         }

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -1,0 +1,976 @@
+use clap::Subcommand;
+use kernel::ToolCoreRequest;
+use loongclaw_app as mvp;
+use loongclaw_spec::CliResult;
+use serde_json::{Value, json};
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum SessionsCommands {
+    /// List visible persisted sessions for the scoped session lineage
+    List {
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        #[arg(long)]
+        state: Option<String>,
+        #[arg(long)]
+        kind: Option<String>,
+        #[arg(long)]
+        parent_session_id: Option<String>,
+        #[arg(long, default_value_t = false)]
+        overdue_only: bool,
+        #[arg(long, default_value_t = false)]
+        include_archived: bool,
+        #[arg(long, default_value_t = false)]
+        include_delegate_lifecycle: bool,
+    },
+    /// Inspect one visible persisted session
+    #[command(visible_alias = "info")]
+    Status { session_id: String },
+    /// Show recent lifecycle events for one visible session
+    Events {
+        session_id: String,
+        #[arg(long)]
+        after_id: Option<i64>,
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
+    /// Wait on one visible session and return incremental events
+    Wait {
+        session_id: String,
+        #[arg(long)]
+        after_id: Option<i64>,
+        #[arg(long, default_value_t = 1_000)]
+        timeout_ms: u64,
+    },
+    /// Show recent transcript turns for one visible session
+    History {
+        session_id: String,
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
+    /// Cancel one visible session
+    Cancel {
+        session_id: String,
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
+    /// Recover one visible session
+    Recover {
+        session_id: String,
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
+    /// Archive one visible terminal session
+    Archive {
+        session_id: String,
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionsCommandOptions {
+    pub config: Option<String>,
+    pub json: bool,
+    pub session: String,
+    pub command: SessionsCommands,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionsCommandExecution {
+    pub resolved_config_path: String,
+    pub current_session_id: String,
+    pub payload: Value,
+}
+
+pub async fn run_sessions_cli(options: SessionsCommandOptions) -> CliResult<()> {
+    let as_json = options.json;
+    let execution = execute_sessions_command(options).await?;
+    if as_json {
+        let pretty = serde_json::to_string_pretty(&execution.payload)
+            .map_err(|error| format!("serialize sessions CLI output failed: {error}"))?;
+        println!("{pretty}");
+        return Ok(());
+    }
+
+    let rendered = render_sessions_cli_text(&execution)?;
+    println!("{rendered}");
+    Ok(())
+}
+
+pub async fn execute_sessions_command(
+    options: SessionsCommandOptions,
+) -> CliResult<SessionsCommandExecution> {
+    let SessionsCommandOptions {
+        config,
+        json: _,
+        session,
+        command,
+    } = options;
+    let (resolved_path, config) = mvp::config::load(config.as_deref())?;
+    mvp::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
+
+    let current_session_id = normalize_session_scope(&session)?;
+    let memory_config =
+        mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let tool_config = &config.tools;
+    let resolved_config_path = resolved_path.display().to_string();
+
+    let payload = match command {
+        SessionsCommands::List {
+            limit,
+            state,
+            kind,
+            parent_session_id,
+            overdue_only,
+            include_archived,
+            include_delegate_lifecycle,
+        } => execute_list_command(
+            &resolved_config_path,
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            limit,
+            state.as_deref(),
+            kind.as_deref(),
+            parent_session_id.as_deref(),
+            overdue_only,
+            include_archived,
+            include_delegate_lifecycle,
+        )?,
+        SessionsCommands::Status { session_id } => execute_status_command(
+            &resolved_config_path,
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &session_id,
+        )?,
+        SessionsCommands::Events {
+            session_id,
+            after_id,
+            limit,
+        } => execute_events_command(
+            &resolved_config_path,
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &session_id,
+            after_id,
+            limit,
+        )?,
+        SessionsCommands::Wait {
+            session_id,
+            after_id,
+            timeout_ms,
+        } => {
+            execute_wait_command(
+                &resolved_config_path,
+                &current_session_id,
+                &memory_config,
+                tool_config,
+                &session_id,
+                after_id,
+                timeout_ms,
+            )
+            .await?
+        }
+        SessionsCommands::History { session_id, limit } => execute_history_command(
+            &resolved_config_path,
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &session_id,
+            limit,
+        )?,
+        SessionsCommands::Cancel {
+            session_id,
+            dry_run,
+        } => execute_mutation_command(
+            "cancel",
+            "session_cancel",
+            "cancel_action",
+            &resolved_config_path,
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &session_id,
+            dry_run,
+        )?,
+        SessionsCommands::Recover {
+            session_id,
+            dry_run,
+        } => execute_mutation_command(
+            "recover",
+            "session_recover",
+            "recovery_action",
+            &resolved_config_path,
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &session_id,
+            dry_run,
+        )?,
+        SessionsCommands::Archive {
+            session_id,
+            dry_run,
+        } => execute_mutation_command(
+            "archive",
+            "session_archive",
+            "archive_action",
+            &resolved_config_path,
+            &current_session_id,
+            &memory_config,
+            tool_config,
+            &session_id,
+            dry_run,
+        )?,
+    };
+
+    Ok(SessionsCommandExecution {
+        resolved_config_path,
+        current_session_id,
+        payload,
+    })
+}
+
+fn execute_list_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    limit: usize,
+    state: Option<&str>,
+    kind: Option<&str>,
+    parent_session_id: Option<&str>,
+    overdue_only: bool,
+    include_archived: bool,
+    include_delegate_lifecycle: bool,
+) -> CliResult<Value> {
+    let raw_limit = limit.clamp(1, 200);
+    let payload = json!({
+        "limit": raw_limit,
+        "state": state,
+        "kind": kind,
+        "parent_session_id": parent_session_id,
+        "overdue_only": overdue_only,
+        "include_archived": include_archived,
+        "include_delegate_lifecycle": include_delegate_lifecycle,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "sessions_list",
+        payload,
+    )?;
+    let filters = outcome
+        .payload
+        .get("filters")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let matched_count = outcome
+        .payload
+        .get("matched_count")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let returned_count = outcome
+        .payload
+        .get("returned_count")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let sessions = outcome
+        .payload
+        .get("sessions")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    Ok(json!({
+        "command": "list",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "filters": filters,
+        "matched_count": matched_count,
+        "returned_count": returned_count,
+        "sessions": sessions,
+    }))
+}
+
+fn execute_status_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    session_id: &str,
+) -> CliResult<Value> {
+    let detail =
+        load_session_status_payload(memory_config, tool_config, current_session_id, session_id)?;
+    let recipes = build_session_recipes(resolved_config_path, current_session_id, session_id);
+    let next_steps = build_session_next_steps();
+
+    Ok(json!({
+        "command": "status",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "session_id": session_id,
+        "detail": detail,
+        "recipes": recipes,
+        "next_steps": next_steps,
+    }))
+}
+
+fn execute_events_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    session_id: &str,
+    after_id: Option<i64>,
+    limit: usize,
+) -> CliResult<Value> {
+    let _ =
+        load_session_status_payload(memory_config, tool_config, current_session_id, session_id)?;
+    let event_limit = limit.clamp(1, 200);
+    let payload = json!({
+        "session_id": session_id,
+        "after_id": after_id,
+        "limit": event_limit,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "session_events",
+        payload,
+    )?;
+    let next_after_id = outcome
+        .payload
+        .get("next_after_id")
+        .cloned()
+        .unwrap_or(Value::Null);
+    let events = outcome
+        .payload
+        .get("events")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    Ok(json!({
+        "command": "events",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "session_id": session_id,
+        "after_id": after_id,
+        "next_after_id": next_after_id,
+        "events": events,
+    }))
+}
+
+async fn execute_wait_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    session_id: &str,
+    after_id: Option<i64>,
+    timeout_ms: u64,
+) -> CliResult<Value> {
+    let _ =
+        load_session_status_payload(memory_config, tool_config, current_session_id, session_id)?;
+    let bounded_timeout_ms = timeout_ms.clamp(1, 30_000);
+    let payload = json!({
+        "session_id": session_id,
+        "after_id": after_id,
+        "timeout_ms": bounded_timeout_ms,
+    });
+    let outcome = mvp::tools::wait_for_session_with_config(
+        payload,
+        current_session_id,
+        memory_config,
+        tool_config,
+    )
+    .await?;
+
+    Ok(json!({
+        "command": "wait",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "session_id": session_id,
+        "wait_status": outcome.status,
+        "detail": outcome.payload,
+    }))
+}
+
+fn execute_history_command(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    session_id: &str,
+    limit: usize,
+) -> CliResult<Value> {
+    let _ =
+        load_session_status_payload(memory_config, tool_config, current_session_id, session_id)?;
+    let history_limit = limit.clamp(1, 200);
+    let payload = json!({
+        "session_id": session_id,
+        "limit": history_limit,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "sessions_history",
+        payload,
+    )?;
+    let turns = outcome
+        .payload
+        .get("turns")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    Ok(json!({
+        "command": "history",
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "session_id": session_id,
+        "limit": history_limit,
+        "turns": turns,
+    }))
+}
+
+fn execute_mutation_command(
+    command_name: &str,
+    tool_name: &str,
+    action_field: &str,
+    resolved_config_path: &str,
+    current_session_id: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    session_id: &str,
+    dry_run: bool,
+) -> CliResult<Value> {
+    let payload = json!({
+        "session_ids": [session_id],
+        "dry_run": dry_run,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        tool_name,
+        payload,
+    )?;
+    let result = extract_single_mutation_result(&outcome.payload)
+        .ok_or_else(|| format!("{command_name} payload missing single result"))?;
+    let message = result.get("message").cloned().unwrap_or(Value::Null);
+    let action = result.get("action").cloned().unwrap_or_else(|| {
+        outcome
+            .payload
+            .get(action_field)
+            .cloned()
+            .unwrap_or(Value::Null)
+    });
+    let inspection = result.get("inspection").cloned().unwrap_or(Value::Null);
+    let mutation_result = result.get("result").cloned().unwrap_or(Value::Null);
+
+    Ok(json!({
+        "command": command_name,
+        "config": resolved_config_path,
+        "current_session_id": current_session_id,
+        "session_id": session_id,
+        "dry_run": dry_run,
+        "result": mutation_result,
+        "message": message,
+        "action": action,
+        "inspection": inspection,
+    }))
+}
+
+fn execute_app_tool_request(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    tool_name: &str,
+    payload: Value,
+) -> CliResult<kernel::ToolCoreOutcome> {
+    let request = ToolCoreRequest {
+        tool_name: tool_name.to_owned(),
+        payload,
+    };
+    let outcome = mvp::tools::execute_app_tool_with_config(
+        request,
+        current_session_id,
+        memory_config,
+        tool_config,
+    )?;
+    Ok(outcome)
+}
+
+fn load_session_status_payload(
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+    tool_config: &mvp::config::ToolConfig,
+    current_session_id: &str,
+    session_id: &str,
+) -> CliResult<Value> {
+    let payload = json!({
+        "session_id": session_id,
+    });
+    let outcome = execute_app_tool_request(
+        memory_config,
+        tool_config,
+        current_session_id,
+        "session_status",
+        payload,
+    )?;
+    Ok(outcome.payload)
+}
+
+fn extract_single_mutation_result(payload: &Value) -> Option<Value> {
+    let results = payload.get("results")?.as_array()?;
+    if results.len() != 1 {
+        return None;
+    }
+    results.first().cloned()
+}
+
+fn build_session_recipes(
+    resolved_config_path: &str,
+    current_session_id: &str,
+    session_id: &str,
+) -> Vec<String> {
+    let command_name = crate::active_cli_command_name();
+    let config_arg = crate::cli_handoff::shell_quote_argument(resolved_config_path);
+    let session_arg = crate::cli_handoff::shell_quote_argument(current_session_id);
+    let target_arg = crate::cli_handoff::shell_quote_argument(session_id);
+
+    let status_recipe = format!(
+        "{command_name} sessions status --config {config_arg} --session {session_arg} {target_arg}"
+    );
+    let history_recipe = format!(
+        "{command_name} sessions history --config {config_arg} --session {session_arg} {target_arg}"
+    );
+    let wait_recipe = format!(
+        "{command_name} sessions wait --config {config_arg} --session {session_arg} {target_arg}"
+    );
+    let events_recipe = format!(
+        "{command_name} sessions events --config {config_arg} --session {session_arg} {target_arg}"
+    );
+
+    vec![status_recipe, history_recipe, wait_recipe, events_recipe]
+}
+
+fn build_session_next_steps() -> Vec<String> {
+    let step_one =
+        "Use `sessions history` to inspect transcript continuity for the selected session."
+            .to_owned();
+    let step_two =
+        "Use `sessions wait` or `sessions events` when you need bounded progress checks."
+            .to_owned();
+    let step_three =
+        "Use `sessions cancel`, `sessions recover`, or `sessions archive` only after status confirms the state transition is valid."
+            .to_owned();
+    vec![step_one, step_two, step_three]
+}
+
+fn normalize_session_scope(raw: &str) -> CliResult<String> {
+    let session = raw.trim();
+    if session.is_empty() {
+        return Err("sessions CLI requires a non-empty session scope".to_owned());
+    }
+    Ok(session.to_owned())
+}
+
+fn required_string_field(value: &Value, field: &str, context: &str) -> CliResult<String> {
+    let text = value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{context} missing string field `{field}`"))?;
+    Ok(text.to_owned())
+}
+
+pub fn render_sessions_cli_text(execution: &SessionsCommandExecution) -> CliResult<String> {
+    let command = execution
+        .payload
+        .get("command")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "sessions CLI payload missing command".to_owned())?;
+
+    let rendered = match command {
+        "list" => render_sessions_list_text(&execution.payload)?,
+        "status" => render_sessions_status_text(&execution.payload)?,
+        "events" => render_sessions_events_text(&execution.payload)?,
+        "wait" => render_sessions_wait_text(&execution.payload)?,
+        "history" => render_sessions_history_text(&execution.payload)?,
+        "cancel" | "recover" | "archive" => render_sessions_mutation_text(&execution.payload)?,
+        other => {
+            return Err(format!("unknown sessions CLI render command `{other}`"));
+        }
+    };
+    Ok(rendered)
+}
+
+fn render_sessions_list_text(payload: &Value) -> CliResult<String> {
+    let sessions = payload
+        .get("sessions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions list payload missing sessions array".to_owned())?;
+    let matched_count = payload
+        .get("matched_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let returned_count = payload
+        .get("returned_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let scope = payload
+        .get("current_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "visible sessions from scope `{scope}`: {returned_count}/{matched_count}"
+    ));
+    if sessions.is_empty() {
+        lines.push("No persisted sessions are currently visible.".to_owned());
+        return Ok(lines.join("\n"));
+    }
+
+    for session in sessions {
+        let line = render_session_brief_line(session)?;
+        lines.push(format!("- {line}"));
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_sessions_status_text(payload: &Value) -> CliResult<String> {
+    let detail = payload
+        .get("detail")
+        .ok_or_else(|| "sessions status payload missing detail".to_owned())?;
+    let recipes = payload
+        .get("recipes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions status payload missing recipes".to_owned())?;
+    let next_steps = payload
+        .get("next_steps")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions status payload missing next_steps".to_owned())?;
+
+    let mut lines = render_session_inspection_lines(detail)?;
+    if !recipes.is_empty() {
+        lines.push("recipes:".to_owned());
+        for recipe in recipes {
+            let text = recipe.as_str().unwrap_or("");
+            lines.push(format!("- {text}"));
+        }
+    }
+    if !next_steps.is_empty() {
+        lines.push("next steps:".to_owned());
+        for step in next_steps {
+            let text = step.as_str().unwrap_or("");
+            lines.push(format!("- {text}"));
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_sessions_events_text(payload: &Value) -> CliResult<String> {
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let events = payload
+        .get("events")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions events payload missing events array".to_owned())?;
+    let next_after_id = payload
+        .get("next_after_id")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "events for `{session_id}` (next_after_id={next_after_id})"
+    ));
+    if events.is_empty() {
+        lines.push("No newer events.".to_owned());
+        return Ok(lines.join("\n"));
+    }
+
+    for event in events {
+        let event_id = event.get("id").and_then(Value::as_i64).unwrap_or_default();
+        let event_kind = event
+            .get("event_kind")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let ts = event.get("ts").and_then(Value::as_i64).unwrap_or_default();
+        lines.push(format!("- #{event_id} {event_kind} ts={ts}"));
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_sessions_wait_text(payload: &Value) -> CliResult<String> {
+    let wait_status = payload
+        .get("wait_status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let detail = payload
+        .get("detail")
+        .ok_or_else(|| "sessions wait payload missing detail".to_owned())?;
+    let events = detail
+        .get("events")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions wait detail missing events array".to_owned())?;
+    let next_after_id = detail
+        .get("next_after_id")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "wait result: {wait_status} (next_after_id={next_after_id})"
+    ));
+    lines.extend(render_session_inspection_lines(detail)?);
+    if !events.is_empty() {
+        lines.push("observed events:".to_owned());
+        for event in events {
+            let event_id = event.get("id").and_then(Value::as_i64).unwrap_or_default();
+            let event_kind = event
+                .get("event_kind")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            lines.push(format!("- #{event_id} {event_kind}"));
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_sessions_history_text(payload: &Value) -> CliResult<String> {
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let limit = payload.get("limit").and_then(Value::as_u64).unwrap_or(0);
+    let turns = payload
+        .get("turns")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "sessions history payload missing turns array".to_owned())?;
+
+    let mut lines = Vec::new();
+    lines.push(format!("history for `{session_id}` (limit={limit})"));
+    if turns.is_empty() {
+        lines.push("No transcript turns are currently stored.".to_owned());
+        return Ok(lines.join("\n"));
+    }
+
+    for turn in turns {
+        let role = turn
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let content = turn.get("content").and_then(Value::as_str).unwrap_or("");
+        lines.push(format!("- {role}: {content}"));
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_sessions_mutation_text(payload: &Value) -> CliResult<String> {
+    let command = payload
+        .get("command")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let dry_run = payload
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let result = payload
+        .get("result")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let message = payload
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let action = payload.get("action").cloned().unwrap_or(Value::Null);
+    let inspection = payload.get("inspection").cloned().unwrap_or(Value::Null);
+
+    let mut lines = Vec::new();
+    lines.push(format!("{command} dry_run={dry_run}"));
+    lines.push(format!("result: {result}"));
+    lines.push(format!("message: {message}"));
+    if !action.is_null() {
+        let rendered_action = serde_json::to_string_pretty(&action)
+            .map_err(|error| format!("render action failed: {error}"))?;
+        lines.push("action:".to_owned());
+        lines.push(rendered_action);
+    }
+    if !inspection.is_null() {
+        lines.extend(render_session_inspection_lines(&inspection)?);
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_session_brief_line(session: &Value) -> CliResult<String> {
+    let session_id = required_string_field(session, "session_id", "session summary")?;
+    let state = session
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let kind = session
+        .get("kind")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let label = session.get("label").and_then(Value::as_str).unwrap_or("-");
+    let task = session
+        .get("workflow")
+        .and_then(|value| value.get("task"))
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let lineage_depth = session
+        .get("workflow")
+        .and_then(|value| value.get("lineage_depth"))
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let line = format!(
+        "{session_id} state={state} kind={kind} label={label} task={task} depth={lineage_depth}"
+    );
+    Ok(line)
+}
+
+fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
+    let session = detail
+        .get("session")
+        .ok_or_else(|| "session inspection missing session".to_owned())?;
+    let session_id = required_string_field(session, "session_id", "session inspection")?;
+    let kind = session
+        .get("kind")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let state = session
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let parent_session_id = session
+        .get("parent_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let label = session.get("label").and_then(Value::as_str).unwrap_or("-");
+    let turn_count = session
+        .get("turn_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let last_turn_at = session
+        .get("last_turn_at")
+        .and_then(Value::as_i64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let last_error = session
+        .get("last_error")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let workflow = detail.get("workflow").cloned().unwrap_or(Value::Null);
+    let task = workflow.get("task").and_then(Value::as_str).unwrap_or("-");
+    let lineage_root_session_id = workflow
+        .get("lineage_root_session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let lineage_depth = workflow
+        .get("lineage_depth")
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let continuity =
+        render_runtime_self_continuity_summary(workflow.get("runtime_self_continuity"));
+    let delegate_mode = detail
+        .get("delegate_lifecycle")
+        .and_then(|value| value.get("mode"))
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let delegate_phase = detail
+        .get("delegate_lifecycle")
+        .and_then(|value| value.get("phase"))
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let timeout_seconds = detail
+        .get("delegate_lifecycle")
+        .and_then(|value| value.get("timeout_seconds"))
+        .and_then(Value::as_u64)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let terminal_outcome_state = detail
+        .get("terminal_outcome_state")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let terminal_status = detail
+        .get("terminal_outcome")
+        .and_then(|value| value.get("status"))
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let recovery_kind = detail
+        .get("recovery")
+        .and_then(|value| value.get("kind"))
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let recent_events = detail
+        .get("recent_events")
+        .and_then(Value::as_array)
+        .map(|value| value.len())
+        .unwrap_or(0);
+
+    let mut lines = Vec::new();
+    lines.push(format!("session_id: {session_id}"));
+    lines.push(format!("kind: {kind}"));
+    lines.push(format!("state: {state}"));
+    lines.push(format!("parent_session_id: {parent_session_id}"));
+    lines.push(format!("label: {label}"));
+    lines.push(format!("task: {task}"));
+    lines.push(format!(
+        "lineage_root_session_id: {lineage_root_session_id}"
+    ));
+    lines.push(format!("lineage_depth: {lineage_depth}"));
+    lines.push(format!("runtime_self_continuity: {continuity}"));
+    lines.push(format!("turn_count: {turn_count}"));
+    lines.push(format!("last_turn_at: {last_turn_at}"));
+    lines.push(format!("last_error: {last_error}"));
+    lines.push(format!("delegate_mode: {delegate_mode}"));
+    lines.push(format!("delegate_phase: {delegate_phase}"));
+    lines.push(format!("timeout_seconds: {timeout_seconds}"));
+    lines.push(format!("terminal_outcome_state: {terminal_outcome_state}"));
+    lines.push(format!("terminal_status: {terminal_status}"));
+    lines.push(format!("recovery_kind: {recovery_kind}"));
+    lines.push(format!("recent_events: {recent_events}"));
+    Ok(lines)
+}
+
+fn render_runtime_self_continuity_summary(runtime_self_continuity: Option<&Value>) -> String {
+    let Some(runtime_self_continuity) = runtime_self_continuity else {
+        return "-".to_owned();
+    };
+    let present = runtime_self_continuity
+        .get("present")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !present {
+        return "absent".to_owned();
+    }
+
+    let resolved_identity_present = runtime_self_continuity
+        .get("resolved_identity_present")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let session_profile_projection_present = runtime_self_continuity
+        .get("session_profile_projection_present")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    format!(
+        "present resolved_identity={} session_profile_projection={}",
+        resolved_identity_present, session_profile_projection_present
+    )
+}

--- a/crates/daemon/src/sessions_cli.rs
+++ b/crates/daemon/src/sessions_cli.rs
@@ -608,6 +608,19 @@ pub fn render_sessions_cli_text(execution: &SessionsCommandExecution) -> CliResu
     Ok(rendered)
 }
 
+fn sanitize_terminal_text(value: &str) -> String {
+    let mut sanitized = String::new();
+    for character in value.chars() {
+        if character.is_control() {
+            let escaped = character.escape_default().to_string();
+            sanitized.push_str(escaped.as_str());
+            continue;
+        }
+        sanitized.push(character);
+    }
+    sanitized
+}
+
 fn render_sessions_list_text(payload: &Value) -> CliResult<String> {
     let sessions = payload
         .get("sessions")
@@ -625,10 +638,11 @@ fn render_sessions_list_text(payload: &Value) -> CliResult<String> {
         .get("current_session_id")
         .and_then(Value::as_str)
         .unwrap_or("unknown");
+    let sanitized_scope = sanitize_terminal_text(scope);
 
     let mut lines = Vec::new();
     lines.push(format!(
-        "visible sessions from scope `{scope}`: {returned_count}/{matched_count}"
+        "visible sessions from scope `{sanitized_scope}`: {returned_count}/{matched_count}"
     ));
     if sessions.is_empty() {
         lines.push("No persisted sessions are currently visible.".to_owned());
@@ -661,14 +675,16 @@ fn render_sessions_status_text(payload: &Value) -> CliResult<String> {
         lines.push("recipes:".to_owned());
         for recipe in recipes {
             let text = recipe.as_str().unwrap_or("");
-            lines.push(format!("- {text}"));
+            let sanitized_text = sanitize_terminal_text(text);
+            lines.push(format!("- {sanitized_text}"));
         }
     }
     if !next_steps.is_empty() {
         lines.push("next steps:".to_owned());
         for step in next_steps {
             let text = step.as_str().unwrap_or("");
-            lines.push(format!("- {text}"));
+            let sanitized_text = sanitize_terminal_text(text);
+            lines.push(format!("- {sanitized_text}"));
         }
     }
 
@@ -690,8 +706,9 @@ fn render_sessions_events_text(payload: &Value) -> CliResult<String> {
         .unwrap_or(0);
 
     let mut lines = Vec::new();
+    let sanitized_session_id = sanitize_terminal_text(session_id);
     lines.push(format!(
-        "events for `{session_id}` (next_after_id={next_after_id})"
+        "events for `{sanitized_session_id}` (next_after_id={next_after_id})"
     ));
     if events.is_empty() {
         lines.push("No newer events.".to_owned());
@@ -705,7 +722,8 @@ fn render_sessions_events_text(payload: &Value) -> CliResult<String> {
             .and_then(Value::as_str)
             .unwrap_or("unknown");
         let ts = event.get("ts").and_then(Value::as_i64).unwrap_or_default();
-        lines.push(format!("- #{event_id} {event_kind} ts={ts}"));
+        let sanitized_event_kind = sanitize_terminal_text(event_kind);
+        lines.push(format!("- #{event_id} {sanitized_event_kind} ts={ts}"));
     }
 
     Ok(lines.join("\n"))
@@ -741,7 +759,8 @@ fn render_sessions_wait_text(payload: &Value) -> CliResult<String> {
                 .get("event_kind")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown");
-            lines.push(format!("- #{event_id} {event_kind}"));
+            let sanitized_event_kind = sanitize_terminal_text(event_kind);
+            lines.push(format!("- #{event_id} {sanitized_event_kind}"));
         }
     }
 
@@ -760,7 +779,10 @@ fn render_sessions_history_text(payload: &Value) -> CliResult<String> {
         .ok_or_else(|| "sessions history payload missing turns array".to_owned())?;
 
     let mut lines = Vec::new();
-    lines.push(format!("history for `{session_id}` (limit={limit})"));
+    let sanitized_session_id = sanitize_terminal_text(session_id);
+    lines.push(format!(
+        "history for `{sanitized_session_id}` (limit={limit})"
+    ));
     if turns.is_empty() {
         lines.push("No transcript turns are currently stored.".to_owned());
         return Ok(lines.join("\n"));
@@ -772,7 +794,9 @@ fn render_sessions_history_text(payload: &Value) -> CliResult<String> {
             .and_then(Value::as_str)
             .unwrap_or("unknown");
         let content = turn.get("content").and_then(Value::as_str).unwrap_or("");
-        lines.push(format!("- {role}: {content}"));
+        let sanitized_role = sanitize_terminal_text(role);
+        let sanitized_content = sanitize_terminal_text(content);
+        lines.push(format!("- {sanitized_role}: {sanitized_content}"));
     }
 
     Ok(lines.join("\n"))
@@ -799,9 +823,12 @@ fn render_sessions_mutation_text(payload: &Value) -> CliResult<String> {
     let inspection = payload.get("inspection").cloned().unwrap_or(Value::Null);
 
     let mut lines = Vec::new();
-    lines.push(format!("{command} dry_run={dry_run}"));
-    lines.push(format!("result: {result}"));
-    lines.push(format!("message: {message}"));
+    let sanitized_command = sanitize_terminal_text(command);
+    let sanitized_result = sanitize_terminal_text(result);
+    let sanitized_message = sanitize_terminal_text(message);
+    lines.push(format!("{sanitized_command} dry_run={dry_run}"));
+    lines.push(format!("result: {sanitized_result}"));
+    lines.push(format!("message: {sanitized_message}"));
     if !action.is_null() {
         let rendered_action = serde_json::to_string_pretty(&action)
             .map_err(|error| format!("render action failed: {error}"))?;
@@ -838,7 +865,10 @@ fn render_session_brief_line(session: &Value) -> CliResult<String> {
         .map(|value| value.to_string())
         .unwrap_or_else(|| "-".to_owned());
     let line = format!(
-        "{session_id} state={state} kind={kind} label={label} task={task} depth={lineage_depth}"
+        "{} state={state} kind={kind} label={} task={} depth={lineage_depth}",
+        sanitize_terminal_text(session_id.as_str()),
+        sanitize_terminal_text(label),
+        sanitize_terminal_text(task),
     );
     Ok(line)
 }
@@ -922,22 +952,28 @@ fn render_session_inspection_lines(detail: &Value) -> CliResult<Vec<String>> {
         .and_then(Value::as_array)
         .map(|value| value.len())
         .unwrap_or(0);
+    let sanitized_session_id = sanitize_terminal_text(session_id.as_str());
+    let sanitized_parent_session_id = sanitize_terminal_text(parent_session_id);
+    let sanitized_label = sanitize_terminal_text(label);
+    let sanitized_task = sanitize_terminal_text(task);
+    let sanitized_lineage_root_session_id = sanitize_terminal_text(lineage_root_session_id);
+    let sanitized_last_error = sanitize_terminal_text(last_error);
 
     let mut lines = Vec::new();
-    lines.push(format!("session_id: {session_id}"));
+    lines.push(format!("session_id: {sanitized_session_id}"));
     lines.push(format!("kind: {kind}"));
     lines.push(format!("state: {state}"));
-    lines.push(format!("parent_session_id: {parent_session_id}"));
-    lines.push(format!("label: {label}"));
-    lines.push(format!("task: {task}"));
+    lines.push(format!("parent_session_id: {sanitized_parent_session_id}"));
+    lines.push(format!("label: {sanitized_label}"));
+    lines.push(format!("task: {sanitized_task}"));
     lines.push(format!(
-        "lineage_root_session_id: {lineage_root_session_id}"
+        "lineage_root_session_id: {sanitized_lineage_root_session_id}"
     ));
     lines.push(format!("lineage_depth: {lineage_depth}"));
     lines.push(format!("runtime_self_continuity: {continuity}"));
     lines.push(format!("turn_count: {turn_count}"));
     lines.push(format!("last_turn_at: {last_turn_at}"));
-    lines.push(format!("last_error: {last_error}"));
+    lines.push(format!("last_error: {sanitized_last_error}"));
     lines.push(format!("delegate_mode: {delegate_mode}"));
     lines.push(format!("delegate_phase: {delegate_phase}"));
     lines.push(format!("timeout_seconds: {timeout_seconds}"));

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -105,6 +105,7 @@ mod runtime_capability_cli;
 mod runtime_experiment_cli;
 mod runtime_restore_cli;
 mod runtime_snapshot_cli;
+mod sessions_cli;
 mod skills_cli;
 mod spec_runtime;
 mod spec_runtime_bridge;

--- a/crates/daemon/tests/integration/sessions_cli.rs
+++ b/crates/daemon/tests/integration/sessions_cli.rs
@@ -1,5 +1,37 @@
 use super::*;
 
+fn create_delegate_session(
+    repo: &mvp::session::repository::SessionRepository,
+    parent_session_id: &str,
+    session_id: &str,
+    label: &str,
+    state: mvp::session::repository::SessionState,
+) {
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: session_id.to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some(parent_session_id.to_owned()),
+        label: Some(label.to_owned()),
+        state,
+    })
+    .expect("create delegate session");
+}
+
+fn append_session_turn(
+    root: &super::tasks_cli::TempDirGuard,
+    session_id: &str,
+    role: &str,
+    content: &str,
+) {
+    let sqlite_path = root.path().join("memory.sqlite3");
+    let memory_config = mvp::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(sqlite_path),
+        ..mvp::memory::runtime_config::MemoryRuntimeConfig::default()
+    };
+    mvp::memory::append_turn_direct(session_id, role, content, &memory_config)
+        .expect("append session turn");
+}
+
 #[test]
 fn sessions_list_cli_parses_global_flags_after_subcommand() {
     let cli = try_parse_cli([
@@ -244,5 +276,320 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
     assert!(
         rendered.contains("runtime_self_continuity: present"),
         "status render should surface continuity summary: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn execute_sessions_command_events_history_and_wait_surface_incremental_payloads() {
+    let root = super::tasks_cli::TempDirGuard::new("loongclaw-sessions-cli-events");
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[]);
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    create_delegate_session(
+        &repo,
+        "ops-root",
+        "delegate:session-1",
+        "Release Research",
+        mvp::session::repository::SessionState::Running,
+    );
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: "delegate:session-1".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("ops-root".to_owned()),
+        payload_json: json!({
+            "task": "research release readiness",
+            "label": "Release Research",
+            "execution": {
+                "mode": "async",
+                "depth": 1,
+                "max_depth": 3,
+                "active_children": 0,
+                "max_active_children": 2,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["file.read"],
+                "kernel_bound": false,
+                "runtime_narrowing": {}
+            }
+        }),
+    })
+    .expect("append delegate_started event");
+    append_session_turn(&root, "delegate:session-1", "user", "hello");
+    append_session_turn(&root, "delegate:session-1", "assistant", "world");
+
+    let events_execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
+        loongclaw_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::sessions_cli::SessionsCommands::Events {
+                session_id: "delegate:session-1".to_owned(),
+                after_id: None,
+                limit: 20,
+            },
+        },
+    )
+    .await
+    .expect("sessions events should succeed");
+
+    let next_after_id = events_execution.payload["next_after_id"]
+        .as_i64()
+        .expect("next_after_id");
+    let rendered_events =
+        loongclaw_daemon::sessions_cli::render_sessions_cli_text(&events_execution)
+            .expect("render sessions events");
+
+    assert_eq!(events_execution.payload["command"], "events");
+    assert_eq!(events_execution.payload["session_id"], "delegate:session-1");
+    assert_eq!(
+        events_execution.payload["events"][0]["event_kind"],
+        "delegate_started"
+    );
+    assert!(next_after_id >= 1);
+    assert!(
+        rendered_events.contains("delegate_started"),
+        "events render should surface event kind: {rendered_events}"
+    );
+
+    let history_execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
+        loongclaw_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::sessions_cli::SessionsCommands::History {
+                session_id: "delegate:session-1".to_owned(),
+                limit: 20,
+            },
+        },
+    )
+    .await
+    .expect("sessions history should succeed");
+
+    let rendered_history =
+        loongclaw_daemon::sessions_cli::render_sessions_cli_text(&history_execution)
+            .expect("render sessions history");
+
+    assert_eq!(history_execution.payload["command"], "history");
+    assert_eq!(
+        history_execution.payload["session_id"],
+        "delegate:session-1"
+    );
+    assert_eq!(history_execution.payload["turns"][0]["role"], "user");
+    assert_eq!(history_execution.payload["turns"][1]["role"], "assistant");
+    assert!(
+        rendered_history.contains("user: hello"),
+        "history render should surface transcript turns: {rendered_history}"
+    );
+
+    let wait_execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
+        loongclaw_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::sessions_cli::SessionsCommands::Wait {
+                session_id: "delegate:session-1".to_owned(),
+                after_id: Some(next_after_id),
+                timeout_ms: 1,
+            },
+        },
+    )
+    .await
+    .expect("sessions wait should succeed");
+
+    let rendered_wait = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&wait_execution)
+        .expect("render sessions wait");
+
+    assert_eq!(wait_execution.payload["command"], "wait");
+    assert_eq!(wait_execution.payload["session_id"], "delegate:session-1");
+    assert_eq!(wait_execution.payload["wait_status"], "timeout");
+    assert_eq!(wait_execution.payload["detail"]["events"], json!([]));
+    assert_eq!(
+        wait_execution.payload["detail"]["session"]["session_id"],
+        "delegate:session-1"
+    );
+    assert!(
+        rendered_wait.contains("wait result: timeout"),
+        "wait render should surface timeout result: {rendered_wait}"
+    );
+}
+
+#[tokio::test]
+async fn execute_sessions_command_cancel_dry_run_surfaces_cancel_action() {
+    let root = super::tasks_cli::TempDirGuard::new("loongclaw-sessions-cli-cancel");
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[]);
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    create_delegate_session(
+        &repo,
+        "ops-root",
+        "delegate:session-1",
+        "Release Check",
+        mvp::session::repository::SessionState::Ready,
+    );
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: "delegate:session-1".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("ops-root".to_owned()),
+        payload_json: json!({
+            "task": "check release readiness",
+            "label": "Release Check",
+            "timeout_seconds": 60
+        }),
+    })
+    .expect("append delegate_queued event");
+
+    let execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
+        loongclaw_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::sessions_cli::SessionsCommands::Cancel {
+                session_id: "delegate:session-1".to_owned(),
+                dry_run: true,
+            },
+        },
+    )
+    .await
+    .expect("sessions cancel dry run should succeed");
+
+    let rendered = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions cancel");
+
+    assert_eq!(execution.payload["command"], "cancel");
+    assert_eq!(execution.payload["dry_run"], true);
+    assert_eq!(execution.payload["result"], "would_apply");
+    assert_eq!(
+        execution.payload["action"]["kind"],
+        "queued_async_cancelled"
+    );
+    assert!(
+        rendered.contains("queued_async_cancelled"),
+        "cancel render should surface cancel action: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn execute_sessions_command_recover_dry_run_surfaces_non_recoverable_result() {
+    let root = super::tasks_cli::TempDirGuard::new("loongclaw-sessions-cli-recover");
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[]);
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    create_delegate_session(
+        &repo,
+        "ops-root",
+        "delegate:session-1",
+        "Release Check",
+        mvp::session::repository::SessionState::Ready,
+    );
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: "delegate:session-1".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("ops-root".to_owned()),
+        payload_json: json!({
+            "task": "check release readiness",
+            "label": "Release Check",
+            "timeout_seconds": 60
+        }),
+    })
+    .expect("append delegate_queued event");
+
+    let execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
+        loongclaw_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::sessions_cli::SessionsCommands::Recover {
+                session_id: "delegate:session-1".to_owned(),
+                dry_run: true,
+            },
+        },
+    )
+    .await
+    .expect("sessions recover dry run should succeed");
+
+    let rendered = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions recover");
+
+    assert_eq!(execution.payload["command"], "recover");
+    assert_eq!(execution.payload["dry_run"], true);
+    assert_eq!(execution.payload["result"], "skipped_not_recoverable");
+    assert!(
+        execution.payload["message"]
+            .as_str()
+            .expect("recover message")
+            .contains("session_recover_not_recoverable"),
+        "recover dry run should surface root cause: {:?}",
+        execution.payload
+    );
+    assert!(
+        rendered.contains("skipped_not_recoverable"),
+        "recover render should surface non-recoverable result: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn execute_sessions_command_archive_dry_run_surfaces_archive_action() {
+    let root = super::tasks_cli::TempDirGuard::new("loongclaw-sessions-cli-archive");
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[]);
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    create_delegate_session(
+        &repo,
+        "ops-root",
+        "delegate:session-1",
+        "Release Archive",
+        mvp::session::repository::SessionState::Running,
+    );
+    repo.finalize_session_terminal(
+        "delegate:session-1",
+        mvp::session::repository::FinalizeSessionTerminalRequest {
+            state: mvp::session::repository::SessionState::Completed,
+            last_error: None,
+            event_kind: "delegate_completed".to_owned(),
+            actor_session_id: Some("ops-root".to_owned()),
+            event_payload_json: json!({
+                "result": "ok"
+            }),
+            outcome_status: "ok".to_owned(),
+            outcome_payload_json: json!({
+                "child_session_id": "delegate:session-1",
+                "result": "ok"
+            }),
+        },
+    )
+    .expect("finalize child session");
+
+    let execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
+        loongclaw_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::sessions_cli::SessionsCommands::Archive {
+                session_id: "delegate:session-1".to_owned(),
+                dry_run: true,
+            },
+        },
+    )
+    .await
+    .expect("sessions archive dry run should succeed");
+
+    let rendered = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions archive");
+
+    assert_eq!(execution.payload["command"], "archive");
+    assert_eq!(execution.payload["dry_run"], true);
+    assert_eq!(execution.payload["result"], "would_apply");
+    assert_eq!(execution.payload["action"]["kind"], "session_archived");
+    assert_eq!(
+        execution.payload["inspection"]["session"]["state"],
+        "completed"
+    );
+    assert!(
+        rendered.contains("session_archived"),
+        "archive render should surface archive action: {rendered}"
     );
 }

--- a/crates/daemon/tests/integration/sessions_cli.rs
+++ b/crates/daemon/tests/integration/sessions_cli.rs
@@ -50,22 +50,42 @@ fn sessions_list_cli_parses_global_flags_after_subcommand() {
     ])
     .expect("sessions list CLI should parse");
 
-    let rendered = format!("{:?}", cli.command);
+    let Some(loongclaw_daemon::Commands::Sessions {
+        config,
+        json,
+        session,
+        command,
+    }) = cli.command
+    else {
+        panic!("expected sessions command, got: {:?}", cli.command);
+    };
+
+    assert_eq!(config.as_deref(), Some("/tmp/loongclaw.toml"));
+    assert!(json, "expected --json flag to be preserved");
+    assert_eq!(session, "ops-root");
+
+    let loongclaw_daemon::sessions_cli::SessionsCommands::List {
+        limit,
+        state,
+        kind,
+        parent_session_id,
+        overdue_only,
+        include_archived,
+        include_delegate_lifecycle,
+    } = command
+    else {
+        panic!("expected sessions list command");
+    };
+
+    assert_eq!(limit, 25);
+    assert_eq!(state, None);
+    assert_eq!(kind.as_deref(), Some("delegate_child"));
+    assert_eq!(parent_session_id, None);
+    assert!(!overdue_only, "unexpected overdue_only flag");
+    assert!(!include_archived, "unexpected include_archived flag");
     assert!(
-        rendered.contains("Sessions"),
-        "expected parsed command to contain Sessions variant: {rendered}"
-    );
-    assert!(
-        rendered.contains("delegate_child"),
-        "expected parsed command to include delegate_child filter: {rendered}"
-    );
-    assert!(
-        rendered.contains("ops-root"),
-        "expected parsed command to include session scope: {rendered}"
-    );
-    assert!(
-        rendered.contains("/tmp/loongclaw.toml"),
-        "expected parsed command to include config path: {rendered}"
+        !include_delegate_lifecycle,
+        "unexpected include_delegate_lifecycle flag"
     );
 }
 
@@ -255,12 +275,36 @@ async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_
         "ops-root"
     );
     assert_eq!(execution.payload["detail"]["session"]["turn_count"], 2);
-    assert_eq!(
-        execution.payload["recipes"]
-            .as_array()
-            .expect("recipes array")
-            .len(),
-        4
+    let recipes = execution.payload["recipes"]
+        .as_array()
+        .expect("recipes array");
+    let recipe_values = recipes
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+    assert!(
+        recipe_values
+            .iter()
+            .any(|recipe| recipe.contains("sessions status")),
+        "expected status recipe in {recipe_values:?}"
+    );
+    assert!(
+        recipe_values
+            .iter()
+            .any(|recipe| recipe.contains("sessions history")),
+        "expected history recipe in {recipe_values:?}"
+    );
+    assert!(
+        recipe_values
+            .iter()
+            .any(|recipe| recipe.contains("sessions wait")),
+        "expected wait recipe in {recipe_values:?}"
+    );
+    assert!(
+        recipe_values
+            .iter()
+            .any(|recipe| recipe.contains("sessions events")),
+        "expected events recipe in {recipe_values:?}"
     );
 
     let rendered = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&execution)
@@ -591,5 +635,105 @@ async fn execute_sessions_command_archive_dry_run_surfaces_archive_action() {
     assert!(
         rendered.contains("session_archived"),
         "archive render should surface archive action: {rendered}"
+    );
+}
+
+#[test]
+fn render_sessions_status_text_escapes_control_characters() {
+    let execution = loongclaw_daemon::sessions_cli::SessionsCommandExecution {
+        resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+        current_session_id: "ops-root".to_owned(),
+        payload: json!({
+            "command": "status",
+            "detail": {
+                "session": {
+                    "session_id": "delegate:\u{1b}[31mchild",
+                    "kind": "delegate_child",
+                    "state": "running",
+                    "parent_session_id": "ops-root\nnext",
+                    "label": "line1\nline2",
+                    "turn_count": 2,
+                    "last_turn_at": 123,
+                    "last_error": "boom\u{1b}[0m"
+                },
+                "workflow": {
+                    "task": "research\ncontinuity",
+                    "lineage_root_session_id": "ops-root",
+                    "lineage_depth": 1,
+                    "runtime_self_continuity": {
+                        "present": true,
+                        "resolved_identity_present": true,
+                        "session_profile_projection_present": false
+                    }
+                },
+                "delegate_lifecycle": {
+                    "mode": "async",
+                    "phase": "running",
+                    "timeout_seconds": 90
+                },
+                "terminal_outcome_state": "present",
+                "terminal_outcome": {
+                    "status": "ok"
+                },
+                "recent_events": []
+            },
+            "recipes": [],
+            "next_steps": []
+        }),
+    };
+
+    let rendered = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions status");
+
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "rendered status should not contain raw escape characters: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("label: line1\\nline2"),
+        "expected escaped newlines in label: {rendered}"
+    );
+    assert!(
+        rendered.contains("last_error: boom\\u{1b}[0m"),
+        "expected escaped escape sequence in last_error: {rendered}"
+    );
+    assert!(
+        rendered.contains("task: research\\ncontinuity"),
+        "expected escaped newlines in task: {rendered}"
+    );
+}
+
+#[test]
+fn render_sessions_history_text_escapes_control_characters() {
+    let execution = loongclaw_daemon::sessions_cli::SessionsCommandExecution {
+        resolved_config_path: "/tmp/loongclaw.toml".to_owned(),
+        current_session_id: "ops-root".to_owned(),
+        payload: json!({
+            "command": "history",
+            "session_id": "delegate:\u{1b}[31mchild",
+            "limit": 20,
+            "turns": [
+                {
+                    "role": "assistant",
+                    "content": "hello\nworld\u{1b}[0m"
+                }
+            ]
+        }),
+    };
+
+    let rendered = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions history");
+
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "rendered history should not contain raw escape characters: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("history for `delegate:\\u{1b}[31mchild`"),
+        "expected escaped session id in history header: {rendered}"
+    );
+    assert!(
+        rendered.contains("- assistant: hello\\nworld\\u{1b}[0m"),
+        "expected escaped turn content in history output: {rendered}"
     );
 }

--- a/crates/daemon/tests/integration/sessions_cli.rs
+++ b/crates/daemon/tests/integration/sessions_cli.rs
@@ -1,0 +1,248 @@
+use super::*;
+
+#[test]
+fn sessions_list_cli_parses_global_flags_after_subcommand() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "sessions",
+        "list",
+        "--kind",
+        "delegate_child",
+        "--limit",
+        "25",
+        "--session",
+        "ops-root",
+        "--json",
+        "--config",
+        "/tmp/loongclaw.toml",
+    ])
+    .expect("sessions list CLI should parse");
+
+    let rendered = format!("{:?}", cli.command);
+    assert!(
+        rendered.contains("Sessions"),
+        "expected parsed command to contain Sessions variant: {rendered}"
+    );
+    assert!(
+        rendered.contains("delegate_child"),
+        "expected parsed command to include delegate_child filter: {rendered}"
+    );
+    assert!(
+        rendered.contains("ops-root"),
+        "expected parsed command to include session scope: {rendered}"
+    );
+    assert!(
+        rendered.contains("/tmp/loongclaw.toml"),
+        "expected parsed command to include config path: {rendered}"
+    );
+}
+
+#[test]
+fn cli_sessions_help_mentions_operator_facing_session_shell() {
+    let help = render_cli_help(["sessions"]);
+
+    assert!(
+        help.contains("operator-facing session shell"),
+        "sessions help should explain the operator-facing shell intent: {help}"
+    );
+    assert!(
+        help.contains("history"),
+        "sessions help should surface transcript inspection: {help}"
+    );
+    assert!(
+        help.contains("recover"),
+        "sessions help should surface recovery actions: {help}"
+    );
+}
+
+#[tokio::test]
+async fn execute_sessions_command_list_returns_visible_sessions_with_workflow_metadata() {
+    let root = super::tasks_cli::TempDirGuard::new("loongclaw-sessions-cli-list");
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[]);
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "delegate:session-1".to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("ops-root".to_owned()),
+        label: Some("Release Research".to_owned()),
+        state: mvp::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: "delegate:session-1".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("ops-root".to_owned()),
+        payload_json: json!({
+            "task": "research release readiness",
+            "label": "Release Research",
+            "execution": {
+                "mode": "async",
+                "depth": 1,
+                "max_depth": 3,
+                "active_children": 0,
+                "max_active_children": 2,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["file.read"],
+                "kernel_bound": false,
+                "runtime_narrowing": {}
+            }
+        }),
+    })
+    .expect("append queued event");
+
+    let execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
+        loongclaw_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::sessions_cli::SessionsCommands::List {
+                limit: 20,
+                state: None,
+                kind: Some("delegate_child".to_owned()),
+                parent_session_id: None,
+                overdue_only: false,
+                include_archived: false,
+                include_delegate_lifecycle: false,
+            },
+        },
+    )
+    .await
+    .expect("sessions list should succeed");
+
+    assert_eq!(execution.payload["command"], "list");
+    assert_eq!(execution.payload["matched_count"], 1);
+    assert_eq!(execution.payload["returned_count"], 1);
+    assert_eq!(
+        execution.payload["sessions"][0]["workflow"]["task"],
+        "research release readiness"
+    );
+
+    let rendered = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions list");
+    assert!(
+        rendered.contains("task=research release readiness"),
+        "list render should surface workflow task: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn execute_sessions_command_status_surfaces_workflow_recipes_and_rendered_summary() {
+    let root = super::tasks_cli::TempDirGuard::new("loongclaw-sessions-cli-status");
+    let _env = super::tasks_cli::TasksCliEnvironmentGuard::set(&[]);
+    let config_path = super::tasks_cli::write_tasks_config(root.path());
+    let repo = super::tasks_cli::load_session_repository(&config_path);
+    super::tasks_cli::ensure_root_session(&repo, "ops-root");
+    repo.create_session(mvp::session::repository::NewSessionRecord {
+        session_id: "delegate:session-1".to_owned(),
+        kind: mvp::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("ops-root".to_owned()),
+        label: Some("Continuity Child".to_owned()),
+        state: mvp::session::repository::SessionState::Running,
+    })
+    .expect("create child session");
+    repo.append_event(mvp::session::repository::NewSessionEvent {
+        session_id: "delegate:session-1".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("ops-root".to_owned()),
+        payload_json: json!({
+            "task": "research continuity",
+            "label": "Continuity Child",
+            "execution": {
+                "mode": "async",
+                "depth": 1,
+                "max_depth": 3,
+                "active_children": 0,
+                "max_active_children": 2,
+                "timeout_seconds": 90,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["file.read"],
+                "kernel_bound": false,
+                "runtime_narrowing": {}
+            },
+            "runtime_self_continuity": {
+                "runtime_self": {
+                    "standing_instructions": ["Stay concise."],
+                    "tool_usage_policy": ["Prefer visible evidence."],
+                    "soul_guidance": ["Keep continuity explicit."],
+                    "identity_context": ["# Identity\n- Name: Child"],
+                    "user_context": ["Operator prefers concise technical summaries."]
+                },
+                "resolved_identity": {
+                    "source": "workspace_self",
+                    "content": "# Identity\n- Name: Child"
+                },
+                "session_profile_projection": "## Session Profile\nOperator prefers concise technical summaries."
+            }
+        }),
+    })
+    .expect("append started event");
+    mvp::memory::append_turn_direct(
+        "delegate:session-1",
+        "user",
+        "hello",
+        &mvp::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(root.path().join("memory.sqlite3")),
+            ..mvp::memory::runtime_config::MemoryRuntimeConfig::default()
+        },
+    )
+    .expect("append user turn");
+    mvp::memory::append_turn_direct(
+        "delegate:session-1",
+        "assistant",
+        "world",
+        &mvp::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(root.path().join("memory.sqlite3")),
+            ..mvp::memory::runtime_config::MemoryRuntimeConfig::default()
+        },
+    )
+    .expect("append assistant turn");
+
+    let execution = loongclaw_daemon::sessions_cli::execute_sessions_command(
+        loongclaw_daemon::sessions_cli::SessionsCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "ops-root".to_owned(),
+            command: loongclaw_daemon::sessions_cli::SessionsCommands::Status {
+                session_id: "delegate:session-1".to_owned(),
+            },
+        },
+    )
+    .await
+    .expect("sessions status should succeed");
+
+    assert_eq!(execution.payload["command"], "status");
+    assert_eq!(
+        execution.payload["detail"]["workflow"]["task"],
+        "research continuity"
+    );
+    assert_eq!(
+        execution.payload["detail"]["workflow"]["lineage_root_session_id"],
+        "ops-root"
+    );
+    assert_eq!(execution.payload["detail"]["session"]["turn_count"], 2);
+    assert_eq!(
+        execution.payload["recipes"]
+            .as_array()
+            .expect("recipes array")
+            .len(),
+        4
+    );
+
+    let rendered = loongclaw_daemon::sessions_cli::render_sessions_cli_text(&execution)
+        .expect("render sessions status");
+    assert!(
+        rendered.contains("task: research continuity"),
+        "status render should surface workflow task: {rendered}"
+    );
+    assert!(
+        rendered.contains("lineage_root_session_id: ops-root"),
+        "status render should surface lineage root: {rendered}"
+    );
+    assert!(
+        rendered.contains("runtime_self_continuity: present"),
+        "status render should surface continuity summary: {rendered}"
+    );
+}

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -19,17 +19,17 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
     canonical_temp_dir.join(format!("{prefix}-{nanos}"))
 }
 
-struct TempDirGuard {
+pub(super) struct TempDirGuard {
     path: PathBuf,
 }
 
 impl TempDirGuard {
-    fn new(prefix: &str) -> Self {
+    pub(super) fn new(prefix: &str) -> Self {
         let path = unique_temp_dir(prefix);
         Self { path }
     }
 
-    fn path(&self) -> &Path {
+    pub(super) fn path(&self) -> &Path {
         &self.path
     }
 }
@@ -40,7 +40,7 @@ impl Drop for TempDirGuard {
     }
 }
 
-struct TasksCliEnvironmentGuard {
+pub(super) struct TasksCliEnvironmentGuard {
     _lock: MutexGuard<'static, ()>,
     saved: Vec<(String, Option<OsString>)>,
 }
@@ -85,7 +85,7 @@ const TASKS_RUNTIME_ENV_KEYS: &[&str] = &[
 ];
 
 impl TasksCliEnvironmentGuard {
-    fn set(pairs: &[(&str, Option<&str>)]) -> Self {
+    pub(super) fn set(pairs: &[(&str, Option<&str>)]) -> Self {
         let lock = super::lock_daemon_test_environment();
         Self::set_with_lock(lock, &[], pairs)
     }
@@ -149,7 +149,7 @@ impl Drop for TasksCliEnvironmentGuard {
     }
 }
 
-fn write_tasks_config_with(
+pub(super) fn write_tasks_config_with(
     root: &Path,
     configure: impl FnOnce(&mut mvp::config::LoongClawConfig),
 ) -> PathBuf {
@@ -165,7 +165,7 @@ fn write_tasks_config_with(
     config_path
 }
 
-fn write_tasks_config(root: &Path) -> PathBuf {
+pub(super) fn write_tasks_config(root: &Path) -> PathBuf {
     write_tasks_config_with(root, |_| {})
 }
 
@@ -228,7 +228,10 @@ fn seed_background_task_record(
     .expect("upsert session tool policy");
 }
 
-fn ensure_root_session(repo: &mvp::session::repository::SessionRepository, root_session_id: &str) {
+pub(super) fn ensure_root_session(
+    repo: &mvp::session::repository::SessionRepository,
+    root_session_id: &str,
+) {
     let existing_root = repo
         .load_session(root_session_id)
         .expect("load root session");
@@ -246,7 +249,9 @@ fn ensure_root_session(repo: &mvp::session::repository::SessionRepository, root_
     .expect("create root session");
 }
 
-fn load_session_repository(config_path: &Path) -> mvp::session::repository::SessionRepository {
+pub(super) fn load_session_repository(
+    config_path: &Path,
+) -> mvp::session::repository::SessionRepository {
     let loaded =
         mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
     let config = loaded.1;

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T09:03:48Z
+- Generated at: 2026-04-01T11:05:08Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -24,7 +24,7 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14472 | 15000 | 528 | 54 | 70 | 16 | 96.5% | TIGHT | 14472 | 0.0% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6324 | 6500 | 176 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.0% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6339 | 6500 | 161 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.2% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10831 functions=98 -->
 <!-- arch-hotspot key=tools_mod lines=14472 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6324 functions=210 -->
+<!-- arch-hotspot key=daemon_lib lines=6339 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T11:05:08Z
+- Generated at: 2026-04-01T11:05:57Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14


### PR DESCRIPTION
## Summary

- Problem: persisted sessions could be inspected indirectly, but operators had no session-centric shell and no lightweight workflow context for recovery-oriented triage.
- Why it matters: restore, wait, and recovery flows required stitching together low-level state instead of working from a single operator surface.
- What changed:
  - added `loong sessions` with `list`, `status`, `events`, `wait`, `history`, `cancel`, `recover`, and `archive` subcommands
  - surfaced additive workflow metadata from existing persisted session facts in the session tool payloads, including lineage and runtime self-continuity hints
  - extended daemon integration coverage and session tool tests for the new metadata and CLI rendering
- What did not change (scope boundary):
  - no schema or migration changes
  - no second session runtime or parallel operator model
  - no replacement of the existing `tasks` shell

## Linked Issues

- Closes #743
- Related #440
- Related #217

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
Passed.

cargo clippy --workspace --all-targets --all-features -- -D warnings
Passed. Existing Cargo target warning remains unchanged: crates/daemon/src/main.rs is shared by bin targets `loong` and `loongclaw`.

cargo test --workspace --locked
Passed.

cargo test --workspace --all-features --locked
Passed.

cargo test -p loongclaw-app workflow --locked
Passed. Verified workflow metadata is surfaced for delegate child sessions.

cargo test -p loongclaw-daemon integration::sessions_cli --locked
Passed. Verified list/status shell behavior and help text for `loong sessions`.
```

## User-visible / Operator-visible Changes

- Added a new `loong sessions` shell for operator-facing session inspection, waiting, event review, recovery, cancellation, and archiving.
- `sessions_list` and `session_status` now expose additive workflow metadata such as task lineage and runtime self-continuity hints.

## Failure Recovery

- Fast rollback or disable path:
  - Revert this PR to remove the new daemon shell entry points and additive session metadata surface.
- Observable failure symptoms reviewers should watch for:
  - `loong sessions` subcommands fail to parse or do not render persisted session state consistently with existing session tools.
  - Session list/status output omits expected workflow lineage hints for delegated sessions.

## Reviewer Focus

- `crates/daemon/src/sessions_cli.rs` for CLI surface area and reuse of existing session tools without duplicating runtime behavior.
- `crates/app/src/tools/session.rs` for additive workflow metadata derivation from persisted facts and summary state.
- `crates/daemon/tests/integration/sessions_cli.rs` and related test helper changes for coverage of list/status output and wiring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "sessions" CLI (loong sessions) to list, inspect, wait, view history, stream events, and manage persisted runtime sessions (cancel/recover/archive).
  * Session inspection now includes workflow metadata (task, lineage info, runtime self-continuity) plus turn counts and last-turn timestamps.

* **Documentation**
  * Added operator-focused examples for inspecting delegated-session workflows to README (EN and ZH).

* **Tests**
  * Expanded integration and rendering tests covering the sessions CLI, workflow metadata, waits, events, history, and mutation dry-runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->