### PR TITLE
fix(channel): add truthful plugin bridge diagnostics

### DIFF
--- a/crates/app/src/channel/registry.rs
+++ b/crates/app/src/channel/registry.rs
@@ -229,6 +229,7 @@ pub struct ChannelOnboardingDescriptor {
 pub enum ChannelDoctorCheckTrigger {
     OperationHealth,
     ReadyRuntime,
+    PluginBridgeHealth,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7647,16 +7648,18 @@ mod tests {
         );
 
         assert_eq!(weixin.onboarding.strategy.as_str(), "plugin_bridge");
-        assert_eq!(
-            weixin.onboarding.status_command,
-            "loongclaw channels --json"
-        );
+        assert_eq!(weixin.onboarding.status_command, "loongclaw doctor");
+        assert_eq!(weixin.onboarding.repair_command, None);
         assert!(weixin.onboarding.setup_hint.contains("ClawBot"));
 
         assert_eq!(qqbot.onboarding.strategy.as_str(), "plugin_bridge");
+        assert_eq!(qqbot.onboarding.status_command, "loongclaw doctor");
+        assert_eq!(qqbot.onboarding.repair_command, None);
         assert!(qqbot.onboarding.setup_hint.contains("QQ Bot"));
 
         assert_eq!(onebot.onboarding.strategy.as_str(), "plugin_bridge");
+        assert_eq!(onebot.onboarding.status_command, "loongclaw doctor");
+        assert_eq!(onebot.onboarding.repair_command, None);
         assert!(onebot.onboarding.setup_hint.contains("OneBot"));
     }
 
@@ -7720,6 +7723,51 @@ mod tests {
         assert_eq!(
             resolve_channel_doctor_operation_spec("telegram", "send"),
             None
+        );
+
+        let weixin_send =
+            resolve_channel_doctor_operation_spec("weixin", "send").expect("weixin send spec");
+        let weixin_send_checks = weixin_send
+            .checks
+            .iter()
+            .map(|check| (check.name, check.trigger))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            weixin_send_checks,
+            vec![(
+                "weixin bridge send contract",
+                ChannelDoctorCheckTrigger::PluginBridgeHealth,
+            )]
+        );
+
+        let qqbot_serve =
+            resolve_channel_doctor_operation_spec("qqbot", "serve").expect("qqbot serve spec");
+        let qqbot_serve_checks = qqbot_serve
+            .checks
+            .iter()
+            .map(|check| (check.name, check.trigger))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            qqbot_serve_checks,
+            vec![(
+                "qqbot bridge serve contract",
+                ChannelDoctorCheckTrigger::PluginBridgeHealth,
+            )]
+        );
+
+        let onebot_serve =
+            resolve_channel_doctor_operation_spec("onebot", "serve").expect("onebot serve spec");
+        let onebot_serve_checks = onebot_serve
+            .checks
+            .iter()
+            .map(|check| (check.name, check.trigger))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            onebot_serve_checks,
+            vec![(
+                "onebot bridge serve contract",
+                ChannelDoctorCheckTrigger::PluginBridgeHealth,
+            )]
         );
     }
 

--- a/crates/app/src/channel/registry_bridge.rs
+++ b/crates/app/src/channel/registry_bridge.rs
@@ -10,11 +10,11 @@ use crate::config::{
 use super::{
     CHANNEL_OPERATION_SEND_ID, CHANNEL_OPERATION_SERVE_ID, ChannelCatalogImplementationStatus,
     ChannelCatalogOperation, ChannelCatalogOperationAvailability,
-    ChannelCatalogOperationRequirement, ChannelCatalogTargetKind, ChannelOnboardingDescriptor,
-    ChannelOnboardingStrategy, ChannelRegistryDescriptor, ChannelRegistryOperationDescriptor,
-    ChannelStatusSnapshot, PLUGIN_BACKED_CHANNEL_CAPABILITIES, disabled_operation,
-    misconfigured_operation, redact_endpoint_status_url, unsupported_operation, validate_http_url,
-    validate_websocket_url,
+    ChannelCatalogOperationRequirement, ChannelCatalogTargetKind, ChannelDoctorCheckSpec,
+    ChannelDoctorCheckTrigger, ChannelOnboardingDescriptor, ChannelOnboardingStrategy,
+    ChannelRegistryDescriptor, ChannelRegistryOperationDescriptor, ChannelStatusSnapshot,
+    PLUGIN_BACKED_CHANNEL_CAPABILITIES, disabled_operation, misconfigured_operation,
+    redact_endpoint_status_url, unsupported_operation, validate_http_url, validate_websocket_url,
 };
 
 const WEIXIN_ENABLED_REQUIREMENT: ChannelCatalogOperationRequirement =
@@ -98,21 +98,31 @@ const WEIXIN_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation 
     supported_target_kinds: &[ChannelCatalogTargetKind::Conversation],
 };
 
