### PR TITLE
feat(tools): add pagination to session tool listings

### DIFF
--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -2530,6 +2530,11 @@ fn sessions_list_definition(descriptor: &ToolDescriptor) -> Value {
                         "maximum": 200,
                         "description": "Maximum visible sessions to return after filtering."
                     },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Number of matching visible sessions to skip before applying limit."
+                    },
                     "state": {
                         "type": "string",
                         "enum": ["ready", "running", "completed", "failed", "timed_out"],
@@ -3220,7 +3225,7 @@ fn tool_argument_hint(name: &str) -> &'static str {
         }
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => "session_id:string",
-        "sessions_list" => "limit?:integer,state?:string",
+        "sessions_list" => "limit?:integer,offset?:integer,state?:string",
         "sessions_send" => "session_id:string,text:string",
         "web.search" => "query:string,provider?:string,max_results?:integer",
         _ => "",
@@ -3597,7 +3602,11 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
         ],
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => &[("session_id", "string")],
-        "sessions_list" => &[("limit", "integer"), ("state", "string")],
+        "sessions_list" => &[
+            ("limit", "integer"),
+            ("offset", "integer"),
+            ("state", "string"),
+        ],
         "sessions_send" => &[("session_id", "string"), ("text", "string")],
         "web.search" => &[
             ("query", "string"),
@@ -4248,5 +4257,31 @@ mod tests {
                 .parameter_types()
                 .contains(&("automatic_fields", "boolean"))
         );
+    }
+
+    #[test]
+    fn sessions_list_definition_and_hint_surface_offset_pagination() {
+        let catalog = tool_catalog();
+        let descriptor = catalog
+            .descriptor("sessions_list")
+            .expect("sessions_list descriptor");
+        let definition = descriptor.provider_definition();
+        let function_definition = &definition["function"];
+        let parameter_definition = &function_definition["parameters"];
+        let property_definition = &parameter_definition["properties"];
+        let offset_definition = &property_definition["offset"];
+        let offset_description_value = &offset_definition["description"];
+        let offset_description = offset_description_value
+            .as_str()
+            .expect("offset description");
+        let parameter_types = descriptor.parameter_types();
+        let has_offset_parameter = parameter_types.contains(&("offset", "integer"));
+
+        assert!(offset_description.contains("skip"));
+        assert_eq!(
+            descriptor.argument_hint(),
+            "limit?:integer,offset?:integer,state?:string"
+        );
+        assert!(has_offset_parameter);
     }
 }

--- a/crates/app/src/tools/payload.rs
+++ b/crates/app/src/tools/payload.rs
@@ -153,6 +153,13 @@ mod tests {
     }
 
     #[test]
