### PR TITLE
Add `--session latest` support to the tasks CLI

### DIFF
--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -7,6 +7,8 @@ use loongclaw_contracts::ToolCoreOutcome;
 use loongclaw_spec::CliResult;
 use serde_json::{Value, json};
 
+const TASKS_SESSION_SELECTOR_LATEST: &str = "latest";
+
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum TasksCommands {
     /// Queue one async background task on top of the current session runtime
@@ -103,9 +105,9 @@ pub async fn execute_tasks_command(
     let (resolved_path, config) = mvp::config::load(config.as_deref())?;
     mvp::runtime_env::initialize_runtime_environment(&config, Some(&resolved_path));
 
-    let current_session_id = normalize_session_scope(&session)?;
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let current_session_id = resolve_session_scope(&session, &memory_config)?;
     let tool_config = &config.tools;
 
     let payload = match command {
@@ -534,6 +536,25 @@ fn normalize_session_scope(raw: &str) -> CliResult<String> {
         return Err("tasks CLI requires a non-empty session scope".to_owned());
     }
     Ok(session.to_owned())
+}
+
+fn resolve_session_scope(
+    raw: &str,
+    memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
+) -> CliResult<String> {
+    let session = normalize_session_scope(raw)?;
+    let should_resolve_latest = session == TASKS_SESSION_SELECTOR_LATEST;
+    if !should_resolve_latest {
+        return Ok(session);
+    }
+
+    let repo = mvp::session::repository::SessionRepository::new(memory_config)?;
+    let latest_session = repo.latest_resumable_root_session_summary()?;
+    let latest_session = latest_session.ok_or_else(|| {
+        "tasks CLI session selector `latest` did not find any resumable root session".to_owned()
+    })?;
+
+    Ok(latest_session.session_id)
 }
 
 fn execute_app_tool_request(

--- a/crates/daemon/tests/integration/tasks_cli.rs
+++ b/crates/daemon/tests/integration/tasks_cli.rs
@@ -1,6 +1,7 @@
 #![allow(unsafe_code)]
 
 use super::*;
+use rusqlite::{Connection, params};
 use std::{
     ffi::OsString,
     fs,
@@ -258,6 +259,66 @@ pub(super) fn load_session_repository(
     let memory_config =
         mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
     mvp::session::repository::SessionRepository::new(&memory_config).expect("session repository")
+}
+
+fn load_memory_runtime_config(
+    config_path: &Path,
+) -> mvp::memory::runtime_config::MemoryRuntimeConfig {
+    let loaded =
+        mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
+    let config = loaded.1;
+    mvp::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory)
+}
+
+fn append_tasks_session_turn(config_path: &Path, session_id: &str, role: &str, content: &str) {
+    let memory_config = load_memory_runtime_config(config_path);
+    mvp::memory::append_turn_direct(session_id, role, content, &memory_config)
+        .expect("append tasks session turn");
+}
+
+fn open_tasks_test_connection(config_path: &Path) -> Connection {
+    let loaded =
+        mvp::config::load(Some(config_path.to_string_lossy().as_ref())).expect("load config");
+    let config = loaded.1;
+    let sqlite_path = PathBuf::from(config.memory.sqlite_path);
+    Connection::open(sqlite_path).expect("open tasks test sqlite connection")
+}
+
+fn set_tasks_test_session_updated_at(config_path: &Path, session_id: &str, updated_at: i64) {
+    let conn = open_tasks_test_connection(config_path);
+    conn.execute(
+        "UPDATE sessions
+         SET updated_at = ?2
+         WHERE session_id = ?1",
+        params![session_id, updated_at],
+    )
+    .expect("set tasks test session updated_at");
+}
+
+fn set_tasks_test_turn_timestamps(config_path: &Path, session_id: &str, ts: i64) {
+    let conn = open_tasks_test_connection(config_path);
+    conn.execute(
+        "UPDATE turns
+         SET ts = ?2
+         WHERE session_id = ?1",
+        params![session_id, ts],
+    )
+    .expect("set tasks test turn timestamps");
+}
+
+fn archive_tasks_test_session(config_path: &Path, session_id: &str, archived_at: i64) {
+    let conn = open_tasks_test_connection(config_path);
+    conn.execute(
+        "INSERT INTO session_events(
+            session_id,
+            event_kind,
+            actor_session_id,
+            payload_json,
+            ts
+         ) VALUES (?1, ?2, NULL, ?3, ?4)",
+        params![session_id, "session_archived", "{}", archived_at],
+    )
+    .expect("insert tasks test archive event");
 }
 
 #[test]
@@ -584,6 +645,158 @@ async fn execute_tasks_command_create_returns_queued_outcome_when_task_hydration
     assert!(
         rendered.contains("task_lookup_error:"),
         "rendered create output should surface hydration warning: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn execute_tasks_command_create_latest_session_selector_resolves_newest_resumable_root() {
+    let root = TempDirGuard::new("loongclaw-tasks-cli-create-latest");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(root.path());
+    let repo = load_session_repository(&config_path);
+
+    ensure_root_session(&repo, "ops-root-old");
+    append_tasks_session_turn(&config_path, "ops-root-old", "user", "older root");
+    set_tasks_test_session_updated_at(&config_path, "ops-root-old", 100);
+    set_tasks_test_turn_timestamps(&config_path, "ops-root-old", 100);
+
+    ensure_root_session(&repo, "ops-root-selected");
+    append_tasks_session_turn(&config_path, "ops-root-selected", "user", "selected root");
+    set_tasks_test_session_updated_at(&config_path, "ops-root-selected", 200);
+    set_tasks_test_turn_timestamps(&config_path, "ops-root-selected", 200);
+
+    ensure_root_session(&repo, "ops-root-empty");
+    set_tasks_test_session_updated_at(&config_path, "ops-root-empty", 300);
+
+    ensure_root_session(&repo, "ops-root-archived");
+    append_tasks_session_turn(
+        &config_path,
+        "ops-root-archived",
+        "assistant",
+        "archived root",
+    );
+    set_tasks_test_session_updated_at(&config_path, "ops-root-archived", 400);
+    set_tasks_test_turn_timestamps(&config_path, "ops-root-archived", 400);
+    archive_tasks_test_session(&config_path, "ops-root-archived", 500);
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "latest".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::Create {
+                task: "research release readiness".to_owned(),
+                label: Some("Release Check".to_owned()),
+                timeout_seconds: Some(45),
+            },
+        },
+    )
+    .await
+    .expect("tasks create with latest selector should succeed");
+
+    let created_task_id = execution.payload["task"]["task_id"]
+        .as_str()
+        .expect("created task id");
+    let created_task = repo
+        .load_session(created_task_id)
+        .expect("load created task session")
+        .expect("created task session");
+
+    assert_eq!(execution.payload["command"], "create");
+    assert_eq!(execution.current_session_id, "ops-root-selected");
+    assert_eq!(execution.payload["current_session_id"], "ops-root-selected");
+    assert_eq!(
+        execution.payload["task"]["scope_session_id"],
+        "ops-root-selected"
+    );
+    assert_eq!(
+        created_task.parent_session_id.as_deref(),
+        Some("ops-root-selected")
+    );
+}
+
+#[tokio::test]
+async fn execute_tasks_command_latest_session_selector_rejects_missing_resumable_root() {
+    let root = TempDirGuard::new("loongclaw-tasks-cli-latest-missing");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(root.path());
+    let repo = load_session_repository(&config_path);
+
+    ensure_root_session(&repo, "ops-root-empty");
+    set_tasks_test_session_updated_at(&config_path, "ops-root-empty", 100);
+
+    let result = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "latest".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::List {
+                limit: 20,
+                state: None,
+                overdue_only: false,
+                include_archived: false,
+            },
+        },
+    )
+    .await;
+
+    let error = match result {
+        Ok(_) => panic!("latest selector should fail without a resumable root session"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.contains("latest"),
+        "expected latest selector error, got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn execute_tasks_command_list_latest_session_selector_uses_selected_root_scope() {
+    let root = TempDirGuard::new("loongclaw-tasks-cli-list-latest");
+    let _env = TasksCliEnvironmentGuard::set(&[]);
+    let config_path = write_tasks_config(root.path());
+    let repo = load_session_repository(&config_path);
+
+    ensure_root_session(&repo, "ops-root-old");
+    append_tasks_session_turn(&config_path, "ops-root-old", "user", "older root");
+    set_tasks_test_session_updated_at(&config_path, "ops-root-old", 100);
+    set_tasks_test_turn_timestamps(&config_path, "ops-root-old", 100);
+    seed_background_task_record(&repo, "ops-root-old", "delegate:old-task", false);
+
+    ensure_root_session(&repo, "ops-root-selected");
+    append_tasks_session_turn(&config_path, "ops-root-selected", "user", "selected root");
+    set_tasks_test_session_updated_at(&config_path, "ops-root-selected", 200);
+    set_tasks_test_turn_timestamps(&config_path, "ops-root-selected", 200);
+    seed_background_task_record(&repo, "ops-root-selected", "delegate:selected-task", false);
+
+    ensure_root_session(&repo, "ops-root-empty");
+    set_tasks_test_session_updated_at(&config_path, "ops-root-empty", 300);
+
+    let execution = loongclaw_daemon::tasks_cli::execute_tasks_command(
+        loongclaw_daemon::tasks_cli::TasksCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            session: "latest".to_owned(),
+            command: loongclaw_daemon::tasks_cli::TasksCommands::List {
+                limit: 20,
+                state: None,
+                overdue_only: false,
+                include_archived: false,
+            },
+        },
+    )
+    .await
+    .expect("tasks list with latest selector should succeed");
+
+    assert_eq!(execution.payload["command"], "list");
+    assert_eq!(execution.current_session_id, "ops-root-selected");
+    assert_eq!(execution.payload["current_session_id"], "ops-root-selected");
+    assert_eq!(execution.payload["matched_count"], 1);
+    assert_eq!(execution.payload["returned_count"], 1);
+    assert_eq!(
+        execution.payload["tasks"][0]["task_id"],
+        "delegate:selected-task"
     );
 }
 

