### PR TITLE
docs: add public memory continuity summary

### DIFF
--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -25,6 +25,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - [Skills Discovery](skills-discovery.md)
 - [Memory Profiles](memory-profiles.md)
 - [Memory Retrieval](memory-retrieval.md)
+- [Runtime-Self Continuity](runtime-self-continuity.md)
 - [Shell Completion](shell-completion.md)
 
 ## Notes
@@ -34,6 +35,7 @@ Product specs describe **what** the product does from the user's perspective, no
 - `Runtime Capability` defines the shipped local capability-candidate review surface layered on top of runtime experiment artifacts.
 - `Local Product Control Plane` defines the shared localhost-only product substrate that future HTTP and Web UI surfaces must consume instead of inventing a second runtime.
 - `Background Tasks`, `Skills Discovery`, and `Memory Retrieval` define the next operator-facing productization surfaces that should be built on top of already-shipped runtime substrate.
+- `Memory Profiles`, `Memory Retrieval`, and `Runtime-Self Continuity` together define the public continuity boundary: bounded advisory memory, explicit retrieval, and strict runtime-self identity separation.
 - `Browser Automation Companion` and `Web UI` are expectation-setting specs for the next user-facing surfaces. They should not be documented as generally available before the implementation exists.
 
 Template for new specs:

--- a/docs/product-specs/runtime-self-continuity.md
+++ b/docs/product-specs/runtime-self-continuity.md
@@ -51,6 +51,32 @@ mixing identity authority with transient task context.
   context.
 - Session-local content is never promoted into durable self-state implicitly.
 
+## Selected Direction
+
+LoongClaw's public continuity direction is intentionally narrow:
+
+- keep runtime-self guidance and resolved runtime identity as the authority lane
+- keep session profile and future durable recall advisory
+- add bounded durable context before broadening retrieval scope
+- add explicit query-aware retrieval before embedding-dependent search becomes
+  required
+
+In practical terms, that means:
+
+- durable hot memory should stay bounded and operator-legible instead of turning
+  into a second identity layer
+- retrieval should start with local text-first recall and clear provenance
+  rather than jumping directly to opaque vendor-managed search
+- future memory providers may enrich advisory context, but they must not become
+  prompt authority or override runtime-owned continuity lanes
+
+Related public specs:
+
+- [Memory Profiles](memory-profiles.md) covers bounded profile projection and
+  advisory durable context
+- [Memory Retrieval](memory-retrieval.md) covers explicit query-aware recall and
+  provenance expectations
+
 ## Acceptance Criteria
 
 - Summary blocks clearly state that they do not replace runtime-self guidance,


### PR DESCRIPTION
## Summary

- Problem:
  the public repo no longer had a concise memory continuity summary after the internal design package moved to knowledge-base.
- Why it matters:
  contributors and operators should be able to understand the public continuity boundary without relying on archived internal materials.
- What changed:
  added a public-safe `Selected Direction` section to `docs/product-specs/runtime-self-continuity.md`, linked the spec from `docs/product-specs/index.md`, and documented how runtime-self, advisory memory, and retrieval fit together.
- What did not change (scope boundary):
  no internal design package was restored to the public repo, no runtime behavior changed, and no roadmap scope was expanded.

## Linked Issues

- Closes #778
- Related #283
- Related #390

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
scripts/check-docs.sh
  -> passed with existing non-blocking release-artifact warnings only
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-778-rustup-run-target rustup run stable-aarch64-apple-darwin cargo test --workspace --locked -j 2
  -> passed
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-778-rustup-run-target rustup run stable-aarch64-apple-darwin cargo test --workspace --all-features --locked -j 2
  -> passed
env CARGO_TARGET_DIR=/tmp/loongclaw-issue-778-rustup-run-target rustup run stable-aarch64-apple-darwin cargo clippy --workspace --all-targets --all-features -- -D warnings
  -> passed
```

## User-visible / Operator-visible Changes

- public product docs now state the selected memory continuity direction and the boundary between runtime-self authority, advisory memory, and explicit retrieval.

## Failure Recovery

- Fast rollback or disable path:
  revert commit `4421b303`.
- Observable failure symptoms reviewers should watch for:
  only doc-surface regressions, such as broken product-spec navigation or wording that blurs the public/internal boundary.

## Reviewer Focus

- check that `runtime-self-continuity.md` stays public-safe and does not reintroduce internal-only implementation detail.
- check that the `docs/product-specs/index.md` note accurately captures the continuity boundary trio without overstating current behavior.