+    fn optional_offset_returns_default_for_non_numeric() {
+        let payload = json!({"offset": "bad"});
+        let offset = optional_payload_offset(&payload, "offset", 0);
+        assert_eq!(offset, 0);
+    }
+
+    #[test]
     fn optional_offset_returns_default_for_negative() {
         let payload = json!({"offset": -2});
         assert_eq!(optional_payload_offset(&payload, "offset", 0), 0);

--- a/crates/app/src/tools/payload.rs
+++ b/crates/app/src/tools/payload.rs
@@ -46,6 +46,18 @@ pub(super) fn optional_payload_limit(
         .unwrap_or(default)
 }
 
+/// Extract an optional non-negative integer field.
+///
+/// Returns `default` when the field is absent or not a valid `u64`.
+pub(super) fn optional_payload_offset(payload: &Value, field: &str, default: usize) -> usize {
+    let raw_value = payload.get(field);
+    let parsed_value = raw_value.and_then(Value::as_u64);
+    let max_value = usize::MAX as u64;
+    let bounded_value = parsed_value.map(|value| value.min(max_value));
+    let offset = bounded_value.map(|value| value as usize);
+    offset.unwrap_or(default)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -126,6 +138,24 @@ mod tests {
     fn optional_limit_returns_default_for_negative() {
         let payload = json!({"limit": -3});
         assert_eq!(optional_payload_limit(&payload, "limit", 10, 20), 10);
+    }
+
+    #[test]
+    fn optional_offset_returns_default_for_missing() {
+        let payload = json!({});
+        assert_eq!(optional_payload_offset(&payload, "offset", 0), 0);
+    }
+
+    #[test]
+    fn optional_offset_returns_value_in_normal_range() {
+        let payload = json!({"offset": 7});
+        assert_eq!(optional_payload_offset(&payload, "offset", 0), 7);
+    }
+
+    #[test]
+    fn optional_offset_returns_default_for_negative() {
+        let payload = json!({"offset": -2});
+        assert_eq!(optional_payload_offset(&payload, "offset", 0), 0);
     }
 
     #[test]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -419,11 +419,15 @@ fn execute_sessions_list(
 
     let matched_count = listed_sessions.len();
     let effective_offset = request.offset.min(matched_count);
-    let remaining_count = matched_count.saturating_sub(effective_offset);
-    let has_more = remaining_count > request.limit;
-    let paged_sessions = listed_sessions.into_iter().skip(effective_offset);
-    let mut listed_sessions = paged_sessions.collect::<Vec<_>>();
-    listed_sessions.truncate(request.limit);
+    let page_limit = request.limit.saturating_add(1);
+    let visible_sessions = listed_sessions.into_iter();
+    let offset_sessions = visible_sessions.skip(effective_offset);
+    let bounded_sessions = offset_sessions.take(page_limit);
+    let mut listed_sessions = bounded_sessions.collect::<Vec<_>>();
+    let has_more = listed_sessions.len() > request.limit;
+    if has_more {
+        let _ = listed_sessions.pop();
+    }
     let returned_count = listed_sessions.len();
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -9,7 +9,10 @@ use tokio::time::{Duration, Instant, sleep};
 use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 use serde_json::{Value, json};
 
-use super::payload::{optional_payload_limit, optional_payload_string, required_payload_string};
+use super::payload::{
+    optional_payload_limit, optional_payload_offset, optional_payload_string,
+    required_payload_string,
+};
 
 use crate::config::{SessionVisibility, ToolConfig};
 #[cfg(feature = "memory-sqlite")]
@@ -110,6 +113,7 @@ struct SessionDelegateCancellationRecord {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionsListRequest {
     limit: usize,
+    offset: usize,
     state: Option<SessionState>,
     kind: Option<SessionKind>,
     parent_session_id: Option<String>,
@@ -414,6 +418,11 @@ fn execute_sessions_list(
     }
 
     let matched_count = listed_sessions.len();
+    let effective_offset = request.offset.min(matched_count);
+    let remaining_count = matched_count.saturating_sub(effective_offset);
+    let has_more = remaining_count > request.limit;
+    let paged_sessions = listed_sessions.into_iter().skip(effective_offset);
+    let mut listed_sessions = paged_sessions.collect::<Vec<_>>();
     listed_sessions.truncate(request.limit);
     let returned_count = listed_sessions.len();
     Ok(ToolCoreOutcome {
@@ -423,6 +432,7 @@ fn execute_sessions_list(
             "filters": sessions_list_filters_json(&request),
             "matched_count": matched_count,
             "returned_count": returned_count,
+            "has_more": has_more,
             "sessions": listed_sessions
                 .into_iter()
                 .map(|(session, delegate_lifecycle)| {
@@ -2682,6 +2692,7 @@ fn parse_sessions_list_request(
             tool_config.sessions.list_limit,
             tool_config.sessions.list_limit,
         ),
+        offset: optional_payload_offset(payload, "offset", 0),
         state: optional_payload_session_state(payload, "state")?,
         kind: optional_payload_session_kind(payload, "kind")?,
         parent_session_id: optional_payload_string(payload, "parent_session_id"),
@@ -3008,6 +3019,7 @@ fn is_session_visibility_skip_error(error: &str) -> bool {
 fn sessions_list_filters_json(request: &SessionsListRequest) -> Value {
     json!({
         "limit": request.limit,
+        "offset": request.offset,
         "state": request.state.map(SessionState::as_str),
         "kind": request.kind.map(SessionKind::as_str),
         "parent_session_id": request.parent_session_id.clone(),
@@ -3139,6 +3151,23 @@ mod tests {
             )
             .expect("update session event ts");
         assert!(updated > 0, "expected at least one updated event row");
+    }
+
+    fn overwrite_session_updated_at(config: &MemoryRuntimeConfig, session_id: &str, ts: i64) {
+        let db_path = config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path for session tools test");
+        let conn = rusqlite::Connection::open(db_path).expect("open sqlite db");
+        let updated = conn
+            .execute(
+                "UPDATE sessions
+                 SET updated_at = ?2
+                 WHERE session_id = ?1",
+                params![session_id, ts],
+            )
+            .expect("update session updated_at");
+        assert!(updated > 0, "expected at least one updated session row");
     }
 
     fn batch_result<'a>(payload: &'a Value, session_id: &str) -> &'a Value {
@@ -3605,6 +3634,78 @@ mod tests {
             sessions[0]["delegate_lifecycle"]["staleness"]["reference"],
             "started"
         );
+    }
+
+    #[test]
+    fn sessions_list_applies_offset_pagination() {
+        let config = isolated_memory_config("sessions-list-offset");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "000-root".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        for session_id in ["001-child", "002-child", "003-child"] {
+            repo.create_session(NewSessionRecord {
+                session_id: session_id.to_owned(),
+                kind: SessionKind::DelegateChild,
+                parent_session_id: Some("000-root".to_owned()),
+                label: Some(session_id.to_owned()),
+                state: SessionState::Running,
+            })
+            .expect("create child");
+        }
+
+        overwrite_session_updated_at(&config, "000-root", 400);
+        overwrite_session_updated_at(&config, "001-child", 300);
+        overwrite_session_updated_at(&config, "002-child", 200);
+        overwrite_session_updated_at(&config, "003-child", 100);
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_list".to_owned(),
+                payload: json!({
+                    "limit": 2,
+                    "offset": 1
+                }),
+            },
+            "000-root",
+            &config,
+        )
+        .expect("sessions_list outcome");
+
+        let sessions_value = &outcome.payload["sessions"];
+        let sessions = sessions_value.as_array().expect("sessions array");
+        let mut ids = Vec::new();
+        for item in sessions {
+            let session_id_value = item.get("session_id");
+            let Some(session_id_value) = session_id_value else {
+                continue;
+            };
+            let session_id = session_id_value.as_str();
+            let Some(session_id) = session_id else {
+                continue;
+            };
+            ids.push(session_id);
+        }
+
+        let filter_offset_value = &outcome.payload["filters"]["offset"];
+        let matched_count_value = &outcome.payload["matched_count"];
+        let returned_count_value = &outcome.payload["returned_count"];
+        let has_more_value = &outcome.payload["has_more"];
+        let filter_offset = filter_offset_value.as_u64().expect("filter offset");
+        let matched_count = matched_count_value.as_u64().expect("matched count");
+        let returned_count = returned_count_value.as_u64().expect("returned count");
+        let has_more = has_more_value.as_bool().expect("has more");
+
+        assert_eq!(ids, vec!["001-child", "002-child"]);
+        assert_eq!(filter_offset, 1);
+        assert_eq!(matched_count, 4);
+        assert_eq!(returned_count, 2);
+        assert!(has_more);
     }
 
     #[test]

--- a/docs/plans/2026-04-01-session-tool-list-pagination-design.md
+++ b/docs/plans/2026-04-01-session-tool-list-pagination-design.md
@@ -1,0 +1,131 @@
+# Session Tool List Pagination Design
+
+## Goal
+
+Add stable pagination semantics to the `sessions_list` app tool so operators and future CLI
+surfaces can page through visible session results instead of being limited to the first truncated
+window.
+
+## Current Repo Facts
+
+- `crates/app/src/tools/session.rs`
+  - `execute_sessions_list()` filters visible sessions and truncates the final vector by `limit`
+  - returns `matched_count` and `returned_count`, but does not expose a way to fetch the next page
+- `crates/app/src/tools/catalog.rs`
+  - `sessions_list_definition()` advertises `limit`, `state`, `kind`, `parent_session_id`,
+    `overdue_only`, `include_archived`, and `include_delegate_lifecycle`
+  - tool hint metadata for `sessions_list` currently only mentions `limit` and `state`
+- `src/utils/listSessionsImpl.ts` in the reference codebase exposes `limit` plus `offset` so
+  callers can paginate across sorted session results without inventing new ad-hoc filters
+
+## Problem
+
+`sessions_list` currently has a one-page contract.
+
+When the visible session set exceeds `limit`, the caller learns only that more matches exist
+through `matched_count > returned_count`. There is no first-class way to request the next page
+without narrowing filters or raising the limit.
+
+That makes the tool awkward for:
+
+- operator workflows that need to scan a large delegate tree
+- future CLI wrappers that want deterministic paging
+- automation that wants stable, repeated windowed reads instead of overfetching
+
+## Constraints
+
+- keep the change small and local to the existing `sessions_list` tool contract
+- do not redesign sorting or session visibility semantics
+- avoid adding new repository-layer pagination because the current app-tool path already filters in
+  memory after visibility and delegate-lifecycle enrichment
+- preserve backward compatibility for callers that omit pagination fields
+
+## Options Considered
+
+### Option 1: Add cursor-style pagination
+
+This would add fields such as `after_session_id` or `next_cursor`.
+
+Why not:
+
+- current ordering is already deterministic for the in-memory list, so index-based paging is
+  enough for the first iteration
+- a cursor contract would require more state coupling between callers and the current sort order
+- it adds more surface area than the tool currently needs
+
+### Option 2: Add `offset` pagination to `sessions_list`
+
+This means callers can request `limit` plus `offset`, and the tool returns a stable page slice plus
+ enough metadata to know whether more results remain.
+
+Why this is the recommended option:
+
+- matches the reference repo's list-session ergonomics
+- preserves the existing tool shape and sorting behavior
+- requires only one new input field and one new response flag
+- keeps future CLI wrapping simple
+
+### Option 3: Expose a new dedicated pagination tool
+
+This would create a second list tool with different paging behavior.
+
+Why not:
+
+- splits one concept across multiple tools
+- duplicates filter semantics and future maintenance work
+- violates the smallest-correct-change goal
+
+## Recommended Design
+
+Extend `sessions_list` with one optional request field:
+
+- `offset: integer`
+
+Behavior:
+
+1. collect and filter visible sessions exactly as today
+2. compute `matched_count` before pagination
+3. skip `offset` sessions from the front of the filtered list
+4. apply the existing `limit`
+5. return:
+   - `matched_count`
+   - `returned_count`
+   - `has_more`
+   - `filters.offset`
+
+Parsing rules:
+
+- missing or invalid `offset` falls back to `0`
+- negative values also fall back to `0`
+- valid positive integers are clamped to `usize`
+
+Documentation updates:
+
+- add `offset` to the JSON schema in `sessions_list_definition()`
+- add `offset` to the compact tool argument hint metadata so prompt-shaping surfaces know the field
+  exists
+
+## Why This Is The Smallest Correct Fix
+
+- no repository query changes
+- no new tool names
+- no new session filtering semantics
+- backward-compatible default behavior when `offset` is omitted
+
+## Testing Strategy
+
+Add red-green coverage for:
+
+- payload parsing: `offset` defaults to `0`, accepts positive integers, and ignores invalid values
+- tool behavior: `sessions_list` with `offset` returns the correct page, preserves
+  `matched_count`, updates `returned_count`, and surfaces `has_more`
+- catalog contract: `sessions_list` schema and hint metadata include `offset`
+
+## Scope Boundary
+
+This PR will not:
+
+- add cursor-based pagination
+- change session ordering
+- add pagination to `sessions_history`, `session_events`, or other tools
+- add or modify the separate daemon CLI sessions shell work

--- a/docs/plans/2026-04-01-session-tool-list-pagination-implementation-plan.md
+++ b/docs/plans/2026-04-01-session-tool-list-pagination-implementation-plan.md
@@ -13,7 +13,7 @@ response contract with `has_more`.
 
 ---
 
-### Task 1: Add the failing payload and tool behavior tests
+## Task 1: Add the failing payload and tool behavior tests
 
 **Files:**
 - Modify: `crates/app/src/tools/payload.rs`
@@ -48,7 +48,7 @@ cargo test -p loongclaw-app sessions_list_applies_offset_pagination --locked
 
 Expected: failing because `offset` is not implemented yet.
 
-### Task 2: Implement the pagination helper and request parsing
+## Task 2: Implement the pagination helper and request parsing
 
 **Files:**
 - Modify: `crates/app/src/tools/payload.rs`
@@ -73,7 +73,7 @@ cargo test -p loongclaw-app sessions_list_applies_offset_pagination --locked
 
 Expected: green.
 
-### Task 3: Wire pagination metadata into the `sessions_list` response contract
+## Task 3: Wire pagination metadata into the `sessions_list` response contract
 
 **Files:**
 - Modify: `crates/app/src/tools/session.rs`
@@ -95,7 +95,7 @@ Add `offset` to the `filters` payload and add `has_more` to the top-level respon
 
 Confirm legacy calls still return the same first page.
 
-### Task 4: Update tool contract metadata
+## Task 4: Update tool contract metadata
 
 **Files:**
 - Modify: `crates/app/src/tools/catalog.rs`
@@ -112,7 +112,7 @@ Add `offset` to the `sessions_list` argument hint and parameter type list.
 
 Keep coverage local to the existing catalog tests.
 
-### Task 5: Run focused and broader verification
+## Task 5: Run focused and broader verification
 
 **Files:**
 - Modify: none unless verification exposes a necessary fix
@@ -135,18 +135,20 @@ cargo test -p loongclaw-app sessions_list --locked
 cargo test -p loongclaw-app tool_catalog --locked
 ```
 
-**Step 3: Run formatting and full workspace tests**
+**Step 3: Run formatting, lint, and full workspace tests**
 
 Run:
 
 ```bash
 cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --locked
+cargo test --workspace --all-features --locked
 ```
 
 Expected: all green.
 
-### Task 6: Prepare clean delivery
+## Task 6: Prepare clean delivery
 
 **Files:**
 - Modify: GitHub artifacts through `gh`, not repository files

--- a/docs/plans/2026-04-01-session-tool-list-pagination-implementation-plan.md
+++ b/docs/plans/2026-04-01-session-tool-list-pagination-implementation-plan.md
@@ -1,0 +1,174 @@
+# Session Tool List Pagination Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `offset`-based pagination to `sessions_list` without changing existing visibility or
+sorting semantics.
+
+**Architecture:** Keep pagination inside the app-tool layer. Parse one new optional `offset`
+parameter, apply it after the current filter pipeline and before truncation, and surface a minimal
+response contract with `has_more`.
+
+**Tech Stack:** Rust, serde_json, existing app-tool tests
+
+---
+
+### Task 1: Add the failing payload and tool behavior tests
+
+**Files:**
+- Modify: `crates/app/src/tools/payload.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Write the failing payload test**
+
+Add tests for a new `optional_payload_offset()` helper:
+
+- missing offset returns `0`
+- positive offset returns the same value
+- invalid or negative offset returns `0`
+
+**Step 2: Write the failing session tool test**
+
+Add a `sessions_list` test that:
+
+- seeds one root plus three visible child sessions
+- fixes their `updated_at` ordering deterministically
+- calls `sessions_list` with `limit=2` and `offset=1`
+- expects the second and third sessions in sort order
+- expects `matched_count=4`, `returned_count=2`, and `has_more=true`
+
+**Step 3: Run the focused tests and verify red**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app optional_payload_offset --locked
+cargo test -p loongclaw-app sessions_list_applies_offset_pagination --locked
+```
+
+Expected: failing because `offset` is not implemented yet.
+
+### Task 2: Implement the pagination helper and request parsing
+
+**Files:**
+- Modify: `crates/app/src/tools/payload.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Add `optional_payload_offset()`**
+
+Return a non-negative `usize` with `0` as the default.
+
+**Step 2: Extend `SessionsListRequest`**
+
+Add an `offset` field and parse it in `parse_sessions_list_request()`.
+
+**Step 3: Re-run the focused tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app optional_payload_offset --locked
+cargo test -p loongclaw-app sessions_list_applies_offset_pagination --locked
+```
+
+Expected: green.
+
+### Task 3: Wire pagination metadata into the `sessions_list` response contract
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Apply `offset` after filtering**
+
+Compute:
+
+- `matched_count`
+- effective page slice
+- `returned_count`
+- `has_more`
+
+**Step 2: Surface pagination metadata**
+
+Add `offset` to the `filters` payload and add `has_more` to the top-level response.
+
+**Step 3: Keep existing behavior unchanged when `offset` is absent**
+
+Confirm legacy calls still return the same first page.
+
+### Task 4: Update tool contract metadata
+
+**Files:**
+- Modify: `crates/app/src/tools/catalog.rs`
+
+**Step 1: Add `offset` to `sessions_list_definition()`**
+
+Describe it as the number of matching visible sessions to skip before applying `limit`.
+
+**Step 2: Update compact hint metadata**
+
+Add `offset` to the `sessions_list` argument hint and parameter type list.
+
+**Step 3: Add or update a contract-focused test if needed**
+
+Keep coverage local to the existing catalog tests.
+
+### Task 5: Run focused and broader verification
+
+**Files:**
+- Modify: none unless verification exposes a necessary fix
+
+**Step 1: Run the focused app-tool tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app optional_payload_offset --locked
+cargo test -p loongclaw-app sessions_list --locked
+```
+
+**Step 2: Run relevant conversation/tool contract coverage**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app sessions_list --locked
+cargo test -p loongclaw-app tool_catalog --locked
+```
+
+**Step 3: Run formatting and full workspace tests**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test --workspace --locked
+```
+
+Expected: all green.
+
+### Task 6: Prepare clean delivery
+
+**Files:**
+- Modify: GitHub artifacts through `gh`, not repository files
+
+**Step 1: Inspect isolated changes**
+
+Run:
+
+```bash
+git status --short
+git diff -- crates/app/src/tools/payload.rs crates/app/src/tools/session.rs crates/app/src/tools/catalog.rs docs/plans/2026-04-01-session-tool-list-pagination-design.md docs/plans/2026-04-01-session-tool-list-pagination-implementation-plan.md
+```
+
+**Step 2: Commit with a scoped message**
+
+Run:
+
+```bash
+git add crates/app/src/tools/payload.rs crates/app/src/tools/session.rs crates/app/src/tools/catalog.rs docs/plans/2026-04-01-session-tool-list-pagination-design.md docs/plans/2026-04-01-session-tool-list-pagination-implementation-plan.md
+git commit -m "Add pagination to session tool listings"
+```
+
+**Step 3: Create linked issue and PR**
+
+Use the repository templates, English GitHub copy, and an explicit closing clause in the PR body.


### PR DESCRIPTION
## Summary

- Problem:
  `sessions_list` reported `matched_count` and `returned_count`, but callers had no first-class way to request the next page after the result set was truncated by `limit`.
- Why it matters:
  Operators and future CLI/tooling wrappers had to overfetch or add ad-hoc filters to inspect larger visible session sets.
- What changed:
  Added optional `offset` parsing for `sessions_list`, applied pagination after filtering and before truncation, returned `has_more`, surfaced `offset` in the response filters, updated tool schema/argument metadata, and added focused tests plus plan docs.
- What did not change (scope boundary):
  No cursor pagination, no sorting changes, no other session tools changed, and no daemon sessions shell changes.

## Linked Issues

- Closes #751
- Related #743

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- Passed.

cargo test -p loongclaw-app sessions_list --locked
- Passed. 8 sessions_list-focused tests green, including the new offset pagination coverage.

cargo test --workspace --locked
- Passed.

cargo clippy --workspace --all-targets --all-features -- -D warnings
- Passed.

cargo test --workspace --all-features --locked
- Passed.

cargo test -p loongclaw-app run_wecom_channel_reconnects_after_transport_drop --all-features --locked -- --nocapture
- Passed in a clean temporary origin/dev worktree while investigating an earlier long-running all-features invocation.
```

Notes:
- Config/env fallback coverage is not applicable here because the change does not alter config parsing, environment lookup, or default selection outside the additive `offset -> 0` request default, which is covered by focused payload tests.
- New tests do not mutate process-global environment.

## User-visible / Operator-visible Changes

- `sessions_list` now accepts an optional `offset` integer.
- The response now includes `filters.offset` and `has_more` so callers can page through visible sessions without overfetching.
- Tool schema and compact argument hints now advertise `offset`.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `53089a11` to remove the additive `offset` input and response metadata.
- Observable failure symptoms reviewers should watch for:
  Incorrect second-page ordering, inconsistent `matched_count`/`returned_count`, or schema/hint drift where `offset` is accepted in code but not advertised to callers.

## Reviewer Focus

- Check `execute_sessions_list()` pagination order and `has_more` semantics after filtering in `crates/app/src/tools/session.rs`.
- Check `optional_payload_offset()` boundary handling in `crates/app/src/tools/payload.rs`.
- Check `sessions_list` schema, hint, and parameter-type metadata stay aligned in `crates/app/src/tools/catalog.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `offset` parameter to sessions_list tool for stable pagination through results.
  * Sessions_list responses now include a `has_more` field to indicate whether additional results are available.
  * Invalid or missing offset values default to 0, providing seamless pagination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->