+const WEIXIN_SEND_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
+    name: "weixin bridge send contract",
+    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+}];
+
+const WEIXIN_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
+    name: "weixin bridge serve contract",
+    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+}];
+
 const WEIXIN_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
     ChannelRegistryOperationDescriptor {
         operation: WEIXIN_SEND_OPERATION,
-        doctor_checks: &[],
+        doctor_checks: WEIXIN_SEND_DOCTOR_CHECKS,
     },
     ChannelRegistryOperationDescriptor {
         operation: WEIXIN_SERVE_OPERATION,
-        doctor_checks: &[],
+        doctor_checks: WEIXIN_SERVE_DOCTOR_CHECKS,
     },
 ];
 
 const WEIXIN_ONBOARDING_DESCRIPTOR: ChannelOnboardingDescriptor = ChannelOnboardingDescriptor {
     strategy: ChannelOnboardingStrategy::PluginBridge,
     setup_hint: "plugin-bridge weixin surface; connect a compatible WeChat ClawBot or iLink bridge under weixin or weixin.accounts.<account> and let that bridge own the upstream login flow until a native LoongClaw adapter exists",
-    status_command: "loongclaw channels --json",
+    status_command: "loongclaw doctor",
     repair_command: None,
 };
 
@@ -194,21 +204,31 @@ const QQBOT_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation {
     supported_target_kinds: &[ChannelCatalogTargetKind::Conversation],
 };
 
+const QQBOT_SEND_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
+    name: "qqbot bridge send contract",
+    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+}];
+
+const QQBOT_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
+    name: "qqbot bridge serve contract",
+    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+}];
+
 const QQBOT_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
     ChannelRegistryOperationDescriptor {
         operation: QQBOT_SEND_OPERATION,
-        doctor_checks: &[],
+        doctor_checks: QQBOT_SEND_DOCTOR_CHECKS,
     },
     ChannelRegistryOperationDescriptor {
         operation: QQBOT_SERVE_OPERATION,
-        doctor_checks: &[],
+        doctor_checks: QQBOT_SERVE_DOCTOR_CHECKS,
     },
 ];
 
 const QQBOT_ONBOARDING_DESCRIPTOR: ChannelOnboardingDescriptor = ChannelOnboardingDescriptor {
     strategy: ChannelOnboardingStrategy::PluginBridge,
     setup_hint: "plugin-bridge qqbot surface; connect an official QQ Bot gateway or compatible plugin bridge under qqbot or qqbot.accounts.<account> and keep target routing stable across c2c, group, and guild-style conversations",
-    status_command: "loongclaw channels --json",
+    status_command: "loongclaw doctor",
     repair_command: None,
 };
 
@@ -296,21 +316,31 @@ const ONEBOT_SERVE_OPERATION: ChannelCatalogOperation = ChannelCatalogOperation 
     supported_target_kinds: &[ChannelCatalogTargetKind::Conversation],
 };
 
+const ONEBOT_SEND_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
+    name: "onebot bridge send contract",
+    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+}];
+
+const ONEBOT_SERVE_DOCTOR_CHECKS: &[ChannelDoctorCheckSpec] = &[ChannelDoctorCheckSpec {
+    name: "onebot bridge serve contract",
+    trigger: ChannelDoctorCheckTrigger::PluginBridgeHealth,
+}];
+
 const ONEBOT_OPERATIONS: &[ChannelRegistryOperationDescriptor] = &[
     ChannelRegistryOperationDescriptor {
         operation: ONEBOT_SEND_OPERATION,
-        doctor_checks: &[],
+        doctor_checks: ONEBOT_SEND_DOCTOR_CHECKS,
     },
     ChannelRegistryOperationDescriptor {
         operation: ONEBOT_SERVE_OPERATION,
-        doctor_checks: &[],
+        doctor_checks: ONEBOT_SERVE_DOCTOR_CHECKS,
     },
 ];
 
 const ONEBOT_ONBOARDING_DESCRIPTOR: ChannelOnboardingDescriptor = ChannelOnboardingDescriptor {
     strategy: ChannelOnboardingStrategy::PluginBridge,
     setup_hint: "plugin-bridge OneBot surface; connect a OneBot-compatible bridge such as NapCat or LLOneBot under onebot or onebot.accounts.<account> and use this surface as the stable protocol contract until a native adapter exists",
-    status_command: "loongclaw channels --json",
+    status_command: "loongclaw doctor",
     repair_command: None,
 };
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1092,6 +1092,14 @@ fn build_channel_operation_doctor_check(
             let runtime_check = build_channel_runtime_check(check_name.as_str(), operation);
             Some(runtime_check)
         }
