### PR TITLE
test(app): lock session recovery helper contracts

### DIFF
--- a/crates/app/src/session/recovery.rs
+++ b/crates/app/src/session/recovery.rs
@@ -162,33 +162,30 @@ fn parse_recovery_event(event: &SessionEventRecord) -> Option<SessionRecoveryRec
         source: RECOVERY_SOURCE_EVENT.to_owned(),
         kind,
         event_kind: event.event_kind.clone(),
-        recovered_state: event
-            .payload_json
-            .get(RECOVERED_STATE_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        recovery_error: event
-            .payload_json
-            .get(RECOVERY_ERROR_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        original_error: event
-            .payload_json
-            .get(ORIGINAL_ERROR_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        attempted_terminal_event_kind: event
-            .payload_json
-            .get(ATTEMPTED_TERMINAL_EVENT_KIND_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        attempted_outcome_status: event
-            .payload_json
-            .get(ATTEMPTED_OUTCOME_STATUS_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
+        recovered_state: normalized_payload_string(&event.payload_json, RECOVERED_STATE_FIELD),
+        recovery_error: normalized_payload_string(&event.payload_json, RECOVERY_ERROR_FIELD),
+        original_error: normalized_payload_string(&event.payload_json, ORIGINAL_ERROR_FIELD),
+        attempted_terminal_event_kind: normalized_payload_string(
+            &event.payload_json,
+            ATTEMPTED_TERMINAL_EVENT_KIND_FIELD,
+        ),
+        attempted_outcome_status: normalized_payload_string(
+            &event.payload_json,
+            ATTEMPTED_OUTCOME_STATUS_FIELD,
+        ),
         ts: event.ts,
     })
+}
+
+fn normalized_payload_string(payload_json: &Value, field: &str) -> Option<String> {
+    let field_value = payload_json.get(field)?;
+    let field_str = field_value.as_str()?;
+    let normalized = field_str.trim();
+    if normalized.is_empty() {
+        return None;
+    }
+
+    Some(field_str.to_owned())
 }
 
 fn synthesize_recovery_from_last_error(last_error: Option<&str>) -> SessionRecoveryRecord {
@@ -228,5 +225,225 @@ fn recovery_kind_from_last_error(last_error: Option<&str>) -> &'static str {
             RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED
         }
         Some(_) | None => RECOVERY_KIND_UNKNOWN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{
+        RECOVERY_EVENT_KIND, RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED,
+        RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
+        RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED,
+        RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED, RECOVERY_KIND_UNKNOWN,
+        RECOVERY_SOURCE_EVENT, RECOVERY_SOURCE_LAST_ERROR, RECOVERY_SOURCE_NONE,
+        SessionRecoveryRecord, build_async_spawn_failure_recovery_payload,
+        observe_missing_recovery, recovery_json, recovery_kind_from_last_error,
+    };
+    use crate::session::repository::SessionEventRecord;
+
+    fn recovery_event(payload_json: serde_json::Value, ts: i64) -> SessionEventRecord {
+        SessionEventRecord {
+            id: 1,
+            session_id: "child-session".to_owned(),
+            event_kind: RECOVERY_EVENT_KIND.to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json,
+            ts,
+        }
+    }
+
+    #[test]
+    fn build_async_spawn_failure_recovery_payload_keeps_expected_fields() {
+        let payload = build_async_spawn_failure_recovery_payload(
+            Some("Child"),
+            "spawn panic",
+            "persist failed",
+        );
+
+        assert_eq!(
+            payload["recovery_kind"],
+            RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        );
+        assert_eq!(payload["recovered_state"], "failed");
+        assert_eq!(payload["recovery_error"], "persist failed");
+        assert_eq!(payload["original_error"], "spawn panic");
+        assert_eq!(payload["label"], "Child");
+    }
+
+    #[test]
+    fn observe_missing_recovery_prefers_newest_recovery_event_over_last_error() {
+        let older_payload = json!({
+            "recovery_kind": "terminal_finalize_persist_failed",
+            "recovered_state": "failed",
+            "recovery_error": "older"
+        });
+        let older_event = recovery_event(older_payload, 11);
+        let newer_payload = json!({
+            "recovery_kind": "async_spawn_failure_persist_failed",
+            "recovered_state": "failed",
+            "recovery_error": "newer",
+            "original_error": "spawn failure"
+        });
+        let newer_event = recovery_event(newer_payload, 22);
+        let recent_events = vec![older_event, newer_event];
+        let recovery = observe_missing_recovery(
+            &recent_events,
+            Some("delegate_terminal_finalize_failed: fallback"),
+        );
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_EVENT);
+        assert_eq!(
+            recovery.kind,
+            RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        );
+        assert_eq!(recovery.recovery_error.as_deref(), Some("newer"));
+        assert_eq!(recovery.original_error.as_deref(), Some("spawn failure"));
+        assert_eq!(recovery.ts, 22);
+    }
+
+    #[test]
+    fn observe_missing_recovery_falls_back_to_last_error_when_event_missing() {
+        let recent_events = Vec::new();
+        let recovery = observe_missing_recovery(
+            &recent_events,
+            Some("delegate_async_queued_overdue_marked_failed: timed out"),
+        );
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_LAST_ERROR);
+        assert_eq!(
+            recovery.kind,
+            RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED
+        );
+        assert_eq!(
+            recovery.recovery_error.as_deref(),
+            Some("delegate_async_queued_overdue_marked_failed: timed out")
+        );
+        assert!(recovery.event_kind.is_empty());
+        assert_eq!(recovery.ts, 0);
+    }
+
+    #[test]
+    fn observe_missing_recovery_uses_none_source_when_metadata_is_missing() {
+        let recent_events = Vec::new();
+        let recovery = observe_missing_recovery(&recent_events, None);
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_NONE);
+        assert_eq!(recovery.kind, RECOVERY_KIND_UNKNOWN);
+        assert!(recovery.recovery_error.is_none());
+        assert!(recovery.event_kind.is_empty());
+        assert_eq!(recovery.ts, 0);
+    }
+
+    #[test]
+    fn recovery_kind_from_last_error_maps_known_prefixes() {
+        let terminal_kind =
+            recovery_kind_from_last_error(Some("delegate_terminal_finalize_failed: busy"));
+        let async_spawn_kind = recovery_kind_from_last_error(Some(
+            "delegate_async_spawn_failure_persist_failed: busy",
+        ));
+        let queued_kind = recovery_kind_from_last_error(Some(
+            "delegate_async_queued_overdue_marked_failed: busy",
+        ));
+        let running_kind = recovery_kind_from_last_error(Some(
+            "delegate_async_running_overdue_marked_failed: busy",
+        ));
+        let unknown_kind = recovery_kind_from_last_error(Some("opaque_failure"));
+
+        assert_eq!(
+            terminal_kind,
+            RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED
+        );
+        assert_eq!(
+            async_spawn_kind,
+            RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        );
+        assert_eq!(
+            queued_kind,
+            RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED
+        );
+        assert_eq!(
+            running_kind,
+            RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED
+        );
+        assert_eq!(unknown_kind, RECOVERY_KIND_UNKNOWN);
+    }
+
+    #[test]
+    fn recovery_json_projects_null_for_empty_event_kind_and_zero_timestamp() {
+        let recovery = SessionRecoveryRecord {
+            source: RECOVERY_SOURCE_LAST_ERROR.to_owned(),
+            kind: RECOVERY_KIND_UNKNOWN.to_owned(),
+            event_kind: String::new(),
+            recovered_state: None,
+            recovery_error: Some("opaque_failure".to_owned()),
+            original_error: None,
+            attempted_terminal_event_kind: None,
+            attempted_outcome_status: None,
+            ts: 0,
+        };
+        let payload = recovery_json(recovery);
+
+        assert_eq!(payload["source"], RECOVERY_SOURCE_LAST_ERROR);
+        assert_eq!(payload["kind"], RECOVERY_KIND_UNKNOWN);
+        assert!(payload["event_kind"].is_null());
+        assert!(payload["ts"].is_null());
+    }
+
+    #[test]
+    fn observe_missing_recovery_normalizes_blank_optional_event_fields() {
+        let payload = json!({
+            "recovery_kind": "terminal_finalize_persist_failed",
+            "recovered_state": "",
+            "recovery_error": "",
+            "original_error": "",
+            "attempted_terminal_event_kind": "",
+            "attempted_outcome_status": ""
+        });
+        let event = recovery_event(payload, 33);
+        let recent_events = vec![event];
+        let recovery = observe_missing_recovery(&recent_events, None);
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_EVENT);
+        assert_eq!(
+            recovery.kind,
+            RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED
+        );
+        assert!(recovery.recovered_state.is_none());
+        assert!(recovery.recovery_error.is_none());
+        assert!(recovery.original_error.is_none());
+        assert!(recovery.attempted_terminal_event_kind.is_none());
+        assert!(recovery.attempted_outcome_status.is_none());
+    }
+
+    #[test]
+    fn observe_missing_recovery_preserves_non_blank_optional_event_fields() {
+        let payload = json!({
+            "recovery_kind": "terminal_finalize_persist_failed",
+            "recovered_state": " failed ",
+            "recovery_error": " persist failed ",
+            "original_error": " original failure ",
+            "attempted_terminal_event_kind": " terminal ",
+            "attempted_outcome_status": " error "
+        });
+        let event = recovery_event(payload, 44);
+        let recent_events = vec![event];
+        let recovery = observe_missing_recovery(&recent_events, None);
+
+        assert_eq!(recovery.recovered_state.as_deref(), Some(" failed "));
+        assert_eq!(recovery.recovery_error.as_deref(), Some(" persist failed "));
+        assert_eq!(
+            recovery.original_error.as_deref(),
+            Some(" original failure ")
+        );
+        assert_eq!(
+            recovery.attempted_terminal_event_kind.as_deref(),
+            Some(" terminal ")
+        );
+        assert_eq!(
+            recovery.attempted_outcome_status.as_deref(),
+            Some(" error ")
+        );
     }
 }

