### PR TITLE
feat(Feishu Emoji) Added support for Feishu bot replies using emojis.

### DIFF
--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -30,6 +30,54 @@ use crate::channel::{
 use crate::config::{FeishuIntegrationConfig, ResolvedFeishuChannelConfig};
 
 const FEISHU_CARD_MESSAGE_CONTENT_LIMIT_BYTES: usize = 30 * 1024;
+pub(super) const FEISHU_ACK_REACTIONS: &[&str] =
+    &["THUMBSUP", "OK", "APPLAUSE", "MUSCLE", "DONE", "SMILE"];
+
+fn pick_uniform_index(len: usize) -> usize {
+    debug_assert!(len > 0);
+    let upper = len as u64;
+    let reject_threshold = (u64::MAX / upper) * upper;
+
+    loop {
+        let value = rand::random::<u64>();
+        if value < reject_threshold {
+            #[allow(clippy::cast_possible_truncation)]
+            return (value % upper) as usize;
+        }
+    }
+}
+
+pub(super) fn random_feishu_ack_reaction() -> &'static str {
+    let index = pick_uniform_index(FEISHU_ACK_REACTIONS.len());
+    FEISHU_ACK_REACTIONS.get(index).unwrap_or(&"THUMBSUP")
+}
+
+pub(super) async fn add_message_reaction(
+    client: &FeishuClient,
+    tenant_access_token: &str,
+    message_id: &str,
+    emoji_type: &str,
+) -> CliResult<()> {
+    let message_id = message_id.trim();
+    if message_id.is_empty() {
+        return Err("feishu reaction requires non-empty message_id".to_owned());
+    }
+    let emoji_type = emoji_type.trim();
+    if emoji_type.is_empty() {
+        return Err("feishu reaction requires non-empty emoji_type".to_owned());
+    }
+
+    let path = format!("/open-apis/im/v1/messages/{message_id}/reactions");
+    let body = serde_json::json!({
+        "reaction_type": {
+            "emoji_type": emoji_type,
+        }
+    });
+    let _ = client
+        .post_json(path.as_str(), Some(tenant_access_token), &[], &body)
+        .await?;
+    Ok(())
+}
 
 pub(super) struct FeishuAdapter {
     client: FeishuClient,
@@ -933,6 +981,77 @@ mod tests {
             .feishu
             .resolve_account(None)
             .expect("resolve feishu test account")
+    }
+
+    #[test]
+    fn feishu_ack_reaction_picker_only_returns_valid_candidates() {
+        for _ in 0..128 {
+            let emoji = random_feishu_ack_reaction();
+            assert!(
+                FEISHU_ACK_REACTIONS.contains(&emoji),
+                "unexpected Feishu ack reaction: {emoji}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn feishu_ack_reaction_helper_posts_expected_request_shape() {
+        let requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let state = MockServerState {
+            requests: requests.clone(),
+        };
+        let router = Router::new().route(
+            "/open-apis/im/v1/messages/om_inbound_ack_1/reactions",
+            post({
+                let state = state.clone();
+                move |request| {
+                    let state = state.clone();
+                    async move {
+                        record_request(State(state), request).await;
+                        Json(json!({
+                            "code": 0,
+                            "data": {
+                                "reaction_id": "reaction_ack_1"
+                            }
+                        }))
+                    }
+                }
+            }),
+        );
+        let (base_url, server) = spawn_mock_feishu_server(router).await;
+        let client = FeishuClient::new(
+            base_url,
+            "cli_a1b2c3".to_owned(),
+            "secret-123".to_owned(),
+            30,
+        )
+        .expect("build feishu client");
+
+        add_message_reaction(&client, "t-token-ack", "om_inbound_ack_1", "THUMBSUP")
+            .await
+            .expect("add ack reaction");
+
+        let recorded = requests.lock().await.clone();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(
+            recorded[0].path,
+            "/open-apis/im/v1/messages/om_inbound_ack_1/reactions"
+        );
+        assert_eq!(
+            recorded[0].authorization.as_deref(),
+            Some("Bearer t-token-ack")
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&recorded[0].body)
+                .expect("parse reaction body"),
+            json!({
+                "reaction_type": {
+                    "emoji_type": "THUMBSUP"
+                }
+            })
+        );
+
+        server.abort();
     }
 
     #[tokio::test]

--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -30,8 +30,15 @@ use crate::channel::{
 use crate::config::{FeishuIntegrationConfig, ResolvedFeishuChannelConfig};
 
 const FEISHU_CARD_MESSAGE_CONTENT_LIMIT_BYTES: usize = 30 * 1024;
-pub(super) const FEISHU_ACK_REACTIONS: &[&str] =
-    &["THUMBSUP", "OK", "APPLAUSE", "MUSCLE", "DONE", "SMILE"];
+pub(super) const FEISHU_ACK_REACTIONS: &[&str] = &[
+    "HappyDragon",
+    "OneSecond",
+    "OK",
+    "APPLAUSE",
+    "GoGoGo",
+    "DONE",
+    "CheckMark",
+];
 
 fn pick_uniform_index(len: usize) -> usize {
     debug_assert!(len > 0);

--- a/crates/app/src/channel/feishu/adapter.rs
+++ b/crates/app/src/channel/feishu/adapter.rs
@@ -138,6 +138,16 @@ impl FeishuAdapter {
         })
     }
 
+    pub(super) async fn add_ack_reaction(&self, message_id: &str) -> CliResult<()> {
+        add_message_reaction(
+            &self.client,
+            self.tenant_access_token()?,
+            message_id,
+            random_feishu_ack_reaction(),
+        )
+        .await
+    }
+
     fn feishu_body(message: &ChannelOutboundMessage) -> CliResult<FeishuOutboundMessageBody> {
         match message {
             ChannelOutboundMessage::Text(text) => messages::resolve_outbound_message_body(

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -2244,11 +2244,20 @@ mod tests {
         let provider_requests = provider_requests.lock().await.clone();
         assert_eq!(provider_requests.len(), 1);
 
-        let feishu_requests = feishu_requests.lock().await.clone();
-        assert_eq!(feishu_requests.len(), 2);
-        assert_eq!(
-            feishu_requests[1].path,
-            "/open-apis/im/v1/messages/om_runtime_end_1/reply"
+        let feishu_requests = wait_for_request_count(&feishu_requests, 3).await;
+        assert_eq!(feishu_requests.len(), 3);
+        assert!(
+            feishu_requests
+                .iter()
+                .any(|request| request.path == "/open-apis/im/v1/messages/om_runtime_end_1/reply"),
+            "reply should still be sent when runtime end bookkeeping fails"
+        );
+        assert!(
+            feishu_requests
+                .iter()
+                .any(|request| request.path
+                    == "/open-apis/im/v1/messages/om_runtime_end_1/reactions"),
+            "ack reaction should still be attempted when runtime end bookkeeping fails"
         );
 
         provider_server.abort();

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -30,7 +30,10 @@ use crate::channel::{
 use crate::config::{LoongClawConfig, ResolvedFeishuChannelConfig};
 use crate::crypto::timing_safe_eq;
 
-use super::adapter::{FeishuAdapter, outbound_reply_message_from_text};
+use super::adapter::{
+    FeishuAdapter, add_message_reaction, outbound_reply_message_from_text,
+    random_feishu_ack_reaction,
+};
 use super::payload::{FeishuCardCallbackEvent, FeishuWebhookAction};
 
 const FEISHU_CALLBACK_RESPONSE_MARKER: &str = "[feishu_callback_response]";
@@ -45,6 +48,7 @@ pub(super) struct FeishuWebhookState {
     verification_token: Option<String>,
     encrypt_key: Option<String>,
     allowed_chat_ids: BTreeSet<String>,
+    ack_reactions: bool,
     ignore_bot_messages: bool,
     seen_events: Arc<Mutex<RecentIdCache>>,
     kernel_ctx: Arc<KernelContext>,
@@ -100,6 +104,7 @@ impl FeishuWebhookState {
                 .map(|value| value.trim().to_owned())
                 .filter(|value| !value.is_empty())
                 .collect(),
+            ack_reactions: resolved.ack_reactions,
             ignore_bot_messages: resolved.ignore_bot_messages,
             config,
             resolved_path,
@@ -585,6 +590,7 @@ async fn handle_feishu_inbound_event(
     })?;
 
     let result = async {
+        maybe_send_feishu_ack_reaction_nonblocking(state, event.message_id.as_str());
         let channel_message = ChannelInboundMessage {
             session: event.session,
             reply_target: event.reply_target,
@@ -648,6 +654,49 @@ async fn handle_feishu_inbound_event(
     }
 
     result
+}
+
+fn maybe_send_feishu_ack_reaction_nonblocking(state: &FeishuWebhookState, message_id: &str) {
+    if !state.ack_reactions {
+        return;
+    }
+    let message_id = message_id.trim();
+    if message_id.is_empty() {
+        return;
+    }
+
+    let config = state.config.clone();
+    let configured_account_id = state.configured_account_id.clone();
+    let message_id = message_id.to_owned();
+    tokio::spawn(async move {
+        if let Err(error) =
+            send_feishu_ack_reaction(config, configured_account_id, &message_id).await
+        {
+            log_feishu_inbound_warning("ack reaction failed", &error);
+        }
+    });
+}
+
+async fn send_feishu_ack_reaction(
+    config: LoongClawConfig,
+    configured_account_id: String,
+    message_id: &str,
+) -> CliResult<()> {
+    let resolved = config
+        .feishu
+        .resolve_account(Some(configured_account_id.as_str()))?;
+    if !resolved.ack_reactions {
+        return Ok(());
+    }
+    let client = FeishuClient::from_configs(&resolved, &config.feishu_integration)?;
+    let tenant_access_token = client.get_tenant_access_token().await?;
+    add_message_reaction(
+        &client,
+        tenant_access_token.as_str(),
+        message_id,
+        random_feishu_ack_reaction(),
+    )
+    .await
 }
 
 fn parse_feishu_structured_callback_response(text: &str) -> Option<FeishuCallbackResponse> {
@@ -1022,6 +1071,20 @@ mod tests {
                 .map(ToOwned::to_owned),
             body: String::from_utf8(body.to_vec()).expect("mock request body utf8"),
         });
+    }
+
+    async fn wait_for_request_count(
+        requests: &Arc<Mutex<Vec<MockRequest>>>,
+        expected_len: usize,
+    ) -> Vec<MockRequest> {
+        for _ in 0..50 {
+            let snapshot = requests.lock().await.clone();
+            if snapshot.len() >= expected_len {
+                return snapshot;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        requests.lock().await.clone()
     }
 
     async fn spawn_mock_provider_server(
@@ -1417,6 +1480,24 @@ mod tests {
                         }
                     }
                 }),
+            )
+            .route(
+                "/open-apis/im/v1/messages/{message_id}/reactions",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "reaction_id": "reaction_webhook_1"
+                                }
+                            }))
+                        }
+                    }
+                }),
             );
         spawn_mock_server(router).await
     }