+        mvp::channel::ChannelDoctorCheckTrigger::PluginBridgeHealth => {
+            if operation.health == mvp::channel::ChannelOperationHealth::Disabled {
+                return None;
+            }
+            let bridge_check =
+                build_plugin_bridge_health_check(check_name.as_str(), snapshot, operation);
+            Some(bridge_check)
+        }
     }
 }
 
@@ -1102,6 +1110,64 @@ fn doctor_check_level_for_health(health: mvp::channel::ChannelOperationHealth) -
         mvp::channel::ChannelOperationHealth::Unsupported
         | mvp::channel::ChannelOperationHealth::Misconfigured => DoctorCheckLevel::Fail,
     }
+}
+
+fn build_plugin_bridge_health_check(
+    name: &str,
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+    operation: &mvp::channel::ChannelOperationStatus,
+) -> DoctorCheck {
+    let level = plugin_bridge_check_level(snapshot, operation);
+    let detail = plugin_bridge_check_detail(snapshot, operation);
+
+    DoctorCheck {
+        name: name.to_owned(),
+        level,
+        detail,
+    }
+}
+
+fn plugin_bridge_check_level(
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+    operation: &mvp::channel::ChannelOperationStatus,
+) -> DoctorCheckLevel {
+    match operation.health {
+        mvp::channel::ChannelOperationHealth::Ready => DoctorCheckLevel::Pass,
+        mvp::channel::ChannelOperationHealth::Disabled => DoctorCheckLevel::Warn,
+        mvp::channel::ChannelOperationHealth::Misconfigured => DoctorCheckLevel::Fail,
+        mvp::channel::ChannelOperationHealth::Unsupported => {
+            let external_plugin_owner = snapshot_has_external_plugin_bridge_owner(snapshot);
+
+            if snapshot.compiled && external_plugin_owner {
+                return DoctorCheckLevel::Pass;
+            }
+
+            DoctorCheckLevel::Fail
+        }
+    }
+}
+
+fn plugin_bridge_check_detail(
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+    operation: &mvp::channel::ChannelOperationStatus,
+) -> String {
+    let external_plugin_owner = snapshot_has_external_plugin_bridge_owner(snapshot);
+    let supported_external_bridge = snapshot.compiled && external_plugin_owner;
+    let is_bridge_contract = operation.health == mvp::channel::ChannelOperationHealth::Unsupported;
+
+    if supported_external_bridge && is_bridge_contract {
+        let detail = operation.detail.as_str();
+        return format!("configured for external bridge runtime ownership; {detail}");
+    }
+
+    operation.detail.clone()
+}
+
+fn snapshot_has_external_plugin_bridge_owner(
+    snapshot: &mvp::channel::ChannelStatusSnapshot,
+) -> bool {
+    let bridge_runtime_owner = snapshot_note_value(snapshot, "bridge_runtime_owner");
+    bridge_runtime_owner == Some("external_plugin")
 }
 
 fn build_channel_runtime_check(
@@ -2076,6 +2142,112 @@ mod tests {
             checks.is_empty(),
             "disabled registry-backed operations should not emit live doctor checks: {checks:#?}"
         );
+    }
+
+    #[test]
+    fn build_channel_surface_checks_reports_plugin_bridge_contract_status_for_configured_surface() {
+        let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "weixin": {
+                "enabled": true,
+                "bridge_url": "https://bridge.example.test/weixin",
+                "bridge_access_token": "weixin-token",
+                "allowed_contact_ids": ["wxid_alice"]
+            },
+            "qqbot": {
+                "enabled": true,
+                "app_id": "10001",
+                "client_secret": "qqbot-secret",
+                "allowed_peer_ids": ["openid-alice"]
+            },
+            "onebot": {
+                "enabled": true,
+                "websocket_url": "ws://127.0.0.1:5700",
+                "access_token": "onebot-token",
+                "allowed_group_ids": ["123456"]
+            }
+        }))
+        .expect("deserialize bridge-backed config");
+
+        let checks = check_channel_surfaces(&config);
+
+        assert!(checks.iter().any(|check| {
+            check.name == "weixin bridge send contract" && check.level == DoctorCheckLevel::Pass
+        }));
+        assert!(checks.iter().any(|check| {
+            check.name == "weixin bridge serve contract" && check.level == DoctorCheckLevel::Pass
+        }));
+        assert!(checks.iter().any(|check| {
+            check.name == "qqbot bridge send contract" && check.level == DoctorCheckLevel::Pass
+        }));
+        assert!(checks.iter().any(|check| {
+            check.name == "qqbot bridge serve contract" && check.level == DoctorCheckLevel::Pass
+        }));
+        assert!(checks.iter().any(|check| {
+            check.name == "onebot bridge send contract" && check.level == DoctorCheckLevel::Pass
+        }));
+        assert!(checks.iter().any(|check| {
+            check.name == "onebot bridge serve contract" && check.level == DoctorCheckLevel::Pass
+        }));
+    }
+
+    #[test]
+    fn build_channel_surface_checks_fails_plugin_bridge_contract_when_serve_requirements_are_missing()
+     {
+        let config: mvp::config::LoongClawConfig = serde_json::from_value(serde_json::json!({
+            "qqbot": {
+                "enabled": true,
+                "app_id": "10001",
+                "client_secret": "qqbot-secret"
+            }
+        }))
+        .expect("deserialize qqbot config");
+
+        let checks = check_channel_surfaces(&config);
+
+        assert!(checks.iter().any(|check| {
+            check.name == "qqbot bridge send contract" && check.level == DoctorCheckLevel::Pass
+        }));
+        assert!(checks.iter().any(|check| {
+            check.name == "qqbot bridge serve contract"
+                && check.level == DoctorCheckLevel::Fail
+                && check.detail.contains("allowed_peer_ids is empty")
+        }));
+    }
+
+    #[test]
+    fn build_channel_surface_checks_fails_plugin_bridge_contract_when_surface_is_uncompiled() {
+        let snapshots = vec![ChannelStatusSnapshot {
+            id: "weixin",
+            configured_account_id: "default".to_owned(),
+            configured_account_label: "default".to_owned(),
+            is_default_account: true,
+            default_account_source:
+                mvp::config::ChannelDefaultAccountSelectionSource::ExplicitDefault,
+            label: "Weixin",
+            aliases: vec!["wechat", "wx"],
+            transport: "wechat_clawbot_ilink_bridge",
+            compiled: false,
+            enabled: true,
+            api_base_url: None,
+            notes: vec!["bridge_runtime_owner=external_plugin".to_owned()],
+            operations: vec![ChannelOperationStatus {
+                id: "send",
+                label: "bridge send",
+                command: "weixin-send",
+                health: ChannelOperationHealth::Unsupported,
+                detail: "weixin bridge surface is unavailable in this build".to_owned(),
+                issues: vec!["weixin bridge surface is unavailable in this build".to_owned()],
+                runtime: None,
+            }],
+        }];
+
+        let checks = build_channel_surface_checks(&snapshots);
+
+        assert!(checks.iter().any(|check| {
+            check.name == "weixin bridge send contract"
+                && check.level == DoctorCheckLevel::Fail
+                && check.detail.contains("unavailable in this build")
+        }));
     }
 
     #[test]