--- a/docs/plans/2026-04-01-tasks-latest-selector-design.md
+++ b/docs/plans/2026-04-01-tasks-latest-selector-design.md
@@ -1,0 +1,138 @@
+# Tasks CLI Latest Session Selector Design
+
+## Goal
+
+Add a minimal `--session latest` selector to the `loongclaw tasks` command family so operators can
+manage background tasks against the newest resumable root session without looking up a concrete
+session id first.
+
+## Tracking
+
+- GitHub issue: `#800`
+
+## Current Repo Facts
+
+- `crates/daemon/src/tasks_cli.rs`
+  - `execute_tasks_command()` loads config and memory runtime state before it normalizes the
+    session scope.
+  - `normalize_session_scope()` currently trims the raw string and rejects empty input.
+  - Every `tasks` subcommand uses the same resolved `current_session_id`.
+- `crates/app/src/session/repository.rs`
+  - `SessionRepository::latest_resumable_root_session_summary()` already returns the newest
+    resumable root session.
+  - That repository method already excludes archived sessions, excludes non-root sessions, and
+    requires persisted turns.
+- `crates/app/src/chat.rs`
+  - `ask` and `chat` already resolve `--session latest` after memory config is available.
+  - The selector semantics already exist in the product as an operator-visible behavior.
+- `crates/daemon/tests/integration/tasks_cli.rs`
+  - Existing integration tests already cover literal session ids across `create`, `list`, `status`,
+    `events`, `wait`, `cancel`, and `recover`.
+  - The best missing coverage is selector resolution at the shared `execute_tasks_command()` entry
+    point.
+
+## Problem
+
+The `tasks` CLI accepts `--session`, but it still treats every non-empty value as a literal session
+id. That creates an inconsistency:
+
+- `ask` and `chat` can resume the latest resumable root with `--session latest`
+- `tasks` still requires a remembered root session id
+
+That inconsistency matters most when an operator wants to inspect or manage delegate work for the
+conversation they were just using.
+
+## Constraints
+
+- keep the existing `tasks --session` flag surface unchanged
+- preserve the current requirement that `tasks` needs a non-empty session scope
+- preserve literal session ids unchanged
+- reuse existing repository selection semantics instead of duplicating SQL or filter rules
+- avoid widening scope to unrelated `--session` consumers in the same PR
+
+## Options Considered
+
+### Option 1: Add a local selector-aware resolver in `tasks_cli.rs`
+
+This means:
+
+- keep `normalize_session_scope()` for trim and empty-check behavior
+- add a thin resolver that maps `latest` to the repository helper
+- keep all selector handling inside the `tasks` entry point
+
+Why this is the recommended option:
+
+- smallest correct change
+- no new public abstraction
+- reuses the repository as the single source of selector truth
+- keeps the patch scoped exactly to the command family that is missing the behavior
+
+### Option 2: Extract a new shared CLI session-selector helper
+
+Why not now:
+
+- `chat` and `tasks` have different session requirements around implicit defaults
+- the repository already contains the hard part of the selection logic
+- adding a broader helper now would increase coupling without reducing meaningful complexity
+
+### Option 3: Broaden `latest` handling to every `--session` consumer
+
+Why not now:
+
+- not every consumer means “latest resumable root conversation”
+- the user asked for a minimal, non-speculative improvement
+- widening scope would add risk without proving additional value in this follow-up
+
+## Recommended Design
+
+Keep the selector behavior local to `tasks_cli.rs`, but reuse the existing repository method for the
+actual selection semantics.
+
+Behavior:
+
+1. load config
+2. initialize the runtime environment
+3. build `MemoryRuntimeConfig`
+4. trim the raw `--session` value
+5. if the trimmed value is empty:
+   - return the existing `tasks CLI requires a non-empty session scope` error
+6. if the trimmed value is not `latest`:
+   - keep returning it as the literal session id
+7. if the trimmed value is `latest`:
+   - open `SessionRepository`
+   - call `latest_resumable_root_session_summary()`
+   - return the concrete root session id
+   - fail with a clear `latest`-specific error if no resumable root session exists
+
+## Error Handling
+
+- Empty input remains the same validation error that `tasks` already returns today.
+- `latest` with no resumable root session should fail before subcommand execution begins.
+- The no-match error should mention both `tasks` and `latest` so operators can see the root cause
+  immediately.
+
+## Testing Strategy
+
+Add daemon integration coverage in `crates/daemon/tests/integration/tasks_cli.rs` for:
+
+- success path:
+  - create two resumable root sessions with distinct timestamps
+  - run `tasks create --session latest`
+  - assert that the resolved `current_session_id` is the newest root session
+  - assert that the queued delegate child is attached to that selected root session
+- failure path:
+  - run a `tasks` command with `--session latest` and no resumable root sessions present
+  - assert that the command fails with a clear `latest` selector error
+
+Existing tasks integration tests already cover literal session ids across the subcommands, so this
+PR only needs to prove the new selector resolution branch and its wiring.
+
+## Scope Boundary
+
+This PR will not:
+
+- add a generic selector DSL
+- add a new CLI flag
+- change `ask` or `chat`
+- change other session-aware CLIs
+- change session repository semantics

