### PR TITLE
test(app): stabilize ACPX fake runtime scripts

### DIFF
--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -1807,15 +1807,13 @@ mod tests {
         body: &str,
     ) -> PathBuf {
         let script_path = temp_dir.join(script_name);
-        write_executable_script_atomically(
-            &script_path,
-            &format!(
-                "#!/bin/sh\nset -eu\nLOG_PATH=\"{}\"\nprintf '%s\\n' \"$*\" >> \"$LOG_PATH\"\n{}\n",
-                log_path.display(),
-                body
-            ),
-        )
-        .expect("write fake acpx script");
+        let script_source = format!(
+            "#!/bin/sh\nset -eu\n# Keep test helper scripts stable even when unrelated tests narrow PATH.\nPATH=\"$(command -p getconf PATH 2>/dev/null || printf '%s' '/usr/bin:/bin')\"\nexport PATH\nLOG_PATH=\"{}\"\nprintf '%s\\n' \"$*\" >> \"$LOG_PATH\"\n{}\n",
+            log_path.display(),
+            body
+        );
+        write_executable_script_atomically(&script_path, &script_source)
+            .expect("write fake acpx script");
         script_path
     }
 
@@ -2415,6 +2413,94 @@ exit 0
 
     #[tokio::test]
     #[cfg(unix)]