--- a/docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-design.md
+++ b/docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-design.md
@@ -1,0 +1,167 @@
+# Weixin and QQBot Bridge Diagnostics Design
+
+**Scope**
+
+This slice deepens operator diagnostics for the plugin-backed `weixin`,
+`qqbot`, and `onebot` channel surfaces that were added in the previous bridge
+support work.
+
+The immediate scope is:
+
+- make `loongclaw doctor` truthfully validate plugin-backed bridge surfaces
+- avoid false failures when a bridge surface is intentionally owned by an
+  external plugin or gateway
+- improve onboarding metadata so operators are pointed at the right status
+  command
+- keep the diagnostic contract registry-first instead of teaching daemon-side
+  callers about individual channels
+
+This slice does not add native `weixin` or `qqbot` runtimes, plugin discovery,
+or health probing of external gateway processes.
+
+**Problem Statement**
+
+The current bridge-backed surfaces expose inventory and setup metadata, but they
+do not participate in operator diagnostics in a truthful way.
+
+The root cause is structural:
+
+- the current doctor pipeline only understands `OperationHealth` and
+  `ReadyRuntime`
+- `OperationHealth::Unsupported` is globally mapped to `Fail`
+- bridge-backed `weixin`, `qqbot`, and `onebot` surfaces intentionally use
+  `Unsupported` to mean "LoongClaw reserves the surface contract, but the live
+  send or serve runtime belongs to an external plugin"
+
+That means the naive change would be wrong in both directions:
+
+- if we keep `doctor_checks: &[]`, `loongclaw doctor` stays silent about bridge
+  surface misconfiguration
+- if we attach the existing `OperationHealth` trigger directly, doctor would
+  report false failures for correctly configured bridge surfaces
+
+Operators would then see "broken" diagnostics for a surface that is actually
+configured exactly as intended.
+
+**Reference Findings**
+
+Recent public PicoClaw channel docs reinforce the same product split that
+LoongClaw needs here:
+
+- the Weixin docs separate onboarding, token-based configuration, and gateway
+  runtime ownership instead of pretending the local product owns the full login
+  flow
+- the QQ docs separate credential validation, sandbox constraints, and gateway
+  runtime behavior
+- the OneBot docs frame the surface as a stable protocol contract in front of
+  external runtimes such as NapCat or Go-CQHTTP
+
+The useful takeaway is not to clone those flows. The useful takeaway is that
+bridge surfaces need first-class diagnostic language that validates LoongClaw's
+own contract without misreporting external runtime ownership as a local fault.
+
+**Chosen Design**
+
+### 1. Add a bridge-specific doctor trigger in the registry contract
+
+LoongClaw should add one new `ChannelDoctorCheckTrigger` variant dedicated to
+plugin-backed bridge surfaces.
+
+Recommended name:
+
+- `PluginBridgeHealth`
+
+This trigger still lives beside operation metadata in the channel registry, so
+doctor semantics remain attached to the same source of truth as operation
+labels, commands, and requirements.
+
+### 2. Keep the existing generic health mapping unchanged
+
+The existing `OperationHealth -> DoctorCheckLevel` mapping should stay as-is for
+native and config-backed surfaces.
+
+That preserves current semantics:
+
+- `Ready` -> `Pass`
+- `Disabled` -> omitted or `Warn` according to current caller behavior
+- `Unsupported` -> `Fail`
+- `Misconfigured` -> `Fail`
+
+This avoids leaking plugin-specific meaning into generic operation health.
+
+### 3. Interpret plugin bridge health from shared snapshot facts
+
+The new trigger should use snapshot facts that already exist in the registry
+projection:
+
+- `snapshot.compiled`
+- `operation.health`
+- `operation.detail`
+- snapshot notes such as `bridge_runtime_owner=external_plugin`
+- snapshot notes such as `selection_error=...`
+
+Recommended semantics:
+
+- `Disabled` -> omit the doctor check, same as current behavior
+- `Misconfigured` -> `Fail`
+- `Ready` -> `Pass`
+- `Unsupported` + `bridge_runtime_owner=external_plugin` + compiled surface ->
+  `Pass`
+- `Unsupported` + uncompiled surface -> `Fail`
+- `Unsupported` without the external-plugin ownership note -> `Fail`
+
+This keeps the rule declarative and generic across `weixin`, `qqbot`, and
+`onebot`.
+
+### 4. Emit operation-level bridge contract checks
+
+Doctor should report one check per bridge operation instead of collapsing send
+and serve into a single channel-wide status.
+
+That matters because the requirements differ:
+
+- outbound send only needs bridge connectivity and credentials
+- inbound serve additionally needs the appropriate allowlist or routing
+  constraints
+
+Examples of truthful outcomes:
+
+- `weixin send` can pass while `weixin serve` fails if
+  `allowed_contact_ids` is still empty
+- `qqbot send` can pass while `qqbot serve` fails if the gateway credentials
+  exist but `allowed_peer_ids` are missing
+
+### 5. Point plugin-backed onboarding status to doctor
+
+Once bridge surfaces participate in doctor, their onboarding metadata should
+use:
+
+- `status_command = "loongclaw doctor"`
+
+and keep:
+
+- `repair_command = None`
+
+That is the most truthful contract:
+
+- the operator can use doctor to verify LoongClaw's bridge-side configuration
+- LoongClaw still does not pretend it can automatically repair an external
+  plugin or gateway
+
+**Why This Is The Right Next Step**
+
+This design fixes the real integration gap without creating new architectural
+debt:
+
+- registry metadata stays authoritative
+- daemon code gains one small new semantic branch instead of channel-specific
+  hardcoding
+- plugin-backed surfaces become visible in doctor without false red failures
+- onboarding guidance becomes consistent with the actual diagnostic entry point
+
+Most importantly, the design preserves a clean separation of concerns:
+
+- LoongClaw validates its bridge-facing contract
+- external plugins or gateways still own their own live runtime process
+- future native adapters can later switch back to the existing
+  `OperationHealth` and `ReadyRuntime` flow without undoing this slice