--- a/docs/plans/2026-04-01-tasks-latest-selector-implementation-plan.md
+++ b/docs/plans/2026-04-01-tasks-latest-selector-implementation-plan.md
@@ -1,0 +1,180 @@
+# Tasks CLI Latest Session Selector Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `--session latest` support to the `loongclaw tasks` command family without changing
+literal session handling or widening selector semantics beyond this entry point.
+
+**Architecture:** Keep the selector resolver local to `crates/daemon/src/tasks_cli.rs`, and reuse
+`SessionRepository::latest_resumable_root_session_summary()` as the source of truth for the newest
+resumable root session.
+
+**Tech Stack:** Rust, tokio, clap, rusqlite-backed SQLite test fixtures, daemon integration tests
+
+---
+
+### Task 1: Write the failing tasks selector tests
+
+**Files:**
+- Modify: `crates/daemon/tests/integration/tasks_cli.rs`
+
+**Step 1: Add the fixture helpers needed for selector ordering**
+
+Add small test helpers that can:
+
+- append a turn to a root session
+- set session `updated_at`
+- set turn timestamps
+
+Keep the helpers local to `tasks_cli.rs`.
+
+**Step 2: Write the failing success-path test**
+
+Create:
+
+- one older resumable root session
+- one newer resumable root session
+
+Run `execute_tasks_command()` with `TasksCommands::Create` and `session: "latest"`.
+
+Assert:
+
+- `current_session_id` resolves to the newer root session
+- the created delegate child session is parented to that newer root session
+
+**Step 3: Write the failing no-match test**
+
+Run `execute_tasks_command()` with `session: "latest"` and no resumable root session in the test
+fixture.
+
+Assert:
+
+- the command returns an error
+- the error mentions `latest`
+
+**Step 4: Run the focused tasks tests and verify red**
+
+Run:
+
+```bash
+cargo test -p loongclaw --test integration latest_session_selector --locked
+```
+
+Expected: the new tests fail because `tasks` still treats `latest` as a literal session id.
+
+### Task 2: Implement selector-aware tasks session resolution
+
+**Files:**
+- Modify: `crates/daemon/src/tasks_cli.rs`
+
+**Step 1: Keep the existing trim and empty validation**
+
+Retain the current empty-string rejection path for `tasks`.
+
+**Step 2: Add a thin `latest` resolver**
+
+Add a local helper that:
+
+- receives the trimmed session value
+- returns literal values unchanged
+- resolves `latest` through `SessionRepository::latest_resumable_root_session_summary()`
+- returns a clear no-match error if the repository has no resumable root session
+
+**Step 3: Wire the resolver into `execute_tasks_command()`**
+
+Resolve the session after `MemoryRuntimeConfig` is available and before subcommand dispatch.
+
+**Step 4: Run the focused tasks tests and verify green**
+
+Run:
+
+```bash
+cargo test -p loongclaw --test integration latest_session_selector --locked
+```
+
+Expected: the selector tests pass.
+
+### Task 3: Re-run the existing tasks integration surface
+
+**Files:**
+- Modify: none unless a regression is exposed
+
+**Step 1: Run the broader tasks integration coverage**
+
+Run:
+
+```bash
+cargo test -p loongclaw --test integration tasks_ --locked
+```
+
+Expected: existing literal-session command coverage stays green.
+
+**Step 2: Keep scope tight**
+
+Do not change CLI parsing, repository semantics, or unrelated command families unless the tests
+prove a real regression or wiring gap.
+
+### Task 4: Run full verification for delivery
+
+**Files:**
+- Modify: none unless verification exposes a necessary fix
+
+**Step 1: Run formatting and diff hygiene**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+git diff --check
+```
+
+**Step 2: Run workspace-level static checks**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+**Step 3: Run broad workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace --locked
+cargo test --workspace --all-features --locked
+```
+
+Record any unrelated baseline issue explicitly instead of folding it into this change.
+
+### Task 5: Prepare clean GitHub delivery
+
+**Files:**
+- Modify: GitHub artifacts through `gh`, not repository files
+
+**Step 1: Inspect the isolated diff**
+
+Run:
+
+```bash
+git status --short
+git diff -- crates/daemon/src/tasks_cli.rs crates/daemon/tests/integration/tasks_cli.rs docs/plans/2026-04-01-tasks-latest-selector-design.md docs/plans/2026-04-01-tasks-latest-selector-implementation-plan.md
+```
+
+**Step 2: Commit with a scoped message**
+
+Run:
+
+```bash
+git add crates/daemon/src/tasks_cli.rs crates/daemon/tests/integration/tasks_cli.rs docs/plans/2026-04-01-tasks-latest-selector-design.md docs/plans/2026-04-01-tasks-latest-selector-implementation-plan.md
+git commit -m "Add latest session selector support for tasks CLI"
+```
+
+**Step 3: Open the PR with the repository template**
+
+Create a PR that:
+
+- links `#800`
+- uses `Closes #800`
+- records the exact verification commands and outcomes
+- keeps the scope boundary explicit: `tasks` only


