### PR TITLE
Add process-level CLI coverage for --session latest

### DIFF
--- a/crates/daemon/tests/integration/ask_cli.rs
+++ b/crates/daemon/tests/integration/ask_cli.rs
@@ -1,0 +1,340 @@
+use super::latest_selector_process_support::LatestSelectorCliFixture;
+use loongclaw_app::config::ProviderKind;
+use loongclaw_contracts::SecretRef;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc;
+use std::sync::mpsc::TryRecvError;
+use std::time::Duration;
+
+const MOCK_PROVIDER_REPLY: &str = "process latest selector ask reply";
+const MOCK_PROVIDER_STREAM_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn render_output(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn read_provider_request(stream: &mut TcpStream) -> String {
+    stream
+        .set_nonblocking(false)
+        .expect("set provider stream blocking");
+    stream
+        .set_read_timeout(Some(MOCK_PROVIDER_STREAM_READ_TIMEOUT))
+        .expect("set provider stream read timeout");
+    let mut request_buffer = [0_u8; 8192];
+    let request_len = stream
+        .read(&mut request_buffer)
+        .expect("read provider request");
+    let request_bytes = request_buffer
+        .get(..request_len)
+        .expect("provider request length should fit within the read buffer");
+    String::from_utf8_lossy(request_bytes).into_owned()
+}
+
+enum MockProviderServerControl {
+    Start,
+    Shutdown,
+}
+
+struct MockProviderServer {
+    base_url: String,
+    control_sender: mpsc::Sender<MockProviderServerControl>,
+    join_handle: std::thread::JoinHandle<Vec<String>>,
+}
+
+impl MockProviderServer {
+    fn spawn() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind local provider listener");
+        let address = listener.local_addr().expect("local provider address");
+        let (control_sender, control_receiver) = mpsc::channel();
+        let join_handle = std::thread::spawn(move || {
+            listener
+                .set_nonblocking(true)
+                .expect("set local provider listener nonblocking");
+            let start_signal = control_receiver
+                .recv()
+                .expect("receive provider server start signal");
+            match start_signal {
+                MockProviderServerControl::Start => {}
+                MockProviderServerControl::Shutdown => return Vec::new(),
+            }
+
+            let mut requests = Vec::new();
+
+            loop {
+                let control_message = control_receiver.try_recv();
+                match control_message {
+                    Ok(MockProviderServerControl::Shutdown) => return requests,
+                    Ok(MockProviderServerControl::Start) => {}
+                    Err(TryRecvError::Disconnected) => return requests,
+                    Err(TryRecvError::Empty) => {}
+                }
+
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let request = read_provider_request(&mut stream);
+                        requests.push(request.clone());
+
+                        let (status_line, response_body) = if request
+                            .starts_with("POST /v1/responses ")
+                        {
+                            (
+                                "HTTP/1.1 200 OK",
+                                format!(r#"{{"output_text":"{MOCK_PROVIDER_REPLY}"}}"#),
+                            )
+                        } else if request.starts_with("POST /v1/chat/completions ") {
+                            (
+                                "HTTP/1.1 200 OK",
+                                format!(
+                                    r#"{{"choices":[{{"message":{{"role":"assistant","content":"{MOCK_PROVIDER_REPLY}"}}}}]}}"#
+                                ),
+                            )
+                        } else {
+                            (
+                                "HTTP/1.1 404 Not Found",
+                                r#"{"error":{"message":"unexpected request"}}"#.to_owned(),
+                            )
+                        };
+                        let response = format!(
+                            "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            response_body.len(),
+                            response_body
+                        );
+                        stream
+                            .write_all(response.as_bytes())
+                            .expect("write provider response");
+
+                        return requests;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::yield_now();
+                    }
+                    Err(error) => panic!("accept provider request: {error}"),
+                }
+            }
+        });
+        let base_url = format!("http://{address}");
+
+        Self {
+            base_url,
+            control_sender,
+            join_handle,
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    fn arm(&self) {
+        self.control_sender
+            .send(MockProviderServerControl::Start)
+            .expect("start local provider server");
+    }
+
+    fn finish(self, stdout: &str, stderr: &str) -> Vec<String> {
+        let shutdown_result = self
+            .control_sender
+            .send(MockProviderServerControl::Shutdown);
+        if let Err(_error) = shutdown_result {}
+
+        match self.join_handle.join() {
+            Ok(requests) => requests,
+            Err(payload) => {
+                panic!(
+                    "join local provider server failed, stdout={stdout:?}, stderr={stderr:?}, panic={payload:?}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn ask_cli_latest_session_selector_process_uses_selected_root_session_history() {
+    let fixture = LatestSelectorCliFixture::new("ask-latest-selector-process");
+    let provider_server = MockProviderServer::spawn();
+    let provider_base_url = provider_server.base_url().to_owned();
+    fixture.write_config_with(|config| {
+        config.provider.kind = ProviderKind::Openai;
+        config.provider.base_url = provider_base_url;
+        config.provider.model = "test-model".to_owned();
+        config.provider.api_key = Some(SecretRef::Inline("test-provider-key".to_owned()));
+    });
+
+    fixture.create_root_session("root-old");
+    fixture.append_session_turn("root-old", "user", "old root turn");
+    fixture.set_session_updated_at("root-old", 100);
+    fixture.set_turn_timestamps("root-old", 100);
+
+    fixture.create_root_session("root-new");
+    fixture.append_session_turn("root-new", "user", "selected user turn");
+    fixture.append_session_turn("root-new", "assistant", "selected assistant turn");
+    fixture.set_session_updated_at("root-new", 200);
+    fixture.set_turn_timestamps("root-new", 200);
+
+    fixture.create_delegate_child_session("delegate-child", "root-new");
+    fixture.append_session_turn("delegate-child", "assistant", "delegate child turn");
+    fixture.set_session_updated_at("delegate-child", 400);
+    fixture.set_turn_timestamps("delegate-child", 400);
+
+    fixture.create_root_session("root-archived");
+    fixture.append_session_turn("root-archived", "assistant", "archived root turn");
+    fixture.set_session_updated_at("root-archived", 500);
+    fixture.set_turn_timestamps("root-archived", 500);
+    fixture.archive_session("root-archived", 600);
+
+    provider_server.arm();
+    let output = fixture.run_process(
+        &[
+            "ask",
+            "--session",
+            "latest",
+            "--message",
+            "Summarize the current session.",
+        ],
+        None,
+    );
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+    let provider_requests = provider_server.finish(&stdout, &stderr);
+
+    assert!(
+        output.status.success(),
+        "ask latest selector should succeed, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains(MOCK_PROVIDER_REPLY),
+        "ask should print the mock provider reply: {stdout:?}"
+    );
+    assert_eq!(
+        provider_requests.len(),
+        1,
+        "ask should issue exactly one provider request: {provider_requests:#?}"
+    );
+
+    let request = &provider_requests[0];
+    let request_path_is_supported = request.starts_with("POST /v1/chat/completions ")
+        || request.starts_with("POST /v1/responses ");
+    assert!(
+        request_path_is_supported,
+        "ask should target a supported provider endpoint: {request}"
+    );
+    assert!(
+        request.contains("selected user turn"),
+        "selected latest root user history should reach the provider request: {request}"
+    );
+    assert!(
+        request.contains("selected assistant turn"),
+        "selected latest root assistant history should reach the provider request: {request}"
+    );
+    assert!(
+        !request.contains("old root turn"),
+        "older root history should not leak into the selected latest request: {request}"
+    );
+    assert!(
+        !request.contains("delegate child turn"),
+        "delegate child history should not be selected as the latest resumable root: {request}"
+    );
+    assert!(
+        !request.contains("archived root turn"),
+        "archived root history should not be selected as the latest resumable root: {request}"
+    );
+}
+
+#[test]
+fn ask_cli_latest_session_selector_process_rejects_missing_resumable_root() {
+    let fixture = LatestSelectorCliFixture::new("ask-latest-selector-empty");
+    let provider_server = MockProviderServer::spawn();
+    let provider_base_url = provider_server.base_url().to_owned();
+    fixture.write_config_with(|config| {
+        config.provider.kind = ProviderKind::Openai;
+        config.provider.base_url = provider_base_url;
+        config.provider.model = "test-model".to_owned();
+        config.provider.api_key = Some(SecretRef::Inline("test-provider-key".to_owned()));
+    });
+
+    provider_server.arm();
+    let output = fixture.run_process(
+        &[
+            "ask",
+            "--session",
+            "latest",
+            "--message",
+            "Summarize the current session.",
+        ],
+        None,
+    );
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+    let provider_requests = provider_server.finish(&stdout, &stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "missing latest root session should fail before ask runs, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stderr.contains("latest"),
+        "error output should mention the latest selector: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("resumable root session"),
+        "error output should explain the missing latest root session: {stderr:?}"
+    );
+    assert!(
+        provider_requests.is_empty(),
+        "selector failure should abort before any provider request: {provider_requests:#?}"
+    );
+}
+
+#[test]
+fn ask_cli_latest_session_selector_process_wait_budget_starts_with_process_run() {
+    let fixture = LatestSelectorCliFixture::new("ask-latest-selector-budget");
+    let provider_server = MockProviderServer::spawn();
+    let provider_base_url = provider_server.base_url().to_owned();
+    fixture.write_config_with(|config| {
+        config.provider.kind = ProviderKind::Openai;
+        config.provider.base_url = provider_base_url;
+        config.provider.model = "test-model".to_owned();
+        config.provider.api_key = Some(SecretRef::Inline("test-provider-key".to_owned()));
+    });
+
+    fixture.create_root_session("root-latest");
+    fixture.append_session_turn("root-latest", "user", "latest root turn");
+    fixture.set_session_updated_at("root-latest", 200);
+    fixture.set_turn_timestamps("root-latest", 200);
+
+    // The delay must exceed the old fixed server budget so this test proves the
+    // wait window now starts with the spawned process run, not server creation.
+    let setup_delay = Duration::from_secs(6);
+    std::thread::sleep(setup_delay);
+
+    provider_server.arm();
+    let output = fixture.run_process(
+        &[
+            "ask",
+            "--session",
+            "latest",
+            "--message",
+            "Summarize the current session.",
+        ],
+        None,
+    );
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+    let provider_requests = provider_server.finish(&stdout, &stderr);
+
+    assert!(
+        output.status.success(),
+        "ask should succeed even after slow fixture setup, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains(MOCK_PROVIDER_REPLY),
+        "ask should still print the mock provider reply after slow setup: {stdout:?}"
+    );
+    assert_eq!(
+        provider_requests.len(),
+        1,
+        "ask should still issue exactly one provider request after slow setup: {provider_requests:#?}"
+    );
+}

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -1,5 +1,6 @@
 #![cfg(unix)]
 
+use super::latest_selector_process_support::LatestSelectorCliFixture;
 use super::*;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -334,5 +335,90 @@ fn chat_without_config_surfaces_config_path_access_errors() {
         fixture.onboard_log().is_empty(),
         "path access errors should not invoke onboarding: {:?}",
         fixture.onboard_log()
+    );
+}
+
+#[test]
+fn chat_cli_latest_session_selector_process_uses_selected_root_session_history() {
+    let fixture = LatestSelectorCliFixture::new("chat-latest-selector-process");
+    fixture.write_config_with(|_| {});
+
+    fixture.create_root_session("root-old");
+    fixture.append_session_turn("root-old", "user", "old root turn");
+    fixture.set_session_updated_at("root-old", 100);
+    fixture.set_turn_timestamps("root-old", 100);
+
+    fixture.create_root_session("root-new");
+    fixture.append_session_turn("root-new", "user", "selected user turn");
+    fixture.append_session_turn("root-new", "assistant", "selected assistant turn");
+    fixture.set_session_updated_at("root-new", 200);
+    fixture.set_turn_timestamps("root-new", 200);
+
+    fixture.create_delegate_child_session("delegate-child", "root-new");
+    fixture.append_session_turn("delegate-child", "assistant", "delegate child turn");
+    fixture.set_session_updated_at("delegate-child", 400);
+    fixture.set_turn_timestamps("delegate-child", 400);
+
+    fixture.create_root_session("root-archived");
+    fixture.append_session_turn("root-archived", "assistant", "archived root turn");
+    fixture.set_session_updated_at("root-archived", 500);
+    fixture.set_turn_timestamps("root-archived", 500);
+    fixture.archive_session("root-archived", 600);
+
+    let output = fixture.run_process(&["chat", "--session", "latest"], Some(b"/history\n/exit\n"));
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "chat latest selector should succeed, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("- session: root-new"),
+        "chat startup should surface the resolved latest session id: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("selected user turn"),
+        "history output should include the selected latest root user turn: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("selected assistant turn"),
+        "history output should include the selected latest root assistant turn: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("old root turn"),
+        "older root history should not appear in the latest session output: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("delegate child turn"),
+        "delegate child history should not appear in the latest root output: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("archived root turn"),
+        "archived root history should not appear in the latest root output: {stdout:?}"
+    );
+}
+
+#[test]
+fn chat_cli_latest_session_selector_process_rejects_missing_resumable_root() {
+    let fixture = LatestSelectorCliFixture::new("chat-latest-selector-empty");
+    fixture.write_config_with(|_| {});
+
+    let output = fixture.run_process(&["chat", "--session", "latest"], None);
+    let stdout = render_output(&output.stdout);
+    let stderr = render_output(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "missing latest root session should fail before chat starts, stdout={stdout:?}, stderr={stderr:?}"
+    );
+    assert!(
+        stderr.contains("latest"),
+        "chat error output should mention the latest selector: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("resumable root session"),
+        "chat error output should explain the missing latest root session: {stderr:?}"
     );
 }

--- a/crates/daemon/tests/integration/latest_selector_process_support.rs
+++ b/crates/daemon/tests/integration/latest_selector_process_support.rs
@@ -1,0 +1,203 @@
+use super::*;
+use rusqlite::{Connection, params};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::MutexGuard;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static LATEST_SELECTOR_FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_temp_path(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let counter = LATEST_SELECTOR_FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let process_id = std::process::id();
+    let temp_dir = std::env::temp_dir();
+    temp_dir.join(format!(
+        "loongclaw-latest-selector-{label}-{process_id}-{nanos}-{counter}"
+    ))
+}
+
+fn cleanup_sqlite_artifacts(sqlite_path: &Path) {
+    let sqlite_path = sqlite_path.display().to_string();
+    let wal_path = format!("{sqlite_path}-wal");
+    let shm_path = format!("{sqlite_path}-shm");
+    let _ = std::fs::remove_file(sqlite_path);
+    let _ = std::fs::remove_file(wal_path);
+    let _ = std::fs::remove_file(shm_path);
+}
+
+fn open_sqlite_connection(sqlite_path: &Path) -> Connection {
+    Connection::open(sqlite_path).expect("open latest selector sqlite connection")
+}
+
+pub(super) struct LatestSelectorCliFixture {
+    _lock: MutexGuard<'static, ()>,
+    root: PathBuf,
+    home_dir: PathBuf,
+    config_path: PathBuf,
+    sqlite_path: PathBuf,
+    memory_config: mvp::memory::runtime_config::MemoryRuntimeConfig,
+}
+
+impl LatestSelectorCliFixture {
+    pub(super) fn new(label: &str) -> Self {
+        let lock = lock_daemon_test_environment();
+        let root = unique_temp_path(label);
+        let home_dir = root.join("home");
+        let config_path = root.join("loongclaw.toml");
+        let sqlite_path = root.join("memory.sqlite3");
+        std::fs::create_dir_all(&home_dir).expect("create latest selector fixture home");
+        cleanup_sqlite_artifacts(&sqlite_path);
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.memory.sqlite_path = sqlite_path.display().to_string();
+        let memory_config =
+            mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+        let resolved_sqlite_path = config.memory.resolved_sqlite_path();
+        mvp::memory::ensure_memory_db_ready(Some(resolved_sqlite_path), &memory_config)
+            .expect("initialize latest selector sqlite memory");
+
+        Self {
+            _lock: lock,
+            root,
+            home_dir,
+            config_path,
+            sqlite_path,
+            memory_config,
+        }
+    }
+
+    pub(super) fn config_path(&self) -> &Path {
+        &self.config_path
+    }
+
+    pub(super) fn sqlite_path(&self) -> &Path {
+        &self.sqlite_path
+    }
+
+    pub(super) fn write_config_with(
+        &self,
+        configure: impl FnOnce(&mut mvp::config::LoongClawConfig),
+    ) -> mvp::config::LoongClawConfig {
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.memory.sqlite_path = self.sqlite_path.display().to_string();
+        config.memory.sliding_window = 8;
+        config.tools.file_root = Some(self.root.display().to_string());
+        configure(&mut config);
+        let config_path_text = self.config_path.to_string_lossy();
+        let config_path_text = config_path_text.as_ref();
+        mvp::config::write(Some(config_path_text), &config, true).expect("write config fixture");
+        config
+    }
+
+    fn session_repository(&self) -> mvp::session::repository::SessionRepository {
+        mvp::session::repository::SessionRepository::new(&self.memory_config)
+            .expect("session repository")
+    }
+
+    pub(super) fn create_root_session(&self, session_id: &str) {
+        let repo = self.session_repository();
+        let record = mvp::session::repository::NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: mvp::session::repository::SessionKind::Root,
+            parent_session_id: None,
+            label: Some(session_id.to_owned()),
+            state: mvp::session::repository::SessionState::Ready,
+        };
+        repo.create_session(record).expect("create root session");
+    }
+
+    pub(super) fn create_delegate_child_session(&self, session_id: &str, parent_session_id: &str) {
+        let repo = self.session_repository();
+        let record = mvp::session::repository::NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: mvp::session::repository::SessionKind::DelegateChild,
+            parent_session_id: Some(parent_session_id.to_owned()),
+            label: Some(session_id.to_owned()),
+            state: mvp::session::repository::SessionState::Ready,
+        };
+        repo.create_session(record)
+            .expect("create delegate child session");
+    }
+
+    pub(super) fn append_session_turn(&self, session_id: &str, role: &str, content: &str) {
+        mvp::memory::append_turn_direct(session_id, role, content, &self.memory_config)
+            .expect("append session turn");
+    }
+
+    pub(super) fn set_session_updated_at(&self, session_id: &str, updated_at: i64) {
+        let conn = open_sqlite_connection(&self.sqlite_path);
+        conn.execute(
+            "UPDATE sessions
+             SET updated_at = ?2
+             WHERE session_id = ?1",
+            params![session_id, updated_at],
+        )
+        .expect("set session updated_at");
+    }
+
+    pub(super) fn set_turn_timestamps(&self, session_id: &str, ts: i64) {
+        let conn = open_sqlite_connection(&self.sqlite_path);
+        conn.execute(
+            "UPDATE turns
+             SET ts = ?2
+             WHERE session_id = ?1",
+            params![session_id, ts],
+        )
+        .expect("set turn timestamps");
+    }
+
+    pub(super) fn archive_session(&self, session_id: &str, archived_at: i64) {
+        let conn = open_sqlite_connection(&self.sqlite_path);
+        conn.execute(
+            "INSERT INTO session_events(
+                session_id,
+                event_kind,
+                actor_session_id,
+                payload_json,
+                ts
+             ) VALUES (?1, ?2, NULL, ?3, ?4)",
+            params![session_id, "session_archived", "{}", archived_at],
+        )
+        .expect("insert session archive event");
+    }
+
+    pub(super) fn run_process(&self, args: &[&str], stdin_bytes: Option<&[u8]>) -> Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_loongclaw"));
+        command
+            .current_dir(&self.root)
+            .env("HOME", &self.home_dir)
+            .env_remove("LOONGCLAW_CONFIG_PATH")
+            .env_remove("USERPROFILE")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command.args(args);
+        command.arg("--config");
+        command.arg(&self.config_path);
+
+        let mut child = command.spawn().expect("spawn latest selector CLI");
+        if let Some(stdin_bytes) = stdin_bytes {
+            let stdin = child.stdin.as_mut().expect("latest selector stdin");
+            stdin
+                .write_all(stdin_bytes)
+                .expect("write latest selector stdin");
+        }
+        drop(child.stdin.take());
+        child
+            .wait_with_output()
+            .expect("wait for latest selector CLI output")
+    }
+}
+
+impl Drop for LatestSelectorCliFixture {
+    fn drop(&mut self) {
+        cleanup_sqlite_artifacts(&self.sqlite_path);
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -84,6 +84,7 @@ fn validation_diagnostic_with_severity(
 
 mod acp;
 mod architecture;
+mod ask_cli;
 mod chat_cli;
 mod cli_tests;
 mod doctor_feishu;
@@ -94,6 +95,7 @@ mod gateway_api_turn;
 mod gateway_owner_state;
 mod gateway_read_models;
 mod import_cli;
+mod latest_selector_process_support;
 mod memory_context_benchmark_cli;
 mod migrate_cli;
 mod migration;

--- a/docs/plans/2026-04-01-cli-process-latest-selector-coverage-design.md
+++ b/docs/plans/2026-04-01-cli-process-latest-selector-coverage-design.md
@@ -1,0 +1,163 @@
+# CLI Process-Level Latest Selector Coverage Design
+
+Date: 2026-04-01
+Issue: `#791`
+Status: Proposed for the current task branch
+
+## Problem
+
+The repository already proves three lower layers of `--session latest`:
+
+1. repository selection returns the newest resumable root session
+2. app-layer CLI runtime bootstrap resolves `latest` into a concrete session id
+3. daemon CLI parsing accepts the literal `latest` token for `ask` and `chat`
+
+What is still missing is a true spawned-process proof that the `loong` binary consumes that
+resolved session id correctly in operator-visible flows.
+
+That gap matters because the current tests would still stay green if:
+
+1. spawned CLI argument wiring bypassed the selector-aware runtime path
+2. chat startup or history commands rendered the wrong session after bootstrap
+3. ask loaded the wrong conversation history before issuing the provider request
+
+## Goal
+
+Add the smallest stable process-level daemon integration slice that proves:
+
+1. `loong chat --session latest` surfaces the resolved root session in startup output
+2. `loong chat --session latest` loads history from the selected latest resumable root session
+3. `loong chat --session latest` fails clearly when no resumable root session exists
+4. `loong ask --session latest` sends provider traffic using the selected latest resumable root
+   session context
+5. `loong ask --session latest` fails clearly when no resumable root session exists
+
+## Non-Goals
+
+1. no selector semantics change
+2. no new selector DSL
+3. no provider runtime refactor
+4. no generic daemon integration harness abstraction unless the tests prove it is required
+5. no sleep-driven timing logic inside the shared provider harness; any elapsed-time regression proof
+   must stay test-local and explicitly justified
+
+## Approaches Considered
+
+### A. Keep all coverage below the process boundary
+
+Pros:
+
+1. cheapest change
+2. reuses the existing app-layer coverage directly
+
+Cons:
+
+1. leaves the exact issue gap open
+2. does not prove real binary wiring or operator-visible output
+
+### B. Add spawned-process tests with minimal file-local fixtures
+
+Pros:
+
+1. proves the real `loong` binary path
+2. keeps changes local to daemon integration tests
+3. reuses existing sqlite session semantics instead of inventing new fakes
+4. can stay deterministic by using seeded sqlite state and a local mock provider
+
+Cons:
+
+1. requires some fixture setup for config, sqlite seeding, and request capture
+
+### C. Build a generic shared CLI process test framework first
+
+Pros:
+
+1. could reduce duplication across future CLI process tests
+
+Cons:
+
+1. adds abstraction before the real need is proven
+2. increases change surface for a narrowly scoped issue
+
+## Decision
+
+Choose approach B.
+
+The smallest correct move is:
+
+1. extend `crates/daemon/tests/integration/chat_cli.rs` with sqlite-backed `latest` fixtures and
+   spawned `loong chat` coverage
+2. add a new sibling integration file for spawned `loong ask` coverage because no existing ask
+   process suite exists
+3. use a local mock provider server for `ask` so the test can assert the selected history reached
+   the provider request body without depending on external credentials or network access
+
+This keeps the scope fully inside daemon integration tests, preserves the existing app/runtime
+ownership boundaries, and avoids broad new abstractions.
+
+## Test Design
+
+### Chat process path
+
+Seed sqlite with:
+
+1. one older resumable root session
+2. one newer resumable root session
+3. one newer delegate-child distractor
+4. one newest archived root distractor
+
+Run:
+
+```bash
+loong chat --config <fixture> --session latest
+```
+
+Pipe scripted stdin:
+
+```text
+/history 8
+/exit
+```
+
+Assert:
+
+1. startup output shows `session: <newest-root>`
+2. history output contains only the newest resumable root turns
+3. distractor session content does not appear
+
+Add a second test with no eligible root session and assert the process exits non-zero with a clear
+`latest` selector error.
+
+### Ask process path
+
+Seed sqlite with the same style of session set.
+
+Configure a local mock provider endpoint that records the incoming request and returns a trivial
+successful response.
+
+Run:
+
+```bash
+loong ask --config <fixture> --session latest --message "Summarize the current session."
+```
+
+Assert:
+
+1. process exits successfully
+2. captured provider request body contains the selected latest root session turns
+3. captured provider request body does not contain distractor session turns
+
+Add a second test with no eligible root session and assert the process exits non-zero with a clear
+`latest` selector error before any provider request is issued.
+
+Add one regression test with a bounded setup delay that exceeds the old fixed mock-server budget so
+the suite proves the wait window starts with the spawned process run rather than server creation.
+
+## Validation Strategy
+
+Minimum required validation for this slice:
+
+1. write the new spawned-process tests first and watch them fail
+2. implement only the minimal fixture support needed to make them pass
+3. run focused daemon integration tests for the new process-level coverage
+4. rerun broader daemon and workspace verification before claiming readiness

--- a/docs/plans/2026-04-01-cli-process-latest-selector-coverage-implementation-plan.md
+++ b/docs/plans/2026-04-01-cli-process-latest-selector-coverage-implementation-plan.md
@@ -1,0 +1,210 @@
+# CLI Process-Level Latest Selector Coverage Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add real spawned-process daemon integration coverage for `loong ask --session latest`
+and `loong chat --session latest` without changing selector semantics.
+
+**Architecture:** Keep the implementation test-only. Reuse sqlite-backed session seeding, extend
+the existing spawned `chat` suite for REPL-visible behavior, and add a minimal spawned `ask` suite
+that captures provider requests through a local mock server.
+
+**Tech Stack:** Rust, tokio, axum or local TCP test server, rusqlite-backed session fixtures,
+daemon integration tests.
+
+---
+
+## Task 1: Land the design and plan artifacts
+
+**Files:**
+- Create: `docs/plans/2026-04-01-cli-process-latest-selector-coverage-design.md`
+- Create: `docs/plans/2026-04-01-cli-process-latest-selector-coverage-implementation-plan.md`
+
+**Step 1: Write the artifacts**
+
+- record that issue `#791` is specifically about process-level coverage beyond the already-landed
+  app-layer tests
+- keep the scope test-only and ownership-preserving
+
+**Step 2: Verify artifacts exist**
+
+Run:
+
+```bash
+test -f docs/plans/2026-04-01-cli-process-latest-selector-coverage-design.md
+test -f docs/plans/2026-04-01-cli-process-latest-selector-coverage-implementation-plan.md
+```
+
+Expected: success
+
+## Task 2: Capture the red baseline for relevant existing coverage
+
+**Files:**
+- Modify: none
+
+**Step 1: Run the current latest-selector tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app cli_runtime_latest_session_selector --locked
+cargo test -p loongclaw-daemon --test integration latest_session_selector --locked
+```
+
+Expected: green, confirming the current gap is specifically process-level coverage.
+
+## Task 3: Add failing spawned chat coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/chat_cli.rs`
+
+**Step 1: Add sqlite-backed chat fixture helpers**
+
+- add minimal helpers that write a temp config file
+- seed root, delegate-child, and archived sessions into sqlite memory
+- keep helpers file-local unless duplication becomes clearly harmful
+
+**Step 2: Add a failing happy-path test**
+
+- spawn `loong chat --config <fixture> --session latest`
+- pipe `/history 8` then `/exit`
+- assert startup output and history reflect the latest resumable root session only
+
+**Step 3: Add a failing no-match test**
+
+- spawn `loong chat --config <fixture> --session latest`
+- do not seed any eligible root session
+- assert the process exits non-zero with a clear `latest` selector error
+
+**Step 4: Run the focused chat tests and verify red**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon --test integration chat_cli_ --locked
+```
+
+Expected: fail because the new coverage does not exist yet or the fixture is incomplete.
+
+## Task 4: Add failing spawned ask coverage
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/mod.rs`
+- Create: `crates/daemon/tests/integration/ask_cli.rs`
+
+**Step 1: Register the new integration module**
+
+- wire `ask_cli` into `crates/daemon/tests/integration/mod.rs`
+
+**Step 2: Add a local mock provider helper**
+
+- capture provider request bodies
+- return a minimal successful completion payload
+- avoid sleeps in the shared harness by waiting on recorded requests or immediate command
+  completion
+- if the old fixed wait budget needs an explicit regression proof, keep any setup delay bounded and
+  local to that single regression test
+
+**Step 3: Add a failing happy-path ask test**
+
+- spawn `loong ask --config <fixture> --session latest --message ...`
+- assert the captured provider request contains only the selected latest root history
+
+**Step 4: Add a failing no-match ask test**
+
+- run the same command without an eligible root session
+- assert the process exits non-zero with a clear `latest` selector error
+- assert no provider request was observed
+
+**Step 5: Run the focused ask tests and verify red**
+
+Run:
+
+```bash
+cargo test -p loongclaw-daemon --test integration ask_cli_ --locked
+```
+
+Expected: fail because the new coverage does not exist yet or the fixture is incomplete.
+
+## Task 5: Implement the minimal fixture support needed for green
+
+**Files:**
+- Modify only the daemon integration test files touched above
+
+**Step 1: Keep all support logic in test code unless a reusable helper is clearly justified**
+
+- prefer small named helper functions
+- keep session seeding explicit and readable
+- avoid generic harness layers
+
+**Step 2: Make the chat tests pass**
+
+- ensure startup output and `/history` use the resolved session
+
+**Step 3: Make the ask tests pass**
+
+- ensure the mock provider captures request bodies deterministically
+- ensure the no-match path exits before provider traffic
+
+## Task 6: Run focused verification
+
+**Files:**
+- Modify: none unless validation exposes a necessary fix
+
+**Run:**
+
+```bash
+cargo test -p loongclaw-daemon --test integration ask_cli_ --locked
+cargo test -p loongclaw-daemon --test integration chat_cli_ --locked
+cargo test -p loongclaw-daemon --test integration latest_session_selector --locked
+```
+
+Expected: green
+
+## Task 7: Run broader verification
+
+**Files:**
+- Modify: none unless validation exposes a necessary fix
+
+**Run:**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test -p loongclaw-app cli_runtime_latest_session_selector --locked
+cargo test -p loongclaw-daemon --test integration --locked
+cargo test --workspace --locked
+cargo test --workspace --all-features --locked
+git diff --check
+```
+
+Expected: all green, or any unrelated baseline failure must be separated explicitly before
+claiming completion.
+
+## Task 8: Prepare clean GitHub delivery
+
+**Files:**
+- Modify: GitHub artifacts through `gh`, not repository files
+
+**Step 1: Inspect isolated changes**
+
+Run:
+
+```bash
+git status --short
+git diff -- docs/plans/2026-04-01-cli-process-latest-selector-coverage-design.md docs/plans/2026-04-01-cli-process-latest-selector-coverage-implementation-plan.md crates/daemon/tests/integration/mod.rs crates/daemon/tests/integration/chat_cli.rs crates/daemon/tests/integration/ask_cli.rs
+```
+
+**Step 2: Commit with a scoped message**
+
+Run:
+
+```bash
+git add docs/plans/2026-04-01-cli-process-latest-selector-coverage-design.md docs/plans/2026-04-01-cli-process-latest-selector-coverage-implementation-plan.md crates/daemon/tests/integration/mod.rs crates/daemon/tests/integration/chat_cli.rs crates/daemon/tests/integration/ask_cli.rs
+git commit -m "Add process-level latest selector CLI coverage"
+```
+
+**Step 3: Create a linked PR**
+
+Use the repository PR template, link `#791` with an explicit closing clause, and record the exact
+verification commands and outcomes.


### PR DESCRIPTION
## Summary

- Problem: Process-level coverage was missing for `loong ask --session latest` and `loong chat --session latest`, so lower-layer selector tests could stay green while the real CLI binary loaded the wrong session or provider context.
- Why it matters: `--session latest` is an operator-facing selector path. Without spawned-process coverage, regressions in binary wiring, startup history rendering, or ask request context could slip past repository- and app-layer tests.
- What changed: Added shared sqlite-backed spawned-process fixture support for latest-selector coverage; added `chat --session latest` process tests for resolved-history success and missing-root failure; added `ask --session latest` process tests for provider-request history selection, missing-root failure, and a bounded regression that proves the mock-provider wait window starts with process execution rather than server creation; added design and implementation plan docs for the slice.
- What did not change (scope boundary): This PR does not change latest-selector semantics, CLI flags, provider behavior, or unrelated diagnostics paths. It only adds process-level regression coverage and the minimal test support required for that coverage.

## Linked Issues

- Closes #791
- Related #N/A

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: N/A
- Rollout / guardrails: N/A
- Rollback path: N/A

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
- Passed.

cargo clippy --workspace --all-targets --all-features -- -D warnings
- Passed.

cargo test --workspace --locked
- Passed.

cargo test --workspace --all-features --locked
- Passed.

for i in {1..5}; do cargo test -p loongclaw-daemon --test integration ask_cli_latest_session_selector_process_uses_selected_root_session_history -- --nocapture || exit 1; done
- Passed 5/5.

git diff --check
- Passed.

git diff --cached --check
- Passed.

Doc/scope review:
- Re-read the staged design and implementation plan docs and aligned them with the final bounded-delay regression so the docs match the implemented harness behavior.
```

## User-visible / Operator-visible Changes

- No new user-facing CLI surface area.
- Operator-visible effect: spawned `ask` and `chat` latest-selector flows now have direct regression coverage at the daemon integration boundary.

## Failure Recovery

- Fast rollback or disable path: Revert commit `b42d558e` (or this PR) to remove the process-level latest-selector coverage and its test-only fixture support. No migration or persisted-data rollback is required.
- Observable failure symptoms reviewers should watch for: `ask --session latest` or `chat --session latest` process tests selecting the wrong root session, missing-root failures reaching the provider unexpectedly, or the ask mock-provider regression test hanging or timing out.

## Reviewer Focus

- Review [`crates/daemon/tests/integration/latest_selector_process_support.rs`](./crates/daemon/tests/integration/latest_selector_process_support.rs) for fixture scope, sqlite seeding clarity, and process isolation.
- Review [`crates/daemon/tests/integration/ask_cli.rs`](./crates/daemon/tests/integration/ask_cli.rs) for the mock-provider lifecycle and the bounded regression proving the wait-window root cause.
- Review [`crates/daemon/tests/integration/chat_cli.rs`](./crates/daemon/tests/integration/chat_cli.rs) for session-selection assertions and coverage boundaries between root, delegate-child, and archived sessions.
- Review the two plan docs under `docs/plans/` for consistency with the final shipped scope.