--- a/docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-design.md
+++ b/docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-design.md
@@ -62,7 +62,7 @@ own contract without misreporting external runtime ownership as a local fault.
 
 **Chosen Design**
 
-### 1. Add a bridge-specific doctor trigger in the registry contract
+## 1. Add a bridge-specific doctor trigger in the registry contract
 
 LoongClaw should add one new `ChannelDoctorCheckTrigger` variant dedicated to
 plugin-backed bridge surfaces.
@@ -75,7 +75,7 @@ This trigger still lives beside operation metadata in the channel registry, so
 doctor semantics remain attached to the same source of truth as operation
 labels, commands, and requirements.
 
-### 2. Keep the existing generic health mapping unchanged
+## 2. Keep the existing generic health mapping unchanged
 
 The existing `OperationHealth -> DoctorCheckLevel` mapping should stay as-is for
 native and config-backed surfaces.
@@ -89,7 +89,7 @@ That preserves current semantics:
 
 This avoids leaking plugin-specific meaning into generic operation health.
 
-### 3. Interpret plugin bridge health from shared snapshot facts
+## 3. Interpret plugin bridge health from shared snapshot facts
 
 The new trigger should use snapshot facts that already exist in the registry
 projection:
@@ -113,7 +113,7 @@ Recommended semantics:
 This keeps the rule declarative and generic across `weixin`, `qqbot`, and
 `onebot`.
 
