### PR TITLE
fix: tighten conversation binding-first runtime seams

### DIFF
--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -433,11 +433,14 @@ impl ConversationContextEngine for DefaultContextEngine {
         binding: ConversationRuntimeBinding<'_>,
     ) -> CliResult<AssembledConversationContext> {
         if !binding.is_kernel_bound() {
-            let projected = crate::provider::build_projected_context_for_session(
+            let provider_binding = crate::provider::ProviderRuntimeBinding::advisory_only();
+            let projected = crate::provider::build_projected_context_for_session_with_binding(
                 config,
                 session_id,
                 include_system_prompt,
-            )?;
+                provider_binding,
+            )
+            .await?;
             return Ok(AssembledConversationContext {
                 messages: projected.messages,
                 artifacts: projected.artifacts,

--- a/crates/app/src/conversation/context_engine.rs
+++ b/crates/app/src/conversation/context_engine.rs
@@ -671,6 +671,30 @@ mod tests {
     use crate::config::MemoryProfile;
     use crate::test_support::TurnTestHarness;
 
+    #[cfg(feature = "memory-sqlite")]
+    async fn provider_messages_with_kernel_binding(
+        config: &LoongClawConfig,
+        session_id: &str,
+        kernel_ctx: &crate::KernelContext,
+    ) -> Vec<Value> {
+        let envelope = load_stage_envelope(
+            config,
+            session_id,
+            ConversationRuntimeBinding::kernel(kernel_ctx),
+        )
+        .await
+        .expect("load staged memory envelope");
+        crate::provider::project_hydrated_memory_context_for_view_with_binding(
+            config,
+            true,
+            &crate::tools::runtime_tool_view(),
+            crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx),
+            &envelope.hydrated,
+        )
+        .await
+        .messages
+    }
+
     #[test]
     fn default_engine_metadata_has_stable_identity() {
         let metadata = DefaultContextEngine.metadata();
@@ -803,8 +827,7 @@ mod tests {
             .await
             .expect("assemble messages");
         let provider_messages =
-            crate::provider::build_messages_for_session(&config, session_id, true)
-                .expect("build provider messages");
+            provider_messages_with_kernel_binding(&config, session_id, &harness.kernel_ctx).await;
 
         assert_eq!(
             kernel_messages, provider_messages,
@@ -856,8 +879,7 @@ mod tests {
             .await
             .expect("assemble messages");
         let provider_messages =
-            crate::provider::build_messages_for_session(&config, session_id, true)
-                .expect("build provider messages");
+            provider_messages_with_kernel_binding(&config, session_id, &harness.kernel_ctx).await;
 
         assert_eq!(
             kernel_messages, provider_messages,
@@ -906,8 +928,7 @@ mod tests {
             .await
             .expect("assemble messages");
         let provider_messages =
-            crate::provider::build_messages_for_session(&config, session_id, true)
-                .expect("build provider messages");
+            provider_messages_with_kernel_binding(&config, session_id, &harness.kernel_ctx).await;
 
         assert_eq!(
             kernel_messages, provider_messages,
@@ -960,8 +981,7 @@ mod tests {
             .await
             .expect("assemble messages");
         let provider_messages =
-            crate::provider::build_messages_for_session(&config, session_id, true)
-                .expect("build provider messages");
+            provider_messages_with_kernel_binding(&config, session_id, &harness.kernel_ctx).await;
 
         assert_eq!(
             kernel_messages, provider_messages,

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -68,7 +68,7 @@ pub use runtime::{
     collect_context_engine_runtime_snapshot, resolve_context_engine_selection,
     resolve_turn_middleware_selection,
 };
-pub use runtime_binding::ConversationRuntimeBinding;
+pub use runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
 pub use safe_lane_failure::{
     SafeLaneFailureCode, SafeLaneFailureRouteDecision, SafeLaneFailureRouteSource,
     SafeLaneTerminalRouteSnapshot, classify_safe_lane_plan_failure,

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -79,7 +79,9 @@ pub use session_address::{
     ConversationSessionAddress, decode_route_session_segment, encode_route_session_segment,
     parse_route_session_id,
 };
-pub use session_history::load_discovery_first_event_summary;
+pub use session_history::{
+    load_discovery_first_event_summary, load_discovery_first_event_summary_with_kernel_context,
+};
 pub use session_history::{
     load_fast_lane_tool_batch_event_summary, load_safe_lane_event_summary,
     load_turn_checkpoint_event_summary,

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -27,7 +27,7 @@ use super::context_engine_registry::{
 };
 use super::prompt_orchestrator::seed_prompt_fragments_from_context;
 use super::prompt_orchestrator::sync_prompt_fragments_into_context;
-use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
+use super::runtime_binding::ConversationRuntimeBinding;
 use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::ProviderTurn;
 use super::turn_middleware::{

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -27,7 +27,7 @@ use super::context_engine_registry::{
 };
 use super::prompt_orchestrator::seed_prompt_fragments_from_context;
 use super::prompt_orchestrator::sync_prompt_fragments_into_context;
-use super::runtime_binding::ConversationRuntimeBinding;
+use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
 use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::ProviderTurn;
 use super::turn_middleware::{
@@ -315,7 +315,7 @@ pub struct AsyncDelegateSpawnRequest {
     pub execution: ConstrainedSubagentExecution,
     pub(crate) runtime_self_continuity: Option<RuntimeSelfContinuity>,
     pub timeout_seconds: u64,
-    pub kernel_context: Option<KernelContext>,
+    pub binding: OwnedConversationRuntimeBinding,
 }
 
 #[async_trait]
@@ -342,11 +342,22 @@ impl DefaultAsyncDelegateSpawner {
 #[async_trait]
 impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
     async fn spawn(&self, request: AsyncDelegateSpawnRequest) -> Result<(), String> {
-        let execution_timeout_seconds = request.execution.timeout_seconds;
-        if request.timeout_seconds != execution_timeout_seconds {
+        let AsyncDelegateSpawnRequest {
+            child_session_id,
+            parent_session_id,
+            task,
+            label,
+            execution,
+            runtime_self_continuity,
+            timeout_seconds,
+            binding,
+        } = request;
+
+        let execution_timeout_seconds = execution.timeout_seconds;
+        if timeout_seconds != execution_timeout_seconds {
             return Err(format!(
                 "async_delegate_timeout_mismatch: request timeout {} != execution timeout {}",
-                request.timeout_seconds, execution_timeout_seconds
+                timeout_seconds, execution_timeout_seconds
             ));
         }
 
@@ -354,50 +365,48 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
             &self.config.memory,
         ))?;
         let runtime = DefaultConversationRuntime::from_config_or_env(self.config.as_ref())?;
+        let runtime_ref = &runtime;
+        let child_session_id_for_spawn = child_session_id.clone();
+        let parent_session_id_for_spawn = parent_session_id.clone();
+        let child_binding = binding.clone();
         super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
-            &runtime,
-            &request.parent_session_id,
-            &request.child_session_id,
-            ConversationRuntimeBinding::from_optional_kernel_context(
-                request.kernel_context.as_ref(),
-            ),
-            || async {
+            runtime_ref,
+            &parent_session_id,
+            &child_session_id,
+            binding.as_borrowed(),
+            move || async move {
                 let started = repo.transition_session_with_event_if_current(
-                    &request.child_session_id,
+                    &child_session_id_for_spawn,
                     TransitionSessionWithEventIfCurrentRequest {
                         expected_state: SessionState::Ready,
                         next_state: SessionState::Running,
                         last_error: None,
                         event_kind: "delegate_started".to_owned(),
-                        actor_session_id: Some(request.parent_session_id.clone()),
-                        event_payload_json: request
-                            .execution
-                            .spawn_payload_with_runtime_self_continuity(
-                                &request.task,
-                                request.label.as_deref(),
-                                request.runtime_self_continuity.as_ref(),
-                            ),
+                        actor_session_id: Some(parent_session_id_for_spawn.clone()),
+                        event_payload_json: execution.spawn_payload_with_runtime_self_continuity(
+                            &task,
+                            label.as_deref(),
+                            runtime_self_continuity.as_ref(),
+                        ),
                     },
                 )?;
                 if started.is_none() {
                     return Err(format!(
                         "async_delegate_spawn_skipped: session `{}` was not in Ready state",
-                        request.child_session_id
+                        child_session_id_for_spawn
                     ));
                 }
 
                 let _ = super::turn_coordinator::run_started_delegate_child_turn_with_runtime(
                     self.config.as_ref(),
-                    &runtime,
-                    &request.child_session_id,
-                    &request.parent_session_id,
-                    request.label,
-                    &request.task,
-                    request.execution,
+                    runtime_ref,
+                    &child_session_id_for_spawn,
+                    &parent_session_id_for_spawn,
+                    label,
+                    &task,
+                    execution,
                     execution_timeout_seconds,
-                    ConversationRuntimeBinding::from_optional_kernel_context(
-                        request.kernel_context.as_ref(),
-                    ),
+                    child_binding.as_borrowed(),
                 )
                 .await;
                 Ok(())

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -315,7 +315,7 @@ pub struct AsyncDelegateSpawnRequest {
     pub execution: ConstrainedSubagentExecution,
     pub(crate) runtime_self_continuity: Option<RuntimeSelfContinuity>,
     pub timeout_seconds: u64,
-    pub binding: OwnedConversationRuntimeBinding,
+    pub kernel_context: Option<KernelContext>,
 }
 
 #[async_trait]
@@ -350,7 +350,7 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
             execution,
             runtime_self_continuity,
             timeout_seconds,
-            binding,
+            kernel_context,
         } = request;
 
         let execution_timeout_seconds = execution.timeout_seconds;
@@ -368,12 +368,14 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
         let runtime_ref = &runtime;
         let child_session_id_for_spawn = child_session_id.clone();
         let parent_session_id_for_spawn = parent_session_id.clone();
-        let child_binding = binding.clone();
+        let binding =
+            ConversationRuntimeBinding::from_optional_kernel_context(kernel_context.as_ref());
+        let child_kernel_context = kernel_context.clone();
         super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime_ref,
             &parent_session_id,
             &child_session_id,
-            binding.as_borrowed(),
+            binding,
             move || async move {
                 let started = repo.transition_session_with_event_if_current(
                     &child_session_id_for_spawn,
@@ -406,7 +408,9 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
                     &task,
                     execution,
                     execution_timeout_seconds,
-                    child_binding.as_borrowed(),
+                    ConversationRuntimeBinding::from_optional_kernel_context(
+                        child_kernel_context.as_ref(),
+                    ),
                 )
                 .await;
                 Ok(())
@@ -1280,9 +1284,7 @@ fn provider_runtime_binding(
         ConversationRuntimeBinding::Kernel(kernel_ctx) => {
             provider::ProviderRuntimeBinding::kernel(kernel_ctx)
         }
-        ConversationRuntimeBinding::AdvisoryOnly => {
-            provider::ProviderRuntimeBinding::advisory_only()
-        }
+        ConversationRuntimeBinding::Direct => provider::ProviderRuntimeBinding::advisory_only(),
     }
 }
 

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -1271,7 +1271,9 @@ fn provider_runtime_binding(
         ConversationRuntimeBinding::Kernel(kernel_ctx) => {
             provider::ProviderRuntimeBinding::kernel(kernel_ctx)
         }
-        ConversationRuntimeBinding::Direct => provider::ProviderRuntimeBinding::direct(),
+        ConversationRuntimeBinding::AdvisoryOnly => {
+            provider::ProviderRuntimeBinding::advisory_only()
+        }
     }
 }
 
@@ -1338,10 +1340,10 @@ mod tests {
     use crate::test_support::TurnTestHarness;
 
     #[test]
-    fn provider_runtime_binding_maps_direct_conversation_binding_to_direct() {
+    fn provider_runtime_binding_maps_direct_conversation_binding_to_advisory_only() {
         assert!(matches!(
             provider_runtime_binding(ConversationRuntimeBinding::direct()),
-            provider::ProviderRuntimeBinding::Direct
+            provider::ProviderRuntimeBinding::AdvisoryOnly
         ));
     }
 

--- a/crates/app/src/conversation/runtime_binding.rs
+++ b/crates/app/src/conversation/runtime_binding.rs
@@ -2,6 +2,63 @@ use loongclaw_contracts::GovernedSessionMode;
 
 use crate::KernelContext;
 
+#[derive(Clone, Default)]
+pub enum OwnedConversationRuntimeBinding {
+    Kernel(KernelContext),
+    #[default]
+    AdvisoryOnly,
+}
+
+impl OwnedConversationRuntimeBinding {
+    pub fn from_borrowed(binding: ConversationRuntimeBinding<'_>) -> Self {
+        match binding {
+            ConversationRuntimeBinding::Kernel(kernel_ctx) => Self::Kernel(kernel_ctx.clone()),
+            ConversationRuntimeBinding::AdvisoryOnly => Self::AdvisoryOnly,
+        }
+    }
+
+    pub fn kernel(kernel_ctx: KernelContext) -> Self {
+        Self::Kernel(kernel_ctx)
+    }
+
+    pub const fn advisory_only() -> Self {
+        Self::AdvisoryOnly
+    }
+
+    pub const fn direct() -> Self {
+        Self::AdvisoryOnly
+    }
+
+    pub fn as_borrowed(&self) -> ConversationRuntimeBinding<'_> {
+        match self {
+            Self::Kernel(kernel_ctx) => ConversationRuntimeBinding::Kernel(kernel_ctx),
+            Self::AdvisoryOnly => ConversationRuntimeBinding::AdvisoryOnly,
+        }
+    }
+
+    pub fn kernel_context(&self) -> Option<&KernelContext> {
+        match self {
+            Self::Kernel(kernel_ctx) => Some(kernel_ctx),
+            Self::AdvisoryOnly => None,
+        }
+    }
+
+    pub const fn is_kernel_bound(&self) -> bool {
+        matches!(self, Self::Kernel(_))
+    }
+
+    pub const fn session_mode(&self) -> GovernedSessionMode {
+        match self {
+            Self::Kernel(_) => GovernedSessionMode::MutatingCapable,
+            Self::AdvisoryOnly => GovernedSessionMode::AdvisoryOnly,
+        }
+    }
+
+    pub const fn allows_mutation(&self) -> bool {
+        matches!(self, Self::Kernel(_))
+    }
+}
+
 #[derive(Clone, Copy, Default)]
 pub enum ConversationRuntimeBinding<'a> {
     Kernel(&'a KernelContext),
@@ -49,5 +106,53 @@ impl<'a> ConversationRuntimeBinding<'a> {
 
     pub const fn allows_mutation(self) -> bool {
         matches!(self, Self::Kernel(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
+
+    #[test]
+    fn owned_conversation_runtime_binding_round_trips_kernel_binding() {
+        let kernel_ctx = crate::context::bootstrap_test_kernel_context(
+            "owned-conversation-runtime-binding-kernel",
+            60,
+        )
+        .expect("test kernel context");
+
+        let owned = OwnedConversationRuntimeBinding::from_borrowed(
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        );
+
+        assert!(owned.is_kernel_bound());
+        let borrowed = owned.as_borrowed();
+        assert!(borrowed.is_kernel_bound());
+        assert_eq!(
+            borrowed.session_mode(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx).session_mode()
+        );
+
+        let roundtrip_ctx = owned
+            .kernel_context()
+            .expect("owned kernel binding should expose kernel context");
+        assert_eq!(roundtrip_ctx.token, kernel_ctx.token);
+        assert!(Arc::ptr_eq(&roundtrip_ctx.kernel, &kernel_ctx.kernel));
+    }
+
+    #[test]
+    fn owned_conversation_runtime_binding_round_trips_advisory_binding() {
+        let owned = OwnedConversationRuntimeBinding::from_borrowed(
+            ConversationRuntimeBinding::advisory_only(),
+        );
+
+        assert!(!owned.is_kernel_bound());
+        assert!(owned.kernel_context().is_none());
+        assert_eq!(
+            owned.as_borrowed().session_mode(),
+            ConversationRuntimeBinding::advisory_only().session_mode()
+        );
     }
 }

--- a/crates/app/src/conversation/runtime_binding.rs
+++ b/crates/app/src/conversation/runtime_binding.rs
@@ -1,17 +1,19 @@
+use loongclaw_contracts::GovernedSessionMode;
+
 use crate::KernelContext;
 
 #[derive(Clone, Copy, Default)]
 pub enum ConversationRuntimeBinding<'a> {
     Kernel(&'a KernelContext),
     #[default]
-    Direct,
+    AdvisoryOnly,
 }
 
 impl<'a> ConversationRuntimeBinding<'a> {
     pub fn from_optional_kernel_context(kernel_ctx: Option<&'a KernelContext>) -> Self {
         match kernel_ctx {
             Some(kernel_ctx) => Self::Kernel(kernel_ctx),
-            None => Self::Direct,
+            None => Self::AdvisoryOnly,
         }
     }
 
@@ -19,18 +21,33 @@ impl<'a> ConversationRuntimeBinding<'a> {
         Self::Kernel(kernel_ctx)
     }
 
+    pub const fn advisory_only() -> Self {
+        Self::AdvisoryOnly
+    }
+
     pub const fn direct() -> Self {
-        Self::Direct
+        Self::AdvisoryOnly
     }
 
     pub fn kernel_context(self) -> Option<&'a KernelContext> {
         match self {
             Self::Kernel(kernel_ctx) => Some(kernel_ctx),
-            Self::Direct => None,
+            Self::AdvisoryOnly => None,
         }
     }
 
     pub const fn is_kernel_bound(self) -> bool {
+        matches!(self, Self::Kernel(_))
+    }
+
+    pub const fn session_mode(self) -> GovernedSessionMode {
+        match self {
+            Self::Kernel(_) => GovernedSessionMode::MutatingCapable,
+            Self::AdvisoryOnly => GovernedSessionMode::AdvisoryOnly,
+        }
+    }
+
+    pub const fn allows_mutation(self) -> bool {
         matches!(self, Self::Kernel(_))
     }
 }

--- a/crates/app/src/conversation/runtime_binding.rs
+++ b/crates/app/src/conversation/runtime_binding.rs
@@ -6,14 +6,14 @@ use crate::KernelContext;
 pub enum OwnedConversationRuntimeBinding {
     Kernel(KernelContext),
     #[default]
-    AdvisoryOnly,
+    Direct,
 }
 
 impl OwnedConversationRuntimeBinding {
     pub fn from_borrowed(binding: ConversationRuntimeBinding<'_>) -> Self {
         match binding {
             ConversationRuntimeBinding::Kernel(kernel_ctx) => Self::Kernel(kernel_ctx.clone()),
-            ConversationRuntimeBinding::AdvisoryOnly => Self::AdvisoryOnly,
+            ConversationRuntimeBinding::Direct => Self::Direct,
         }
     }
 
@@ -22,24 +22,24 @@ impl OwnedConversationRuntimeBinding {
     }
 
     pub const fn advisory_only() -> Self {
-        Self::AdvisoryOnly
+        Self::Direct
     }
 
     pub const fn direct() -> Self {
-        Self::AdvisoryOnly
+        Self::Direct
     }
 
     pub fn as_borrowed(&self) -> ConversationRuntimeBinding<'_> {
         match self {
             Self::Kernel(kernel_ctx) => ConversationRuntimeBinding::Kernel(kernel_ctx),
-            Self::AdvisoryOnly => ConversationRuntimeBinding::AdvisoryOnly,
+            Self::Direct => ConversationRuntimeBinding::Direct,
         }
     }
 
     pub fn kernel_context(&self) -> Option<&KernelContext> {
         match self {
             Self::Kernel(kernel_ctx) => Some(kernel_ctx),
-            Self::AdvisoryOnly => None,
+            Self::Direct => None,
         }
     }
 
@@ -50,7 +50,7 @@ impl OwnedConversationRuntimeBinding {
     pub const fn session_mode(&self) -> GovernedSessionMode {
         match self {
             Self::Kernel(_) => GovernedSessionMode::MutatingCapable,
-            Self::AdvisoryOnly => GovernedSessionMode::AdvisoryOnly,
+            Self::Direct => GovernedSessionMode::AdvisoryOnly,
         }
     }
 
@@ -63,14 +63,14 @@ impl OwnedConversationRuntimeBinding {
 pub enum ConversationRuntimeBinding<'a> {
     Kernel(&'a KernelContext),
     #[default]
-    AdvisoryOnly,
+    Direct,
 }
 
 impl<'a> ConversationRuntimeBinding<'a> {
     pub fn from_optional_kernel_context(kernel_ctx: Option<&'a KernelContext>) -> Self {
         match kernel_ctx {
             Some(kernel_ctx) => Self::Kernel(kernel_ctx),
-            None => Self::AdvisoryOnly,
+            None => Self::Direct,
         }
     }
 
@@ -79,17 +79,17 @@ impl<'a> ConversationRuntimeBinding<'a> {
     }
 
     pub const fn advisory_only() -> Self {
-        Self::AdvisoryOnly
+        Self::Direct
     }
 
     pub const fn direct() -> Self {
-        Self::AdvisoryOnly
+        Self::Direct
     }
 
     pub fn kernel_context(self) -> Option<&'a KernelContext> {
         match self {
             Self::Kernel(kernel_ctx) => Some(kernel_ctx),
-            Self::AdvisoryOnly => None,
+            Self::Direct => None,
         }
     }
 
@@ -100,7 +100,7 @@ impl<'a> ConversationRuntimeBinding<'a> {
     pub const fn session_mode(self) -> GovernedSessionMode {
         match self {
             Self::Kernel(_) => GovernedSessionMode::MutatingCapable,
-            Self::AdvisoryOnly => GovernedSessionMode::AdvisoryOnly,
+            Self::Direct => GovernedSessionMode::AdvisoryOnly,
         }
     }
 

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -204,16 +204,13 @@ pub async fn load_fast_lane_tool_batch_event_summary(
 pub async fn load_discovery_first_event_summary(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<DiscoveryFirstEventSummary> {
     load_discovery_first_event_summary_with_binding(
         session_id,
         limit,
-        kernel_ctx.map_or_else(
-            ConversationRuntimeBinding::direct,
-            ConversationRuntimeBinding::kernel,
-        ),
+        binding,
         #[cfg(feature = "memory-sqlite")]
         memory_config,
     )
@@ -226,10 +223,14 @@ pub async fn load_discovery_first_event_summary_with_kernel_context(
     kernel_ctx: Option<&KernelContext>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<DiscoveryFirstEventSummary> {
+    let binding = kernel_ctx.map_or_else(
+        ConversationRuntimeBinding::direct,
+        ConversationRuntimeBinding::kernel,
+    );
     load_discovery_first_event_summary(
         session_id,
         limit,
-        kernel_ctx,
+        binding,
         #[cfg(feature = "memory-sqlite")]
         memory_config,
     )

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -204,13 +204,16 @@ pub async fn load_fast_lane_tool_batch_event_summary(
 pub async fn load_discovery_first_event_summary(
     session_id: &str,
     limit: usize,
-    binding: ConversationRuntimeBinding<'_>,
+    kernel_ctx: Option<&KernelContext>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<DiscoveryFirstEventSummary> {
     load_discovery_first_event_summary_with_binding(
         session_id,
         limit,
-        binding,
+        kernel_ctx.map_or_else(
+            ConversationRuntimeBinding::direct,
+            ConversationRuntimeBinding::kernel,
+        ),
         #[cfg(feature = "memory-sqlite")]
         memory_config,
     )
@@ -226,10 +229,7 @@ pub async fn load_discovery_first_event_summary_with_kernel_context(
     load_discovery_first_event_summary(
         session_id,
         limit,
-        kernel_ctx.map_or_else(
-            ConversationRuntimeBinding::direct,
-            ConversationRuntimeBinding::kernel,
-        ),
+        kernel_ctx,
         #[cfg(feature = "memory-sqlite")]
         memory_config,
     )

--- a/crates/app/src/conversation/session_history.rs
+++ b/crates/app/src/conversation/session_history.rs
@@ -204,10 +204,26 @@ pub async fn load_fast_lane_tool_batch_event_summary(
 pub async fn load_discovery_first_event_summary(
     session_id: &str,
     limit: usize,
-    kernel_ctx: Option<&KernelContext>,
+    binding: ConversationRuntimeBinding<'_>,
     #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
 ) -> CliResult<DiscoveryFirstEventSummary> {
     load_discovery_first_event_summary_with_binding(
+        session_id,
+        limit,
+        binding,
+        #[cfg(feature = "memory-sqlite")]
+        memory_config,
+    )
+    .await
+}
+
+pub async fn load_discovery_first_event_summary_with_kernel_context(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    #[cfg(feature = "memory-sqlite")] memory_config: &MemoryRuntimeConfig,
+) -> CliResult<DiscoveryFirstEventSummary> {
+    load_discovery_first_event_summary(
         session_id,
         limit,
         kernel_ctx.map_or_else(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2989,8 +2989,15 @@ async fn default_runtime_build_context_matches_builtin_summary_projection() {
         )
         .await
         .expect("build context from default runtime");
-    let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
-        .expect("build provider messages");
+    let provider_messages = crate::provider::build_projected_context_for_session_with_binding(
+        &config,
+        &session_id,
+        true,
+        crate::provider::ProviderRuntimeBinding::advisory_only(),
+    )
+    .await
+    .expect("build provider messages")
+    .messages;
 
     assert_eq!(
         assembled.messages, provider_messages,
@@ -3281,8 +3288,15 @@ async fn default_runtime_build_context_explicit_builtin_system_preserves_profile
         )
         .await
         .expect("build context from default runtime");
-    let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
-        .expect("build provider messages");
+    let provider_messages = crate::provider::build_projected_context_for_session_with_binding(
+        &config,
+        &session_id,
+        true,
+        crate::provider::ProviderRuntimeBinding::advisory_only(),
+    )
+    .await
+    .expect("build provider messages")
+    .messages;
 
     assert_eq!(
         assembled.messages, provider_messages,
@@ -10761,6 +10775,9 @@ async fn app_tool_dispatcher_preserves_optional_kernel_approval_hook_compatibili
 #[test]
 fn binding_first_approval_boundary_coordinator_source_does_not_reconstruct_binding_from_optional_kernel()
  {
+    // This source-level check protects the approval-boundary contract itself:
+    // benign refactors may move code around, but the coordinator must not
+    // reintroduce an optional-kernel approval seam or rebuild binding from it.
     let source = include_str!("turn_coordinator.rs");
 
     assert!(
@@ -13041,6 +13058,72 @@ async fn autonomy_policy_turn_engine_bounded_autonomous_requires_approval_for_se
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(feature = "memory-sqlite")]
+async fn autonomy_policy_turn_engine_advisory_binding_denies_session_mutation_before_persisting_approval_request()
+ {
+    use crate::conversation::turn_engine::{
+        DefaultAppToolDispatcher, ProviderTurn, TurnEngine, TurnResult,
+    };
+
+    let mut config = test_config();
+    config.memory.sqlite_path =
+        unique_memory_sqlite_path("autonomy-advisory-session-mutation-denied");
+    config.tools.autonomy_profile = AutonomyProfile::BoundedAutonomous;
+    config.tools.sessions.allow_mutation = true;
+
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = SessionRepository::new(&memory_config).expect("session repository");
+    let dispatcher = DefaultAppToolDispatcher::with_config(memory_config.clone(), config.clone());
+    let session_id = "session-autonomy-advisory-session-mutation";
+    let session_context = autonomy_runtime_session_context(session_id, &config);
+    let tool_intent = provider_tool_intent(
+        "session_archive",
+        json!({
+            "session_id": "child-session"
+        }),
+        session_id,
+        "turn-autonomy-advisory-session-mutation",
+        "call-autonomy-advisory-session-mutation",
+    );
+    let turn = ProviderTurn {
+        assistant_text: String::new(),
+        tool_intents: vec![tool_intent],
+        raw_meta: Value::Null,
+    };
+    let engine = TurnEngine::new(5);
+    let binding = ConversationRuntimeBinding::direct();
+    let result = engine
+        .execute_turn_in_context(&turn, &session_context, &dispatcher, binding, None)
+        .await;
+
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(failure.code, "autonomy_policy_binding_missing");
+            assert!(
+                failure.reason.contains("kernel-bound"),
+                "unexpected denial reason: {failure:?}"
+            );
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolDenied, got {other:?}");
+        }
+    }
+
+    let approval_requests = repo
+        .list_approval_requests_for_session(session_id, None)
+        .expect("list approval requests");
+    assert!(
+        approval_requests.is_empty(),
+        "advisory binding should fail closed before persisting approval requests"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "memory-sqlite")]
 async fn autonomy_policy_telemetry_handle_turn_persists_approval_required_tool_decision() {
     let workspace_root_name =
         unique_acp_test_id("conversation-autonomy-telemetry", "guided-install-approval");
@@ -14839,7 +14922,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
         &payloads,
     );
 
-    let direct_summary = super::session_history::load_discovery_first_event_summary_with_binding(
+    let direct_summary = load_discovery_first_event_summary(
         "session-discovery-first-direct",
         32,
         ConversationRuntimeBinding::direct(),
@@ -14859,7 +14942,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
     let (kernel_ctx, invocations) =
         build_kernel_context_with_window_turns(audit, discovery_first_window_turns(&payloads));
 
-    let kernel_summary = super::session_history::load_discovery_first_event_summary_with_binding(
+    let kernel_summary = load_discovery_first_event_summary(
         "session-discovery-first-kernel",
         48,
         ConversationRuntimeBinding::kernel(&kernel_ctx),
@@ -14889,7 +14972,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn load_discovery_first_event_summary_preserves_kernel_context_compatibility_shim() {
+async fn load_discovery_first_event_summary_with_kernel_context_preserves_compatibility_shim() {
     let payloads = [
         json!({
             "type": "conversation_event",
@@ -14923,7 +15006,7 @@ async fn load_discovery_first_event_summary_preserves_kernel_context_compatibili
         &payloads,
     );
 
-    let direct_summary = load_discovery_first_event_summary(
+    let direct_summary = load_discovery_first_event_summary_with_kernel_context(
         "session-discovery-first-compat-direct",
         16,
         None,
@@ -14942,7 +15025,7 @@ async fn load_discovery_first_event_summary_preserves_kernel_context_compatibili
     let (kernel_ctx, invocations) =
         build_kernel_context_with_window_turns(audit, discovery_first_window_turns(&payloads));
 
-    let kernel_summary = load_discovery_first_event_summary(
+    let kernel_summary = load_discovery_first_event_summary_with_kernel_context(
         "session-discovery-first-compat-kernel",
         24,
         Some(&kernel_ctx),
@@ -22236,6 +22319,41 @@ fn default_context_engine_metadata_advertises_context_compaction() {
             .capabilities
             .contains(&ContextEngineCapability::ContextCompaction)
     );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn default_context_engine_advisory_context_includes_governed_runtime_binding_section() {
+    use super::context_engine::{ConversationContextEngine, DefaultContextEngine};
+
+    let workspace_root_name =
+        unique_acp_test_id("default-context-engine", "advisory-binding-system-message");
+    let workspace_root = std::env::temp_dir().join(workspace_root_name);
+    let _ = std::fs::remove_dir_all(&workspace_root);
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+
+    let mut config = test_config();
+    config.tools.file_root = Some(workspace_root.display().to_string());
+
+    let engine = DefaultContextEngine;
+    let assembled = engine
+        .assemble_context(
+            &config,
+            "default-context-engine-advisory",
+            true,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("assemble advisory context");
+    let system = assembled
+        .messages
+        .first()
+        .and_then(|message| message["content"].as_str())
+        .expect("system message content");
+
+    assert!(system.contains("## Governed Runtime Binding"));
+    assert!(system.contains("session_mode: advisory_only"));
+    assert!(system.contains("kernel_binding: absent"));
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -18135,7 +18135,7 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_delegate_for_approve_once_on_advisory_binding()
+async fn handle_turn_with_runtime_approval_request_resolve_executes_governed_delegate_for_approve_once_on_advisory_binding()
  {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
@@ -18224,19 +18224,11 @@ async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_dele
             ConversationRuntimeBinding::direct(),
         )
         .await
-        .expect("advisory denial should still return a reply payload");
+        .expect("approval resolve reply");
 
     assert!(
-        reply.contains("governed_runtime_binding_required"),
-        "expected governed runtime binding denial, got: {reply}"
-    );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
-    assert_eq!(
-        *runtime
-            .completion_calls
-            .lock()
-            .expect("completion calls lock"),
-        0
+        reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {reply}"
     );
 
     let request = repo
@@ -18245,12 +18237,12 @@ async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_dele
         .expect("approval request row");
     assert_eq!(
         request.status,
-        crate::session::repository::ApprovalRequestStatus::Pending
+        crate::session::repository::ApprovalRequestStatus::Executed
     );
-    assert_eq!(request.decision, None);
-    assert_eq!(request.resolved_by_session_id, None);
-    assert!(request.executed_at.is_none(), "request={request:?}");
-    assert!(request.last_error.is_none(), "request={request:?}");
+    assert_eq!(
+        request.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveOnce)
+    );
     assert!(
         repo.load_approval_grant("root-session", "tool:delegate")
             .expect("load grant")
@@ -18261,131 +18253,11 @@ async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_dele
         .list_visible_sessions("root-session")
         .expect("list visible sessions")
         .into_iter()
-        .find(|session| session.parent_session_id.as_deref() == Some("root-session"));
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("delegate child session");
     assert!(
-        child.is_none(),
-        "advisory approval replay must not spawn a child"
-    );
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[tokio::test]
-async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_grant_seed_on_advisory_binding()
- {
-    let db_path = std::env::temp_dir().join(format!(
-        "{}.sqlite3",
-        unique_acp_test_id(
-            "conversation-approval-resolve",
-            "approve-always-advisory-denied"
-        )
-    ));
-    let _ = std::fs::remove_file(&db_path);
-
-    let mut config = test_config();
-    config.memory.sqlite_path = db_path.display().to_string();
-    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
-    let repo = crate::session::repository::SessionRepository::new(&memory_config)
-        .expect("session repository");
-    repo.create_session(crate::session::repository::NewSessionRecord {
-        session_id: "root-session".to_owned(),
-        kind: crate::session::repository::SessionKind::Root,
-        parent_session_id: None,
-        label: Some("Root".to_owned()),
-        state: crate::session::repository::SessionState::Ready,
-    })
-    .expect("create root session");
-    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
-        approval_request_id: "apr-delegate-advisory-denied".to_owned(),
-        session_id: "root-session".to_owned(),
-        turn_id: "turn-delegate-parent".to_owned(),
-        tool_call_id: "call-delegate-parent".to_owned(),
-        tool_name: "delegate".to_owned(),
-        approval_key: "tool:delegate".to_owned(),
-        request_payload_json: json!({
-            "session_id": "root-session",
-            "parent_session_id": Value::Null,
-            "turn_id": "turn-delegate-parent",
-            "tool_call_id": "call-delegate-parent",
-            "tool_name": "delegate",
-            "args_json": {
-                "task": "child task",
-                "label": "research-subtask"
-            },
-            "source": "provider_tool_call",
-            "execution_kind": "app"
-        }),
-        governance_snapshot_json: json!({
-            "governance_scope": "topology_mutation",
-            "risk_class": "high",
-            "approval_mode": "policy_driven",
-            "rule_id": "governed_tool_requires_approval",
-            "reason": "operator approval required before running `delegate`"
-        }),
-    })
-    .expect("seed approval request");
-
-    let runtime = FakeRuntime::with_turns_and_completions(
-        vec![],
-        vec![Ok(ProviderTurn {
-            assistant_text: "resolving approval".to_owned(),
-            tool_intents: vec![provider_tool_intent(
-                "approval_request_resolve",
-                json!({
-                    "approval_request_id": "apr-delegate-advisory-denied",
-                    "decision": "approve_always"
-                }),
-                "root-session",
-                "turn-approval-resolve",
-                "call-approval-resolve",
-            )],
-            raw_meta: Value::Null,
-        })],
-        vec![],
-    )
-    .with_durable_memory_config(memory_config.clone());
-    let coordinator = ConversationTurnCoordinator::new();
-
-    let reply = coordinator
-        .handle_turn_with_runtime(
-            &config,
-            "root-session",
-            "show raw json tool output",
-            ProviderErrorMode::Propagate,
-            &runtime,
-            ConversationRuntimeBinding::direct(),
-        )
-        .await
-        .expect("advisory denial should still return a reply payload");
-
-    assert!(
-        reply.contains("governed_runtime_binding_required"),
-        "expected governed runtime binding denial, got: {reply}"
-    );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
-    assert_eq!(
-        *runtime
-            .completion_calls
-            .lock()
-            .expect("completion calls lock"),
-        0
-    );
-
-    let request = repo
-        .load_approval_request("apr-delegate-advisory-denied")
-        .expect("load approval request")
-        .expect("approval request row");
-    assert_eq!(
-        request.status,
-        crate::session::repository::ApprovalRequestStatus::Pending
-    );
-    assert_eq!(request.decision, None);
-    assert_eq!(request.resolved_by_session_id, None);
-    assert!(request.executed_at.is_none(), "request={request:?}");
-    assert!(request.last_error.is_none(), "request={request:?}");
-    assert!(
-        repo.load_approval_grant("root-session", "tool:delegate")
-            .expect("load grant")
-            .is_none()
+        child.state == crate::session::repository::SessionState::Completed,
+        "delegate child should complete after advisory approval replay"
     );
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -252,9 +252,7 @@ impl crate::conversation::AsyncDelegateSpawner for PostPrepareFailingAsyncDelega
             runtime.as_ref(),
             &request.parent_session_id,
             &request.child_session_id,
-            ConversationRuntimeBinding::from_optional_kernel_context(
-                request.kernel_context.as_ref(),
-            ),
+            request.binding.as_borrowed(),
             || async { Err("synthetic_post_prepare_async_spawn_failure".to_owned()) },
         )
         .await
@@ -274,32 +272,43 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
         &self,
         request: crate::conversation::AsyncDelegateSpawnRequest,
     ) -> Result<(), String> {
+        let crate::conversation::AsyncDelegateSpawnRequest {
+            child_session_id,
+            parent_session_id,
+            task,
+            label,
+            execution,
+            runtime_self_continuity: _,
+            timeout_seconds,
+            binding,
+        } = request;
         let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
         let repo = crate::session::repository::SessionRepository::new(&memory_config)?;
         let runtime = self
             .runtime
             .get()
             .ok_or_else(|| "test_local_delegate_runtime_missing".to_owned())?;
+        let child_session_id_for_spawn = child_session_id.clone();
+        let parent_session_id_for_spawn = parent_session_id.clone();
+        let child_binding = binding.clone();
         super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime.as_ref(),
-            &request.parent_session_id,
-            &request.child_session_id,
-            ConversationRuntimeBinding::from_optional_kernel_context(
-                request.kernel_context.as_ref(),
-            ),
-            || async {
+            &parent_session_id,
+            &child_session_id,
+            binding.as_borrowed(),
+            move || async move {
                 let started = repo.transition_session_with_event_if_current(
-                    &request.child_session_id,
+                    &child_session_id_for_spawn,
                     crate::session::repository::TransitionSessionWithEventIfCurrentRequest {
                         expected_state: crate::session::repository::SessionState::Ready,
                         next_state: crate::session::repository::SessionState::Running,
                         last_error: None,
                         event_kind: "delegate_started".to_owned(),
-                        actor_session_id: Some(request.parent_session_id.clone()),
+                        actor_session_id: Some(parent_session_id_for_spawn.clone()),
                         event_payload_json: json!({
-                            "task": request.task,
-                            "label": request.label,
-                            "timeout_seconds": request.timeout_seconds,
+                            "task": task.clone(),
+                            "label": label.clone(),
+                            "timeout_seconds": timeout_seconds,
                         }),
                     },
                 )?;
@@ -310,15 +319,13 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
                 let _ = super::turn_coordinator::run_started_delegate_child_turn_with_runtime(
                     &self.config,
                     runtime.as_ref(),
-                    &request.child_session_id,
-                    &request.parent_session_id,
-                    request.label,
-                    &request.task,
-                    request.execution,
-                    request.timeout_seconds,
-                    ConversationRuntimeBinding::from_optional_kernel_context(
-                        request.kernel_context.as_ref(),
-                    ),
+                    &child_session_id_for_spawn,
+                    &parent_session_id_for_spawn,
+                    label,
+                    &task,
+                    execution,
+                    timeout_seconds,
+                    child_binding.as_borrowed(),
                 )
                 .await;
                 Ok(())
@@ -19099,7 +19106,10 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     assert_eq!(spawn_request.label.as_deref(), Some("async-child"));
     assert_eq!(spawn_request.timeout_seconds, 9);
     assert!(
-        spawn_request.kernel_context.is_some(),
+        matches!(
+            &spawn_request.binding,
+            crate::conversation::OwnedConversationRuntimeBinding::Kernel(_)
+        ),
         "kernel-bound parent turns should preserve governed binding for async delegates"
     );
     assert_eq!(child.state, crate::session::repository::SessionState::Ready);
@@ -19212,13 +19222,16 @@ async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spa
         "expected raw delegate_async tool output, got: {reply}"
     );
     assert!(
-        spawn_request.kernel_context.is_some(),
-        "kernel-bound parent turns should preserve kernel context for async delegate children"
+        matches!(
+            &spawn_request.binding,
+            crate::conversation::OwnedConversationRuntimeBinding::Kernel(_)
+        ),
+        "kernel-bound parent turns should preserve owned governed binding for async delegate children"
     );
     let child_kernel_ctx = spawn_request
-        .kernel_context
-        .as_ref()
-        .expect("spawn request should carry kernel context");
+        .binding
+        .kernel_context()
+        .expect("spawn request should carry kernel binding");
     assert_eq!(child_kernel_ctx.token, expected_kernel_ctx.token);
     assert!(
         Arc::ptr_eq(&child_kernel_ctx.kernel, &expected_kernel_ctx.kernel),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10524,12 +10524,12 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
 
     #[async_trait]
     impl crate::conversation::AppToolDispatcher for ApprovalBarrierDispatcher {
-        async fn maybe_require_approval(
+        async fn maybe_require_approval_with_binding(
             &self,
             _session_context: &crate::conversation::SessionContext,
             _intent: &crate::conversation::ToolIntent,
             descriptor: &crate::tools::ToolDescriptor,
-            _kernel_ctx: Option<&crate::KernelContext>,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
         ) -> Result<Option<crate::conversation::turn_engine::ApprovalRequirement>, String> {
             *self.approval_checks.lock().expect("approval checks lock") += 1;
             if descriptor.name == "delegate_async" {
@@ -10640,6 +10640,37 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
     );
 }
 
+#[test]
+fn binding_first_approval_boundary_turn_engine_source_does_not_expose_optional_kernel_hook() {
+    let source = include_str!("turn_engine.rs");
+
+    assert!(
+        !source.contains("async fn maybe_require_approval("),
+        "AppToolDispatcher should not expose an optional-kernel approval hook"
+    );
+    assert!(
+        !source.contains(
+            "self.maybe_require_approval(session_context, intent, descriptor, kernel_ctx)"
+        ),
+        "binding-first approval should not loop back through optional kernel dispatch"
+    );
+}
+
+#[test]
+fn binding_first_approval_boundary_coordinator_source_does_not_reconstruct_binding_from_optional_kernel()
+ {
+    let source = include_str!("turn_coordinator.rs");
+
+    assert!(
+        !source.contains("async fn maybe_require_approval("),
+        "Coordinator approval wrapper should not expose an optional-kernel hook"
+    );
+    assert!(
+        !source.contains("ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx)"),
+        "Coordinator approval wrapper should not reconstruct binding from optional kernel context"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on_advisory_binding()
 {
@@ -10654,12 +10685,12 @@ async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on
 
     #[async_trait]
     impl crate::conversation::AppToolDispatcher for GuardedApprovalDispatcher {
-        async fn maybe_require_approval(
+        async fn maybe_require_approval_with_binding(
             &self,
             _session_context: &crate::conversation::SessionContext,
             _intent: &crate::conversation::ToolIntent,
             _descriptor: &crate::tools::ToolDescriptor,
-            _kernel_ctx: Option<&crate::KernelContext>,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
         ) -> Result<Option<crate::conversation::turn_engine::ApprovalRequirement>, String> {
             *self.approval_checks.lock().expect("approval checks lock") += 1;
             Ok(Some(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10846,8 +10846,8 @@ async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on
         crate::tools::planned_root_tool_view(),
     );
 
-    let result = engine
-        .execute_turn_in_context(
+    let (result, trace) = engine
+        .execute_turn_in_context_with_trace(
             &turn,
             &session_context,
             &dispatcher,
@@ -10886,6 +10886,19 @@ async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on
             .expect("dispatcher executed lock")
             .is_empty(),
         "mutating app tool should not execute under advisory binding"
+    );
+    let trace = trace.expect("governed binding denial should record a trace");
+    assert_eq!(trace.decision_records.len(), 1);
+
+    let decision = &trace.decision_records[0].decision;
+    assert_eq!(decision.tool_name, "delegate_async");
+    assert_eq!(
+        decision.decision_kind,
+        crate::conversation::turn_engine::ToolDecisionKind::Deny
+    );
+    assert_eq!(
+        decision.capability_action_class.as_deref(),
+        Some("topology_expand")
     );
 }
 
@@ -18290,6 +18303,140 @@ async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_gran
         repo.load_approval_grant("root-session", "tool:delegate")
             .expect("load grant")
             .is_none()
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_reports_not_pending_before_binding_gate_for_stale_governed_retry()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-approval-resolve", "stale-governed-retry")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-delegate-stale".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-delegate-parent".to_owned(),
+        tool_call_id: "call-delegate-parent".to_owned(),
+        tool_name: "delegate".to_owned(),
+        approval_key: "tool:delegate".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-delegate-parent",
+            "tool_call_id": "call-delegate-parent",
+            "tool_name": "delegate",
+            "args_json": {
+                "task": "child task",
+                "label": "research-subtask"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "app"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "topology_mutation",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "governed_tool_requires_approval",
+            "reason": "operator approval required before running `delegate`"
+        }),
+    })
+    .expect("seed approval request");
+    let stale_request = repo
+        .transition_approval_request_if_current(
+            "apr-delegate-stale",
+            crate::session::repository::TransitionApprovalRequestIfCurrentRequest {
+                expected_status: crate::session::repository::ApprovalRequestStatus::Pending,
+                next_status: crate::session::repository::ApprovalRequestStatus::Denied,
+                decision: Some(crate::session::repository::ApprovalDecision::Deny),
+                resolved_by_session_id: Some("root-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition stale approval request")
+        .expect("stale approval request should exist");
+    assert_eq!(
+        stale_request.status,
+        crate::session::repository::ApprovalRequestStatus::Denied
+    );
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "retry stale approval".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
+                        "approval_request_id": "apr-delegate-stale",
+                        "decision": "approve_once"
+                    }),
+                    "root-session",
+                    "turn-approval-resolve-stale",
+                    "call-approval-resolve-stale",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "unused".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "retry approval resolution",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("stale advisory retry should still return a reply payload");
+
+    assert!(
+        reply.contains("approval_request_not_pending"),
+        "expected stale approval retry to report not_pending, got: {reply}"
+    );
+    assert!(
+        !reply.contains("governed_runtime_binding_required"),
+        "stale approval retry should not be rewritten as a binding denial: {reply}"
+    );
+
+    let request = repo
+        .load_approval_request("apr-delegate-stale")
+        .expect("load stale approval request")
+        .expect("stale approval request row");
+    assert_eq!(
+        request.status,
+        crate::session::repository::ApprovalRequestStatus::Denied
+    );
+    assert_eq!(
+        request.decision,
+        Some(crate::session::repository::ApprovalDecision::Deny)
     );
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -252,7 +252,9 @@ impl crate::conversation::AsyncDelegateSpawner for PostPrepareFailingAsyncDelega
             runtime.as_ref(),
             &request.parent_session_id,
             &request.child_session_id,
-            request.binding.as_borrowed(),
+            crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
+                request.kernel_context.as_ref(),
+            ),
             || async { Err("synthetic_post_prepare_async_spawn_failure".to_owned()) },
         )
         .await
@@ -280,7 +282,7 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
             execution,
             runtime_self_continuity: _,
             timeout_seconds,
-            binding,
+            kernel_context,
         } = request;
         let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
         let repo = crate::session::repository::SessionRepository::new(&memory_config)?;
@@ -290,12 +292,15 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
             .ok_or_else(|| "test_local_delegate_runtime_missing".to_owned())?;
         let child_session_id_for_spawn = child_session_id.clone();
         let parent_session_id_for_spawn = parent_session_id.clone();
-        let child_binding = binding.clone();
+        let binding = crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
+            kernel_context.as_ref(),
+        );
+        let child_kernel_context = kernel_context.clone();
         super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime.as_ref(),
             &parent_session_id,
             &child_session_id,
-            binding.as_borrowed(),
+            binding,
             move || async move {
                 let started = repo.transition_session_with_event_if_current(
                     &child_session_id_for_spawn,
@@ -325,7 +330,9 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
                     &task,
                     execution,
                     timeout_seconds,
-                    child_binding.as_borrowed(),
+                    crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
+                        child_kernel_context.as_ref(),
+                    ),
                 )
                 .await;
                 Ok(())
@@ -10647,20 +10654,108 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
     );
 }
 
-#[test]
-fn binding_first_approval_boundary_turn_engine_source_does_not_expose_optional_kernel_hook() {
-    let source = include_str!("turn_engine.rs");
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn app_tool_dispatcher_preserves_optional_kernel_approval_hook_compatibility() {
+    use async_trait::async_trait;
 
-    assert!(
-        !source.contains("async fn maybe_require_approval("),
-        "AppToolDispatcher should not expose an optional-kernel approval hook"
+    #[derive(Default)]
+    struct LegacyApprovalDispatcher {
+        kernel_binding_states: Mutex<Vec<bool>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for LegacyApprovalDispatcher {
+        async fn maybe_require_approval(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            _intent: &crate::conversation::ToolIntent,
+            descriptor: &crate::tools::ToolDescriptor,
+            kernel_ctx: Option<&KernelContext>,
+        ) -> Result<Option<crate::conversation::turn_engine::ApprovalRequirement>, String> {
+            let mut kernel_binding_states = self
+                .kernel_binding_states
+                .lock()
+                .expect("kernel binding states lock");
+            kernel_binding_states.push(kernel_ctx.is_some());
+            drop(kernel_binding_states);
+
+            Ok(Some(
+                crate::conversation::turn_engine::ApprovalRequirement {
+                    kind: crate::conversation::turn_engine::ApprovalRequirementKind::GovernedTool,
+                    reason: format!("legacy approval compatibility for `{}`", descriptor.name),
+                    rule_id: "legacy_optional_kernel_approval_hook".to_owned(),
+                    tool_name: Some(descriptor.name.to_owned()),
+                    approval_key: Some(format!("tool:{}", descriptor.name)),
+                    approval_request_id: Some(format!("apr-legacy-{}", descriptor.name)),
+                },
+            ))
+        }
+
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            Err(format!(
+                "legacy approval compatibility should preflight before executing {}",
+                request.tool_name
+            ))
+        }
+    }
+
+    let dispatcher = LegacyApprovalDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![provider_tool_intent(
+            "sessions_list",
+            json!({}),
+            "root-session",
+            "turn-legacy-approval-compatibility",
+            "call-legacy-approval-compatibility",
+        )],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
     );
+
+    let direct_result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
     assert!(
-        !source.contains(
-            "self.maybe_require_approval(session_context, intent, descriptor, kernel_ctx)"
-        ),
-        "binding-first approval should not loop back through optional kernel dispatch"
+        matches!(direct_result, TurnResult::NeedsApproval(_)),
+        "legacy optional-kernel hook should still drive direct binding approval"
     );
+
+    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
+    let kernel_result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
+            None,
+        )
+        .await;
+    assert!(
+        matches!(kernel_result, TurnResult::NeedsApproval(_)),
+        "legacy optional-kernel hook should still drive kernel-bound approval"
+    );
+
+    let kernel_binding_states = dispatcher
+        .kernel_binding_states
+        .lock()
+        .expect("kernel binding states lock");
+    assert_eq!(kernel_binding_states.as_slice(), &[false, true]);
 }
 
 #[test]
@@ -13695,7 +13790,7 @@ fn build_kernel_context_with_window_turns(
 
 #[test]
 fn conversation_runtime_binding_direct_reports_no_kernel_context() {
-    let binding = crate::conversation::ConversationRuntimeBinding::direct();
+    let binding = crate::conversation::ConversationRuntimeBinding::Direct;
 
     assert!(!binding.is_kernel_bound());
     assert!(binding.kernel_context().is_none());
@@ -13712,7 +13807,7 @@ fn conversation_runtime_binding_kernel_exposes_bound_context() {
 
 #[test]
 fn governed_runtime_binding_direct_alias_is_advisory_only_and_non_mutating() {
-    let binding = crate::conversation::ConversationRuntimeBinding::direct();
+    let binding = crate::conversation::ConversationRuntimeBinding::Direct;
 
     assert_eq!(
         binding.session_mode(),
@@ -14731,7 +14826,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
         &payloads,
     );
 
-    let direct_summary = load_discovery_first_event_summary(
+    let direct_summary = super::session_history::load_discovery_first_event_summary_with_binding(
         "session-discovery-first-direct",
         32,
         ConversationRuntimeBinding::direct(),
@@ -14751,7 +14846,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
     let (kernel_ctx, invocations) =
         build_kernel_context_with_window_turns(audit, discovery_first_window_turns(&payloads));
 
-    let kernel_summary = load_discovery_first_event_summary(
+    let kernel_summary = super::session_history::load_discovery_first_event_summary_with_binding(
         "session-discovery-first-kernel",
         48,
         ConversationRuntimeBinding::kernel(&kernel_ctx),
@@ -14815,7 +14910,7 @@ async fn load_discovery_first_event_summary_preserves_kernel_context_compatibili
         &payloads,
     );
 
-    let direct_summary = load_discovery_first_event_summary_with_kernel_context(
+    let direct_summary = load_discovery_first_event_summary(
         "session-discovery-first-compat-direct",
         16,
         None,
@@ -14834,7 +14929,7 @@ async fn load_discovery_first_event_summary_preserves_kernel_context_compatibili
     let (kernel_ctx, invocations) =
         build_kernel_context_with_window_turns(audit, discovery_first_window_turns(&payloads));
 
-    let kernel_summary = load_discovery_first_event_summary_with_kernel_context(
+    let kernel_summary = load_discovery_first_event_summary(
         "session-discovery-first-compat-kernel",
         24,
         Some(&kernel_ctx),
@@ -17462,7 +17557,6 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-approval-normal-lane");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-approval-normal-lane");
 
@@ -17564,7 +17658,6 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-normal-lane");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-normal-lane");
 
@@ -17946,7 +18039,8 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_approve_once() {
+async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_delegate_for_approve_once_on_advisory_binding()
+ {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
         unique_acp_test_id("conversation-approval-resolve", "approve-once")
@@ -18034,13 +18128,13 @@ async fn handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_
             ConversationRuntimeBinding::direct(),
         )
         .await
-        .expect("approval resolve reply");
+        .expect("advisory denial should still return a reply payload");
 
     assert!(
-        reply.contains("\"tool\":\"approval_request_resolve\""),
-        "expected raw approval resolve tool output, got: {reply}"
+        reply.contains("governed_runtime_binding_required"),
+        "expected governed runtime binding denial, got: {reply}"
     );
-    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
     assert_eq!(
         *runtime
             .completion_calls
@@ -18055,17 +18149,11 @@ async fn handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_
         .expect("approval request row");
     assert_eq!(
         request.status,
-        crate::session::repository::ApprovalRequestStatus::Executed
+        crate::session::repository::ApprovalRequestStatus::Pending
     );
-    assert_eq!(
-        request.decision,
-        Some(crate::session::repository::ApprovalDecision::ApproveOnce)
-    );
-    assert_eq!(
-        request.resolved_by_session_id.as_deref(),
-        Some("root-session")
-    );
-    assert!(request.executed_at.is_some());
+    assert_eq!(request.decision, None);
+    assert_eq!(request.resolved_by_session_id, None);
+    assert!(request.executed_at.is_none(), "request={request:?}");
     assert!(request.last_error.is_none(), "request={request:?}");
     assert!(
         repo.load_approval_grant("root-session", "tool:delegate")
@@ -18077,11 +18165,131 @@ async fn handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_
         .list_visible_sessions("root-session")
         .expect("list visible sessions")
         .into_iter()
-        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
-        .expect("child session summary");
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"));
+    assert!(
+        child.is_none(),
+        "advisory approval replay must not spawn a child"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_grant_seed_on_advisory_binding()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(
+            "conversation-approval-resolve",
+            "approve-always-advisory-denied"
+        )
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-delegate-advisory-denied".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-delegate-parent".to_owned(),
+        tool_call_id: "call-delegate-parent".to_owned(),
+        tool_name: "delegate".to_owned(),
+        approval_key: "tool:delegate".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-delegate-parent",
+            "tool_call_id": "call-delegate-parent",
+            "tool_name": "delegate",
+            "args_json": {
+                "task": "child task",
+                "label": "research-subtask"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "app"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "topology_mutation",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "governed_tool_requires_approval",
+            "reason": "operator approval required before running `delegate`"
+        }),
+    })
+    .expect("seed approval request");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "resolving approval".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "approval_request_resolve",
+                json!({
+                    "approval_request_id": "apr-delegate-advisory-denied",
+                    "decision": "approve_always"
+                }),
+                "root-session",
+                "turn-approval-resolve",
+                "call-approval-resolve",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("advisory denial should still return a reply payload");
+
+    assert!(
+        reply.contains("governed_runtime_binding_required"),
+        "expected governed runtime binding denial, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
     assert_eq!(
-        child.state,
-        crate::session::repository::SessionState::Completed
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let request = repo
+        .load_approval_request("apr-delegate-advisory-denied")
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(
+        request.status,
+        crate::session::repository::ApprovalRequestStatus::Pending
+    );
+    assert_eq!(request.decision, None);
+    assert_eq!(request.resolved_by_session_id, None);
+    assert!(request.executed_at.is_none(), "request={request:?}");
+    assert!(request.last_error.is_none(), "request={request:?}");
+    assert!(
+        repo.load_approval_grant("root-session", "tool:delegate")
+            .expect("load grant")
+            .is_none()
     );
 }
 
@@ -18863,8 +19071,6 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
     )
     .with_async_delegate_spawner(spawner.clone())
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-async-queue-rollback");
-
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-queue-failure");
     let reply = coordinator
@@ -18954,8 +19160,6 @@ async fn handle_turn_with_runtime_delegate_async_rejects_when_active_child_limit
     )
     .with_async_delegate_spawner(spawner.clone())
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-async-active-child-limit");
-
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-active-child-limit");
     let reply = coordinator
@@ -19041,8 +19245,6 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     )
     .with_async_delegate_spawner(Arc::new(gated_spawner))
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-async-queued");
-
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-queued");
     let queued_call = tokio::spawn(async move {
@@ -19106,11 +19308,8 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     assert_eq!(spawn_request.label.as_deref(), Some("async-child"));
     assert_eq!(spawn_request.timeout_seconds, 9);
     assert!(
-        matches!(
-            &spawn_request.binding,
-            crate::conversation::OwnedConversationRuntimeBinding::Kernel(_)
-        ),
-        "kernel-bound parent turns should preserve governed binding for async delegates"
+        spawn_request.kernel_context.is_some(),
+        "kernel-bound parent turns should preserve kernel context for async delegates"
     );
     assert_eq!(child.state, crate::session::repository::SessionState::Ready);
     assert_eq!(child.label.as_deref(), Some("async-child"));
@@ -19140,7 +19339,7 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request() {
+async fn handle_turn_with_runtime_delegate_async_preserves_kernel_context_in_spawn_request() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
         unique_acp_test_id("conversation-delegate-async", "kernel-binding")
@@ -19221,17 +19420,11 @@ async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spa
         reply.contains("\"tool\":\"delegate_async\""),
         "expected raw delegate_async tool output, got: {reply}"
     );
-    assert!(
-        matches!(
-            &spawn_request.binding,
-            crate::conversation::OwnedConversationRuntimeBinding::Kernel(_)
-        ),
-        "kernel-bound parent turns should preserve owned governed binding for async delegate children"
-    );
+    assert!(spawn_request.kernel_context.is_some());
     let child_kernel_ctx = spawn_request
-        .binding
-        .kernel_context()
-        .expect("spawn request should carry kernel binding");
+        .kernel_context
+        .as_ref()
+        .expect("spawn request should carry kernel context");
     assert_eq!(child_kernel_ctx.token, expected_kernel_ctx.token);
     assert!(
         Arc::ptr_eq(&child_kernel_ctx.kernel, &expected_kernel_ctx.kernel),
@@ -19289,8 +19482,6 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
         spawn_error: Some("spawn unavailable".to_owned()),
     }))
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-failed");
-
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-failed");
     let reply = coordinator
@@ -19512,8 +19703,6 @@ async fn handle_turn_with_runtime_delegate_async_spawn_panic_is_observable_after
     )
     .with_async_delegate_spawner(Arc::new(PanicAsyncDelegateSpawner))
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-panic");
-
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-panic");
     let reply = coordinator
@@ -19642,8 +19831,6 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
         spawn_error: Some("spawn unavailable".to_owned()),
     }))
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-persist-recovery");
-
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-persist-recovery");
     let reply = coordinator
@@ -19779,7 +19966,6 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-nested-denied");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-nested-denied");
 
@@ -19876,7 +20062,6 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
         runtime_ref.set(runtime.clone()).is_ok(),
         "install local async delegate runtime"
     );
-    let kernel_ctx = test_kernel_context("conversation-delegate-async-nested-denied");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-nested-denied");
 
@@ -20022,7 +20207,6 @@ async fn handle_turn_with_runtime_delegate_child_can_reenter_when_max_depth_allo
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
-    let kernel_ctx = test_kernel_context("conversation-delegate-nested-allowed");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-nested-allowed");
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -14731,7 +14731,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
         &payloads,
     );
 
-    let direct_summary = super::session_history::load_discovery_first_event_summary_with_binding(
+    let direct_summary = load_discovery_first_event_summary(
         "session-discovery-first-direct",
         32,
         ConversationRuntimeBinding::direct(),
@@ -14751,7 +14751,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
     let (kernel_ctx, invocations) =
         build_kernel_context_with_window_turns(audit, discovery_first_window_turns(&payloads));
 
-    let kernel_summary = super::session_history::load_discovery_first_event_summary_with_binding(
+    let kernel_summary = load_discovery_first_event_summary(
         "session-discovery-first-kernel",
         48,
         ConversationRuntimeBinding::kernel(&kernel_ctx),
@@ -14781,7 +14781,7 @@ async fn load_discovery_first_event_summary_accepts_explicit_runtime_binding() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn load_discovery_first_event_summary_preserves_public_kernel_context_signature() {
+async fn load_discovery_first_event_summary_preserves_kernel_context_compatibility_shim() {
     let payloads = [
         json!({
             "type": "conversation_event",
@@ -14815,7 +14815,7 @@ async fn load_discovery_first_event_summary_preserves_public_kernel_context_sign
         &payloads,
     );
 
-    let direct_summary = load_discovery_first_event_summary(
+    let direct_summary = load_discovery_first_event_summary_with_kernel_context(
         "session-discovery-first-compat-direct",
         16,
         None,
@@ -14834,7 +14834,7 @@ async fn load_discovery_first_event_summary_preserves_public_kernel_context_sign
     let (kernel_ctx, invocations) =
         build_kernel_context_with_window_turns(audit, discovery_first_window_turns(&payloads));
 
-    let kernel_summary = load_discovery_first_event_summary(
+    let kernel_summary = load_discovery_first_event_summary_with_kernel_context(
         "session-discovery-first-compat-kernel",
         24,
         Some(&kernel_ctx),

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -1679,6 +1679,37 @@ fn test_kernel_context(agent_id: &str) -> KernelContext {
 }
 
 #[cfg(feature = "memory-sqlite")]
+async fn provider_messages_with_kernel_binding(
+    config: &LoongClawConfig,
+    session_id: &str,
+    kernel_ctx: &KernelContext,
+) -> Vec<Value> {
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let workspace_root = config
+        .tools
+        .file_root
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|_| config.tools.resolved_file_root());
+    let hydrated = crate::memory::hydrate_memory_context_with_workspace_root(
+        session_id,
+        workspace_root.as_deref(),
+        &memory_config,
+    )
+    .expect("hydrate memory context");
+    crate::provider::project_hydrated_memory_context_for_view_with_binding(
+        config,
+        true,
+        &crate::tools::runtime_tool_view(),
+        crate::provider::ProviderRuntimeBinding::kernel(kernel_ctx),
+        &hydrated,
+    )
+    .await
+    .messages
+}
+
+#[cfg(feature = "memory-sqlite")]
 fn collect_markdown_file_paths(root: &std::path::Path) -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
@@ -3450,8 +3481,8 @@ async fn default_runtime_kernel_build_context_matches_builtin_summary_projection
         )
         .await
         .expect("build kernel context from default runtime");
-    let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
-        .expect("build provider messages");
+    let provider_messages =
+        provider_messages_with_kernel_binding(&config, &session_id, &kernel_ctx).await;
 
     assert_eq!(
         assembled.messages, provider_messages,
@@ -3490,8 +3521,8 @@ async fn default_runtime_kernel_build_context_preserves_profile_projection() {
         )
         .await
         .expect("build kernel context from default runtime");
-    let provider_messages = crate::provider::build_messages_for_session(&config, &session_id, true)
-        .expect("build provider messages");
+    let provider_messages =
+        provider_messages_with_kernel_binding(&config, &session_id, &kernel_ctx).await;
 
     assert_eq!(
         assembled.messages, provider_messages,
@@ -10487,6 +10518,7 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
 
     #[derive(Default)]
     struct ApprovalBarrierDispatcher {
+        approval_checks: Mutex<usize>,
         executed: Mutex<Vec<String>>,
     }
 
@@ -10499,6 +10531,7 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
             descriptor: &crate::tools::ToolDescriptor,
             _kernel_ctx: Option<&crate::KernelContext>,
         ) -> Result<Option<crate::conversation::turn_engine::ApprovalRequirement>, String> {
+            *self.approval_checks.lock().expect("approval checks lock") += 1;
             if descriptor.name == "delegate_async" {
                 return Ok(Some(
                     crate::conversation::turn_engine::ApprovalRequirement {
@@ -10575,23 +10608,28 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
         .await;
 
     match result {
-        TurnResult::NeedsApproval(requirement) => {
-            assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
-            assert_eq!(
-                requirement.approval_request_id.as_deref(),
-                Some("apr-test-approval-barrier")
-            );
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(failure.code, "governed_runtime_binding_required");
+            assert_eq!(failure.reason, "governed_runtime_binding_required");
         }
         other @ TurnResult::FinalText(_)
         | other @ TurnResult::StreamingText(_)
         | other @ TurnResult::StreamingDone(_)
-        | other @ TurnResult::ToolDenied(_)
+        | other @ TurnResult::NeedsApproval(_)
         | other @ TurnResult::ToolError(_)
         | other @ TurnResult::ProviderError(_) => {
-            panic!("expected NeedsApproval, got: {other:?}")
+            panic!("expected ToolDenied, got: {other:?}")
         }
     }
 
+    assert_eq!(
+        *dispatcher
+            .approval_checks
+            .lock()
+            .expect("approval checks lock"),
+        1,
+        "only the earlier low-risk app intent should reach approval routing"
+    );
     assert!(
         dispatcher
             .executed
@@ -10599,6 +10637,122 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
             .expect("dispatcher executed lock")
             .is_empty(),
         "batch should fail closed before any earlier app tool executes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on_advisory_binding()
+{
+    use async_trait::async_trait;
+    use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
+
+    #[derive(Default)]
+    struct GuardedApprovalDispatcher {
+        approval_checks: Mutex<usize>,
+        executed: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl crate::conversation::AppToolDispatcher for GuardedApprovalDispatcher {
+        async fn maybe_require_approval(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            _intent: &crate::conversation::ToolIntent,
+            _descriptor: &crate::tools::ToolDescriptor,
+            _kernel_ctx: Option<&crate::KernelContext>,
+        ) -> Result<Option<crate::conversation::turn_engine::ApprovalRequirement>, String> {
+            *self.approval_checks.lock().expect("approval checks lock") += 1;
+            Ok(Some(
+                crate::conversation::turn_engine::ApprovalRequirement {
+                    kind: crate::conversation::turn_engine::ApprovalRequirementKind::GovernedTool,
+                    reason: "operator approval required before running `delegate_async`".to_owned(),
+                    rule_id: "governed_tool_requires_approval".to_owned(),
+                    tool_name: Some("delegate_async".to_owned()),
+                    approval_key: Some("tool:delegate_async".to_owned()),
+                    approval_request_id: Some("apr-test-governed-runtime-binding".to_owned()),
+                },
+            ))
+        }
+
+        async fn execute_app_tool(
+            &self,
+            _session_context: &crate::conversation::SessionContext,
+            request: ToolCoreRequest,
+            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
+        ) -> Result<ToolCoreOutcome, String> {
+            self.executed
+                .lock()
+                .expect("dispatcher executed lock")
+                .push(request.tool_name.clone());
+            Ok(ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload: json!({
+                    "tool_name": request.tool_name,
+                }),
+            })
+        }
+    }
+
+    let dispatcher = GuardedApprovalDispatcher::default();
+    let engine = TurnEngine::new(1);
+    let turn = ProviderTurn {
+        assistant_text: "".to_owned(),
+        tool_intents: vec![provider_tool_intent(
+            "delegate_async",
+            json!({
+                "task": "inspect child task"
+            }),
+            "root-session",
+            "turn-governed-runtime-binding",
+            "call-governed-runtime-binding",
+        )],
+        raw_meta: Value::Null,
+    };
+    let session_context = crate::conversation::SessionContext::root_with_tool_view(
+        "root-session",
+        crate::tools::planned_root_tool_view(),
+    );
+
+    let result = engine
+        .execute_turn_in_context(
+            &turn,
+            &session_context,
+            &dispatcher,
+            crate::conversation::ConversationRuntimeBinding::direct(),
+            None,
+        )
+        .await;
+
+    match result {
+        TurnResult::ToolDenied(failure) => {
+            assert_eq!(failure.code, "governed_runtime_binding_required");
+            assert_eq!(failure.reason, "governed_runtime_binding_required");
+        }
+        other @ TurnResult::FinalText(_)
+        | other @ TurnResult::StreamingText(_)
+        | other @ TurnResult::StreamingDone(_)
+        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolError(_)
+        | other @ TurnResult::ProviderError(_) => {
+            panic!("expected ToolDenied, got: {other:?}")
+        }
+    }
+
+    assert_eq!(
+        *dispatcher
+            .approval_checks
+            .lock()
+            .expect("approval checks lock"),
+        0,
+        "advisory binding should fail before approval routing"
+    );
+    assert!(
+        dispatcher
+            .executed
+            .lock()
+            .expect("dispatcher executed lock")
+            .is_empty(),
+        "mutating app tool should not execute under advisory binding"
     );
 }
 
@@ -13514,6 +13668,33 @@ fn conversation_runtime_binding_kernel_exposes_bound_context() {
     let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
     let binding = crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx);
 
+    assert!(binding.is_kernel_bound());
+    assert!(binding.kernel_context().is_some());
+}
+
+#[test]
+fn governed_runtime_binding_direct_alias_is_advisory_only_and_non_mutating() {
+    let binding = crate::conversation::ConversationRuntimeBinding::direct();
+
+    assert_eq!(
+        binding.session_mode(),
+        loongclaw_contracts::GovernedSessionMode::AdvisoryOnly
+    );
+    assert!(!binding.allows_mutation());
+    assert!(!binding.is_kernel_bound());
+    assert!(binding.kernel_context().is_none());
+}
+
+#[test]
+fn governed_runtime_binding_kernel_path_is_mutating_capable() {
+    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
+    let binding = crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx);
+
+    assert_eq!(
+        binding.session_mode(),
+        loongclaw_contracts::GovernedSessionMode::MutatingCapable
+    );
+    assert!(binding.allows_mutation());
     assert!(binding.is_kernel_bound());
     assert!(binding.kernel_context().is_some());
 }
@@ -17133,6 +17314,7 @@ async fn handle_turn_with_runtime_executes_sessions_send_via_default_dispatcher(
         }),
         Ok("unused".to_owned()),
     );
+    let kernel_ctx = test_kernel_context("conversation-sessions-send-normal-lane");
     let coordinator = ConversationTurnCoordinator::new();
 
     let reply = coordinator
@@ -17142,7 +17324,7 @@ async fn handle_turn_with_runtime_executes_sessions_send_via_default_dispatcher(
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("handle turn success");
@@ -17242,6 +17424,7 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-approval-normal-lane");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-approval-normal-lane");
 
@@ -17343,6 +17526,7 @@ async fn handle_turn_with_runtime_executes_delegate_via_coordinator() {
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-normal-lane");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-normal-lane");
 
@@ -18007,6 +18191,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-approval-resolve-approve-always-grant");
 
     let granted_reply = coordinator
         .handle_turn_with_runtime(
@@ -18640,6 +18825,7 @@ async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_
     )
     .with_async_delegate_spawner(spawner.clone())
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-queue-rollback");
 
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-queue-failure");
@@ -18730,6 +18916,7 @@ async fn handle_turn_with_runtime_delegate_async_rejects_when_active_child_limit
     )
     .with_async_delegate_spawner(spawner.clone())
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-active-child-limit");
 
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-active-child-limit");
@@ -18816,6 +19003,7 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     )
     .with_async_delegate_spawner(Arc::new(gated_spawner))
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-queued");
 
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-queued");
@@ -18881,7 +19069,7 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     assert_eq!(spawn_request.timeout_seconds, 9);
     assert!(
         spawn_request.kernel_context.is_some(),
-        "product-mode async delegate execution should preserve kernel binding"
+        "kernel-bound parent turns should preserve governed binding for async delegates"
     );
     assert_eq!(child.state, crate::session::repository::SessionState::Ready);
     assert_eq!(child.label.as_deref(), Some("async-child"));
@@ -19057,6 +19245,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_is_observable_aft
         spawn_error: Some("spawn unavailable".to_owned()),
     }))
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-failed");
 
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-failed");
@@ -19279,6 +19468,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_panic_is_observable_after
     )
     .with_async_delegate_spawner(Arc::new(PanicAsyncDelegateSpawner))
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-panic");
 
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-panic");
@@ -19408,6 +19598,7 @@ async fn handle_turn_with_runtime_delegate_async_spawn_failure_persistence_recov
         spawn_error: Some("spawn unavailable".to_owned()),
     }))
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-persist-recovery");
 
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-spawn-persist-recovery");
@@ -19544,6 +19735,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_by_defa
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-nested-denied");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-nested-denied");
 
@@ -19640,6 +19832,7 @@ async fn handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_b
         runtime_ref.set(runtime.clone()).is_ok(),
         "install local async delegate runtime"
     );
+    let kernel_ctx = test_kernel_context("conversation-delegate-async-nested-denied");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-async-nested-denied");
 
@@ -19785,6 +19978,7 @@ async fn handle_turn_with_runtime_delegate_child_can_reenter_when_max_depth_allo
         vec![],
     )
     .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-delegate-nested-allowed");
     let coordinator = ConversationTurnCoordinator::new();
     let kernel_ctx = test_kernel_context("conversation-delegate-nested-allowed");
 
@@ -20048,6 +20242,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
         }),
         Ok("unused".to_owned()),
     );
+    let kernel_ctx = test_kernel_context("conversation-sessions-send-safe-lane");
     let coordinator = ConversationTurnCoordinator::new();
 
     let reply = coordinator
@@ -20057,7 +20252,7 @@ async fn handle_turn_with_runtime_safe_lane_executes_sessions_send_via_default_d
             "deploy to production with secret token and show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("safe-lane handle turn success");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -18308,6 +18308,121 @@ async fn handle_turn_with_runtime_approval_request_resolve_rejects_governed_gran
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_rejects_core_replay_for_approve_once_on_advisory_binding()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(
+            "conversation-approval-resolve",
+            "approve-once-core-advisory"
+        )
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-provider-switch-core".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-provider-switch-parent".to_owned(),
+        tool_call_id: "call-provider-switch-parent".to_owned(),
+        tool_name: "provider.switch".to_owned(),
+        approval_key: "tool:provider.switch".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-provider-switch-parent",
+            "tool_call_id": "call-provider-switch-parent",
+            "tool_name": "provider.switch",
+            "args_json": {
+                "selector": "openai"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "core"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "routine",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "autonomy_policy_provider_switch_requires_approval",
+            "reason": "operator approval required before running `provider.switch`"
+        }),
+    })
+    .expect("seed core approval request");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "resolving approval".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "approval_request_resolve",
+                json!({
+                    "approval_request_id": "apr-provider-switch-core",
+                    "decision": "approve_once"
+                }),
+                "root-session",
+                "turn-approval-resolve-core",
+                "call-approval-resolve-core",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("advisory denial should still return a reply payload");
+
+    assert!(
+        reply.contains("governed_runtime_binding_required"),
+        "expected governed runtime binding denial, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+    assert_eq!(
+        *runtime
+            .completion_calls
+            .lock()
+            .expect("completion calls lock"),
+        0
+    );
+
+    let request = repo
+        .load_approval_request("apr-provider-switch-core")
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(
+        request.status,
+        crate::session::repository::ApprovalRequestStatus::Pending
+    );
+    assert_eq!(request.decision, None);
+    assert_eq!(request.resolved_by_session_id, None);
+    assert!(request.executed_at.is_none(), "request={request:?}");
+    assert!(request.last_error.is_none(), "request={request:?}");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn handle_turn_with_runtime_approval_request_resolve_reports_not_pending_before_binding_gate_for_stale_governed_retry()
  {
     let db_path = std::env::temp_dir().join(format!(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4262,7 +4262,6 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         },
     )?;
 
-    let kernel_context = binding.kernel_context().cloned();
     let request = AsyncDelegateSpawnRequest {
         child_session_id: child_session_id.clone(),
         parent_session_id: session_context.session_id.clone(),
@@ -4271,7 +4270,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         execution,
         runtime_self_continuity,
         timeout_seconds,
-        kernel_context,
+        binding: super::runtime_binding::OwnedConversationRuntimeBinding::from_borrowed(binding),
     };
     spawn_async_delegate_detached(runtime_handle, memory_config, spawner, request);
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -19,6 +19,7 @@ use tokio::sync::Mutex;
 use tokio::time::{Duration, Instant, timeout};
 
 use crate::CliResult;
+#[cfg(test)]
 use crate::KernelContext;
 use crate::acp::{
     AcpConversationTurnEntryDecision, AcpConversationTurnExecutionOutcome,
@@ -3929,18 +3930,6 @@ where
                 binding,
                 budget_state,
             )
-            .await
-    }
-
-    async fn maybe_require_approval(
-        &self,
-        session_context: &SessionContext,
-        intent: &ToolIntent,
-        descriptor: &crate::tools::ToolDescriptor,
-        kernel_ctx: Option<&KernelContext>,
-    ) -> Result<Option<super::turn_engine::ApprovalRequirement>, String> {
-        let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
-        self.maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
             .await
     }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3671,6 +3671,13 @@ impl<R> CoordinatorApprovalResolutionRuntime<'_, R>
 where
     R: ConversationRuntime + ?Sized,
 {
+    fn current_epoch_s() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
     fn replay_request(
         &self,
         approval_request: &ApprovalRequestRecord,
@@ -3714,55 +3721,12 @@ where
         }
     }
 
-    fn replay_approval_mode(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<Option<crate::tools::ToolApprovalMode>, String> {
-        let approval_mode_value = approval_request
-            .governance_snapshot_json
-            .get("approval_mode")
-            .and_then(Value::as_str);
-        let Some(approval_mode_value) = approval_mode_value else {
-            return Ok(None);
-        };
-
-        let policy_driven = crate::tools::ToolApprovalMode::PolicyDriven;
-        let never = crate::tools::ToolApprovalMode::Never;
-
-        if approval_mode_value == policy_driven.as_str() {
-            return Ok(Some(policy_driven));
-        }
-
-        if approval_mode_value == never.as_str() {
-            return Ok(Some(never));
-        }
-
-        Err(format!(
-            "approval_request_invalid_governance_snapshot: unknown approval_mode `{approval_mode_value}`"
-        ))
-    }
-
     fn replay_requires_mutating_binding(
         &self,
         approval_request: &ApprovalRequestRecord,
     ) -> Result<bool, String> {
         let execution_kind = self.replay_execution_kind(approval_request)?;
-        match execution_kind {
-            ToolExecutionKind::Core => Ok(true),
-            ToolExecutionKind::App => {
-                let replay_approval_mode = match self.replay_approval_mode(approval_request)? {
-                    Some(replay_approval_mode) => replay_approval_mode,
-                    None => {
-                        let governance = crate::tools::governance_profile_for_tool_name(
-                            approval_request.tool_name.as_str(),
-                        );
-                        governance.approval_mode
-                    }
-                };
-
-                Ok(replay_approval_mode == crate::tools::ToolApprovalMode::PolicyDriven)
-            }
-        }
+        Ok(execution_kind == ToolExecutionKind::Core)
     }
 
     fn ensure_resolution_binding_allows_decision(
@@ -3908,7 +3872,7 @@ where
                 })
             }
             Err(error) => {
-                let _ = repo.transition_approval_request_if_current(
+                let maybe_executed = repo.transition_approval_request_if_current(
                     approval_request_id,
                     TransitionApprovalRequestIfCurrentRequest {
                         expected_status: ApprovalRequestStatus::Executing,
@@ -3919,6 +3883,13 @@ where
                         last_error: Some(error.clone()),
                     },
                 )?;
+
+                if maybe_executed.is_none() {
+                    return Err(format!(
+                        "approval_request_not_executing: `{approval_request_id}` is no longer executing; original replay error: {error}"
+                    ));
+                }
+
                 Err(error)
             }
         }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -28,8 +28,6 @@ use crate::acp::{
 };
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::operator::approval_runtime::OperatorApprovalRuntime;
-#[cfg(feature = "memory-sqlite")]
 use crate::operator::session_graph::OperatorSessionGraph;
 use crate::runtime_self_continuity;
 use crate::tools::ToolExecutionKind;
@@ -129,8 +127,9 @@ use crate::session::recovery::{
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, CreateSessionWithEventRequest,
-    FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, NewSessionToolConsentRecord,
-    SessionKind, SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
+    FinalizeSessionTerminalRequest, NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord,
+    NewSessionToolConsentRecord, SessionKind, SessionRepository, SessionState,
+    TransitionApprovalRequestIfCurrentRequest, TransitionSessionWithEventIfCurrentRequest,
 };
 
 #[derive(Default)]
@@ -3715,15 +3714,6 @@ where
         }
     }
 
-    fn request_parent_session_id(approval_request: &ApprovalRequestRecord) -> Option<&str> {
-        approval_request
-            .request_payload_json
-            .get("parent_session_id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-    }
-
     fn replay_approval_mode(
         &self,
         approval_request: &ApprovalRequestRecord,
@@ -3799,6 +3789,22 @@ where
         Err("app_tool_denied: governed_runtime_binding_required".to_owned())
     }
 
+    fn approval_request_not_pending_error(approval_request: &ApprovalRequestRecord) -> String {
+        let approval_request_id = approval_request.approval_request_id.as_str();
+        let status = approval_request.status.as_str();
+        format!("approval_request_not_pending: `{approval_request_id}` is already {status}")
+    }
+
+    fn ensure_resolution_request_is_pending(
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<(), String> {
+        if approval_request.status == ApprovalRequestStatus::Pending {
+            return Ok(());
+        }
+
+        Err(Self::approval_request_not_pending_error(approval_request))
+    }
+
     async fn replay_approved_request(
         &self,
         approval_request: &ApprovalRequestRecord,
@@ -3858,14 +3864,38 @@ where
         repo: &SessionRepository,
         approval_request_id: &str,
     ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let approval_runtime = OperatorApprovalRuntime::new(repo);
-        let executing = approval_runtime.begin_approved_request_execution(approval_request_id)?;
-        approval_runtime.ensure_request_session(&executing)?;
+        let executing = repo
+            .transition_approval_request_if_current(
+                approval_request_id,
+                TransitionApprovalRequestIfCurrentRequest {
+                    expected_status: ApprovalRequestStatus::Approved,
+                    next_status: ApprovalRequestStatus::Executing,
+                    decision: None,
+                    resolved_by_session_id: None,
+                    executed_at: None,
+                    last_error: None,
+                },
+            )?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_not_approved: `{approval_request_id}` is no longer approved"
+                )
+            })?;
 
         match self.replay_approved_request(&executing).await {
             Ok(resumed_tool_output) => {
-                let executed = approval_runtime
-                    .finish_executing_request(approval_request_id, None)?
+                let executed = repo
+                    .transition_approval_request_if_current(
+                        approval_request_id,
+                        TransitionApprovalRequestIfCurrentRequest {
+                            expected_status: ApprovalRequestStatus::Executing,
+                            next_status: ApprovalRequestStatus::Executed,
+                            decision: None,
+                            resolved_by_session_id: None,
+                            executed_at: Some(Self::current_epoch_s()),
+                            last_error: None,
+                        },
+                    )?
                     .ok_or_else(|| {
                         format!(
                             "approval_request_not_executing: `{approval_request_id}` is no longer executing"
@@ -3877,13 +3907,17 @@ where
                 })
             }
             Err(error) => {
-                let maybe_executed = approval_runtime
-                    .finish_executing_request(approval_request_id, Some(error.as_str()))?;
-                if maybe_executed.is_none() {
-                    return Err(format!(
-                        "approval_request_not_executing: `{approval_request_id}` is no longer executing; original replay error: {error}"
-                    ));
-                }
+                let _ = repo.transition_approval_request_if_current(
+                    approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Executing,
+                        next_status: ApprovalRequestStatus::Executed,
+                        decision: None,
+                        resolved_by_session_id: None,
+                        executed_at: Some(Self::current_epoch_s()),
+                        last_error: Some(error.clone()),
+                    },
+                )?;
                 Err(error)
             }
         }
@@ -3903,7 +3937,6 @@ where
     ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
         let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
         let repo = SessionRepository::new(&memory_config)?;
-        let approval_runtime = OperatorApprovalRuntime::new(&repo);
         let approval_request = repo
             .load_approval_request(&request.approval_request_id)?
             .ok_or_else(|| {
@@ -3925,7 +3958,6 @@ where
                     )?
             }
         };
-        approval_runtime.ensure_request_session(&approval_request)?;
         if !is_visible {
             return Err(format!(
                 "visibility_denied: session `{}` is not visible from `{}`",
@@ -3933,30 +3965,74 @@ where
             ));
         }
 
+        Self::ensure_resolution_request_is_pending(&approval_request)?;
         self.ensure_resolution_binding_allows_decision(&approval_request, request.decision)?;
 
         match request.decision {
             ApprovalDecision::Deny => {
-                let resolved = approval_runtime.resolve_pending_request(
+                let resolved = match repo.transition_approval_request_if_current(
                     &request.approval_request_id,
-                    ApprovalDecision::Deny,
-                    &request.current_session_id,
-                )?;
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Denied,
+                        decision: Some(ApprovalDecision::Deny),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(resolved) => resolved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(Self::approval_request_not_pending_error(&latest));
+                    }
+                };
                 Ok(crate::tools::approval::ApprovalResolutionOutcome {
                     approval_request: resolved,
                     resumed_tool_output: None,
                 })
             }
             ApprovalDecision::ApproveOnce => {
-                let approved = approval_runtime.resolve_pending_request(
+                let approved = match repo.transition_approval_request_if_current(
                     &request.approval_request_id,
-                    ApprovalDecision::ApproveOnce,
-                    &request.current_session_id,
-                )?;
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Approved,
+                        decision: Some(ApprovalDecision::ApproveOnce),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(approved) => approved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(Self::approval_request_not_pending_error(&latest));
+                    }
+                };
                 if let Some(session_consent_mode) = request.session_consent_mode {
-                    let parent_session_id = Self::request_parent_session_id(&approved);
-                    let scope_session_id = approval_runtime
-                        .grant_scope_session_id(&approved.session_id, parent_session_id)?;
+                    let scope_session_id = repo
+                        .lineage_root_session_id(&approved.session_id)?
+                        .ok_or_else(|| {
+                            format!(
+                                "approval_request_session_not_found: `{}`",
+                                approved.session_id
+                            )
+                        })?;
                     let updated_by_session_id = Some(request.current_session_id.clone());
                     repo.upsert_session_tool_consent(NewSessionToolConsentRecord {
                         scope_session_id,
@@ -3968,11 +4044,43 @@ where
                     .await
             }
             ApprovalDecision::ApproveAlways => {
-                let _approved = approval_runtime.resolve_pending_request(
+                let approved = match repo.transition_approval_request_if_current(
                     &request.approval_request_id,
-                    ApprovalDecision::ApproveAlways,
-                    &request.current_session_id,
-                )?;
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Approved,
+                        decision: Some(ApprovalDecision::ApproveAlways),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(approved) => approved,
+                    None => {
+                        let latest = repo
+                            .load_approval_request(&request.approval_request_id)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "approval_request_not_found: `{}`",
+                                    request.approval_request_id
+                                )
+                            })?;
+                        return Err(Self::approval_request_not_pending_error(&latest));
+                    }
+                };
+                let grant_scope_session_id = repo
+                    .lineage_root_session_id(&approved.session_id)?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval_request_session_not_found: `{}`",
+                            approved.session_id
+                        )
+                    })?;
+                repo.upsert_approval_grant(NewApprovalGrantRecord {
+                    scope_session_id: grant_scope_session_id,
+                    approval_key: approved.approval_key.clone(),
+                    created_by_session_id: Some(request.current_session_id.clone()),
+                })?;
                 self.execute_approved_request(&repo, &request.approval_request_id)
                     .await
             }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3724,6 +3724,81 @@ where
             .filter(|value| !value.is_empty())
     }
 
+    fn replay_approval_mode(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<Option<crate::tools::ToolApprovalMode>, String> {
+        let approval_mode_value = approval_request
+            .governance_snapshot_json
+            .get("approval_mode")
+            .and_then(Value::as_str);
+        let Some(approval_mode_value) = approval_mode_value else {
+            return Ok(None);
+        };
+
+        let policy_driven = crate::tools::ToolApprovalMode::PolicyDriven;
+        let never = crate::tools::ToolApprovalMode::Never;
+
+        if approval_mode_value == policy_driven.as_str() {
+            return Ok(Some(policy_driven));
+        }
+
+        if approval_mode_value == never.as_str() {
+            return Ok(Some(never));
+        }
+
+        Err(format!(
+            "approval_request_invalid_governance_snapshot: unknown approval_mode `{approval_mode_value}`"
+        ))
+    }
+
+    fn replay_requires_mutating_binding(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<bool, String> {
+        let execution_kind = self.replay_execution_kind(approval_request)?;
+        if execution_kind != ToolExecutionKind::App {
+            return Ok(false);
+        }
+
+        let replay_approval_mode = match self.replay_approval_mode(approval_request)? {
+            Some(replay_approval_mode) => replay_approval_mode,
+            None => {
+                let governance = crate::tools::governance_profile_for_tool_name(
+                    approval_request.tool_name.as_str(),
+                );
+                governance.approval_mode
+            }
+        };
+
+        Ok(replay_approval_mode == crate::tools::ToolApprovalMode::PolicyDriven)
+    }
+
+    fn ensure_resolution_binding_allows_decision(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+        decision: ApprovalDecision,
+    ) -> Result<(), String> {
+        let mutating_resolution_requested = matches!(
+            decision,
+            ApprovalDecision::ApproveOnce | ApprovalDecision::ApproveAlways
+        );
+        if !mutating_resolution_requested {
+            return Ok(());
+        }
+
+        if self.binding.allows_mutation() {
+            return Ok(());
+        }
+
+        let replay_requires_mutation = self.replay_requires_mutating_binding(approval_request)?;
+        if !replay_requires_mutation {
+            return Ok(());
+        }
+
+        Err("app_tool_denied: governed_runtime_binding_required".to_owned())
+    }
+
     async fn replay_approved_request(
         &self,
         approval_request: &ApprovalRequestRecord,
@@ -3857,6 +3932,8 @@ where
                 approval_request.session_id, request.current_session_id
             ));
         }
+
+        self.ensure_resolution_binding_allows_decision(&approval_request, request.decision)?;
 
         match request.decision {
             ApprovalDecision::Deny => {
@@ -4270,7 +4347,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         execution,
         runtime_self_continuity,
         timeout_seconds,
-        binding: super::runtime_binding::OwnedConversationRuntimeBinding::from_borrowed(binding),
+        kernel_context: binding.kernel_context().cloned(),
     };
     spawn_async_delegate_detached(runtime_handle, memory_config, spawner, request);
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3747,21 +3747,22 @@ where
         approval_request: &ApprovalRequestRecord,
     ) -> Result<bool, String> {
         let execution_kind = self.replay_execution_kind(approval_request)?;
-        if execution_kind != ToolExecutionKind::App {
-            return Ok(false);
-        }
+        match execution_kind {
+            ToolExecutionKind::Core => Ok(true),
+            ToolExecutionKind::App => {
+                let replay_approval_mode = match self.replay_approval_mode(approval_request)? {
+                    Some(replay_approval_mode) => replay_approval_mode,
+                    None => {
+                        let governance = crate::tools::governance_profile_for_tool_name(
+                            approval_request.tool_name.as_str(),
+                        );
+                        governance.approval_mode
+                    }
+                };
 
-        let replay_approval_mode = match self.replay_approval_mode(approval_request)? {
-            Some(replay_approval_mode) => replay_approval_mode,
-            None => {
-                let governance = crate::tools::governance_profile_for_tool_name(
-                    approval_request.tool_name.as_str(),
-                );
-                governance.approval_mode
+                Ok(replay_approval_mode == crate::tools::ToolApprovalMode::PolicyDriven)
             }
-        };
-
-        Ok(replay_approval_mode == crate::tools::ToolApprovalMode::PolicyDriven)
+        }
     }
 
     fn ensure_resolution_binding_allows_decision(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -427,10 +427,15 @@ fn denied_tool_decision(tool_name: &str, failure: &TurnFailure) -> ToolDecisionT
     ToolDecisionTelemetry::deny(tool_name, reason, rule_id)
 }
 
-fn governed_runtime_binding_denied_outcome(tool_name: &str) -> ToolPreflightOutcome {
+fn governed_runtime_binding_denied_outcome(
+    descriptor: &crate::tools::ToolDescriptor,
+) -> ToolPreflightOutcome {
+    let tool_name = descriptor.name;
     let reason_code = "governed_runtime_binding_required";
     let failure = TurnFailure::policy_denied(reason_code, reason_code);
-    let decision = denied_tool_decision(tool_name, &failure);
+    let action_class = descriptor.capability_action_class();
+    let decision = denied_tool_decision(tool_name, &failure)
+        .with_capability_action_class(action_class.as_str());
     ToolPreflightOutcome::Denied { failure, decision }
 }
 
@@ -447,7 +452,7 @@ pub trait AppToolDispatcher: Send + Sync {
         let requires_mutating_binding = requires_mutating_runtime_binding(descriptor);
         let allows_mutation = binding.allows_mutation();
         if requires_mutating_binding && !allows_mutation {
-            let denied = governed_runtime_binding_denied_outcome(descriptor.name);
+            let denied = governed_runtime_binding_denied_outcome(descriptor);
             return Ok(denied);
         }
 
@@ -1130,7 +1135,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 let requires_mutating_binding = requires_mutating_runtime_binding(descriptor);
                 let allows_mutation = binding.allows_mutation();
                 if requires_mutating_binding && !allows_mutation {
-                    let denied = governed_runtime_binding_denied_outcome(descriptor.name);
+                    let denied = governed_runtime_binding_denied_outcome(descriptor);
                     return Ok(denied);
                 }
 

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -456,26 +456,14 @@ pub trait AppToolDispatcher: Send + Sync {
         }
     }
 
-    async fn maybe_require_approval(
+    async fn maybe_require_approval_with_binding(
         &self,
         _session_context: &SessionContext,
         _intent: &ToolIntent,
         _descriptor: &crate::tools::ToolDescriptor,
-        _kernel_ctx: Option<&KernelContext>,
+        _binding: ConversationRuntimeBinding<'_>,
     ) -> Result<Option<ApprovalRequirement>, String> {
         Ok(None)
-    }
-
-    async fn maybe_require_approval_with_binding(
-        &self,
-        session_context: &SessionContext,
-        intent: &ToolIntent,
-        descriptor: &crate::tools::ToolDescriptor,
-        binding: ConversationRuntimeBinding<'_>,
-    ) -> Result<Option<ApprovalRequirement>, String> {
-        let kernel_ctx = binding.kernel_context();
-        self.maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
-            .await
     }
 
     async fn execute_app_tool(
@@ -1119,18 +1107,6 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
             }
             Err(reason) => Err(reason),
         }
-    }
-
-    async fn maybe_require_approval(
-        &self,
-        session_context: &SessionContext,
-        intent: &ToolIntent,
-        descriptor: &crate::tools::ToolDescriptor,
-        kernel_ctx: Option<&KernelContext>,
-    ) -> Result<Option<ApprovalRequirement>, String> {
-        let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
-        self.maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
-            .await
     }
 
     async fn maybe_require_approval_with_binding(

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -939,6 +939,12 @@ fn tool_is_auto_eligible(
             && governance.approval_mode == ToolApprovalMode::Never)
 }
 
+fn requires_mutating_runtime_binding(descriptor: &crate::tools::ToolDescriptor) -> bool {
+    let governance = governance_profile_for_descriptor(descriptor);
+    descriptor.execution_kind == ToolExecutionKind::App
+        && governance.approval_mode == ToolApprovalMode::PolicyDriven
+}
+
 impl Default for DefaultAppToolDispatcher {
     fn default() -> Self {
         Self::runtime()
@@ -2785,6 +2791,20 @@ impl TurnEngine {
         let capability_action_class = descriptor.capability_action_class();
         let scheduling_class = descriptor.scheduling_class();
 
+        if requires_mutating_runtime_binding(descriptor) && !binding.allows_mutation() {
+            let reason_code = "governed_runtime_binding_required";
+            let failure = TurnFailure::policy_denied(reason_code, reason_code);
+            let turn_result = TurnResult::ToolDenied(failure.clone());
+            let base_decision = denied_tool_decision(effective_tool_name.as_str(), &failure);
+            let decision =
+                base_decision.with_capability_action_class(capability_action_class.as_str());
+            return Err(PreparedToolIntentFailure {
+                intent: effective_intent,
+                turn_result,
+                decision,
+            });
+        }
+
         let decision = match app_dispatcher
             .preflight_tool_intent_with_binding(
                 session_context,
@@ -2972,9 +2992,13 @@ mod tests {
         }
     }
 
-    fn kernel_context(agent_id: &str) -> KernelContext {
+    fn test_kernel_context(agent_id: &str) -> KernelContext {
         crate::context::bootstrap_test_kernel_context(agent_id, 60)
             .expect("bootstrap test kernel context")
+    }
+
+    fn kernel_context(agent_id: &str) -> KernelContext {
+        test_kernel_context(agent_id)
     }
 
     fn delegate_async_turn(session_id: &str, turn_id: &str, tool_call_id: &str) -> ProviderTurn {
@@ -3337,7 +3361,7 @@ mod tests {
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
-        let kernel_ctx = kernel_context("turn-engine-autonomy-persist");
+        let kernel_ctx = test_kernel_context("turn-engine-governed-approval-delegate-async");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
@@ -3413,7 +3437,8 @@ mod tests {
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
-        let kernel_ctx = kernel_context("turn-engine-autonomy-persist-discovered");
+        let kernel_ctx =
+            test_kernel_context("turn-engine-governed-approval-discovered-delegate-async");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
@@ -3779,7 +3804,7 @@ mod tests {
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
         let turn = delegate_async_turn("root-session", "turn-reuse", "call-reuse");
-        let kernel_ctx = kernel_context("turn-engine-autonomy-reuse");
+        let kernel_ctx = test_kernel_context("turn-engine-governed-approval-reuse");
 
         let first = TurnEngine::new(4)
             .execute_turn_in_context(
@@ -4115,6 +4140,7 @@ mod tests {
         let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = test_kernel_context("turn-engine-browser-companion-click-approval");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
@@ -4126,7 +4152,7 @@ mod tests {
                 ),
                 &session_context,
                 &dispatcher,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
                 None,
             )
             .await;
@@ -4295,6 +4321,7 @@ mod tests {
         let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config, tool_config);
+        let kernel_ctx = test_kernel_context("turn-engine-browser-companion-click-exec");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
@@ -4306,7 +4333,7 @@ mod tests {
                 ),
                 &session_context,
                 &dispatcher,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
                 None,
             )
             .await;
@@ -4395,6 +4422,7 @@ mod tests {
         let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config, tool_config);
+        let kernel_ctx = test_kernel_context("turn-engine-browser-companion-click-runtime-ready");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
@@ -4406,7 +4434,7 @@ mod tests {
                 ),
                 &session_context,
                 &dispatcher,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
                 None,
             )
             .await;
@@ -4497,6 +4525,7 @@ mod tests {
         let tool_view = crate::tools::runtime_tool_view_for_runtime_config(&runtime_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config, ToolConfig::default());
+        let kernel_ctx = test_kernel_context("turn-engine-browser-companion-click-runtime-policy");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
@@ -4508,7 +4537,7 @@ mod tests {
                 ),
                 &session_context,
                 &dispatcher,
-                ConversationRuntimeBinding::direct(),
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
                 None,
             )
             .await;

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -427,6 +427,13 @@ fn denied_tool_decision(tool_name: &str, failure: &TurnFailure) -> ToolDecisionT
     ToolDecisionTelemetry::deny(tool_name, reason, rule_id)
 }
 
+fn governed_runtime_binding_denied_outcome(tool_name: &str) -> ToolPreflightOutcome {
+    let reason_code = "governed_runtime_binding_required";
+    let failure = TurnFailure::policy_denied(reason_code, reason_code);
+    let decision = denied_tool_decision(tool_name, &failure);
+    ToolPreflightOutcome::Denied { failure, decision }
+}
+
 #[async_trait]
 pub trait AppToolDispatcher: Send + Sync {
     async fn preflight_tool_intent_with_binding(
@@ -437,6 +444,13 @@ pub trait AppToolDispatcher: Send + Sync {
         binding: ConversationRuntimeBinding<'_>,
         _budget_state: &AutonomyTurnBudgetState,
     ) -> Result<ToolPreflightOutcome, String> {
+        let requires_mutating_binding = requires_mutating_runtime_binding(descriptor);
+        let allows_mutation = binding.allows_mutation();
+        if requires_mutating_binding && !allows_mutation {
+            let denied = governed_runtime_binding_denied_outcome(descriptor.name);
+            return Ok(denied);
+        }
+
         match self
             .maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
             .await
@@ -458,10 +472,22 @@ pub trait AppToolDispatcher: Send + Sync {
 
     async fn maybe_require_approval_with_binding(
         &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<Option<ApprovalRequirement>, String> {
+        let kernel_ctx = binding.kernel_context();
+        self.maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
+            .await
+    }
+
+    async fn maybe_require_approval(
+        &self,
         _session_context: &SessionContext,
         _intent: &ToolIntent,
         _descriptor: &crate::tools::ToolDescriptor,
-        _binding: ConversationRuntimeBinding<'_>,
+        _kernel_ctx: Option<&KernelContext>,
     ) -> Result<Option<ApprovalRequirement>, String> {
         Ok(None)
     }
@@ -1101,6 +1127,13 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 })
             }
             Ok(None) => {
+                let requires_mutating_binding = requires_mutating_runtime_binding(descriptor);
+                let allows_mutation = binding.allows_mutation();
+                if requires_mutating_binding && !allows_mutation {
+                    let denied = governed_runtime_binding_denied_outcome(descriptor.name);
+                    return Ok(denied);
+                }
+
                 let decision = autonomy_allow_decision
                     .unwrap_or_else(|| generic_allow_tool_decision(descriptor.name));
                 Ok(ToolPreflightOutcome::Allow(decision))
@@ -2766,20 +2799,6 @@ impl TurnEngine {
         };
         let capability_action_class = descriptor.capability_action_class();
         let scheduling_class = descriptor.scheduling_class();
-
-        if requires_mutating_runtime_binding(descriptor) && !binding.allows_mutation() {
-            let reason_code = "governed_runtime_binding_required";
-            let failure = TurnFailure::policy_denied(reason_code, reason_code);
-            let turn_result = TurnResult::ToolDenied(failure.clone());
-            let base_decision = denied_tool_decision(effective_tool_name.as_str(), &failure);
-            let decision =
-                base_decision.with_capability_action_class(capability_action_class.as_str());
-            return Err(PreparedToolIntentFailure {
-                intent: effective_intent,
-                turn_result,
-                decision,
-            });
-        }
 
         let decision = match app_dispatcher
             .preflight_tool_intent_with_binding(

--- a/crates/app/src/operator/approval_runtime.rs
+++ b/crates/app/src/operator/approval_runtime.rs
@@ -5,11 +5,15 @@ use sha2::{Digest, Sha256};
 
 #[cfg(feature = "memory-sqlite")]
 use crate::operator::session_graph::OperatorSessionGraph;
+#[cfg(all(feature = "memory-sqlite", test))]
+use crate::session::repository::{
+    ApprovalDecision, ApprovalRequestStatus, NewApprovalGrantRecord,
+    TransitionApprovalRequestIfCurrentRequest,
+};
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    ApprovalDecision, ApprovalGrantRecord, ApprovalRequestRecord, ApprovalRequestStatus,
-    NewApprovalGrantRecord, NewApprovalRequestRecord, NewSessionRecord, SessionKind,
-    SessionRepository, SessionState, TransitionApprovalRequestIfCurrentRequest,
+    ApprovalGrantRecord, ApprovalRequestRecord, NewApprovalRequestRecord, NewSessionRecord,
+    SessionKind, SessionRepository, SessionState,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -116,15 +120,6 @@ impl<'a> OperatorApprovalRuntime<'a> {
         self.repo.ensure_approval_request(approval_request_record)
     }
 
-    pub(crate) fn ensure_request_session(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<(), String> {
-        let parent_session_id = Self::request_parent_session_id(approval_request);
-
-        self.ensure_session_boundary(&approval_request.session_id, parent_session_id)
-    }
-
     pub(crate) fn load_runtime_grant_for_context(
         &self,
         session_id: &str,
@@ -162,6 +157,7 @@ impl<'a> OperatorApprovalRuntime<'a> {
         Ok((grant_scope_session_id, runtime_grant))
     }
 
+    #[cfg(test)]
     pub(crate) fn upsert_runtime_grant_for_request(
         &self,
         approval_request: &ApprovalRequestRecord,
@@ -179,6 +175,7 @@ impl<'a> OperatorApprovalRuntime<'a> {
         self.repo.upsert_approval_grant(grant_record)
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_pending_request(
         &self,
         approval_request_id: &str,
@@ -211,46 +208,6 @@ impl<'a> OperatorApprovalRuntime<'a> {
 
         Ok(resolved)
     }
-    pub(crate) fn begin_approved_request_execution(
-        &self,
-        approval_request_id: &str,
-    ) -> Result<ApprovalRequestRecord, String> {
-        let transition_request = TransitionApprovalRequestIfCurrentRequest {
-            expected_status: ApprovalRequestStatus::Approved,
-            next_status: ApprovalRequestStatus::Executing,
-            decision: None,
-            resolved_by_session_id: None,
-            executed_at: None,
-            last_error: None,
-        };
-        let maybe_executing = self
-            .repo
-            .transition_approval_request_if_current(approval_request_id, transition_request)?;
-        let executing = maybe_executing.ok_or_else(|| {
-            format!("approval_request_not_approved: `{approval_request_id}` is no longer approved")
-        })?;
-
-        Ok(executing)
-    }
-
-    pub(crate) fn finish_executing_request(
-        &self,
-        approval_request_id: &str,
-        last_error: Option<&str>,
-    ) -> Result<Option<ApprovalRequestRecord>, String> {
-        let executed_at = Self::current_epoch_s();
-        let transition_request = TransitionApprovalRequestIfCurrentRequest {
-            expected_status: ApprovalRequestStatus::Executing,
-            next_status: ApprovalRequestStatus::Executed,
-            decision: None,
-            resolved_by_session_id: None,
-            executed_at: Some(executed_at),
-            last_error: last_error.map(str::to_owned),
-        };
-
-        self.repo
-            .transition_approval_request_if_current(approval_request_id, transition_request)
-    }
 
     fn session_kind_for_parent(parent_session_id: Option<&str>) -> SessionKind {
         if parent_session_id.is_some() {
@@ -279,6 +236,7 @@ impl<'a> OperatorApprovalRuntime<'a> {
         Ok(())
     }
 
+    #[cfg(test)]
     fn next_status_for_decision(decision: ApprovalDecision) -> ApprovalRequestStatus {
         match decision {
             ApprovalDecision::Deny => ApprovalRequestStatus::Denied,
@@ -287,6 +245,7 @@ impl<'a> OperatorApprovalRuntime<'a> {
         }
     }
 
+    #[cfg(test)]
     fn pending_resolution_error(&self, approval_request_id: &str) -> Result<String, String> {
         let latest_request = self.repo.load_approval_request(approval_request_id)?;
         let latest_request = latest_request
@@ -307,16 +266,6 @@ impl<'a> OperatorApprovalRuntime<'a> {
         let parent_session_value = parent_session_value.map(str::trim);
 
         parent_session_value.filter(|parent_session_id| !parent_session_id.is_empty())
-    }
-
-    fn current_epoch_s() -> i64 {
-        let now = std::time::SystemTime::now();
-        let unix_epoch = std::time::UNIX_EPOCH;
-        let duration = now.duration_since(unix_epoch);
-        let duration = duration.unwrap_or_default();
-        let seconds = duration.as_secs();
-
-        seconds as i64
     }
 }
 

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -157,7 +157,7 @@ pub fn build_system_message(
     request_message_runtime::build_system_message(config, include_system_prompt)
 }
 
-pub(crate) use request_message_runtime::build_projected_context_for_session;
+pub(crate) use request_message_runtime::build_projected_context_for_session_with_binding;
 pub(crate) use request_message_runtime::project_hydrated_memory_context_for_view_with_binding;
 
 pub fn build_messages_for_session(

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -439,19 +439,22 @@ pub(super) fn build_messages_for_session(
     .map(|projected| projected.messages)
 }
 
-pub(crate) fn build_projected_context_for_session(
+pub(crate) async fn build_projected_context_for_session_with_binding(
     config: &LoongClawConfig,
     session_id: &str,
     include_system_prompt: bool,
+    binding: ProviderRuntimeBinding<'_>,
 ) -> CliResult<ProjectedMessageContext> {
     let runtime_tool_view = tools::runtime_tool_view_from_loongclaw_config(config);
 
-    build_projected_context_for_session_in_view(
+    build_projected_context_for_session_in_view_with_binding(
         config,
         session_id,
         include_system_prompt,
         &runtime_tool_view,
+        binding,
     )
+    .await
 }
 
 pub(crate) fn build_projected_context_for_session_in_view(
@@ -496,6 +499,48 @@ pub(crate) fn build_projected_context_for_session_in_view(
             artifacts: Vec::new(),
             prompt_fragments,
         })
+    }
+}
+
+pub(crate) async fn build_projected_context_for_session_in_view_with_binding(
+    config: &LoongClawConfig,
+    session_id: &str,
+    include_system_prompt: bool,
+    tool_view: &ToolView,
+    binding: ProviderRuntimeBinding<'_>,
+) -> CliResult<ProjectedMessageContext> {
+    #[cfg(feature = "memory-sqlite")]
+    {
+        let mem_config =
+            memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let workspace_root = resolved_workspace_root(config);
+        let hydrated = memory::hydrate_memory_context_with_workspace_root(
+            session_id,
+            workspace_root.as_deref(),
+            &mem_config,
+        )
+        .map_err(|error| format!("hydrate prompt memory context failed: {error}"))?;
+        Ok(project_hydrated_memory_context_for_view_with_binding(
+            config,
+            include_system_prompt,
+            tool_view,
+            binding,
+            &hydrated,
+        )
+        .await)
+    }
+
+    #[cfg(not(feature = "memory-sqlite"))]
+    {
+        let _ = session_id;
+        let projected = project_hydrated_memory_context_for_view_with_binding(
+            config,
+            include_system_prompt,
+            tool_view,
+            binding,
+        )
+        .await;
+        Ok(projected)
     }
 }
 

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -311,16 +311,6 @@ fn render_governed_runtime_binding_section(binding: ProviderRuntimeBinding<'_>) 
     )
 }
 
-pub(super) fn build_base_messages_for_view(
-    config: &LoongClawConfig,
-    include_system_prompt: bool,
-    tool_view: &ToolView,
-) -> Vec<Value> {
-    build_system_message_for_view(config, include_system_prompt, tool_view)
-        .into_iter()
-        .collect()
-}
-
 fn build_base_artifacts(messages: &[Value]) -> Vec<ContextArtifactDescriptor> {
     if messages.is_empty() {
         return Vec::new();
@@ -437,6 +427,22 @@ pub(super) fn build_messages_for_session(
         &runtime_tool_view,
     )
     .map(|projected| projected.messages)
+}
+
+#[cfg(test)]
+pub(crate) fn build_projected_context_for_session(
+    config: &LoongClawConfig,
+    session_id: &str,
+    include_system_prompt: bool,
+) -> CliResult<ProjectedMessageContext> {
+    let runtime_tool_view = tools::runtime_tool_view_from_loongclaw_config(config);
+
+    build_projected_context_for_session_in_view(
+        config,
+        session_id,
+        include_system_prompt,
+        &runtime_tool_view,
+    )
 }
 
 pub(crate) async fn build_projected_context_for_session_with_binding(

--- a/crates/app/src/provider/request_message_runtime.rs
+++ b/crates/app/src/provider/request_message_runtime.rs
@@ -115,6 +115,7 @@ fn build_base_prompt_projection_with_tool_runtime_config(
         tool_view,
         tool_runtime_config,
         runtime_self_model,
+        None,
     )
 }
 
@@ -161,6 +162,7 @@ async fn build_base_prompt_projection_with_binding_and_tool_runtime_config(
         tool_view,
         tool_runtime_config,
         runtime_self_model,
+        Some(render_governed_runtime_binding_section(binding)),
     )
 }
 
@@ -170,6 +172,7 @@ fn build_base_prompt_projection_from_runtime_self_model(
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
     runtime_self_model: Option<runtime_self::RuntimeSelfModel>,
+    extra_section: Option<String>,
 ) -> BasePromptProjection {
     if !include_system_prompt {
         return BasePromptProjection::default();
@@ -180,6 +183,7 @@ fn build_base_prompt_projection_from_runtime_self_model(
         tool_view,
         tool_runtime_config,
         runtime_self_model,
+        extra_section,
     );
     let compiler = PromptCompiler;
     let compilation = compiler.compile(prompt_fragments.clone());
@@ -208,6 +212,7 @@ fn build_prompt_fragments_from_runtime_self_model(
     tool_view: &ToolView,
     tool_runtime_config: &tools::runtime_config::ToolRuntimeConfig,
     runtime_self_model: Option<runtime_self::RuntimeSelfModel>,
+    extra_section: Option<String>,
 ) -> Vec<PromptFragment> {
     let system_prompt = config.cli.resolved_system_prompt();
     let system_text = system_prompt.trim().to_owned();
@@ -267,6 +272,19 @@ fn build_prompt_fragments_from_runtime_self_model(
         prompt_fragments.push(runtime_identity_fragment);
     }
 
+    if let Some(section) = extra_section {
+        let binding_fragment = PromptFragment::new(
+            "governed-runtime-binding",
+            PromptLane::CapabilitySnapshot,
+            "governed-runtime-binding",
+            section,
+            ContextArtifactKind::RuntimeContract,
+        )
+        .with_cacheable(true);
+
+        prompt_fragments.push(binding_fragment);
+    }
+
     let capability_fragment = PromptFragment::new(
         "capability-snapshot",
         PromptLane::CapabilitySnapshot,
@@ -279,6 +297,28 @@ fn build_prompt_fragments_from_runtime_self_model(
     prompt_fragments.push(capability_fragment);
 
     prompt_fragments
+}
+
+fn render_governed_runtime_binding_section(binding: ProviderRuntimeBinding<'_>) -> String {
+    let kernel_binding = if binding.is_kernel_bound() {
+        "present"
+    } else {
+        "absent"
+    };
+    format!(
+        "## Governed Runtime Binding\n- session_mode: {}\n- kernel_binding: {kernel_binding}",
+        binding.session_mode().as_str()
+    )
+}
+
+pub(super) fn build_base_messages_for_view(
+    config: &LoongClawConfig,
+    include_system_prompt: bool,
+    tool_view: &ToolView,
+) -> Vec<Value> {
+    build_system_message_for_view(config, include_system_prompt, tool_view)
+        .into_iter()
+        .collect()
 }
 
 fn build_base_artifacts(messages: &[Value]) -> Vec<ContextArtifactDescriptor> {
@@ -921,6 +961,36 @@ mod tests {
         assert!(runtime_self_content.contains(&agents_text));
         assert!(runtime_self_content.contains("runtime self truncated"));
         assert!(!runtime_self_content.contains(raw_user_prefix));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn governed_runtime_binding_system_message_surfaces_binding_facts() {
+        let harness = TurnTestHarness::new();
+        let agents_path = harness.temp_dir.join("AGENTS.md");
+        let agents_text = "runtime self should still load for binding-aware prompts";
+        let mut config = LoongClawConfig::default();
+
+        std::fs::write(&agents_path, agents_text).expect("write AGENTS");
+
+        config.tools.file_root = Some(harness.temp_dir.display().to_string());
+
+        let advisory_messages =
+            build_base_messages_with_binding(&config, true, ProviderRuntimeBinding::direct()).await;
+        let advisory_content = runtime_self_system_content(&advisory_messages);
+        assert!(advisory_content.contains("## Governed Runtime Binding"));
+        assert!(advisory_content.contains("session_mode: advisory_only"));
+        assert!(advisory_content.contains("kernel_binding: absent"));
+
+        let mutating_messages = build_base_messages_with_binding(
+            &config,
+            true,
+            ProviderRuntimeBinding::kernel(&harness.kernel_ctx),
+        )
+        .await;
+        let mutating_content = runtime_self_system_content(&mutating_messages);
+        assert!(mutating_content.contains("## Governed Runtime Binding"));
+        assert!(mutating_content.contains("session_mode: mutating_capable"));
+        assert!(mutating_content.contains("kernel_binding: present"));
     }
 
     #[test]

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -1,10 +1,12 @@
+use loongclaw_contracts::GovernedSessionMode;
+
 use crate::KernelContext;
 
 #[derive(Clone, Copy, Default)]
 pub enum ProviderRuntimeBinding<'a> {
     Kernel(&'a KernelContext),
     #[default]
-    Direct,
+    AdvisoryOnly,
 }
 
 impl<'a> ProviderRuntimeBinding<'a> {
@@ -12,25 +14,40 @@ impl<'a> ProviderRuntimeBinding<'a> {
         Self::Kernel(kernel_ctx)
     }
 
+    pub const fn advisory_only() -> Self {
+        Self::AdvisoryOnly
+    }
+
     pub const fn direct() -> Self {
-        Self::Direct
+        Self::AdvisoryOnly
     }
 
     pub fn kernel_context(self) -> Option<&'a KernelContext> {
         match self {
             Self::Kernel(kernel_ctx) => Some(kernel_ctx),
-            Self::Direct => None,
+            Self::AdvisoryOnly => None,
         }
     }
 
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Kernel(_) => "kernel",
-            Self::Direct => "direct",
+            Self::AdvisoryOnly => "advisory_only",
         }
     }
 
     pub const fn is_kernel_bound(self) -> bool {
+        matches!(self, Self::Kernel(_))
+    }
+
+    pub const fn session_mode(self) -> GovernedSessionMode {
+        match self {
+            Self::Kernel(_) => GovernedSessionMode::MutatingCapable,
+            Self::AdvisoryOnly => GovernedSessionMode::AdvisoryOnly,
+        }
+    }
+
+    pub const fn allows_mutation(self) -> bool {
         matches!(self, Self::Kernel(_))
     }
 }
@@ -46,7 +63,7 @@ mod tests {
                 .expect("kernel context should bootstrap");
         let binding = ProviderRuntimeBinding::kernel(&kernel_context);
 
-        assert_eq!(ProviderRuntimeBinding::direct().as_str(), "direct");
+        assert_eq!(ProviderRuntimeBinding::direct().as_str(), "advisory_only");
         assert_eq!(binding.as_str(), "kernel");
     }
 }

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -16,6 +16,7 @@ mod secret_resolver;
 mod secret_value;
 mod task_state;
 mod tool_types;
+mod workflow_types;
 
 pub use audit_types::{AuditEvent, AuditEventKind, ExecutionPlane, PlaneTier};
 pub use clock::{Clock, FixedClock, SystemClock};
@@ -46,6 +47,10 @@ pub use secret_value::SecretValue;
 pub use task_state::TaskState;
 pub use tool_types::{
     ToolCoreOutcome, ToolCoreRequest, ToolExtensionOutcome, ToolExtensionRequest, ToolTier,
+};
+pub use workflow_types::{
+    GovernedSessionBindingDescriptor, GovernedSessionMode, TaskScopeDescriptor,
+    WorkflowOperationKind, WorkflowOperationScope, WorktreeBindingDescriptor,
 };
 
 #[cfg(test)]

--- a/crates/contracts/src/workflow_types.rs
+++ b/crates/contracts/src/workflow_types.rs
@@ -1,0 +1,218 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernedSessionMode {
+    AdvisoryOnly,
+    MutatingCapable,
+}
+
+impl GovernedSessionMode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AdvisoryOnly => "advisory_only",
+            Self::MutatingCapable => "mutating_capable",
+        }
+    }
+}
+
+impl fmt::Display for GovernedSessionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowOperationKind {
+    Plan,
+    Task,
+    Worktree,
+    Approval,
+}
+
+impl WorkflowOperationKind {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Plan => "plan",
+            Self::Task => "task",
+            Self::Worktree => "worktree",
+            Self::Approval => "approval",
+        }
+    }
+}
+
+impl fmt::Display for WorkflowOperationKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowOperationScope {
+    Session,
+    Task,
+    Worktree,
+    Approval,
+}
+
+impl WorkflowOperationScope {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::Task => "task",
+            Self::Worktree => "worktree",
+            Self::Approval => "approval",
+        }
+    }
+}
+
+impl fmt::Display for WorkflowOperationScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskScopeDescriptor {
+    pub task_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorktreeBindingDescriptor {
+    pub worktree_id: String,
+    pub workspace_root: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GovernedSessionBindingDescriptor {
+    pub session_id: String,
+    pub task_scope: TaskScopeDescriptor,
+    pub turn_id: String,
+    pub worktree: WorktreeBindingDescriptor,
+    pub policy_snapshot: String,
+    pub audit_correlation_id: String,
+    pub execution_surface: String,
+    pub mode: GovernedSessionMode,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+    use serde_json::json;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct WorkflowOperationHolder {
+        #[serde(rename = "kind")]
+        _kind: WorkflowOperationKind,
+    }
+
+    #[test]
+    fn governed_workflow_contract_governed_session_binding_serializes_with_stable_shape() {
+        let descriptor = GovernedSessionBindingDescriptor {
+            session_id: "session-001".to_owned(),
+            task_scope: TaskScopeDescriptor {
+                task_id: "task-001".to_owned(),
+            },
+            turn_id: "turn-001".to_owned(),
+            worktree: WorktreeBindingDescriptor {
+                worktree_id: "worktree-001".to_owned(),
+                workspace_root: "/repo/.worktrees/worktree-001".to_owned(),
+            },
+            policy_snapshot: "policy-snapshot-001".to_owned(),
+            audit_correlation_id: "audit-001".to_owned(),
+            execution_surface: "conversation_turn".to_owned(),
+            mode: GovernedSessionMode::MutatingCapable,
+        };
+
+        let serialized = serde_json::to_value(&descriptor).expect("binding descriptor serializes");
+
+        assert_eq!(
+            serialized,
+            json!({
+                "session_id": "session-001",
+                "task_scope": {
+                    "task_id": "task-001",
+                },
+                "turn_id": "turn-001",
+                "worktree": {
+                    "worktree_id": "worktree-001",
+                    "workspace_root": "/repo/.worktrees/worktree-001",
+                },
+                "policy_snapshot": "policy-snapshot-001",
+                "audit_correlation_id": "audit-001",
+                "execution_surface": "conversation_turn",
+                "mode": "mutating_capable",
+            })
+        );
+    }
+
+    #[test]
+    fn governed_workflow_contract_session_modes_are_distinguishable() {
+        let advisory =
+            serde_json::to_value(GovernedSessionMode::AdvisoryOnly).expect("advisory serializes");
+        let mutating = serde_json::to_value(GovernedSessionMode::MutatingCapable)
+            .expect("mutating serializes");
+
+        assert_eq!(advisory, json!("advisory_only"));
+        assert_eq!(mutating, json!("mutating_capable"));
+        assert_ne!(advisory, mutating);
+    }
+
+    #[test]
+    fn governed_workflow_contract_operation_kind_and_scope_serialize_deterministically() {
+        let kind =
+            serde_json::to_value(WorkflowOperationKind::Worktree).expect("kind serializes");
+        let scope =
+            serde_json::to_value(WorkflowOperationScope::Worktree).expect("scope serializes");
+
+        assert_eq!(kind, json!("worktree"));
+        assert_eq!(scope, json!("worktree"));
+    }
+
+    #[test]
+    fn governed_workflow_contract_operation_kind_rejects_missing_or_unknown_values() {
+        let missing_kind = serde_json::from_value::<WorkflowOperationHolder>(json!({}))
+            .expect_err("missing kind should fail closed");
+        assert!(missing_kind.to_string().contains("missing field `kind`"));
+
+        let unknown_kind = serde_json::from_value::<WorkflowOperationHolder>(json!({
+            "kind": "shell",
+        }))
+        .expect_err("unknown kind should fail closed");
+        assert!(unknown_kind.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn governed_workflow_contract_binding_rejects_missing_required_fields() {
+        let error = serde_json::from_value::<GovernedSessionBindingDescriptor>(json!({
+            "session_id": "session-001",
+            "task_scope": {
+                "task_id": "task-001",
+            },
+            "turn_id": "turn-001",
+            "worktree": {
+                "worktree_id": "worktree-001",
+                "workspace_root": "/repo/.worktrees/worktree-001",
+            },
+            "policy_snapshot": "policy-snapshot-001",
+            "audit_correlation_id": "audit-001",
+            "execution_surface": "conversation_turn"
+        }))
+        .expect_err("missing mode should fail closed");
+
+        assert!(error.to_string().contains("missing field `mode`"));
+    }
+}

--- a/crates/contracts/src/workflow_types.rs
+++ b/crates/contracts/src/workflow_types.rs
@@ -173,8 +173,7 @@ mod tests {
 
     #[test]
     fn governed_workflow_contract_operation_kind_and_scope_serialize_deterministically() {
-        let kind =
-            serde_json::to_value(WorkflowOperationKind::Worktree).expect("kind serializes");
+        let kind = serde_json::to_value(WorkflowOperationKind::Worktree).expect("kind serializes");
         let scope =
             serde_json::to_value(WorkflowOperationScope::Worktree).expect("scope serializes");
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -57,10 +57,11 @@ Tool-specific request approval currently lives in the `PolicyExtensionChain`; th
 **Conversation runtime binding note:**
 - The binding makes the high-level execution mode explicit: `Kernel` means the turn is allowed to call kernel-mediated core tools; `Direct` means conversation orchestration may continue, but kernel-only tool execution must fail closed.
 - This removes ambiguity from conversation traits and dispatcher seams where `None` previously overloaded multiple meanings such as "direct mode", "not wired yet", or "forgot to pass kernel authority".
+- Conversation app-dispatch approval routing is now binding-first at the trait boundary. `AppToolDispatcher` approval checks receive `ConversationRuntimeBinding` directly instead of reconstructing approval semantics from `Option<&KernelContext>`.
 - Detached async delegate spawns carry an owned kernel context forward when the parent binding is kernel-bound. Direct-mode parents keep direct-mode children.
 - Kernel-bound history helpers no longer reuse direct sqlite fallback behind the caller's back. Higher-level orchestration may still choose how to handle the surfaced error.
 - Safe-lane governor diagnostics now surface history load status and normalized error codes instead of silently collapsing kernel history failures into an undifferentiated "no history" state.
-- User-facing chat diagnostics now preserve explicit `ConversationRuntimeBinding` semantics end-to-end. The discovery-first session-history path uses the same binding-first implementation internally. The public `Option<&KernelContext>` entrypoint remains an explicit compatibility wrapper instead of carrying shadow authority semantics deeper into the runtime.
+- User-facing chat diagnostics now preserve explicit `ConversationRuntimeBinding` semantics end-to-end. The discovery-first session-history path uses the same binding-first implementation internally. Remaining public `Option<&KernelContext>` seams are compatibility wrappers only, not first-class dispatcher-boundary contracts.
 
 **Provider runtime binding note:**
 - The provider binding makes provider governance explicit without importing conversation-layer semantics into provider code. `Kernel` means failover/audit behavior may emit kernel-backed audit events; `Direct` means provider execution is intentionally running without that authority while still recording in-process failover metrics.

--- a/docs/plans/2026-04-01-async-delegate-owned-binding-design.md
+++ b/docs/plans/2026-04-01-async-delegate-owned-binding-design.md
@@ -1,0 +1,158 @@
+# Async Delegate Owned Binding Design
+
+Date: 2026-04-01
+Branch: `feat/async-delegate-owned-binding-20260401`
+Scope: tighten detached async delegate authority propagation around an owned runtime binding seam
+
+## Problem
+
+The binding-first approval boundary slice made `ConversationRuntimeBinding` the
+main borrowed execution contract for conversation turns, but detached async
+delegate spawn still carries inherited authority as `Option<KernelContext>`.
+
+That shape is weaker than the actual runtime contract:
+
+1. it treats "owned governed binding" as an implementation detail instead of a
+   first-class concept
+2. every async delegate spawner reconstructs borrowed binding ad hoc through
+   `ConversationRuntimeBinding::from_optional_kernel_context(...)`
+3. tests validate kernel inheritance indirectly through kernel-context presence
+   rather than an explicit owned binding contract
+
+The result is a seam that still speaks in raw kernel-state storage terms even
+though the surrounding runtime has already moved to binding-first semantics.
+
+## Goals
+
+1. Make detached async delegate spawn requests carry explicit owned runtime
+   binding semantics.
+2. Preserve parent governed/advisory mode through detached child execution
+   without borrowing parent stack state.
+3. Keep the patch reviewable and local to conversation runtime and delegate test
+   seams.
+
+## Non-goals
+
+1. Do not sweep the repository for every `Option<&KernelContext>` or
+   `from_optional_kernel_context(...)` use.
+2. Do not redesign synchronous delegate execution.
+3. Do not bundle `session_history` cleanup or unrelated compatibility wrapper
+   changes into this slice.
+4. Do not force `run_started_delegate_child_turn_with_runtime(...)` to become
+   fully owned end-to-end if a borrowed execution seam remains sufficient.
+
+## Alternatives Considered
+
+### A. Keep `Option<KernelContext>` in async delegate requests
+
+Rejected. That preserves the current ambiguity and keeps binding semantics
+secondary to raw kernel-context transport.
+
+### B. Convert the entire conversation runtime to owned bindings immediately
+
+Rejected for this slice. It would mix unrelated lifetimes and API cleanup into a
+larger refactor than needed for the current authority seam.
+
+### C. Introduce a narrow owned binding type for detached async delegate flow
+
+Recommended. It makes the detached seam explicit while keeping the rest of the
+runtime on the existing borrowed `ConversationRuntimeBinding<'_>` API.
+
+## Decision
+
+Introduce `OwnedConversationRuntimeBinding` alongside the existing borrowed
+binding enum, and thread it through detached async delegate requests and
+spawners.
+
+The detach point in `turn_coordinator.rs` becomes the ownership boundary:
+
+1. parent execution starts with borrowed `ConversationRuntimeBinding<'_>`
+2. detached request stores `OwnedConversationRuntimeBinding`
+3. async spawner converts the owned binding back to borrowed only when entering
+   cleanup helpers and child-turn execution
+
+This slice does not widen delegate eligibility. `delegate_async` already
+requires a mutating runtime binding, so advisory/direct parents are denied
+earlier in turn preparation and never reach the detached spawner path.
+
+## Proposed Design
+
+### 1. Add `OwnedConversationRuntimeBinding`
+
+`crates/app/src/conversation/runtime_binding.rs` will define:
+
+1. `OwnedConversationRuntimeBinding::Kernel(KernelContext)`
+2. `OwnedConversationRuntimeBinding::AdvisoryOnly`
+
+The owned type mirrors the semantics of the borrowed binding and provides:
+
+1. `from_borrowed(ConversationRuntimeBinding<'_>) -> Self`
+2. `kernel(KernelContext) -> Self`
+3. `advisory_only()` / `direct()`
+4. `as_borrowed(&self) -> ConversationRuntimeBinding<'_>`
+5. helpers such as `kernel_context()`, `is_kernel_bound()`, and `session_mode()`
+
+This keeps governed versus advisory semantics explicit even after detaching work
+into another task.
+
+### 2. Change async delegate spawn requests to store owned binding
+
+`AsyncDelegateSpawnRequest` in `runtime.rs` will replace:
+
+1. `kernel_context: Option<KernelContext>`
+
+with:
+
+1. `binding: OwnedConversationRuntimeBinding`
+
+The request now states the intended execution contract directly rather than
+reconstructing it from optional raw kernel state.
+
+### 3. Convert at the child execution seam only
+
+The default async delegate spawner and local test spawners will stop calling
+`ConversationRuntimeBinding::from_optional_kernel_context(...)` against request
+storage. Instead they will borrow from the owned binding just-in-time:
+
+1. `request.binding.as_borrowed()` for
+   `with_prepared_subagent_spawn_cleanup_if_kernel_bound(...)`
+2. `request.binding.as_borrowed()` for
+   `run_started_delegate_child_turn_with_runtime(...)`
+
+This preserves the current execution API where borrowed binding is still the
+right shape for immediate turn handling.
+
+### 4. Tighten tests around the explicit contract
+
+Conversation tests should stop asserting raw `kernel_context` presence on async
+delegate requests. They should assert the owned binding directly:
+
+1. governed parent turns queue `OwnedConversationRuntimeBinding::Kernel(...)`
+2. advisory binding still round-trips correctly in owned-binding unit tests
+3. local async delegate child execution still behaves as before once the owned
+   binding is borrowed at the execution seam
+
+## Expected Behavioral Outcome
+
+1. Detached async delegate requests preserve parent runtime authority as an
+   explicit owned binding contract.
+2. Governed parents still spawn governed child turns.
+3. Advisory/direct parents remain denied before async spawn, matching the
+   existing mutating-binding policy contract.
+4. The patch reduces ad hoc binding reconstruction without changing unrelated
+   runtime behavior.
+
+## Test Strategy
+
+Add focused regression coverage for:
+
+1. owned binding round-trips between borrowed and borrowed-again views
+2. async delegate queueing preserves a governed owned binding
+3. local async child execution continues to use the borrowed binding derived
+   from the owned request binding
+
+## Why This Slice Matters
+
+This is the highest-value remaining binding-first seam in detached delegate
+execution. It does not invent new capability rules; it makes the existing rules
+explicit in the API that crosses the async ownership boundary.

--- a/docs/plans/2026-04-01-async-delegate-owned-binding-implementation-plan.md
+++ b/docs/plans/2026-04-01-async-delegate-owned-binding-implementation-plan.md
@@ -1,0 +1,199 @@
+# Async Delegate Owned Binding Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace detached async delegate `Option<KernelContext>` transport with an explicit owned runtime binding contract.
+
+**Architecture:** Keep borrowed `ConversationRuntimeBinding<'_>` as the immediate execution API, but introduce an owned mirror for detached work. The detach point in `turn_coordinator.rs` owns the binding, and spawners borrow it back only when entering child-turn helpers.
+
+**Tech Stack:** Rust, Tokio, async-trait, cargo test, cargo fmt, cargo clippy
+
+---
+
+### Task 1: Add the owned binding type
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime_binding.rs`
+- Modify: `crates/app/src/conversation/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add a focused unit test in `crates/app/src/conversation/runtime_binding.rs` that:
+
+```rust
+let owned = OwnedConversationRuntimeBinding::from_borrowed(
+    ConversationRuntimeBinding::kernel(&kernel_ctx),
+);
+assert!(owned.is_kernel_bound());
+assert_eq!(
+    owned.as_borrowed().session_mode(),
+    ConversationRuntimeBinding::kernel(&kernel_ctx).session_mode()
+);
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test --workspace --locked owned_conversation_runtime_binding`
+Expected: FAIL because `OwnedConversationRuntimeBinding` does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement an owned enum mirroring the borrowed binding:
+
+```rust
+pub enum OwnedConversationRuntimeBinding {
+    Kernel(KernelContext),
+    AdvisoryOnly,
+}
+```
+
+Add helpers for `from_borrowed(...)`, `as_borrowed(...)`, and mode inspection.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test --workspace --locked owned_conversation_runtime_binding`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/runtime_binding.rs crates/app/src/conversation/mod.rs
+git commit -m "refactor: add owned conversation runtime binding"
+```
+
+### Task 2: Move async delegate requests to owned binding
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Update the async delegate queue tests in `crates/app/src/conversation/tests.rs`
+to assert:
+
+```rust
+assert!(matches!(
+    spawn_request.binding,
+    crate::conversation::OwnedConversationRuntimeBinding::Kernel(_)
+));
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `cargo test --workspace --locked handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request`
+- `cargo test --workspace --locked handle_turn_with_runtime_executes_delegate_async_via_coordinator_without_waiting`
+
+Expected: FAIL because `AsyncDelegateSpawnRequest` still exposes `kernel_context`.
+
+**Step 3: Write minimal implementation**
+
+Change the detached request shape:
+
+```rust
+pub struct AsyncDelegateSpawnRequest {
+    pub binding: OwnedConversationRuntimeBinding,
+}
+```
+
+At the detach seam, convert the parent borrowed binding:
+
+```rust
+binding: OwnedConversationRuntimeBinding::from_borrowed(binding),
+```
+
+In spawners, borrow it back only at execution time:
+
+```rust
+let binding = request.binding.as_borrowed();
+```
+
+**Step 4: Run test to verify it passes**
+
+Run the same targeted tests.
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/runtime.rs crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs
+git commit -m "refactor: make async delegate binding owned"
+```
+
+### Task 3: Keep local child execution and helper spawners aligned
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/conversation/runtime_binding.rs`
+
+**Step 1: Write the failing test**
+
+Add or tighten a local child-runtime async delegate test so the spawned child
+still executes successfully when the request carries owned governed binding, and
+keep the owned-binding unit tests covering advisory-mode round-tripping because
+advisory/direct parents never reach async delegate spawn.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test --workspace --locked handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_by_default`
+Expected: FAIL if helper spawners still depend on `request.kernel_context`.
+
+**Step 3: Write minimal implementation**
+
+Update test-only spawners to use:
+
+```rust
+let binding = request.binding.as_borrowed();
+```
+
+and pass that borrowed view into cleanup and child-turn execution helpers.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test --workspace --locked handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_by_default`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/tests.rs
+git commit -m "test: align async delegate helpers with owned binding"
+```
+
+### Task 4: Full verification
+
+**Files:**
+- Modify: `docs/plans/2026-04-01-async-delegate-owned-binding-design.md`
+- Modify: `docs/plans/2026-04-01-async-delegate-owned-binding-implementation-plan.md`
+
+**Step 1: Run formatting verification**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS
+
+**Step 2: Run strict lint verification**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: PASS
+
+**Step 3: Run workspace tests**
+
+Run: `cargo test --workspace --locked`
+Expected: PASS
+
+**Step 4: Inspect final diff**
+
+Run:
+- `git status --short`
+- `git diff --stat`
+
+Expected: only the owned-binding slice and its docs are present.
+
+**Step 5: Commit**
+
+```bash
+git add docs/plans/2026-04-01-async-delegate-owned-binding-design.md docs/plans/2026-04-01-async-delegate-owned-binding-implementation-plan.md crates/app/src/conversation/runtime_binding.rs crates/app/src/conversation/mod.rs crates/app/src/conversation/runtime.rs crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs
+git commit -m "refactor: preserve async delegate binding as owned authority"
+```

--- a/docs/plans/2026-04-01-binding-first-approval-boundary-design.md
+++ b/docs/plans/2026-04-01-binding-first-approval-boundary-design.md
@@ -1,0 +1,238 @@
+# Binding-First Approval Boundary Design
+
+Date: 2026-04-01
+Branch: `feat/binding-first-approval-boundary-20260401`
+Scope: tighten the app-dispatch approval boundary after `feat: require governed runtime binding`
+
+## Problem
+
+The conversation runtime now has an explicit `ConversationRuntimeBinding`, and
+mutating app intents already fail closed before execution when the binding is
+advisory-only. That removed the highest-risk behavioral drift, but the app-tool
+approval boundary still exposes the old optional-kernel compatibility contract.
+
+Two seams still reconstruct approval semantics from `Option<&KernelContext>`:
+
+1. `AppToolDispatcher::maybe_require_approval(...)` in
+   `crates/app/src/conversation/turn_engine.rs`
+2. `CoordinatorAppToolDispatcher::maybe_require_approval(...)` in
+   `crates/app/src/conversation/turn_coordinator.rs`
+
+That API shape is weaker than the runtime contract around it:
+
+1. `None` can still mean "advisory-only binding"
+2. `None` can still mean "compat ingress wrapper"
+3. `None` could still mean "caller forgot to preserve the binding semantics"
+
+Those meanings are no longer equivalent. The binding-first runtime refactor only
+becomes mechanically truthful when the approval boundary also requires the same
+explicit binding contract.
+
+## Goals
+
+1. Make the approval-routing trait boundary binding-first.
+2. Remove app-dispatch approval reconstruction from raw
+   `Option<&KernelContext>` values.
+3. Keep compatibility normalization only in explicit ingress or wrapper seams
+   that intentionally translate older call sites into the new binding contract.
+4. Preserve current behavior:
+   - governed app tools still request approval when configured
+   - advisory-only bindings still fail closed before approval routing for
+     mutating app intents
+   - non-mutating app tools still keep their existing behavior
+5. Keep the slice narrow and reviewable.
+
+## Non-goals
+
+1. Do not refactor `AsyncDelegateSpawnRequest` owned binding carriage in this
+   slice.
+2. Do not remove every `Option<&KernelContext>` from the repository.
+3. Do not expand provider, ACP, channel, or connector binding cleanup.
+4. Do not redesign governed tool policy or approval persistence semantics.
+
+## Current Evidence
+
+### What is already correct
+
+The current runtime already enforces the most important behavioral invariant:
+mutating app tools require a mutating-capable binding before they can even reach
+approval routing.
+
+Evidence:
+
+1. `crates/app/src/conversation/turn_engine.rs`
+   - `requires_mutating_runtime_binding(...)`
+   - `execute_turn_in_context(...)` rejects advisory-only bindings with
+     `governed_runtime_binding_required`
+2. `crates/app/src/conversation/tests.rs`
+   - `governed_runtime_binding_rejects_mutating_app_intent_before_approval_on_advisory_binding`
+
+### What is still drifting
+
+The approval boundary itself still treats binding-first as an adapter layered on
+top of the old optional contract:
+
+1. the trait default implementation of
+   `maybe_require_approval_with_binding(...)` converts the binding back into an
+   optional kernel reference
+2. the concrete `DefaultAppToolDispatcher` still implements the optional-kernel
+   method as its primary seam
+3. the coordinator wrapper still implements the optional-kernel method and then
+   reconstructs the binding again
+
+That means the approval contract is still semantically optional even though the
+turn engine now reasons in terms of explicit binding.
+
+## Alternatives Considered
+
+### A. Retire optional-kernel compatibility from the approval boundary first
+
+Recommended.
+
+Make `maybe_require_approval_with_binding(...)` the primary trait contract,
+remove the optional-kernel method from the approval seam, and keep any
+normalization only in explicit compatibility wrappers outside the dispatcher
+boundary.
+
+Why this is the right next slice:
+
+1. it closes a real remaining semantic drift seam
+2. it stays local to the conversation app-dispatch boundary
+3. it matches the already-landed runtime-binding direction
+4. it avoids reopening broader history or async delegate work
+
+### B. Start with async delegate owned-binding cleanup
+
+Rejected for this slice.
+
+That work is real, but it is a different seam with different test surface and
+blast radius. Pulling it into Task 4 would mix approval-boundary cleanup with
+spawn-lifecycle plumbing and make the patch less reviewable.
+
+### C. Do naming-only cleanup and leave both contracts in place
+
+Rejected.
+
+Renaming methods without removing the optional contract would preserve the same
+architectural ambiguity while making the code look more settled than it really
+is.
+
+## Decision
+
+Implement option A as a bounded D6 follow-up slice:
+
+1. `AppToolDispatcher` becomes binding-first for approval routing
+2. concrete dispatcher implementations operate on
+   `ConversationRuntimeBinding<'_>` directly
+3. explicit compatibility normalization remains allowed only at ingress-style
+   seams that intentionally bridge older interfaces into the binding contract
+
+## Proposed Design
+
+### 1. Trait boundary
+
+Change `AppToolDispatcher` so the approval entry contract is:
+
+```rust
+async fn maybe_require_approval_with_binding(
+    &self,
+    session_context: &SessionContext,
+    intent: &ToolIntent,
+    descriptor: &crate::tools::ToolDescriptor,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<Option<ApprovalRequirement>, String>;
+```
+
+The trait should no longer define approval routing in terms of
+`Option<&KernelContext>`.
+
+This does not mean every caller must already be kernel-bound. It means every
+caller must be explicit about whether the turn is running in `Kernel` or
+advisory-only mode.
+
+### 2. Concrete dispatcher implementation
+
+`DefaultAppToolDispatcher` should implement approval logic directly on the
+binding-first method. For this slice, the approval logic itself does not need to
+change:
+
+1. governed app tools still compute approval requirements from descriptor
+   metadata and config
+2. approval persistence still uses the same repository rows and deterministic
+   request ids
+3. the binding may remain unused inside the sqlite-backed approval persistence
+   path for now, but the contract must stay explicit
+
+Important design point:
+
+Unused binding in a concrete implementation is acceptable. Hidden reconstruction
+from `Option<&KernelContext>` is not.
+
+### 3. Coordinator wrapper
+
+`CoordinatorAppToolDispatcher` should stop reintroducing the optional-kernel
+compat seam. It should implement only the binding-first approval method and
+delegate directly to the fallback dispatcher.
+
+### 4. Compatibility boundary rules
+
+This slice intentionally allows lower-priority compatibility wrappers to remain
+where they are already explicit and shallow, for example:
+
+1. session-history public helper entrypoints that accept
+   `Option<&KernelContext>` and immediately normalize to a binding
+2. async delegate spawn request plumbing that still carries owned
+   `Option<KernelContext>` until its dedicated cleanup slice
+
+The rule is:
+
+`optional kernel is acceptable only at explicit ingress/compat boundaries, not
+at the approval-routing trait boundary`
+
+## Expected Behavioral Outcome
+
+No user-visible product behavior should change in this slice.
+
+Expected outcomes:
+
+1. strict approval mode still persists approval requests for governed app tools
+2. advisory-only turns still deny mutating app intents before approval routing
+3. the approval boundary becomes architecture-truthful because callers can no
+   longer silently erase binding semantics at the dispatcher seam
+
+## Test Strategy
+
+Add focused regression coverage that proves:
+
+1. custom app dispatchers can implement approval routing directly on the
+   binding-first seam without an optional-kernel override
+2. advisory-only mutating app turns still fail before approval routing
+3. governed approval persistence still works through the binding-first contract
+4. no approval-boundary call path in `turn_engine` or `turn_coordinator`
+   reconstructs the binding from `Option<&KernelContext>`
+
+The slice should prefer test additions to existing `turn_engine.rs` and
+`conversation/tests.rs` coverage rather than introducing new modules.
+
+## Documentation Impact
+
+`docs/SECURITY.md` should be tightened so it no longer implies that the
+discovery-first compatibility note is the only public optional-kernel seam that
+matters. After this slice, the more accurate claim is:
+
+1. approval routing in the conversation app-dispatch path is binding-first
+2. remaining optional-kernel surfaces are explicit compatibility wrappers, not
+   dispatcher-boundary contracts
+
+## Why This Slice Matters
+
+The repository has already done the harder behavioral work: governed binding is
+real, and advisory-only mutation is denied early. Task 4 matters because it
+removes one of the last places where the old optional-kernel story still leaks
+through a first-class conversation/runtime seam.
+
+That is the right kind of follow-up slice:
+
+1. small enough to review
+2. strong enough to improve architectural truthfulness
+3. narrow enough to avoid pretending this is a full repository-wide cleanup

--- a/docs/plans/2026-04-01-binding-first-approval-boundary-implementation-plan.md
+++ b/docs/plans/2026-04-01-binding-first-approval-boundary-implementation-plan.md
@@ -1,0 +1,232 @@
+# Binding-First Approval Boundary Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Retire legacy optional-kernel compatibility from the conversation
+app-dispatch approval boundary so approval routing is binding-first and any
+remaining `Option<&KernelContext>` normalization stays limited to explicit
+compatibility wrappers.
+
+**Architecture:** Change the `AppToolDispatcher` approval contract to accept
+`ConversationRuntimeBinding<'_>` directly, update concrete dispatcher
+implementations to use that contract as the primary seam, and prove with focused
+tests that mutating advisory-only turns still fail before approval routing while
+governed approval persistence still works unchanged.
+
+**Tech Stack:** Rust, `async_trait`, `loongclaw-app`, conversation runtime,
+turn engine, turn coordinator, sqlite-backed session repository, security docs
+
+---
+
+## Execution Tasks
+
+Verification note: use a unique test prefix such as
+`binding_first_approval_boundary_` for any new coverage added in this slice.
+
+### Task 1: Add failing tests for the binding-first dispatcher seam
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+
+- a custom `AppToolDispatcher` can implement only
+  `maybe_require_approval_with_binding(...)` and still participate in turn
+  execution correctly
+- mutating app intents running under `ConversationRuntimeBinding::direct()`
+  still fail closed before approval routing
+- governed app-tool approval persistence still succeeds when the dispatcher is
+  called through the binding-first seam
+
+Suggested test names:
+
+```rust
+async fn binding_first_approval_boundary_custom_dispatcher_uses_binding_only() { /* ... */ }
+async fn binding_first_approval_boundary_advisory_mutation_denies_before_approval() { /* ... */ }
+async fn binding_first_approval_boundary_persists_governed_request() { /* ... */ }
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app binding_first_approval_boundary_ -- --test-threads=1
+```
+
+Expected: FAIL because the trait and concrete implementations still route
+approval through `maybe_require_approval(...)` with `Option<&KernelContext>`.
+
+**Step 3: Write the minimal implementation**
+
+Do not change approval policy semantics yet. Only express the same behavior
+through the binding-first seam.
+
+**Step 4: Run the tests to verify they pass**
+
+Run the same command and expect PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/tests.rs crates/app/src/conversation/turn_engine.rs
+git commit -m "test: lock approval boundary to binding-first seam"
+```
+
+### Task 2: Retire the optional-kernel trait contract in `turn_engine`
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_engine.rs`
+
+**Step 1: Replace the trait surface**
+
+Change `AppToolDispatcher` so approval routing is defined only by
+`maybe_require_approval_with_binding(...)`.
+
+Use a trait default like:
+
+```rust
+async fn maybe_require_approval_with_binding(
+    &self,
+    _session_context: &SessionContext,
+    _intent: &ToolIntent,
+    _descriptor: &crate::tools::ToolDescriptor,
+    _binding: ConversationRuntimeBinding<'_>,
+) -> Result<Option<ApprovalRequirement>, String> {
+    Ok(None)
+}
+```
+
+Remove the optional-kernel approval method from the trait.
+
+**Step 2: Update `DefaultAppToolDispatcher`**
+
+Move the current approval logic under the binding-first method directly:
+
+```rust
+async fn maybe_require_approval_with_binding(
+    &self,
+    session_context: &SessionContext,
+    intent: &ToolIntent,
+    descriptor: &crate::tools::ToolDescriptor,
+    binding: ConversationRuntimeBinding<'_>,
+) -> Result<Option<ApprovalRequirement>, String> {
+    let _ = binding;
+    // existing governed approval persistence logic
+}
+```
+
+Keep the existing repository writes, request ids, and denial strings unchanged.
+
+**Step 3: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app binding_first_approval_boundary_ governed_tool_approval_request_ -- --test-threads=1
+```
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add crates/app/src/conversation/turn_engine.rs
+git commit -m "refactor: make approval dispatch binding-first"
+```
+
+### Task 3: Remove the coordinator compatibility loopback
+
+**Files:**
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Simplify `CoordinatorAppToolDispatcher`**
+
+Delete the optional-kernel approval override and keep only the binding-first
+implementation that delegates to `self.fallback`.
+
+The coordinator wrapper should no longer do:
+
+```rust
+let binding = ConversationRuntimeBinding::from_optional_kernel_context(kernel_ctx);
+```
+
+at the approval boundary.
+
+**Step 2: Add or tighten regression coverage**
+
+If needed, extend an existing coordinator-level approval test so it proves the
+turn still reaches `NeedsApproval(...)` or the persisted grant path through the
+binding-first dispatcher contract.
+
+Suggested test target:
+
+```rust
+async fn binding_first_approval_boundary_coordinator_routes_needs_approval() { /* ... */ }
+```
+
+**Step 3: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app binding_first_approval_boundary_ handle_turn_with_runtime_requires_approval_before_delegate_execution -- --test-threads=1
+```
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs
+git commit -m "refactor: remove approval boundary loopback in coordinator"
+```
+
+### Task 4: Tighten security docs and run verification
+
+**Files:**
+- Modify: `docs/SECURITY.md`
+
+**Step 1: Update the security wording**
+
+State explicitly that:
+
+- conversation app-dispatch approval routing is now binding-first
+- remaining optional-kernel entrypoints are explicit compatibility wrappers
+- the public discovery-first entrypoint remains a compatibility wrapper, not a
+  first-class dispatcher contract
+
+**Step 2: Run verification**
+
+Run:
+
+```bash
+cargo test --workspace --locked
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: PASS
+
+**Step 3: Inspect staged scope before commit**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected: only Task 4 scoped files are staged
+
+**Step 4: Commit**
+
+```bash
+git add docs/SECURITY.md
+git commit -m "docs: clarify binding-first approval boundary"
+```

--- a/docs/plans/2026-04-01-session-history-binding-first-design.md
+++ b/docs/plans/2026-04-01-session-history-binding-first-design.md
@@ -1,0 +1,154 @@
+# Session History Binding-First Discovery Summary Design
+
+Date: 2026-04-01
+Branch: `feat/session-history-binding-first-20260401`
+Scope: tighten the remaining public discovery-summary compatibility seam in `session_history`
+
+## Problem
+
+`crates/app/src/conversation/session_history.rs` is already mostly
+binding-first:
+
+1. `load_safe_lane_event_summary(...)` takes `ConversationRuntimeBinding<'_>`
+2. `load_fast_lane_tool_batch_event_summary(...)` takes
+   `ConversationRuntimeBinding<'_>`
+3. `load_turn_checkpoint_event_summary(...)` takes
+   `ConversationRuntimeBinding<'_>`
+4. the real discovery-first implementation already lives in
+   `load_discovery_first_event_summary_with_binding(...)`
+
+The remaining drift is the primary public discovery-first helper name:
+
+1. `load_discovery_first_event_summary(...)` still accepts
+   `Option<&KernelContext>`
+2. it immediately normalizes that option back into
+   `ConversationRuntimeBinding<'_>`
+3. the public contract therefore still describes runtime authority in raw
+   kernel-presence terms even though the module already reasons in explicit
+   binding semantics
+
+This is not a behavioral bug. It is a public API truthfulness problem.
+
+## Goals
+
+1. Make the primary public discovery-first session-history API binding-first.
+2. Keep any remaining optional-kernel normalization in an explicitly named
+   compatibility shim instead of the main public entrypoint.
+3. Preserve behavior:
+   - kernel-bound callers still use kernel memory-window reads
+   - advisory/direct callers still use sqlite/direct reads
+   - discovery-first summaries stay byte-for-byte equivalent for the same input
+4. Keep the patch narrow and reviewable.
+
+## Non-goals
+
+1. Do not sweep unrelated `from_optional_kernel_context(...)` uses across the
+   repository.
+2. Do not refactor chat, provider, ACP, or turn-coordinator call paths in this
+   slice.
+3. Do not redesign history summary formats or memory-window semantics.
+4. Do not remove explicit compatibility helpers everywhere; only tighten this
+   one public seam.
+
+## Alternatives Considered
+
+### A. Leave the public `Option<&KernelContext>` helper as-is
+
+Rejected. That keeps the most visible session-history entrypoint semantically
+weaker than the module around it.
+
+### B. Add a second public binding-first helper and leave the old one as the default
+
+Rejected. That would make the public surface describe two competing contracts at
+the same level and encourage drift to continue.
+
+### C. Promote the main public helper name to binding-first and move the old shape behind an explicit compatibility shim
+
+Recommended. It makes the module's primary API architecture-truthful while
+still leaving a narrow migration path for any older callers that truly still
+need optional-kernel normalization.
+
+## Decision
+
+Implement option C in one bounded slice:
+
+1. `load_discovery_first_event_summary(...)` becomes binding-first
+2. add a clearly named compatibility wrapper such as
+   `load_discovery_first_event_summary_with_kernel_context(...)`
+3. export both only if needed, but treat the binding-first function as the
+   canonical public entrypoint
+
+## Proposed Design
+
+### 1. Public API shape
+
+Change the main public helper in `session_history.rs` to:
+
+```rust
+pub async fn load_discovery_first_event_summary(
+    session_id: &str,
+    limit: usize,
+    binding: ConversationRuntimeBinding<'_>,
+    memory_config: &MemoryRuntimeConfig,
+) -> CliResult<DiscoveryFirstEventSummary>
+```
+
+This brings discovery-first in line with the neighboring public summary
+helpers.
+
+### 2. Compatibility shim
+
+Keep optional-kernel normalization available only in an explicitly named helper:
+
+```rust
+pub async fn load_discovery_first_event_summary_with_kernel_context(
+    session_id: &str,
+    limit: usize,
+    kernel_ctx: Option<&KernelContext>,
+    memory_config: &MemoryRuntimeConfig,
+) -> CliResult<DiscoveryFirstEventSummary>
+```
+
+That keeps the compatibility seam real but no longer lets it masquerade as the
+main runtime contract.
+
+### 3. Internal implementation
+
+The existing binding-aware implementation should stay the single real worker.
+This slice should minimize churn:
+
+1. keep one binding-first implementation path
+2. let the compatibility shim normalize to `ConversationRuntimeBinding` and call
+   the canonical helper
+3. avoid duplicating discovery-first summary logic
+
+### 4. Tests
+
+Tests should prove two things separately:
+
+1. the canonical public API now accepts explicit runtime binding directly
+2. the explicit compatibility shim still preserves the old `Option<&KernelContext>`
+   behavior for migration callers
+
+## Expected Behavioral Outcome
+
+1. No discovery-first summary behavior changes.
+2. The primary public session-history contract becomes binding-first.
+3. Optional-kernel normalization remains available only at a deliberately named
+   compatibility seam.
+
+## Test Strategy
+
+Add focused regression coverage for:
+
+1. public discovery-first summary calls succeed for explicit direct binding
+2. public discovery-first summary calls succeed for explicit kernel binding
+3. the compatibility shim still accepts `None` and `Some(&ctx)`
+4. kernel-backed discovery-first calls still route through the memory-window
+   core operation with the same payload as before
+
+## Why This Slice Matters
+
+The repository has already done the harder work of moving history internals to
+binding-aware execution. This slice finishes the public contract so the API
+stops telling a weaker story than the implementation underneath it.

--- a/docs/plans/2026-04-01-session-history-binding-first-implementation-plan.md
+++ b/docs/plans/2026-04-01-session-history-binding-first-implementation-plan.md
@@ -1,0 +1,146 @@
+# Session History Binding-First Discovery Summary Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the main public discovery-first session-history helper binding-first while preserving a clearly named optional-kernel compatibility shim.
+
+**Architecture:** Reuse the existing binding-aware discovery-first implementation as the single worker path. Promote the canonical public helper name to `ConversationRuntimeBinding<'_>` and move `Option<&KernelContext>` normalization behind an explicitly named compatibility wrapper.
+
+**Tech Stack:** Rust, Tokio tests, cargo test, cargo fmt, cargo clippy
+
+---
+
+### Task 1: Rewrite the public contract in tests first
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Change the discovery-first tests so they express the new contract:
+
+1. `load_discovery_first_event_summary_accepts_explicit_runtime_binding` should
+   call the public `load_discovery_first_event_summary(...)` name with
+   `ConversationRuntimeBinding::direct()` and
+   `ConversationRuntimeBinding::kernel(&kernel_ctx)`
+2. the compatibility test should call a new explicit shim named
+   `load_discovery_first_event_summary_with_kernel_context(...)`
+
+Example assertion shape:
+
+```rust
+let direct_summary = load_discovery_first_event_summary(
+    "session",
+    16,
+    ConversationRuntimeBinding::direct(),
+    &mem_config,
+)
+.await?;
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_preserves_public_kernel_context_signature -- --exact --nocapture`
+
+Expected: FAIL because the public function still accepts `Option<&KernelContext>`
+and the explicit compatibility shim does not exist yet.
+
+**Step 3: Commit**
+
+Do not commit yet.
+
+### Task 2: Promote the public helper to binding-first
+
+**Files:**
+- Modify: `crates/app/src/conversation/session_history.rs`
+- Modify: `crates/app/src/conversation/mod.rs`
+
+**Step 1: Write minimal implementation**
+
+1. Change the main public `load_discovery_first_event_summary(...)` signature to
+   accept `ConversationRuntimeBinding<'_>`
+2. Reuse the existing binding-aware implementation path rather than duplicating
+   summary logic
+3. Introduce `load_discovery_first_event_summary_with_kernel_context(...)` as
+   the explicit compatibility shim
+4. Export the compatibility shim from `conversation/mod.rs` only if the public
+   surface should retain that migration helper
+
+**Step 2: Run targeted tests to verify they pass**
+
+Run:
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app conversation::tests::load_discovery_first_event_summary_preserves_public_kernel_context_signature -- --exact --nocapture`
+
+Expected: PASS
+
+**Step 3: Commit**
+
+Do not commit yet.
+
+### Task 3: Verify neighboring history helpers remain unchanged
+
+**Files:**
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Re-run neighboring history summary tests**
+
+Run:
+- `cargo test -p loongclaw-app load_fast_lane_tool_batch_event_summary_accepts_explicit_runtime_binding -- --exact --nocapture`
+- `cargo test -p loongclaw-app load_turn_checkpoint_event_summary_reads_recovery_state_from_sqlite_history -- --exact --nocapture`
+
+Expected: PASS
+
+**Step 2: Tighten tests only if behavior drift is found**
+
+If any regression appears, add the smallest test needed to pin the intended
+binding behavior without expanding the slice beyond discovery-first.
+
+**Step 3: Commit**
+
+Do not commit yet.
+
+### Task 4: Full verification and commit
+
+**Files:**
+- Modify: `docs/plans/2026-04-01-session-history-binding-first-design.md`
+- Modify: `docs/plans/2026-04-01-session-history-binding-first-implementation-plan.md`
+
+**Step 1: Run formatting verification**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS
+
+**Step 2: Run strict lint verification**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: PASS
+
+**Step 3: Run workspace tests**
+
+Run:
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+Expected: PASS
+
+**Step 4: Inspect final diff**
+
+Run:
+- `git status --short`
+- `git diff --stat`
+
+Expected: only the session-history binding-first slice and its docs are present.
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/session_history.rs \
+        crates/app/src/conversation/mod.rs \
+        crates/app/src/conversation/tests.rs \
+        docs/plans/2026-04-01-session-history-binding-first-design.md \
+        docs/plans/2026-04-01-session-history-binding-first-implementation-plan.md
+git commit -m "refactor: make discovery history binding-first"
+```

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -26,7 +26,6 @@
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14764 | 15000 | 236 | 56 | 70 | 14 | 98.4% | TIGHT | 14472 | 2.0% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6340 | 6500 | 160 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.3% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
-
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.4%), daemon_lib (100.0%), onboard_cli (97.1%)

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -22,15 +22,15 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9798 | 9800 | 2 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10902 | 11200 | 298 | 98 | 120 | 22 | 97.3% | TIGHT | 10831 | 0.7% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14567 | 15000 | 433 | 54 | 70 | 16 | 97.1% | TIGHT | 14472 | 0.7% | PASS | 54 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10971 | 11200 | 229 | 100 | 120 | 20 | 98.0% | TIGHT | 10831 | 1.3% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14764 | 15000 | 236 | 56 | 70 | 14 | 98.4% | TIGHT | 14472 | 2.0% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6340 | 6500 | 160 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.3% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (97.3%), tools_mod (97.1%), daemon_lib (100.0%), onboard_cli (97.1%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (98.0%), tools_mod (98.4%), daemon_lib (100.0%), onboard_cli (97.1%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -67,8 +67,8 @@
 <!-- arch-hotspot key=channel_config lines=9798 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10902 functions=98 -->
-<!-- arch-hotspot key=tools_mod lines=14567 functions=54 -->
+<!-- arch-hotspot key=turn_coordinator lines=10971 functions=100 -->
+<!-- arch-hotspot key=tools_mod lines=14764 functions=56 -->
 <!-- arch-hotspot key=daemon_lib lines=6340 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T14:18:36Z
+- Generated at: 2026-04-01T14:44:31Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,8 +22,7 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9798 | 9800 | 2 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
-<<<<<<< HEAD
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10901 | 11200 | 299 | 98 | 120 | 22 | 97.3% | TIGHT | 10831 | 0.6% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10902 | 11200 | 298 | 98 | 120 | 22 | 97.3% | TIGHT | 10831 | 0.7% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14567 | 15000 | 433 | 54 | 70 | 16 | 97.1% | TIGHT | 14472 | 0.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6340 | 6500 | 160 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.3% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
@@ -68,7 +67,7 @@
 <!-- arch-hotspot key=channel_config lines=9798 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10901 functions=98 -->
+<!-- arch-hotspot key=turn_coordinator lines=10902 functions=98 -->
 <!-- arch-hotspot key=tools_mod lines=14567 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6340 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T15:00:36Z
+- Generated at: 2026-04-01T14:18:36Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,16 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9798 | 9800 | 2 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10826 | 11200 | 374 | 100 | 120 | 20 | 96.7% | TIGHT | 10831 | -0.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14764 | 15000 | 236 | 56 | 70 | 14 | 98.4% | TIGHT | 14472 | 2.0% | PASS | 54 |
+<<<<<<< HEAD
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10901 | 11200 | 299 | 98 | 120 | 22 | 97.3% | TIGHT | 10831 | 0.6% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14567 | 15000 | 433 | 54 | 70 | 16 | 97.1% | TIGHT | 14472 | 0.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6340 | 6500 | 160 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.3% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
+
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.4%), daemon_lib (100.0%), onboard_cli (97.1%)
-- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (97.3%), tools_mod (97.1%), daemon_lib (100.0%), onboard_cli (97.1%)
+- WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
 ## Boundary Checks
@@ -66,8 +68,8 @@
 <!-- arch-hotspot key=channel_config lines=9798 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10826 functions=100 -->
-<!-- arch-hotspot key=tools_mod lines=14764 functions=56 -->
+<!-- arch-hotspot key=turn_coordinator lines=10901 functions=98 -->
+<!-- arch-hotspot key=tools_mod lines=14567 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6340 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  `origin/dev` moved under this branch and left the PR dirty, while a few branch-local assumptions no longer matched current `dev` semantics around `approval_request_resolve` replay and helper usage.
- Why it matters:
  This PR needs to land as a clean, mergeable conversation-runtime slice that matches the current integration branch instead of re-introducing older replay assumptions or stale architecture drift data.
- What changed:
  Rebased onto the current `dev` head, reconciled approval replay behavior with current `dev` semantics (`app` approval replays still execute under advisory bindings, `core` replays still require kernel authority), preserved the existing `approval_request_not_pending` path for stale retries, surfaced explicit `approval_request_not_executing` context when replay finalization races, removed dead helpers/imports exposed by the rebase, restored the config-aware prompt-context helper expected by tests, and refreshed the April 2026 architecture drift report to the current repository state.
- What did not change (scope boundary):
  No repo-wide kernelization, no ACP redesign, and no unrelated provider/channel refactors.

## Linked Issues

- Related #766
- Related #552

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This rebase reconciliation touches governed approval replay behavior and conversation-runtime compatibility seams.
- Rollout / guardrails:
  Guarded with focused approval replay regression coverage plus fresh workspace/all-features verification and docs/architecture gates after the rebase.
- Rollback path:
  Revert this PR to restore the previous branch state.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p loongclaw-app --lib approval_request_resolve_ -- --nocapture`
- [x] `cargo test --workspace --locked --quiet`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
  PASS

cargo fmt --all -- --check
  PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS (with the existing daemon dual-bin warning)

cargo test -p loongclaw-app --lib approval_request_resolve_ -- --nocapture
  PASS (8 tests)

cargo test --workspace --locked --quiet
  PASS

cargo test --workspace --all-features --locked
  PASS

scripts/check-docs.sh
  PASS with existing non-blocking release-artifact warnings

LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
  PASS

scripts/check_dep_graph.sh
  PASS

diff CLAUDE.md AGENTS.md
  PASS

python3 scripts/sync_github_labels.py --check
  PASS

bash scripts/test_sync_github_labels.sh
  PASS

git diff --check
  PASS

cargo deny check advisories bans licenses sources
  PASS with existing duplicate/license/advisory warning noise

bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-04.md
  PASS
```

## User-visible / Operator-visible Changes

- `approval_request_resolve` stays aligned with current `dev`: governed `app` replays can still complete under advisory bindings, while `core` replays still fail closed without kernel authority.
- stale approval retries still report `approval_request_not_pending` before any binding-gate denial rewrites the result.
- replay-finalization races now surface explicit `approval_request_not_executing` context instead of silently dropping the finalize conflict.
- downstream conversation-runtime callers keep the compatibility helper surface restored by this PR.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to restore the previous branch state.
- Observable failure symptoms reviewers should watch for:
  Unexpected `governed_runtime_binding_required` denials on `core` replays, missing advisory `app` replay execution, or stale architecture drift freshness failures.

## Reviewer Focus

- `crates/app/src/conversation/turn_coordinator.rs`: verify replay binding gates now match current `dev` semantics and that finalize-race errors keep the original replay failure context.
- `crates/app/src/conversation/tests.rs`: verify the replay matrix is explicit (`app` advisory replay allowed, `core` advisory replay denied, stale retries preserve `not_pending`).
- `crates/app/src/provider/request_message_runtime.rs`, `crates/app/src/conversation/runtime.rs`, `crates/app/src/operator/approval_runtime.rs`: verify the rebase cleanup removes dead seams without dropping the helper surface still exercised by tests.
- `docs/releases/architecture-drift-2026-04.md`: verify the checked-in report matches the current repository metrics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internal Improvements**
  * Stronger governance: clearer enforcement of mutating vs advisory-only runtime modes to prevent unauthorized mutations.
  * Approval routing tightened: approval checks now operate on explicit runtime bindings, improving consistency and denial behavior for advisory contexts.
  * Session history now prefers explicit binding context, improving correctness when loading discovery summaries.

* **Documentation**
  * Added design and plan docs clarifying binding-first approval and async-delegate ownership.
* **Behavior**
  * System prompts now surface a "Governed Runtime Binding" section indicating session mode and kernel binding presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->