@@ -1692,33 +1773,120 @@ mod tests {
             "provider should receive the binary fetch note"
         );
 
-        let feishu_requests = feishu_requests.lock().await.clone();
-        assert_eq!(feishu_requests.len(), 2);
+        let feishu_requests = wait_for_request_count(&feishu_requests, 3).await;
+        assert_eq!(feishu_requests.len(), 4);
+        let reaction_request = feishu_requests
+            .iter()
+            .find(|request| request.path == "/open-apis/im/v1/messages/om_inbound_file_1/reactions")
+            .expect("webhook flow should add ack reaction");
         assert_eq!(
-            feishu_requests[1].path,
-            "/open-apis/im/v1/messages/om_inbound_file_1/reply"
-        );
-        assert_eq!(
-            feishu_requests[1].authorization.as_deref(),
+            reaction_request.authorization.as_deref(),
             Some("Bearer t-token-webhook")
         );
         assert!(
-            feishu_requests[1]
-                .body
-                .contains("\"msg_type\":\"interactive\""),
+            reaction_request.body.contains("\"emoji_type\""),
+            "reaction request should include a Feishu emoji type"
+        );
+        let reply_request = feishu_requests
+            .iter()
+            .find(|request| request.path == "/open-apis/im/v1/messages/om_inbound_file_1/reply")
+            .expect("webhook flow should still send a reply");
+        assert!(
+            reply_request.body.contains("\"msg_type\":\"interactive\""),
             "webhook reply should send markdown-capable interactive cards"
         );
         assert!(
-            feishu_requests[1]
-                .body
-                .contains("\\\"tag\\\":\\\"markdown\\\""),
+            reply_request.body.contains("\\\"tag\\\":\\\"markdown\\\""),
             "reply body should wrap the provider reply in a markdown card"
         );
         assert!(
-            feishu_requests[1]
+            reply_request
                 .body
                 .contains("\\\"content\\\":\\\"## structured inbound ack\\\\n\\\\n- rendered\\\""),
             "reply body should preserve provider markdown content"
+        );
+
+        provider_server.abort();
+        feishu_server.abort();
+    }
+
+    #[tokio::test]
+    async fn feishu_webhook_skips_ack_reaction_when_disabled() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let (provider_base_url, provider_server) =
+            spawn_mock_provider_server(provider_requests.clone()).await;
+        let (feishu_base_url, feishu_server) =
+            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_disabled_1").await;
+
+        let mut config = test_webhook_config(&provider_base_url, &feishu_base_url);
+        config.feishu.ack_reactions = false;
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve feishu account");
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before webhook test");
+        let kernel_ctx =
+            bootstrap_test_kernel_context("feishu-webhook-no-ack-test", DEFAULT_TOKEN_TTL_S)
+                .expect("bootstrap kernel context");
+        let runtime = Arc::new(
+            ChannelOperationRuntimeTracker::start(
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+            )
+            .await
+            .expect("start runtime tracker"),
+        );
+        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+
+        let payload = json!({
+            "token": "verify-token",
+            "header": {
+                "event_id": "evt_ack_disabled",
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "sender": {
+                    "sender_type": "user",
+                    "sender_id": {
+                        "open_id": "ou_sender_disabled"
+                    }
+                },
+                "message": {
+                    "chat_id": "oc_demo",
+                    "message_id": "om_inbound_no_ack_1",
+                    "message_type": "text",
+                    "content": "{\"text\":\"hello without ack\"}"
+                }
+            }
+        });
+        let raw_body = serde_json::to_string(&payload).expect("serialize payload");
+        let headers = signed_headers(&raw_body, "encrypt-key");
+        let response = handle_feishu_webhook_payload(
+            state,
+            &headers,
+            raw_body.as_str(),
+            serde_json::from_str(raw_body.as_str()).expect("payload value"),
+        )
+        .await
+        .expect("webhook should succeed");
+
+        assert_eq!(response.body(), &json!({"code": 0, "msg": "ok"}));
+
+        let feishu_requests = wait_for_request_count(&feishu_requests, 2).await;
+        assert_eq!(feishu_requests.len(), 2);
+        assert!(
+            feishu_requests
+                .iter()
+                .all(|request| request.path
+                    != "/open-apis/im/v1/messages/om_inbound_no_ack_1/reactions"),
+            "disabled ack_reactions should skip the reaction API call"
         );
 
         provider_server.abort();

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -48,6 +48,7 @@ pub(super) struct FeishuWebhookState {
     ack_reactions: bool,
     ignore_bot_messages: bool,
     seen_events: Arc<Mutex<RecentIdCache>>,
+    seen_ack_reactions: Arc<Mutex<RecentIdCache>>,
     kernel_ctx: Arc<KernelContext>,
     runtime: Arc<ChannelOperationRuntimeTracker>,
 }