-### 4. Emit operation-level bridge contract checks
+## 4. Emit operation-level bridge contract checks
 
 Doctor should report one check per bridge operation instead of collapsing send
 and serve into a single channel-wide status.
@@ -131,7 +131,7 @@ Examples of truthful outcomes:
 - `qqbot send` can pass while `qqbot serve` fails if the gateway credentials
   exist but `allowed_peer_ids` are missing
 
-### 5. Point plugin-backed onboarding status to doctor
+## 5. Point plugin-backed onboarding status to doctor
 
 Once bridge surfaces participate in doctor, their onboarding metadata should
 use:

--- a/docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-implementation-plan.md
+++ b/docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-implementation-plan.md
@@ -1,0 +1,163 @@
+# Weixin and QQBot Bridge Diagnostics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add truthful doctor coverage and onboarding diagnostics for the plugin-backed `weixin`, `qqbot`, and `onebot` bridge surfaces.
+
+**Architecture:** Extend the shared channel registry with a bridge-specific doctor trigger, wire the daemon doctor path to interpret plugin-owned bridge snapshots correctly, and update onboarding metadata to point operators at `loongclaw doctor`. Keep all semantics attached to registry descriptors and shared inventory data rather than daemon-local channel special cases.
+
+**Tech Stack:** Rust channel registry metadata, daemon doctor CLI logic, Rust unit tests, Markdown design and analysis docs.
+
+---
+
+### Task 1: Save the design and analysis artifacts
+
+**Files:**
+- Create: `docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-design.md`
+- Create: `/Users/chum/lc-knowledge-base/projects/loongclaw/analysis/2026/2026-04-01-weixin-qqbot-bridge-diagnostics-analysis.md`
+
+**Step 1: Persist the public design**
+
+Write the repo-facing design document that explains the root cause and chosen
+registry-first fix.
+
+**Step 2: Persist the private analysis**
+
+Archive the broader reasoning, rejected approaches, and external reference notes
+under `lc-knowledge-base`.
+
+### Task 2: Add failing registry and doctor tests
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+
+**Step 1: Write failing registry tests**
+
+Add tests that expect:
+
+- plugin-backed surfaces to use `loongclaw doctor` as `status_command`
+- plugin-backed operations to resolve bridge-specific doctor trigger metadata
+
+**Step 2: Write failing doctor tests**
+
+Add tests that expect:
+
+- configured bridge-backed send and serve surfaces to pass bridge contract
+  checks instead of failing on `Unsupported`
+- misconfigured bridge-backed surfaces to still fail
+- uncompiled bridge-backed surfaces to still fail
+
+**Step 3: Run focused tests to verify they fail**
+
+Run:
+
+- `cargo test -p loongclaw-app channel::registry::tests::resolve_channel_catalog_entry_exposes_onboarding_contracts`
+- `cargo test -p loongclaw-app channel::registry::tests::resolve_channel_doctor_operation_spec_uses_registry_metadata`
+- `cargo test -p loongclaw-daemon doctor_cli::tests::build_channel_surface_checks_reports_plugin_bridge_contract_status_for_configured_surface`
+
+Expected: failures because the new trigger and onboarding metadata do not exist
+yet.
+
+### Task 3: Add the bridge-specific registry metadata
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/app/src/channel/registry_bridge.rs`
+
+**Step 1: Extend the doctor trigger enum**
+
+Add a new trigger variant for plugin-backed bridge diagnostics.
+
+**Step 2: Define bridge doctor specs**
+
+Attach bridge-specific doctor check specs to the `send` and `serve` operation
+descriptors for:
+
+- `weixin`
+- `qqbot`
+- `onebot`
+
+**Step 3: Update onboarding metadata**
+
+Switch bridge-backed onboarding `status_command` to `loongclaw doctor` while
+leaving `repair_command` unset.
+
+### Task 4: Implement doctor-side bridge health interpretation
+
+**Files:**
+- Modify: `crates/daemon/src/doctor_cli.rs`
+
+**Step 1: Add a bridge-health builder**
+
+Implement a focused helper that maps a bridge-backed snapshot and operation to a
+truthful `DoctorCheck`.
+
+**Step 2: Keep generic health logic untouched**
+
+Continue using the existing `doctor_check_level_for_health` helper for the
+generic trigger paths.
+
+**Step 3: Route the new trigger**
+
+Teach `build_channel_operation_doctor_check` to use the new bridge helper only
+for the new trigger variant.
+
+### Task 5: Re-run focused tests and tighten names if needed
+
+**Files:**
+- Modify: `crates/app/src/channel/registry.rs`
+- Modify: `crates/app/src/channel/registry_bridge.rs`
+- Modify: `crates/daemon/src/doctor_cli.rs`
+
+**Step 1: Run the focused registry tests**
+
+Run:
+
+- `cargo test -p loongclaw-app channel::registry::tests::resolve_channel_catalog_entry_exposes_onboarding_contracts`
+- `cargo test -p loongclaw-app channel::registry::tests::resolve_channel_doctor_operation_spec_uses_registry_metadata`
+
+Expected: pass.
+
+**Step 2: Run the focused doctor tests**
+
+Run:
+
+- `cargo test -p loongclaw-daemon doctor_cli::tests::build_channel_surface_checks_reports_plugin_bridge_contract_status_for_configured_surface`
+- `cargo test -p loongclaw-daemon doctor_cli::tests::build_channel_surface_checks_fails_plugin_bridge_contract_when_surface_is_uncompiled`
+
+Expected: pass.
+
+**Step 3: Refine wording only after green**
+
+If test output shows awkward operator-facing names or details, make the smallest
+text-only cleanup and keep the tests green.
+
+### Task 6: Run full verification
+
+**Files:**
+- Modify: none
+
+**Step 1: Run targeted crate tests**
+
+Run:
+
+- `cargo test -p loongclaw-app --locked`
+- `cargo test -p loongclaw-daemon --locked doctor_cli::tests::`
+
+**Step 2: Run repository verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
+
+**Step 3: Inspect the diff**
+
+Run:
+
+- `git status --short`
+- `git diff -- crates/app/src/channel/registry.rs crates/app/src/channel/registry_bridge.rs crates/daemon/src/doctor_cli.rs docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-design.md docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-implementation-plan.md`
+
+Plan complete and saved to `docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-implementation-plan.md`.

--- a/docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-implementation-plan.md
+++ b/docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-implementation-plan.md
@@ -1,20 +1,20 @@
 # Weixin and QQBot Bridge Diagnostics Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Add truthful doctor coverage and onboarding diagnostics for the plugin-backed `weixin`, `qqbot`, and `onebot` bridge surfaces.
 
 **Architecture:** Extend the shared channel registry with a bridge-specific doctor trigger, wire the daemon doctor path to interpret plugin-owned bridge snapshots correctly, and update onboarding metadata to point operators at `loongclaw doctor`. Keep all semantics attached to registry descriptors and shared inventory data rather than daemon-local channel special cases.
 
-**Tech Stack:** Rust channel registry metadata, daemon doctor CLI logic, Rust unit tests, Markdown design and analysis docs.
+**Tech Stack:** Rust channel registry metadata, daemon doctor CLI logic, Rust unit tests, and Markdown design docs.
 
 ---
+
+## Tasks
 
 ### Task 1: Save the design and analysis artifacts
 
 **Files:**
 - Create: `docs/plans/2026-04-01-weixin-qqbot-bridge-diagnostics-design.md`
-- Create: `/Users/chum/lc-knowledge-base/projects/loongclaw/analysis/2026/2026-04-01-weixin-qqbot-bridge-diagnostics-analysis.md`
+- Create: a private analysis note outside this repository, if needed
 
 **Step 1: Persist the public design**
 
@@ -24,7 +24,7 @@ registry-first fix.
 **Step 2: Persist the private analysis**
 
 Archive the broader reasoning, rejected approaches, and external reference notes
-under `lc-knowledge-base`.
+in a private analysis archive outside this repository.
 
 ### Task 2: Add failing registry and doctor tests
 

--- a/docs/product-specs/channel-setup.md
+++ b/docs/product-specs/channel-setup.md
@@ -183,6 +183,9 @@ and iMessage / BlueBubbles are shipped as account-aware outbound surfaces:
 - they also expose config-derived account snapshots and bridge endpoint
   summaries through `loongclaw channels --json` when the bridge surface is
   configured
+- `loongclaw doctor` validates the local bridge contract for these surfaces and
+  treats external plugin runtime ownership as expected instead of as a native
+  runtime failure
 - their reserved native `*-send` and `*-serve` command ids remain non-runnable
   catalog stubs until LoongClaw ships the adapter itself
 - they do not join `multi-channel-serve` because the active reply loop still

--- a/docs/product-specs/doctor.md
+++ b/docs/product-specs/doctor.md
@@ -25,6 +25,10 @@ can recover a broken setup without reverse-engineering runtime internals.
 - [ ] Doctor checks cover the current MVP path: config presence, provider
       readiness, SQLite memory readiness, shipped channel prerequisites, and
       the optional browser preview companion readiness path.
+- [ ] Doctor treats plugin-backed bridge surfaces such as `weixin`, `qqbot`,
+      and `onebot` as first-class channel checks, validating LoongClaw's local
+      bridge contract without falsely failing just because the live runtime is
+      owned by an external plugin or gateway.
 - [ ] Durable audit readiness checks exercise the runtime `open + lock + unlock`
       path for JSONL retention instead of relying on metadata-only validation.
 - [ ] When `tools.browser_companion.enabled=true`, doctor surfaces companion


### PR DESCRIPTION
## Summary

- Problem:
  Plugin-backed `weixin`, `qqbot`, and `onebot` bridge surfaces already expose
  truthful registry metadata, but `loongclaw doctor` either stays silent about
  their contract health or would misreport intentional external runtime
  ownership as a failure if it reused the generic operation-health trigger.
- Why it matters:
  Operators need `loongclaw doctor` to validate LoongClaw's side of the bridge
  contract without pretending the daemon owns the upstream plugin or gateway
  runtime.
- What changed:
  Added a registry-owned `PluginBridgeHealth` trigger, attached bridge contract
  checks to the plugin-backed `send` and `serve` operations for `weixin`,
  `qqbot`, and `onebot`, taught doctor to treat compiled
  `bridge_runtime_owner=external_plugin` surfaces as healthy contract checks,
  updated plugin-backed onboarding to point at `loongclaw doctor`, and added
  tests plus design/docs updates.
- What did not change (scope boundary):
  No native channel runtimes were added. No external gateway probing was added.
  No daemon-side channel allowlists or hardcoded channel doctor branches were
  introduced. These surfaces still do not join `multi-channel-serve`.

## Linked Issues

- Closes #747
- Related #745

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  pass

cargo clippy --workspace --all-targets --all-features -- -D warnings
  pass

cargo test -p loongclaw-daemon --locked doctor_cli::tests::build_channel_surface_checks_reports_plugin_bridge_contract_status_for_configured_surface -- --nocapture
  pass

cargo test -p loongclaw-app --locked acp::acpx::tests::runtime_backend_supports_local_abort_for_running_prompt -- --nocapture
  pass on rerun after one non-reproducible failure during the first `cargo test --workspace --locked` sweep

cargo test --workspace --locked
  pass on fresh rerun

cargo test --workspace --all-features --locked
  pass

LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
  pass

scripts/check_dep_graph.sh
  pass

diff CLAUDE.md AGENTS.md
  pass

scripts/check-docs.sh
  pass with pre-existing non-blocking release-artifact warnings

task verify
  unavailable in this environment (`task: command not found`)

task check:conventions
  blocked in this environment because the Task runner is unavailable and the
  expected `~/.claude/skills/convention-engineering/scripts/main.go` helper is missing

cargo deny check advisories bans licenses sources
  existing repo baseline failure: `quoted_printable v0.5.2` uses `0BSD`, which current deny policy does not allow
```