--- a/docs/plans/2026-04-01-session-recovery-contract-tests-design.md
+++ b/docs/plans/2026-04-01-session-recovery-contract-tests-design.md
@@ -1,0 +1,61 @@
+# Session Recovery Contract Tests Design
+
+**Date:** 2026-04-01
+
+**Goal:** Add direct unit coverage for `crates/app/src/session/recovery.rs` so recovery payload construction, fallback synthesis, and JSON projection cannot drift behind broader coordinator and session-tool behavior.
+
+## Problem
+
+`session::recovery` currently owns the lowest-level recovery contract for:
+- async spawn failure recovery payloads
+- missing-recovery observation rules
+- `last_error` to recovery-kind synthesis
+- JSON projection returned to higher layers
+
+Those semantics are exercised today only through higher-level coordinator and session-tool tests. That coverage is valuable, but it is indirect. A future refactor could change helper behavior while still keeping most end-to-end tests green because the surrounding orchestration remains intact.
+
+## Proposed Scope
+
+This iteration adds focused unit tests under `crates/app/src/session/recovery.rs`.
+
+It will verify:
+- `build_async_spawn_failure_recovery_payload(...)` preserves the expected shape
+- `observe_missing_recovery(...)` prefers the newest recovery event over `last_error`
+- `observe_missing_recovery(...)` falls back to `last_error` synthesis when no recovery event exists
+- `recovery_kind_from_last_error(...)` maps each known prefix to the correct recovery kind
+- `recovery_json(...)` emits `null` for empty event kinds and zero timestamps
+
+## Non-Goals
+
+This iteration will not:
+- extract a new read-side helper for delegate child boundary reconstruction
+- change `conversation/runtime.rs`
+- change `conversation/turn_coordinator.rs`
+- change operator runtime ownership boundaries
+- redesign recovery payload fields
+
+## Why This Cut
+
+I considered two alternatives:
+
+1. Extract the delegate read-side helper first.
+
+That would move more architecture forward, but it would touch more behavior at once and would still leave the recovery helper contract under-tested.
+
+2. Combine read-side extraction and recovery tests in one pass.
+
+That would be faster in raw throughput, but it would produce a wider review surface and blur whether failures come from helper drift or ownership refactoring.
+
+The chosen cut is smaller and cleaner. It strengthens the test fence first, which lowers the risk of the next ownership extraction.
+
+## Validation Plan
+
+The change should be validated with:
+- targeted `session::recovery` unit tests
+- `cargo test -p loongclaw-app --lib session::recovery`
+- `cargo test --workspace --locked`
+- `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+
+## Expected Outcome
+
+After this lands, recovery contract drift should fail fast in a local unit test instead of surfacing later through coordinator or session-tool regressions.

--- a/docs/plans/2026-04-01-session-recovery-contract-tests-implementation-plan.md
+++ b/docs/plans/2026-04-01-session-recovery-contract-tests-implementation-plan.md
@@ -1,0 +1,151 @@
+# Session Recovery Contract Tests Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add direct unit tests for `session::recovery` so delegate recovery payload and fallback semantics are locked by local contract tests.
+
+**Architecture:** Keep production behavior unchanged unless a test exposes a genuine contract bug. Add tests next to `session::recovery` for payload construction, event-vs-error precedence, kind synthesis, and JSON projection. Do not widen this pass into read-side ownership refactors.
+
+**Tech Stack:** Rust, `serde_json`, existing session recovery types, focused unit tests in `crates/app/src/session/recovery.rs`, workspace cargo verification.
+
+---
+
+### Task 1: Add the failing unit tests for the recovery helper contract
+
+**Files:**
+- Modify: `crates/app/src/session/recovery.rs`
+- Create: `docs/plans/2026-04-01-session-recovery-contract-tests-design.md`
+- Create: `docs/plans/2026-04-01-session-recovery-contract-tests-implementation-plan.md`
+
+**Step 1: Write the failing tests**
+
+Add tests that cover:
+- async spawn failure recovery payload fields
+- newest recovery event winning over `last_error`
+- `last_error` fallback synthesis when no event exists
+- known prefix to recovery-kind mapping
+- `recovery_json(...)` null projection for empty event kind and zero timestamp
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app --lib session::recovery
+```
+
+Expected:
+- at least one new recovery test fails before the helper behavior or visibility is adjusted
+
+**Step 3: Keep the red state local**
+
+Do not commit or push a broken tree. Confirm the failing signal locally before any implementation step.
+
+### Task 2: Make the helper contract explicit with minimal code changes
+
+**Files:**
+- Modify: `crates/app/src/session/recovery.rs`
+
+**Step 1: Implement the smallest behavior or visibility adjustment needed**
+
+Only change production code if a test reveals a real gap.
+
+Keep each line atomic:
+- one lookup per line
+- one conversion per line
+- one condition per line
+
+**Step 2: Re-run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app --lib session::recovery
+```
+
+Expected:
+- all new recovery tests pass
+
+### Task 3: Verify nearby behavior still holds
+
+**Files:**
+- Verify only
+
+**Step 1: Run the closest session-tool and coordinator recovery tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app --all-features session_status_synthesizes_recovery
+cargo test -p loongclaw-app --all-features finalize_async_delegate_spawn_failure
+```
+
+Expected:
+- existing higher-level recovery behavior remains green
+
+**Step 2: Run lint on the touched crate**
+
+Run:
+
+```bash
+cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
+```
+
+Expected:
+- no warnings
+
+### Task 4: Run broad verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run workspace tests**
+
+```bash
+cargo test --workspace --locked
+```
+
+**Step 2: Run all-feature workspace tests**
+
+```bash
+cargo test --workspace --all-features --locked
+```
+
+Expected:
+- workspace verification passes
+- if an unrelated blocker appears, stop and document it explicitly before claiming completion
+
+### Task 5: Commit and deliver cleanly
+
+**Files:**
+- Modify only the files touched by this plan
+
+**Step 1: Inspect staged scope**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected:
+- only the intended recovery test and planning files are staged
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-04-01-session-recovery-contract-tests-design.md
+git add docs/plans/2026-04-01-session-recovery-contract-tests-implementation-plan.md
+git add crates/app/src/session/recovery.rs
+git commit -m "test(app): lock session recovery helper contracts"
+```
+
+**Step 3: Push and open the stacked PR**
+
+Use the issue template and PR template workflow:
+- issue first
+- English GitHub text
+- `--body-file` for multi-line Markdown
+- explicit stacked-branch note in the PR body


### PR DESCRIPTION
## Summary

- Problem: `session::recovery` helper semantics were only protected indirectly, and blank optional recovery event fields could surface as `Some("")` in recovered session output.
- Why it matters: that weakens the recovery contract, makes low-level regressions harder to catch locally, and allows recovery JSON drift behind broader coordinator/session-tool coverage.
- What changed: added direct unit coverage for payload construction, event-vs-`last_error` precedence, recovery-kind synthesis, JSON projection, blank optional normalization, and preservation of non-blank optional values; updated `parse_recovery_event(...)` to collapse blank optional payload strings to `None` without rewriting non-blank strings.
- What did not change (scope boundary): no operator runtime ownership refactor, no new public SDK surface, and no redesign of recovery payload fields.
- Stacked delivery note: this PR targets `feat/operator-delegate-runtime-phase2` and stacks on top of `chumyin/loongclaw#13`.

