### PR TITLE
chore: prepare loongclaw crates.io publish flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           python3 -c "from pathlib import Path; compile(Path('scripts/sync_github_labels.py').read_text(), 'scripts/sync_github_labels.py', 'exec')"
           bash -n scripts/check_glibc_floor.sh
           bash -n scripts/install.sh
+          bash -n scripts/publish_crates_io.sh
           bash -n scripts/architecture_budget_lib.sh
           bash -n scripts/check_architecture_boundaries.sh
           bash -n scripts/check_architecture_drift_freshness.sh
@@ -56,6 +57,7 @@ jobs:
           bash -n scripts/test_generate_architecture_drift_report.sh
           bash -n scripts/test_check_glibc_floor.sh
           bash -n scripts/test_install_sh.sh
+          bash -n scripts/test_publish_crates_io.sh
           bash -n scripts/release_artifact_lib.sh
           bash -n scripts/bootstrap_release_local_artifacts.sh
           bash -n scripts/test_release_artifact_lib.sh
@@ -76,6 +78,7 @@ jobs:
           bash scripts/test_generate_architecture_drift_report.sh
           bash scripts/test_check_glibc_floor.sh
           bash scripts/test_install_sh.sh
+          bash scripts/test_publish_crates_io.sh
           bash scripts/test_release_artifact_lib.sh
           bash scripts/test_release_workflow_hardening.sh
           bash scripts/test_bootstrap_release_local_artifacts.sh
@@ -237,7 +240,7 @@ jobs:
           export CXX_aarch64_linux_android="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang++"
           export AR_aarch64_linux_android="${toolchain}/llvm-ar"
           export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
-          cargo build --release --locked -p loongclaw-daemon --bin "${BIN_NAME}" --bin "${LEGACY_BIN_NAME}" --target aarch64-linux-android
+          cargo build --release --locked -p loongclaw --bin "${BIN_NAME}" --bin "${LEGACY_BIN_NAME}" --target aarch64-linux-android
 
   docs-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
         env:
           LOONGCLAW_RELEASE_BUILD: "1"
         run: |
-          cargo zigbuild --release --locked -p loongclaw-daemon --bin ${{ env.BIN_NAME }} --bin ${{ env.LEGACY_BIN_NAME }} \
+          cargo zigbuild --release --locked -p loongclaw --bin ${{ env.BIN_NAME }} --bin ${{ env.LEGACY_BIN_NAME }} \
             --target "${{ matrix.target }}.${{ env.LINUX_ARM64_GLIBC_FLOOR }}"
 
       - name: Build release binary (Android/Termux)
@@ -179,13 +179,13 @@ jobs:
           export CXX_aarch64_linux_android="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang++"
           export AR_aarch64_linux_android="${toolchain}/llvm-ar"
           export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${toolchain}/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
-          cargo build --release --locked -p loongclaw-daemon --bin "${BIN_NAME}" --bin "${LEGACY_BIN_NAME}" --target "${{ matrix.target }}"
+          cargo build --release --locked -p loongclaw --bin "${BIN_NAME}" --bin "${LEGACY_BIN_NAME}" --target "${{ matrix.target }}"
 
       - name: Build release binary (native)
         if: matrix.use_zig != true && matrix.use_android_ndk != true
         env:
           LOONGCLAW_RELEASE_BUILD: "1"
-        run: cargo build --release --locked -p loongclaw-daemon --bin ${{ env.BIN_NAME }} --bin ${{ env.LEGACY_BIN_NAME }} --target ${{ matrix.target }}
+        run: cargo build --release --locked -p loongclaw --bin ${{ env.BIN_NAME }} --bin ${{ env.LEGACY_BIN_NAME }} --target ${{ matrix.target }}
 
       - name: Package archive (Unix)
         if: matrix.archive == 'tar.gz'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.26.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+checksum = "9698bf0769c641b18618039fe2ebd41eb3541f98433000f64e663fab7cea2c87"
 dependencies = [
  "gimli",
 ]
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.97.0"
+version = "1.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+checksum = "f64a6eded248c6b453966e915d32aeddb48ea63ad17932682774eb026fbef5b1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.99.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "db96d720d3c622fcbe08bae1c4b04a72ce6257d8b0584cb5418da00ae20a344f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -794,9 +794,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.58"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -1578,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1778,6 +1778,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1986,9 +1987,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.12"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -2011,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -2027,12 +2028,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2090,9 +2089,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags",
  "libc",
