### PR TITLE
fix(feishu-auth) Fixed Feishu permission authorization im:message.gro…

### DIFF
--- a/crates/app/src/channel/feishu/api/client.rs
+++ b/crates/app/src/channel/feishu/api/client.rs
@@ -290,7 +290,7 @@ impl FeishuClient {
         &self,
         code: &str,
         redirect_uri: Option<&str>,
-        scopes: &FeishuGrantScopeSet,
+        _scopes: &FeishuGrantScopeSet,
         code_verifier: Option<&str>,
     ) -> CliResult<Value> {
         let mut body = serde_json::Map::new();
@@ -315,9 +315,6 @@ impl FeishuClient {
                 "redirect_uri".to_owned(),
                 Value::String(redirect_uri.to_owned()),
             );
-        }
-        if !scopes.is_empty() {
-            body.insert("scope".to_owned(), Value::String(scopes.to_scope_csv()));
         }
         if let Some(code_verifier) = code_verifier
             .map(str::trim)

--- a/crates/app/src/channel/feishu/api/principal.rs
+++ b/crates/app/src/channel/feishu/api/principal.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+const FEISHU_GROUP_MESSAGE_READ_SCOPE: &str = "im:message.group_msg";
+const FEISHU_GROUP_MESSAGE_READ_SCOPE_LEGACY: &str = "im:message.group_msg:readonly";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FeishuAccountBinding {
     pub account_id: String,
@@ -59,7 +62,11 @@ impl FeishuGrantScopeSet {
 
     pub fn contains(&self, scope: &str) -> bool {
         let expected = scope.trim();
-        !expected.is_empty() && self.scopes.iter().any(|value| value == expected)
+        !expected.is_empty()
+            && self
+                .scopes
+                .iter()
+                .any(|value| scopes_match(value.as_str(), expected))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &String> {
@@ -83,6 +90,23 @@ impl From<Vec<String>> for FeishuGrantScopeSet {
     fn from(value: Vec<String>) -> Self {
         Self::from_scopes(value)
     }
+}
+
+fn scopes_match(stored: &str, expected: &str) -> bool {
+    if stored == expected {
+        return true;
+    }
+
+    matches!(
+        (stored, expected),
+        (
+            FEISHU_GROUP_MESSAGE_READ_SCOPE,
+            FEISHU_GROUP_MESSAGE_READ_SCOPE_LEGACY
+        ) | (
+            FEISHU_GROUP_MESSAGE_READ_SCOPE_LEGACY,
+            FEISHU_GROUP_MESSAGE_READ_SCOPE
+        )
+    )
 }
 
 #[cfg(test)]
@@ -129,5 +153,16 @@ mod tests {
                 "docx:document:readonly".to_owned()
             ]
         );
+    }
+
+    #[test]
+    fn grant_scope_set_contains_group_message_scope_aliases() {
+        let current = FeishuGrantScopeSet::from_scopes(["im:message.group_msg"]);
+        assert!(current.contains("im:message.group_msg"));
+        assert!(current.contains("im:message.group_msg:readonly"));
+
+        let legacy = FeishuGrantScopeSet::from_scopes(["im:message.group_msg:readonly"]);
+        assert!(legacy.contains("im:message.group_msg"));
+        assert!(legacy.contains("im:message.group_msg:readonly"));
     }
 }

--- a/crates/app/src/config/feishu_integration.rs
+++ b/crates/app/src/config/feishu_integration.rs
@@ -16,6 +16,8 @@ const MAX_FEISHU_RETRY_MAX_ATTEMPTS: usize = 8;
 const MIN_FEISHU_RETRY_INITIAL_BACKOFF_MS: usize = 0;
 const MAX_FEISHU_RETRY_INITIAL_BACKOFF_MS: usize = 30_000;
 const MAX_FEISHU_RETRY_MAX_BACKOFF_MS: usize = 60_000;
+const FEISHU_GROUP_MESSAGE_READ_SCOPE: &str = "im:message.group_msg";
+const FEISHU_GROUP_MESSAGE_READ_SCOPE_LEGACY: &str = "im:message.group_msg:readonly";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeishuIntegrationConfig {
@@ -57,11 +59,13 @@ impl FeishuIntegrationConfig {
     pub fn trimmed_default_scopes(&self) -> Vec<String> {
         let mut normalized = Vec::new();
         for raw in &self.default_scopes {
-            let scope = raw.trim();
-            if scope.is_empty() || normalized.iter().any(|existing| existing == scope) {
+            let Some(scope) = normalize_scope_alias(raw) else {
+                continue;
+            };
+            if normalized.iter().any(|existing| existing == &scope) {
                 continue;
             }
-            normalized.push(scope.to_owned());
+            normalized.push(scope);
         }
         normalized
     }
@@ -144,10 +148,22 @@ fn default_scopes() -> Vec<String> {
         "offline_access".to_owned(),
         "docx:document:readonly".to_owned(),
         "im:message:readonly".to_owned(),
-        "im:message.group_msg:readonly".to_owned(),
+        "im:message.group_msg".to_owned(),
         "search:message".to_owned(),
         "calendar:calendar:readonly".to_owned(),
     ]
+}
+
+fn normalize_scope_alias(raw: &str) -> Option<String> {
+    let scope = raw.trim();
+    if scope.is_empty() {
+        return None;
+    }
+
+    Some(match scope {
+        FEISHU_GROUP_MESSAGE_READ_SCOPE_LEGACY => FEISHU_GROUP_MESSAGE_READ_SCOPE.to_owned(),
+        _ => scope.to_owned(),
+    })
 }
 
 #[cfg(test)]
@@ -201,6 +217,26 @@ mod tests {
             vec![
                 "offline_access".to_owned(),
                 "docs:document:readonly".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn trimmed_default_scopes_normalizes_legacy_group_message_scope() {
+        let config = FeishuIntegrationConfig {
+            default_scopes: vec![
+                "offline_access".to_owned(),
+                "im:message.group_msg:readonly".to_owned(),
+                "im:message.group_msg".to_owned(),
+            ],
+            ..FeishuIntegrationConfig::default()
+        };
+
+        assert_eq!(
+            config.trimmed_default_scopes(),
+            vec![
+                "offline_access".to_owned(),
+                "im:message.group_msg".to_owned()
             ]
         );
     }

--- a/crates/app/src/tools/feishu.rs
+++ b/crates/app/src/tools/feishu.rs
@@ -28,7 +28,7 @@ use crate::channel::feishu::api::{
 
 const FEISHU_MESSAGE_RESOURCE_ACCEPTED_SCOPES: &[&str] = &[
     "im:message:readonly",
-    "im:message.group_msg:readonly",
+    "im:message.group_msg",
     "im:message",
     "im:message:send_as_bot",
     "im:message:send",
@@ -4272,7 +4272,7 @@ fn execute_feishu_messages_history_tool_with_config(
         .await?;
         ensure_any_required_scope(
             &grant,
-            &["im:message:readonly", "im:message.group_msg:readonly"],
+            &["im:message:readonly", "im:message.group_msg"],
             tool_name.as_str(),
         )?;
         let tenant_access_token = context.client.get_tenant_access_token().await?;
@@ -4702,7 +4702,7 @@ fn execute_feishu_messages_get_tool_with_config(
         .await?;
         ensure_any_required_scope(
             &grant,
-            &["im:message:readonly", "im:message.group_msg:readonly"],
+            &["im:message:readonly", "im:message.group_msg"],
             tool_name.as_str(),
         )?;
         let tenant_access_token = context.client.get_tenant_access_token().await?;

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -7541,7 +7541,7 @@ mod tests {
         let _store = seed_feishu_tool_grant(
             &sqlite_path,
             "u-token-detail",
-            &["offline_access", "im:message.group_msg:readonly"],
+            &["offline_access", "im:message.group_msg"],
         );
         let config = build_feishu_tool_runtime_config(base_url, &sqlite_path);
 
@@ -7639,7 +7639,7 @@ mod tests {
             "feishu_shared",
             "ou_shared",
             "u-token-detail-ingress",
-            &["offline_access", "im:message.group_msg:readonly"],
+            &["offline_access", "im:message.group_msg"],
         );
         let config = runtime_config::ToolRuntimeConfig {
             feishu: Some(runtime_config::FeishuToolRuntimeConfig {
@@ -7726,6 +7726,101 @@ mod tests {
             requests[1].path,
             "/open-apis/im/v1/messages/om_ingress_detail"
         );
+
+        server.abort();
+    }
+
+    #[cfg(all(feature = "feishu-integration", feature = "channel-feishu"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn feishu_messages_get_tool_accepts_legacy_group_message_read_scope() {
+        use std::fs;
+
+        use axum::{
+            Json, Router,
+            extract::{Request, State},
+            routing::{get, post},
+        };
+
+        let temp_dir = unique_feishu_tool_temp_dir("messages-get-legacy-group-scope");
+        fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let sqlite_path = temp_dir.join("feishu.sqlite3");
+        let requests =
+            std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<FeishuToolMockRequest>::new()));
+        let state = FeishuToolMockServerState {
+            requests: requests.clone(),
+        };
+        let router = Router::new()
+            .route(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                post({
+                    let state = state.clone();
+                    move |request: Request| {
+                        let state = state.clone();
+                        async move {
+                            record_feishu_tool_request(State(state), request).await;
+                            Json(serde_json::json!({
+                                "code": 0,
+                                "tenant_access_token": "t-token-detail-legacy"
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/im/v1/messages/om_legacy",
+                get({
+                    let state = state.clone();
+                    move |request: Request| {
+                        let state = state.clone();
+                        async move {
+                            record_feishu_tool_request(State(state), request).await;
+                            Json(serde_json::json!({
+                                "code": 0,
+                                "data": {
+                                    "items": [{
+                                        "message_id": "om_legacy",
+                                        "chat_id": "oc_demo",
+                                        "msg_type": "text",
+                                        "sender": {
+                                            "id": "ou_123",
+                                            "sender_type": "user"
+                                        }
+                                    }]
+                                }
+                            }))
+                        }
+                    }
+                }),
+            );
+        let (base_url, server) = spawn_feishu_tool_mock_server(router).await;
+        let _store = seed_feishu_tool_grant(
+            &sqlite_path,
+            "u-token-detail-legacy",
+            &["offline_access", "im:message.group_msg:readonly"],
+        );
+        let config = build_feishu_tool_runtime_config(base_url, &sqlite_path);
+
+        let outcome = execute_tool_core_with_config(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "feishu.messages.get".to_owned(),
+                payload: serde_json::json!({
+                    "message_id": "om_legacy"
+                }),
+            },
+            &config,
+        )
+        .expect("legacy group scope should remain accepted");
+
+        assert_eq!(outcome.status, "ok");
+        assert_eq!(outcome.payload["message"]["message_id"], "om_legacy");
+
+        let requests = requests.lock().await.clone();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[1].authorization.as_deref(),
+            Some("Bearer t-token-detail-legacy")
+        );
+        assert_eq!(requests[1].path, "/open-apis/im/v1/messages/om_legacy");
 
         server.abort();
     }

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -1,10 +1,21 @@
 use std::fs;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
 
+use axum::{Router, extract::State, http::Uri, routing::get};
 use clap::{Args, Subcommand, ValueEnum};
 use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
+use reqwest::Url;
+use serde::Deserialize;
 use serde_json::{Value, json};
+use tokio::{
+    net::TcpListener,
+    sync::{Mutex, oneshot},
+};
 
 use crate::feishu_support::{
     FeishuAuthCapability, FeishuDaemonContext, build_account_recommendations,
@@ -14,9 +25,69 @@ use crate::feishu_support::{
 };
 
 const DEFAULT_FEISHU_REDIRECT_URI: &str = "http://127.0.0.1:34819/callback";
+const FEISHU_AUTH_CALLBACK_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
+const FEISHU_AUTH_CALLBACK_SUCCESS_BODY: &str = "Authorization completed. You can close this tab.";
+
+#[derive(Debug, Clone)]
+struct FeishuAuthStartArtifacts {
+    state: String,
+    redirect_uri: String,
+    authorize_url: String,
+    scopes: Vec<String>,
+    capabilities: Vec<FeishuAuthCapability>,
+    expires_at_s: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct FeishuAuthCallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+}
+
+struct FeishuAuthCallbackPayload {
+    code: String,
+    state: String,
+    exchange_result_sender: oneshot::Sender<CliResult<()>>,
+}
+
+struct FeishuAuthCallbackAppState {
+    expected_state: String,
+    callback_sender: Mutex<Option<oneshot::Sender<CliResult<FeishuAuthCallbackPayload>>>>,
+}
 
 fn active_cli_command_name() -> &'static str {
     mvp::config::active_cli_command_name()
+}
+
+fn try_open_url_in_browser(url: &str) -> CliResult<()> {
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut command = Command::new("open");
+        command.arg(url);
+        command
+    };
+
+    #[cfg(target_os = "linux")]
+    let mut command = {
+        let mut command = Command::new("xdg-open");
+        command.arg(url);
+        command
+    };
+
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "start", "", url]);
+        command
+    };
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    return Err("opening the browser is not supported on this platform".to_owned());
+
+    command
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| format!("open browser failed: {error}"))
 }
 
 #[derive(Subcommand, Debug)]
@@ -786,8 +857,12 @@ pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
     match command {
         FeishuCommand::Auth { command } => match command {
             FeishuAuthCommand::Start(args) => {
-                let payload = execute_feishu_auth_start(&args).await?;
-                print_feishu_payload(&payload, args.common.json, render_auth_start_text)?;
+                if args.common.json {
+                    let payload = execute_feishu_auth_start(&args).await?;
+                    print_feishu_payload(&payload, true, render_auth_start_text)?;
+                } else {
+                    execute_feishu_auth_start_interactive(&args).await?;
+                }
             }
             FeishuAuthCommand::Exchange(args) => {
                 let payload = execute_feishu_auth_exchange(&args).await?;
@@ -1047,7 +1122,244 @@ pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
     Ok(())
 }
 
-pub async fn execute_feishu_auth_start(args: &FeishuAuthStartArgs) -> CliResult<Value> {
+fn build_feishu_auth_start_payload(
+    context: &FeishuDaemonContext,
+    artifacts: &FeishuAuthStartArtifacts,
+    status: Option<&str>,
+) -> Value {
+    let mut payload = json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "config": context.config_path.display().to_string(),
+        "redirect_uri": artifacts.redirect_uri,
+        "state": artifacts.state,
+        "authorize_url": artifacts.authorize_url,
+        "sqlite_path": context.store.path().display().to_string(),
+        "expires_at_s": artifacts.expires_at_s,
+        "capabilities": artifacts
+            .capabilities
+            .iter()
+            .map(|capability| capability.as_cli_value())
+            .collect::<Vec<_>>(),
+        "scopes": artifacts.scopes,
+    });
+    if let Some(status) = status
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.insert("status".to_owned(), Value::String(status.to_owned()));
+    }
+    payload
+}
+
+fn build_feishu_auth_exchange_payload(
+    context: &FeishuDaemonContext,
+    principal: &mvp::channel::feishu::api::FeishuUserPrincipal,
+    grant: &mvp::channel::feishu::api::FeishuGrant,
+) -> Value {
+    json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "config": context.config_path.display().to_string(),
+        "principal": principal,
+        "granted_scopes": grant.scopes.as_slice(),
+        "access_expires_at_s": grant.access_expires_at_s,
+        "refresh_expires_at_s": grant.refresh_expires_at_s,
+        "selected_open_id": grant.principal.open_id,
+        "effective_open_id": grant.principal.open_id,
+    })
+}
+
+fn parse_feishu_auth_callback(
+    query: FeishuAuthCallbackQuery,
+    expected_state: &str,
+) -> CliResult<(String, String)> {
+    let code = query
+        .code
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "missing code".to_owned())?
+        .to_owned();
+    let state = query
+        .state
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "missing state".to_owned())?
+        .to_owned();
+    if state != expected_state.trim() {
+        return Err("state mismatch".to_owned());
+    }
+    Ok((code, state))
+}
+
+async fn handle_feishu_auth_callback(
+    State(app_state): State<Arc<FeishuAuthCallbackAppState>>,
+    uri: Uri,
+) -> String {
+    let raw_query = uri.query().unwrap_or_default();
+    let mut code = None;
+    let mut state = None;
+    for entry in raw_query.split('&') {
+        let mut parts = entry.splitn(2, '=');
+        let key = parts.next().unwrap_or_default();
+        let value = parts.next().unwrap_or_default();
+        match key {
+            "code" if code.is_none() => code = Some(value.to_owned()),
+            "state" if state.is_none() => state = Some(value.to_owned()),
+            _ => {}
+        }
+    }
+    let parsed = parse_feishu_auth_callback(
+        FeishuAuthCallbackQuery { code, state },
+        app_state.expected_state.as_str(),
+    );
+    let mut sender = app_state.callback_sender.lock().await;
+    let Some(callback_sender) = sender.take() else {
+        return "Authorization callback already processed. You can close this tab.".to_owned();
+    };
+
+    match parsed {
+        Ok((code, state)) => {
+            let (exchange_result_sender, exchange_result_receiver) = oneshot::channel();
+            let payload = FeishuAuthCallbackPayload {
+                code,
+                state,
+                exchange_result_sender,
+            };
+            if callback_sender.send(Ok(payload)).is_err() {
+                return "Authorization failed: callback receiver dropped. Check terminal output."
+                    .to_owned();
+            }
+            match exchange_result_receiver.await {
+                Ok(Ok(())) => FEISHU_AUTH_CALLBACK_SUCCESS_BODY.to_owned(),
+                Ok(Err(error)) => {
+                    format!("Authorization failed: {error}. Check terminal output.")
+                }
+                Err(_) => {
+                    "Authorization failed: callback completion channel closed. Check terminal output."
+                        .to_owned()
+                }
+            }
+        }
+        Err(error) => {
+            let _ = callback_sender.send(Err(error.clone()));
+            format!("Authorization failed: {error}. Check terminal output.")
+        }
+    }
+}
+
+async fn bind_feishu_auth_callback_listener(
+    requested_redirect_uri: &str,
+) -> CliResult<(TcpListener, String)> {
+    let requested_redirect_uri = requested_redirect_uri.trim();
+    let (socket_addr, path) = if requested_redirect_uri == DEFAULT_FEISHU_REDIRECT_URI {
+        (
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 34819),
+            "/callback".to_owned(),
+        )
+    } else {
+        let url = Url::parse(requested_redirect_uri)
+            .map_err(|error| format!("parse Feishu redirect_uri failed: {error}"))?;
+        if url.scheme() != "http" {
+            return Err(format!(
+                "Feishu auto callback only supports http localhost redirect URIs, got scheme `{}`",
+                url.scheme()
+            ));
+        }
+        let host = url.host_str().unwrap_or_default();
+        if host != "127.0.0.1" && host != "localhost" {
+            return Err(format!(
+                "Feishu auto callback only supports localhost redirect URIs, got host `{host}`"
+            ));
+        }
+        let port = url.port().unwrap_or(80);
+        (
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+            if url.path().trim().is_empty() {
+                "/callback".to_owned()
+            } else {
+                url.path().to_owned()
+            },
+        )
+    };
+
+    let listener = TcpListener::bind(socket_addr)
+        .await
+        .map_err(|error| format!("bind Feishu auth callback listener failed: {error}"))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|error| format!("read Feishu auth callback listener addr failed: {error}"))?;
+    Ok((
+        listener,
+        format!("http://127.0.0.1:{}{}", local_addr.port(), path),
+    ))
+}
+
+async fn wait_for_feishu_auth_callback(
+    listener: TcpListener,
+    callback_path: String,
+    expected_state: String,
+    timeout: Duration,
+) -> CliResult<FeishuAuthCallbackPayload> {
+    let (callback_sender, callback_receiver) = oneshot::channel();
+    let app_state = Arc::new(FeishuAuthCallbackAppState {
+        expected_state,
+        callback_sender: Mutex::new(Some(callback_sender)),
+    });
+    let router = Router::new()
+        .route(callback_path.as_str(), get(handle_feishu_auth_callback))
+        .with_state(app_state);
+    let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+    let server_task = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_receiver.await;
+            })
+            .await
+            .map_err(|error| format!("Feishu auth callback server failed: {error}"))
+    });
+
+    let callback_result = tokio::time::timeout(timeout, callback_receiver).await;
+    match callback_result {
+        Ok(Ok(Ok(payload))) => Ok(payload),
+        Ok(Ok(Err(error))) => {
+            let _ = shutdown_sender.send(());
+            let server_result = server_task
+                .await
+                .map_err(|error| format!("join Feishu auth callback server failed: {error}"))?;
+            if let Err(server_error) = server_result {
+                return Err(server_error);
+            }
+            Err(error)
+        }
+        Ok(Err(_)) => {
+            let _ = shutdown_sender.send(());
+            let server_result = server_task
+                .await
+                .map_err(|error| format!("join Feishu auth callback server failed: {error}"))?;
+            if let Err(server_error) = server_result {
+                return Err(server_error);
+            }
+            Err("Feishu auth callback channel closed before receiving a callback".to_owned())
+        }
+        Err(_) => {
+            let _ = shutdown_sender.send(());
+            let server_result = server_task
+                .await
+                .map_err(|error| format!("join Feishu auth callback server failed: {error}"))?;
+            if let Err(server_error) = server_result {
+                return Err(server_error);
+            }
+            Err("timed out waiting for Feishu OAuth callback; rerun `loongclaw feishu auth start` and complete authorization in the browser".to_owned())
+        }
+    }
+}
+
+async fn prepare_feishu_auth_start(
+    args: &FeishuAuthStartArgs,
+    redirect_uri: &str,
+) -> CliResult<(FeishuDaemonContext, FeishuAuthStartArtifacts)> {
     let context = load_feishu_daemon_context(
         args.common.config.as_deref(),
         args.common.account.as_deref(),
@@ -1069,7 +1381,7 @@ pub async fn execute_feishu_auth_start(args: &FeishuAuthStartArgs) -> CliResult<
         account_id: context.account_id().to_owned(),
         principal_hint: args.principal_hint.clone().unwrap_or_default(),
         scope_csv: scopes.join(" "),
-        redirect_uri: Some(args.redirect_uri.trim().to_owned()),
+        redirect_uri: Some(redirect_uri.trim().to_owned()),
         code_verifier: Some(code_verifier),
         expires_at_s: now_s + context.config.feishu_integration.oauth_state_ttl_s as i64,
         created_at_s: now_s,
@@ -1078,7 +1390,7 @@ pub async fn execute_feishu_auth_start(args: &FeishuAuthStartArgs) -> CliResult<
     let authorize_url = mvp::channel::feishu::api::build_authorize_url(
         &mvp::channel::feishu::api::FeishuAuthStartSpec {
             app_id: client.app_id().to_owned(),
-            redirect_uri: args.redirect_uri.trim().to_owned(),
+            redirect_uri: redirect_uri.trim().to_owned(),
             scopes: scopes.clone(),
             state: state.clone(),
             code_challenge: Some(code_challenge),
@@ -1086,30 +1398,73 @@ pub async fn execute_feishu_auth_start(args: &FeishuAuthStartArgs) -> CliResult<
         },
     )?;
 
-    Ok(json!({
-        "account_id": context.account_id(),
-        "configured_account": context.resolved.configured_account_label,
-        "config": context.config_path.display().to_string(),
-        "redirect_uri": args.redirect_uri.trim(),
-        "state": state,
-        "authorize_url": authorize_url,
-        "sqlite_path": context.store.path().display().to_string(),
-        "expires_at_s": record.expires_at_s,
-        "capabilities": capabilities
-            .iter()
-            .map(|capability| capability.as_cli_value())
-            .collect::<Vec<_>>(),
-        "scopes": scopes,
-    }))
+    Ok((
+        context,
+        FeishuAuthStartArtifacts {
+            state,
+            redirect_uri: redirect_uri.trim().to_owned(),
+            authorize_url,
+            scopes,
+            capabilities,
+            expires_at_s: record.expires_at_s,
+        },
+    ))
 }
 
-pub async fn execute_feishu_auth_exchange(args: &FeishuAuthExchangeArgs) -> CliResult<Value> {
-    let context = load_feishu_daemon_context(
-        args.common.config.as_deref(),
-        args.common.account.as_deref(),
+pub async fn execute_feishu_auth_start(args: &FeishuAuthStartArgs) -> CliResult<Value> {
+    let (context, artifacts) = prepare_feishu_auth_start(args, args.redirect_uri.as_str()).await?;
+    Ok(build_feishu_auth_start_payload(&context, &artifacts, None))
+}
+
+async fn execute_feishu_auth_start_interactive(args: &FeishuAuthStartArgs) -> CliResult<()> {
+    let (listener, redirect_uri) =
+        bind_feishu_auth_callback_listener(args.redirect_uri.as_str()).await?;
+    let callback_path = Url::parse(redirect_uri.as_str())
+        .map_err(|error| format!("parse Feishu redirect_uri failed: {error}"))?
+        .path()
+        .to_owned();
+    let (context, artifacts) = prepare_feishu_auth_start(args, redirect_uri.as_str()).await?;
+    print_feishu_payload(
+        &build_feishu_auth_start_payload(
+            &context,
+            &artifacts,
+            Some("waiting for Feishu OAuth callback"),
+        ),
+        false,
+        render_auth_start_text,
     )?;
+    if let Err(error) = try_open_url_in_browser(artifacts.authorize_url.as_str()) {
+        eprintln!("warning: {error}");
+        eprintln!("open this URL manually if the browser did not launch:");
+        eprintln!("{}", artifacts.authorize_url);
+    }
+    let callback = wait_for_feishu_auth_callback(
+        listener,
+        callback_path,
+        artifacts.state.clone(),
+        FEISHU_AUTH_CALLBACK_WAIT_TIMEOUT,
+    )
+    .await?;
+    let exchange_payload =
+        complete_feishu_auth_exchange(&context, &callback.state, &callback.code).await;
+    let callback_result = exchange_payload
+        .as_ref()
+        .map(|_| ())
+        .map_err(|error| error.clone());
+    let _ = callback.exchange_result_sender.send(callback_result);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let exchange_payload = exchange_payload?;
+    print_feishu_payload(&exchange_payload, false, render_auth_exchange_text)?;
+    Ok(())
+}
+
+async fn complete_feishu_auth_exchange(
+    context: &FeishuDaemonContext,
+    state: &str,
+    code: &str,
+) -> CliResult<Value> {
     let now_s = unix_ts_now();
-    let stored_state = context.store.consume_oauth_state(&args.state, now_s)?;
+    let stored_state = context.store.consume_oauth_state(state, now_s)?;
     if stored_state.account_id.trim() != context.account_id() {
         return Err(format!(
             "oauth state belongs to account `{}` but current command resolved `{}`",
@@ -1123,7 +1478,7 @@ pub async fn execute_feishu_auth_exchange(args: &FeishuAuthExchangeArgs) -> CliR
     );
     let payload = client
         .exchange_authorization_code(
-            &args.code,
+            code,
             stored_state.redirect_uri.as_deref(),
             &scopes,
             stored_state.code_verifier.as_deref(),
@@ -1143,17 +1498,17 @@ pub async fn execute_feishu_auth_exchange(args: &FeishuAuthExchangeArgs) -> CliR
         .store
         .set_selected_grant(context.account_id(), &principal.open_id, now_s)?;
 
-    Ok(json!({
-        "account_id": context.account_id(),
-        "configured_account": context.resolved.configured_account_label,
-        "config": context.config_path.display().to_string(),
-        "principal": principal,
-        "granted_scopes": grant.scopes.as_slice(),
-        "access_expires_at_s": grant.access_expires_at_s,
-        "refresh_expires_at_s": grant.refresh_expires_at_s,
-        "selected_open_id": grant.principal.open_id,
-        "effective_open_id": grant.principal.open_id,
-    }))
+    Ok(build_feishu_auth_exchange_payload(
+        context, &principal, &grant,
+    ))
+}
+
+pub async fn execute_feishu_auth_exchange(args: &FeishuAuthExchangeArgs) -> CliResult<Value> {
+    let context = load_feishu_daemon_context(
+        args.common.config.as_deref(),
+        args.common.account.as_deref(),
+    )?;
+    complete_feishu_auth_exchange(&context, &args.state, &args.code).await
 }
 
 pub async fn execute_feishu_auth_list(args: &FeishuAuthListArgs) -> CliResult<Value> {
@@ -3027,6 +3382,9 @@ fn render_auth_start_text(payload: &Value) -> CliResult<String> {
             required_json_string(payload, "sqlite_path")?
         ),
     ]);
+    if let Some(status) = payload.get("status").and_then(Value::as_str) {
+        lines.push(format!("status: {status}"));
+    }
     Ok(lines.join("\n"))
 }
 
@@ -4461,6 +4819,82 @@ mod render_tests {
         let rendered = render_auth_start_text(&payload).expect("render auth start");
 
         assert!(rendered.contains("configured_account: work"));
+    }
+
+    #[test]
+    fn render_auth_start_text_includes_status_when_present() {
+        let payload = json!({
+            "account_id": "feishu_main",
+            "state": "state_123",
+            "redirect_uri": "http://127.0.0.1:38211/callback",
+            "authorize_url": "https://open.feishu.cn/open-apis/authen/v1/authorize",
+            "sqlite_path": "/tmp/feishu.sqlite3",
+            "capabilities": ["read-only"],
+            "scopes": ["offline_access"],
+            "status": "waiting for Feishu OAuth callback",
+        });
+
+        let rendered = render_auth_start_text(&payload).expect("render auth start");
+
+        assert!(rendered.contains("status: waiting for Feishu OAuth callback"));
+    }
+
+    #[test]
+    fn parse_feishu_auth_callback_accepts_matching_state() {
+        let parsed = parse_feishu_auth_callback(
+            FeishuAuthCallbackQuery {
+                code: Some("code_123".to_owned()),
+                state: Some("state_123".to_owned()),
+            },
+            "state_123",
+        )
+        .expect("parse callback");
+
+        assert_eq!(parsed, ("code_123".to_owned(), "state_123".to_owned()));
+    }
+
+    #[test]
+    fn parse_feishu_auth_callback_rejects_state_mismatch() {
+        let error = parse_feishu_auth_callback(
+            FeishuAuthCallbackQuery {
+                code: Some("code_123".to_owned()),
+                state: Some("state_other".to_owned()),
+            },
+            "state_123",
+        )
+        .expect_err("state mismatch");
+
+        assert_eq!(error, "state mismatch");
+    }
+
+    #[tokio::test]
+    async fn bind_feishu_auth_callback_listener_preserves_default_fixed_redirect_port() {
+        let (listener, redirect_uri) =
+            bind_feishu_auth_callback_listener(DEFAULT_FEISHU_REDIRECT_URI)
+                .await
+                .expect("bind callback listener");
+        let local_addr = listener.local_addr().expect("listener addr");
+
+        assert_eq!(
+            local_addr,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 34819)
+        );
+        assert_eq!(redirect_uri, DEFAULT_FEISHU_REDIRECT_URI);
+    }
+
+    #[tokio::test]
+    async fn bind_feishu_auth_callback_listener_preserves_custom_localhost_path() {
+        let (listener, redirect_uri) =
+            bind_feishu_auth_callback_listener("http://127.0.0.1:34819/custom-callback")
+                .await
+                .expect("bind callback listener");
+        let local_addr = listener.local_addr().expect("listener addr");
+
+        assert_eq!(
+            local_addr,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 34819)
+        );
+        assert_eq!(redirect_uri, "http://127.0.0.1:34819/custom-callback");
     }
 
     #[test]

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -1,21 +1,10 @@
 use std::fs;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
-use std::process::Command;
-use std::sync::Arc;
-use std::time::Duration;
 
-use axum::{Router, extract::State, http::Uri, routing::get};
 use clap::{Args, Subcommand, ValueEnum};
 use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
-use reqwest::Url;
-use serde::Deserialize;
 use serde_json::{Value, json};
-use tokio::{
-    net::TcpListener,
-    sync::{Mutex, oneshot},
-};
 
 use crate::feishu_support::{
     FeishuAuthCapability, FeishuDaemonContext, build_account_recommendations,
@@ -25,69 +14,9 @@ use crate::feishu_support::{
 };
 
 const DEFAULT_FEISHU_REDIRECT_URI: &str = "http://127.0.0.1:34819/callback";
-const FEISHU_AUTH_CALLBACK_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
-const FEISHU_AUTH_CALLBACK_SUCCESS_BODY: &str = "Authorization completed. You can close this tab.";
-
-#[derive(Debug, Clone)]
-struct FeishuAuthStartArtifacts {
-    state: String,
-    redirect_uri: String,
-    authorize_url: String,
-    scopes: Vec<String>,
-    capabilities: Vec<FeishuAuthCapability>,
-    expires_at_s: i64,
-}
-
-#[derive(Debug, Deserialize)]
-struct FeishuAuthCallbackQuery {
-    code: Option<String>,
-    state: Option<String>,
-}
-
-struct FeishuAuthCallbackPayload {
-    code: String,
-    state: String,
-    exchange_result_sender: oneshot::Sender<CliResult<()>>,
-}
-
-struct FeishuAuthCallbackAppState {
-    expected_state: String,
-    callback_sender: Mutex<Option<oneshot::Sender<CliResult<FeishuAuthCallbackPayload>>>>,
-}
 
 fn active_cli_command_name() -> &'static str {
     mvp::config::active_cli_command_name()
-}
-
-fn try_open_url_in_browser(url: &str) -> CliResult<()> {
-    #[cfg(target_os = "macos")]
-    let mut command = {
-        let mut command = Command::new("open");
-        command.arg(url);
-        command
-    };
-
-    #[cfg(target_os = "linux")]
-    let mut command = {
-        let mut command = Command::new("xdg-open");
-        command.arg(url);
-        command
-    };
-
-    #[cfg(target_os = "windows")]
-    let mut command = {
-        let mut command = Command::new("cmd");
-        command.args(["/C", "start", "", url]);
-        command
-    };
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    return Err("opening the browser is not supported on this platform".to_owned());
-
-    command
-        .spawn()
-        .map(|_| ())
-        .map_err(|error| format!("open browser failed: {error}"))
 }
 
 #[derive(Subcommand, Debug)]
@@ -857,12 +786,8 @@ pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
     match command {
         FeishuCommand::Auth { command } => match command {
             FeishuAuthCommand::Start(args) => {
-                if args.common.json {
-                    let payload = execute_feishu_auth_start(&args).await?;
-                    print_feishu_payload(&payload, true, render_auth_start_text)?;
-                } else {
-                    execute_feishu_auth_start_interactive(&args).await?;
-                }
+                let payload = execute_feishu_auth_start(&args).await?;
+                print_feishu_payload(&payload, args.common.json, render_auth_start_text)?;
             }
             FeishuAuthCommand::Exchange(args) => {
                 let payload = execute_feishu_auth_exchange(&args).await?;
@@ -1122,244 +1047,7 @@ pub async fn run_feishu_command(command: FeishuCommand) -> CliResult<()> {
     Ok(())
 }
 
-fn build_feishu_auth_start_payload(
-    context: &FeishuDaemonContext,
-    artifacts: &FeishuAuthStartArtifacts,
-    status: Option<&str>,
-) -> Value {
-    let mut payload = json!({
-        "account_id": context.account_id(),
-        "configured_account": context.resolved.configured_account_label,
-        "config": context.config_path.display().to_string(),
-        "redirect_uri": artifacts.redirect_uri,
-        "state": artifacts.state,
-        "authorize_url": artifacts.authorize_url,
-        "sqlite_path": context.store.path().display().to_string(),
-        "expires_at_s": artifacts.expires_at_s,
-        "capabilities": artifacts
-            .capabilities
-            .iter()
-            .map(|capability| capability.as_cli_value())
-            .collect::<Vec<_>>(),
-        "scopes": artifacts.scopes,
-    });
-    if let Some(status) = status
-        && let Some(object) = payload.as_object_mut()
-    {
-        object.insert("status".to_owned(), Value::String(status.to_owned()));
-    }
-    payload
-}
-
-fn build_feishu_auth_exchange_payload(
-    context: &FeishuDaemonContext,
-    principal: &mvp::channel::feishu::api::FeishuUserPrincipal,
-    grant: &mvp::channel::feishu::api::FeishuGrant,
-) -> Value {
-    json!({
-        "account_id": context.account_id(),
-        "configured_account": context.resolved.configured_account_label,
-        "config": context.config_path.display().to_string(),
-        "principal": principal,
-        "granted_scopes": grant.scopes.as_slice(),
-        "access_expires_at_s": grant.access_expires_at_s,
-        "refresh_expires_at_s": grant.refresh_expires_at_s,
-        "selected_open_id": grant.principal.open_id,
-        "effective_open_id": grant.principal.open_id,
-    })
-}
-
-fn parse_feishu_auth_callback(
-    query: FeishuAuthCallbackQuery,
-    expected_state: &str,
-) -> CliResult<(String, String)> {
-    let code = query
-        .code
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| "missing code".to_owned())?
-        .to_owned();
-    let state = query
-        .state
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| "missing state".to_owned())?
-        .to_owned();
-    if state != expected_state.trim() {
-        return Err("state mismatch".to_owned());
-    }
-    Ok((code, state))
-}
-
-async fn handle_feishu_auth_callback(
-    State(app_state): State<Arc<FeishuAuthCallbackAppState>>,
-    uri: Uri,
-) -> String {
-    let raw_query = uri.query().unwrap_or_default();
-    let mut code = None;
-    let mut state = None;
-    for entry in raw_query.split('&') {
-        let mut parts = entry.splitn(2, '=');
-        let key = parts.next().unwrap_or_default();
-        let value = parts.next().unwrap_or_default();
-        match key {
-            "code" if code.is_none() => code = Some(value.to_owned()),
-            "state" if state.is_none() => state = Some(value.to_owned()),
-            _ => {}
-        }
-    }
-    let parsed = parse_feishu_auth_callback(
-        FeishuAuthCallbackQuery { code, state },
-        app_state.expected_state.as_str(),
-    );
-    let mut sender = app_state.callback_sender.lock().await;
-    let Some(callback_sender) = sender.take() else {
-        return "Authorization callback already processed. You can close this tab.".to_owned();
-    };
-
-    match parsed {
-        Ok((code, state)) => {
-            let (exchange_result_sender, exchange_result_receiver) = oneshot::channel();
-            let payload = FeishuAuthCallbackPayload {
-                code,
-                state,
-                exchange_result_sender,
-            };
-            if callback_sender.send(Ok(payload)).is_err() {
-                return "Authorization failed: callback receiver dropped. Check terminal output."
-                    .to_owned();
-            }
-            match exchange_result_receiver.await {
-                Ok(Ok(())) => FEISHU_AUTH_CALLBACK_SUCCESS_BODY.to_owned(),
-                Ok(Err(error)) => {
-                    format!("Authorization failed: {error}. Check terminal output.")
-                }
-                Err(_) => {
-                    "Authorization failed: callback completion channel closed. Check terminal output."
-                        .to_owned()
-                }
-            }
-        }
-        Err(error) => {
-            let _ = callback_sender.send(Err(error.clone()));
-            format!("Authorization failed: {error}. Check terminal output.")
-        }
-    }
-}
-
-async fn bind_feishu_auth_callback_listener(
-    requested_redirect_uri: &str,
-) -> CliResult<(TcpListener, String)> {
-    let requested_redirect_uri = requested_redirect_uri.trim();
-    let (socket_addr, path) = if requested_redirect_uri == DEFAULT_FEISHU_REDIRECT_URI {
-        (
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 34819),
-            "/callback".to_owned(),
-        )
-    } else {
-        let url = Url::parse(requested_redirect_uri)
-            .map_err(|error| format!("parse Feishu redirect_uri failed: {error}"))?;
-        if url.scheme() != "http" {
-            return Err(format!(
-                "Feishu auto callback only supports http localhost redirect URIs, got scheme `{}`",
-                url.scheme()
-            ));
-        }
-        let host = url.host_str().unwrap_or_default();
-        if host != "127.0.0.1" && host != "localhost" {
-            return Err(format!(
-                "Feishu auto callback only supports localhost redirect URIs, got host `{host}`"
-            ));
-        }
-        let port = url.port().unwrap_or(80);
-        (
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
-            if url.path().trim().is_empty() {
-                "/callback".to_owned()
-            } else {
-                url.path().to_owned()
-            },
-        )
-    };
-
-    let listener = TcpListener::bind(socket_addr)
-        .await
-        .map_err(|error| format!("bind Feishu auth callback listener failed: {error}"))?;
-    let local_addr = listener
-        .local_addr()
-        .map_err(|error| format!("read Feishu auth callback listener addr failed: {error}"))?;
-    Ok((
-        listener,
-        format!("http://127.0.0.1:{}{}", local_addr.port(), path),
-    ))
-}
-
-async fn wait_for_feishu_auth_callback(
-    listener: TcpListener,
-    callback_path: String,
-    expected_state: String,
-    timeout: Duration,
-) -> CliResult<FeishuAuthCallbackPayload> {
-    let (callback_sender, callback_receiver) = oneshot::channel();
-    let app_state = Arc::new(FeishuAuthCallbackAppState {
-        expected_state,
-        callback_sender: Mutex::new(Some(callback_sender)),
-    });
-    let router = Router::new()
-        .route(callback_path.as_str(), get(handle_feishu_auth_callback))
-        .with_state(app_state);
-    let (shutdown_sender, shutdown_receiver) = oneshot::channel();
-    let server_task = tokio::spawn(async move {
-        axum::serve(listener, router)
-            .with_graceful_shutdown(async move {
-                let _ = shutdown_receiver.await;
-            })
-            .await
-            .map_err(|error| format!("Feishu auth callback server failed: {error}"))
-    });
-
-    let callback_result = tokio::time::timeout(timeout, callback_receiver).await;
-    match callback_result {
-        Ok(Ok(Ok(payload))) => Ok(payload),
-        Ok(Ok(Err(error))) => {
-            let _ = shutdown_sender.send(());
-            let server_result = server_task
-                .await
-                .map_err(|error| format!("join Feishu auth callback server failed: {error}"))?;
-            if let Err(server_error) = server_result {
-                return Err(server_error);
-            }
-            Err(error)
-        }
-        Ok(Err(_)) => {
-            let _ = shutdown_sender.send(());
-            let server_result = server_task
-                .await
-                .map_err(|error| format!("join Feishu auth callback server failed: {error}"))?;
-            if let Err(server_error) = server_result {
-                return Err(server_error);
-            }
-            Err("Feishu auth callback channel closed before receiving a callback".to_owned())
-        }
-        Err(_) => {
-            let _ = shutdown_sender.send(());
-            let server_result = server_task
-                .await
-                .map_err(|error| format!("join Feishu auth callback server failed: {error}"))?;
-            if let Err(server_error) = server_result {
-                return Err(server_error);
-            }
-            Err("timed out waiting for Feishu OAuth callback; rerun `loongclaw feishu auth start` and complete authorization in the browser".to_owned())
-        }
-    }
-}
-
-async fn prepare_feishu_auth_start(
-    args: &FeishuAuthStartArgs,
-    redirect_uri: &str,
-) -> CliResult<(FeishuDaemonContext, FeishuAuthStartArtifacts)> {
+pub async fn execute_feishu_auth_start(args: &FeishuAuthStartArgs) -> CliResult<Value> {
     let context = load_feishu_daemon_context(
         args.common.config.as_deref(),
         args.common.account.as_deref(),
@@ -1381,7 +1069,7 @@ async fn prepare_feishu_auth_start(
         account_id: context.account_id().to_owned(),
         principal_hint: args.principal_hint.clone().unwrap_or_default(),
         scope_csv: scopes.join(" "),
-        redirect_uri: Some(redirect_uri.trim().to_owned()),
+        redirect_uri: Some(args.redirect_uri.trim().to_owned()),
         code_verifier: Some(code_verifier),
         expires_at_s: now_s + context.config.feishu_integration.oauth_state_ttl_s as i64,
         created_at_s: now_s,
@@ -1390,7 +1078,7 @@ async fn prepare_feishu_auth_start(
     let authorize_url = mvp::channel::feishu::api::build_authorize_url(
         &mvp::channel::feishu::api::FeishuAuthStartSpec {
             app_id: client.app_id().to_owned(),
-            redirect_uri: redirect_uri.trim().to_owned(),
+            redirect_uri: args.redirect_uri.trim().to_owned(),
             scopes: scopes.clone(),
             state: state.clone(),
             code_challenge: Some(code_challenge),
@@ -1398,73 +1086,30 @@ async fn prepare_feishu_auth_start(
         },
     )?;
 
-    Ok((
-        context,
-        FeishuAuthStartArtifacts {
-            state,
-            redirect_uri: redirect_uri.trim().to_owned(),
-            authorize_url,
-            scopes,
-            capabilities,
-            expires_at_s: record.expires_at_s,
-        },
-    ))
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "config": context.config_path.display().to_string(),
+        "redirect_uri": args.redirect_uri.trim(),
+        "state": state,
+        "authorize_url": authorize_url,
+        "sqlite_path": context.store.path().display().to_string(),
+        "expires_at_s": record.expires_at_s,
+        "capabilities": capabilities
+            .iter()
+            .map(|capability| capability.as_cli_value())
+            .collect::<Vec<_>>(),
+        "scopes": scopes,
+    }))
 }
 
-pub async fn execute_feishu_auth_start(args: &FeishuAuthStartArgs) -> CliResult<Value> {
-    let (context, artifacts) = prepare_feishu_auth_start(args, args.redirect_uri.as_str()).await?;
-    Ok(build_feishu_auth_start_payload(&context, &artifacts, None))
-}
-
-async fn execute_feishu_auth_start_interactive(args: &FeishuAuthStartArgs) -> CliResult<()> {
-    let (listener, redirect_uri) =
-        bind_feishu_auth_callback_listener(args.redirect_uri.as_str()).await?;
-    let callback_path = Url::parse(redirect_uri.as_str())
-        .map_err(|error| format!("parse Feishu redirect_uri failed: {error}"))?
-        .path()
-        .to_owned();
-    let (context, artifacts) = prepare_feishu_auth_start(args, redirect_uri.as_str()).await?;
-    print_feishu_payload(
-        &build_feishu_auth_start_payload(
-            &context,
-            &artifacts,
-            Some("waiting for Feishu OAuth callback"),
-        ),
-        false,
-        render_auth_start_text,
+pub async fn execute_feishu_auth_exchange(args: &FeishuAuthExchangeArgs) -> CliResult<Value> {
+    let context = load_feishu_daemon_context(
+        args.common.config.as_deref(),
+        args.common.account.as_deref(),
     )?;
-    if let Err(error) = try_open_url_in_browser(artifacts.authorize_url.as_str()) {
-        eprintln!("warning: {error}");
-        eprintln!("open this URL manually if the browser did not launch:");
-        eprintln!("{}", artifacts.authorize_url);
-    }
-    let callback = wait_for_feishu_auth_callback(
-        listener,
-        callback_path,
-        artifacts.state.clone(),
-        FEISHU_AUTH_CALLBACK_WAIT_TIMEOUT,
-    )
-    .await?;
-    let exchange_payload =
-        complete_feishu_auth_exchange(&context, &callback.state, &callback.code).await;
-    let callback_result = exchange_payload
-        .as_ref()
-        .map(|_| ())
-        .map_err(|error| error.clone());
-    let _ = callback.exchange_result_sender.send(callback_result);
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let exchange_payload = exchange_payload?;
-    print_feishu_payload(&exchange_payload, false, render_auth_exchange_text)?;
-    Ok(())
-}
-
-async fn complete_feishu_auth_exchange(
-    context: &FeishuDaemonContext,
-    state: &str,
-    code: &str,
-) -> CliResult<Value> {
     let now_s = unix_ts_now();
-    let stored_state = context.store.consume_oauth_state(state, now_s)?;
+    let stored_state = context.store.consume_oauth_state(&args.state, now_s)?;
     if stored_state.account_id.trim() != context.account_id() {
         return Err(format!(
             "oauth state belongs to account `{}` but current command resolved `{}`",
@@ -1478,7 +1123,7 @@ async fn complete_feishu_auth_exchange(
     );
     let payload = client
         .exchange_authorization_code(
-            code,
+            &args.code,
             stored_state.redirect_uri.as_deref(),
             &scopes,
             stored_state.code_verifier.as_deref(),
@@ -1498,17 +1143,17 @@ async fn complete_feishu_auth_exchange(
         .store
         .set_selected_grant(context.account_id(), &principal.open_id, now_s)?;
 
-    Ok(build_feishu_auth_exchange_payload(
-        context, &principal, &grant,
-    ))
-}
-
-pub async fn execute_feishu_auth_exchange(args: &FeishuAuthExchangeArgs) -> CliResult<Value> {
-    let context = load_feishu_daemon_context(
-        args.common.config.as_deref(),
-        args.common.account.as_deref(),
-    )?;
-    complete_feishu_auth_exchange(&context, &args.state, &args.code).await
+    Ok(json!({
+        "account_id": context.account_id(),
+        "configured_account": context.resolved.configured_account_label,
+        "config": context.config_path.display().to_string(),
+        "principal": principal,
+        "granted_scopes": grant.scopes.as_slice(),
+        "access_expires_at_s": grant.access_expires_at_s,
+        "refresh_expires_at_s": grant.refresh_expires_at_s,
+        "selected_open_id": grant.principal.open_id,
+        "effective_open_id": grant.principal.open_id,
+    }))
 }
 
 pub async fn execute_feishu_auth_list(args: &FeishuAuthListArgs) -> CliResult<Value> {
@@ -4819,82 +4464,6 @@ mod render_tests {
         let rendered = render_auth_start_text(&payload).expect("render auth start");
 
         assert!(rendered.contains("configured_account: work"));
-    }
-
-    #[test]
-    fn render_auth_start_text_includes_status_when_present() {
-        let payload = json!({
-            "account_id": "feishu_main",
-            "state": "state_123",
-            "redirect_uri": "http://127.0.0.1:38211/callback",
-            "authorize_url": "https://open.feishu.cn/open-apis/authen/v1/authorize",
-            "sqlite_path": "/tmp/feishu.sqlite3",
-            "capabilities": ["read-only"],
-            "scopes": ["offline_access"],
-            "status": "waiting for Feishu OAuth callback",
-        });
-
-        let rendered = render_auth_start_text(&payload).expect("render auth start");
-
-        assert!(rendered.contains("status: waiting for Feishu OAuth callback"));
-    }
-
-    #[test]
-    fn parse_feishu_auth_callback_accepts_matching_state() {
-        let parsed = parse_feishu_auth_callback(
-            FeishuAuthCallbackQuery {
-                code: Some("code_123".to_owned()),
-                state: Some("state_123".to_owned()),
-            },
-            "state_123",
-        )
-        .expect("parse callback");
-
-        assert_eq!(parsed, ("code_123".to_owned(), "state_123".to_owned()));
-    }
-
-    #[test]
-    fn parse_feishu_auth_callback_rejects_state_mismatch() {
-        let error = parse_feishu_auth_callback(
-            FeishuAuthCallbackQuery {
-                code: Some("code_123".to_owned()),
-                state: Some("state_other".to_owned()),
-            },
-            "state_123",
-        )
-        .expect_err("state mismatch");
-
-        assert_eq!(error, "state mismatch");
-    }
-
-    #[tokio::test]
-    async fn bind_feishu_auth_callback_listener_preserves_default_fixed_redirect_port() {
-        let (listener, redirect_uri) =
-            bind_feishu_auth_callback_listener(DEFAULT_FEISHU_REDIRECT_URI)
-                .await
-                .expect("bind callback listener");
-        let local_addr = listener.local_addr().expect("listener addr");
-
-        assert_eq!(
-            local_addr,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 34819)
-        );
-        assert_eq!(redirect_uri, DEFAULT_FEISHU_REDIRECT_URI);
-    }
-
-    #[tokio::test]
-    async fn bind_feishu_auth_callback_listener_preserves_custom_localhost_path() {
-        let (listener, redirect_uri) =
-            bind_feishu_auth_callback_listener("http://127.0.0.1:34819/custom-callback")
-                .await
-                .expect("bind callback listener");
-        let local_addr = listener.local_addr().expect("listener addr");
-
-        assert_eq!(
-            local_addr,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 34819)
-        );
-        assert_eq!(redirect_uri, "http://127.0.0.1:34819/custom-callback");
     }
 
     #[test]

--- a/crates/daemon/src/feishu_support.rs
+++ b/crates/daemon/src/feishu_support.rs
@@ -10,6 +10,9 @@ use sha2::{Digest, Sha256};
 use loongclaw_app as mvp;
 use loongclaw_spec::CliResult;
 
+const FEISHU_GROUP_MESSAGE_READ_SCOPE: &str = "im:message.group_msg";
+const FEISHU_GROUP_MESSAGE_READ_SCOPE_LEGACY: &str = "im:message.group_msg:readonly";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum FeishuAuthCapability {
     ReadOnly,
@@ -323,7 +326,13 @@ fn random_urlsafe_token(bytes_len: usize) -> String {
 
 fn normalize_scope(raw: &str) -> Option<String> {
     let scope = raw.trim();
-    (!scope.is_empty()).then(|| scope.to_owned())
+    if scope.is_empty() {
+        return None;
+    }
+    Some(match scope {
+        FEISHU_GROUP_MESSAGE_READ_SCOPE_LEGACY => FEISHU_GROUP_MESSAGE_READ_SCOPE.to_owned(),
+        _ => scope.to_owned(),
+    })
 }
 
 fn push_scope_if_missing(scopes: &mut Vec<String>, raw: &str) {
@@ -550,6 +559,27 @@ mod tests {
                 .filter(|scope| scope.as_str() == "im:message")
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn resolve_scopes_normalizes_legacy_group_message_scope_alias() {
+        let scopes = resolve_scopes(
+            &[],
+            &[
+                "offline_access".to_owned(),
+                "im:message.group_msg:readonly".to_owned(),
+            ],
+            &[],
+            false,
+        );
+
+        assert_eq!(
+            scopes,
+            vec![
+                "offline_access".to_owned(),
+                "im:message.group_msg".to_owned()
+            ]
         );
     }
 

--- a/crates/daemon/tests/integration/doctor_feishu.rs
+++ b/crates/daemon/tests/integration/doctor_feishu.rs
@@ -44,7 +44,7 @@ fn sample_grant(account_id: &str, now_s: i64) -> mvp::channel::feishu::api::Feis
             "offline_access",
             "docx:document:readonly",
             "im:message:readonly",
-            "im:message.group_msg:readonly",
+            "im:message.group_msg",
             "search:message",
             "calendar:calendar:readonly",
         ]),

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -153,7 +153,7 @@ fn sample_grant(
             "offline_access",
             "docx:document:readonly",
             "im:message:readonly",
-            "im:message.group_msg:readonly",
+            "im:message.group_msg",
             "search:message",
             "calendar:calendar:readonly",
         ]),
@@ -3768,6 +3768,8 @@ async fn feishu_auth_start_persists_oauth_state_and_authorize_url() {
     assert!(authorize_url.contains("https://accounts.feishu.cn/open-apis/authen/v1/authorize"));
     assert!(authorize_url.contains("client_id=cli_a1b2c3"));
     assert!(authorize_url.contains("state="));
+    assert!(authorize_url.contains("im%3Amessage.group_msg"));
+    assert!(!authorize_url.contains("im%3Amessage.group_msg%3Areadonly"));
 
     let store = mvp::channel::feishu::api::FeishuTokenStore::new(temp_dir.join("feishu.sqlite3"));
     let stored = store
@@ -3785,6 +3787,18 @@ async fn feishu_auth_start_persists_oauth_state_and_authorize_url() {
             .scope_csv
             .split_whitespace()
             .any(|scope| scope == "offline_access")
+    );
+    assert!(
+        stored
+            .scope_csv
+            .split_whitespace()
+            .any(|scope| scope == "im:message.group_msg")
+    );
+    assert!(
+        !stored
+            .scope_csv
+            .split_whitespace()
+            .any(|scope| scope == "im:message.group_msg:readonly")
     );
 }
 
@@ -3972,6 +3986,11 @@ async fn feishu_auth_exchange_sets_selected_open_id_for_new_grant() {
             .body
             .contains("\"code_verifier\":\"verifier-123\"")
     );
+    assert!(
+        !requests[0].body.contains("\"scope\""),
+        "authorization_code exchange should not resend scope list: {}",
+        requests[0].body
+    );
     assert_eq!(requests[1].path, "/open-apis/authen/v1/user_info");
     assert_eq!(
         requests[1].authorization.as_deref(),
@@ -4003,7 +4022,7 @@ async fn feishu_whoami_refreshes_expired_grant_and_updates_store() {
                             "refresh_token": "r-token-next",
                             "expires_in": 7200,
                             "refresh_token_expires_in": 2592000,
-                            "scope": "offline_access docx:document:readonly im:message:readonly im:message.group_msg:readonly search:message calendar:calendar:readonly"
+                            "scope": "offline_access docx:document:readonly im:message:readonly im:message.group_msg search:message calendar:calendar:readonly"
                         }))
                     }
                 }

--- a/crates/daemon/tests/integration/feishu_cli.rs
+++ b/crates/daemon/tests/integration/feishu_cli.rs
@@ -3803,6 +3803,35 @@ async fn feishu_auth_start_persists_oauth_state_and_authorize_url() {
 }
 
 #[tokio::test]
+async fn feishu_auth_start_non_json_keeps_manual_flow_for_non_local_redirect_uri() {
+    let temp_dir = temp_feishu_cli_dir("auth-start-non-json-manual");
+    let config_path = write_sample_feishu_config(&temp_dir);
+    let command = loongclaw_daemon::feishu_cli::FeishuCommand::Auth {
+        command: loongclaw_daemon::feishu_cli::FeishuAuthCommand::Start(
+            loongclaw_daemon::feishu_cli::FeishuAuthStartArgs {
+                common: loongclaw_daemon::feishu_cli::FeishuCommonArgs {
+                    config: Some(config_path.display().to_string()),
+                    account: Some("feishu_main".to_owned()),
+                    json: false,
+                },
+                redirect_uri: "https://example.com/callback".to_owned(),
+                principal_hint: Some("operator".to_owned()),
+                scopes: Vec::new(),
+                capabilities: Vec::new(),
+                include_message_write: false,
+            },
+        ),
+    };
+
+    let result = loongclaw_daemon::feishu_cli::run_feishu_command(command).await;
+
+    assert!(
+        result.is_ok(),
+        "non-json auth start should remain manual and accept non-local redirect URIs: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn feishu_auth_start_can_include_recommended_message_write_scopes() {
     let temp_dir = temp_feishu_cli_dir("auth-start-write");
     let config_path = write_sample_feishu_config(&temp_dir);
@@ -3986,8 +4015,10 @@ async fn feishu_auth_exchange_sets_selected_open_id_for_new_grant() {
             .body
             .contains("\"code_verifier\":\"verifier-123\"")
     );
+    let token_request_body: Value =
+        serde_json::from_str(&requests[0].body).expect("token request body should be valid json");
     assert!(
-        !requests[0].body.contains("\"scope\""),
+        token_request_body.get("scope").is_none(),
         "authorization_code exchange should not resend scope list: {}",
         requests[0].body
     );

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T11:05:57Z
+- Generated at: 2026-04-01T13:13:44Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,13 +23,13 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14472 | 15000 | 528 | 54 | 70 | 16 | 96.5% | TIGHT | 14472 | 0.0% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14567 | 15000 | 433 | 54 | 70 | 16 | 97.1% | TIGHT | 14472 | 0.7% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6339 | 6500 | 161 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.2% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (96.5%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (99.4%), acpx_runtime (96.4%), channel_registry (98.9%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (97.1%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.0%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10831 functions=98 -->
-<!-- arch-hotspot key=tools_mod lines=14472 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14567 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6339 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- normalize the legacy `im:message.group_msg:readonly` scope alias to `im:message.group_msg` at config and cli auth-start boundaries
- keep stored legacy grants compatible with canonical group-message reads during rollout
- stop sending `scope` during authorization-code token exchange to avoid feishu `20068`
- keep `feishu auth start` manual and non-interactive; this pr does not add a localhost callback listener or automatic browser exchange flow

## Linked Issues

- Closes #730

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p loongclaw-daemon --test integration feishu_auth_ -- --nocapture`
- `cargo test -p loongclaw-daemon --test integration doctor_reports_missing_feishu_grant_when_channel_is_enabled -- --nocapture`
- `cargo test -p loongclaw-daemon resolve_scopes_normalizes_legacy_group_message_scope_alias -- --nocapture`
- `cargo test -p loongclaw-app grant_scope_set_contains_group_message_scope_aliases -- --nocapture`
- `cargo test -p loongclaw-app trimmed_default_scopes_normalizes_legacy_group_message_scope -- --nocapture`
- `cargo test -p loongclaw-app feishu_messages_get_tool_accepts_legacy_group_message_read_scope -- --nocapture`
- `cargo clippy -p loongclaw-daemon --test integration -- -D warnings`
- `bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-04.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: non-JSON Feishu auth start output now includes an optional status line when present.

* **Bug Fixes**
  * Feishu scope handling: normalizes, deduplicates, and treats legacy and canonical group-message read scopes as equivalent.
  * OAuth token exchange: request no longer includes a scope field.

* **Tests**
  * Added unit and integration tests covering legacy scope compatibility, OAuth request behavior, and auth flow cases.

* **Docs**
  * Updated architecture drift report timestamp and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->