### PR DESCRIPTION
## Summary

- Problem: `loongclaw tasks --session latest` still treated `latest` as a literal session id, unlike the existing selector behavior in `ask` and `chat`.
- Why it matters: operators had to look up a concrete root session id before creating or inspecting delegate tasks for the conversation they were already using.
- What changed:
  - added local selector-aware session resolution in `crates/daemon/src/tasks_cli.rs`
  - resolved `latest` through `SessionRepository::latest_resumable_root_session_summary()` after `MemoryRuntimeConfig` is available
  - added integration coverage for newest resumable root selection, missing resumable root failure, and `tasks list` root scoping
  - added design and implementation-plan docs for the change
- What did not change (scope boundary):
  - no changes to `ask` or `chat`
  - no broader selector DSL or new CLI flags
  - no changes to session repository semantics
  - no new process-level env serialization or locking mechanism

## Linked Issues

- Closes #800
- Related # n/a

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --check
Passed.

cargo fmt --all -- --check
Passed.

cargo clippy --workspace --all-targets --all-features -- -D warnings
Passed.

cargo test -p loongclaw --test integration tasks_ --locked
Passed; focused tasks CLI integration coverage remained green, including the new latest-selector scenarios.

cargo test --workspace --locked
Passed.

cargo test --workspace --all-features --locked
Passed.