@@ -107,6 +108,7 @@ impl FeishuWebhookState {
             resolved_path,
             adapter: Arc::new(Mutex::new(adapter)),
             seen_events: Arc::new(Mutex::new(RecentIdCache::new(2_048))),
+            seen_ack_reactions: Arc::new(Mutex::new(RecentIdCache::new(4_096))),
             kernel_ctx: Arc::new(kernel_ctx),
             runtime,
         }
@@ -588,6 +590,7 @@ async fn handle_feishu_inbound_event(
 
     let result = async {
         let inbound_message_id = event.message_id.clone();
+        maybe_send_feishu_ack_reaction_nonblocking(state, inbound_message_id.as_str()).await;
         let channel_message = ChannelInboundMessage {
             session: event.session,
             reply_target: event.reply_target,
@@ -639,18 +642,6 @@ async fn handle_feishu_inbound_event(
                     )
                 })?;
         }
-        if state.ack_reactions {
-            adapter
-                .add_ack_reaction(inbound_message_id.as_str())
-                .await
-                .map_err(|error| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("feishu ack reaction failed: {error}"),
-                    )
-                })?;
-        }
-
         Ok(FeishuParsedActionResponse::immediate(
             json!({"code": 0, "msg": "ok"}),
         ))
@@ -662,6 +653,45 @@ async fn handle_feishu_inbound_event(
     }
 
     result