+    async fn runtime_backend_executes_session_turn_and_controls_when_path_is_narrowed() {
+        let temp_dir = unique_temp_dir("loongclaw-acpx-runtime-narrow-path");
+        let log_path = temp_dir.join("calls.log");
+        let script_path = write_fake_acpx_script(
+            &temp_dir,
+            "fake-acpx",
+            &log_path,
+            r#"
+case "$*" in
+  "--version")
+    echo 'acpx 0.1.16'
+    exit 0
+    ;;
+esac
+
+if printf '%s' "$*" | grep -q 'sessions ensure --name'; then
+  echo '{"acpxSessionId":"sess-42","agentSessionId":"agent-42","acpxRecordId":"record-42"}'
+  exit 0
+fi
+
+if printf '%s' "$*" | grep -q 'prompt --session'; then
+  cat >/dev/null
+  echo '{"type":"text","content":"hello "}'
+  echo '{"type":"text","content":"world"}'
+  echo '{"type":"usage_update","used":7,"size":128}'
+  echo '{"type":"done"}'
+  exit 0
+fi
+
+if printf '%s' "$*" | grep -q 'status --session'; then
+  echo '{"status":"ready","acpxSessionId":"sess-42","agentSessionId":"agent-42","acpxRecordId":"record-42"}'
+  exit 0
+fi
+
+exit 0
+"#,
+        );
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("PATH", &temp_dir);
+        let config = fake_acpx_config(&script_path, &temp_dir);
+        let backend = AcpxCliProbeBackend;
+        let bootstrap = AcpSessionBootstrap {
+            session_key: "agent:codex:session-42".to_owned(),
+            conversation_id: Some("telegram:42".to_owned()),
+            binding: Some(crate::acp::AcpSessionBindingScope {
+                route_session_id: "telegram:bot_123456:42".to_owned(),
+                channel_id: Some("telegram".to_owned()),
+                account_id: Some("bot_123456".to_owned()),
+                conversation_id: Some("42".to_owned()),
+                thread_id: Some("thread-42".to_owned()),
+            }),
+            working_directory: Some(temp_dir.clone()),
+            initial_prompt: None,
+            mode: Some(AcpSessionMode::Interactive),
+            mcp_servers: Vec::new(),
+            metadata: BTreeMap::new(),
+        };
+
+        let handle = backend
+            .ensure_session(&config, &bootstrap)
+            .await
+            .expect("ensure session");
+        let result = backend
+            .run_turn(
+                &config,
+                &handle,
+                &AcpTurnRequest {
+                    session_key: bootstrap.session_key.clone(),
+                    input: "hello runtime".to_owned(),
+                    working_directory: None,
+                    metadata: BTreeMap::new(),
+                },
+            )
+            .await
+            .expect("run turn");
+
+        assert_eq!(result.output_text, "hello world");
+        assert_eq!(
+            result.usage,
+            Some(serde_json::json!({
+                "used": 7,
+                "size": 128,
+            }))
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
     async fn runtime_backend_supports_local_abort_for_running_prompt() {
         let temp_dir = unique_temp_dir("loongclaw-acpx-abort");
         let log_path = temp_dir.join("calls.log");
@@ -2508,6 +2594,97 @@ exit 0
                 .and_then(|event| value_string(event, "stopReason")),
             Some("cancelled".to_owned())
         );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn runtime_backend_supports_local_abort_when_path_is_narrowed() {
+        let temp_dir = unique_temp_dir("loongclaw-acpx-abort-narrow-path");
+        let log_path = temp_dir.join("calls.log");
+        let script_path = write_fake_acpx_script(
+            &temp_dir,
+            "fake-acpx",
+            &log_path,
+            r#"
+case "$*" in
+  "--version")
+    echo 'acpx 0.1.16'
+    exit 0
+    ;;
+esac
+
+if printf '%s' "$*" | grep -q 'sessions ensure --name'; then
+  echo '{"acpxSessionId":"sess-abort","agentSessionId":"agent-abort","acpxRecordId":"record-abort"}'
+  exit 0
+fi
+
+if printf '%s' "$*" | grep -q 'prompt --session'; then
+  cat >/dev/null
+  sleep 30
+  exit 0
+fi
+
+exit 0
+"#,
+        );
+        let mut env = crate::test_support::ScopedEnv::new();
+        env.set("PATH", &temp_dir);
+        let config = fake_acpx_config(&script_path, &temp_dir);
+        let backend = AcpxCliProbeBackend;
+        let bootstrap = AcpSessionBootstrap {
+            session_key: "agent:codex:session-abort".to_owned(),
+            conversation_id: Some("telegram:abort".to_owned()),
+            binding: None,
+            working_directory: Some(temp_dir.clone()),
+            initial_prompt: None,
+            mode: Some(AcpSessionMode::Interactive),
+            mcp_servers: Vec::new(),
+            metadata: BTreeMap::new(),
+        };
+        let handle = backend
+            .ensure_session(&config, &bootstrap)
+            .await
+            .expect("ensure abortable session");
+
+        let abort_controller = crate::acp::AcpAbortController::new();
+        let abort_signal = abort_controller.signal();
+        let turn_task = {
+            let backend = AcpxCliProbeBackend;
+            let config = config.clone();
+            let handle = handle.clone();
+            let session_key = bootstrap.session_key.clone();
+            tokio::spawn(async move {
+                backend
+                    .run_turn_with_sink(
+                        &config,
+                        &handle,
+                        &AcpTurnRequest {
+                            session_key,
+                            input: "abort me".to_owned(),
+                            working_directory: None,
+                            metadata: BTreeMap::new(),
+                        },
+                        Some(abort_signal),
+                        None,
+                    )
+                    .await
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        abort_controller.abort();
+
+        let result = tokio::time::timeout(Duration::from_secs(2), async {
+            turn_task
+                .await
+                .expect("abortable turn join should succeed")
+                .expect("abortable turn result should resolve")
+        })
+        .await
+        .expect("aborted prompt should stop promptly");
+
+        assert_eq!(result.stop_reason, Some(AcpTurnStopReason::Cancelled));
+        assert_eq!(result.output_text, "");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Problem: ACPX runtime tests in `crates/app/src/acp/acpx.rs` used fake shell scripts that inherited the ambient `PATH`, so unrelated tests that temporarily narrowed `PATH` could make those scripts silently skip their JSON-emitting branches and exit `0`.
- Why it matters: that made default parallel `cargo test --workspace --locked` runs intermittently fail with empty ACPX output or `Completed` instead of `Cancelled`, even though the ACPX logic itself was not deterministically broken.
- What changed: normalized the fake ACPX script `PATH` inside `write_fake_acpx_script` using the shell's standard utility lookup path, and added two narrowed-`PATH` regression tests covering the streamed-output and local-abort paths.
- What did not change (scope boundary): no production ACPX runtime behavior changed; this is a test-helper isolation fix plus regression coverage.

## Linked Issues

- Closes #783
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
- PASS

cargo test -p loongclaw-app acp::acpx::tests::runtime_backend_executes_session_turn_and_controls_when_path_is_narrowed -- --exact --nocapture
- PASS

cargo test -p loongclaw-app acp::acpx::tests::runtime_backend_supports_local_abort_when_path_is_narrowed -- --exact --nocapture
- PASS

10x loop:
cargo test -p loongclaw-app --all-features acp::acpx::tests -- --nocapture
- PASS for 10 consecutive runs

cargo test -p loongclaw-app --locked
- PASS

cargo test -p loongclaw-app --all-features --locked
- PASS

cargo test --workspace --locked
- FAIL in this local environment, but the observed failures moved off ACPX and remained in the existing daemon browser companion test cluster:
  - browser_companion_diagnostics::tests::collect_browser_companion_diagnostics_rejects_partial_expected_version_matches
  - doctor_cli::tests::browser_companion_doctor_checks_pass_when_runtime_gate_is_open
  - doctor_cli::tests::browser_companion_doctor_checks_warn_when_expected_version_mismatches
  - doctor_cli::tests::browser_companion_doctor_checks_warn_when_runtime_gate_is_closed
  - onboard_cli::tests::browser_companion_onboard_preflight_passes_when_runtime_gate_is_open

cargo test --workspace --all-features --locked
- not rerun after the app-focused fix because the default workspace test lane is already blocked by the unrelated daemon browser companion baseline above.
```

Process-global env note:

- The new regression tests intentionally narrow `PATH` via `crate::test_support::ScopedEnv`.
- `ScopedEnv` acquires the app test env mutex and restores the original values on drop.

## User-visible / Operator-visible Changes

- None. This only hardens ACPX test fixtures against unrelated `PATH` mutations.

## Failure Recovery

- Fast rollback or disable path: revert commit `da411f77`.
- Observable failure symptoms reviewers should watch for: ACPX fake-runtime tests regressing back to empty `output_text`, missing `usage_update`, or `Completed` replacing `Cancelled` when `PATH` is narrowed.

## Reviewer Focus

- Review the `write_fake_acpx_script` prologue in `crates/app/src/acp/acpx.rs` to confirm the PATH normalization is constrained to test helpers only.
- Review the two new narrowed-`PATH` tests to confirm they cover both the streamed prompt path and the local-abort path.
- Sanity-check that no production ACPX runtime logic changed outside the test module.