## User-visible / Operator-visible Changes

- `loongclaw doctor` now reports bridge contract checks for plugin-backed
  `weixin`, `qqbot`, and `onebot` surfaces.
- Correctly configured external-plugin bridge surfaces no longer fail doctor
  just because the live runtime owner is outside LoongClaw.
- Plugin-backed onboarding now points operators at `loongclaw doctor` for
  bridge validation, and the docs describe that contract explicitly.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `4c05bb06`, or drop this stacked PR before merge while keeping
  the base bridge-surface PR unchanged.
- Observable failure symptoms reviewers should watch for:
  Correctly configured plugin-owned bridge surfaces still show `Fail`, or
  misconfigured `serve` contracts stop surfacing missing allowlist or routing
  requirements.

## Reviewer Focus

- Check `crates/app/src/channel/registry_bridge.rs` and
  `crates/app/src/channel/registry.rs` for registry-first ownership of the new
  doctor semantics instead of daemon-local channel hardcoding.
- Check `crates/daemon/src/doctor_cli.rs` for the exact pass/fail boundary:
  only compiled `Unsupported` surfaces with
  `bridge_runtime_owner=external_plugin` should pass the bridge-contract check.
- Check the updated onboarding/docs text for consistency with the actual doctor
  behavior and the scope boundary of plugin-backed surfaces.