+}
+
+async fn maybe_send_feishu_ack_reaction_nonblocking(state: &FeishuWebhookState, message_id: &str) {
+    if !state.ack_reactions {
+        return;
+    }
+    let message_id = message_id.trim();
+    if message_id.is_empty() {
+        return;
+    }
+
+    {
+        let mut dedupe = state.seen_ack_reactions.lock().await;
+        if !matches!(
+            dedupe.begin_processing(message_id),
+            RecentIdReservation::Accepted
+        ) {
+            return;
+        }
+    }
+
+    let message_id = message_id.to_owned();
+    let adapter = Arc::clone(&state.adapter);
+    let seen_ack_reactions = Arc::clone(&state.seen_ack_reactions);
+    tokio::spawn(async move {
+        let result = {
+            let adapter = adapter.lock().await;
+            adapter.add_ack_reaction(message_id.as_str()).await
+        };
+
+        let mut dedupe = seen_ack_reactions.lock().await;
+        match result {
+            Ok(()) => dedupe.mark_completed(message_id.as_str()),
+            Err(error) => {
+                dedupe.release(message_id.as_str());
+                log_feishu_inbound_warning("ack reaction failed", &error);
+            }
+        }
+    });
 }
 
 fn parse_feishu_structured_callback_response(text: &str) -> Option<FeishuCallbackResponse> {
@@ -1467,6 +1497,82 @@ mod tests {
         spawn_mock_server(router).await
     }
 
+    async fn spawn_mock_feishu_api_server_with_failing_reactions(
+        requests: Arc<Mutex<Vec<MockRequest>>>,
+        reply_message_id: &'static str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let state = MockServerState { requests };
+        let router = Router::new()
+            .route(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "tenant_access_token": "t-token-webhook"
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/interactive/v1/card/update",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "msg": "ok"
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/im/v1/messages/{message_id}/reply",
+                post({
+                    let state = state.clone();
+                    move |axum::extract::Path(message_id): axum::extract::Path<String>, request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "message_id": reply_message_id,
+                                    "root_id": message_id
+                                }
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/im/v1/messages/{message_id}/reactions",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 99991663,
+                                "msg": "reaction failed"
+                            }))
+                        }
+                    }
+                }),
+            );
+        spawn_mock_server(router).await
+    }
+
     fn test_webhook_config(provider_base_url: &str, feishu_base_url: &str) -> LoongClawConfig {
         let temp_dir = temp_webhook_test_dir("runtime");
         std::fs::create_dir_all(&temp_dir).expect("create webhook temp dir");
@@ -1859,7 +1965,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn feishu_webhook_provider_failure_does_not_send_ack_reaction() {
+    async fn feishu_webhook_provider_failure_retry_does_not_duplicate_ack_reaction() {
         let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
         let (provider_base_url, provider_server) =
@@ -1916,7 +2022,7 @@ mod tests {
         let raw_body = serde_json::to_string(&payload).expect("serialize payload");
         let headers = signed_headers(&raw_body, "encrypt-key");
         let error = handle_feishu_webhook_payload(
-            state,
+            state.clone(),
             &headers,
             raw_body.as_str(),
             serde_json::from_str(raw_body.as_str()).expect("payload value"),
@@ -1927,17 +2033,121 @@ mod tests {
         assert_eq!(error.0, StatusCode::INTERNAL_SERVER_ERROR);
         assert!(error.1.contains("provider processing failed"));
 
-        let feishu_requests = wait_for_request_count(&feishu_requests, 1).await;
-        assert_eq!(feishu_requests.len(), 1);
-        assert!(
-            feishu_requests.iter().all(|request| request.path
-                != "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reactions"),
-            "failed inbound handling must not emit an ack reaction before retry"
+        let error_retry = handle_feishu_webhook_payload(
+            state,
+            &headers,
+            raw_body.as_str(),
+            serde_json::from_str(raw_body.as_str()).expect("payload value"),
+        )
+        .await
+        .expect_err("webhook retry should still surface provider failure");
+        assert_eq!(error_retry.0, StatusCode::INTERNAL_SERVER_ERROR);
+
+        let feishu_requests = wait_for_request_count(&feishu_requests, 2).await;
+        assert_eq!(feishu_requests.len(), 2);
+        assert_eq!(
+            feishu_requests
+                .iter()
+                .filter(|request| request.path
+                    == "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reactions")
+                .count(),
+            1,
+            "retrying a failed inbound turn must not duplicate ack reactions"
         );
         assert!(
             feishu_requests.iter().all(|request| request.path
                 != "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reply"),
             "failed inbound handling must not send a reply"
+        );
+
+        provider_server.abort();
+        feishu_server.abort();
+    }
+
+    #[tokio::test]
+    async fn feishu_webhook_reaction_failure_stays_best_effort_after_reply() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let (provider_base_url, provider_server) =
+            spawn_mock_provider_server(provider_requests.clone()).await;
+        let (feishu_base_url, feishu_server) = spawn_mock_feishu_api_server_with_failing_reactions(
+            feishu_requests.clone(),
+            "om_reply_reaction_failure_1",
+        )
+        .await;
+
+        let config = test_webhook_config(&provider_base_url, &feishu_base_url);
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve feishu account");
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before webhook test");
+        let kernel_ctx = bootstrap_test_kernel_context(
+            "feishu-webhook-reaction-failure-best-effort",
+            DEFAULT_TOKEN_TTL_S,
+        )
+        .expect("bootstrap kernel context");
+        let runtime = Arc::new(
+            ChannelOperationRuntimeTracker::start(
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+            )
+            .await
+            .expect("start runtime tracker"),
+        );
+        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+
+        let payload = json!({
+            "token": "verify-token",
+            "header": {
+                "event_id": "evt_reaction_failure_best_effort",
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "sender": {
+                    "sender_type": "user",
+                    "sender_id": {
+                        "open_id": "ou_sender_reaction_failure"
+                    }
+                },
+                "message": {
+                    "chat_id": "oc_demo",
+                    "message_id": "om_inbound_reaction_failure_1",
+                    "message_type": "text",
+                    "content": "{\"text\":\"reaction failure should not fail webhook\"}"
+                }
+            }
+        });
+        let raw_body = serde_json::to_string(&payload).expect("serialize payload");
+        let headers = signed_headers(&raw_body, "encrypt-key");
+        let response = handle_feishu_webhook_payload(
+            state,
+            &headers,
+            raw_body.as_str(),
+            serde_json::from_str(raw_body.as_str()).expect("payload value"),
+        )
+        .await
+        .expect("reaction failure should stay best-effort");
+
+        assert_eq!(response.body(), &json!({"code": 0, "msg": "ok"}));
+
+        let feishu_requests = wait_for_request_count(&feishu_requests, 3).await;
+        assert_eq!(feishu_requests.len(), 3);
+        assert!(
+            feishu_requests.iter().any(|request| request.path
+                == "/open-apis/im/v1/messages/om_inbound_reaction_failure_1/reply"),
+            "reply should still be sent even when reaction fails"
+        );
+        assert!(
+            feishu_requests.iter().any(|request| request.path
+                == "/open-apis/im/v1/messages/om_inbound_reaction_failure_1/reactions"),
+            "reaction attempt should still be issued"
         );
 
         provider_server.abort();

--- a/crates/app/src/channel/feishu/webhook.rs
+++ b/crates/app/src/channel/feishu/webhook.rs
@@ -30,10 +30,7 @@ use crate::channel::{
 use crate::config::{LoongClawConfig, ResolvedFeishuChannelConfig};
 use crate::crypto::timing_safe_eq;
 
-use super::adapter::{
-    FeishuAdapter, add_message_reaction, outbound_reply_message_from_text,
-    random_feishu_ack_reaction,
-};
+use super::adapter::{FeishuAdapter, outbound_reply_message_from_text};
 use super::payload::{FeishuCardCallbackEvent, FeishuWebhookAction};
 
 const FEISHU_CALLBACK_RESPONSE_MARKER: &str = "[feishu_callback_response]";
@@ -590,14 +587,14 @@ async fn handle_feishu_inbound_event(
     })?;
 
     let result = async {
-        maybe_send_feishu_ack_reaction_nonblocking(state, event.message_id.as_str());
+        let inbound_message_id = event.message_id.clone();
         let channel_message = ChannelInboundMessage {
             session: event.session,
             reply_target: event.reply_target,
             text: event.text,
             delivery: crate::channel::ChannelDelivery {
                 ack_cursor: None,
-                source_message_id: Some(event.message_id),
+                source_message_id: Some(inbound_message_id.clone()),
                 sender_principal_key: event.principal.as_ref().map(|value| value.storage_key()),
                 thread_root_id: event.root_id,
                 parent_message_id: event.parent_id,
@@ -642,6 +639,17 @@ async fn handle_feishu_inbound_event(
                     )
                 })?;
         }
+        if state.ack_reactions {
+            adapter
+                .add_ack_reaction(inbound_message_id.as_str())
+                .await
+                .map_err(|error| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("feishu ack reaction failed: {error}"),
+                    )
+                })?;
+        }
 
         Ok(FeishuParsedActionResponse::immediate(
             json!({"code": 0, "msg": "ok"}),
@@ -654,49 +662,6 @@ async fn handle_feishu_inbound_event(
     }
 
     result
-}
-
-fn maybe_send_feishu_ack_reaction_nonblocking(state: &FeishuWebhookState, message_id: &str) {
-    if !state.ack_reactions {
-        return;
-    }
-    let message_id = message_id.trim();
-    if message_id.is_empty() {
-        return;
-    }
-
-    let config = state.config.clone();
-    let configured_account_id = state.configured_account_id.clone();
-    let message_id = message_id.to_owned();
-    tokio::spawn(async move {
-        if let Err(error) =
-            send_feishu_ack_reaction(config, configured_account_id, &message_id).await
-        {
-            log_feishu_inbound_warning("ack reaction failed", &error);
-        }
-    });
-}
-
-async fn send_feishu_ack_reaction(
-    config: LoongClawConfig,
-    configured_account_id: String,
-    message_id: &str,
-) -> CliResult<()> {
-    let resolved = config
-        .feishu
-        .resolve_account(Some(configured_account_id.as_str()))?;
-    if !resolved.ack_reactions {
-        return Ok(());
-    }
-    let client = FeishuClient::from_configs(&resolved, &config.feishu_integration)?;
-    let tenant_access_token = client.get_tenant_access_token().await?;
-    add_message_reaction(
-        &client,
-        tenant_access_token.as_str(),
-        message_id,
-        random_feishu_ack_reaction(),
-    )
-    .await
 }
 
 fn parse_feishu_structured_callback_response(text: &str) -> Option<FeishuCallbackResponse> {
@@ -1774,7 +1739,7 @@ mod tests {
         );
 
         let feishu_requests = wait_for_request_count(&feishu_requests, 3).await;
-        assert_eq!(feishu_requests.len(), 4);
+        assert_eq!(feishu_requests.len(), 3);
         let reaction_request = feishu_requests
             .iter()
             .find(|request| request.path == "/open-apis/im/v1/messages/om_inbound_file_1/reactions")
@@ -1887,6 +1852,92 @@ mod tests {
                 .all(|request| request.path
                     != "/open-apis/im/v1/messages/om_inbound_no_ack_1/reactions"),
             "disabled ack_reactions should skip the reaction API call"
+        );
+
+        provider_server.abort();
+        feishu_server.abort();
+    }
+
+    #[tokio::test]
+    async fn feishu_webhook_provider_failure_does_not_send_ack_reaction() {
+        let provider_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let feishu_requests = Arc::new(Mutex::new(Vec::<MockRequest>::new()));
+        let (provider_base_url, provider_server) =
+            spawn_mock_provider_failure_server(provider_requests.clone()).await;
+        let (feishu_base_url, feishu_server) =
+            spawn_mock_feishu_api_server(feishu_requests.clone(), "om_reply_unused").await;
+
+        let config = test_webhook_config(&provider_base_url, &feishu_base_url);
+        let resolved = config
+            .feishu
+            .resolve_account(None)
+            .expect("resolve feishu account");
+        let mut adapter = FeishuAdapter::new(&resolved).expect("build feishu adapter");
+        adapter
+            .refresh_tenant_token()
+            .await
+            .expect("refresh tenant token before webhook test");
+        let kernel_ctx =
+            bootstrap_test_kernel_context("feishu-webhook-provider-failure", DEFAULT_TOKEN_TTL_S)
+                .expect("bootstrap kernel context");
+        let runtime = Arc::new(
+            ChannelOperationRuntimeTracker::start(
+                ChannelPlatform::Feishu,
+                "serve",
+                resolved.account.id.as_str(),
+                resolved.account.label.as_str(),
+            )
+            .await
+            .expect("start runtime tracker"),
+        );
+        let state = FeishuWebhookState::new(config, &resolved, adapter, kernel_ctx, runtime);
+
+        let payload = json!({
+            "token": "verify-token",
+            "header": {
+                "event_id": "evt_provider_failure_no_ack",
+                "event_type": "im.message.receive_v1"
+            },
+            "event": {
+                "sender": {
+                    "sender_type": "user",
+                    "sender_id": {
+                        "open_id": "ou_sender_provider_failure"
+                    }
+                },
+                "message": {
+                    "chat_id": "oc_demo",
+                    "message_id": "om_inbound_failure_no_ack_1",
+                    "message_type": "text",
+                    "content": "{\"text\":\"provider failure should not ack\"}"
+                }
+            }
+        });
+        let raw_body = serde_json::to_string(&payload).expect("serialize payload");
+        let headers = signed_headers(&raw_body, "encrypt-key");
+        let error = handle_feishu_webhook_payload(
+            state,
+            &headers,
+            raw_body.as_str(),
+            serde_json::from_str(raw_body.as_str()).expect("payload value"),
+        )
+        .await
+        .expect_err("webhook should surface provider failure");
+
+        assert_eq!(error.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(error.1.contains("provider processing failed"));
+
+        let feishu_requests = wait_for_request_count(&feishu_requests, 1).await;
+        assert_eq!(feishu_requests.len(), 1);
+        assert!(
+            feishu_requests.iter().all(|request| request.path
+                != "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reactions"),
+            "failed inbound handling must not emit an ack reaction before retry"
+        );
+        assert!(
+            feishu_requests.iter().all(|request| request.path
+                != "/open-apis/im/v1/messages/om_inbound_failure_no_ack_1/reply"),
+            "failed inbound handling must not send a reply"
         );
 
         provider_server.abort();

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -514,6 +514,20 @@ mod tests {
         });
     }
 
+    async fn wait_for_request_count(
+        requests: &Arc<Mutex<Vec<MockRequest>>>,
+        expected_len: usize,
+    ) -> Vec<MockRequest> {
+        for _ in 0..50 {
+            let snapshot = requests.lock().await.clone();
+            if snapshot.len() >= expected_len {
+                return snapshot;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        requests.lock().await.clone()
+    }
+
     async fn spawn_mock_provider_server(
         requests: Arc<Mutex<Vec<MockRequest>>>,
     ) -> (String, tokio::task::JoinHandle<()>) {
@@ -575,6 +589,24 @@ mod tests {
                                 "data": {
                                     "message_id": reply_message_id,
                                     "root_id": message_id
+                                }
+                            }))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/open-apis/im/v1/messages/{message_id}/reactions",
+                post({
+                    let state = state.clone();
+                    move |request| {
+                        let state = state.clone();
+                        async move {
+                            record_request(State(state), request).await;
+                            Json(json!({
+                                "code": 0,
+                                "data": {
+                                    "reaction_id": "reaction_websocket_1"
                                 }
                             }))
                         }
@@ -1042,30 +1074,34 @@ mod tests {
             "provider request should include the websocket inbound message"
         );
 
-        let feishu_requests = feishu_requests.lock().await.clone();
-        assert_eq!(feishu_requests.len(), 2);
+        let feishu_requests = wait_for_request_count(&feishu_requests, 3).await;
+        assert_eq!(feishu_requests.len(), 4);
+        let reaction_request = feishu_requests
+            .iter()
+            .find(|request| request.path == "/open-apis/im/v1/messages/om_inbound_ws_1/reactions")
+            .expect("websocket flow should add ack reaction");
         assert_eq!(
-            feishu_requests[1].path,
-            "/open-apis/im/v1/messages/om_inbound_ws_1/reply"
-        );
-        assert_eq!(
-            feishu_requests[1].authorization.as_deref(),
+            reaction_request.authorization.as_deref(),
             Some("Bearer t-token-websocket")
         );
         assert!(
-            feishu_requests[1]
-                .body
-                .contains("\"msg_type\":\"interactive\""),
+            reaction_request.body.contains("\"emoji_type\""),
+            "reaction request should include a Feishu emoji type"
+        );
+        let reply_request = feishu_requests
+            .iter()
+            .find(|request| request.path == "/open-apis/im/v1/messages/om_inbound_ws_1/reply")
+            .expect("websocket flow should still send a reply");
+        assert!(
+            reply_request.body.contains("\"msg_type\":\"interactive\""),
             "websocket flow should send markdown-capable interactive cards"
         );
         assert!(
-            feishu_requests[1]
-                .body
-                .contains("\\\"tag\\\":\\\"markdown\\\""),
+            reply_request.body.contains("\\\"tag\\\":\\\"markdown\\\""),
             "websocket flow should wrap the provider reply in a markdown card"
         );
         assert!(
-            feishu_requests[1]
+            reply_request
                 .body
                 .contains("\\\"content\\\":\\\"## structured inbound ack\\\\n\\\\n- rendered\\\""),
             "websocket flow should preserve provider markdown content"

--- a/crates/app/src/channel/feishu/websocket.rs
+++ b/crates/app/src/channel/feishu/websocket.rs
@@ -1075,7 +1075,7 @@ mod tests {
         );
 
         let feishu_requests = wait_for_request_count(&feishu_requests, 3).await;
-        assert_eq!(feishu_requests.len(), 4);
+        assert_eq!(feishu_requests.len(), 3);
         let reaction_request = feishu_requests
             .iter()
             .find(|request| request.path == "/open-apis/im/v1/messages/om_inbound_ws_1/reactions")

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -7914,6 +7914,9 @@ where
 mod tlon_support;
 
 #[cfg(test)]
+mod feishu_tests;
+
+#[cfg(test)]
 mod hotspot_tests;
 
 #[cfg(test)]
@@ -8236,139 +8239,6 @@ mod tests {
         assert_eq!(route.requested_account_id.as_deref(), Some("work"));
         assert_eq!(route.selected_configured_account_id, "work");
         assert!(!route.uses_implicit_fallback_default());
-    }
-
-    #[test]
-    fn feishu_multi_account_resolution_merges_base_and_account_overrides() {
-        let config: FeishuChannelConfig = serde_json::from_value(json!({
-            "enabled": true,
-            "mode": "webhook",
-            "app_id_env": "BASE_FEISHU_APP_ID",
-            "app_secret_env": "BASE_FEISHU_APP_SECRET",
-            "verification_token_env": "BASE_FEISHU_VERIFY",
-            "encrypt_key_env": "BASE_FEISHU_ENCRYPT",
-            "receive_id_type": "chat_id",
-            "webhook_bind": "127.0.0.1:8080",
-            "webhook_path": "/feishu/events",
-            "allowed_chat_ids": ["oc_base"],
-            "acp": {
-                "bootstrap_mcp_servers": ["filesystem"],
-                "working_directory": " /workspace/base "
-            },
-            "default_account": "Lark Prod",
-            "accounts": {
-                "Lark Prod": {
-                    "domain": "lark",
-                    "app_id": "cli_lark_123",
-                    "app_secret": "secret",
-                    "verification_token": "verify",
-                    "encrypt_key": "encrypt",
-                    "allowed_chat_ids": ["oc_lark"],
-                    "acp": {
-                        "bootstrap_mcp_servers": ["search"],
-                        "working_directory": "/workspace/lark-prod"
-                    }
-                },
-                "Feishu Backup": {
-                    "enabled": false,
-                    "app_id": "cli_backup_456",
-                    "app_secret": "secret"
-                }
-            }
-        }))
-        .expect("deserialize feishu multi-account config");
-
-        assert_eq!(
-            config.configured_account_ids(),
-            vec!["feishu-backup", "lark-prod"]
-        );
-        assert_eq!(config.default_configured_account_id(), "lark-prod");
-
-        let resolved = config
-            .resolve_account(None)
-            .expect("resolve default feishu account");
-        assert_eq!(resolved.configured_account_id, "lark-prod");
-        assert_eq!(resolved.domain, FeishuDomain::Lark);
-        assert_eq!(resolved.account.id, "lark_cli_lark_123");
-        assert_eq!(resolved.account.label, "lark:cli_lark_123");
-        assert_eq!(resolved.allowed_chat_ids, vec!["oc_lark".to_owned()]);
-        assert_eq!(
-            resolved.acp.bootstrap_mcp_servers,
-            vec!["search".to_owned()]
-        );
-        assert_eq!(
-            resolved.acp.resolved_working_directory(),
-            Some(std::path::PathBuf::from("/workspace/lark-prod"))
-        );
-        assert_eq!(resolved.receive_id_type, "chat_id");
-        assert_eq!(resolved.mode, FeishuChannelServeMode::Webhook);
-        assert_eq!(resolved.resolved_base_url(), "https://open.larksuite.com");
-        assert!(resolved.ack_reactions);
-
-        let disabled = config
-            .resolve_account(Some("Feishu Backup"))
-            .expect("resolve explicit feishu account");
-        assert_eq!(disabled.configured_account_id, "feishu-backup");
-        assert!(!disabled.enabled);
-        assert_eq!(disabled.allowed_chat_ids, vec!["oc_base".to_owned()]);
-        assert_eq!(
-            disabled.acp.bootstrap_mcp_servers,
-            vec!["filesystem".to_owned()]
-        );
-        assert_eq!(
-            disabled.acp.resolved_working_directory(),
-            Some(std::path::PathBuf::from("/workspace/base"))
-        );
-    }
-
-    #[test]
-    fn feishu_ack_reactions_default_to_true_and_allow_account_override() {
-        let base_config: FeishuChannelConfig = serde_json::from_value(json!({
-            "enabled": true,
-            "app_id": "cli_base",
-            "app_secret": "base-secret"
-        }))
-        .expect("deserialize base feishu config");
-
-        let default_resolved = base_config
-            .resolve_account(None)
-            .expect("resolve default feishu account");
-        assert!(default_resolved.ack_reactions);
-
-        let override_config: FeishuChannelConfig = serde_json::from_value(json!({
-            "enabled": true,
-            "app_id": "cli_base",
-            "app_secret": "base-secret",
-            "accounts": {
-                "Quiet Bot": {
-                    "ack_reactions": false,
-                    "app_id": "cli_quiet",
-                    "app_secret": "quiet-secret"
-                }
-            }
-        }))
-        .expect("deserialize override feishu config");
-
-        let quiet_resolved = override_config
-            .resolve_account(Some("Quiet Bot"))
-            .expect("resolve quiet feishu account");
-        assert!(!quiet_resolved.ack_reactions);
-    }
-
-    #[test]
-    fn feishu_mode_defaults_to_websocket_when_not_configured() {
-        let config: FeishuChannelConfig = serde_json::from_value(json!({
-            "enabled": true,
-            "app_id": "cli_a1b2c3",
-            "app_secret": "secret"
-        }))
-        .expect("deserialize feishu config");
-
-        let resolved = config
-            .resolve_account(None)
-            .expect("resolve default feishu account");
-
-        assert_eq!(resolved.mode, FeishuChannelServeMode::Websocket);
     }
 
     #[test]

--- a/crates/app/src/config/channels.rs
+++ b/crates/app/src/config/channels.rs
@@ -390,6 +390,8 @@ pub struct FeishuAccountConfig {
     #[serde(default)]
     pub allowed_chat_ids: Option<Vec<String>>,
     #[serde(default)]
+    pub ack_reactions: Option<bool>,
+    #[serde(default)]
     pub ignore_bot_messages: Option<bool>,
     #[serde(default)]
     pub acp: Option<ChannelAcpConfig>,
@@ -433,6 +435,7 @@ pub struct ResolvedFeishuChannelConfig {
     pub encrypt_key: Option<SecretRef>,
     pub encrypt_key_env: Option<String>,
     pub allowed_chat_ids: Vec<String>,
+    pub ack_reactions: bool,
     pub ignore_bot_messages: bool,
     pub acp: ChannelAcpConfig,
 }
@@ -621,6 +624,8 @@ pub struct FeishuChannelConfig {
     pub encrypt_key_env: Option<String>,
     #[serde(default)]
     pub allowed_chat_ids: Vec<String>,
+    #[serde(default = "default_true")]
+    pub ack_reactions: bool,
     #[serde(default = "default_true")]
     pub ignore_bot_messages: bool,
     #[serde(default)]
@@ -2200,6 +2205,7 @@ impl Default for FeishuChannelConfig {
             encrypt_key: None,
             encrypt_key_env: Some(FEISHU_ENCRYPT_KEY_ENV.to_owned()),
             allowed_chat_ids: Vec::new(),
+            ack_reactions: true,
             ignore_bot_messages: true,
             acp: ChannelAcpConfig::default(),
             accounts: BTreeMap::new(),
@@ -2767,6 +2773,9 @@ impl FeishuChannelConfig {
             allowed_chat_ids: account_override
                 .and_then(|account| account.allowed_chat_ids.clone())
                 .unwrap_or_else(|| self.allowed_chat_ids.clone()),
+            ack_reactions: account_override
+                .and_then(|account| account.ack_reactions)
+                .unwrap_or(self.ack_reactions),
             ignore_bot_messages: account_override
                 .and_then(|account| account.ignore_bot_messages)
                 .unwrap_or(self.ignore_bot_messages),
@@ -2798,6 +2807,7 @@ impl FeishuChannelConfig {
             encrypt_key: merged.encrypt_key,
             encrypt_key_env: merged.encrypt_key_env,
             allowed_chat_ids: merged.allowed_chat_ids,
+            ack_reactions: merged.ack_reactions,
             ignore_bot_messages: merged.ignore_bot_messages,
             acp: merged.acp,
         })
@@ -8293,6 +8303,7 @@ mod tests {
         assert_eq!(resolved.receive_id_type, "chat_id");
         assert_eq!(resolved.mode, FeishuChannelServeMode::Webhook);
         assert_eq!(resolved.resolved_base_url(), "https://open.larksuite.com");
+        assert!(resolved.ack_reactions);
 
         let disabled = config
             .resolve_account(Some("Feishu Backup"))
@@ -8308,6 +8319,40 @@ mod tests {
             disabled.acp.resolved_working_directory(),
             Some(std::path::PathBuf::from("/workspace/base"))
         );
+    }
+
+    #[test]
+    fn feishu_ack_reactions_default_to_true_and_allow_account_override() {
+        let base_config: FeishuChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "app_id": "cli_base",
+            "app_secret": "base-secret"
+        }))
+        .expect("deserialize base feishu config");
+
+        let default_resolved = base_config
+            .resolve_account(None)
+            .expect("resolve default feishu account");
+        assert!(default_resolved.ack_reactions);
+
+        let override_config: FeishuChannelConfig = serde_json::from_value(json!({
+            "enabled": true,
+            "app_id": "cli_base",
+            "app_secret": "base-secret",
+            "accounts": {
+                "Quiet Bot": {
+                    "ack_reactions": false,
+                    "app_id": "cli_quiet",
+                    "app_secret": "quiet-secret"
+                }
+            }
+        }))
+        .expect("deserialize override feishu config");
+
+        let quiet_resolved = override_config
+            .resolve_account(Some("Quiet Bot"))
+            .expect("resolve quiet feishu account");
+        assert!(!quiet_resolved.ack_reactions);
     }
 
     #[test]

--- a/crates/app/src/config/channels/feishu_tests.rs
+++ b/crates/app/src/config/channels/feishu_tests.rs
@@ -1,0 +1,135 @@
+use super::*;
+use serde_json::json;
+
+#[test]
+fn feishu_multi_account_resolution_merges_base_and_account_overrides() {
+    let config: FeishuChannelConfig = serde_json::from_value(json!({
+        "enabled": true,
+        "mode": "webhook",
+        "app_id_env": "BASE_FEISHU_APP_ID",
+        "app_secret_env": "BASE_FEISHU_APP_SECRET",
+        "verification_token_env": "BASE_FEISHU_VERIFY",
+        "encrypt_key_env": "BASE_FEISHU_ENCRYPT",
+        "receive_id_type": "chat_id",
+        "webhook_bind": "127.0.0.1:8080",
+        "webhook_path": "/feishu/events",
+        "allowed_chat_ids": ["oc_base"],
+        "acp": {
+            "bootstrap_mcp_servers": ["filesystem"],
+            "working_directory": " /workspace/base "
+        },
+        "default_account": "Lark Prod",
+        "accounts": {
+            "Lark Prod": {
+                "domain": "lark",
+                "app_id": "cli_lark_123",
+                "app_secret": "secret",
+                "verification_token": "verify",
+                "encrypt_key": "encrypt",
+                "allowed_chat_ids": ["oc_lark"],
+                "acp": {
+                    "bootstrap_mcp_servers": ["search"],
+                    "working_directory": "/workspace/lark-prod"
+                }
+            },
+            "Feishu Backup": {
+                "enabled": false,
+                "app_id": "cli_backup_456",
+                "app_secret": "secret"
+            }
+        }
+    }))
+    .expect("deserialize feishu multi-account config");
+
+    assert_eq!(
+        config.configured_account_ids(),
+        vec!["feishu-backup", "lark-prod"]
+    );
+    assert_eq!(config.default_configured_account_id(), "lark-prod");
+
+    let resolved = config
+        .resolve_account(None)
+        .expect("resolve default feishu account");
+    assert_eq!(resolved.configured_account_id, "lark-prod");
+    assert_eq!(resolved.domain, FeishuDomain::Lark);
+    assert_eq!(resolved.account.id, "lark_cli_lark_123");
+    assert_eq!(resolved.account.label, "lark:cli_lark_123");
+    assert_eq!(resolved.allowed_chat_ids, vec!["oc_lark".to_owned()]);
+    assert_eq!(
+        resolved.acp.bootstrap_mcp_servers,
+        vec!["search".to_owned()]
+    );
+    assert_eq!(
+        resolved.acp.resolved_working_directory(),
+        Some(std::path::PathBuf::from("/workspace/lark-prod"))
+    );
+    assert_eq!(resolved.receive_id_type, "chat_id");
+    assert_eq!(resolved.mode, FeishuChannelServeMode::Webhook);
+    assert_eq!(resolved.resolved_base_url(), "https://open.larksuite.com");
+    assert!(resolved.ack_reactions);
+
+    let disabled = config
+        .resolve_account(Some("Feishu Backup"))
+        .expect("resolve explicit feishu account");
+    assert_eq!(disabled.configured_account_id, "feishu-backup");
+    assert!(!disabled.enabled);
+    assert_eq!(disabled.allowed_chat_ids, vec!["oc_base".to_owned()]);
+    assert_eq!(
+        disabled.acp.bootstrap_mcp_servers,
+        vec!["filesystem".to_owned()]
+    );
+    assert_eq!(
+        disabled.acp.resolved_working_directory(),
+        Some(std::path::PathBuf::from("/workspace/base"))
+    );
+}
+
+#[test]
+fn feishu_ack_reactions_default_to_true_and_allow_account_override() {
+    let base_config: FeishuChannelConfig = serde_json::from_value(json!({
+        "enabled": true,
+        "app_id": "cli_base",
+        "app_secret": "base-secret"
+    }))
+    .expect("deserialize base feishu config");
+
+    let default_resolved = base_config
+        .resolve_account(None)
+        .expect("resolve default feishu account");
+    assert!(default_resolved.ack_reactions);
+
+    let override_config: FeishuChannelConfig = serde_json::from_value(json!({
+        "enabled": true,
+        "app_id": "cli_base",
+        "app_secret": "base-secret",
+        "accounts": {
+            "Quiet Bot": {
+                "ack_reactions": false,
+                "app_id": "cli_quiet",
+                "app_secret": "quiet-secret"
+            }
+        }
+    }))
+    .expect("deserialize override feishu config");
+
+    let quiet_resolved = override_config
+        .resolve_account(Some("Quiet Bot"))
+        .expect("resolve quiet feishu account");
+    assert!(!quiet_resolved.ack_reactions);
+}
+
+#[test]
+fn feishu_mode_defaults_to_websocket_when_not_configured() {
+    let config: FeishuChannelConfig = serde_json::from_value(json!({
+        "enabled": true,
+        "app_id": "cli_a1b2c3",
+        "app_secret": "secret"
+    }))
+    .expect("deserialize feishu config");
+
+    let resolved = config
+        .resolve_account(None)
+        .expect("resolve default feishu account");
+
+    assert_eq!(resolved.mode, FeishuChannelServeMode::Websocket);
+}

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-02T04:26:30Z
+- Generated at: 2026-04-02T09:19:10Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -19,7 +19,7 @@
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2716 | 2800 | 84 | 56 | 65 | 9 | 97.0% | TIGHT | 2698 | 0.7% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10464 | 10500 | 36 | 88 | 90 | 2 | 99.7% | TIGHT | 9922 | 5.5% | PASS | 88 |
-| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9798 | 9800 | 2 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | 0.0% | PASS | 90 |
+| channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10971 | 11200 | 229 | 100 | 120 | 20 | 98.0% | TIGHT | 10831 | 1.3% | PASS | 98 |
@@ -64,7 +64,7 @@
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2716 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=10464 functions=88 -->
-<!-- arch-hotspot key=channel_config lines=9798 functions=90 -->
+<!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10971 functions=100 -->


### PR DESCRIPTION
## Summary

- Problem:
  Feishu inbound messages did not receive automatic emoji acknowledgement reactions, and the behavior was missing in both webhook and websocket ingress flows.
- Why it matters:
  This left Feishu behind the intended lightweight acknowledgement experience and made the integration feel less responsive when users sent a message to the bot.
- What changed:
  Added Feishu channel-level `ack_reactions` config support, introduced a reusable Feishu message reaction helper plus a random Feishu emoji candidate set, and wired best-effort non-blocking ack reactions into the shared inbound handling path used by both webhook and websocket modes. Added regression tests for config behavior, reaction request shape, enabled-path behavior, and disabled-path behavior.
- What did not change (scope boundary):
  This does not add a user-facing `feishu.messages.react` tool, does not add reaction list/remove APIs, and does not change normal provider reply generation or outbound message formatting.

## Linked Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-app feishu_ack_reaction -- --nocapture
- Passed. Covered Feishu ack reaction candidate validity, config default/account override, and reaction request shape.

cargo test -p loongclaw-app feishu_webhook_skips_ack_reaction_when_disabled -- --nocapture
- Passed. Covered the disabled config path and verified no reaction API call is sent when ack_reactions=false.

cargo test -p loongclaw-app feishu_websocket_session_reaches_provider_and_replies -- --nocapture
- Passed. Covered websocket ingress and verified the inbound flow still replies successfully with the new ack reaction behavior enabled.

cargo fmt --all
- Passed. Applied formatting after code changes.

cargo fmt --all -- --check
- Passed. Verified formatting is clean after the final edits.
```

## User-visible / Operator-visible Changes

- Feishu users now get an immediate random emoji reaction when they send a message to the bot.
- Operators can disable the behavior with `feishu.ack_reactions = false` or an account-level override.

## Failure Recovery

- Fast rollback or disable path:
  Set `feishu.ack_reactions = false` globally or per configured Feishu account to stop sending reactions without affecting normal replies.
- Observable failure symptoms reviewers should watch for:
  Missing or delayed reaction acknowledgements on inbound Feishu messages, extra warning logs for failed Feishu reaction API calls, or unexpected duplicate tenant token fetches around inbound processing.

## Reviewer Focus

- Review [crates/app/src/config/[channels.rs](http://channels.rs/)](/Users/liangzhanbo/CodeStudio/loongclaw/crates/app/src/config/[channels.rs](http://channels.rs/)) for Feishu config defaulting and account override behavior.
- Review [crates/app/src/channel/feishu/[adapter.rs](http://adapter.rs/)](/Users/liangzhanbo/CodeStudio/loongclaw/crates/app/src/channel/feishu/[adapter.rs](http://adapter.rs/)) for the allowed emoji set, random selection, and reaction request shape.
- Review [crates/app/src/channel/feishu/[webhook.rs](http://webhook.rs/)](/Users/liangzhanbo/CodeStudio/loongclaw/crates/app/src/channel/feishu/[webhook.rs](http://webhook.rs/)) and [crates/app/src/channel/feishu/[websocket.rs](http://websocket.rs/)](/Users/liangzhanbo/CodeStudio/loongclaw/crates/app/src/channel/feishu/[websocket.rs](http://websocket.rs/)) for shared ingress behavior, non-blocking reaction dispatch, and the disabled-path coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feishu integration can post an automatic, deduplicated acknowledgment emoji on incoming messages; selection is randomized from a fixed set with a safe fallback. Configurable per channel/account and enabled by default.
  * Reactions are sent best-effort and performed asynchronously to avoid delaying webhook handling.

* **Bug Fixes**
  * Reaction failures are logged and retried behavior avoids duplicates; webhook success is preserved when reaction calls fail.

* **Tests**
  * Added tests for ack behavior, config overrides, deduplication, and API interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->