### PR TITLE
fix: unify daemon test env guards for parallel daemon tests

### DIFF
--- a/crates/daemon/src/audit_cli.rs
+++ b/crates/daemon/src/audit_cli.rs
@@ -2938,7 +2938,7 @@ mod tests {
     use crate::kernel::{
         AuditEvent, AuditEventKind, Capability, CapabilityToken, ExecutionPlane, PlaneTier,
     };
-    use crate::mvp::test_support::ScopedEnv;
+    use crate::test_support::ScopedEnv;
 
     use super::*;
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1513,6 +1513,7 @@ pub async fn run_demo() -> CliResult<()> {
 #[cfg(test)]
 mod first_run_entry_tests {
     use super::*;
+    use crate::test_support::ScopedEnv;
     use std::{
         fs,
         path::{Path, PathBuf},
@@ -1533,8 +1534,8 @@ mod first_run_entry_tests {
         std::env::temp_dir().join(format!("{prefix}-{pid}-{nanos}-{counter}"))
     }
 
-    fn isolated_home(prefix: &str) -> (mvp::test_support::ScopedEnv, PathBuf) {
-        let mut env = mvp::test_support::ScopedEnv::new();
+    fn isolated_home(prefix: &str) -> (ScopedEnv, PathBuf) {
+        let mut env = ScopedEnv::new();
         let home = unique_temp_dir(prefix);
         fs::create_dir_all(&home).expect("create isolated home");
         env.set("HOME", &home);
@@ -1571,7 +1572,7 @@ mod first_run_entry_tests {
 
     #[test]
     fn resolve_default_entry_command_honors_loongclaw_config_path_override() {
-        let mut env = mvp::test_support::ScopedEnv::new();
+        let mut env = ScopedEnv::new();
         let config_path = unique_temp_dir("loongclaw-default-entry-env").join("custom-config.toml");
         if let Some(parent) = config_path.parent() {
             fs::create_dir_all(parent).expect("create config parent");
@@ -1592,7 +1593,7 @@ mod first_run_entry_tests {
 
     #[test]
     fn resolve_default_entry_command_routes_to_onboard_when_config_path_is_a_directory() {
-        let mut env = mvp::test_support::ScopedEnv::new();
+        let mut env = ScopedEnv::new();
         let config_dir = unique_temp_dir("loongclaw-default-entry-dir");
         fs::create_dir_all(&config_dir).expect("create config directory");
         env.set("LOONGCLAW_CONFIG_PATH", &config_dir);
@@ -1605,7 +1606,7 @@ mod first_run_entry_tests {
 
     #[test]
     fn run_welcome_cli_rejects_missing_config_file() {
-        let mut env = mvp::test_support::ScopedEnv::new();
+        let mut env = ScopedEnv::new();
         let config_path = unique_temp_dir("loongclaw-welcome-missing").join("missing-config.toml");
         env.set("LOONGCLAW_CONFIG_PATH", &config_path);
 
@@ -1623,7 +1624,7 @@ mod first_run_entry_tests {
 
     #[test]
     fn run_welcome_cli_rejects_directory_config_path() {
-        let mut env = mvp::test_support::ScopedEnv::new();
+        let mut env = ScopedEnv::new();
         let config_dir = unique_temp_dir("loongclaw-welcome-dir");
         fs::create_dir_all(&config_dir).expect("create config directory");
         env.set("LOONGCLAW_CONFIG_PATH", &config_dir);

--- a/crates/daemon/src/provider_credential_policy.rs
+++ b/crates/daemon/src/provider_credential_policy.rs
@@ -282,6 +282,7 @@ fn secret_ref_has_inline_literal(secret_ref: Option<&SecretRef>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::ScopedEnv;
 
     #[test]
     fn provider_credential_env_hints_prioritize_oauth_defaults() {
@@ -320,7 +321,7 @@ mod tests {
 
     #[test]
     fn provider_has_locally_available_credentials_accepts_x_api_key_providers() {
-        let mut env = mvp::test_support::ScopedEnv::new();
+        let mut env = ScopedEnv::new();
         env.set("ANTHROPIC_API_KEY", "test-anthropic-key");
         let provider = mvp::config::ProviderConfig {
             kind: mvp::config::ProviderKind::Anthropic,
@@ -363,7 +364,7 @@ mod tests {
 
     #[test]
     fn provider_available_credential_env_binding_preserves_oauth_env_bindings() {
-        let mut env = mvp::test_support::ScopedEnv::new();
+        let mut env = ScopedEnv::new();
         env.set("OPENAI_SESSION_TOKEN", "test-openai-session-token");
         let provider = mvp::config::ProviderConfig {
             kind: mvp::config::ProviderKind::Openai,
@@ -396,7 +397,7 @@ mod tests {
 
     #[test]
     fn provider_available_credential_env_binding_uses_first_populated_env_hint() {
-        let mut env = mvp::test_support::ScopedEnv::new();
+        let mut env = ScopedEnv::new();
         env.set("OPENAI_API_KEY", "test-openai-key");
         let provider =
             mvp::config::ProviderConfig::fresh_for_kind(mvp::config::ProviderKind::Openai);

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -44,6 +44,8 @@ pub struct ScopedEnv {
 }
 
 impl ScopedEnv {
+    // Daemon-side tests must share this guard so every env mutation in the
+    // daemon test process is serialized behind one lock.
     pub fn new() -> Self {
         let lock = lock_daemon_test_environment();
         let saved = Vec::new();

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-01T13:13:44Z
+- Generated at: 2026-04-01T13:28:17Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -24,7 +24,7 @@
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1779 | 6400 | 4621 | 0 | 110 | 110 | 27.8% | HEALTHY | 1779 | 0.0% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10831 | 11200 | 369 | 98 | 120 | 22 | 96.7% | TIGHT | 10831 | 0.0% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14567 | 15000 | 433 | 54 | 70 | 16 | 97.1% | TIGHT | 14472 | 0.7% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6339 | 6500 | 161 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.2% | PASS | 210 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6340 | 6500 | 160 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.3% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=channel_mod lines=1779 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10831 functions=98 -->
 <!-- arch-hotspot key=tools_mod lines=14567 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6339 functions=210 -->
+<!-- arch-hotspot key=daemon_lib lines=6340 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  `loongclaw-daemon` tests were mutating process environment state through two
  different guards, so daemon-side env changes were not actually serialized
  behind one shared lock.
- Why it matters:
  Parallel daemon lib and workspace test runs could intermittently fail in the
  browser companion doctor checks with 10s probe timeouts, which blocks clean
  contributor and CI verification on otherwise unrelated work.
- What changed:
  Repointed daemon-side test env mutation call sites in `lib.rs`, `audit_cli.rs`,
  and `provider_credential_policy.rs` to `crate::test_support::ScopedEnv`, and
  documented in daemon test support that daemon-side env mutations must share
  that guard.
- What did not change (scope boundary):
  This PR does not change production runtime behavior, browser companion probe
  semantics, or any user-facing config surface.

## Linked Issues

- Closes #794

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-daemon --lib -q
cargo fmt --all -- --check
git diff --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
cargo test --workspace --locked -q
cargo test --workspace --all-features --locked -q

Results:
- `cargo test -p loongclaw-daemon --lib -q` passed after unifying daemon-side env guards
- `cargo test --workspace --locked -q` passed
- `cargo test --workspace --all-features --locked -q` passed
- architecture and dependency graph checks passed
```

## User-visible / Operator-visible Changes

- None. This only stabilizes daemon-side test execution under parallel test scheduling.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `e338a0bd`.
- Observable failure symptoms reviewers should watch for:
  Reintroduced `mvp::test_support::ScopedEnv` uses under `crates/daemon/src/*`
  or renewed flaky `doctor_cli::tests::browser_companion_doctor_checks_*`
  timeouts during parallel daemon test runs.

## Reviewer Focus

- Confirm the touched daemon tests now all route env mutation through
  `crate::test_support::ScopedEnv`.
- Confirm the fix stays scoped to test-only code and does not affect production
  runtime paths.
- Confirm the daemon test support comment accurately reflects the intended
  serialization rule for future test additions.