git diff --name-only origin/dev...HEAD
Reviewed touched-file scope after rebasing onto the latest `origin/dev`; the branch only changes `crates/daemon/src/tasks_cli.rs`, `crates/daemon/tests/integration/tasks_cli.rs`, and the two `docs/plans/2026-04-01-tasks-latest-selector-*.md` files.

Process-global env note: the added daemon integration cases continue to use the existing guard-based test harness, so env state is restored on drop. This PR does not add new cross-process env serialization or locking.
```

## User-visible / Operator-visible Changes

- `loongclaw tasks ... --session latest` now resolves to the newest resumable root session instead of treating `latest` as a literal id.
- `tasks create` and `tasks list` operate against the selected root session.
- If no resumable root session exists, the command now fails with a clear `latest`-specific error.

## Failure Recovery

- Fast rollback or disable path: revert this PR to restore literal-only `tasks --session` behavior.
- Observable failure symptoms reviewers should watch for: `tasks` resolving `latest` to the wrong root session, selecting archived or empty sessions, or returning a generic error when no resumable root session exists.

## Reviewer Focus

- `crates/daemon/src/tasks_cli.rs`: confirm the selector resolution stays local to `tasks` and reuses existing repository semantics.
- `crates/daemon/tests/integration/tasks_cli.rs`: review the ordering fixtures and the three selector coverage paths.
- `docs/plans/2026-04-01-tasks-latest-selector-design.md` and `docs/plans/2026-04-01-tasks-latest-selector-implementation-plan.md`: confirm the documented scope boundary matches the shipped behavior.
