### PR TITLE
refactor(app): extract session inspection read model

### DIFF
--- a/crates/app/src/session/inspection.rs
+++ b/crates/app/src/session/inspection.rs
@@ -1,0 +1,507 @@
+#[cfg(feature = "memory-sqlite")]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+
+#[cfg(feature = "memory-sqlite")]
+use crate::conversation::ConstrainedSubagentExecution;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::recovery::{SessionRecoveryRecord, observe_missing_recovery, recovery_json};
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    SessionEventRecord, SessionKind, SessionObservationRecord, SessionRepository, SessionState,
+    SessionSummaryRecord, SessionTerminalOutcomeRecord,
+};
+#[cfg(feature = "memory-sqlite")]
+use crate::session::{
+    DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED, DELEGATE_CANCEL_REQUESTED_EVENT_KIND,
+};
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SessionInspectionSnapshot {
+    pub session: SessionSummaryRecord,
+    pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
+    pub recent_events: Vec<SessionEventRecord>,
+    pub delegate_events: Vec<SessionEventRecord>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SessionObservationSnapshot {
+    pub inspection: SessionInspectionSnapshot,
+    pub tail_events: Vec<SessionEventRecord>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionDelegateLifecycleRecord {
+    pub mode: &'static str,
+    pub phase: &'static str,
+    pub queued_at: Option<i64>,
+    pub started_at: Option<i64>,
+    pub timeout_seconds: Option<u64>,
+    pub execution: Option<ConstrainedSubagentExecution>,
+    pub staleness: Option<SessionDelegateStalenessRecord>,
+    pub cancellation: Option<SessionDelegateCancellationRecord>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionDelegateStalenessRecord {
+    pub state: &'static str,
+    pub reference: &'static str,
+    pub elapsed_seconds: u64,
+    pub threshold_seconds: u64,
+    pub deadline_at: i64,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionDelegateCancellationRecord {
+    pub state: &'static str,
+    pub reference: String,
+    pub requested_at: i64,
+    pub reason: String,
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn load_session_observation_snapshot(
+    repo: &SessionRepository,
+    target_session_id: &str,
+    recent_event_limit: usize,
+    tail_after_id: Option<i64>,
+    tail_page_limit: usize,
+) -> Result<SessionObservationSnapshot, String> {
+    let observation = repo.load_session_observation(
+        target_session_id,
+        recent_event_limit,
+        tail_after_id,
+        tail_page_limit,
+    )?;
+    let SessionObservationRecord {
+        session,
+        terminal_outcome,
+        recent_events,
+        tail_events,
+    } = observation.ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
+    let delegate_events = load_delegate_lifecycle_events(repo, &session)?;
+    let inspection = SessionInspectionSnapshot {
+        session,
+        terminal_outcome,
+        recent_events,
+        delegate_events,
+    };
+
+    Ok(SessionObservationSnapshot {
+        inspection,
+        tail_events,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn session_state_is_terminal(state: SessionState) -> bool {
+    matches!(
+        state,
+        SessionState::Completed | SessionState::Failed | SessionState::TimedOut
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) -> Value {
+    let now_ts = current_unix_ts();
+
+    session_inspection_payload_at(snapshot, now_ts)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn session_inspection_payload_at(
+    snapshot: SessionInspectionSnapshot,
+    now_ts: i64,
+) -> Value {
+    let terminal_outcome_state =
+        session_terminal_outcome_state(snapshot.session.state, snapshot.terminal_outcome.is_some());
+    let delegate_lifecycle = session_delegate_lifecycle_at(
+        &snapshot.session,
+        snapshot.delegate_events.as_slice(),
+        now_ts,
+    );
+    let recovery = match terminal_outcome_state {
+        "missing" => Some(observe_missing_recovery(
+            snapshot.recent_events.as_slice(),
+            snapshot.session.last_error.as_deref(),
+        )),
+        _ => None,
+    };
+    let terminal_outcome_missing_reason = match terminal_outcome_state {
+        "missing" => session_terminal_outcome_missing_reason(recovery.as_ref()),
+        _ => None,
+    };
+
+    json!({
+        "session": {
+            "session_id": snapshot.session.session_id,
+            "kind": snapshot.session.kind.as_str(),
+            "parent_session_id": snapshot.session.parent_session_id,
+            "label": snapshot.session.label,
+            "state": snapshot.session.state.as_str(),
+            "created_at": snapshot.session.created_at,
+            "updated_at": snapshot.session.updated_at,
+            "archived": snapshot.session.archived_at.is_some(),
+            "archived_at": snapshot.session.archived_at,
+            "last_error": snapshot.session.last_error,
+        },
+        "terminal_outcome_state": terminal_outcome_state,
+        "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
+        "delegate_lifecycle": delegate_lifecycle.map(session_delegate_lifecycle_json),
+        "recovery": recovery.map(recovery_json),
+        "terminal_outcome": snapshot.terminal_outcome.map(session_terminal_outcome_json),
+        "recent_events": snapshot
+            .recent_events
+            .into_iter()
+            .map(session_event_json)
+            .collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn session_delegate_lifecycle_at(
+    session: &SessionSummaryRecord,
+    recent_events: &[SessionEventRecord],
+    now_ts: i64,
+) -> Option<SessionDelegateLifecycleRecord> {
+    if session.kind != SessionKind::DelegateChild {
+        return None;
+    }
+
+    let mut queued_at = None;
+    let mut started_at = None;
+    let mut queued_timeout_seconds = None;
+    let mut started_timeout_seconds = None;
+    let mut execution = None;
+    let mut cancellation = None;
+
+    for event in recent_events {
+        match event.event_kind.as_str() {
+            "delegate_queued" => {
+                queued_at = Some(event.ts);
+                execution = execution.or_else(|| {
+                    ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
+                });
+                queued_timeout_seconds = event
+                    .payload_json
+                    .get("timeout_seconds")
+                    .and_then(Value::as_u64)
+                    .or_else(|| {
+                        execution
+                            .as_ref()
+                            .map(|execution| execution.timeout_seconds)
+                    });
+            }
+            "delegate_started" => {
+                started_at = Some(event.ts);
+                execution = execution.or_else(|| {
+                    ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
+                });
+                started_timeout_seconds = event
+                    .payload_json
+                    .get("timeout_seconds")
+                    .and_then(Value::as_u64)
+                    .or_else(|| {
+                        execution
+                            .as_ref()
+                            .map(|execution| execution.timeout_seconds)
+                    });
+            }
+            DELEGATE_CANCEL_REQUESTED_EVENT_KIND => {
+                let reason = event
+                    .payload_json
+                    .get("cancel_reason")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or(DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED)
+                    .to_owned();
+                let reference = event
+                    .payload_json
+                    .get("reference")
+                    .and_then(Value::as_str)
+                    .filter(|value| *value == "running")
+                    .unwrap_or("running");
+                cancellation = Some(SessionDelegateCancellationRecord {
+                    state: "requested",
+                    reference: reference.to_owned(),
+                    requested_at: event.ts,
+                    reason,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    if session.parent_session_id.is_none() && queued_at.is_none() && started_at.is_none() {
+        return None;
+    }
+
+    let phase = match session.state {
+        SessionState::Ready => "queued",
+        SessionState::Running => "running",
+        SessionState::Completed => "completed",
+        SessionState::Failed => "failed",
+        SessionState::TimedOut => "timed_out",
+    };
+    let timeout_seconds = started_timeout_seconds.or(queued_timeout_seconds);
+    let mode = execution
+        .as_ref()
+        .map(|execution| match execution.mode {
+            crate::conversation::ConstrainedSubagentMode::Async => "async",
+            crate::conversation::ConstrainedSubagentMode::Inline => "inline",
+        })
+        .unwrap_or_else(|| {
+            if queued_at.is_some() || matches!(session.state, SessionState::Ready) {
+                "async"
+            } else {
+                "inline"
+            }
+        });
+    let staleness = match session.state {
+        SessionState::Ready => {
+            session_delegate_staleness_at("queued", queued_at, timeout_seconds, now_ts)
+        }
+        SessionState::Running => session_delegate_staleness_at(
+            if started_at.is_some() {
+                "started"
+            } else {
+                "queued"
+            },
+            started_at.or(queued_at),
+            timeout_seconds,
+            now_ts,
+        ),
+        SessionState::Completed | SessionState::Failed | SessionState::TimedOut => None,
+    };
+    let cancellation = if session.state == SessionState::Running {
+        cancellation
+    } else {
+        None
+    };
+
+    Some(SessionDelegateLifecycleRecord {
+        mode,
+        phase,
+        queued_at,
+        started_at,
+        timeout_seconds,
+        execution,
+        staleness,
+        cancellation,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn session_delegate_lifecycle_json(lifecycle: SessionDelegateLifecycleRecord) -> Value {
+    json!({
+        "mode": lifecycle.mode,
+        "phase": lifecycle.phase,
+        "queued_at": lifecycle.queued_at,
+        "started_at": lifecycle.started_at,
+        "timeout_seconds": lifecycle.timeout_seconds,
+        "execution": lifecycle.execution,
+        "staleness": lifecycle.staleness.map(session_delegate_staleness_json),
+        "cancellation": lifecycle
+            .cancellation
+            .map(session_delegate_cancellation_json),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn session_event_json(event: SessionEventRecord) -> Value {
+    json!({
+        "id": event.id,
+        "session_id": event.session_id,
+        "event_kind": event.event_kind,
+        "actor_session_id": event.actor_session_id,
+        "payload_json": event.payload_json,
+        "ts": event.ts,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn session_terminal_outcome_json(outcome: SessionTerminalOutcomeRecord) -> Value {
+    json!({
+        "session_id": outcome.session_id,
+        "status": outcome.status,
+        "payload": outcome.payload_json,
+        "recorded_at": outcome.recorded_at,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn load_delegate_lifecycle_events(
+    repo: &SessionRepository,
+    session: &SessionSummaryRecord,
+) -> Result<Vec<SessionEventRecord>, String> {
+    if session.kind != SessionKind::DelegateChild {
+        return Ok(Vec::new());
+    }
+
+    repo.list_delegate_lifecycle_events(&session.session_id)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_terminal_outcome_state(state: SessionState, has_terminal_outcome: bool) -> &'static str {
+    if has_terminal_outcome {
+        return "present";
+    }
+    if session_state_is_terminal(state) {
+        return "missing";
+    }
+
+    "not_terminal"
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_terminal_outcome_missing_reason(
+    recovery: Option<&SessionRecoveryRecord>,
+) -> Option<String> {
+    recovery.map(|recovery| recovery.kind.clone())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_delegate_staleness_at(
+    reference: &'static str,
+    reference_at: Option<i64>,
+    timeout_seconds: Option<u64>,
+    now_ts: i64,
+) -> Option<SessionDelegateStalenessRecord> {
+    let reference_at = reference_at?;
+    let threshold_seconds = timeout_seconds?;
+    let elapsed_seconds = now_ts.saturating_sub(reference_at).max(0) as u64;
+    let deadline_at = reference_at.saturating_add(threshold_seconds.min(i64::MAX as u64) as i64);
+    let state = if elapsed_seconds > threshold_seconds {
+        "overdue"
+    } else {
+        "fresh"
+    };
+
+    Some(SessionDelegateStalenessRecord {
+        state,
+        reference,
+        elapsed_seconds,
+        threshold_seconds,
+        deadline_at,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_delegate_staleness_json(staleness: SessionDelegateStalenessRecord) -> Value {
+    json!({
+        "state": staleness.state,
+        "reference": staleness.reference,
+        "elapsed_seconds": staleness.elapsed_seconds,
+        "threshold_seconds": staleness.threshold_seconds,
+        "deadline_at": staleness.deadline_at,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_delegate_cancellation_json(cancellation: SessionDelegateCancellationRecord) -> Value {
+    json!({
+        "state": cancellation.state,
+        "reference": cancellation.reference,
+        "requested_at": cancellation.requested_at,
+        "reason": cancellation.reason,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn current_unix_ts() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SessionInspectionSnapshot, session_inspection_payload_at, session_state_is_terminal,
+    };
+    use crate::session::recovery::RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED;
+    use crate::session::repository::{
+        SessionEventRecord, SessionKind, SessionState, SessionSummaryRecord,
+    };
+
+    fn summary(state: SessionState, last_error: Option<&str>) -> SessionSummaryRecord {
+        SessionSummaryRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state,
+            created_at: 10,
+            updated_at: 20,
+            archived_at: None,
+            turn_count: 0,
+            last_turn_at: None,
+            last_error: last_error.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn session_state_is_terminal_only_reports_terminal_states() {
+        assert!(!session_state_is_terminal(SessionState::Ready));
+        assert!(!session_state_is_terminal(SessionState::Running));
+        assert!(session_state_is_terminal(SessionState::Completed));
+        assert!(session_state_is_terminal(SessionState::Failed));
+        assert!(session_state_is_terminal(SessionState::TimedOut));
+    }
+
+    #[test]
+    fn session_inspection_payload_synthesizes_recovery_for_missing_terminal_outcome() {
+        let snapshot = SessionInspectionSnapshot {
+            session: summary(
+                SessionState::Failed,
+                Some("delegate_terminal_finalize_failed: persist failed"),
+            ),
+            terminal_outcome: None,
+            recent_events: Vec::<SessionEventRecord>::new(),
+            delegate_events: Vec::<SessionEventRecord>::new(),
+        };
+
+        let payload = session_inspection_payload_at(snapshot, 200);
+
+        assert_eq!(payload["terminal_outcome_state"], "missing");
+        assert_eq!(
+            payload["terminal_outcome_missing_reason"],
+            RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED
+        );
+        assert_eq!(
+            payload["recovery"]["kind"],
+            RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED
+        );
+        assert_eq!(
+            payload["recovery"]["recovery_error"],
+            "delegate_terminal_finalize_failed: persist failed"
+        );
+    }
+
+    #[test]
+    fn session_inspection_payload_omits_recovery_for_non_terminal_session() {
+        let snapshot = SessionInspectionSnapshot {
+            session: summary(
+                SessionState::Ready,
+                Some("delegate_terminal_finalize_failed: persist failed"),
+            ),
+            terminal_outcome: None,
+            recent_events: Vec::<SessionEventRecord>::new(),
+            delegate_events: Vec::<SessionEventRecord>::new(),
+        };
+
+        let payload = session_inspection_payload_at(snapshot, 200);
+
+        assert_eq!(payload["terminal_outcome_state"], "not_terminal");
+        assert!(payload["terminal_outcome_missing_reason"].is_null());
+        assert!(payload["recovery"].is_null());
+    }
+}

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -2,6 +2,9 @@
 pub mod recovery;
 
 #[cfg(feature = "memory-sqlite")]
+pub mod inspection;
+
+#[cfg(feature = "memory-sqlite")]
 pub mod repository;
 
 #[allow(dead_code)]

--- a/crates/app/src/session/recovery.rs
+++ b/crates/app/src/session/recovery.rs
@@ -162,33 +162,30 @@ fn parse_recovery_event(event: &SessionEventRecord) -> Option<SessionRecoveryRec
         source: RECOVERY_SOURCE_EVENT.to_owned(),
         kind,
         event_kind: event.event_kind.clone(),
-        recovered_state: event
-            .payload_json
-            .get(RECOVERED_STATE_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        recovery_error: event
-            .payload_json
-            .get(RECOVERY_ERROR_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        original_error: event
-            .payload_json
-            .get(ORIGINAL_ERROR_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        attempted_terminal_event_kind: event
-            .payload_json
-            .get(ATTEMPTED_TERMINAL_EVENT_KIND_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        attempted_outcome_status: event
-            .payload_json
-            .get(ATTEMPTED_OUTCOME_STATUS_FIELD)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
+        recovered_state: normalized_payload_string(&event.payload_json, RECOVERED_STATE_FIELD),
+        recovery_error: normalized_payload_string(&event.payload_json, RECOVERY_ERROR_FIELD),
+        original_error: normalized_payload_string(&event.payload_json, ORIGINAL_ERROR_FIELD),
+        attempted_terminal_event_kind: normalized_payload_string(
+            &event.payload_json,
+            ATTEMPTED_TERMINAL_EVENT_KIND_FIELD,
+        ),
+        attempted_outcome_status: normalized_payload_string(
+            &event.payload_json,
+            ATTEMPTED_OUTCOME_STATUS_FIELD,
+        ),
         ts: event.ts,
     })
+}
+
+fn normalized_payload_string(payload_json: &Value, field: &str) -> Option<String> {
+    let field_value = payload_json.get(field)?;
+    let field_str = field_value.as_str()?;
+    let normalized = field_str.trim();
+    if normalized.is_empty() {
+        return None;
+    }
+
+    Some(field_str.to_owned())
 }
 
 fn synthesize_recovery_from_last_error(last_error: Option<&str>) -> SessionRecoveryRecord {
@@ -228,5 +225,225 @@ fn recovery_kind_from_last_error(last_error: Option<&str>) -> &'static str {
             RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED
         }
         Some(_) | None => RECOVERY_KIND_UNKNOWN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{
+        RECOVERY_EVENT_KIND, RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED,
+        RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
+        RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED,
+        RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED, RECOVERY_KIND_UNKNOWN,
+        RECOVERY_SOURCE_EVENT, RECOVERY_SOURCE_LAST_ERROR, RECOVERY_SOURCE_NONE,
+        SessionRecoveryRecord, build_async_spawn_failure_recovery_payload,
+        observe_missing_recovery, recovery_json, recovery_kind_from_last_error,
+    };
+    use crate::session::repository::SessionEventRecord;
+
+    fn recovery_event(payload_json: serde_json::Value, ts: i64) -> SessionEventRecord {
+        SessionEventRecord {
+            id: 1,
+            session_id: "child-session".to_owned(),
+            event_kind: RECOVERY_EVENT_KIND.to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json,
+            ts,
+        }
+    }
+
+    #[test]
+    fn build_async_spawn_failure_recovery_payload_keeps_expected_fields() {
+        let payload = build_async_spawn_failure_recovery_payload(
+            Some("Child"),
+            "spawn panic",
+            "persist failed",
+        );
+
+        assert_eq!(
+            payload["recovery_kind"],
+            RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        );
+        assert_eq!(payload["recovered_state"], "failed");
+        assert_eq!(payload["recovery_error"], "persist failed");
+        assert_eq!(payload["original_error"], "spawn panic");
+        assert_eq!(payload["label"], "Child");
+    }
+
+    #[test]
+    fn observe_missing_recovery_prefers_newest_recovery_event_over_last_error() {
+        let older_payload = json!({
+            "recovery_kind": "terminal_finalize_persist_failed",
+            "recovered_state": "failed",
+            "recovery_error": "older"
+        });
+        let older_event = recovery_event(older_payload, 11);
+        let newer_payload = json!({
+            "recovery_kind": "async_spawn_failure_persist_failed",
+            "recovered_state": "failed",
+            "recovery_error": "newer",
+            "original_error": "spawn failure"
+        });
+        let newer_event = recovery_event(newer_payload, 22);
+        let recent_events = vec![older_event, newer_event];
+        let recovery = observe_missing_recovery(
+            &recent_events,
+            Some("delegate_terminal_finalize_failed: fallback"),
+        );
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_EVENT);
+        assert_eq!(
+            recovery.kind,
+            RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        );
+        assert_eq!(recovery.recovery_error.as_deref(), Some("newer"));
+        assert_eq!(recovery.original_error.as_deref(), Some("spawn failure"));
+        assert_eq!(recovery.ts, 22);
+    }
+
+    #[test]
+    fn observe_missing_recovery_falls_back_to_last_error_when_event_missing() {
+        let recent_events = Vec::new();
+        let recovery = observe_missing_recovery(
+            &recent_events,
+            Some("delegate_async_queued_overdue_marked_failed: timed out"),
+        );
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_LAST_ERROR);
+        assert_eq!(
+            recovery.kind,
+            RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED
+        );
+        assert_eq!(
+            recovery.recovery_error.as_deref(),
+            Some("delegate_async_queued_overdue_marked_failed: timed out")
+        );
+        assert!(recovery.event_kind.is_empty());
+        assert_eq!(recovery.ts, 0);
+    }
+
+    #[test]
+    fn observe_missing_recovery_uses_none_source_when_metadata_is_missing() {
+        let recent_events = Vec::new();
+        let recovery = observe_missing_recovery(&recent_events, None);
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_NONE);
+        assert_eq!(recovery.kind, RECOVERY_KIND_UNKNOWN);
+        assert!(recovery.recovery_error.is_none());
+        assert!(recovery.event_kind.is_empty());
+        assert_eq!(recovery.ts, 0);
+    }
+
+    #[test]
+    fn recovery_kind_from_last_error_maps_known_prefixes() {
+        let terminal_kind =
+            recovery_kind_from_last_error(Some("delegate_terminal_finalize_failed: busy"));
+        let async_spawn_kind = recovery_kind_from_last_error(Some(
+            "delegate_async_spawn_failure_persist_failed: busy",
+        ));
+        let queued_kind = recovery_kind_from_last_error(Some(
+            "delegate_async_queued_overdue_marked_failed: busy",
+        ));
+        let running_kind = recovery_kind_from_last_error(Some(
+            "delegate_async_running_overdue_marked_failed: busy",
+        ));
+        let unknown_kind = recovery_kind_from_last_error(Some("opaque_failure"));
+
+        assert_eq!(
+            terminal_kind,
+            RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED
+        );
+        assert_eq!(
+            async_spawn_kind,
+            RECOVERY_KIND_ASYNC_SPAWN_FAILURE_PERSIST_FAILED
+        );
+        assert_eq!(
+            queued_kind,
+            RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED
+        );
+        assert_eq!(
+            running_kind,
+            RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED
+        );
+        assert_eq!(unknown_kind, RECOVERY_KIND_UNKNOWN);
+    }
+
+    #[test]
+    fn recovery_json_projects_null_for_empty_event_kind_and_zero_timestamp() {
+        let recovery = SessionRecoveryRecord {
+            source: RECOVERY_SOURCE_LAST_ERROR.to_owned(),
+            kind: RECOVERY_KIND_UNKNOWN.to_owned(),
+            event_kind: String::new(),
+            recovered_state: None,
+            recovery_error: Some("opaque_failure".to_owned()),
+            original_error: None,
+            attempted_terminal_event_kind: None,
+            attempted_outcome_status: None,
+            ts: 0,
+        };
+        let payload = recovery_json(recovery);
+
+        assert_eq!(payload["source"], RECOVERY_SOURCE_LAST_ERROR);
+        assert_eq!(payload["kind"], RECOVERY_KIND_UNKNOWN);
+        assert!(payload["event_kind"].is_null());
+        assert!(payload["ts"].is_null());
+    }
+
+    #[test]
+    fn observe_missing_recovery_normalizes_blank_optional_event_fields() {
+        let payload = json!({
+            "recovery_kind": "terminal_finalize_persist_failed",
+            "recovered_state": "",
+            "recovery_error": "",
+            "original_error": "",
+            "attempted_terminal_event_kind": "",
+            "attempted_outcome_status": ""
+        });
+        let event = recovery_event(payload, 33);
+        let recent_events = vec![event];
+        let recovery = observe_missing_recovery(&recent_events, None);
+
+        assert_eq!(recovery.source, RECOVERY_SOURCE_EVENT);
+        assert_eq!(
+            recovery.kind,
+            RECOVERY_KIND_TERMINAL_FINALIZE_PERSIST_FAILED
+        );
+        assert!(recovery.recovered_state.is_none());
+        assert!(recovery.recovery_error.is_none());
+        assert!(recovery.original_error.is_none());
+        assert!(recovery.attempted_terminal_event_kind.is_none());
+        assert!(recovery.attempted_outcome_status.is_none());
+    }
+
+    #[test]
+    fn observe_missing_recovery_preserves_non_blank_optional_event_fields() {
+        let payload = json!({
+            "recovery_kind": "terminal_finalize_persist_failed",
+            "recovered_state": " failed ",
+            "recovery_error": " persist failed ",
+            "original_error": " original failure ",
+            "attempted_terminal_event_kind": " terminal ",
+            "attempted_outcome_status": " error "
+        });
+        let event = recovery_event(payload, 44);
+        let recent_events = vec![event];
+        let recovery = observe_missing_recovery(&recent_events, None);
+
+        assert_eq!(recovery.recovered_state.as_deref(), Some(" failed "));
+        assert_eq!(recovery.recovery_error.as_deref(), Some(" persist failed "));
+        assert_eq!(
+            recovery.original_error.as_deref(),
+            Some(" original failure ")
+        );
+        assert_eq!(
+            recovery.attempted_terminal_event_kind.as_deref(),
+            Some(" terminal ")
+        );
+        assert_eq!(
+            recovery.attempted_outcome_status.as_deref(),
+            Some(" error ")
+        );
     }
 }

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -13,15 +13,20 @@ use super::payload::{optional_payload_limit, optional_payload_string, required_p
 
 use crate::config::{SessionVisibility, ToolConfig};
 #[cfg(feature = "memory-sqlite")]
-use crate::conversation::ConstrainedSubagentExecution;
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
+use crate::session::inspection::{
+    SessionDelegateLifecycleRecord, SessionInspectionSnapshot, SessionObservationSnapshot,
+    load_delegate_lifecycle_events, load_session_observation_snapshot,
+    session_delegate_lifecycle_at, session_delegate_lifecycle_json, session_event_json,
+    session_inspection_payload, session_state_is_terminal,
+};
+#[cfg(feature = "memory-sqlite")]
 use crate::session::recovery::{
     RECOVERY_EVENT_KIND, RECOVERY_KIND_QUEUED_ASYNC_OVERDUE_MARKED_FAILED,
-    RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED, SessionRecoveryRecord,
-    build_queued_async_overdue_recovery_payload, build_running_async_overdue_recovery_payload,
-    observe_missing_recovery, recovery_json,
+    RECOVERY_KIND_RUNNING_ASYNC_OVERDUE_MARKED_FAILED, build_queued_async_overdue_recovery_payload,
+    build_running_async_overdue_recovery_payload,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::session::{
@@ -31,8 +36,7 @@ use crate::session::{
 
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    SessionEventRecord, SessionKind, SessionObservationRecord, SessionRepository, SessionState,
-    SessionSummaryRecord, SessionTerminalOutcomeRecord,
+    SessionEventRecord, SessionKind, SessionRepository, SessionState, SessionSummaryRecord,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -51,54 +55,6 @@ fn delegate_error_outcome(
             "error": error,
         }),
     }
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq)]
-pub(super) struct SessionInspectionSnapshot {
-    pub session: SessionSummaryRecord,
-    pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
-    pub recent_events: Vec<SessionEventRecord>,
-    pub delegate_events: Vec<SessionEventRecord>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq)]
-pub(super) struct SessionObservationSnapshot {
-    pub inspection: SessionInspectionSnapshot,
-    pub tail_events: Vec<SessionEventRecord>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SessionDelegateLifecycleRecord {
-    mode: &'static str,
-    phase: &'static str,
-    queued_at: Option<i64>,
-    started_at: Option<i64>,
-    timeout_seconds: Option<u64>,
-    execution: Option<ConstrainedSubagentExecution>,
-    staleness: Option<SessionDelegateStalenessRecord>,
-    cancellation: Option<SessionDelegateCancellationRecord>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SessionDelegateStalenessRecord {
-    state: &'static str,
-    reference: &'static str,
-    elapsed_seconds: u64,
-    threshold_seconds: u64,
-    deadline_at: i64,
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SessionDelegateCancellationRecord {
-    state: &'static str,
-    reference: String,
-    requested_at: i64,
-    reason: String,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1214,113 +1170,13 @@ pub(super) fn observe_visible_session_with_policies(
         &target_session_id,
         tool_config.sessions.visibility,
     )?;
-    let SessionObservationRecord {
-        session,
-        terminal_outcome,
-        recent_events,
-        tail_events,
-    } = repo
-        .load_session_observation(
-            &target_session_id,
-            recent_event_limit,
-            tail_after_id,
-            tail_page_limit,
-        )?
-        .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
-    let delegate_events = load_delegate_lifecycle_events(&repo, &session)?;
-
-    Ok(SessionObservationSnapshot {
-        inspection: SessionInspectionSnapshot {
-            session,
-            terminal_outcome,
-            recent_events,
-            delegate_events,
-        },
-        tail_events,
-    })
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn load_delegate_lifecycle_events(
-    repo: &SessionRepository,
-    session: &SessionSummaryRecord,
-) -> Result<Vec<SessionEventRecord>, String> {
-    if session.kind != SessionKind::DelegateChild {
-        return Ok(Vec::new());
-    }
-    repo.list_delegate_lifecycle_events(&session.session_id)
-}
-
-#[cfg(feature = "memory-sqlite")]
-pub(super) fn session_state_is_terminal(state: SessionState) -> bool {
-    matches!(
-        state,
-        SessionState::Completed | SessionState::Failed | SessionState::TimedOut
+    load_session_observation_snapshot(
+        &repo,
+        &target_session_id,
+        recent_event_limit,
+        tail_after_id,
+        tail_page_limit,
     )
-}
-
-#[cfg(feature = "memory-sqlite")]
-pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) -> Value {
-    let terminal_outcome_state =
-        session_terminal_outcome_state(snapshot.session.state, snapshot.terminal_outcome.is_some());
-    let delegate_lifecycle = session_delegate_lifecycle_at(
-        &snapshot.session,
-        snapshot.delegate_events.as_slice(),
-        current_unix_ts(),
-    );
-    let recovery = match terminal_outcome_state {
-        "missing" => Some(observe_missing_recovery(
-            snapshot.recent_events.as_slice(),
-            snapshot.session.last_error.as_deref(),
-        )),
-        _ => None,
-    };
-    let terminal_outcome_missing_reason = match terminal_outcome_state {
-        "missing" => session_terminal_outcome_missing_reason(recovery.as_ref()),
-        _ => None,
-    };
-    json!({
-        "session": {
-            "session_id": snapshot.session.session_id,
-            "kind": snapshot.session.kind.as_str(),
-            "parent_session_id": snapshot.session.parent_session_id,
-            "label": snapshot.session.label,
-            "state": snapshot.session.state.as_str(),
-            "created_at": snapshot.session.created_at,
-            "updated_at": snapshot.session.updated_at,
-            "archived": snapshot.session.archived_at.is_some(),
-            "archived_at": snapshot.session.archived_at,
-            "last_error": snapshot.session.last_error,
-        },
-        "terminal_outcome_state": terminal_outcome_state,
-        "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
-        "delegate_lifecycle": delegate_lifecycle.map(session_delegate_lifecycle_json),
-        "recovery": recovery.map(recovery_json),
-        "terminal_outcome": snapshot.terminal_outcome.map(session_terminal_outcome_json),
-        "recent_events": snapshot
-            .recent_events
-            .into_iter()
-            .map(session_event_json)
-            .collect::<Vec<_>>(),
-    })
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn session_terminal_outcome_state(state: SessionState, has_terminal_outcome: bool) -> &'static str {
-    if has_terminal_outcome {
-        "present"
-    } else if session_state_is_terminal(state) {
-        "missing"
-    } else {
-        "not_terminal"
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn session_terminal_outcome_missing_reason(
-    recovery: Option<&SessionRecoveryRecord>,
-) -> Option<String> {
-    recovery.map(|recovery| recovery.kind.clone())
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1957,201 +1813,6 @@ fn build_session_cancel_plan(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn session_delegate_lifecycle_at(
-    session: &SessionSummaryRecord,
-    recent_events: &[SessionEventRecord],
-    now_ts: i64,
-) -> Option<SessionDelegateLifecycleRecord> {
-    if session.kind != SessionKind::DelegateChild {
-        return None;
-    }
-
-    let mut queued_at = None;
-    let mut started_at = None;
-    let mut queued_timeout_seconds = None;
-    let mut started_timeout_seconds = None;
-    let mut execution = None;
-    let mut cancellation = None;
-    for event in recent_events {
-        match event.event_kind.as_str() {
-            "delegate_queued" => {
-                queued_at = Some(event.ts);
-                execution = execution.or_else(|| {
-                    ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
-                });
-                queued_timeout_seconds = event
-                    .payload_json
-                    .get("timeout_seconds")
-                    .and_then(Value::as_u64)
-                    .or_else(|| {
-                        execution
-                            .as_ref()
-                            .map(|execution| execution.timeout_seconds)
-                    });
-            }
-            "delegate_started" => {
-                started_at = Some(event.ts);
-                execution = execution.or_else(|| {
-                    ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
-                });
-                started_timeout_seconds = event
-                    .payload_json
-                    .get("timeout_seconds")
-                    .and_then(Value::as_u64)
-                    .or_else(|| {
-                        execution
-                            .as_ref()
-                            .map(|execution| execution.timeout_seconds)
-                    });
-            }
-            DELEGATE_CANCEL_REQUESTED_EVENT_KIND => {
-                let reason = event
-                    .payload_json
-                    .get("cancel_reason")
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .unwrap_or(DELEGATE_CANCEL_REASON_OPERATOR_REQUESTED)
-                    .to_owned();
-                let reference = event
-                    .payload_json
-                    .get("reference")
-                    .and_then(Value::as_str)
-                    .filter(|value| *value == "running")
-                    .unwrap_or("running");
-                cancellation = Some(SessionDelegateCancellationRecord {
-                    state: "requested",
-                    reference: reference.to_owned(),
-                    requested_at: event.ts,
-                    reason,
-                });
-            }
-            _ => {}
-        }
-    }
-
-    if session.parent_session_id.is_none() && queued_at.is_none() && started_at.is_none() {
-        return None;
-    }
-
-    let phase = match session.state {
-        SessionState::Ready => "queued",
-        SessionState::Running => "running",
-        SessionState::Completed => "completed",
-        SessionState::Failed => "failed",
-        SessionState::TimedOut => "timed_out",
-    };
-    let timeout_seconds = started_timeout_seconds.or(queued_timeout_seconds);
-    let mode = execution
-        .as_ref()
-        .map(|execution| match execution.mode {
-            crate::conversation::ConstrainedSubagentMode::Async => "async",
-            crate::conversation::ConstrainedSubagentMode::Inline => "inline",
-        })
-        .unwrap_or_else(|| {
-            if queued_at.is_some() || matches!(session.state, SessionState::Ready) {
-                "async"
-            } else {
-                "inline"
-            }
-        });
-    let staleness = match session.state {
-        SessionState::Ready => {
-            session_delegate_staleness_at("queued", queued_at, timeout_seconds, now_ts)
-        }
-        SessionState::Running => session_delegate_staleness_at(
-            if started_at.is_some() {
-                "started"
-            } else {
-                "queued"
-            },
-            started_at.or(queued_at),
-            timeout_seconds,
-            now_ts,
-        ),
-        SessionState::Completed | SessionState::Failed | SessionState::TimedOut => None,
-    };
-
-    Some(SessionDelegateLifecycleRecord {
-        mode,
-        phase,
-        queued_at,
-        started_at,
-        timeout_seconds,
-        execution,
-        staleness,
-        cancellation: if session.state == SessionState::Running {
-            cancellation
-        } else {
-            None
-        },
-    })
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn session_delegate_staleness_at(
-    reference: &'static str,
-    reference_at: Option<i64>,
-    timeout_seconds: Option<u64>,
-    now_ts: i64,
-) -> Option<SessionDelegateStalenessRecord> {
-    let reference_at = reference_at?;
-    let threshold_seconds = timeout_seconds?;
-    let elapsed_seconds = now_ts.saturating_sub(reference_at).max(0) as u64;
-    let deadline_at = reference_at.saturating_add(threshold_seconds.min(i64::MAX as u64) as i64);
-    let state = if elapsed_seconds > threshold_seconds {
-        "overdue"
-    } else {
-        "fresh"
-    };
-
-    Some(SessionDelegateStalenessRecord {
-        state,
-        reference,
-        elapsed_seconds,
-        threshold_seconds,
-        deadline_at,
-    })
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn session_delegate_lifecycle_json(lifecycle: SessionDelegateLifecycleRecord) -> Value {
-    json!({
-        "mode": lifecycle.mode,
-        "phase": lifecycle.phase,
-        "queued_at": lifecycle.queued_at,
-        "started_at": lifecycle.started_at,
-        "timeout_seconds": lifecycle.timeout_seconds,
-        "execution": lifecycle.execution,
-        "staleness": lifecycle.staleness.map(session_delegate_staleness_json),
-        "cancellation": lifecycle
-            .cancellation
-            .map(session_delegate_cancellation_json),
-    })
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn session_delegate_staleness_json(staleness: SessionDelegateStalenessRecord) -> Value {
-    json!({
-        "state": staleness.state,
-        "reference": staleness.reference,
-        "elapsed_seconds": staleness.elapsed_seconds,
-        "threshold_seconds": staleness.threshold_seconds,
-        "deadline_at": staleness.deadline_at,
-    })
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn session_delegate_cancellation_json(cancellation: SessionDelegateCancellationRecord) -> Value {
-    json!({
-        "state": cancellation.state,
-        "reference": cancellation.reference,
-        "requested_at": cancellation.requested_at,
-        "reason": cancellation.reason,
-    })
-}
-
-#[cfg(feature = "memory-sqlite")]
 fn current_unix_ts() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2569,30 +2230,6 @@ fn session_summary_json_with_delegate_lifecycle(
         );
     }
     payload
-}
-
-#[cfg(feature = "memory-sqlite")]
-pub(super) fn session_event_json(event: SessionEventRecord) -> Value {
-    json!({
-        "id": event.id,
-        "session_id": event.session_id,
-        "event_kind": event.event_kind,
-        "actor_session_id": event.actor_session_id,
-        "payload_json": event.payload_json,
-        "ts": event.ts,
-    })
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn session_terminal_outcome_json(
-    outcome: crate::session::repository::SessionTerminalOutcomeRecord,
-) -> Value {
-    json!({
-        "session_id": outcome.session_id,
-        "status": outcome.status,
-        "payload": outcome.payload_json,
-        "recorded_at": outcome.recorded_at,
-    })
 }
 
 #[cfg(test)]
@@ -4537,8 +4174,9 @@ mod tests {
             ts: 100,
         }];
 
-        let lifecycle = super::session_delegate_lifecycle_at(&session, &events, 140)
-            .expect("delegate lifecycle");
+        let lifecycle =
+            crate::session::inspection::session_delegate_lifecycle_at(&session, &events, 140)
+                .expect("delegate lifecycle");
 
         assert_eq!(lifecycle.mode, "async");
         assert_eq!(lifecycle.phase, "queued");
@@ -4807,8 +4445,9 @@ mod tests {
             },
         ];
 
-        let lifecycle = super::session_delegate_lifecycle_at(&session, &events, 130)
-            .expect("delegate lifecycle");
+        let lifecycle =
+            crate::session::inspection::session_delegate_lifecycle_at(&session, &events, 130)
+                .expect("delegate lifecycle");
 
         assert_eq!(
             lifecycle.mode, "async",

--- a/docs/plans/2026-04-01-session-inspection-read-model-design.md
+++ b/docs/plans/2026-04-01-session-inspection-read-model-design.md
@@ -1,0 +1,179 @@
+# Session Inspection Read Model Extraction Design
+
+**Date:** 2026-04-01
+
+**Tracking Issue:** `loongclaw-ai/loongclaw#776`
+
+**Goal:** Extract the session inspection read-side model from `crates/app/src/tools/session.rs` into a dedicated `session` domain module so observation assembly, delegate lifecycle inference, recovery synthesis, and inspection payload shaping no longer live inside the tool surface.
+
+## Problem
+
+`crates/app/src/tools/session.rs` currently owns several different responsibilities at once:
+
+- tool request parsing and output wiring
+- repository-backed observation loading
+- delegate lifecycle inference
+- missing terminal outcome interpretation
+- recovery projection
+- inspection JSON shaping
+
+That shape was acceptable while the feature set was still narrow, but it is now a structural liability.
+
+The main issue is not line count by itself.
+The issue is that the tool surface owns domain rules that should be reusable and testable without going through the session tool entrypoint.
+
+That has three concrete costs:
+
+- read-side session behavior is harder to reuse from future operator or SDK surfaces
+- `tools/session.rs` review scope stays wide even for narrow domain fixes
+- read-side logic drifts independently from the write-side operator seams that were already extracted into `operator::delegate_runtime`
+
+## Current State
+
+The current read-side inspection flow spans these seams:
+
+- `SessionRepository::load_session_observation(...)` returns the raw repository snapshot
+- `tools/session.rs` builds `SessionInspectionSnapshot`
+- `tools/session.rs` loads delegate lifecycle events
+- `tools/session.rs` derives delegate lifecycle state
+- `tools/session.rs` synthesizes missing recovery information
+- `tools/session.rs` emits the final JSON payload
+
+This means the session tool is acting as both a transport surface and a domain read model owner.
+
+## Proposed Cut
+
+Create a new internal module:
+
+- `crates/app/src/session/inspection.rs`
+
+Move the session inspection read-side model into that module.
+
+The new module should own:
+
+- read-side snapshot structs used by inspection
+- repository-backed observation loading helpers
+- delegate lifecycle derivation
+- terminal outcome state derivation
+- missing-recovery interpretation
+- inspection JSON projection
+
+`tools/session.rs` should keep only:
+
+- tool payload parsing
+- tool-level option defaults and validation
+- action orchestration for list, inspect, wait, recover, cancel, archive
+- response formatting specific to the tool surface
+
+## Proposed API Shape
+
+The first iteration should stay intentionally narrow.
+
+I recommend exposing only a small internal API from `session::inspection`:
+
+- `load_session_observation_snapshot(...) -> Result<SessionObservationSnapshot, String>`
+- `session_inspection_payload(...) -> Value`
+- `session_state_is_terminal(...) -> bool`
+
+The new module can keep additional helper structs and helper functions private unless another caller already needs them.
+
+This is the smallest extraction that still moves ownership cleanly.
+
+## Behavioral Rules To Preserve
+
+This cut should not change user-visible session inspection behavior.
+
+The extraction must preserve:
+
+- the current inspection JSON field names
+- the current delegate lifecycle payload shape
+- the current recovery payload shape
+- the current newest-recovery-event-over-`last_error` precedence
+- the current rule that only delegate children expose delegate lifecycle
+- the current rule that missing terminal outcomes only synthesize recovery for terminal sessions
+
+## Testing Strategy
+
+The safest path is to keep the outer session-tool integration tests green while adding a few focused tests near the new module boundary.
+
+That should include:
+
+- preserving current `session_status_*` recovery expectations
+- preserving current delegate lifecycle payload expectations
+- adding direct unit coverage around the new inspection module for:
+  - missing terminal outcome state derivation
+  - recovery attachment rules
+  - delegate lifecycle derivation from event history
+
+The goal is not to redesign the behavior.
+The goal is to make the behavior locally testable under its true owner.
+
+## Alternatives Considered
+
+### 1. Full typed read model plus separate serializer
+
+This would be architecturally cleaner in the long run.
+
+I am not choosing it now because it would widen the diff substantially.
+It would mix ownership extraction with payload redesign risk.
+
+### 2. Keep logic in `tools/session.rs` and only add comments or tests
+
+This is the cheapest short-term path.
+
+I am not choosing it because it does not solve the ownership problem.
+It keeps future SDK-facing reuse blocked on the tool surface.
+
+### 3. Extract both read-side inspection and write-side session mutations together
+
+This would create a broader `session` service layer in one pass.
+
+I am not choosing it because it is too wide for the next stacked PR.
+It would blur whether regressions come from read-side extraction or write-side refactoring.
+
+## Why This Cut
+
+This cut is the best next step after the recent delegate runtime and recovery work.
+
+The write-side operator seam already exists.
+The recovery helper contract is now directly fenced.
+The largest remaining structural concentration is the read-side inspection model in `tools/session.rs`.
+
+Extracting that read-side seam now gives the highest structural payoff for the lowest behavior risk.
+
+## Scope
+
+In scope:
+
+- add `session::inspection`
+- move session inspection read-side types and helpers out of `tools/session.rs`
+- preserve existing inspection JSON behavior
+- add direct tests for the extracted read-side seam
+
+Out of scope:
+
+- redesign session inspection payloads
+- change repository schemas
+- change delegate child write-side creation
+- extract session mutation services for cancel, recover, or archive
+- expose a new public SDK surface in this pass
+
+## Validation Plan
+
+This work should be validated with:
+
+- focused tests for the new inspection module
+- existing `tools/session.rs` integration tests that cover delegate lifecycle and recovery inspection
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+## Expected Outcome
+
+After this lands:
+
+- `tools/session.rs` becomes a thinner tool surface
+- session inspection behavior has a clear domain owner
+- future session inspection reuse from operator or SDK surfaces becomes easier
+- the next refactor can target write-side session actions without mixing in read-side inspection rules

--- a/docs/plans/2026-04-01-session-inspection-read-model-implementation-plan.md
+++ b/docs/plans/2026-04-01-session-inspection-read-model-implementation-plan.md
@@ -1,0 +1,257 @@
+# Session Inspection Read Model Extraction Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Tracking Issue:** `loongclaw-ai/loongclaw#776`
+
+**Goal:** Extract the session inspection read-side model from `tools/session.rs` into `session::inspection` without changing the existing inspection payload contract.
+
+**Architecture:** Introduce a dedicated `session::inspection` internal module that owns repository-backed observation loading, delegate lifecycle derivation, recovery attachment, and inspection JSON assembly. Keep the session tool surface as an orchestration and request/response adapter layer. Preserve current behavior first; do not redesign the payload shape in this pass.
+
+**Tech Stack:** Rust, `serde_json`, existing `SessionRepository`, existing `session::recovery` helpers, existing session tool integration tests, workspace cargo verification.
+
+---
+
+### Task 1: Add the new session inspection module skeleton
+
+**Files:**
+- Modify: `crates/app/src/session/mod.rs`
+- Create: `crates/app/src/session/inspection.rs`
+
+**Step 1: Create the new module export**
+
+Add:
+
+```rust
+#[cfg(feature = "memory-sqlite")]
+pub mod inspection;
+```
+
+**Step 2: Create the destination module with compile-only placeholders**
+
+Start with:
+
+```rust
+#[cfg(feature = "memory-sqlite")]
+use serde_json::Value;
+```
+
+and the first extracted structs and function signatures.
+
+**Step 3: Run compile-focused check**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app --lib session::recovery -- --nocapture
+```
+
+Expected:
+- compile still succeeds while the new module is introduced incrementally
+
+### Task 2: Move the read-side snapshot and observation-loading types
+
+**Files:**
+- Modify: `crates/app/src/session/inspection.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Move these structs into `session::inspection`**
+
+Move:
+
+- `SessionInspectionSnapshot`
+- `SessionObservationSnapshot`
+
+**Step 2: Move repository-backed observation loading helpers**
+
+Move:
+
+- the helper that loads the observation snapshot from `SessionRepository`
+- the helper that loads delegate lifecycle events for delegate children
+
+Keep function names descriptive and domain-owned.
+
+**Step 3: Update `tools/session.rs` call sites to use the new module**
+
+Replace local calls with imports from `crate::session::inspection`.
+
+**Step 4: Run targeted inspection tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app session_status -- --nocapture
+```
+
+Expected:
+- existing session status tests still pass after the move
+
+### Task 3: Move delegate lifecycle derivation into the new module
+
+**Files:**
+- Modify: `crates/app/src/session/inspection.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Move the read-side lifecycle structs**
+
+Move:
+
+- `SessionDelegateLifecycleRecord`
+- `SessionDelegateStalenessRecord`
+- `SessionDelegateCancellationRecord`
+
+**Step 2: Move the derivation helpers**
+
+Move:
+
+- `session_delegate_lifecycle_at(...)`
+- `session_delegate_staleness_at(...)`
+- JSON helpers for lifecycle, staleness, and cancellation
+
+**Step 3: Preserve current JSON shape exactly**
+
+Do not rename fields.
+Do not add or remove payload keys.
+
+**Step 4: Run focused lifecycle tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app session_delegate_lifecycle -- --nocapture
+```
+
+Expected:
+- lifecycle-specific tests stay green
+
+### Task 4: Move terminal outcome and recovery attachment rules
+
+**Files:**
+- Modify: `crates/app/src/session/inspection.rs`
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Move the inspection payload assembly helpers**
+
+Move:
+
+- `session_state_is_terminal(...)`
+- `session_terminal_outcome_state(...)`
+- `session_terminal_outcome_missing_reason(...)`
+- `session_inspection_payload(...)`
+
+**Step 2: Keep recovery synthesis delegated to `session::recovery`**
+
+Use:
+
+- `observe_missing_recovery(...)`
+- `recovery_json(...)`
+
+Do not duplicate recovery logic in the new module.
+
+**Step 3: Add direct tests near the new owner**
+
+Add tests for:
+
+- terminal sessions with missing terminal outcome attach recovery
+- non-terminal sessions do not attach recovery
+- missing terminal outcome reason tracks the recovery kind
+
+**Step 4: Run targeted recovery-facing inspection tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app session_status_synthesizes_recovery -- --nocapture
+```
+
+Expected:
+- recovery-facing inspection behavior remains unchanged
+
+### Task 5: Thin `tools/session.rs` down to the tool surface
+
+**Files:**
+- Modify: `crates/app/src/tools/session.rs`
+
+**Step 1: Remove the extracted duplicate definitions from the tool module**
+
+Delete moved structs and helper functions from `tools/session.rs`.
+
+**Step 2: Replace them with narrow imports from `session::inspection`**
+
+Keep only tool-surface orchestration logic in the file.
+
+**Step 3: Re-read the file for remaining structural mixing**
+
+Specifically check that `tools/session.rs` no longer owns:
+
+- observation loading details
+- lifecycle derivation details
+- inspection payload assembly
+
+### Task 6: Run crate-level verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run formatting**
+
+```bash
+cargo fmt --all -- --check
+```
+
+**Step 2: Run strict lint**
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+**Step 3: Run workspace tests**
+
+```bash
+cargo test --workspace --locked
+```
+
+**Step 4: Run all-feature workspace tests**
+
+```bash
+cargo test --workspace --all-features --locked
+```
+
+Expected:
+- all verification passes
+- if a baseline-only failure appears, stop and document it explicitly
+
+### Task 7: Commit and deliver
+
+**Files:**
+- Only the files touched by this extraction
+
+**Step 1: Inspect staged scope**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected:
+- only inspection extraction files and supporting tests/docs are staged
+
+**Step 2: Commit**
+
+Use a narrow message such as:
+
+```bash
+git commit -m "refactor(app): extract session inspection read model"
+```
+
+**Step 3: Push and open a stacked PR**
+
+Use:
+
+- issue-first workflow
+- English GitHub text
+- `--body-file` for multi-line markdown
+- explicit stacked-branch note

--- a/docs/plans/2026-04-01-session-recovery-contract-tests-design.md
+++ b/docs/plans/2026-04-01-session-recovery-contract-tests-design.md
@@ -1,0 +1,61 @@
+# Session Recovery Contract Tests Design
+
+**Date:** 2026-04-01
+
+**Goal:** Add direct unit coverage for `crates/app/src/session/recovery.rs` so recovery payload construction, fallback synthesis, and JSON projection cannot drift behind broader coordinator and session-tool behavior.
+
+## Problem
+
+`session::recovery` currently owns the lowest-level recovery contract for:
+- async spawn failure recovery payloads
+- missing-recovery observation rules
+- `last_error` to recovery-kind synthesis
+- JSON projection returned to higher layers
+
+Those semantics are exercised today only through higher-level coordinator and session-tool tests. That coverage is valuable, but it is indirect. A future refactor could change helper behavior while still keeping most end-to-end tests green because the surrounding orchestration remains intact.
+
+## Proposed Scope
+
+This iteration adds focused unit tests under `crates/app/src/session/recovery.rs`.
+
+It will verify:
+- `build_async_spawn_failure_recovery_payload(...)` preserves the expected shape
+- `observe_missing_recovery(...)` prefers the newest recovery event over `last_error`
+- `observe_missing_recovery(...)` falls back to `last_error` synthesis when no recovery event exists
+- `recovery_kind_from_last_error(...)` maps each known prefix to the correct recovery kind
+- `recovery_json(...)` emits `null` for empty event kinds and zero timestamps
+
+## Non-Goals
+
+This iteration will not:
+- extract a new read-side helper for delegate child boundary reconstruction
+- change `conversation/runtime.rs`
+- change `conversation/turn_coordinator.rs`
+- change operator runtime ownership boundaries
+- redesign recovery payload fields
+
+## Why This Cut
+
+I considered two alternatives:
+
+1. Extract the delegate read-side helper first.
+
+That would move more architecture forward, but it would touch more behavior at once and would still leave the recovery helper contract under-tested.
+
+2. Combine read-side extraction and recovery tests in one pass.
+
+That would be faster in raw throughput, but it would produce a wider review surface and blur whether failures come from helper drift or ownership refactoring.
+
+The chosen cut is smaller and cleaner. It strengthens the test fence first, which lowers the risk of the next ownership extraction.
+
+## Validation Plan
+
+The change should be validated with:
+- targeted `session::recovery` unit tests
+- `cargo test -p loongclaw-app --lib session::recovery`
+- `cargo test --workspace --locked`
+- `cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings`
+
+## Expected Outcome
+
+After this lands, recovery contract drift should fail fast in a local unit test instead of surfacing later through coordinator or session-tool regressions.

--- a/docs/plans/2026-04-01-session-recovery-contract-tests-implementation-plan.md
+++ b/docs/plans/2026-04-01-session-recovery-contract-tests-implementation-plan.md
@@ -1,0 +1,151 @@
+# Session Recovery Contract Tests Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add direct unit tests for `session::recovery` so delegate recovery payload and fallback semantics are locked by local contract tests.
+
+**Architecture:** Keep production behavior unchanged unless a test exposes a genuine contract bug. Add tests next to `session::recovery` for payload construction, event-vs-error precedence, kind synthesis, and JSON projection. Do not widen this pass into read-side ownership refactors.
+
+**Tech Stack:** Rust, `serde_json`, existing session recovery types, focused unit tests in `crates/app/src/session/recovery.rs`, workspace cargo verification.
+
+---
+
+### Task 1: Add the failing unit tests for the recovery helper contract
+
+**Files:**
+- Modify: `crates/app/src/session/recovery.rs`
+- Create: `docs/plans/2026-04-01-session-recovery-contract-tests-design.md`
+- Create: `docs/plans/2026-04-01-session-recovery-contract-tests-implementation-plan.md`
+
+**Step 1: Write the failing tests**
+
+Add tests that cover:
+- async spawn failure recovery payload fields
+- newest recovery event winning over `last_error`
+- `last_error` fallback synthesis when no event exists
+- known prefix to recovery-kind mapping
+- `recovery_json(...)` null projection for empty event kind and zero timestamp
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app --lib session::recovery
+```
+
+Expected:
+- at least one new recovery test fails before the helper behavior or visibility is adjusted
+
+**Step 3: Keep the red state local**
+
+Do not commit or push a broken tree. Confirm the failing signal locally before any implementation step.
+
+### Task 2: Make the helper contract explicit with minimal code changes
+
+**Files:**
+- Modify: `crates/app/src/session/recovery.rs`
+
+**Step 1: Implement the smallest behavior or visibility adjustment needed**
+
+Only change production code if a test reveals a real gap.
+
+Keep each line atomic:
+- one lookup per line
+- one conversion per line
+- one condition per line
+
+**Step 2: Re-run the targeted tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app --lib session::recovery
+```
+
+Expected:
+- all new recovery tests pass
+
+### Task 3: Verify nearby behavior still holds
+
+**Files:**
+- Verify only
+
+**Step 1: Run the closest session-tool and coordinator recovery tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app --all-features session_status_synthesizes_recovery
+cargo test -p loongclaw-app --all-features finalize_async_delegate_spawn_failure
+```
+
+Expected:
+- existing higher-level recovery behavior remains green
+
+**Step 2: Run lint on the touched crate**
+
+Run:
+
+```bash
+cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
+```
+
+Expected:
+- no warnings
+
+### Task 4: Run broad verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run workspace tests**
+
+```bash
+cargo test --workspace --locked
+```
+
+**Step 2: Run all-feature workspace tests**
+
+```bash
+cargo test --workspace --all-features --locked
+```
+
+Expected:
+- workspace verification passes
+- if an unrelated blocker appears, stop and document it explicitly before claiming completion
+
+### Task 5: Commit and deliver cleanly
+
+**Files:**
+- Modify only the files touched by this plan
+
+**Step 1: Inspect staged scope**
+
+Run:
+
+```bash
+git status --short
+git diff --cached --name-only
+git diff --cached
+```
+
+Expected:
+- only the intended recovery test and planning files are staged
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-04-01-session-recovery-contract-tests-design.md
+git add docs/plans/2026-04-01-session-recovery-contract-tests-implementation-plan.md
+git add crates/app/src/session/recovery.rs
+git commit -m "test(app): lock session recovery helper contracts"
+```
+
+**Step 3: Push and open the stacked PR**
+
+Use the issue template and PR template workflow:
+- issue first
+- English GitHub text
+- `--body-file` for multi-line Markdown
+- explicit stacked-branch note in the PR body


### PR DESCRIPTION
## Summary

- Problem: `crates/app/src/tools/session.rs` owned session inspection read-side loading, payload synthesis, and delegate lifecycle projection, which kept tool-surface orchestration coupled to read-model semantics.
- Why it matters: That coupling makes the session tool harder to evolve and leaves no clear read-side owner for future inspection surfaces or SDK-facing reuse.
- What changed: added `crate::session::inspection` as the read-side owner for observation snapshots, inspection payload synthesis, delegate lifecycle projection, and related JSON helpers; rewired `tools/session.rs` to consume that module; added direct tests for terminal-state classification and missing terminal-outcome recovery synthesis.
- Stack note: this work is logically stacked on #775; GitHub cannot target the fork-only `feat/operator-recovery-contract-tests-phase3` head as an upstream base branch, so this PR targets `feat/operator-delegate-runtime-phase2` for review transport.
- What did not change (scope boundary): no session payload schema changes, no write-side extraction, no delegate runtime changes, and no new public API surface.

## Linked Issues

- Closes #776
- Related #775

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- PASS

LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
- PASS

scripts/check_dep_graph.sh
- PASS

cargo clippy -p loongclaw-app --all-targets --all-features -- -D warnings
- PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
- PASS

cargo test -p loongclaw-app session::inspection::tests -- --nocapture
- PASS

cargo test -p loongclaw-app session_delegate_lifecycle -- --nocapture
- PASS

cargo test -p loongclaw-app session_status -- --nocapture
- PASS

cargo test -p loongclaw-app --locked
- PASS

cargo test -p loongclaw-app --all-features --locked -- --test-threads=1
- PASS

cargo test --workspace --all-features --locked
- PASS

cargo test --workspace --locked -- --test-threads=1
- PASS

cargo test --workspace --locked
- FAIL in this local environment under default parallel execution.
  Observed ACPX timing-sensitive test failures:
  - acp::acpx::tests::runtime_backend_executes_session_turn_and_controls
  - acp::acpx::tests::runtime_backend_supports_local_abort_for_running_prompt
  Both tests pass when isolated, and the full workspace suite passes serially, which points to existing ACPX parallel timing instability rather than a deterministic regression from this refactor.
```

## User-visible / Operator-visible Changes

- None. This keeps the existing session inspection response schema stable while moving read-side ownership into `crate::session::inspection`.

## Failure Recovery

- Fast rollback or disable path: revert commit `6382b591` on top of this stacked branch.
- Observable failure symptoms reviewers should watch for: `session_status` or related inspection payloads dropping `delegate_lifecycle`, `recovery`, `terminal_outcome_state`, `terminal_outcome_missing_reason`, or `recent_events`.

## Reviewer Focus

- Compare the ownership split between `crates/app/src/tools/session.rs` and `crates/app/src/session/inspection.rs`; the tool surface should keep orchestration while the new module owns read-side semantics.
- Treat commit `2cd273bf` as already-covered stack context from #775 and focus review on `e6b36f00` and `6382b591`.
- Check payload parity for `delegate_lifecycle`, `recovery`, `terminal_outcome`, and `recent_events`.
- Review the new direct tests for missing terminal outcomes and non-terminal recovery suppression.
