### PR TITLE
Add latest session selector for CLI ask/chat

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -4514,6 +4514,8 @@ mod tests {
         MemoryCoreRequest, StaticPolicyEngine, VerticalPackManifest,
     };
     #[cfg(feature = "memory-sqlite")]
+    use rusqlite::{Connection, params};
+    #[cfg(feature = "memory-sqlite")]
     use serde_json::{Value, json};
     #[test]
     fn cli_chat_options_detect_explicit_acp_requests() {
@@ -4625,6 +4627,90 @@ mod tests {
         .expect("initialize sqlite memory");
 
         (config, memory_config, sqlite_path)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn create_root_session(repo: &SessionRepository, session_id: &str) {
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn create_delegate_child_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        parent_session_id: &str,
+    ) {
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some(parent_session_id.to_owned()),
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create delegate child session");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn append_session_turn(
+        session_id: &str,
+        role: &str,
+        content: &str,
+        memory_config: &MemoryRuntimeConfig,
+    ) {
+        crate::memory::append_turn_direct(session_id, role, content, memory_config)
+            .expect("append session turn");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn open_chat_test_connection(sqlite_path: &Path) -> Connection {
+        Connection::open(sqlite_path).expect("open chat test sqlite connection")
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn set_chat_test_session_updated_at(sqlite_path: &Path, session_id: &str, updated_at: i64) {
+        let conn = open_chat_test_connection(sqlite_path);
+        conn.execute(
+            "UPDATE sessions
+             SET updated_at = ?2
+             WHERE session_id = ?1",
+            params![session_id, updated_at],
+        )
+        .expect("set chat test session updated_at");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn set_chat_test_turn_timestamps(sqlite_path: &Path, session_id: &str, ts: i64) {
+        let conn = open_chat_test_connection(sqlite_path);
+        conn.execute(
+            "UPDATE turns
+             SET ts = ?2
+             WHERE session_id = ?1",
+            params![session_id, ts],
+        )
+        .expect("set chat test turn timestamps");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn archive_chat_test_session(sqlite_path: &Path, session_id: &str, archived_at: i64) {
+        let conn = open_chat_test_connection(sqlite_path);
+        conn.execute(
+            "INSERT INTO session_events(
+                session_id,
+                event_kind,
+                actor_session_id,
+                payload_json,
+                ts
+             ) VALUES (?1, ?2, NULL, ?3, ?4)",
+            params![session_id, "session_archived", "{}", archived_at],
+        )
+        .expect("insert chat test archive event");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -4941,16 +5027,8 @@ mod tests {
     fn cli_runtime_resolves_latest_session_selector_to_latest_resumable_root() {
         let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-selector");
         let repo = SessionRepository::new(&memory_config).expect("repository");
-        repo.create_session(NewSessionRecord {
-            session_id: "selected-session".to_owned(),
-            kind: SessionKind::Root,
-            parent_session_id: None,
-            label: Some("selected-session".to_owned()),
-            state: SessionState::Ready,
-        })
-        .expect("create selected session");
-        crate::memory::append_turn_direct("selected-session", "user", "hello", &memory_config)
-            .expect("persist selected turn");
+        create_root_session(&repo, "selected-session");
+        append_session_turn("selected-session", "user", "hello", &memory_config);
 
         let runtime = initialize_cli_turn_runtime_with_loaded_config(
             PathBuf::from("/tmp/loongclaw.toml"),
@@ -4964,6 +5042,35 @@ mod tests {
         .expect("latest selector runtime");
 
         assert_eq!(runtime.session_id, "selected-session");
+
+        cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[test]
+    #[cfg(feature = "memory-sqlite")]
+    fn cli_runtime_latest_session_selector_updates_startup_summary_session_id() {
+        let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-summary");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        create_root_session(&repo, "selected-session");
+        append_session_turn("selected-session", "user", "selected hello", &memory_config);
+
+        let options = CliChatOptions::default();
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("latest"),
+            &options,
+            "cli-chat-latest-summary-test",
+            CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )
+        .expect("latest selector runtime");
+        let summary =
+            build_cli_chat_startup_summary(&runtime, &options).expect("build startup summary");
+
+        assert_eq!(runtime.session_id, "selected-session");
+        assert_eq!(summary.session_id, "selected-session");
+        assert_ne!(summary.session_id, CLI_SESSION_SELECTOR_LATEST);
 
         cleanup_chat_test_memory(&sqlite_path);
     }
@@ -5047,6 +5154,139 @@ mod tests {
         .expect("concurrent runtime");
 
         assert_eq!(runtime.session_id, "latest");
+
+        cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[test]
+    #[cfg(feature = "memory-sqlite")]
+    fn cli_runtime_latest_session_selector_prefers_newest_resumable_root() {
+        let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-runtime-order");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+
+        create_root_session(&repo, "root-old");
+        append_session_turn("root-old", "user", "old root turn", &memory_config);
+        set_chat_test_session_updated_at(&sqlite_path, "root-old", 100);
+        set_chat_test_turn_timestamps(&sqlite_path, "root-old", 100);
+
+        create_root_session(&repo, "root-new");
+        append_session_turn("root-new", "user", "new root turn", &memory_config);
+        set_chat_test_session_updated_at(&sqlite_path, "root-new", 200);
+        set_chat_test_turn_timestamps(&sqlite_path, "root-new", 200);
+
+        create_delegate_child_session(&repo, "delegate-child", "root-new");
+        append_session_turn(
+            "delegate-child",
+            "assistant",
+            "delegate child turn",
+            &memory_config,
+        );
+        set_chat_test_session_updated_at(&sqlite_path, "delegate-child", 400);
+        set_chat_test_turn_timestamps(&sqlite_path, "delegate-child", 400);
+
+        create_root_session(&repo, "root-archived");
+        append_session_turn(
+            "root-archived",
+            "assistant",
+            "archived root turn",
+            &memory_config,
+        );
+        set_chat_test_session_updated_at(&sqlite_path, "root-archived", 500);
+        set_chat_test_turn_timestamps(&sqlite_path, "root-archived", 500);
+        archive_chat_test_session(&sqlite_path, "root-archived", 600);
+
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("latest"),
+            &CliChatOptions::default(),
+            "cli-chat-latest-runtime-order-test",
+            CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )
+        .expect("latest selector runtime");
+
+        assert_eq!(runtime.session_id, "root-new");
+
+        cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn cli_runtime_latest_session_selector_drives_history_loads() {
+        let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-history");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+
+        create_root_session(&repo, "root-old");
+        append_session_turn("root-old", "user", "old user turn", &memory_config);
+        append_session_turn(
+            "root-old",
+            "assistant",
+            "old assistant turn",
+            &memory_config,
+        );
+        set_chat_test_session_updated_at(&sqlite_path, "root-old", 100);
+        set_chat_test_turn_timestamps(&sqlite_path, "root-old", 100);
+
+        create_root_session(&repo, "root-new");
+        append_session_turn("root-new", "user", "selected user turn", &memory_config);
+        append_session_turn(
+            "root-new",
+            "assistant",
+            "selected assistant turn",
+            &memory_config,
+        );
+        set_chat_test_session_updated_at(&sqlite_path, "root-new", 200);
+        set_chat_test_turn_timestamps(&sqlite_path, "root-new", 200);
+
+        create_delegate_child_session(&repo, "delegate-child", "root-new");
+        append_session_turn(
+            "delegate-child",
+            "assistant",
+            "delegate child turn",
+            &memory_config,
+        );
+        set_chat_test_session_updated_at(&sqlite_path, "delegate-child", 400);
+        set_chat_test_turn_timestamps(&sqlite_path, "delegate-child", 400);
+
+        create_root_session(&repo, "root-archived");
+        append_session_turn(
+            "root-archived",
+            "assistant",
+            "archived root turn",
+            &memory_config,
+        );
+        set_chat_test_session_updated_at(&sqlite_path, "root-archived", 500);
+        set_chat_test_turn_timestamps(&sqlite_path, "root-archived", 500);
+        archive_chat_test_session(&sqlite_path, "root-archived", 600);
+
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("latest"),
+            &CliChatOptions::default(),
+            "cli-chat-latest-history-test",
+            CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )
+        .expect("latest selector runtime");
+        let history_lines = load_history_lines(
+            &runtime.session_id,
+            32,
+            ConversationRuntimeBinding::direct(),
+            &memory_config,
+        )
+        .await
+        .expect("load history lines");
+
+        assert_eq!(runtime.session_id, "root-new");
+        assert_eq!(
+            history_lines,
+            vec![
+                "user: selected user turn".to_owned(),
+                "assistant: selected assistant turn".to_owned(),
+            ]
+        );
 
         cleanup_chat_test_memory(&sqlite_path);
     }

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -51,6 +51,8 @@ use super::conversation::{load_fast_lane_tool_batch_event_summary, load_safe_lan
 use super::memory;
 #[cfg(feature = "memory-sqlite")]
 use super::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use super::session::repository::SessionRepository;
 use super::tui_surface::{
     TuiActionSpec, TuiCalloutTone, TuiChecklistItemSpec, TuiChecklistStatus, TuiChoiceSpec,
     TuiHeaderStyle, TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec,
@@ -58,6 +60,7 @@ use super::tui_surface::{
 };
 
 pub const DEFAULT_FIRST_PROMPT: &str = "Summarize this repository and suggest the best next step.";
+const CLI_SESSION_SELECTOR_LATEST: &str = "latest";
 const TEST_ONBOARD_EXECUTABLE_ENV: &str = "LOONGCLAW_TEST_ONBOARD_EXECUTABLE";
 const CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS: usize = 80;
 const CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS: usize = 240;
@@ -475,7 +478,6 @@ fn initialize_cli_turn_runtime_with_loaded_config(
         return Err("CLI channel is disabled by config.cli.enabled=false".to_owned());
     }
 
-    let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
     if initialize_runtime_environment {
         crate::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
     }
@@ -490,19 +492,29 @@ fn initialize_cli_turn_runtime_with_loaded_config(
         .acp_working_directory
         .clone()
         .or_else(|| config.acp.dispatch.resolved_working_directory());
-    let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
 
     #[cfg(feature = "memory-sqlite")]
-    let (memory_config, memory_label) = {
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+
+    #[cfg(feature = "memory-sqlite")]
+    let memory_label = {
         let sqlite_path = config.memory.resolved_sqlite_path();
         let initialized = memory::ensure_memory_db_ready(Some(sqlite_path), &memory_config)
             .map_err(|error| format!("failed to initialize sqlite memory: {error}"))?;
-        (memory_config, initialized.display().to_string())
+        initialized.display().to_string()
     };
 
     #[cfg(not(feature = "memory-sqlite"))]
     let memory_label = "disabled".to_owned();
+
+    #[cfg(feature = "memory-sqlite")]
+    let session_id =
+        resolve_cli_runtime_session_id(session_hint, session_requirement, &memory_config)?;
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
+
+    let session_address = ConversationSessionAddress::from_session_id(session_id.clone());
 
     Ok(CliTurnRuntime {
         resolved_path,
@@ -536,6 +548,29 @@ fn resolve_cli_session_id(
             }
         },
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_cli_runtime_session_id(
+    session_hint: Option<&str>,
+    session_requirement: CliSessionRequirement,
+    memory_config: &MemoryRuntimeConfig,
+) -> CliResult<String> {
+    let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
+    let should_resolve_latest = session_requirement == CliSessionRequirement::AllowImplicitDefault
+        && session_id == CLI_SESSION_SELECTOR_LATEST;
+
+    if !should_resolve_latest {
+        return Ok(session_id);
+    }
+
+    let repo = SessionRepository::new(memory_config)?;
+    let latest_session = repo.latest_resumable_root_session_summary()?;
+    let latest_session = latest_session.ok_or_else(|| {
+        "CLI session selector `latest` did not find any resumable root session".to_owned()
+    })?;
+
+    Ok(latest_session.session_id)
 }
 
 #[allow(clippy::print_stdout)] // CLI output
@@ -4466,6 +4501,10 @@ mod tests {
     };
 
     #[cfg(feature = "memory-sqlite")]
+    use crate::session::repository::{
+        NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    };
+    #[cfg(feature = "memory-sqlite")]
     use async_trait::async_trait;
     #[cfg(feature = "memory-sqlite")]
     use loongclaw_contracts::{Capability, ExecutionRoute, HarnessKind, MemoryPlaneError};
@@ -4895,6 +4934,121 @@ mod tests {
             error.contains("explicit session"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    #[cfg(feature = "memory-sqlite")]
+    fn cli_runtime_resolves_latest_session_selector_to_latest_resumable_root() {
+        let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-selector");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "selected-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("selected-session".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create selected session");
+        crate::memory::append_turn_direct("selected-session", "user", "hello", &memory_config)
+            .expect("persist selected turn");
+
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("latest"),
+            &CliChatOptions::default(),
+            "cli-chat-latest-selector-test",
+            CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )
+        .expect("latest selector runtime");
+
+        assert_eq!(runtime.session_id, "selected-session");
+
+        cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[test]
+    #[cfg(feature = "memory-sqlite")]
+    fn cli_runtime_rejects_latest_session_selector_when_no_resumable_root_exists() {
+        let (config, _memory_config, sqlite_path) = init_chat_test_memory("latest-selector-none");
+        let result = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("latest"),
+            &CliChatOptions::default(),
+            "cli-chat-latest-selector-empty-test",
+            CliSessionRequirement::AllowImplicitDefault,
+            false,
+        );
+        let error = match result {
+            Ok(_) => panic!("latest selector should fail without a resumable root session"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("latest"), "unexpected error: {error}");
+
+        cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[test]
+    #[cfg(feature = "memory-sqlite")]
+    fn cli_runtime_keeps_default_session_when_no_hint_is_provided() {
+        let (config, _memory_config, sqlite_path) = init_chat_test_memory("default-selector");
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            None,
+            &CliChatOptions::default(),
+            "cli-chat-default-selector-test",
+            CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )
+        .expect("default session runtime");
+
+        assert_eq!(runtime.session_id, "default");
+
+        cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[test]
+    #[cfg(feature = "memory-sqlite")]
+    fn cli_runtime_keeps_explicit_literal_session_id() {
+        let (config, _memory_config, sqlite_path) = init_chat_test_memory("literal-selector");
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("custom-session"),
+            &CliChatOptions::default(),
+            "cli-chat-literal-selector-test",
+            CliSessionRequirement::AllowImplicitDefault,
+            false,
+        )
+        .expect("literal session runtime");
+
+        assert_eq!(runtime.session_id, "custom-session");
+
+        cleanup_chat_test_memory(&sqlite_path);
+    }
+
+    #[test]
+    #[cfg(feature = "memory-sqlite")]
+    fn concurrent_cli_runtime_keeps_latest_literal_when_explicit_session_is_required() {
+        let (config, _memory_config, sqlite_path) = init_chat_test_memory("concurrent-latest");
+        let runtime = initialize_cli_turn_runtime_with_loaded_config(
+            PathBuf::from("/tmp/loongclaw.toml"),
+            config,
+            Some("latest"),
+            &CliChatOptions::default(),
+            "cli-chat-concurrent-latest-test",
+            CliSessionRequirement::RequireExplicit,
+            false,
+        )
+        .expect("concurrent runtime");
+
+        assert_eq!(runtime.session_id, "latest");
+
+        cleanup_chat_test_memory(&sqlite_path);
     }
 
     #[tokio::test]

--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -21,6 +21,9 @@ use crate::acp::{
 use crate::context::{DEFAULT_TOKEN_TTL_S, bootstrap_kernel_context_with_config};
 
 mod cli_input;
+#[cfg(all(test, feature = "memory-sqlite"))]
+#[allow(clippy::expect_used)]
+mod latest_session_selector_tests;
 
 use self::cli_input::ConcurrentCliInputReader;
 
@@ -4501,10 +4504,6 @@ mod tests {
     };
 
     #[cfg(feature = "memory-sqlite")]
-    use crate::session::repository::{
-        NewSessionRecord, SessionKind, SessionRepository, SessionState,
-    };
-    #[cfg(feature = "memory-sqlite")]
     use async_trait::async_trait;
     #[cfg(feature = "memory-sqlite")]
     use loongclaw_contracts::{Capability, ExecutionRoute, HarnessKind, MemoryPlaneError};
@@ -4513,8 +4512,6 @@ mod tests {
         CoreMemoryAdapter, FixedClock, InMemoryAuditSink, LoongClawKernel, MemoryCoreOutcome,
         MemoryCoreRequest, StaticPolicyEngine, VerticalPackManifest,
     };
-    #[cfg(feature = "memory-sqlite")]
-    use rusqlite::{Connection, params};
     #[cfg(feature = "memory-sqlite")]
     use serde_json::{Value, json};
     #[test]
@@ -4606,14 +4603,16 @@ mod tests {
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn cleanup_chat_test_memory(sqlite_path: &Path) {
+    pub(super) fn cleanup_chat_test_memory(sqlite_path: &Path) {
         let _ = std::fs::remove_file(sqlite_path);
         let _ = std::fs::remove_file(format!("{}-wal", sqlite_path.display()));
         let _ = std::fs::remove_file(format!("{}-shm", sqlite_path.display()));
     }
 
     #[cfg(feature = "memory-sqlite")]
-    fn init_chat_test_memory(label: &str) -> (LoongClawConfig, MemoryRuntimeConfig, PathBuf) {
+    pub(super) fn init_chat_test_memory(
+        label: &str,
+    ) -> (LoongClawConfig, MemoryRuntimeConfig, PathBuf) {
         let sqlite_path = unique_chat_sqlite_path(label);
         cleanup_chat_test_memory(&sqlite_path);
 
@@ -4627,90 +4626,6 @@ mod tests {
         .expect("initialize sqlite memory");
 
         (config, memory_config, sqlite_path)
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    fn create_root_session(repo: &SessionRepository, session_id: &str) {
-        repo.create_session(NewSessionRecord {
-            session_id: session_id.to_owned(),
-            kind: SessionKind::Root,
-            parent_session_id: None,
-            label: Some(session_id.to_owned()),
-            state: SessionState::Ready,
-        })
-        .expect("create root session");
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    fn create_delegate_child_session(
-        repo: &SessionRepository,
-        session_id: &str,
-        parent_session_id: &str,
-    ) {
-        repo.create_session(NewSessionRecord {
-            session_id: session_id.to_owned(),
-            kind: SessionKind::DelegateChild,
-            parent_session_id: Some(parent_session_id.to_owned()),
-            label: Some(session_id.to_owned()),
-            state: SessionState::Ready,
-        })
-        .expect("create delegate child session");
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    fn append_session_turn(
-        session_id: &str,
-        role: &str,
-        content: &str,
-        memory_config: &MemoryRuntimeConfig,
-    ) {
-        crate::memory::append_turn_direct(session_id, role, content, memory_config)
-            .expect("append session turn");
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    fn open_chat_test_connection(sqlite_path: &Path) -> Connection {
-        Connection::open(sqlite_path).expect("open chat test sqlite connection")
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    fn set_chat_test_session_updated_at(sqlite_path: &Path, session_id: &str, updated_at: i64) {
-        let conn = open_chat_test_connection(sqlite_path);
-        conn.execute(
-            "UPDATE sessions
-             SET updated_at = ?2
-             WHERE session_id = ?1",
-            params![session_id, updated_at],
-        )
-        .expect("set chat test session updated_at");
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    fn set_chat_test_turn_timestamps(sqlite_path: &Path, session_id: &str, ts: i64) {
-        let conn = open_chat_test_connection(sqlite_path);
-        conn.execute(
-            "UPDATE turns
-             SET ts = ?2
-             WHERE session_id = ?1",
-            params![session_id, ts],
-        )
-        .expect("set chat test turn timestamps");
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    fn archive_chat_test_session(sqlite_path: &Path, session_id: &str, archived_at: i64) {
-        let conn = open_chat_test_connection(sqlite_path);
-        conn.execute(
-            "INSERT INTO session_events(
-                session_id,
-                event_kind,
-                actor_session_id,
-                payload_json,
-                ts
-             ) VALUES (?1, ?2, NULL, ?3, ?4)",
-            params![session_id, "session_archived", "{}", archived_at],
-        )
-        .expect("insert chat test archive event");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -5020,275 +4935,6 @@ mod tests {
             error.contains("explicit session"),
             "unexpected error: {error}"
         );
-    }
-
-    #[test]
-    #[cfg(feature = "memory-sqlite")]
-    fn cli_runtime_resolves_latest_session_selector_to_latest_resumable_root() {
-        let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-selector");
-        let repo = SessionRepository::new(&memory_config).expect("repository");
-        create_root_session(&repo, "selected-session");
-        append_session_turn("selected-session", "user", "hello", &memory_config);
-
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            Some("latest"),
-            &CliChatOptions::default(),
-            "cli-chat-latest-selector-test",
-            CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )
-        .expect("latest selector runtime");
-
-        assert_eq!(runtime.session_id, "selected-session");
-
-        cleanup_chat_test_memory(&sqlite_path);
-    }
-
-    #[test]
-    #[cfg(feature = "memory-sqlite")]
-    fn cli_runtime_latest_session_selector_updates_startup_summary_session_id() {
-        let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-summary");
-        let repo = SessionRepository::new(&memory_config).expect("repository");
-        create_root_session(&repo, "selected-session");
-        append_session_turn("selected-session", "user", "selected hello", &memory_config);
-
-        let options = CliChatOptions::default();
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            Some("latest"),
-            &options,
-            "cli-chat-latest-summary-test",
-            CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )
-        .expect("latest selector runtime");
-        let summary =
-            build_cli_chat_startup_summary(&runtime, &options).expect("build startup summary");
-
-        assert_eq!(runtime.session_id, "selected-session");
-        assert_eq!(summary.session_id, "selected-session");
-        assert_ne!(summary.session_id, CLI_SESSION_SELECTOR_LATEST);
-
-        cleanup_chat_test_memory(&sqlite_path);
-    }
-
-    #[test]
-    #[cfg(feature = "memory-sqlite")]
-    fn cli_runtime_rejects_latest_session_selector_when_no_resumable_root_exists() {
-        let (config, _memory_config, sqlite_path) = init_chat_test_memory("latest-selector-none");
-        let result = initialize_cli_turn_runtime_with_loaded_config(
-            PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            Some("latest"),
-            &CliChatOptions::default(),
-            "cli-chat-latest-selector-empty-test",
-            CliSessionRequirement::AllowImplicitDefault,
-            false,
-        );
-        let error = match result {
-            Ok(_) => panic!("latest selector should fail without a resumable root session"),
-            Err(error) => error,
-        };
-
-        assert!(error.contains("latest"), "unexpected error: {error}");
-
-        cleanup_chat_test_memory(&sqlite_path);
-    }
-
-    #[test]
-    #[cfg(feature = "memory-sqlite")]
-    fn cli_runtime_keeps_default_session_when_no_hint_is_provided() {
-        let (config, _memory_config, sqlite_path) = init_chat_test_memory("default-selector");
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            None,
-            &CliChatOptions::default(),
-            "cli-chat-default-selector-test",
-            CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )
-        .expect("default session runtime");
-
-        assert_eq!(runtime.session_id, "default");
-
-        cleanup_chat_test_memory(&sqlite_path);
-    }
-
-    #[test]
-    #[cfg(feature = "memory-sqlite")]
-    fn cli_runtime_keeps_explicit_literal_session_id() {
-        let (config, _memory_config, sqlite_path) = init_chat_test_memory("literal-selector");
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            Some("custom-session"),
-            &CliChatOptions::default(),
-            "cli-chat-literal-selector-test",
-            CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )
-        .expect("literal session runtime");
-
-        assert_eq!(runtime.session_id, "custom-session");
-
-        cleanup_chat_test_memory(&sqlite_path);
-    }
-
-    #[test]
-    #[cfg(feature = "memory-sqlite")]
-    fn concurrent_cli_runtime_keeps_latest_literal_when_explicit_session_is_required() {
-        let (config, _memory_config, sqlite_path) = init_chat_test_memory("concurrent-latest");
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            Some("latest"),
-            &CliChatOptions::default(),
-            "cli-chat-concurrent-latest-test",
-            CliSessionRequirement::RequireExplicit,
-            false,
-        )
-        .expect("concurrent runtime");
-
-        assert_eq!(runtime.session_id, "latest");
-
-        cleanup_chat_test_memory(&sqlite_path);
-    }
-
-    #[test]
-    #[cfg(feature = "memory-sqlite")]
-    fn cli_runtime_latest_session_selector_prefers_newest_resumable_root() {
-        let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-runtime-order");
-        let repo = SessionRepository::new(&memory_config).expect("repository");
-
-        create_root_session(&repo, "root-old");
-        append_session_turn("root-old", "user", "old root turn", &memory_config);
-        set_chat_test_session_updated_at(&sqlite_path, "root-old", 100);
-        set_chat_test_turn_timestamps(&sqlite_path, "root-old", 100);
-
-        create_root_session(&repo, "root-new");
-        append_session_turn("root-new", "user", "new root turn", &memory_config);
-        set_chat_test_session_updated_at(&sqlite_path, "root-new", 200);
-        set_chat_test_turn_timestamps(&sqlite_path, "root-new", 200);
-
-        create_delegate_child_session(&repo, "delegate-child", "root-new");
-        append_session_turn(
-            "delegate-child",
-            "assistant",
-            "delegate child turn",
-            &memory_config,
-        );
-        set_chat_test_session_updated_at(&sqlite_path, "delegate-child", 400);
-        set_chat_test_turn_timestamps(&sqlite_path, "delegate-child", 400);
-
-        create_root_session(&repo, "root-archived");
-        append_session_turn(
-            "root-archived",
-            "assistant",
-            "archived root turn",
-            &memory_config,
-        );
-        set_chat_test_session_updated_at(&sqlite_path, "root-archived", 500);
-        set_chat_test_turn_timestamps(&sqlite_path, "root-archived", 500);
-        archive_chat_test_session(&sqlite_path, "root-archived", 600);
-
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            Some("latest"),
-            &CliChatOptions::default(),
-            "cli-chat-latest-runtime-order-test",
-            CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )
-        .expect("latest selector runtime");
-
-        assert_eq!(runtime.session_id, "root-new");
-
-        cleanup_chat_test_memory(&sqlite_path);
-    }
-
-    #[cfg(feature = "memory-sqlite")]
-    #[tokio::test]
-    async fn cli_runtime_latest_session_selector_drives_history_loads() {
-        let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-history");
-        let repo = SessionRepository::new(&memory_config).expect("repository");
-
-        create_root_session(&repo, "root-old");
-        append_session_turn("root-old", "user", "old user turn", &memory_config);
-        append_session_turn(
-            "root-old",
-            "assistant",
-            "old assistant turn",
-            &memory_config,
-        );
-        set_chat_test_session_updated_at(&sqlite_path, "root-old", 100);
-        set_chat_test_turn_timestamps(&sqlite_path, "root-old", 100);
-
-        create_root_session(&repo, "root-new");
-        append_session_turn("root-new", "user", "selected user turn", &memory_config);
-        append_session_turn(
-            "root-new",
-            "assistant",
-            "selected assistant turn",
-            &memory_config,
-        );
-        set_chat_test_session_updated_at(&sqlite_path, "root-new", 200);
-        set_chat_test_turn_timestamps(&sqlite_path, "root-new", 200);
-
-        create_delegate_child_session(&repo, "delegate-child", "root-new");
-        append_session_turn(
-            "delegate-child",
-            "assistant",
-            "delegate child turn",
-            &memory_config,
-        );
-        set_chat_test_session_updated_at(&sqlite_path, "delegate-child", 400);
-        set_chat_test_turn_timestamps(&sqlite_path, "delegate-child", 400);
-
-        create_root_session(&repo, "root-archived");
-        append_session_turn(
-            "root-archived",
-            "assistant",
-            "archived root turn",
-            &memory_config,
-        );
-        set_chat_test_session_updated_at(&sqlite_path, "root-archived", 500);
-        set_chat_test_turn_timestamps(&sqlite_path, "root-archived", 500);
-        archive_chat_test_session(&sqlite_path, "root-archived", 600);
-
-        let runtime = initialize_cli_turn_runtime_with_loaded_config(
-            PathBuf::from("/tmp/loongclaw.toml"),
-            config,
-            Some("latest"),
-            &CliChatOptions::default(),
-            "cli-chat-latest-history-test",
-            CliSessionRequirement::AllowImplicitDefault,
-            false,
-        )
-        .expect("latest selector runtime");
-        let history_lines = load_history_lines(
-            &runtime.session_id,
-            32,
-            ConversationRuntimeBinding::direct(),
-            &memory_config,
-        )
-        .await
-        .expect("load history lines");
-
-        assert_eq!(runtime.session_id, "root-new");
-        assert_eq!(
-            history_lines,
-            vec![
-                "user: selected user turn".to_owned(),
-                "assistant: selected assistant turn".to_owned(),
-            ]
-        );
-
-        cleanup_chat_test_memory(&sqlite_path);
     }
 
     #[tokio::test]

--- a/crates/app/src/chat/latest_session_selector_tests.rs
+++ b/crates/app/src/chat/latest_session_selector_tests.rs
@@ -1,0 +1,344 @@
+use super::tests::{cleanup_chat_test_memory, init_chat_test_memory};
+use super::*;
+use crate::conversation::ConversationRuntimeBinding;
+use crate::session::repository::{NewSessionRecord, SessionKind, SessionRepository, SessionState};
+use rusqlite::{Connection, params};
+use std::path::{Path, PathBuf};
+
+fn create_root_session(repo: &SessionRepository, session_id: &str) {
+    repo.create_session(NewSessionRecord {
+        session_id: session_id.to_owned(),
+        kind: SessionKind::Root,
+        parent_session_id: None,
+        label: Some(session_id.to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create root session");
+}
+
+fn create_delegate_child_session(
+    repo: &SessionRepository,
+    session_id: &str,
+    parent_session_id: &str,
+) {
+    repo.create_session(NewSessionRecord {
+        session_id: session_id.to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some(parent_session_id.to_owned()),
+        label: Some(session_id.to_owned()),
+        state: SessionState::Ready,
+    })
+    .expect("create delegate child session");
+}
+
+fn append_session_turn(
+    session_id: &str,
+    role: &str,
+    content: &str,
+    memory_config: &MemoryRuntimeConfig,
+) {
+    crate::memory::append_turn_direct(session_id, role, content, memory_config)
+        .expect("append session turn");
+}
+
+fn open_chat_test_connection(sqlite_path: &Path) -> Connection {
+    Connection::open(sqlite_path).expect("open chat test sqlite connection")
+}
+
+fn set_chat_test_session_updated_at(sqlite_path: &Path, session_id: &str, updated_at: i64) {
+    let conn = open_chat_test_connection(sqlite_path);
+    conn.execute(
+        "UPDATE sessions
+         SET updated_at = ?2
+         WHERE session_id = ?1",
+        params![session_id, updated_at],
+    )
+    .expect("set chat test session updated_at");
+}
+
+fn set_chat_test_turn_timestamps(sqlite_path: &Path, session_id: &str, ts: i64) {
+    let conn = open_chat_test_connection(sqlite_path);
+    conn.execute(
+        "UPDATE turns
+         SET ts = ?2
+         WHERE session_id = ?1",
+        params![session_id, ts],
+    )
+    .expect("set chat test turn timestamps");
+}
+
+fn archive_chat_test_session(sqlite_path: &Path, session_id: &str, archived_at: i64) {
+    let conn = open_chat_test_connection(sqlite_path);
+    conn.execute(
+        "INSERT INTO session_events(
+            session_id,
+            event_kind,
+            actor_session_id,
+            payload_json,
+            ts
+         ) VALUES (?1, ?2, NULL, ?3, ?4)",
+        params![session_id, "session_archived", "{}", archived_at],
+    )
+    .expect("insert chat test archive event");
+}
+
+#[test]
+fn cli_runtime_resolves_latest_session_selector_to_latest_resumable_root() {
+    let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-selector");
+    let repo = SessionRepository::new(&memory_config).expect("repository");
+    create_root_session(&repo, "selected-session");
+    append_session_turn("selected-session", "user", "hello", &memory_config);
+
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+        Some("latest"),
+        &CliChatOptions::default(),
+        "cli-chat-latest-selector-test",
+        CliSessionRequirement::AllowImplicitDefault,
+        false,
+    )
+    .expect("latest selector runtime");
+
+    assert_eq!(runtime.session_id, "selected-session");
+
+    cleanup_chat_test_memory(&sqlite_path);
+}
+
+#[test]
+fn cli_runtime_latest_session_selector_updates_startup_summary_session_id() {
+    let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-summary");
+    let repo = SessionRepository::new(&memory_config).expect("repository");
+    create_root_session(&repo, "selected-session");
+    append_session_turn("selected-session", "user", "selected hello", &memory_config);
+
+    let options = CliChatOptions::default();
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+        Some("latest"),
+        &options,
+        "cli-chat-latest-summary-test",
+        CliSessionRequirement::AllowImplicitDefault,
+        false,
+    )
+    .expect("latest selector runtime");
+    let summary =
+        build_cli_chat_startup_summary(&runtime, &options).expect("build startup summary");
+
+    assert_eq!(runtime.session_id, "selected-session");
+    assert_eq!(summary.session_id, "selected-session");
+    assert_ne!(summary.session_id, CLI_SESSION_SELECTOR_LATEST);
+
+    cleanup_chat_test_memory(&sqlite_path);
+}
+
+#[test]
+fn cli_runtime_rejects_latest_session_selector_when_no_resumable_root_exists() {
+    let (config, _memory_config, sqlite_path) = init_chat_test_memory("latest-selector-none");
+    let result = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+        Some("latest"),
+        &CliChatOptions::default(),
+        "cli-chat-latest-selector-empty-test",
+        CliSessionRequirement::AllowImplicitDefault,
+        false,
+    );
+    let error = match result {
+        Ok(_) => panic!("latest selector should fail without a resumable root session"),
+        Err(error) => error,
+    };
+
+    assert!(error.contains("latest"), "unexpected error: {error}");
+
+    cleanup_chat_test_memory(&sqlite_path);
+}
+
+#[test]
+fn cli_runtime_keeps_default_session_when_no_hint_is_provided() {
+    let (config, _memory_config, sqlite_path) = init_chat_test_memory("default-selector");
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+        None,
+        &CliChatOptions::default(),
+        "cli-chat-default-selector-test",
+        CliSessionRequirement::AllowImplicitDefault,
+        false,
+    )
+    .expect("default session runtime");
+
+    assert_eq!(runtime.session_id, "default");
+
+    cleanup_chat_test_memory(&sqlite_path);
+}
+
+#[test]
+fn cli_runtime_keeps_explicit_literal_session_id() {
+    let (config, _memory_config, sqlite_path) = init_chat_test_memory("literal-selector");
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+        Some("custom-session"),
+        &CliChatOptions::default(),
+        "cli-chat-literal-selector-test",
+        CliSessionRequirement::AllowImplicitDefault,
+        false,
+    )
+    .expect("literal session runtime");
+
+    assert_eq!(runtime.session_id, "custom-session");
+
+    cleanup_chat_test_memory(&sqlite_path);
+}
+
+#[test]
+fn concurrent_cli_runtime_keeps_latest_literal_when_explicit_session_is_required() {
+    let (config, _memory_config, sqlite_path) = init_chat_test_memory("concurrent-latest");
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+        Some("latest"),
+        &CliChatOptions::default(),
+        "cli-chat-concurrent-latest-test",
+        CliSessionRequirement::RequireExplicit,
+        false,
+    )
+    .expect("concurrent runtime");
+
+    assert_eq!(runtime.session_id, "latest");
+
+    cleanup_chat_test_memory(&sqlite_path);
+}
+
+#[test]
+fn cli_runtime_latest_session_selector_prefers_newest_resumable_root() {
+    let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-runtime-order");
+    let repo = SessionRepository::new(&memory_config).expect("repository");
+
+    create_root_session(&repo, "root-old");
+    append_session_turn("root-old", "user", "old root turn", &memory_config);
+    set_chat_test_session_updated_at(&sqlite_path, "root-old", 100);
+    set_chat_test_turn_timestamps(&sqlite_path, "root-old", 100);
+
+    create_root_session(&repo, "root-new");
+    append_session_turn("root-new", "user", "new root turn", &memory_config);
+    set_chat_test_session_updated_at(&sqlite_path, "root-new", 200);
+    set_chat_test_turn_timestamps(&sqlite_path, "root-new", 200);
+
+    create_delegate_child_session(&repo, "delegate-child", "root-new");
+    append_session_turn(
+        "delegate-child",
+        "assistant",
+        "delegate child turn",
+        &memory_config,
+    );
+    set_chat_test_session_updated_at(&sqlite_path, "delegate-child", 400);
+    set_chat_test_turn_timestamps(&sqlite_path, "delegate-child", 400);
+
+    create_root_session(&repo, "root-archived");
+    append_session_turn(
+        "root-archived",
+        "assistant",
+        "archived root turn",
+        &memory_config,
+    );
+    set_chat_test_session_updated_at(&sqlite_path, "root-archived", 500);
+    set_chat_test_turn_timestamps(&sqlite_path, "root-archived", 500);
+    archive_chat_test_session(&sqlite_path, "root-archived", 600);
+
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+        Some("latest"),
+        &CliChatOptions::default(),
+        "cli-chat-latest-runtime-order-test",
+        CliSessionRequirement::AllowImplicitDefault,
+        false,
+    )
+    .expect("latest selector runtime");
+
+    assert_eq!(runtime.session_id, "root-new");
+
+    cleanup_chat_test_memory(&sqlite_path);
+}
+
+#[tokio::test]
+async fn cli_runtime_latest_session_selector_drives_history_loads() {
+    let (config, memory_config, sqlite_path) = init_chat_test_memory("latest-history");
+    let repo = SessionRepository::new(&memory_config).expect("repository");
+
+    create_root_session(&repo, "root-old");
+    append_session_turn("root-old", "user", "old user turn", &memory_config);
+    append_session_turn(
+        "root-old",
+        "assistant",
+        "old assistant turn",
+        &memory_config,
+    );
+    set_chat_test_session_updated_at(&sqlite_path, "root-old", 100);
+    set_chat_test_turn_timestamps(&sqlite_path, "root-old", 100);
+
+    create_root_session(&repo, "root-new");
+    append_session_turn("root-new", "user", "selected user turn", &memory_config);
+    append_session_turn(
+        "root-new",
+        "assistant",
+        "selected assistant turn",
+        &memory_config,
+    );
+    set_chat_test_session_updated_at(&sqlite_path, "root-new", 200);
+    set_chat_test_turn_timestamps(&sqlite_path, "root-new", 200);
+
+    create_delegate_child_session(&repo, "delegate-child", "root-new");
+    append_session_turn(
+        "delegate-child",
+        "assistant",
+        "delegate child turn",
+        &memory_config,
+    );
+    set_chat_test_session_updated_at(&sqlite_path, "delegate-child", 400);
+    set_chat_test_turn_timestamps(&sqlite_path, "delegate-child", 400);
+
+    create_root_session(&repo, "root-archived");
+    append_session_turn(
+        "root-archived",
+        "assistant",
+        "archived root turn",
+        &memory_config,
+    );
+    set_chat_test_session_updated_at(&sqlite_path, "root-archived", 500);
+    set_chat_test_turn_timestamps(&sqlite_path, "root-archived", 500);
+    archive_chat_test_session(&sqlite_path, "root-archived", 600);
+
+    let runtime = initialize_cli_turn_runtime_with_loaded_config(
+        PathBuf::from("/tmp/loongclaw.toml"),
+        config,
+        Some("latest"),
+        &CliChatOptions::default(),
+        "cli-chat-latest-history-test",
+        CliSessionRequirement::AllowImplicitDefault,
+        false,
+    )
+    .expect("latest selector runtime");
+    let history_lines = load_history_lines(
+        &runtime.session_id,
+        32,
+        ConversationRuntimeBinding::direct(),
+        &memory_config,
+    )
+    .await
+    .expect("load history lines");
+
+    assert_eq!(runtime.session_id, "root-new");
+    assert_eq!(
+        history_lines,
+        vec![
+            "user: selected user turn".to_owned(),
+            "assistant: selected assistant turn".to_owned(),
+        ]
+    );
+
+    cleanup_chat_test_memory(&sqlite_path);
+}

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -500,6 +500,13 @@ impl SessionRepository {
         Self::load_session_summary_with_legacy_fallback_with_conn(&conn, &session_id)
     }
 
+    pub fn latest_resumable_root_session_summary(
+        &self,
+    ) -> Result<Option<SessionSummaryRecord>, String> {
+        let conn = self.open_connection()?;
+        Self::latest_resumable_root_session_summary_with_conn(&conn)
+    }
+
     pub fn load_session_observation(
         &self,
         session_id: &str,
@@ -1844,6 +1851,153 @@ impl SessionRepository {
         Self::infer_legacy_session_summary_with_conn(conn, session_id)
     }
 
+    fn latest_resumable_root_session_summary_with_conn(
+        conn: &Connection,
+    ) -> Result<Option<SessionSummaryRecord>, String> {
+        let mut candidates = Self::list_resumable_root_session_summaries_with_conn(conn)?;
+        sort_session_summaries(&mut candidates);
+        Ok(candidates.into_iter().next())
+    }
+
+    fn list_resumable_root_session_summaries_with_conn(
+        conn: &Connection,
+    ) -> Result<Vec<SessionSummaryRecord>, String> {
+        let mut candidates = Self::list_concrete_session_summaries_with_conn(conn)?;
+        let legacy_candidates = Self::list_legacy_turn_only_session_summaries_with_conn(conn)?;
+
+        candidates.retain(is_resumable_root_session_summary);
+        for candidate in legacy_candidates {
+            if is_resumable_root_session_summary(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+
+        Ok(candidates)
+    }
+
+    fn list_concrete_session_summaries_with_conn(
+        conn: &Connection,
+    ) -> Result<Vec<SessionSummaryRecord>, String> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT
+                    s.session_id,
+                    s.kind,
+                    s.parent_session_id,
+                    s.label,
+                    s.state,
+                    s.created_at,
+                    s.updated_at,
+                    s.last_error,
+                    archived.archived_at,
+                    COUNT(t.id) AS turn_count,
+                    MAX(t.ts) AS last_turn_at
+                 FROM sessions s
+                 LEFT JOIN (
+                    SELECT session_id, MAX(ts) AS archived_at
+                    FROM session_events
+                    WHERE event_kind = 'session_archived'
+                    GROUP BY session_id
+                 ) archived ON archived.session_id = s.session_id
+                 LEFT JOIN turns t ON t.session_id = s.session_id
+                 GROUP BY
+                    s.session_id,
+                    s.kind,
+                    s.parent_session_id,
+                    s.label,
+                    s.state,
+                    s.created_at,
+                    s.updated_at,
+                    s.last_error,
+                    archived.archived_at",
+            )
+            .map_err(|error| format!("prepare concrete session summary query failed: {error}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(RawSessionSummaryRecord {
+                    session_id: row.get(0)?,
+                    kind: row.get(1)?,
+                    parent_session_id: row.get(2)?,
+                    label: row.get(3)?,
+                    state: row.get(4)?,
+                    created_at: row.get(5)?,
+                    updated_at: row.get(6)?,
+                    last_error: row.get(7)?,
+                    archived_at: row.get(8)?,
+                    turn_count: row.get(9)?,
+                    last_turn_at: row.get(10)?,
+                })
+            })
+            .map_err(|error| format!("query concrete session summaries failed: {error}"))?;
+
+        let mut sessions = Vec::new();
+        for row in rows {
+            let raw =
+                row.map_err(|error| format!("decode concrete session summary failed: {error}"))?;
+            let summary = SessionSummaryRecord::try_from_raw(raw)?;
+            sessions.push(summary);
+        }
+
+        Ok(sessions)
+    }
+
+    fn list_legacy_turn_only_session_summaries_with_conn(
+        conn: &Connection,
+    ) -> Result<Vec<SessionSummaryRecord>, String> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT
+                    t.session_id,
+                    MIN(t.ts) AS created_at,
+                    MAX(t.ts) AS updated_at,
+                    COUNT(t.id) AS turn_count
+                 FROM turns t
+                 LEFT JOIN sessions s ON s.session_id = t.session_id
+                 WHERE s.session_id IS NULL
+                 GROUP BY t.session_id",
+            )
+            .map_err(|error| format!("prepare legacy session summary query failed: {error}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<i64>>(1)?,
+                    row.get::<_, Option<i64>>(2)?,
+                    row.get::<_, i64>(3)?,
+                ))
+            })
+            .map_err(|error| format!("query legacy session summaries failed: {error}"))?;
+
+        let mut sessions = Vec::new();
+        for row in rows {
+            let decoded_row =
+                row.map_err(|error| format!("decode legacy session summary failed: {error}"))?;
+            let (session_id, created_at_value, updated_at_value, turn_count_value) = decoded_row;
+            let created_at = created_at_value.unwrap_or_default();
+            let updated_at = updated_at_value.unwrap_or(created_at);
+            let bounded_turn_count = turn_count_value.max(0);
+            let turn_count = bounded_turn_count as usize;
+            let kind = infer_legacy_session_kind(&session_id);
+
+            let summary = SessionSummaryRecord {
+                session_id,
+                kind,
+                parent_session_id: None,
+                label: None,
+                state: SessionState::Ready,
+                created_at,
+                updated_at,
+                archived_at: None,
+                turn_count,
+                last_turn_at: Some(updated_at),
+                last_error: None,
+            };
+            sessions.push(summary);
+        }
+
+        Ok(sessions)
+    }
+
     fn list_recent_events_with_conn(
         conn: &Connection,
         session_id: &str,
@@ -2353,6 +2507,19 @@ fn infer_legacy_session_kind(session_id: &str) -> SessionKind {
     }
 }
 
+fn is_resumable_root_session_summary(summary: &SessionSummaryRecord) -> bool {
+    if summary.kind != SessionKind::Root {
+        return false;
+    }
+    if summary.archived_at.is_some() {
+        return false;
+    }
+    if summary.turn_count == 0 {
+        return false;
+    }
+    true
+}
+
 fn sort_session_summaries(sessions: &mut [SessionSummaryRecord]) {
     sessions.sort_by(|left, right| {
         right
@@ -2390,6 +2557,78 @@ mod tests {
             sqlite_path: Some(db_path),
             ..MemoryRuntimeConfig::default()
         }
+    }
+
+    fn create_root_session(repo: &SessionRepository, session_id: &str) {
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+    }
+
+    fn create_delegate_child_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        parent_session_id: &str,
+    ) {
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some(parent_session_id.to_owned()),
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create delegate child session");
+    }
+
+    fn append_session_turn(
+        config: &MemoryRuntimeConfig,
+        session_id: &str,
+        role: &str,
+        content: &str,
+    ) {
+        append_turn_direct(session_id, role, content, config).expect("append session turn");
+    }
+
+    fn set_session_updated_at(repo: &SessionRepository, session_id: &str, updated_at: i64) {
+        let conn = repo.open_connection().expect("open connection");
+        conn.execute(
+            "UPDATE sessions
+             SET updated_at = ?2
+             WHERE session_id = ?1",
+            params![session_id, updated_at],
+        )
+        .expect("set session updated_at");
+    }
+
+    fn set_turn_timestamps(repo: &SessionRepository, session_id: &str, ts: i64) {
+        let conn = repo.open_connection().expect("open connection");
+        conn.execute(
+            "UPDATE turns
+             SET ts = ?2
+             WHERE session_id = ?1",
+            params![session_id, ts],
+        )
+        .expect("set turn timestamps");
+    }
+
+    fn archive_session(repo: &SessionRepository, session_id: &str, archived_at: i64) {
+        let conn = repo.open_connection().expect("open connection");
+        conn.execute(
+            "INSERT INTO session_events(
+                session_id,
+                event_kind,
+                actor_session_id,
+                payload_json,
+                ts
+             ) VALUES (?1, ?2, NULL, ?3, ?4)",
+            params![session_id, "session_archived", "{}", archived_at],
+        )
+        .expect("insert archive event");
     }
 
     #[test]
@@ -2869,6 +3108,109 @@ mod tests {
             .find(|session| session.session_id == "telegram:456")
             .expect("telegram legacy session");
         assert_eq!(telegram_session.kind, SessionKind::Root);
+    }
+
+    #[test]
+    fn latest_resumable_root_session_prefers_newest_eligible_root() {
+        let config = isolated_memory_config("latest-resumable-root");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        create_root_session(&repo, "root-old");
+        append_session_turn(&config, "root-old", "user", "old");
+        set_session_updated_at(&repo, "root-old", 100);
+        set_turn_timestamps(&repo, "root-old", 100);
+
+        create_root_session(&repo, "root-new");
+        append_session_turn(&config, "root-new", "user", "new");
+        set_session_updated_at(&repo, "root-new", 200);
+        set_turn_timestamps(&repo, "root-new", 200);
+
+        create_delegate_child_session(&repo, "delegate-child", "root-new");
+        append_session_turn(&config, "delegate-child", "assistant", "child");
+        set_session_updated_at(&repo, "delegate-child", 400);
+        set_turn_timestamps(&repo, "delegate-child", 400);
+
+        create_root_session(&repo, "root-archived");
+        append_session_turn(&config, "root-archived", "assistant", "archived");
+        set_session_updated_at(&repo, "root-archived", 500);
+        set_turn_timestamps(&repo, "root-archived", 500);
+        archive_session(&repo, "root-archived", 600);
+
+        create_root_session(&repo, "root-empty");
+        set_session_updated_at(&repo, "root-empty", 700);
+
+        let latest = repo
+            .latest_resumable_root_session_summary()
+            .expect("load latest resumable root session")
+            .expect("eligible root session");
+
+        assert_eq!(latest.session_id, "root-new");
+        assert_eq!(latest.kind, SessionKind::Root);
+        assert_eq!(latest.archived_at, None);
+        assert_eq!(latest.turn_count, 1);
+    }
+
+    #[test]
+    fn latest_resumable_root_session_includes_legacy_root_when_newest() {
+        let config = isolated_memory_config("latest-legacy-root");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        create_root_session(&repo, "root-session");
+        append_session_turn(&config, "root-session", "user", "root");
+        set_session_updated_at(&repo, "root-session", 100);
+        set_turn_timestamps(&repo, "root-session", 100);
+
+        append_session_turn(&config, "telegram:latest", "assistant", "legacy");
+        set_turn_timestamps(&repo, "telegram:latest", 200);
+
+        let latest = repo
+            .latest_resumable_root_session_summary()
+            .expect("load latest resumable root session")
+            .expect("latest session");
+
+        assert_eq!(latest.session_id, "telegram:latest");
+        assert_eq!(latest.kind, SessionKind::Root);
+        assert_eq!(latest.turn_count, 1);
+        assert_eq!(latest.last_turn_at, Some(200));
+        assert!(
+            repo.load_session("telegram:latest")
+                .expect("load legacy session")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn latest_resumable_root_session_returns_none_when_no_root_is_resumable() {
+        let config = isolated_memory_config("latest-no-resumable-root");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        create_root_session(&repo, "root-empty");
+        set_session_updated_at(&repo, "root-empty", 300);
+
+        create_root_session(&repo, "root-archived");
+        append_session_turn(&config, "root-archived", "assistant", "archived");
+        set_session_updated_at(&repo, "root-archived", 400);
+        set_turn_timestamps(&repo, "root-archived", 400);
+        archive_session(&repo, "root-archived", 500);
+
+        create_delegate_child_session(&repo, "delegate-child", "root-archived");
+        append_session_turn(&config, "delegate-child", "assistant", "delegate");
+        set_session_updated_at(&repo, "delegate-child", 600);
+        set_turn_timestamps(&repo, "delegate-child", 600);
+
+        append_session_turn(
+            &config,
+            "delegate:legacy-child",
+            "assistant",
+            "legacy delegate",
+        );
+        set_turn_timestamps(&repo, "delegate:legacy-child", 700);
+
+        let latest = repo
+            .latest_resumable_root_session_summary()
+            .expect("load latest resumable root session");
+
+        assert!(latest.is_none());
     }
 
     #[test]

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -1900,6 +1900,7 @@ impl SessionRepository {
                     GROUP BY session_id
                  ) archived ON archived.session_id = s.session_id
                  LEFT JOIN turns t ON t.session_id = s.session_id
+                 WHERE s.kind = 'root'
                  GROUP BY
                     s.session_id,
                     s.kind,

--- a/crates/daemon/tests/integration/cli_tests.rs
+++ b/crates/daemon/tests/integration/cli_tests.rs
@@ -1422,6 +1422,19 @@ fn chat_cli_accepts_acp_runtime_option_flags() {
 }
 
 #[test]
+fn chat_cli_accepts_latest_session_selector() {
+    let cli = try_parse_cli(["loongclaw", "chat", "--session", "latest"])
+        .expect("chat CLI should accept the latest session selector");
+
+    match cli.command {
+        Some(Commands::Chat { session, .. }) => {
+            assert_eq!(session.as_deref(), Some("latest"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
 fn feishu_send_cli_accepts_generic_target_and_target_kind() {
     let cli = try_parse_cli([
         "loongclaw",

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -263,6 +263,29 @@ fn ask_cli_accepts_message_session_and_acp_flags() {
 }
 
 #[test]
+fn ask_cli_accepts_latest_session_selector() {
+    let cli = try_parse_cli([
+        "loongclaw",
+        "ask",
+        "--message",
+        "Summarize this repository",
+        "--session",
+        "latest",
+    ])
+    .expect("ask CLI should accept the latest session selector");
+
+    match cli.command {
+        Some(Commands::Ask {
+            message, session, ..
+        }) => {
+            assert_eq!(message, "Summarize this repository");
+            assert_eq!(session.as_deref(), Some("latest"));
+        }
+        other => panic!("unexpected command parse result: {other:?}"),
+    }
+}
+
+#[test]
 fn init_spec_cli_accepts_plugin_trust_guard_preset() {
     let cli = try_parse_cli([
         "loongclaw",

--- a/docs/plans/2026-04-01-cli-latest-selector-e2e-coverage-design.md
+++ b/docs/plans/2026-04-01-cli-latest-selector-e2e-coverage-design.md
@@ -1,0 +1,91 @@
+# CLI Latest Selector End-to-End Coverage Design
+
+Date: 2026-04-01
+Issue: `#759`
+PR: `#765`
+Status: Proposed for the current task branch
+
+## Problem
+
+The current `latest` selector coverage proves three narrow layers:
+
+1. repository selection finds the expected resumable root session
+2. app-layer runtime bootstrap resolves `latest` into a concrete session id
+3. daemon CLI parsing accepts the literal `latest` flag value
+
+What is still missing is one higher-level proof that the resolved session id is actually consumed by
+the downstream CLI surfaces that matter once bootstrap completes.
+
+## Goal
+
+Add the smallest end-to-end coverage slice that proves:
+
+1. `latest` resolves through the real sqlite-backed runtime bootstrap
+2. the resolved session id flows into the chat startup summary
+3. the resolved session id is then used for real history reads
+
+## Non-Goals
+
+1. no new selector behavior
+2. no process-level binary harness for `ask` or `chat`
+3. no provider execution coverage
+4. no new generic CLI session-selector abstraction
+
+## Approaches Considered
+
+### A. Add process-level `loongclaw chat/ask` integration tests
+
+Pros:
+
+- closest to a real operator invocation
+
+Cons:
+
+- requires substantially more harness setup for config, provider behavior, and interactive I/O
+- increases flake risk without improving confidence on the specific selector handoff bug surface
+
+### B. Extend app-layer runtime tests with real sqlite memory and downstream consumers
+
+Pros:
+
+- directly exercises the real selector bootstrap path already shared by `ask` and `chat`
+- keeps changes local to the module that owns the behavior
+- can prove both startup summary and history loading use the resolved session id
+
+Cons:
+
+- not a full OS-process execution path
+
+### C. Add more repository or clap-only tests
+
+Pros:
+
+- cheapest change
+
+Cons:
+
+- does not cover the missing handoff from selector resolution into downstream CLI behavior
+
+## Decision
+
+Choose approach B.
+
+The smallest correct move is to extend `crates/app/src/chat.rs` tests with real sqlite-backed
+runtime initialization and then assert behavior at the first downstream consumers:
+
+1. `build_cli_chat_startup_summary`
+2. `load_history_lines`
+
+This keeps the test on the exact ownership boundary where the selector is implemented, avoids a
+large new harness, and meaningfully increases confidence that `latest` is not only parsed and
+resolved, but actually used by CLI behavior after bootstrap.
+
+## Validation Strategy
+
+Minimum required validation for this slice:
+
+1. add a failing async test that seeds multiple sessions and proves history comes from the resolved
+   latest root session
+2. add a failing summary-level test that proves the startup summary exposes the resolved session id
+3. implement only the minimal code needed if the tests reveal an actual gap
+4. rerun focused tests plus the full project verification already expected for this PR

--- a/docs/plans/2026-04-01-cli-latest-selector-e2e-coverage-implementation-plan.md
+++ b/docs/plans/2026-04-01-cli-latest-selector-e2e-coverage-implementation-plan.md
@@ -1,0 +1,68 @@
+# CLI Latest Selector End-to-End Coverage Implementation Plan
+
+Date: 2026-04-01
+Issue: `#759`
+PR: `#765`
+
+## Task 1: Add failing startup-summary coverage
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+
+**Steps:**
+1. Seed at least one resumable root session in sqlite memory.
+2. Initialize the real CLI runtime with `session_hint = Some("latest")`.
+3. Build the startup summary from that runtime.
+4. Assert the summary exposes the resolved session id instead of the literal selector token.
+
+**Validation:**
+```bash
+cargo test -p loongclaw-app cli_runtime_latest_session_selector_updates_startup_summary --locked
+```
+
+Expected: failing before the new coverage exists.
+
+## Task 2: Add failing downstream history coverage
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+
+**Steps:**
+1. Seed multiple sessions, including one newest resumable root session and at least one distractor.
+2. Initialize the real CLI runtime with `session_hint = Some("latest")`.
+3. Load history lines using the runtime's resolved session id.
+4. Assert the returned history matches only the newest resumable root session.
+
+**Validation:**
+```bash
+cargo test -p loongclaw-app cli_runtime_latest_session_selector_drives_history_loads --locked
+```
+
+Expected: failing before the new coverage exists.
+
+## Task 3: Implement the minimal supporting change if needed
+
+**Files:**
+- Modify only if the new tests expose a real gap
+
+**Steps:**
+1. Diagnose whether the failure is in selector resolution, summary propagation, or history loading.
+2. Apply the smallest ownership-preserving fix.
+3. Avoid broad refactors or new abstractions.
+
+## Task 4: Run focused and broad verification
+
+**Files:**
+- Modify: none unless validation exposes a necessary fix
+
+**Commands:**
+```bash
+cargo fmt --all -- --check
+cargo test -p loongclaw-app cli_runtime_latest_session_selector_updates_startup_summary --locked
+cargo test -p loongclaw-app cli_runtime_latest_session_selector_drives_history_loads --locked
+cargo test --workspace --locked
+cargo test --workspace --all-features --locked
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: all green.

--- a/docs/plans/2026-04-01-cli-session-latest-selector-design.md
+++ b/docs/plans/2026-04-01-cli-session-latest-selector-design.md
@@ -1,0 +1,156 @@
+# CLI Session Latest Selector Design
+
+## Goal
+
+Add a minimal `--session latest` selector to `loong ask` and `loong chat` so the CLI can resume
+the most recent meaningful root conversation without requiring the operator to remember a concrete
+session id.
+
+## Current Repo Facts
+
+- `crates/app/src/chat.rs`
+  - `initialize_cli_turn_runtime_with_loaded_config()` resolves the session id before the CLI
+    runtime is fully constructed
+  - `resolve_cli_session_id()` currently treats any non-empty `--session` value as a literal
+    session id
+- `crates/app/src/session/repository.rs`
+  - `SessionSummaryRecord` already exposes the metadata needed for selection:
+    - `kind`
+    - `updated_at`
+    - `archived_at`
+    - `turn_count`
+  - `load_session_summary_with_legacy_fallback()` already preserves legacy turn-only sessions for
+    single-session lookups
+  - `list_visible_sessions()` already sorts session summaries by `updated_at DESC, session_id ASC`
+- `crates/daemon/src/lib.rs`
+  - `Ask` and `Chat` already parse `--session` as an optional string
+  - CLI parsing does not need a new flag to support selector semantics
+
+## Problem
+
+The CLI supports only two session-selection modes today:
+
+- omit `--session` and fall back to the implicit `default` session
+- pass an explicit concrete session id
+
+That leaves a real continuity workflow uncovered:
+
+- resume the latest meaningful root conversation
+
+Without that selector, operators must either remember ids, inspect the session store manually, or
+reuse `default` even when that is not the conversation they actually want.
+
+## Constraints
+
+- keep the change local to the existing `--session` flag
+- do not add a generic selector language in the first iteration
+- preserve current behavior for omitted `--session`
+- preserve current behavior for explicit concrete session ids
+- avoid hardcoding session ids or out-of-band state
+- keep legacy turn-only root sessions eligible when possible
+
+## Options Considered
+
+### Option 1: Interpret `latest` inside `resolve_cli_session_id()` with direct repository access
+
+Why not:
+
+- `resolve_cli_session_id()` currently has no config or memory context
+- adding filesystem/database discovery directly into that narrow helper would blur responsibilities
+- it would make testing and future selector growth harder
+
+### Option 2: Resolve session selectors after config is loaded and memory is ready
+
+This means:
+
+- keep `--session` parsing unchanged
+- add a selector-aware resolver in the CLI runtime initialization path
+- let that resolver use `SessionRepository` and `MemoryRuntimeConfig`
+
+Why this is the recommended option:
+
+- smallest correct structural change
+- reuses the existing session repository instead of inventing a parallel lookup path
+- keeps selector behavior scoped to the CLI runtime layer
+- preserves the literal-session-id fast path
+
+### Option 3: Add a separate `--latest-session` flag
+
+Why not:
+
+- duplicates selection concepts across flags
+- complicates CLI precedence rules
+- provides less extensibility than keeping selection under the existing `--session` surface
+
+## Recommended Design
+
+Treat `latest` as a reserved selector value only for the CLI ask/chat session-resolution path.
+
+Behavior:
+
+1. trim the incoming `session_hint`
+2. if no hint is provided:
+   - keep the current implicit `default` behavior for normal ask/chat
+   - keep the current explicit-session requirement for concurrent CLI host
+3. if the hint is not `latest`:
+   - keep returning it as a literal session id
+4. if the hint is `latest`:
+   - open the configured session repository
+   - resolve the latest resumable root session
+   - return its concrete session id
+   - fail with a clear error if no eligible session exists
+
+Minimal selection rule:
+
+- session kind must be `root`
+- session must not be archived
+- session must have at least one persisted turn
+- newest `updated_at` wins
+- `session_id ASC` remains the stable tie-breaker
+- legacy turn-only root sessions remain eligible
+
+## Legacy Compatibility Decision
+
+`latest` should include legacy turn-only root sessions.
+
+Reason:
+
+- the repository already preserves legacy session continuity for targeted summary lookups
+- excluding those sessions would silently skip real conversation history after upgrade
+- this can be implemented cleanly in one repository helper instead of spreading fallback logic
+
+## Why This Is The Smallest Correct Fix
+
+- no new CLI flags
+- no new daemon command family
+- no generic selector DSL
+- no repo/worktree identity persistence in this iteration
+- no change to existing explicit session id behavior
+
+## Testing Strategy
+
+Add red-green coverage for:
+
+- repository selection:
+  - newest eligible root session is selected
+  - delegate-child sessions are excluded
+  - archived sessions are excluded
+  - empty sessions are excluded
+  - legacy turn-only root sessions remain eligible
+- app runtime selection:
+  - `latest` resolves to the expected concrete session id during CLI runtime initialization
+  - missing eligible sessions returns a clear error
+  - omitted `--session` still uses `default`
+  - explicit concrete session ids still pass through unchanged
+- daemon CLI parsing:
+  - `--session latest` is accepted for `chat`
+  - `--session latest` is accepted for `ask`
+
+## Scope Boundary
+
+This PR will not:
+
+- add repo-scoped or worktree-scoped selection
+- add selectors beyond `latest`
+- add new session-history or session-inspection CLI commands
+- modify the separate daemon sessions shell work

--- a/docs/plans/2026-04-01-cli-session-latest-selector-implementation-plan.md
+++ b/docs/plans/2026-04-01-cli-session-latest-selector-implementation-plan.md
@@ -13,7 +13,7 @@ fallback compatibility.
 
 ---
 
-### Task 1: Add the failing repository selection tests
+## Task 1: Add the failing repository selection tests
 
 **Files:**
 - Modify: `crates/app/src/session/repository.rs`
@@ -48,7 +48,7 @@ cargo test -p loongclaw-app latest_resumable_root --locked
 
 Expected: failing because the helper does not exist yet.
 
-### Task 2: Add the failing CLI runtime tests
+## Task 2: Add the failing CLI runtime tests
 
 **Files:**
 - Modify: `crates/app/src/chat.rs`
@@ -73,7 +73,7 @@ cargo test -p loongclaw-app latest_session --locked
 
 Expected: failing because selector resolution is not implemented yet.
 
-### Task 3: Add the failing daemon CLI parsing test
+## Task 3: Add the failing daemon CLI parsing test
 
 **Files:**
 - Modify: `crates/daemon/tests/integration/mod.rs`
@@ -97,7 +97,7 @@ cargo test -p loongclaw-daemon latest_session_selector --locked
 
 Expected: likely already green at the parsing layer, which confirms no parser change is required.
 
-### Task 4: Implement the repository helper
+## Task 4: Implement the repository helper
 
 **Files:**
 - Modify: `crates/app/src/session/repository.rs`
@@ -127,7 +127,7 @@ cargo test -p loongclaw-app latest_resumable_root --locked
 
 Expected: green.
 
-### Task 5: Implement selector-aware CLI session resolution
+## Task 5: Implement selector-aware CLI session resolution
 
 **Files:**
 - Modify: `crates/app/src/chat.rs`
@@ -160,7 +160,7 @@ cargo test -p loongclaw-app latest_session --locked
 
 Expected: green.
 
-### Task 6: Confirm daemon CLI parsing coverage
+## Task 6: Confirm daemon CLI parsing coverage
 
 **Files:**
 - Modify: `crates/daemon/tests/integration/mod.rs`
@@ -180,7 +180,7 @@ Expected: green.
 
 Do not change clap flag structure unless the tests prove it is necessary.
 
-### Task 7: Run focused and broad verification
+## Task 7: Run focused and broad verification
 
 **Files:**
 - Modify: none unless verification exposes a necessary fix
@@ -218,7 +218,7 @@ cargo test --workspace --all-features --locked
 Expected: all green, or any unrelated baseline failure must be explicitly investigated and
 separated from this feature before claiming readiness.
 
-### Task 8: Prepare clean GitHub delivery
+## Task 8: Prepare clean GitHub delivery
 
 **Files:**
 - Modify: GitHub artifacts through `gh`, not repository files

--- a/docs/plans/2026-04-01-cli-session-latest-selector-implementation-plan.md
+++ b/docs/plans/2026-04-01-cli-session-latest-selector-implementation-plan.md
@@ -1,0 +1,247 @@
+# CLI Session Latest Selector Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `--session latest` support for `loong ask` and `loong chat` without changing the
+existing implicit-default or explicit-session-id behavior.
+
+**Architecture:** Keep selector semantics in the CLI runtime layer and add one repository helper
+that returns the latest resumable root session using existing session summary metadata and legacy
+fallback compatibility.
+
+**Tech Stack:** Rust, rusqlite, clap, existing app and daemon integration tests
+
+---
+
+### Task 1: Add the failing repository selection tests
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+
+**Step 1: Write a failing test for the normal selector rule**
+
+Add a repository test that creates:
+
+- one archived root session with turns
+- one delegate-child session with newer timestamps
+- one empty root session without turns
+- one eligible root session
+
+Assert that the new helper returns the eligible root session id.
+
+**Step 2: Write a failing test for legacy compatibility**
+
+Add a repository test that creates:
+
+- one concrete root session with older activity
+- one legacy turn-only root session with newer activity
+
+Assert that the new helper returns the legacy root session id.
+
+**Step 3: Run the focused repository tests and verify red**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app latest_resumable_root --locked
+```
+
+Expected: failing because the helper does not exist yet.
+
+### Task 2: Add the failing CLI runtime tests
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+
+**Step 1: Write a failing runtime resolution test**
+
+Use the existing chat test memory helpers to seed session history and assert that
+`initialize_cli_turn_runtime_with_loaded_config()` resolves `Some("latest")` to the expected
+concrete session id.
+
+**Step 2: Write a failing no-match test**
+
+Assert that `Some("latest")` returns a clear error when no eligible resumable root session exists.
+
+**Step 3: Run the focused chat tests and verify red**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app latest_session --locked
+```
+
+Expected: failing because selector resolution is not implemented yet.
+
+### Task 3: Add the failing daemon CLI parsing test
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/mod.rs`
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Add a parsing test for `ask --session latest`**
+
+Assert that clap parsing accepts `latest` as the `session` value for `ask`.
+
+**Step 2: Add a parsing test for `chat --session latest`**
+
+Assert that clap parsing accepts `latest` as the `session` value for `chat`.
+
+**Step 3: Run the focused daemon parsing tests and verify red/green boundary**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon latest_session_selector --locked
+```
+
+Expected: likely already green at the parsing layer, which confirms no parser change is required.
+
+### Task 4: Implement the repository helper
+
+**Files:**
+- Modify: `crates/app/src/session/repository.rs`
+
+**Step 1: Add one public helper for selector resolution**
+
+Add a method that returns the latest resumable root `SessionSummaryRecord` or `None`.
+
+**Step 2: Reuse existing summary semantics**
+
+The helper should:
+
+- include concrete session summaries
+- include eligible legacy turn-only root sessions
+- exclude archived sessions
+- exclude delegate-child sessions
+- exclude sessions with `turn_count == 0`
+- keep deterministic newest-first ordering
+
+**Step 3: Re-run the focused repository tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app latest_resumable_root --locked
+```
+
+Expected: green.
+
+### Task 5: Implement selector-aware CLI session resolution
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+
+**Step 1: Split literal and selector handling**
+
+Keep the existing trim/default logic, then add a selector-aware resolver that can use the loaded
+config and memory runtime.
+
+**Step 2: Add `latest` handling**
+
+When the trimmed value equals `latest`, resolve the newest eligible root session through the new
+repository helper.
+
+**Step 3: Preserve existing behavior**
+
+Confirm:
+
+- omitted `--session` still yields `default`
+- concurrent host still requires an explicit concrete or selector value
+- explicit session ids still pass through unchanged
+
+**Step 4: Re-run the focused chat tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app latest_session --locked
+```
+
+Expected: green.
+
+### Task 6: Confirm daemon CLI parsing coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/mod.rs`
+- Modify: `crates/daemon/tests/integration/cli_tests.rs`
+
+**Step 1: Run the focused daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon latest_session_selector --locked
+```
+
+Expected: green.
+
+**Step 2: Keep scope tight**
+
+Do not change clap flag structure unless the tests prove it is necessary.
+
+### Task 7: Run focused and broad verification
+
+**Files:**
+- Modify: none unless verification exposes a necessary fix
+
+**Step 1: Run focused app and daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app latest_resumable_root --locked
+cargo test -p loongclaw-app latest_session --locked
+cargo test -p loongclaw-daemon latest_session_selector --locked
+```
+
+**Step 2: Run broader relevant coverage**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app chat --locked
+cargo test -p loongclaw-app session::repository --locked
+```
+
+**Step 3: Run formatting and workspace verification**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --locked
+cargo test --workspace --all-features --locked
+```
+
+Expected: all green, or any unrelated baseline failure must be explicitly investigated and
+separated from this feature before claiming readiness.
+
+### Task 8: Prepare clean GitHub delivery
+
+**Files:**
+- Modify: GitHub artifacts through `gh`, not repository files
+
+**Step 1: Inspect isolated changes**
+
+Run:
+
+```bash
+git status --short
+git diff -- crates/app/src/chat.rs crates/app/src/session/repository.rs crates/daemon/tests/integration/mod.rs crates/daemon/tests/integration/cli_tests.rs docs/plans/2026-04-01-cli-session-latest-selector-design.md docs/plans/2026-04-01-cli-session-latest-selector-implementation-plan.md
+```
+
+**Step 2: Commit with a scoped message**
+
+Run:
+
+```bash
+git add crates/app/src/chat.rs crates/app/src/session/repository.rs crates/daemon/tests/integration/mod.rs crates/daemon/tests/integration/cli_tests.rs docs/plans/2026-04-01-cli-session-latest-selector-design.md docs/plans/2026-04-01-cli-session-latest-selector-implementation-plan.md
+git commit -m "Add latest session selector for CLI ask and chat"
+```
+
+**Step 3: Create linked PR**
+
+Use the repository PR template, link `#759` with an explicit closing clause, and record the exact
+verification commands and outcomes.

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T06:33:24Z
+- Generated at: 2026-04-01T09:03:48Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -20,7 +20,7 @@
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2698 | 2800 | 102 | 56 | 65 | 9 | 96.4% | TIGHT | 2698 | 0.0% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10378 | 10500 | 122 | 89 | 90 | 1 | 98.9% | TIGHT | 9922 | 4.6% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9798 | 9800 | 2 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
-| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6936 | 7300 | 364 | 146 | 160 | 14 | 95.0% | TIGHT | 6936 | 0.0% | PASS | 146 |
+| chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14472 | 15000 | 528 | 54 | 70 | 16 | 96.5% | TIGHT | 14472 | 0.0% | PASS | 54 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.0%), turn_coordinator (96.7%), tools_mod (96.5%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (96.5%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -65,7 +65,7 @@
 <!-- arch-hotspot key=acpx_runtime lines=2698 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=10378 functions=89 -->
 <!-- arch-hotspot key=channel_config lines=9798 functions=90 -->
-<!-- arch-hotspot key=chat_runtime lines=6936 functions=146 -->
+<!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10831 functions=98 -->
 <!-- arch-hotspot key=tools_mod lines=14472 functions=54 -->


### PR DESCRIPTION
## Summary

- Problem: `loong ask` and `loong chat` could not resume the newest meaningful root conversation without a concrete session id, and the follow-up app-layer coverage pushed `crates/app/src/chat.rs` over the architecture hotspot budget.
- Why it matters: operators should be able to resume the latest CLI conversation directly, and the supporting test coverage should not make the PR fail governance for unrelated structural reasons.
- What changed:
  - Added `--session latest` resolution in the app-layer CLI runtime bootstrap.
  - Added a repository helper that selects the latest resumable root session by existing summary semantics, including legacy turn-only root sessions.
  - Added regression coverage for repository selection, runtime resolution, and daemon CLI parsing acceptance for `ask` and `chat`.
  - Added sqlite-backed app-layer coverage that proves the resolved `latest` session id flows into chat startup summaries and direct history loading.
  - Refactored the latest-selector app-layer tests into a dedicated `chat/latest_session_selector_tests.rs` module so `chat_runtime` stays within the architecture contract.
  - Refreshed `docs/releases/architecture-drift-2026-04.md` to match the post-refactor hotspot metrics required by the governance gate.
- What did not change (scope boundary):
  - No new CLI flag or generic selector DSL.
  - No change to omitted `--session` behavior; it still falls back to `default`.
  - No change to concurrent explicit-session flows; there `latest` remains a literal session id.
  - No change to architecture budgets, boundary definitions, or governance policy thresholds.

## Linked Issues

- Closes #759
- Related #759

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- Passed.

cargo test -p loongclaw-app latest_session_selector --locked
- Passed. All 8 latest-selector runtime tests in the dedicated test module.

scripts/check_architecture_drift_freshness.sh
- Passed.

LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh
- Passed. `chat_runtime` is back under budget at 6976 / 7300 lines and 147 / 160 functions.

git diff --check
- Passed.

cargo test --workspace --locked
- Passed.

cargo test --workspace --all-features --locked
- Passed.

cargo clippy --workspace --all-targets --all-features -- -D warnings
- Passed.

./scripts/check_dep_graph.sh
- Passed.

LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
- Passed.

scripts/bootstrap_release_local_artifacts.sh
- Passed.
```

## User-visible / Operator-visible Changes

- `loong ask --session latest` and `loong chat --session latest` now resume the latest resumable root session instead of requiring a concrete session id.
- If no eligible root session exists, the CLI now returns a clear `latest` selector error.
- Omitted `--session` still resolves to `default`, and concurrent explicit-session flows still treat `latest` literally.

## Failure Recovery

- Fast rollback or disable path: revert commits `347c0a4f`, `ae9990ce`, `6fbc8571`, and `ac40c6d9`, or use an explicit session id / omit `--session` to keep previous operator workflows.
- Observable failure symptoms reviewers should watch for: `latest` selecting a different conversation than expected if an operator assumes `last_turn_at` ordering instead of the existing `updated_at DESC, session_id ASC` repository semantics, or future app-layer tests pushing `chat.rs` back over the hotspot budget.

## Reviewer Focus

- `crates/app/src/chat.rs`: verify that selector semantics are only applied on the `AllowImplicitDefault` runtime path and that the chat hotspot budget stays below the configured limit.
- `crates/app/src/chat/latest_session_selector_tests.rs`: verify the dedicated app-layer coverage still exercises startup-summary and history-loading behavior without reintroducing `chat.rs` bloat.
- `crates/app/src/session/repository.rs`: verify eligibility filtering, ordering, and legacy root-session fallback behavior.
- `crates/daemon/tests/integration/mod.rs` and `crates/daemon/tests/integration/cli_tests.rs`: verify `ask` and `chat` continue to accept the literal `latest` selector value.
- `docs/releases/architecture-drift-2026-04.md`: verify the refreshed hotspot metrics match the refactored `chat_runtime` footprint.