@@ -2156,6 +2155,7 @@ dependencies = [
  "dialoguer",
  "dunce",
  "ed25519-dalek",
+ "hex",
  "libc",
  "loongclaw-app",
  "loongclaw-bench",
@@ -2165,12 +2165,15 @@ dependencies = [
  "rand 0.10.0",
  "reqwest",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "time",
  "tokio",
+ "tokio-stream",
  "toml",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "wat",
@@ -2257,6 +2260,7 @@ dependencies = [
  "zeroize",
 ]
 
+[[package]]
 name = "loongclaw-kernel"
 version = "0.1.0-alpha.3"
 dependencies = [
@@ -2389,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -2424,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -3054,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3229,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.36.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+checksum = "223b960be86f7d302b7168cdbab137f9bdbf7e04a90c185312fab14dff49dc5f"
 dependencies = [
  "bitflags",
  "cssparser",
@@ -3308,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -3424,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"
@@ -3770,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3785,27 +3789,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tower"
@@ -4056,9 +4060,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4132,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4145,19 +4149,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4165,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4178,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -4203,16 +4211,6 @@ checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.245.1",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.246.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1929aad146499e47362c876fcbcbb0363f730951d93438f511178626e999a8"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.246.1",
 ]
 
 [[package]]
@@ -4263,17 +4261,6 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.246.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d991c35d79bf8336dc1cd632ed4aacf0dc5fac4bc466c670625b037b972bb9c"
-dependencies = [
- "bitflags",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -4452,31 +4439,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "246.0.1"
+version = "245.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf2d50bc7478dcca61d00df4dadf922ef46c5924db20a97e6daaf09fe1cb09"
+checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.246.1",
+ "wasm-encoder 0.245.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.246.1"
+version = "1.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723f2473b47f738c12fc11c8e0bb8b27ce7cf9c78cf1a29dadbc2d34a2513292"
+checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4748,9 +4735,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen"
@@ -4887,18 +4874,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9698bf0769c641b18618039fe2ebd41eb3541f98433000f64e663fab7cea2c87"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "gimli",
 ]
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.96.0"
+version = "1.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64a6eded248c6b453966e915d32aeddb48ea63ad17932682774eb026fbef5b1"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.98.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db96d720d3c622fcbe08bae1c4b04a72ce6257d8b0584cb5418da00ae20a344f"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.100.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
+checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -794,9 +794,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1578,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1778,7 +1778,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1987,9 +1986,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2012,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -2028,10 +2027,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2089,9 +2090,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags",
  "libc",
@@ -2144,8 +2145,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loongclaw"
+version = "0.1.0-alpha.3"
+dependencies = [
+ "axum",
+ "base64",
+ "chrono",
+ "clap",
+ "clap_complete",
+ "dialoguer",
+ "dunce",
+ "ed25519-dalek",
+ "libc",
+ "loongclaw-app",
+ "loongclaw-bench",
+ "loongclaw-contracts",
+ "loongclaw-kernel",
+ "loongclaw-spec",
+ "rand 0.10.0",
+ "reqwest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "time",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "wat",
+]
+
+[[package]]
 name = "loongclaw-app"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "aes",
  "async-trait",
@@ -2200,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-bench"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "hex",
  "loongclaw-kernel",
@@ -2214,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-contracts"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "semver",
  "serde",
@@ -2224,45 +2257,8 @@ dependencies = [
  "zeroize",
 ]
 
-[[package]]
-name = "loongclaw-daemon"
-version = "0.1.0-alpha.2"
-dependencies = [
- "axum",
- "base64",
- "chrono",
- "clap",
- "clap_complete",
- "dialoguer",
- "dunce",
- "ed25519-dalek",
- "hex",
- "libc",
- "loongclaw-app",
- "loongclaw-bench",
- "loongclaw-contracts",
- "loongclaw-kernel",
- "loongclaw-spec",
- "rand 0.10.0",
- "reqwest",
- "rusqlite",
- "semver",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "time",
- "tokio",
- "tokio-stream",
- "toml",
- "tower",
- "tracing",
- "tracing-subscriber",
- "wat",
-]
-
-[[package]]
 name = "loongclaw-kernel"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2277,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-protocol"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "serde",
@@ -2288,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "loongclaw-spec"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -2393,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2428,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -3058,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3233,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223b960be86f7d302b7168cdbab137f9bdbf7e04a90c185312fab14dff49dc5f"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
  "bitflags",
  "cssparser",
@@ -3312,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3428,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -3774,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3789,27 +3785,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4060,9 +4056,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4136,9 +4132,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4149,23 +4145,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4173,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4186,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4211,6 +4203,16 @@ checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.246.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1929aad146499e47362c876fcbcbb0363f730951d93438f511178626e999a8"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.1",
 ]
 
 [[package]]
@@ -4261,6 +4263,17 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.246.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d991c35d79bf8336dc1cd632ed4aacf0dc5fac4bc466c670625b037b972bb9c"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -4439,31 +4452,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "245.0.1"
+version = "246.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+checksum = "96cf2d50bc7478dcca61d00df4dadf922ef46c5924db20a97e6daaf09fe1cb09"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.246.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.246.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "723f2473b47f738c12fc11c8e0bb8b27ce7cf9c78cf1a29dadbc2d34a2513292"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4735,9 +4748,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -4874,18 +4887,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 authors = ["chumyin"]
+repository = "https://github.com/loongclaw-ai/loongclaw"
+homepage = "https://github.com/loongclaw-ai/loongclaw"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,9 +34,9 @@ tasks:
   smoke:
     desc: Run representative spec-runner smoke scenarios
     cmds:
-      - cargo run -p loongclaw-daemon --bin loong -- run-spec --spec examples/spec/runtime-extension.json --print-audit
-      - cargo run -p loongclaw-daemon --bin loong -- run-spec --spec examples/spec/tool-search.json --print-audit
-      - cargo run -p loongclaw-daemon --bin loong -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
+      - cargo run -p loongclaw --bin loong -- run-spec --spec examples/spec/runtime-extension.json --print-audit
+      - cargo run -p loongclaw --bin loong -- run-spec --spec examples/spec/tool-search.json --print-audit
+      - cargo run -p loongclaw --bin loong -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit
 
   benchmark:pressure:
     desc: Run programmatic pressure benchmark with gate enforcement

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+description = "Internal support crate for LoongClaw: providers, tools, channels, and runtime"
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 default = ["channel-cli", "channel-telegram", "channel-feishu", "channel-matrix", "channel-wecom", "channel-discord", "channel-dingtalk", "channel-slack", "channel-webhook", "channel-google-chat", "channel-line", "channel-signal", "channel-twitch", "channel-teams", "channel-tlon", "channel-whatsapp", "channel-email", "channel-mattermost", "channel-nextcloud-talk", "channel-synology-chat", "channel-irc", "channel-imessage", "channel-nostr", "config-toml", "memory-sqlite", "feishu-integration", "tool-shell", "tool-file", "tool-browser", "tool-webfetch", "tool-websearch", "provider-openai", "provider-anthropic", "provider-bedrock", "provider-volcengine"]
@@ -45,8 +48,8 @@ tool-websearch = []
 test-support = []
 
 [dependencies]
-loongclaw-contracts = { path = "../contracts" }
-loongclaw-kernel = { path = "../kernel" }
+loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
+loongclaw-kernel = { version = "0.1.0-alpha.3", path = "../kernel" }
 bytes = "1"
 async-trait.workspace = true
 console.workspace = true

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -4,13 +4,16 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+description = "Internal support crate for LoongClaw: benchmark harness and gates"
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 test-support = []
 
 [dependencies]
-loongclaw-spec = { path = "../spec" }
-kernel = { package = "loongclaw-kernel", path = "../kernel" }
+loongclaw-spec = { version = "0.1.0-alpha.3", path = "../spec" }
+kernel = { package = "loongclaw-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+description = "Internal support crate for LoongClaw: stable shared contracts"
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
-name = "loongclaw-daemon"
+name = "loongclaw"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
 default-run = "loong"
+description = "Primary CLI crate for LoongClaw vertical AI agents"
+repository.workspace = true
+homepage.workspace = true
+readme = "../../README.md"
 
 [lib]
 name = "loongclaw_daemon"
@@ -58,11 +62,11 @@ axum.workspace = true
 clap.workspace = true
 clap_complete = "4.5"
 dialoguer.workspace = true
-kernel = { package = "loongclaw-kernel", path = "../kernel" }
-loongclaw-bench = { path = "../bench" }
-loongclaw-app = { path = "../app", default-features = false }
-loongclaw-contracts = { path = "../contracts" }
-loongclaw-spec = { path = "../spec" }
+kernel = { package = "loongclaw-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
+loongclaw-bench = { version = "0.1.0-alpha.3", path = "../bench" }
+loongclaw-app = { version = "0.1.0-alpha.3", path = "../app", default-features = false }
+loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
+loongclaw-spec = { version = "0.1.0-alpha.3", path = "../spec" }
 serde.workspace = true
 serde_json.workspace = true
 hex.workspace = true
@@ -91,7 +95,7 @@ name = "loongclaw"
 path = "src/main.rs"
 
 [dev-dependencies]
-loongclaw-spec = { path = "../spec", features = ["test-hooks"] }
+loongclaw-spec = { version = "0.1.0-alpha.3", path = "../spec", features = ["test-hooks"] }
 sha2.workspace = true
 tower = { version = "0.5", features = ["util"] }
 wat = "1"

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -4,9 +4,12 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+description = "Internal support crate for LoongClaw: kernel primitives and governance core"
+repository.workspace = true
+homepage.workspace = true
 
 [dependencies]
-loongclaw-contracts = { path = "../contracts" }
+loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
 async-trait.workspace = true
 futures-util.workspace = true
 serde.workspace = true

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+description = "Internal support crate for LoongClaw: protocol and transport types"
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 test-support = []

--- a/crates/spec/Cargo.toml
+++ b/crates/spec/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+description = "Internal support crate for LoongClaw: specification execution surfaces"
+repository.workspace = true
+homepage.workspace = true
 
 [features]
 test-hooks = []
@@ -11,9 +14,9 @@ test-support = ["test-hooks"]
 
 [dependencies]
 async-trait.workspace = true
-kernel = { package = "loongclaw-kernel", path = "../kernel" }
-loongclaw-contracts = { path = "../contracts" }
-loongclaw-protocol = { path = "../protocol" }
+kernel = { package = "loongclaw-kernel", version = "0.1.0-alpha.3", path = "../kernel" }
+loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
+loongclaw-protocol = { version = "0.1.0-alpha.3", path = "../protocol" }
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true

--- a/scripts/benchmark_programmatic_pressure.sh
+++ b/scripts/benchmark_programmatic_pressure.sh
@@ -20,7 +20,7 @@ if [[ "$BENCH_PROFILE" != "dev" && "$BENCH_PROFILE" != "release" ]]; then
   exit 2
 fi
 
-CARGO_ARGS=(run -p loongclaw-daemon)
+CARGO_ARGS=(run -p loongclaw)
 if [[ "$BENCH_PROFILE" == "release" ]]; then
   CARGO_ARGS+=(--release)
 fi

--- a/scripts/benchmark_wasm_cache.sh
+++ b/scripts/benchmark_wasm_cache.sh
@@ -23,7 +23,7 @@ if [[ "$ENFORCE_GATE" != "true" && "$ENFORCE_GATE" != "false" ]]; then
   exit 2
 fi
 
-CARGO_ARGS=(run -p loongclaw-daemon)
+CARGO_ARGS=(run -p loongclaw)
 if [[ "$BENCH_PROFILE" == "release" ]]; then
   CARGO_ARGS+=(--release)
 fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -118,7 +118,7 @@ function Install-FromSource {
     $previousReleaseBuild = $env:LOONGCLAW_RELEASE_BUILD
     try {
         $env:LOONGCLAW_RELEASE_BUILD = "1"
-        cargo build -p loongclaw-daemon --bin $BinName --release --locked | Out-Host
+        cargo build -p loongclaw --bin $BinName --release --locked | Out-Host
     } finally {
         if ($hadReleaseBuild) {
             $env:LOONGCLAW_RELEASE_BUILD = $previousReleaseBuild

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -772,7 +772,7 @@ install_from_source() {
   (
     cd "${repo_root}"
     LOONGCLAW_RELEASE_BUILD=1 \
-      cargo build -p loongclaw-daemon --bin "${bin_name}" --release --locked
+      cargo build -p loongclaw --bin "${bin_name}" --release --locked
   )
 
   source_binary="${repo_root}/target/release/${primary_binary_name}"

--- a/scripts/lint_programmatic_pressure_baseline.sh
+++ b/scripts/lint_programmatic_pressure_baseline.sh
@@ -18,7 +18,7 @@ fi
 COMMAND_ARGS+=(cargo)
 COMMAND_ARGS+=(run)
 COMMAND_ARGS+=(-p)
-COMMAND_ARGS+=(loongclaw-daemon)
+COMMAND_ARGS+=(loongclaw)
 COMMAND_ARGS+=(--bin)
 COMMAND_ARGS+=(loong)
 COMMAND_ARGS+=(--)

--- a/scripts/publish_crates_io.sh
+++ b/scripts/publish_crates_io.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PACKAGES=(
+  loongclaw-contracts
+  loongclaw-protocol
+  loongclaw-kernel
+  loongclaw-spec
+  loongclaw-bench
+  loongclaw-app
+  loongclaw
+)
+
+mode="dry-run"
+from_package=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/publish_crates_io.sh [--publish] [--from <package>] [--help]
+
+Default behavior is a dry run:
+  scripts/publish_crates_io.sh
+
+Real publish mode:
+  scripts/publish_crates_io.sh --publish
+
+Resume from a package in the publish chain:
+  scripts/publish_crates_io.sh --from loongclaw-spec
+EOF
+}
+
+package_exists() {
+  local candidate="$1"
+  local pkg
+  for pkg in "${PACKAGES[@]}"; do
+    if [[ "$pkg" == "$candidate" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --publish)
+      mode="publish"
+      ;;
+    --from)
+      shift
+      if [[ "$#" -eq 0 ]]; then
+        echo "error: --from requires a package name" >&2
+        usage >&2
+        exit 2
+      fi
+      from_package="$1"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ -n "$from_package" ]] && ! package_exists "$from_package"; then
+  echo "error: unknown package in publish order: $from_package" >&2
+  exit 2
+fi
+
+echo "mode: $mode"
+if [[ -n "$from_package" ]]; then
+  echo "starting from: $from_package"
+else
+  echo "starting from: ${PACKAGES[0]}"
+fi
+
+start_emitting="false"
+if [[ -z "$from_package" ]]; then
+  start_emitting="true"
+fi
+
+for pkg in "${PACKAGES[@]}"; do
+  if [[ "$pkg" == "$from_package" ]]; then
+    start_emitting="true"
+  fi
+  if [[ "$start_emitting" != "true" ]]; then
+    continue
+  fi
+
+  cmd=(cargo publish -p "$pkg" --locked)
+  if [[ "$mode" == "dry-run" ]]; then
+    cmd=(cargo publish --dry-run -p "$pkg" --locked)
+  fi
+
+  printf '==> %s\n' "${cmd[*]}"
+  "${cmd[@]}"
+done

--- a/scripts/stress_daemon_tests.sh
+++ b/scripts/stress_daemon_tests.sh
@@ -47,7 +47,7 @@ run_mode() {
     local log_file="$LOG_DIR/traps-${trap_mode}-mode-${mode}-run-${run_index}.log"
     local cmd=(
       cargo test
-      -p loongclaw-daemon
+      -p loongclaw
       --bin loong
       --all-features
     )

--- a/scripts/test_publish_crates_io.sh
+++ b/scripts/test_publish_crates_io.sh
@@ -37,16 +37,18 @@ assert_lines_exact() {
   local file="$1"
   shift
 
-  local expected_lines
-  local actual_lines
+  local expected_lines=("$@")
+  local actual_lines=()
   local expected_count
   local actual_count
   local index
   local expected_line
   local actual_line
+  local line
 
-  mapfile -t expected_lines < <(printf '%s\n' "$@")
-  mapfile -t actual_lines < "$file"
+  while IFS= read -r line; do
+    actual_lines+=("$line")
+  done < "$file"
 
   expected_count="${#expected_lines[@]}"
   actual_count="${#actual_lines[@]}"

--- a/scripts/test_publish_crates_io.sh
+++ b/scripts/test_publish_crates_io.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/publish_crates_io.sh"
+PACKAGE_CHAIN=(
+  loongclaw-contracts
+  loongclaw-protocol
+  loongclaw-kernel
+  loongclaw-spec
+  loongclaw-bench
+  loongclaw-app
+  loongclaw
+)
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq -- "$needle" "$file"; then
+    echo "expected to find '$needle' in $file" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    echo "did not expect to find '$needle' in $file" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_lines_exact() {
+  local file="$1"
+  shift
+
+  local expected_lines
+  local actual_lines
+  local expected_count
+  local actual_count
+  local index
+  local expected_line
+  local actual_line
+
+  mapfile -t expected_lines < <(printf '%s\n' "$@")
+  mapfile -t actual_lines < "$file"
+
+  expected_count="${#expected_lines[@]}"
+  actual_count="${#actual_lines[@]}"
+
+  if [[ "$actual_count" -ne "$expected_count" ]]; then
+    echo "expected $expected_count lines in $file but found $actual_count" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+
+  for index in "${!expected_lines[@]}"; do
+    expected_line="${expected_lines[$index]}"
+    actual_line="${actual_lines[$index]}"
+
+    if [[ "$actual_line" != "$expected_line" ]]; then
+      echo "expected line $((index + 1)) to be '$expected_line' but found '$actual_line'" >&2
+      cat "$file" >&2
+      exit 1
+    fi
+  done
+}
+
+assert_publish_sequence() {
+  local file="$1"
+  local mode="$2"
+  shift 2
+
+  local expected_lines=()
+  local pkg
+  local line
+
+  for pkg in "$@"; do
+    line="publish -p $pkg --locked"
+    if [[ "$mode" == "dry-run" ]]; then
+      line="publish --dry-run -p $pkg --locked"
+    fi
+    expected_lines+=("$line")
+  done
+
+  assert_lines_exact "$file" "${expected_lines[@]}"
+}
+
+make_fake_cargo() {
+  local stub_dir="$1"
+  local invocation_log="$2"
+  cat >"$stub_dir/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$FAKE_CARGO_INVOCATION_LOG"
+EOF
+  chmod +x "$stub_dir/cargo"
+}
+
+run_default_dry_run_test() {
+  local tmp_dir stub_dir invocation_log output_file
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' RETURN
+  stub_dir="$tmp_dir/stub"
+  mkdir -p "$stub_dir"
+  invocation_log="$tmp_dir/invocations.log"
+  output_file="$tmp_dir/output.txt"
+
+  : >"$invocation_log"
+  make_fake_cargo "$stub_dir" "$invocation_log"
+
+  PATH="$stub_dir:$PATH" \
+    FAKE_CARGO_INVOCATION_LOG="$invocation_log" \
+    bash "$SCRIPT_UNDER_TEST" >"$output_file" 2>&1
+
+  assert_publish_sequence "$invocation_log" "dry-run" "${PACKAGE_CHAIN[@]}"
+  assert_contains "$output_file" "mode: dry-run"
+}
+
+run_publish_mode_test() {
+  local tmp_dir stub_dir invocation_log output_file
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' RETURN
+  stub_dir="$tmp_dir/stub"
+  mkdir -p "$stub_dir"
+  invocation_log="$tmp_dir/invocations.log"
+  output_file="$tmp_dir/output.txt"
+
+  : >"$invocation_log"
+  make_fake_cargo "$stub_dir" "$invocation_log"
+
+  PATH="$stub_dir:$PATH" \
+    FAKE_CARGO_INVOCATION_LOG="$invocation_log" \
+    bash "$SCRIPT_UNDER_TEST" --publish >"$output_file" 2>&1
+
+  assert_publish_sequence "$invocation_log" "publish" "${PACKAGE_CHAIN[@]}"
+  assert_contains "$output_file" "mode: publish"
+}
+
+run_resume_from_test() {
+  local tmp_dir stub_dir invocation_log output_file
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' RETURN
+  stub_dir="$tmp_dir/stub"
+  mkdir -p "$stub_dir"
+  invocation_log="$tmp_dir/invocations.log"
+  output_file="$tmp_dir/output.txt"
+
+  : >"$invocation_log"
+  make_fake_cargo "$stub_dir" "$invocation_log"
+
+  PATH="$stub_dir:$PATH" \
+    FAKE_CARGO_INVOCATION_LOG="$invocation_log" \
+    bash "$SCRIPT_UNDER_TEST" --from loongclaw-spec >"$output_file" 2>&1
+
+  assert_publish_sequence \
+    "$invocation_log" \
+    "dry-run" \
+    loongclaw-spec \
+    loongclaw-bench \
+    loongclaw-app \
+    loongclaw
+  assert_contains "$output_file" "starting from: loongclaw-spec"
+}
+
+run_default_dry_run_test
+run_publish_mode_test
+run_resume_from_test
+
+echo "publish_crates_io.sh harness checks passed"


### PR DESCRIPTION
## Summary
This PR prepares the workspace for a future crates.io release where the public install command is `cargo install loongclaw`.

It does not perform any crates.io publish.

## What changed
- renamed the installable package from `loongclaw-daemon` to `loongclaw`
- added workspace publish metadata and crate descriptions
- added explicit versions for internal workspace path dependencies so the publish graph is valid
- bumped the workspace version to `0.1.0-alpha.3`
- added `scripts/publish_crates_io.sh` with dry-run-by-default behavior and resume support
- added `scripts/test_publish_crates_io.sh` and wired script checks into CI
- updated release, install, task, and benchmark scripts to reference the publishable package name

## Validation
- `bash -n scripts/publish_crates_io.sh`
- `bash -n scripts/test_publish_crates_io.sh`
- `bash scripts/test_publish_crates_io.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`

Closes #784


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added crates.io publishing scripts with dry-run and resume capabilities for release management.

* **Chores**
  * Bumped version to 0.1.0-alpha.3.
  * Reorganized main package structure and updated naming conventions.
  * Updated CI and release build workflows and configurations.
  * Added project metadata including repository and homepage information across all crates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->