### PR TITLE
feat(app): introduce private operator runtime seam

### DIFF
--- a/crates/app/src/acp/manager.rs
+++ b/crates/app/src/acp/manager.rs
@@ -176,7 +176,7 @@ impl AcpSessionManager {
         request: &AcpTurnRequest,
         sink: Option<&dyn AcpTurnEventSink>,
     ) -> CliResult<AcpTurnResult> {
-        let started_at = std::time::Instant::now();
+        let end_to_end_started_at = std::time::Instant::now();
         let actor_key = actor_key_for_bootstrap(bootstrap);
         let _turn_queue_guard = self.acquire_turn_queue_guard(actor_key.clone()).await?;
         self.cleanup_idle_sessions(config).await?;
@@ -207,6 +207,7 @@ impl AcpSessionManager {
         });
         self.register_active_turn(actor_key.as_str(), active_turn.clone())?;
         let turn_started_ms = now_ms();
+        let execution_started_at = std::time::Instant::now();
         let buffered_sink = BufferedAcpTurnEventSink::default();
         let result = match sink {
             Some(external_sink) => {
@@ -238,11 +239,13 @@ impl AcpSessionManager {
         };
 
         self.clear_active_turn(actor_key.as_str())?;
+        let end_to_end_duration_ms = end_to_end_started_at.elapsed().as_millis();
+        let execution_duration_ms = execution_started_at.elapsed().as_millis();
+        let queue_wait_ms = end_to_end_duration_ms.saturating_sub(execution_duration_ms);
         match result {
             Ok(mut result) => {
                 self.record_turn_completion(turn_started_ms, true)?;
                 let streamed_events = buffered_sink.snapshot()?;
-                let duration_ms = started_at.elapsed().as_millis();
                 let reported_event_count = result.events.len();
                 let streamed_event_count = streamed_events.len();
                 result.events = merge_turn_events(&result.events, &streamed_events);
@@ -258,7 +261,9 @@ impl AcpSessionManager {
                     reported_event_count,
                     streamed_event_count,
                     merged_event_count = result.events.len(),
-                    duration_ms,
+                    end_to_end_duration_ms,
+                    execution_duration_ms,
+                    queue_wait_ms,
                     has_trace_id = trace_id.is_some(),
                     "ACP turn completed"
                 );
@@ -273,7 +278,10 @@ impl AcpSessionManager {
                 tracing::warn!(
                     target: "loongclaw.acp",
                     backend_id = %handle.backend_id,
-                    duration_ms = started_at.elapsed().as_millis(),
+                    trace_id = ?trace_id,
+                    end_to_end_duration_ms,
+                    execution_duration_ms,
+                    queue_wait_ms,
                     error = %crate::observability::summarize_error(error.as_str()),
                     has_trace_id = trace_id.is_some(),
                     "ACP turn failed"

--- a/crates/app/src/channel/dispatch.rs
+++ b/crates/app/src/channel/dispatch.rs
@@ -3326,16 +3326,22 @@ pub(crate) async fn process_inbound_with_provider(
     feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<String> {
     let started_at = std::time::Instant::now();
-    let turn_config = reload_channel_turn_config(config, resolved_path)?;
-    let runtime = DefaultConversationRuntime::from_config_or_env(&turn_config)?;
-    let result = process_inbound_with_runtime_and_feedback(
-        &turn_config,
-        &runtime,
-        message,
-        ConversationRuntimeBinding::kernel(kernel_ctx),
-        feedback_policy,
-    )
-    .await;
+    let result = match reload_channel_turn_config(config, resolved_path) {
+        Ok(turn_config) => match DefaultConversationRuntime::from_config_or_env(&turn_config) {
+            Ok(runtime) => {
+                process_inbound_with_runtime_and_feedback(
+                    &turn_config,
+                    &runtime,
+                    message,
+                    ConversationRuntimeBinding::kernel(kernel_ctx),
+                    feedback_policy,
+                )
+                .await
+            }
+            Err(error) => Err(error),
+        },
+        Err(error) => Err(error),
+    };
     let duration_ms = started_at.elapsed().as_millis();
     match &result {
         Ok(reply) => {

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -38,6 +38,8 @@ use super::turn_middleware_registry::{
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
+use crate::operator::session_graph::OperatorSessionGraph;
+#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     SessionKind, SessionRepository, SessionState, SessionToolPolicyRecord,
     TransitionSessionWithEventIfCurrentRequest,
@@ -266,7 +268,8 @@ fn build_base_tool_view_from_snapshot(
     };
 
     if snapshot.parent_session_id.is_some() {
-        let depth = match repo.session_lineage_depth(session_id) {
+        let session_graph = OperatorSessionGraph::new(repo);
+        let depth = match session_graph.lineage_depth(session_id) {
             Ok(depth) => depth,
             Err(error)
                 if error.starts_with("session_lineage_broken:")

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -17392,6 +17392,144 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_approve_always_persists_grant_without_session_row()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(
+            "conversation-approval-resolve",
+            "approve-always-missing-session-row"
+        )
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-missing-session-row".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-delegate-parent".to_owned(),
+        tool_call_id: "call-delegate-parent".to_owned(),
+        tool_name: "delegate".to_owned(),
+        approval_key: "tool:delegate".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-delegate-parent",
+            "tool_call_id": "call-delegate-parent",
+            "tool_name": "delegate",
+            "args_json": {
+                "task": "child task",
+                "label": "research-subtask"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "app"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "topology_mutation",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "governed_tool_requires_approval",
+            "reason": "operator approval required before running `delegate`"
+        }),
+    })
+    .expect("seed approval request");
+
+    let connection = Connection::open(&db_path).expect("open sqlite connection");
+
+    connection
+        .execute(
+            "DELETE FROM sessions WHERE session_id = ?1",
+            rusqlite::params!["root-session"],
+        )
+        .expect("delete root session row");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "resolving approval".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
+                        "approval_request_id": "apr-missing-session-row",
+                        "decision": "approve_always"
+                    }),
+                    "root-session",
+                    "turn-approval-resolve",
+                    "call-approval-resolve",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("approval resolve reply");
+
+    assert!(
+        reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {reply}"
+    );
+
+    let resolved = repo
+        .load_approval_request("apr-missing-session-row")
+        .expect("load approval request")
+        .expect("approval request row");
+
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(
+        resolved.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveAlways)
+    );
+
+    let grant = repo
+        .load_approval_grant("root-session", "tool:delegate")
+        .expect("load approval grant");
+
+    assert!(
+        grant.is_some(),
+        "expected root-session grant to be persisted"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_delegate() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -39,8 +39,9 @@ use crate::memory::{
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord, NewSessionToolPolicyRecord,
-    SessionKind, SessionRepository, SessionState,
+    ApprovalRequestStatus, NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord,
+    NewSessionToolPolicyRecord, SessionKind, SessionRepository, SessionState,
+    TransitionApprovalRequestIfCurrentRequest,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -325,6 +326,162 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
         )
         .await?;
         Ok(())
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct ApprovalFinalizationConflictRuntime {
+    inner: FakeRuntime,
+    memory_config: MemoryRuntimeConfig,
+    approval_request_id: String,
+    replay_error: String,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl ApprovalFinalizationConflictRuntime {
+    fn new(
+        inner: FakeRuntime,
+        memory_config: MemoryRuntimeConfig,
+        approval_request_id: &str,
+        replay_error: &str,
+    ) -> Self {
+        Self {
+            inner,
+            memory_config,
+            approval_request_id: approval_request_id.to_owned(),
+            replay_error: replay_error.to_owned(),
+        }
+    }
+
+    fn finalize_request_out_of_band_if_executing(&self) -> CliResult<bool> {
+        let repo = SessionRepository::new(&self.memory_config)?;
+        let transition_request = TransitionApprovalRequestIfCurrentRequest {
+            expected_status: ApprovalRequestStatus::Executing,
+            next_status: ApprovalRequestStatus::Executed,
+            decision: None,
+            resolved_by_session_id: None,
+            executed_at: Some(1),
+            last_error: Some("out_of_band_finalize".to_owned()),
+        };
+        let finalized = repo.transition_approval_request_if_current(
+            &self.approval_request_id,
+            transition_request,
+        )?;
+
+        Ok(finalized.is_some())
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl ConversationRuntime for ApprovalFinalizationConflictRuntime {
+    fn session_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<SessionContext> {
+        let finalized = self.finalize_request_out_of_band_if_executing()?;
+
+        if finalized {
+            return Err(self.replay_error.clone());
+        }
+
+        self.inner.session_context(config, session_id, binding)
+    }
+
+    fn tool_view(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<crate::tools::ToolView> {
+        self.inner.tool_view(config, session_id, binding)
+    }
+
+    async fn build_context(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<AssembledConversationContext> {
+        self.inner
+            .build_context(config, session_id, include_system_prompt, binding)
+            .await
+    }
+
+    async fn build_messages(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        include_system_prompt: bool,
+        tool_view: &crate::tools::ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<Vec<Value>> {
+        self.inner
+            .build_messages(
+                config,
+                session_id,
+                include_system_prompt,
+                tool_view,
+                binding,
+            )
+            .await
+    }
+
+    async fn request_completion(
+        &self,
+        config: &LoongClawConfig,
+        messages: &[Value],
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<String> {
+        self.inner
+            .request_completion(config, messages, binding)
+            .await
+    }
+
+    async fn request_turn(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
+        messages: &[Value],
+        tool_view: &crate::tools::ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<ProviderTurn> {
+        self.inner
+            .request_turn(config, session_id, turn_id, messages, tool_view, binding)
+            .await
+    }
+
+    async fn request_turn_streaming(
+        &self,
+        config: &LoongClawConfig,
+        session_id: &str,
+        turn_id: &str,
+        messages: &[Value],
+        tool_view: &crate::tools::ToolView,
+        binding: ConversationRuntimeBinding<'_>,
+        on_token: crate::provider::StreamingTokenCallback,
+    ) -> CliResult<ProviderTurn> {
+        self.inner
+            .request_turn_streaming(
+                config, session_id, turn_id, messages, tool_view, binding, on_token,
+            )
+            .await
+    }
+
+    async fn persist_turn(
+        &self,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> CliResult<()> {
+        self.inner
+            .persist_turn(session_id, role, content, binding)
+            .await
     }
 }
 
@@ -17526,6 +17683,118 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_persis
         grant.is_some(),
         "expected root-session grant to be persisted"
     );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_surfaces_finalize_conflict_on_replay_error()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-approval-resolve", "finalize-conflict")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-delegate-finalize-conflict".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-delegate-parent".to_owned(),
+        tool_call_id: "call-delegate-parent".to_owned(),
+        tool_name: "delegate".to_owned(),
+        approval_key: "tool:delegate".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-delegate-parent",
+            "tool_call_id": "call-delegate-parent",
+            "tool_name": "delegate",
+            "args_json": {
+                "task": "child task",
+                "label": "finalize-conflict"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "app"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "topology_mutation",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "governed_tool_requires_approval",
+            "reason": "operator approval required before running `delegate`"
+        }),
+    })
+    .expect("seed approval request");
+
+    let inner_runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "resolving approval".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "approval_request_resolve",
+                json!({
+                    "approval_request_id": "apr-delegate-finalize-conflict",
+                    "decision": "approve_once"
+                }),
+                "root-session",
+                "turn-approval-resolve",
+                "call-approval-resolve",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let runtime = ApprovalFinalizationConflictRuntime::new(
+        inner_runtime,
+        memory_config.clone(),
+        "apr-delegate-finalize-conflict",
+        "synthetic_replay_failure",
+    );
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("finalization conflict should surface in the raw reply");
+
+    assert!(
+        reply.contains("approval_request_not_executing"),
+        "reply={reply}"
+    );
+    assert!(reply.contains("synthetic_replay_failure"), "reply={reply}");
+
+    let resolved = repo
+        .load_approval_request("apr-delegate-finalize-conflict")
+        .expect("load approval request")
+        .expect("approval request row");
+
+    assert_eq!(
+        resolved.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(resolved.last_error.as_deref(), Some("out_of_band_finalize"));
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -5,8 +5,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 #[cfg(feature = "memory-sqlite")]
 use std::panic::AssertUnwindSafe;
-#[cfg(feature = "memory-sqlite")]
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 #[cfg(feature = "memory-sqlite")]
@@ -28,6 +26,10 @@ use crate::acp::{
     execute_acp_conversation_turn_for_address,
 };
 use crate::memory::runtime_config::MemoryRuntimeConfig;
+#[cfg(feature = "memory-sqlite")]
+use crate::operator::approval_runtime::OperatorApprovalRuntime;
+#[cfg(feature = "memory-sqlite")]
+use crate::operator::session_graph::OperatorSessionGraph;
 use crate::runtime_self_continuity;
 use crate::tools::ToolExecutionKind;
 
@@ -125,9 +127,8 @@ use crate::session::recovery::{
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, CreateSessionWithEventRequest,
-    FinalizeSessionTerminalRequest, NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord,
-    NewSessionToolConsentRecord, SessionKind, SessionRepository, SessionState,
-    TransitionApprovalRequestIfCurrentRequest, TransitionSessionWithEventIfCurrentRequest,
+    FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, NewSessionToolConsentRecord,
+    SessionKind, SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
 };
 
 #[derive(Default)]
@@ -3669,13 +3670,6 @@ impl<R> CoordinatorApprovalResolutionRuntime<'_, R>
 where
     R: ConversationRuntime + ?Sized,
 {
-    fn current_epoch_s() -> i64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_secs() as i64)
-            .unwrap_or(0)
-    }
-
     fn replay_request(
         &self,
         approval_request: &ApprovalRequestRecord,
@@ -3717,6 +3711,15 @@ where
                 "approval_request_invalid_execution_kind: expected `core` or `app`, got `{execution_kind}`"
             )),
         }
+    }
+
+    fn request_parent_session_id(approval_request: &ApprovalRequestRecord) -> Option<&str> {
+        approval_request
+            .request_payload_json
+            .get("parent_session_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
     }
 
     async fn replay_approved_request(
@@ -3778,38 +3781,14 @@ where
         repo: &SessionRepository,
         approval_request_id: &str,
     ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let executing = repo
-            .transition_approval_request_if_current(
-                approval_request_id,
-                TransitionApprovalRequestIfCurrentRequest {
-                    expected_status: ApprovalRequestStatus::Approved,
-                    next_status: ApprovalRequestStatus::Executing,
-                    decision: None,
-                    resolved_by_session_id: None,
-                    executed_at: None,
-                    last_error: None,
-                },
-            )?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_not_approved: `{approval_request_id}` is no longer approved"
-                )
-            })?;
+        let approval_runtime = OperatorApprovalRuntime::new(repo);
+        let executing = approval_runtime.begin_approved_request_execution(approval_request_id)?;
+        approval_runtime.ensure_request_session(&executing)?;
 
         match self.replay_approved_request(&executing).await {
             Ok(resumed_tool_output) => {
-                let executed = repo
-                    .transition_approval_request_if_current(
-                        approval_request_id,
-                        TransitionApprovalRequestIfCurrentRequest {
-                            expected_status: ApprovalRequestStatus::Executing,
-                            next_status: ApprovalRequestStatus::Executed,
-                            decision: None,
-                            resolved_by_session_id: None,
-                            executed_at: Some(Self::current_epoch_s()),
-                            last_error: None,
-                        },
-                    )?
+                let executed = approval_runtime
+                    .finish_executing_request(approval_request_id, None)?
                     .ok_or_else(|| {
                         format!(
                             "approval_request_not_executing: `{approval_request_id}` is no longer executing"
@@ -3821,16 +3800,9 @@ where
                 })
             }
             Err(error) => {
-                let _ = repo.transition_approval_request_if_current(
+                let _ = approval_runtime.finish_executing_request(
                     approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Executing,
-                        next_status: ApprovalRequestStatus::Executed,
-                        decision: None,
-                        resolved_by_session_id: None,
-                        executed_at: Some(Self::current_epoch_s()),
-                        last_error: Some(error.clone()),
-                    },
+                    Some(error.as_str()),
                 )?;
                 Err(error)
             }
@@ -3851,6 +3823,7 @@ where
     ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
         let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
         let repo = SessionRepository::new(&memory_config)?;
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
         let approval_request = repo
             .load_approval_request(&request.approval_request_id)?
             .ok_or_else(|| {
@@ -3872,6 +3845,7 @@ where
                     )?
             }
         };
+        approval_runtime.ensure_request_session(&approval_request)?;
         if !is_visible {
             return Err(format!(
                 "visibility_denied: session `{}` is not visible from `{}`",
@@ -3881,77 +3855,26 @@ where
 
         match request.decision {
             ApprovalDecision::Deny => {
-                let resolved = match repo.transition_approval_request_if_current(
+                let resolved = approval_runtime.resolve_pending_request(
                     &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Denied,
-                        decision: Some(ApprovalDecision::Deny),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(resolved) => resolved,
-                    None => {
-                        let latest = repo
-                            .load_approval_request(&request.approval_request_id)?
-                            .ok_or_else(|| {
-                                format!(
-                                    "approval_request_not_found: `{}`",
-                                    request.approval_request_id
-                                )
-                            })?;
-                        return Err(format!(
-                            "approval_request_not_pending: `{}` is already {}",
-                            request.approval_request_id,
-                            latest.status.as_str()
-                        ));
-                    }
-                };
+                    ApprovalDecision::Deny,
+                    &request.current_session_id,
+                )?;
                 Ok(crate::tools::approval::ApprovalResolutionOutcome {
                     approval_request: resolved,
                     resumed_tool_output: None,
                 })
             }
             ApprovalDecision::ApproveOnce => {
-                let approved = match repo.transition_approval_request_if_current(
+                let approved = approval_runtime.resolve_pending_request(
                     &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Approved,
-                        decision: Some(ApprovalDecision::ApproveOnce),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(approved) => approved,
-                    None => {
-                        let latest = repo
-                            .load_approval_request(&request.approval_request_id)?
-                            .ok_or_else(|| {
-                                format!(
-                                    "approval_request_not_found: `{}`",
-                                    request.approval_request_id
-                                )
-                            })?;
-                        return Err(format!(
-                            "approval_request_not_pending: `{}` is already {}",
-                            request.approval_request_id,
-                            latest.status.as_str()
-                        ));
-                    }
-                };
+                    ApprovalDecision::ApproveOnce,
+                    &request.current_session_id,
+                )?;
                 if let Some(session_consent_mode) = request.session_consent_mode {
-                    let scope_session_id = repo
-                        .lineage_root_session_id(&approved.session_id)?
-                        .ok_or_else(|| {
-                            format!(
-                                "approval_request_session_not_found: `{}`",
-                                approved.session_id
-                            )
-                        })?;
+                    let parent_session_id = Self::request_parent_session_id(&approved);
+                    let scope_session_id = approval_runtime
+                        .grant_scope_session_id(&approved.session_id, parent_session_id)?;
                     let updated_by_session_id = Some(request.current_session_id.clone());
                     repo.upsert_session_tool_consent(NewSessionToolConsentRecord {
                         scope_session_id,
@@ -3963,47 +3886,11 @@ where
                     .await
             }
             ApprovalDecision::ApproveAlways => {
-                let approved = match repo.transition_approval_request_if_current(
+                let _approved = approval_runtime.resolve_pending_request(
                     &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Approved,
-                        decision: Some(ApprovalDecision::ApproveAlways),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(approved) => approved,
-                    None => {
-                        let latest = repo
-                            .load_approval_request(&request.approval_request_id)?
-                            .ok_or_else(|| {
-                                format!(
-                                    "approval_request_not_found: `{}`",
-                                    request.approval_request_id
-                                )
-                            })?;
-                        return Err(format!(
-                            "approval_request_not_pending: `{}` is already {}",
-                            request.approval_request_id,
-                            latest.status.as_str()
-                        ));
-                    }
-                };
-                let grant_scope_session_id = repo
-                    .lineage_root_session_id(&approved.session_id)?
-                    .ok_or_else(|| {
-                        format!(
-                            "approval_request_session_not_found: `{}`",
-                            approved.session_id
-                        )
-                    })?;
-                repo.upsert_approval_grant(NewApprovalGrantRecord {
-                    scope_session_id: grant_scope_session_id,
-                    approval_key: approved.approval_key.clone(),
-                    created_by_session_id: Some(request.current_session_id.clone()),
-                })?;
+                    ApprovalDecision::ApproveAlways,
+                    &request.current_session_id,
+                )?;
                 self.execute_approved_request(&repo, &request.approval_request_id)
                     .await
             }
@@ -4719,16 +4606,9 @@ fn next_delegate_child_depth_for_delegate(
     repo: &SessionRepository,
     session_context: &SessionContext,
 ) -> Result<usize, String> {
-    let current_depth = repo.session_lineage_depth(&session_context.session_id)?;
-    let next_child_depth = current_depth.saturating_add(1);
-    if next_child_depth > config.tools.delegate.max_depth {
-        return Err(format!(
-            "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {}",
-            config.tools.delegate.max_depth
-        ));
-    }
-
-    Ok(next_child_depth)
+    let session_graph = OperatorSessionGraph::new(repo);
+    session_graph
+        .next_delegate_child_depth(&session_context.session_id, config.tools.delegate.max_depth)
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3800,10 +3800,13 @@ where
                 })
             }
             Err(error) => {
-                let _ = approval_runtime.finish_executing_request(
-                    approval_request_id,
-                    Some(error.as_str()),
-                )?;
+                let maybe_executed = approval_runtime
+                    .finish_executing_request(approval_request_id, Some(error.as_str()))?;
+                if maybe_executed.is_none() {
+                    return Err(format!(
+                        "approval_request_not_executing: `{approval_request_id}` is no longer executing; original replay error: {error}"
+                    ));
+                }
                 Err(error)
             }
         }

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -18,6 +18,10 @@ use crate::config::{
 use crate::context::KernelContext;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
+use crate::operator::approval_runtime::{GovernedToolApprovalRequest, OperatorApprovalRuntime};
+#[cfg(feature = "memory-sqlite")]
+use crate::operator::session_graph::OperatorSessionGraph;
+#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     NewApprovalRequestRecord, NewSessionRecord, SessionKind, SessionRepository, SessionState,
 };
@@ -613,10 +617,11 @@ impl DefaultAppToolDispatcher {
         session_context: &SessionContext,
     ) -> Result<ToolView, String> {
         let repo = SessionRepository::new(&self.memory_config)?;
+        let session_graph = OperatorSessionGraph::new(&repo);
         if let Some(session) = repo.load_session(&session_context.session_id)? {
             if session.parent_session_id.is_some() {
-                let depth = repo
-                    .session_lineage_depth(&session_context.session_id)
+                let depth = session_graph
+                    .lineage_depth(&session_context.session_id)
                     .map_err(|error| {
                         format!(
                             "compute session lineage depth for dispatcher tool view failed: {error}"
@@ -688,23 +693,11 @@ impl DefaultAppToolDispatcher {
         repo: &SessionRepository,
         session_context: &SessionContext,
     ) -> Result<String, String> {
-        let mut current_session_id = session_context.session_id.clone();
-        let mut visited = BTreeSet::new();
-
-        loop {
-            if !visited.insert(current_session_id.clone()) {
-                return Err(format!(
-                    "session_lineage_cycle_detected: `{current_session_id}` reappeared while resolving approval grant scope"
-                ));
-            }
-            let Some(session) = repo.load_session(&current_session_id)? else {
-                return Ok(current_session_id);
-            };
-            match session.parent_session_id {
-                Some(parent_session_id) => current_session_id = parent_session_id,
-                None => return Ok(current_session_id),
-            }
-        }
+        let session_graph = OperatorSessionGraph::new(repo);
+        session_graph.effective_lineage_root_session_id(
+            &session_context.session_id,
+            session_context.parent_session_id.as_deref(),
+        )
     }
 
     fn autonomy_policy_snapshot(&self) -> crate::tools::runtime_config::AutonomyPolicySnapshot {
@@ -714,9 +707,7 @@ impl DefaultAppToolDispatcher {
     }
 
     fn approval_key_for_descriptor(descriptor: &crate::tools::ToolDescriptor) -> String {
-        let tool_name = descriptor.name;
-        let approval_key = format!("tool:{tool_name}");
-        approval_key
+        OperatorApprovalRuntime::approval_key_for_tool_name(descriptor.name)
     }
 
     fn is_tool_call_preapproved(&self, approval_key: &str) -> bool {
@@ -806,8 +797,12 @@ impl DefaultAppToolDispatcher {
         approval_key: &str,
     ) -> Result<bool, String> {
         let repo = SessionRepository::new(&self.memory_config)?;
-        let scope_session_id = Self::lineage_root_session_id(&repo, session_context)?;
-        let grant = repo.load_approval_grant(&scope_session_id, approval_key)?;
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
+        let grant = approval_runtime.load_runtime_grant_for_context(
+            &session_context.session_id,
+            session_context.parent_session_id.as_deref(),
+            approval_key,
+        )?;
         Ok(grant.is_some())
     }
 
@@ -847,7 +842,14 @@ impl DefaultAppToolDispatcher {
                 "app_tool_denied: governed tool `{approval_key}` is denied by approval policy"
             ));
         }
-        if self.has_approval_grant(session_context, approval_key.as_str())? {
+        let repo = SessionRepository::new(&self.memory_config)?;
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
+        let runtime_grant = approval_runtime.load_runtime_grant_for_context(
+            &session_context.session_id,
+            session_context.parent_session_id.as_deref(),
+            &approval_key,
+        )?;
+        if runtime_grant.is_some() {
             return Ok(None);
         }
 
@@ -856,22 +858,28 @@ impl DefaultAppToolDispatcher {
             descriptor.name
         );
         let rule_id = "governed_tool_requires_approval";
-        let governance_snapshot_json = json!({
-            "governance_scope": governance.scope.as_str(),
-            "risk_class": governance.risk_class.as_str(),
-            "approval_mode": governance.approval_mode.as_str(),
-            "rule_id": rule_id,
-            "reason": reason,
-        });
-        let requirement = self.persist_approval_request(
-            session_context,
-            intent,
-            descriptor,
-            approval_key.as_str(),
-            reason.as_str(),
+        let approval_request = GovernedToolApprovalRequest {
+            session_id: &session_context.session_id,
+            parent_session_id: session_context.parent_session_id.as_deref(),
+            turn_id: &intent.turn_id,
+            tool_call_id: &intent.tool_call_id,
+            tool_name: descriptor.name,
+            args_json: intent.args_json.clone(),
+            source: &intent.source,
+            governance_scope: governance.scope.as_str(),
+            risk_class: governance.risk_class.as_str(),
+            approval_mode: governance.approval_mode.as_str(),
+            reason: &reason,
             rule_id,
-            governance_snapshot_json,
-        )?;
+        };
+        let stored = approval_runtime.ensure_governed_tool_approval_request(approval_request)?;
+        let requirement = ApprovalRequirement::governed_tool(
+            descriptor.name,
+            approval_key,
+            reason,
+            rule_id,
+            Some(stored.approval_request_id),
+        );
         Ok(Some(requirement))
     }
 
@@ -1124,7 +1132,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
         {
             let _ = binding;
             let governance = governance_profile_for_descriptor(descriptor);
-            let approval_key = format!("tool:{}", descriptor.name);
+            let approval_key = Self::approval_key_for_descriptor(descriptor);
             let governed_approval_eligible = descriptor.execution_kind == ToolExecutionKind::App
                 && governance.approval_mode == ToolApprovalMode::PolicyDriven;
             let approval_key_is_denied = governed_approval_eligible

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -9,6 +9,7 @@ pub mod crypto;
 pub mod memory;
 pub mod migration;
 pub(crate) mod observability;
+pub(crate) mod operator;
 pub mod presentation;
 pub mod prompt;
 pub mod provider;

--- a/crates/app/src/operator/approval_runtime.rs
+++ b/crates/app/src/operator/approval_runtime.rs
@@ -1,0 +1,672 @@
+#[cfg(feature = "memory-sqlite")]
+use loongclaw_contracts::ToolCoreRequest;
+#[cfg(feature = "memory-sqlite")]
+use serde_json::{Value, json};
+#[cfg(feature = "memory-sqlite")]
+use sha2::{Digest, Sha256};
+
+#[cfg(feature = "memory-sqlite")]
+use crate::operator::session_graph::OperatorSessionGraph;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    ApprovalDecision, ApprovalGrantRecord, ApprovalRequestRecord, ApprovalRequestStatus,
+    NewApprovalGrantRecord, NewApprovalRequestRecord, NewSessionRecord, SessionKind,
+    SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
+};
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) struct GovernedToolApprovalRequest<'a> {
+    pub session_id: &'a str,
+    pub parent_session_id: Option<&'a str>,
+    pub turn_id: &'a str,
+    pub tool_call_id: &'a str,
+    pub tool_name: &'a str,
+    pub args_json: Value,
+    pub source: &'a str,
+    pub governance_scope: &'a str,
+    pub risk_class: &'a str,
+    pub approval_mode: &'a str,
+    pub reason: &'a str,
+    pub rule_id: &'a str,
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) struct OperatorApprovalRuntime<'a> {
+    repo: &'a SessionRepository,
+    session_graph: OperatorSessionGraph<'a>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl<'a> OperatorApprovalRuntime<'a> {
+    pub(crate) fn new(repo: &'a SessionRepository) -> Self {
+        let session_graph = OperatorSessionGraph::new(repo);
+
+        Self {
+            repo,
+            session_graph,
+        }
+    }
+
+    pub(crate) fn approval_key_for_tool_name(tool_name: &str) -> String {
+        format!("tool:{tool_name}")
+    }
+
+    pub(crate) fn governed_approval_request_id(
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+        tool_name: &str,
+    ) -> String {
+        let mut hasher = Sha256::new();
+
+        hasher.update(session_id.as_bytes());
+        hasher.update([0]);
+        hasher.update(turn_id.as_bytes());
+        hasher.update([0]);
+        hasher.update(tool_call_id.as_bytes());
+        hasher.update([0]);
+        hasher.update(tool_name.as_bytes());
+
+        let digest = hasher.finalize();
+        let request_id = format!("apr_{digest:x}");
+
+        request_id
+    }
+
+    pub(crate) fn ensure_governed_tool_approval_request(
+        &self,
+        request: GovernedToolApprovalRequest<'_>,
+    ) -> Result<ApprovalRequestRecord, String> {
+        self.ensure_session_boundary(request.session_id, request.parent_session_id)?;
+
+        let approval_key = Self::approval_key_for_tool_name(request.tool_name);
+        let approval_request_id = Self::governed_approval_request_id(
+            request.session_id,
+            request.turn_id,
+            request.tool_call_id,
+            request.tool_name,
+        );
+        let request_payload_json = json!({
+            "session_id": request.session_id,
+            "parent_session_id": request.parent_session_id,
+            "turn_id": request.turn_id,
+            "tool_call_id": request.tool_call_id,
+            "tool_name": request.tool_name,
+            "args_json": request.args_json,
+            "source": request.source,
+            "execution_kind": "app",
+        });
+        let governance_snapshot_json = json!({
+            "governance_scope": request.governance_scope,
+            "risk_class": request.risk_class,
+            "approval_mode": request.approval_mode,
+            "rule_id": request.rule_id,
+            "reason": request.reason,
+        });
+        let approval_request_record = NewApprovalRequestRecord {
+            approval_request_id,
+            session_id: request.session_id.to_owned(),
+            turn_id: request.turn_id.to_owned(),
+            tool_call_id: request.tool_call_id.to_owned(),
+            tool_name: request.tool_name.to_owned(),
+            approval_key,
+            request_payload_json,
+            governance_snapshot_json,
+        };
+
+        self.repo.ensure_approval_request(approval_request_record)
+    }
+
+    pub(crate) fn ensure_request_session(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<(), String> {
+        let parent_session_id = Self::request_parent_session_id(approval_request);
+
+        self.ensure_session_boundary(&approval_request.session_id, parent_session_id)
+    }
+
+    pub(crate) fn load_runtime_grant_for_context(
+        &self,
+        session_id: &str,
+        parent_session_id: Option<&str>,
+        approval_key: &str,
+    ) -> Result<Option<ApprovalGrantRecord>, String> {
+        let grant_scope_session_id = self.grant_scope_session_id(session_id, parent_session_id)?;
+        let runtime_grant = self
+            .repo
+            .load_approval_grant(&grant_scope_session_id, approval_key)?;
+
+        Ok(runtime_grant)
+    }
+
+    pub(crate) fn grant_scope_session_id(
+        &self,
+        session_id: &str,
+        parent_session_id: Option<&str>,
+    ) -> Result<String, String> {
+        self.session_graph
+            .effective_lineage_root_session_id(session_id, parent_session_id)
+    }
+
+    pub(crate) fn load_runtime_grant_for_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<(String, Option<ApprovalGrantRecord>), String> {
+        let parent_session_id = Self::request_parent_session_id(approval_request);
+        let grant_scope_session_id =
+            self.grant_scope_session_id(&approval_request.session_id, parent_session_id)?;
+        let runtime_grant = self
+            .repo
+            .load_approval_grant(&grant_scope_session_id, &approval_request.approval_key)?;
+
+        Ok((grant_scope_session_id, runtime_grant))
+    }
+
+    pub(crate) fn upsert_runtime_grant_for_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+        created_by_session_id: Option<&str>,
+    ) -> Result<ApprovalGrantRecord, String> {
+        let parent_session_id = Self::request_parent_session_id(approval_request);
+        let scope_session_id =
+            self.grant_scope_session_id(&approval_request.session_id, parent_session_id)?;
+        let grant_record = NewApprovalGrantRecord {
+            scope_session_id,
+            approval_key: approval_request.approval_key.clone(),
+            created_by_session_id: created_by_session_id.map(str::to_owned),
+        };
+
+        self.repo.upsert_approval_grant(grant_record)
+    }
+
+    pub(crate) fn resolve_pending_request(
+        &self,
+        approval_request_id: &str,
+        decision: ApprovalDecision,
+        current_session_id: &str,
+    ) -> Result<ApprovalRequestRecord, String> {
+        let next_status = Self::next_status_for_decision(decision);
+        let transition_request = TransitionApprovalRequestIfCurrentRequest {
+            expected_status: ApprovalRequestStatus::Pending,
+            next_status,
+            decision: Some(decision),
+            resolved_by_session_id: Some(current_session_id.to_owned()),
+            executed_at: None,
+            last_error: None,
+        };
+
+        let maybe_resolved = self
+            .repo
+            .transition_approval_request_if_current(approval_request_id, transition_request)?;
+        let resolved = match maybe_resolved {
+            Some(resolved) => resolved,
+            None => {
+                return Err(self.pending_resolution_error(approval_request_id)?);
+            }
+        };
+
+        if decision == ApprovalDecision::ApproveAlways {
+            let _ = self.upsert_runtime_grant_for_request(&resolved, Some(current_session_id))?;
+        }
+
+        Ok(resolved)
+    }
+
+    pub(crate) fn replayable_tool_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<ToolCoreRequest, String> {
+        let execution_kind = approval_request
+            .request_payload_json
+            .get("execution_kind")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "approval_request_invalid_payload: missing execution_kind".to_owned())?;
+
+        if execution_kind != "app" {
+            return Err(format!(
+                "approval_request_invalid_execution_kind: expected `app`, got `{execution_kind}`"
+            ));
+        }
+
+        let tool_name_value = approval_request
+            .request_payload_json
+            .get("tool_name")
+            .and_then(Value::as_str);
+        let tool_name_value = tool_name_value.map(str::trim);
+        let tool_name = tool_name_value
+            .filter(|tool_name| !tool_name.is_empty())
+            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
+        let payload = approval_request
+            .request_payload_json
+            .get("args_json")
+            .cloned()
+            .ok_or_else(|| "approval_request_invalid_payload: missing args_json".to_owned())?;
+
+        Ok(ToolCoreRequest {
+            tool_name: tool_name.to_owned(),
+            payload,
+        })
+    }
+
+    pub(crate) fn begin_approved_request_execution(
+        &self,
+        approval_request_id: &str,
+    ) -> Result<ApprovalRequestRecord, String> {
+        let transition_request = TransitionApprovalRequestIfCurrentRequest {
+            expected_status: ApprovalRequestStatus::Approved,
+            next_status: ApprovalRequestStatus::Executing,
+            decision: None,
+            resolved_by_session_id: None,
+            executed_at: None,
+            last_error: None,
+        };
+        let maybe_executing = self
+            .repo
+            .transition_approval_request_if_current(approval_request_id, transition_request)?;
+        let executing = maybe_executing.ok_or_else(|| {
+            format!("approval_request_not_approved: `{approval_request_id}` is no longer approved")
+        })?;
+
+        Ok(executing)
+    }
+
+    pub(crate) fn finish_executing_request(
+        &self,
+        approval_request_id: &str,
+        last_error: Option<&str>,
+    ) -> Result<Option<ApprovalRequestRecord>, String> {
+        let executed_at = Self::current_epoch_s();
+        let transition_request = TransitionApprovalRequestIfCurrentRequest {
+            expected_status: ApprovalRequestStatus::Executing,
+            next_status: ApprovalRequestStatus::Executed,
+            decision: None,
+            resolved_by_session_id: None,
+            executed_at: Some(executed_at),
+            last_error: last_error.map(str::to_owned),
+        };
+
+        self.repo
+            .transition_approval_request_if_current(approval_request_id, transition_request)
+    }
+
+    fn session_kind_for_parent(parent_session_id: Option<&str>) -> SessionKind {
+        if parent_session_id.is_some() {
+            return SessionKind::DelegateChild;
+        }
+
+        SessionKind::Root
+    }
+
+    fn ensure_session_boundary(
+        &self,
+        session_id: &str,
+        parent_session_id: Option<&str>,
+    ) -> Result<(), String> {
+        let session_kind = Self::session_kind_for_parent(parent_session_id);
+        let session_record = NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: session_kind,
+            parent_session_id: parent_session_id.map(str::to_owned),
+            label: None,
+            state: SessionState::Ready,
+        };
+
+        let _ = self.repo.ensure_session(session_record)?;
+
+        Ok(())
+    }
+
+    fn next_status_for_decision(decision: ApprovalDecision) -> ApprovalRequestStatus {
+        match decision {
+            ApprovalDecision::Deny => ApprovalRequestStatus::Denied,
+            ApprovalDecision::ApproveOnce => ApprovalRequestStatus::Approved,
+            ApprovalDecision::ApproveAlways => ApprovalRequestStatus::Approved,
+        }
+    }
+
+    fn pending_resolution_error(&self, approval_request_id: &str) -> Result<String, String> {
+        let latest_request = self.repo.load_approval_request(approval_request_id)?;
+        let latest_request = latest_request
+            .ok_or_else(|| format!("approval_request_not_found: `{approval_request_id}`"))?;
+        let latest_status = latest_request.status.as_str();
+        let error = format!(
+            "approval_request_not_pending: `{approval_request_id}` is already {latest_status}"
+        );
+
+        Ok(error)
+    }
+
+    fn request_parent_session_id(approval_request: &ApprovalRequestRecord) -> Option<&str> {
+        let parent_session_value = approval_request
+            .request_payload_json
+            .get("parent_session_id")
+            .and_then(Value::as_str);
+        let parent_session_value = parent_session_value.map(str::trim);
+
+        parent_session_value.filter(|parent_session_id| !parent_session_id.is_empty())
+    }
+
+    fn current_epoch_s() -> i64 {
+        let now = std::time::SystemTime::now();
+        let unix_epoch = std::time::UNIX_EPOCH;
+        let duration = now.duration_since(unix_epoch);
+        let duration = duration.unwrap_or_default();
+        let seconds = duration.as_secs();
+
+        seconds as i64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GovernedToolApprovalRequest, OperatorApprovalRuntime};
+
+    use serde_json::json;
+
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{
+        ApprovalDecision, ApprovalRequestStatus, NewApprovalGrantRecord, NewSessionRecord,
+        SessionKind, SessionRepository, SessionState,
+    };
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let process_id = std::process::id();
+        let temp_dir = std::env::temp_dir();
+        let directory_name =
+            format!("loongclaw-operator-approval-runtime-{test_name}-{process_id}");
+        let base_dir = temp_dir.join(directory_name);
+        let _ = std::fs::create_dir_all(&base_dir);
+
+        let db_path = base_dir.join("memory.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+            ..MemoryRuntimeConfig::default()
+        }
+    }
+
+    fn seed_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        kind: SessionKind,
+        parent_session_id: Option<&str>,
+    ) {
+        let session_record = NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind,
+            parent_session_id: parent_session_id.map(str::to_owned),
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        };
+
+        repo.create_session(session_record).expect("create session");
+    }
+
+    fn delete_session_row(memory_config: &MemoryRuntimeConfig, session_id: &str) {
+        let db_path = memory_config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path")
+            .to_path_buf();
+        let conn = rusqlite::Connection::open(db_path).expect("open sqlite connection");
+
+        conn.execute(
+            "DELETE FROM sessions WHERE session_id = ?1",
+            rusqlite::params![session_id],
+        )
+        .expect("delete session row");
+    }
+
+    fn seed_runtime_grant(
+        repo: &SessionRepository,
+        scope_session_id: &str,
+        approval_key: &str,
+        created_by_session_id: Option<&str>,
+    ) {
+        let grant_record = NewApprovalGrantRecord {
+            scope_session_id: scope_session_id.to_owned(),
+            approval_key: approval_key.to_owned(),
+            created_by_session_id: created_by_session_id.map(str::to_owned),
+        };
+
+        let _ = repo
+            .upsert_approval_grant(grant_record)
+            .expect("upsert runtime grant");
+    }
+
+    #[test]
+    fn operator_approval_runtime_persists_governed_tool_request() {
+        let memory_config = isolated_memory_config("persist-request");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
+
+        let request = GovernedToolApprovalRequest {
+            session_id: "root-session",
+            parent_session_id: None,
+            turn_id: "turn-1",
+            tool_call_id: "call-1",
+            tool_name: "delegate",
+            args_json: json!({
+                "task": "run delegate task"
+            }),
+            source: "assistant",
+            governance_scope: "session",
+            risk_class: "high",
+            approval_mode: "policy_driven",
+            reason: "operator approval required before running `delegate`",
+            rule_id: "governed_tool_requires_approval",
+        };
+
+        let stored = approval_runtime
+            .ensure_governed_tool_approval_request(request)
+            .expect("persist approval request");
+
+        assert_eq!(stored.session_id, "root-session");
+        assert_eq!(stored.tool_name, "delegate");
+        assert_eq!(stored.status, ApprovalRequestStatus::Pending);
+        assert_eq!(stored.approval_key, "tool:delegate");
+    }
+
+    #[test]
+    fn operator_approval_runtime_loads_runtime_grant_from_lineage_root_scope() {
+        let memory_config = isolated_memory_config("grant-scope");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
+        seed_runtime_grant(&repo, "root-session", "tool:delegate", Some("root-session"));
+
+        let runtime_grant = approval_runtime
+            .load_runtime_grant_for_context("child-session", Some("root-session"), "tool:delegate")
+            .expect("load runtime grant")
+            .expect("runtime grant");
+
+        assert_eq!(runtime_grant.scope_session_id, "root-session");
+        assert_eq!(runtime_grant.approval_key, "tool:delegate");
+    }
+
+    #[test]
+    fn operator_approval_runtime_approve_always_creates_runtime_grant() {
+        let memory_config = isolated_memory_config("approve-always");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
+        let request = GovernedToolApprovalRequest {
+            session_id: "child-session",
+            parent_session_id: Some("root-session"),
+            turn_id: "turn-1",
+            tool_call_id: "call-1",
+            tool_name: "delegate",
+            args_json: json!({
+                "task": "run delegate task"
+            }),
+            source: "assistant",
+            governance_scope: "session",
+            risk_class: "high",
+            approval_mode: "policy_driven",
+            reason: "operator approval required before running `delegate`",
+            rule_id: "governed_tool_requires_approval",
+        };
+
+        let stored = approval_runtime
+            .ensure_governed_tool_approval_request(request)
+            .expect("persist approval request");
+        let resolved = approval_runtime
+            .resolve_pending_request(
+                &stored.approval_request_id,
+                ApprovalDecision::ApproveAlways,
+                "root-session",
+            )
+            .expect("resolve approval request");
+
+        assert_eq!(resolved.status, ApprovalRequestStatus::Approved);
+
+        let runtime_grant = approval_runtime
+            .load_runtime_grant_for_context("child-session", Some("root-session"), "tool:delegate")
+            .expect("load runtime grant")
+            .expect("runtime grant");
+
+        assert_eq!(runtime_grant.scope_session_id, "root-session");
+    }
+
+    #[test]
+    fn operator_approval_runtime_uses_request_session_scope_when_session_row_is_missing() {
+        let memory_config = isolated_memory_config("missing-session-row");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
+        seed_runtime_grant(&repo, "root-session", "tool:delegate", Some("root-session"));
+
+        delete_session_row(&memory_config, "root-session");
+
+        let grant_scope_session_id = approval_runtime
+            .grant_scope_session_id("root-session", None)
+            .expect("load grant scope session id");
+        let runtime_grant = approval_runtime
+            .load_runtime_grant_for_context("root-session", None, "tool:delegate")
+            .expect("load runtime grant")
+            .expect("runtime grant");
+
+        assert_eq!(grant_scope_session_id, "root-session");
+        assert_eq!(runtime_grant.scope_session_id, "root-session");
+    }
+
+    #[test]
+    fn operator_approval_runtime_uses_request_parent_scope_when_child_row_is_missing() {
+        let memory_config = isolated_memory_config("missing-child-session-row");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
+        let request = GovernedToolApprovalRequest {
+            session_id: "child-session",
+            parent_session_id: Some("root-session"),
+            turn_id: "turn-1",
+            tool_call_id: "call-1",
+            tool_name: "delegate",
+            args_json: json!({
+                "task": "run delegate task"
+            }),
+            source: "assistant",
+            governance_scope: "session",
+            risk_class: "high",
+            approval_mode: "policy_driven",
+            reason: "operator approval required before running `delegate`",
+            rule_id: "governed_tool_requires_approval",
+        };
+        let stored = approval_runtime
+            .ensure_governed_tool_approval_request(request)
+            .expect("persist approval request");
+
+        delete_session_row(&memory_config, "child-session");
+
+        let resolved = approval_runtime
+            .resolve_pending_request(
+                &stored.approval_request_id,
+                ApprovalDecision::ApproveAlways,
+                "root-session",
+            )
+            .expect("resolve approval request");
+
+        assert_eq!(resolved.status, ApprovalRequestStatus::Approved);
+
+        let grant_lookup = approval_runtime
+            .load_runtime_grant_for_request(&resolved)
+            .expect("load runtime grant for request");
+        let runtime_grant = grant_lookup.1.expect("runtime grant");
+
+        assert_eq!(runtime_grant.scope_session_id, "root-session");
+    }
+
+    #[test]
+    fn operator_approval_runtime_persists_grant_when_scope_session_row_is_missing() {
+        let memory_config = isolated_memory_config("missing-scope-session-row");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let approval_runtime = OperatorApprovalRuntime::new(&repo);
+        let request = GovernedToolApprovalRequest {
+            session_id: "root-session",
+            parent_session_id: None,
+            turn_id: "turn-1",
+            tool_call_id: "call-1",
+            tool_name: "delegate",
+            args_json: json!({
+                "task": "run delegate task"
+            }),
+            source: "assistant",
+            governance_scope: "session",
+            risk_class: "high",
+            approval_mode: "policy_driven",
+            reason: "operator approval required before running `delegate`",
+            rule_id: "governed_tool_requires_approval",
+        };
+        let stored = approval_runtime
+            .ensure_governed_tool_approval_request(request)
+            .expect("persist approval request");
+
+        delete_session_row(&memory_config, "root-session");
+
+        let resolved = approval_runtime
+            .resolve_pending_request(
+                &stored.approval_request_id,
+                ApprovalDecision::ApproveAlways,
+                "root-session",
+            )
+            .expect("resolve approval request");
+        let runtime_grant = approval_runtime
+            .load_runtime_grant_for_request(&resolved)
+            .expect("load runtime grant for request")
+            .1
+            .expect("runtime grant");
+
+        assert_eq!(runtime_grant.scope_session_id, "root-session");
+    }
+}

--- a/crates/app/src/operator/approval_runtime.rs
+++ b/crates/app/src/operator/approval_runtime.rs
@@ -68,7 +68,8 @@ impl<'a> OperatorApprovalRuntime<'a> {
         hasher.update(tool_name.as_bytes());
 
         let digest = hasher.finalize();
-        let request_id = format!("apr_{digest:x}");
+        let digest = hex::encode(digest);
+        let request_id = format!("apr_{digest}");
 
         request_id
     }

--- a/crates/app/src/operator/approval_runtime.rs
+++ b/crates/app/src/operator/approval_runtime.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "memory-sqlite")]
-use loongclaw_contracts::ToolCoreRequest;
-#[cfg(feature = "memory-sqlite")]
 use serde_json::{Value, json};
 #[cfg(feature = "memory-sqlite")]
 use sha2::{Digest, Sha256};
@@ -213,43 +211,6 @@ impl<'a> OperatorApprovalRuntime<'a> {
 
         Ok(resolved)
     }
-
-    pub(crate) fn replayable_tool_request(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<ToolCoreRequest, String> {
-        let execution_kind = approval_request
-            .request_payload_json
-            .get("execution_kind")
-            .and_then(Value::as_str)
-            .ok_or_else(|| "approval_request_invalid_payload: missing execution_kind".to_owned())?;
-
-        if execution_kind != "app" {
-            return Err(format!(
-                "approval_request_invalid_execution_kind: expected `app`, got `{execution_kind}`"
-            ));
-        }
-
-        let tool_name_value = approval_request
-            .request_payload_json
-            .get("tool_name")
-            .and_then(Value::as_str);
-        let tool_name_value = tool_name_value.map(str::trim);
-        let tool_name = tool_name_value
-            .filter(|tool_name| !tool_name.is_empty())
-            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
-        let payload = approval_request
-            .request_payload_json
-            .get("args_json")
-            .cloned()
-            .ok_or_else(|| "approval_request_invalid_payload: missing args_json".to_owned())?;
-
-        Ok(ToolCoreRequest {
-            tool_name: tool_name.to_owned(),
-            payload,
-        })
-    }
-
     pub(crate) fn begin_approved_request_execution(
         &self,
         approval_request_id: &str,

--- a/crates/app/src/operator/mod.rs
+++ b/crates/app/src/operator/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod approval_runtime;
+pub(crate) mod session_graph;

--- a/crates/app/src/operator/session_graph.rs
+++ b/crates/app/src/operator/session_graph.rs
@@ -1,0 +1,214 @@
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::SessionRepository;
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) struct OperatorSessionGraph<'a> {
+    repo: &'a SessionRepository,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl<'a> OperatorSessionGraph<'a> {
+    pub(crate) fn new(repo: &'a SessionRepository) -> Self {
+        Self { repo }
+    }
+
+    pub(crate) fn lineage_depth(&self, session_id: &str) -> Result<usize, String> {
+        self.repo.session_lineage_depth(session_id)
+    }
+
+    pub(crate) fn lineage_root_session_id(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<String>, String> {
+        self.repo.lineage_root_session_id(session_id)
+    }
+
+    pub(crate) fn effective_lineage_root_session_id(
+        &self,
+        session_id: &str,
+        parent_session_id: Option<&str>,
+    ) -> Result<String, String> {
+        let stored_lineage_root_session_id = self.lineage_root_session_id(session_id)?;
+
+        if let Some(stored_lineage_root_session_id) = stored_lineage_root_session_id {
+            return Ok(stored_lineage_root_session_id);
+        }
+
+        let Some(parent_session_id) = parent_session_id else {
+            return Ok(session_id.to_owned());
+        };
+
+        let stored_parent_lineage_root_session_id =
+            self.lineage_root_session_id(parent_session_id)?;
+
+        if let Some(stored_parent_lineage_root_session_id) = stored_parent_lineage_root_session_id {
+            return Ok(stored_parent_lineage_root_session_id);
+        }
+
+        Ok(parent_session_id.to_owned())
+    }
+
+    pub(crate) fn next_delegate_child_depth(
+        &self,
+        session_id: &str,
+        max_depth: usize,
+    ) -> Result<usize, String> {
+        let current_depth = self.lineage_depth(session_id)?;
+        let next_child_depth = current_depth.saturating_add(1);
+
+        if next_child_depth > max_depth {
+            let error = format!(
+                "delegate_depth_exceeded: next child depth {next_child_depth} exceeds configured max_depth {max_depth}"
+            );
+            return Err(error);
+        }
+
+        Ok(next_child_depth)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OperatorSessionGraph;
+
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::{
+        NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    };
+
+    fn isolated_memory_config(test_name: &str) -> MemoryRuntimeConfig {
+        let process_id = std::process::id();
+        let temp_dir = std::env::temp_dir();
+        let directory_name = format!("loongclaw-operator-session-graph-{test_name}-{process_id}");
+        let base_dir = temp_dir.join(directory_name);
+        let _ = std::fs::create_dir_all(&base_dir);
+
+        let db_path = base_dir.join("memory.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        MemoryRuntimeConfig {
+            sqlite_path: Some(db_path),
+            ..MemoryRuntimeConfig::default()
+        }
+    }
+
+    fn seed_session(
+        repo: &SessionRepository,
+        session_id: &str,
+        kind: SessionKind,
+        parent_session_id: Option<&str>,
+    ) {
+        let session_record = NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind,
+            parent_session_id: parent_session_id.map(str::to_owned),
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        };
+
+        repo.create_session(session_record).expect("create session");
+    }
+
+    #[test]
+    fn operator_session_graph_returns_lineage_root_for_delegate_descendant() {
+        let memory_config = isolated_memory_config("lineage-root");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        seed_session(
+            &repo,
+            "grandchild-session",
+            SessionKind::DelegateChild,
+            Some("child-session"),
+        );
+
+        let session_graph = OperatorSessionGraph::new(&repo);
+        let lineage_root_session_id = session_graph
+            .lineage_root_session_id("grandchild-session")
+            .expect("compute lineage root");
+
+        assert_eq!(lineage_root_session_id.as_deref(), Some("root-session"));
+    }
+
+    #[test]
+    fn operator_session_graph_computes_next_delegate_child_depth() {
+        let memory_config = isolated_memory_config("next-child-depth");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        let session_graph = OperatorSessionGraph::new(&repo);
+        let root_child_depth = session_graph
+            .next_delegate_child_depth("root-session", 3)
+            .expect("compute root child depth");
+        let nested_child_depth = session_graph
+            .next_delegate_child_depth("child-session", 3)
+            .expect("compute nested child depth");
+
+        assert_eq!(root_child_depth, 1);
+        assert_eq!(nested_child_depth, 2);
+    }
+
+    #[test]
+    fn operator_session_graph_rejects_delegate_child_depth_over_limit() {
+        let memory_config = isolated_memory_config("depth-limit");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+
+        let session_graph = OperatorSessionGraph::new(&repo);
+        let result = session_graph.next_delegate_child_depth("child-session", 1);
+        let error = result.expect_err("depth overflow should fail");
+
+        assert!(
+            error.contains("delegate_depth_exceeded"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn operator_session_graph_falls_back_to_session_id_when_root_row_is_missing() {
+        let memory_config = isolated_memory_config("missing-root-row");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+        let session_graph = OperatorSessionGraph::new(&repo);
+
+        let effective_lineage_root_session_id = session_graph
+            .effective_lineage_root_session_id("root-session", None)
+            .expect("compute effective lineage root");
+
+        assert_eq!(effective_lineage_root_session_id, "root-session");
+    }
+
+    #[test]
+    fn operator_session_graph_falls_back_to_parent_scope_when_child_row_is_missing() {
+        let memory_config = isolated_memory_config("missing-child-row");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let session_graph = OperatorSessionGraph::new(&repo);
+        let effective_lineage_root_session_id = session_graph
+            .effective_lineage_root_session_id("child-session", Some("root-session"))
+            .expect("compute effective lineage root");
+
+        assert_eq!(effective_lineage_root_session_id, "root-session");
+    }
+}

--- a/crates/app/src/operator/session_graph.rs
+++ b/crates/app/src/operator/session_graph.rs
@@ -28,7 +28,11 @@ impl<'a> OperatorSessionGraph<'a> {
         session_id: &str,
         parent_session_id: Option<&str>,
     ) -> Result<String, String> {
-        let stored_lineage_root_session_id = self.lineage_root_session_id(session_id)?;
+        let stored_lineage_root_session_id = match self.lineage_root_session_id(session_id) {
+            Ok(lineage_root_session_id) => lineage_root_session_id,
+            Err(error) if error.starts_with("session_lineage_broken:") => None,
+            Err(error) => return Err(error),
+        };
 
         if let Some(stored_lineage_root_session_id) = stored_lineage_root_session_id {
             return Ok(stored_lineage_root_session_id);
@@ -39,7 +43,11 @@ impl<'a> OperatorSessionGraph<'a> {
         };
 
         let stored_parent_lineage_root_session_id =
-            self.lineage_root_session_id(parent_session_id)?;
+            match self.lineage_root_session_id(parent_session_id) {
+                Ok(lineage_root_session_id) => lineage_root_session_id,
+                Err(error) if error.starts_with("session_lineage_broken:") => None,
+                Err(error) => return Err(error),
+            };
 
         if let Some(stored_parent_lineage_root_session_id) = stored_parent_lineage_root_session_id {
             return Ok(stored_parent_lineage_root_session_id);
@@ -71,6 +79,8 @@ impl<'a> OperatorSessionGraph<'a> {
 mod tests {
     use super::OperatorSessionGraph;
 
+    use rusqlite::params;
+
     use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
         NewSessionRecord, SessionKind, SessionRepository, SessionState,
@@ -90,6 +100,20 @@ mod tests {
             sqlite_path: Some(db_path),
             ..MemoryRuntimeConfig::default()
         }
+    }
+
+    fn delete_session_row(memory_config: &MemoryRuntimeConfig, session_id: &str) {
+        let sqlite_path = memory_config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path should be configured");
+        let conn = rusqlite::Connection::open(sqlite_path).expect("open sqlite connection");
+
+        conn.execute(
+            "DELETE FROM sessions WHERE session_id = ?1",
+            params![session_id],
+        )
+        .expect("delete session row");
     }
 
     fn seed_session(
@@ -203,6 +227,28 @@ mod tests {
         let repo = SessionRepository::new(&memory_config).expect("create session repository");
 
         seed_session(&repo, "root-session", SessionKind::Root, None);
+
+        let session_graph = OperatorSessionGraph::new(&repo);
+        let effective_lineage_root_session_id = session_graph
+            .effective_lineage_root_session_id("child-session", Some("root-session"))
+            .expect("compute effective lineage root");
+
+        assert_eq!(effective_lineage_root_session_id, "root-session");
+    }
+
+    #[test]
+    fn operator_session_graph_falls_back_to_parent_scope_when_parent_row_is_missing() {
+        let memory_config = isolated_memory_config("missing-parent-row");
+        let repo = SessionRepository::new(&memory_config).expect("create session repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        delete_session_row(&memory_config, "root-session");
 
         let session_graph = OperatorSessionGraph::new(&repo);
         let effective_lineage_root_session_id = session_graph

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -1230,9 +1230,6 @@ impl SessionRepository {
         let scope_session_id =
             normalize_required_text(&record.scope_session_id, "scope_session_id")?;
         let approval_key = normalize_required_text(&record.approval_key, "approval_key")?;
-        if self.load_session(&scope_session_id)?.is_none() {
-            return Err(format!("session `{scope_session_id}` not found"));
-        }
         let created_by_session_id = normalize_optional_text(record.created_by_session_id);
         let ts = unix_ts_now();
         let conn = self.open_connection()?;

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -11,6 +11,8 @@ use crate::config::ToolConfig;
 use crate::config::{SessionVisibility, ToolConsentMode};
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
+use crate::operator::approval_runtime::OperatorApprovalRuntime;
+#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     ApprovalDecision, ApprovalGrantRecord, ApprovalRequestRecord, ApprovalRequestStatus,
     SessionRepository,
@@ -565,6 +567,7 @@ fn derive_attention_view(
     repo: &SessionRepository,
     record: &ApprovalRequestRecord,
 ) -> Result<DerivedAttentionView, String> {
+    let approval_runtime = OperatorApprovalRuntime::new(repo);
     let mut execution_signals = Vec::new();
     match record.status {
         ApprovalRequestStatus::Pending => execution_signals.push(AttentionSignal {
@@ -601,13 +604,8 @@ fn derive_attention_view(
         | ApprovalRequestStatus::Cancelled => {}
     }
 
-    let grant_scope_session_id = repo.lineage_root_session_id(&record.session_id)?;
-    let grant_record = match grant_scope_session_id.as_deref() {
-        Some(scope_session_id) => {
-            repo.load_approval_grant(scope_session_id, &record.approval_key)?
-        }
-        None => None,
-    };
+    let (grant_scope_session_id, grant_record) =
+        approval_runtime.load_runtime_grant_for_request(record)?;
     let grant_age_seconds = grant_record
         .as_ref()
         .map(|grant| unix_ts_now().saturating_sub(grant.updated_at).max(0));
@@ -652,7 +650,7 @@ fn derive_attention_view(
         execution_signals,
         grant_signals,
         grant_state,
-        grant_scope_session_id,
+        grant_scope_session_id: Some(grant_scope_session_id),
         grant_record,
         grant_age_seconds,
     })
@@ -1099,6 +1097,22 @@ mod tests {
             params![updated_at, scope_session_id, approval_key],
         )
         .expect("age runtime grant");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn delete_session_row(config: &MemoryRuntimeConfig, session_id: &str) {
+        let db_path = config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path")
+            .to_path_buf();
+        let conn = Connection::open(db_path).expect("open sqlite connection");
+
+        conn.execute(
+            "DELETE FROM sessions WHERE session_id = ?1",
+            params![session_id],
+        )
+        .expect("delete session row");
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1644,5 +1658,52 @@ mod tests {
             outcome.payload["approval_request"]["grant_attention"]["needs_attention"],
             true
         );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_status_uses_request_session_scope_when_session_row_is_missing() {
+        let config = isolated_memory_config("approval-grant-missing-session-row");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-missing-session-row",
+            "root-session",
+            "delegate",
+            "rule-missing-session-row",
+        );
+        approve_request(
+            &repo,
+            "apr-missing-session-row",
+            ApprovalDecision::ApproveAlways,
+            "root-session",
+        );
+        mark_request_executed(&repo, "apr-missing-session-row", None);
+        seed_runtime_grant(&repo, "root-session", "tool:delegate");
+        delete_session_row(&config, "root-session");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-missing-session-row",
+                }),
+            },
+            "root-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        let approval_request = &outcome.payload["approval_request"];
+        let grant_review = &approval_request["grant_review"];
+        let grant_attention = &approval_request["grant_attention"];
+
+        assert_eq!(grant_review["state"], "clean");
+        assert_eq!(grant_review["scope_session_id"], "root-session");
+        assert_eq!(grant_review["grant_exists"], true);
+        assert_eq!(grant_attention["needs_attention"], false);
     }
 }

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -1706,4 +1706,71 @@ mod tests {
         assert_eq!(grant_review["grant_exists"], true);
         assert_eq!(grant_attention["needs_attention"], false);
     }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn approval_request_status_uses_root_scope_for_child_request_when_root_row_is_missing() {
+        let config = isolated_memory_config("approval-grant-missing-root-row-child-request");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_session(
+            &repo,
+            "child-session",
+            SessionKind::DelegateChild,
+            Some("root-session"),
+        );
+        repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id: "apr-missing-root-row-child-request".to_owned(),
+            session_id: "child-session".to_owned(),
+            turn_id: "turn-apr-missing-root-row-child-request".to_owned(),
+            tool_call_id: "call-apr-missing-root-row-child-request".to_owned(),
+            tool_name: "delegate".to_owned(),
+            approval_key: "tool:delegate".to_owned(),
+            request_payload_json: json!({
+                "session_id": "child-session",
+                "parent_session_id": "root-session",
+                "tool_name": "delegate",
+                "args_json": {
+                    "task": "run-apr-missing-root-row-child-request"
+                },
+            }),
+            governance_snapshot_json: json!({
+                "reason": "approval required for delegate",
+                "rule_id": "rule-missing-root-row-child-request",
+            }),
+        })
+        .expect("seed child approval request");
+        approve_request(
+            &repo,
+            "apr-missing-root-row-child-request",
+            ApprovalDecision::ApproveAlways,
+            "root-session",
+        );
+        mark_request_executed(&repo, "apr-missing-root-row-child-request", None);
+        seed_runtime_grant(&repo, "root-session", "tool:delegate");
+        delete_session_row(&config, "root-session");
+
+        let outcome = crate::tools::execute_app_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "approval_request_status".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-missing-root-row-child-request",
+                }),
+            },
+            "child-session",
+            &config,
+            &ToolConfig::default(),
+        )
+        .expect("approval_request_status outcome");
+
+        let approval_request = &outcome.payload["approval_request"];
+        let grant_review = &approval_request["grant_review"];
+        let grant_attention = &approval_request["grant_attention"];
+
+        assert_eq!(grant_review["state"], "clean");
+        assert_eq!(grant_review["scope_session_id"], "root-session");
+        assert_eq!(grant_review["grant_exists"], true);
+        assert_eq!(grant_attention["needs_attention"], false);
+    }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -663,28 +663,30 @@ pub fn execute_tool_core_with_config(
     let requested_tool_name = request.tool_name.clone();
     let payload_kind = crate::observability::json_value_kind(&request.payload);
     let payload_keys = crate::observability::top_level_json_keys(&request.payload);
-    if !trusted_internal_tool_payload_enabled()
-        && payload_uses_reserved_internal_tool_context(&request.payload)
-    {
-        return Err(format!(
-            "tool `{}` payload.{LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY} is reserved for trusted internal tool context; retry without that field",
-            request.tool_name
-        ));
-    }
-    let canonical_name = canonical_tool_name(request.tool_name.as_str());
-    let request = ToolCoreRequest {
-        tool_name: canonical_name.to_owned(),
-        payload: request.payload,
-    };
-    let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)?
-        .map(|narrowing| config.narrowed(&narrowing));
-    let config = effective_config.as_ref().unwrap_or(config);
+    let canonical_name = canonical_tool_name(request.tool_name.as_str()).to_owned();
+    let payload = request.payload;
     let started_at = std::time::Instant::now();
-    let result = match canonical_name {
-        "tool.search" => execute_tool_search_tool_with_config(request, config),
-        "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
-        _ => execute_discoverable_tool_core_with_config(request, config),
-    };
+    let result = (|| {
+        ensure_untrusted_payload_does_not_use_reserved_internal_tool_context(
+            requested_tool_name.as_str(),
+            &payload,
+            "payload",
+        )?;
+
+        let request = ToolCoreRequest {
+            tool_name: canonical_name.clone(),
+            payload,
+        };
+        let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)?;
+        let effective_config = effective_config.map(|narrowing| config.narrowed(&narrowing));
+        let config = effective_config.as_ref().unwrap_or(config);
+
+        match canonical_name.as_str() {
+            "tool.search" => execute_tool_search_tool_with_config(request, config),
+            "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
+            _ => execute_discoverable_tool_core_with_config(request, config),
+        }
+    })();
     let duration_ms = started_at.elapsed().as_millis();
     match &result {
         Ok(outcome) => {

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -33,6 +33,87 @@ impl Drop for StdinGuard {
     }
 }
 
+fn command_kind(command: &Commands) -> String {
+    let rendered = format!("{command:?}");
+    let mut segments = rendered.split(|character: char| !character.is_ascii_alphanumeric());
+    let variant_name = segments.next().unwrap_or("unknown");
+
+    camel_case_to_snake_case(variant_name)
+}
+
+fn camel_case_to_snake_case(value: &str) -> String {
+    let mut rendered = String::new();
+    let mut previous_was_lowercase = false;
+
+    for character in value.chars() {
+        let is_uppercase = character.is_ascii_uppercase();
+        if is_uppercase && previous_was_lowercase {
+            rendered.push('_');
+        }
+
+        let lowercased = character.to_ascii_lowercase();
+        rendered.push(lowercased);
+        previous_was_lowercase = character.is_ascii_lowercase();
+    }
+
+    rendered
+}
+
+fn error_code(error: &str) -> String {
+    let trimmed = error.trim();
+    let mut segments = trimmed.split(':');
+    let raw_candidate = segments.next().unwrap_or_default();
+    let candidate = raw_candidate.trim();
+    let is_empty = candidate.is_empty();
+    let is_stable_code = !is_empty
+        && candidate.chars().all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
+        });
+
+    if is_stable_code {
+        return candidate.to_owned();
+    }
+
+    "unclassified".to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{command_kind, error_code};
+    use loongclaw_daemon::{Commands, MultiChannelServeChannelAccount};
+
+    #[test]
+    fn command_kind_uses_stable_snake_case_labels() {
+        let validate_config = Commands::ValidateConfig {
+            config: None,
+            json: false,
+            output: None,
+            locale: "en".to_owned(),
+            fail_on_diagnostics: false,
+        };
+        let multi_channel_serve = Commands::MultiChannelServe {
+            config: None,
+            session: "session-1".to_owned(),
+            channel_account: vec![MultiChannelServeChannelAccount {
+                channel_id: "telegram".to_owned(),
+                account_id: "ops".to_owned(),
+            }],
+        };
+
+        assert_eq!(command_kind(&validate_config), "validate_config");
+        assert_eq!(command_kind(&multi_channel_serve), "multi_channel_serve");
+    }
+
+    #[test]
+    fn error_code_extracts_stable_prefixes_only() {
+        let stable_error = "config_file_missing: could not read `/tmp/private.toml`";
+        let unstable_error = "Failed to read `/tmp/private.toml`";
+
+        assert_eq!(error_code(stable_error), "config_file_missing");
+        assert_eq!(error_code(unstable_error), "unclassified");
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let _stdin_guard = StdinGuard;
@@ -40,10 +121,10 @@ async fn main() {
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
     let cli = parse_cli();
     let command = cli.command.unwrap_or_else(resolve_default_entry_command);
-    let command_name = debug_variant_name(&command);
+    let command_kind = command_kind(&command);
     tracing::debug!(
         target: "loongclaw.daemon",
-        command = %command_name,
+        command_kind = %command_kind,
         "parsed CLI command"
     );
     let result = match command {
@@ -992,9 +1073,11 @@ async fn main() {
         }
     };
     if let Err(error) = result {
+        let error_code = error_code(error.as_str());
         tracing::error!(
             target: "loongclaw.daemon",
-            error = %error,
+            command_kind = %command_kind,
+            error_code = %error_code,
             "CLI command failed"
         );
         #[allow(clippy::print_stderr)]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -77,43 +77,6 @@ fn error_code(error: &str) -> String {
     "unclassified".to_owned()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{command_kind, error_code};
-    use loongclaw_daemon::{Commands, MultiChannelServeChannelAccount};
-
-    #[test]
-    fn command_kind_uses_stable_snake_case_labels() {
-        let validate_config = Commands::ValidateConfig {
-            config: None,
-            json: false,
-            output: None,
-            locale: "en".to_owned(),
-            fail_on_diagnostics: false,
-        };
-        let multi_channel_serve = Commands::MultiChannelServe {
-            config: None,
-            session: "session-1".to_owned(),
-            channel_account: vec![MultiChannelServeChannelAccount {
-                channel_id: "telegram".to_owned(),
-                account_id: "ops".to_owned(),
-            }],
-        };
-
-        assert_eq!(command_kind(&validate_config), "validate_config");
-        assert_eq!(command_kind(&multi_channel_serve), "multi_channel_serve");
-    }
-
-    #[test]
-    fn error_code_extracts_stable_prefixes_only() {
-        let stable_error = "config_file_missing: could not read `/tmp/private.toml`";
-        let unstable_error = "Failed to read `/tmp/private.toml`";
-
-        assert_eq!(error_code(stable_error), "config_file_missing");
-        assert_eq!(error_code(unstable_error), "unclassified");
-    }
-}
-
 #[tokio::main]
 async fn main() {
     let _stdin_guard = StdinGuard;
@@ -1086,5 +1049,42 @@ async fn main() {
         }
         flush_stdin();
         std::process::exit(2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{command_kind, error_code};
+    use loongclaw_daemon::{Commands, MultiChannelServeChannelAccount};
+
+    #[test]
+    fn command_kind_uses_stable_snake_case_labels() {
+        let validate_config = Commands::ValidateConfig {
+            config: None,
+            json: false,
+            output: None,
+            locale: "en".to_owned(),
+            fail_on_diagnostics: false,
+        };
+        let multi_channel_serve = Commands::MultiChannelServe {
+            config: None,
+            session: "session-1".to_owned(),
+            channel_account: vec![MultiChannelServeChannelAccount {
+                channel_id: "telegram".to_owned(),
+                account_id: "ops".to_owned(),
+            }],
+        };
+
+        assert_eq!(command_kind(&validate_config), "validate_config");
+        assert_eq!(command_kind(&multi_channel_serve), "multi_channel_serve");
+    }
+
+    #[test]
+    fn error_code_extracts_stable_prefixes_only() {
+        let stable_error = "config_file_missing: could not read `/tmp/private.toml`";
+        let unstable_error = "Failed to read `/tmp/private.toml`";
+
+        assert_eq!(error_code(stable_error), "config_file_missing");
+        assert_eq!(error_code(unstable_error), "unclassified");
     }
 }

--- a/crates/daemon/tests/integration/logging.rs
+++ b/crates/daemon/tests/integration/logging.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+#[test]
+fn validate_config_logging_redacts_raw_config_path_from_tracing_fields() {
+    let missing_path = std::env::temp_dir().join(format!(
+        "loongclaw-private-config-{}-missing.toml",
+        std::process::id()
+    ));
+    let missing_path = missing_path.display().to_string();
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_loongclaw"))
+        .args(["validate-config", "--config", missing_path.as_str()])
+        .env("LOONGCLAW_LOG", "debug")
+        .env("LOONGCLAW_LOG_FORMAT", "compact")
+        .output()
+        .expect("run loongclaw validate-config");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stderr should include one user-facing error"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    let path_mentions = stderr.matches(missing_path.as_str()).count();
+
+    assert_eq!(
+        path_mentions, 1,
+        "raw config path should only appear in the final user-facing error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("command_kind=validate_config"),
+        "expected sanitized command kind in logs, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("error_code="),
+        "expected stable error code field in logs, got: {stderr}"
+    );
+}

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -96,6 +96,7 @@ mod gateway_owner_state;
 mod gateway_read_models;
 mod import_cli;
 mod latest_selector_process_support;
+mod logging;
 mod memory_context_benchmark_cli;
 mod migrate_cli;
 mod migration;

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T13:28:17Z
+- Generated at: 2026-04-01T14:19:32Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -16,21 +16,21 @@
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3679 | 3700 | 21 | 44 | 80 | 36 | 99.4% | TIGHT | 3547 | 3.7% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.0% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 356 | 650 | 294 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 0.0% | PASS | 14 |
-| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3383 | 3600 | 217 | 8 | 12 | 4 | 94.0% | WATCH | 3383 | 0.0% | PASS | 8 |
+| acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2698 | 2800 | 102 | 56 | 65 | 9 | 96.4% | TIGHT | 2698 | 0.0% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10378 | 10500 | 122 | 89 | 90 | 1 | 98.9% | TIGHT | 9922 | 4.6% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9798 | 9800 | 2 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14567 | 15000 | 433 | 54 | 70 | 16 | 97.1% | TIGHT | 14472 | 0.7% | PASS | 54 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10714 | 11200 | 486 | 98 | 120 | 22 | 95.7% | TIGHT | 10831 | -1.1% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14569 | 15000 | 431 | 54 | 70 | 16 | 97.1% | TIGHT | 14472 | 0.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6340 | 6500 | 160 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.3% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (97.1%), daemon_lib (100.0%), onboard_cli (97.1%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (95.7%), tools_mod (97.1%), daemon_lib (100.0%), onboard_cli (97.1%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -61,14 +61,14 @@
 <!-- arch-hotspot key=spec_execution lines=3679 functions=44 -->
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=356 functions=14 -->
-<!-- arch-hotspot key=acp_manager lines=3383 functions=8 -->
+<!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2698 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=10378 functions=89 -->
 <!-- arch-hotspot key=channel_config lines=9798 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10831 functions=98 -->
-<!-- arch-hotspot key=tools_mod lines=14567 functions=54 -->
+<!-- arch-hotspot key=turn_coordinator lines=10714 functions=98 -->
+<!-- arch-hotspot key=tools_mod lines=14569 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6340 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: session lineage and approval runtime semantics were duplicated across conversation, approval, and persistence call sites.
- Why it matters: duplicated host-runtime rules drift easily and made the `approve_always` persistence path fragile when the original scope session row was missing.
- What changed: added a private `app::operator` seam for session graph and approval runtime behavior, routed existing conversation and approval call sites through it, and fixed approval-grant persistence so replay remains resilient when the scope session row has been deleted.
- What did not change (scope boundary): no new public SDK surface, no new top-level workspace crate, and no intended user-visible workflow redesign.

## Linked Issues

- Closes #762
- Related #762

## Change Type

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this refactor touches internal approval/session runtime semantics and the grant persistence edge case used during approval replay.
- Rollout / guardrails: keep the change private to `crates/app/src/operator/`, preserve existing call-site behavior, and cover the missing-session-row path with targeted regression tests plus full workspace tests.
- Rollback path: revert `4d959a6dc74e32025ebb6c527766b3569d15a283`.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] Not applicable: this change does not alter config/env fallback, limits, or defaults.
- [x] Not applicable: the added tests do not rely on process-global env mutation.

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
diff CLAUDE.md AGENTS.md
cargo test --workspace --locked
cargo test --workspace --all-features --locked
cargo test -p loongclaw-app --all-features operator_approval_runtime_persists_grant_when_scope_session_row_is_missing
scripts/check-docs.sh
python3 scripts/sync_github_labels.py --check
bash scripts/test_sync_github_labels.sh
cargo deny check advisories bans licenses sources
```

All listed commands above were run in the branch worktree. The CI-parity and targeted regression commands passed. The repo-local architecture, dependency-graph, mirror, docs, and GitHub label checks also passed. `cargo deny check advisories bans licenses sources` surfaced a pre-existing repository baseline failure in the deny policy (`quoted_printable` 0BSD license allowance) plus an existing yanked dependency warning (`unicode-segmentation`); this PR does not modify `Cargo.lock` or `deny.toml`.

## User-visible / Operator-visible Changes

- No intended user-visible workflow change. Approval replay and `approve_always` grant persistence now remain valid even when the original scope session row is no longer present.

## Failure Recovery

- Fast rollback or disable path: revert `4d959a6dc74e32025ebb6c527766b3569d15a283`.
- Observable failure symptoms reviewers should watch for: approval replay fails to reconstruct the request boundary, `approve_always` stops persisting grants for deleted scope sessions, or delegate-depth / lineage checks diverge between conversation and tool call sites.

## Reviewer Focus

- `crates/app/src/operator/approval_runtime.rs`
- `crates/app/src/operator/session_graph.rs`
- `crates/app/src/session/repository.rs`
- Approval replay flow in conversation runtime and the missing-session-row regression path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed approval request finalization conflicts in concurrent execution scenarios
  * Improved session boundary validation for nested approval workflows

* **Improvements**
  * Enhanced observability with detailed execution timing metrics and structured error codes
  * Refined approval grant workflow for delegated tool access
  * Strengthened session lineage validation for complex delegation scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->