### PR TITLE
fix(daemon): honor browser companion runtime timeout in diagnostics

### DIFF
--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -9,7 +9,6 @@ pub(crate) const BROWSER_COMPANION_INSTALL_CHECK_NAME: &str = "browser companion
 pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser companion runtime gate";
 
 const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
-const BROWSER_COMPANION_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,6 +17,7 @@ pub(crate) struct BrowserCompanionDiagnostics {
     pub(crate) expected_version: Option<String>,
     pub(crate) observed_version: Option<String>,
     pub(crate) runtime_ready: bool,
+    pub(crate) probe_timeout_seconds: u64,
     pub(crate) install_status: BrowserCompanionInstallStatus,
 }
 
@@ -38,7 +38,7 @@ impl BrowserCompanionDiagnostics {
             BrowserCompanionInstallStatus::ProbeTimedOut { command } => {
                 format!(
                     "command `{command} {BROWSER_COMPANION_VERSION_ARG}` timed out after {}s",
-                    BROWSER_COMPANION_PROBE_TIMEOUT.as_secs()
+                    self.probe_timeout_seconds
                 )
             }
             BrowserCompanionInstallStatus::ProbeFailed { command, error } => {
@@ -139,17 +139,19 @@ pub(crate) async fn collect_browser_companion_diagnostics(
 
     let runtime_ready = runtime.is_runtime_ready();
     let expected_version = runtime.expected_version;
+    let probe_timeout_seconds = runtime.timeout_seconds;
     let Some(command) = runtime.command else {
         return Some(BrowserCompanionDiagnostics {
             command: None,
             expected_version,
             observed_version: None,
             runtime_ready,
+            probe_timeout_seconds,
             install_status: BrowserCompanionInstallStatus::MissingCommand,
         });
     };
 
-    match probe_browser_companion_version(&command).await {
+    match probe_browser_companion_version(&command, probe_timeout_seconds).await {
         Ok(observed_version) => {
             let install_status = match expected_version.as_deref() {
                 Some(expected_version)
@@ -168,6 +170,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
                 expected_version,
                 observed_version: Some(observed_version),
                 runtime_ready,
+                probe_timeout_seconds,
                 install_status,
             })
         }
@@ -176,6 +179,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
             expected_version,
             observed_version: None,
             runtime_ready,
+            probe_timeout_seconds,
             install_status: BrowserCompanionInstallStatus::MissingBinary { command },
         }),
         Err(BrowserCompanionProbeError::TimedOut) => Some(BrowserCompanionDiagnostics {
@@ -183,6 +187,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
             expected_version,
             observed_version: None,
             runtime_ready,
+            probe_timeout_seconds,
             install_status: BrowserCompanionInstallStatus::ProbeTimedOut { command },
         }),
         Err(BrowserCompanionProbeError::SpawnFailed(error)) => Some(BrowserCompanionDiagnostics {
@@ -190,6 +195,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
             expected_version,
             observed_version: None,
             runtime_ready,
+            probe_timeout_seconds,
             install_status: BrowserCompanionInstallStatus::ProbeFailed { command, error },
         }),
         Err(BrowserCompanionProbeError::Exited {
@@ -200,6 +206,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
             expected_version,
             observed_version: Some(observed.clone()),
             runtime_ready,
+            probe_timeout_seconds,
             install_status: BrowserCompanionInstallStatus::ProbeExited {
                 command,
                 observed,
@@ -211,12 +218,14 @@ pub(crate) async fn collect_browser_companion_diagnostics(
 
 async fn probe_browser_companion_version(
     command: &str,
+    timeout_seconds: u64,
 ) -> Result<String, BrowserCompanionProbeError> {
+    let timeout_budget = Duration::from_secs(timeout_seconds.max(1));
     let mut probe = Command::new(command);
     probe.arg(BROWSER_COMPANION_VERSION_ARG);
     probe.kill_on_drop(true);
 
-    match timeout(BROWSER_COMPANION_PROBE_TIMEOUT, probe.output()).await {
+    match timeout(timeout_budget, probe.output()).await {
         Ok(Ok(output)) => {
             let observed = observed_output(&output.stdout, &output.stderr);
             if output.status.success() {
@@ -384,6 +393,36 @@ mod tests {
                     && observed_version == "loongclaw-browser-companion 11.5.0"
             ),
             "partial version matches should still warn as mismatches: {diagnostics:#?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_browser_companion_diagnostics_uses_runtime_probe_timeout_budget() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let temp_dir = browser_companion_temp_dir("probe-timeout-budget");
+        let script_path = temp_dir.join("browser-companion");
+        write_browser_companion_script(&script_path, "#!/bin/sh\nsleep 2\necho late\n");
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.timeout_seconds = 1;
+
+        let diagnostics = collect_browser_companion_diagnostics(&config)
+            .await
+            .expect("diagnostics should be collected");
+
+        assert!(
+            matches!(
+                diagnostics.install_status,
+                BrowserCompanionInstallStatus::ProbeTimedOut { .. }
+            ),
+            "slow probes should time out when the runtime timeout budget is exhausted: {diagnostics:#?}"
+        );
+        assert!(
+            diagnostics.install_detail().contains("timed out after 1s"),
+            "timeout detail should reflect the runtime-configured probe budget: {diagnostics:#?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Problem:
  Browser companion diagnostics used a hidden 3 second probe timeout instead of the existing browser companion runtime timeout policy, which made freshly created script-backed fixtures intermittently fail under default parallel workspace execution.
- Why it matters:
  The daemon browser companion diagnostics, doctor, and onboarding checks all share this probe path, so the hidden 3 second budget produced false-negative local verification runs and made the managed companion lane look unhealthy even when the command would succeed if given the configured runtime budget.
- What changed:
  The shared diagnostics path now passes `runtime.timeout_seconds` into the version probe and carries that effective budget into timeout reporting. I also added a regression test that proves the probe timeout detail reflects the runtime-configured budget.
- What did not change (scope boundary):
  This does not change browser companion command parsing, install status mapping, or the runtime policy shape. It only removes the hidden 3 second probe budget inside daemon-side diagnostics.

## Linked Issues

- Closes #787
- Related #786

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-browser-companion-787-target cargo test -p loongclaw-daemon browser_companion -- --nocapture
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-browser-companion-787-target bash -lc 'for i in 1 2; do cargo test --workspace --locked --quiet || exit 1; done'
  PASS (2 consecutive workspace runs)

CARGO_TARGET_DIR=/tmp/loongclaw-browser-companion-787-target cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-browser-companion-787-target cargo test --workspace --all-features --locked --quiet
  PASS
```

Before/after behavior and regression coverage:
- Before: daemon browser companion diagnostics always timed out after a hidden 3 second budget, even when the runtime policy already carried a larger timeout.
- After: daemon diagnostics reuse `tools.browser_companion.timeout_seconds`, and the new regression test covers the explicit boundary case where `timeout_seconds = 1` produces a timeout detail of `1s`.
- Fallback/default path: default runtime policy now reaches diagnostics unchanged instead of being shadowed by a daemon-local constant.
- Env restoration/serialization: the regression test uses the existing `BrowserCompanionEnvGuard`, which serializes process-global env mutation through `lock_daemon_test_environment` and restores `LOONGCLAW_BROWSER_COMPANION_READY` on drop.

## User-visible / Operator-visible Changes

- Browser companion diagnostics, `loongclaw doctor`, and onboarding preflight now honor the configured browser companion runtime timeout instead of an internal 3 second probe budget.

## Failure Recovery

- Fast rollback or disable path:
  Revert this commit to restore the previous fixed 3 second daemon probe budget.
- Observable failure symptoms reviewers should watch for:
  Browser companion diagnostics still reporting `timed out after 3s` or timing out despite `tools.browser_companion.timeout_seconds` being set higher.

## Reviewer Focus

- `crates/daemon/src/browser_companion_diagnostics.rs`
- Confirm that timeout reporting now reflects the runtime-configured budget and that doctor/onboard inherit the shared diagnostics result without any extra timeout-specific branching.