## Linked Issues

- Closes loongclaw-ai/loongclaw#773
- Related loongclaw-ai/loongclaw#770, chumyin/loongclaw#13

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-app --lib session::recovery -- --nocapture
  PASS

cargo fmt --all -- --check
  PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS

cargo test --workspace --locked
  PASS

cargo test --workspace --all-features --locked
  PASS

LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
  PASS

scripts/check_dep_graph.sh
  PASS

diff CLAUDE.md AGENTS.md
  PASS

scripts/check-docs.sh
  PASS with non-blocking warnings about missing local release/debug trace artifacts under .docs/

python3 scripts/sync_github_labels.py --check
  PASS

bash scripts/test_sync_github_labels.sh
  PASS

check:conventions equivalent
  NOT RUNNABLE in this environment because <redacted-path> is absent

cargo deny check advisories bans licenses sources
  REPOSITORY BASELINE FAILURE: license policy still rejects 0BSD from quoted_printable v0.5.2 via lettre; unrelated to this PR
```

## User-visible / Operator-visible Changes

- None. This is a low-level recovery contract hardening pass plus direct helper coverage.

## Failure Recovery

- Fast rollback or disable path: revert commit `2cd273bf` from this stacked branch.
- Observable failure symptoms reviewers should watch for: recovered session payloads retaining `""` instead of `null` for optional recovery fields, recovery helper precedence drifting away from newest-event-over-`last_error`, or helper normalization trimming non-blank values unexpectedly.

## Reviewer Focus

- Review [crates/app/src/session/recovery.rs](https://github.com/loongclaw-ai/loongclaw/blob/feat/operator-delegate-runtime-phase2/crates/app/src/session/recovery.rs) for the helper contract around blank optional payload strings.
- Check that the new unit tests fence the intended precedence and JSON projection seams without widening scope into delegate runtime ownership work.
- Sanity-check the added planning docs for the chosen cut and scope boundary rationale.
