### PR TITLE
Share CLI latest-session selector resolution across chat and tasks

### DIFF
--- a/crates/app/src/chat.rs
+++ b/crates/app/src/chat.rs
@@ -55,7 +55,9 @@ use super::memory;
 #[cfg(feature = "memory-sqlite")]
 use super::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use super::session::repository::SessionRepository;
+use super::session::LATEST_SESSION_SELECTOR;
+#[cfg(feature = "memory-sqlite")]
+use super::session::latest_resumable_root_session_id;
 use super::tui_surface::{
     TuiActionSpec, TuiCalloutTone, TuiChecklistItemSpec, TuiChecklistStatus, TuiChoiceSpec,
     TuiHeaderStyle, TuiKeyValueSpec, TuiMessageSpec, TuiScreenSpec, TuiSectionSpec,
@@ -63,7 +65,6 @@ use super::tui_surface::{
 };
 
 pub const DEFAULT_FIRST_PROMPT: &str = "Summarize this repository and suggest the best next step.";
-const CLI_SESSION_SELECTOR_LATEST: &str = "latest";
 const TEST_ONBOARD_EXECUTABLE_ENV: &str = "LOONGCLAW_TEST_ONBOARD_EXECUTABLE";
 const CLI_CHAT_LIVE_PREVIEW_MIN_EMIT_CHARS: usize = 80;
 const CLI_CHAT_LIVE_PREVIEW_MAX_EMIT_CHARS: usize = 240;
@@ -561,19 +562,18 @@ fn resolve_cli_runtime_session_id(
 ) -> CliResult<String> {
     let session_id = resolve_cli_session_id(session_hint, session_requirement)?;
     let should_resolve_latest = session_requirement == CliSessionRequirement::AllowImplicitDefault
-        && session_id == CLI_SESSION_SELECTOR_LATEST;
+        && session_id == LATEST_SESSION_SELECTOR;
 
     if !should_resolve_latest {
         return Ok(session_id);
     }
 
-    let repo = SessionRepository::new(memory_config)?;
-    let latest_session = repo.latest_resumable_root_session_summary()?;
-    let latest_session = latest_session.ok_or_else(|| {
+    let latest_session_id = latest_resumable_root_session_id(memory_config)?;
+    let latest_session_id = latest_session_id.ok_or_else(|| {
         "CLI session selector `latest` did not find any resumable root session".to_owned()
     })?;
 
-    Ok(latest_session.session_id)
+    Ok(latest_session_id)
 }
 
 #[allow(clippy::print_stdout)] // CLI output

--- a/crates/app/src/chat/latest_session_selector_tests.rs
+++ b/crates/app/src/chat/latest_session_selector_tests.rs
@@ -128,7 +128,7 @@ fn cli_runtime_latest_session_selector_updates_startup_summary_session_id() {
 
     assert_eq!(runtime.session_id, "selected-session");
     assert_eq!(summary.session_id, "selected-session");
-    assert_ne!(summary.session_id, CLI_SESSION_SELECTOR_LATEST);
+    assert_ne!(summary.session_id, crate::session::LATEST_SESSION_SELECTOR);
 
     cleanup_chat_test_memory(&sqlite_path);
 }

--- a/crates/app/src/session/mod.rs
+++ b/crates/app/src/session/mod.rs
@@ -4,6 +4,19 @@ pub mod recovery;
 #[cfg(feature = "memory-sqlite")]
 pub mod repository;
 
+#[cfg(feature = "memory-sqlite")]
+pub const LATEST_SESSION_SELECTOR: &str = "latest";
+
+#[cfg(feature = "memory-sqlite")]
+pub fn latest_resumable_root_session_id(
+    memory_config: &crate::memory::runtime_config::MemoryRuntimeConfig,
+) -> crate::CliResult<Option<String>> {
+    let repo = repository::SessionRepository::new(memory_config)?;
+    let latest_session = repo.latest_resumable_root_session_summary()?;
+    let latest_session_id = latest_session.map(|summary| summary.session_id);
+    Ok(latest_session_id)
+}
+
 #[allow(dead_code)]
 pub(crate) const DELEGATE_CANCEL_REQUESTED_EVENT_KIND: &str = "delegate_cancel_requested";
 #[allow(dead_code)]
@@ -28,4 +41,147 @@ pub(crate) fn parse_delegate_cancelled_reason(error: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+#[cfg(all(test, feature = "memory-sqlite"))]
+#[allow(clippy::expect_used)]
+mod latest_cli_session_selector_tests {
+    use super::LATEST_SESSION_SELECTOR;
+    use super::latest_resumable_root_session_id;
+    use crate::memory;
+    use crate::memory::runtime_config::MemoryRuntimeConfig;
+    use crate::session::repository::NewSessionRecord;
+    use crate::session::repository::SessionKind;
+    use crate::session::repository::SessionRepository;
+    use crate::session::repository::SessionState;
+    use crate::test_support::unique_temp_dir;
+    use rusqlite::Connection;
+    use rusqlite::params;
+    use std::path::Path;
+    use std::path::PathBuf;
+
+    fn init_selector_test_memory(label: &str) -> (PathBuf, MemoryRuntimeConfig) {
+        let root = unique_temp_dir(label);
+        std::fs::create_dir_all(&root).expect("create selector test workspace");
+
+        let sqlite_path = root.join("memory.sqlite3");
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(sqlite_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        memory::ensure_memory_db_ready(Some(sqlite_path), &config)
+            .expect("initialize selector test memory");
+
+        (root, config)
+    }
+
+    fn cleanup_selector_test_memory(root: &Path) {
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    fn create_root_session(repo: &SessionRepository, session_id: &str) {
+        repo.create_session(NewSessionRecord {
+            session_id: session_id.to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some(session_id.to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root session");
+    }
+
+    fn append_session_turn(
+        memory_config: &MemoryRuntimeConfig,
+        session_id: &str,
+        role: &str,
+        content: &str,
+    ) {
+        memory::append_turn_direct(session_id, role, content, memory_config)
+            .expect("append selector test turn");
+    }
+
+    fn set_session_updated_at(sqlite_path: &Path, session_id: &str, updated_at: i64) {
+        let conn = Connection::open(sqlite_path).expect("open selector sqlite connection");
+        conn.execute(
+            "UPDATE sessions
+             SET updated_at = ?2
+             WHERE session_id = ?1",
+            params![session_id, updated_at],
+        )
+        .expect("set selector updated_at");
+    }
+
+    fn archive_session(sqlite_path: &Path, session_id: &str, archived_at: i64) {
+        let conn = Connection::open(sqlite_path).expect("open selector sqlite connection");
+        conn.execute(
+            "INSERT INTO session_events(
+                session_id,
+                event_kind,
+                actor_session_id,
+                payload_json,
+                ts
+             ) VALUES (?1, ?2, NULL, ?3, ?4)",
+            params![session_id, "session_archived", "{}", archived_at],
+        )
+        .expect("archive selector session");
+    }
+
+    #[test]
+    fn latest_cli_session_selector_returns_newest_resumable_root_session_id() {
+        let (root, memory_config) = init_selector_test_memory("latest-cli-selector");
+        let sqlite_path = memory_config
+            .sqlite_path
+            .clone()
+            .expect("selector sqlite path");
+        let repo = SessionRepository::new(&memory_config).expect("selector repository");
+
+        assert_eq!(LATEST_SESSION_SELECTOR, "latest");
+
+        create_root_session(&repo, "root-old");
+        append_session_turn(&memory_config, "root-old", "user", "old");
+        set_session_updated_at(&sqlite_path, "root-old", 100);
+
+        create_root_session(&repo, "root-new");
+        append_session_turn(&memory_config, "root-new", "user", "new");
+        set_session_updated_at(&sqlite_path, "root-new", 200);
+
+        create_root_session(&repo, "root-archived");
+        append_session_turn(&memory_config, "root-archived", "assistant", "archived");
+        set_session_updated_at(&sqlite_path, "root-archived", 300);
+        archive_session(&sqlite_path, "root-archived", 400);
+
+        let selected_session_id = latest_resumable_root_session_id(&memory_config)
+            .expect("resolve latest session id")
+            .expect("selected session id");
+
+        assert_eq!(selected_session_id, "root-new");
+
+        cleanup_selector_test_memory(&root);
+    }
+
+    #[test]
+    fn latest_cli_session_selector_returns_none_without_resumable_root_session() {
+        let (root, memory_config) = init_selector_test_memory("latest-cli-selector-none");
+        let sqlite_path = memory_config
+            .sqlite_path
+            .clone()
+            .expect("selector sqlite path");
+        let repo = SessionRepository::new(&memory_config).expect("selector repository");
+
+        create_root_session(&repo, "root-empty");
+        set_session_updated_at(&sqlite_path, "root-empty", 100);
+
+        create_root_session(&repo, "root-archived");
+        append_session_turn(&memory_config, "root-archived", "assistant", "archived");
+        set_session_updated_at(&sqlite_path, "root-archived", 200);
+        archive_session(&sqlite_path, "root-archived", 300);
+
+        let selected_session_id =
+            latest_resumable_root_session_id(&memory_config).expect("resolve latest session id");
+
+        assert!(selected_session_id.is_none());
+
+        cleanup_selector_test_memory(&root);
+    }
 }

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -7,8 +7,6 @@ use loongclaw_contracts::ToolCoreOutcome;
 use loongclaw_spec::CliResult;
 use serde_json::{Value, json};
 
-const TASKS_SESSION_SELECTOR_LATEST: &str = "latest";
-
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum TasksCommands {
     /// Queue one async background task on top of the current session runtime
@@ -543,18 +541,17 @@ fn resolve_session_scope(
     memory_config: &mvp::memory::runtime_config::MemoryRuntimeConfig,
 ) -> CliResult<String> {
     let session = normalize_session_scope(raw)?;
-    let should_resolve_latest = session == TASKS_SESSION_SELECTOR_LATEST;
+    let should_resolve_latest = session == mvp::session::LATEST_SESSION_SELECTOR;
     if !should_resolve_latest {
         return Ok(session);
     }
 
-    let repo = mvp::session::repository::SessionRepository::new(memory_config)?;
-    let latest_session = repo.latest_resumable_root_session_summary()?;
-    let latest_session = latest_session.ok_or_else(|| {
+    let latest_session_id = mvp::session::latest_resumable_root_session_id(memory_config)?;
+    let latest_session_id = latest_session_id.ok_or_else(|| {
         "tasks CLI session selector `latest` did not find any resumable root session".to_owned()
     })?;
 
-    Ok(latest_session.session_id)
+    Ok(latest_session_id)
 }
 
 fn execute_app_tool_request(

--- a/docs/plans/2026-04-02-shared-cli-session-selector-design.md
+++ b/docs/plans/2026-04-02-shared-cli-session-selector-design.md
@@ -1,0 +1,120 @@
+# Shared CLI Session Selector Design
+
+Date: 2026-04-02
+Issue: `#809`
+PR: pending
+Status: Proposed for the current task branch
+
+## Problem
+
+The CLI surface now supports `--session latest` in multiple places, but the resolution logic is
+still split across separate ownership boundaries:
+
+1. `crates/app/src/chat.rs` resolves `latest` for `ask` and `chat`
+2. `crates/daemon/src/tasks_cli.rs` resolves `latest` again for `tasks`
+
+Both paths currently call the same repository query, but they do so through duplicated local
+logic. That duplication creates a long-term drift risk:
+
+1. one surface can change selector semantics without the other
+2. one surface can change the `latest` token constant without the other
+3. repository contract changes can be patched in one place and missed in the other
+
+The operator-visible feature works today, but the ownership boundary is still wrong.
+
+## Goal
+
+Create one shared CLI session-selector helper that owns the reusable `latest` lookup contract,
+then route both `chat` and `tasks` through that helper without changing the surrounding
+surface-specific rules.
+
+## Non-Goals
+
+1. no new session selector DSL
+2. no change to implicit default-session behavior in `chat`
+3. no change to `tasks` session normalization rules beyond using the shared helper
+4. no change to repository selection semantics
+5. no attempt to unify every session-hint code path into one large abstraction
+
+## Approaches Considered
+
+### A. Keep the current duplicated logic and add a comment
+
+Pros:
+
+1. smallest immediate diff
+
+Cons:
+
+1. leaves the root cause unchanged
+2. still allows semantic drift across CLI surfaces
+3. does not create a reusable ownership boundary for future selector work
+
+### B. Add a small shared helper for `latest` resolution only
+
+Pros:
+
+1. fixes the actual duplication seam
+2. keeps default-session and explicit-session policies local to each caller
+3. minimizes change scope while still improving long-term maintainability
+4. keeps the repository dependency in one reusable place
+
+Cons:
+
+1. adds one small shared session helper surface
+
+### C. Fully unify all CLI session-hint handling behind a large generic resolver
+
+Pros:
+
+1. centralizes more logic in one place
+
+Cons:
+
+1. expands scope far beyond the actual duplication
+2. couples unrelated policies such as implicit default handling and explicit-session enforcement
+3. increases regression risk for behavior that is already correct today
+
+## Decision
+
+Choose approach B.
+
+The smallest correct move is to introduce one shared helper in the app session layer that exposes:
+
+1. the canonical `latest` selector token
+2. one helper that resolves the newest resumable root session id from a `MemoryRuntimeConfig`
+
+Callers will keep their own boundary-specific behavior:
+
+1. `chat` will still decide when `latest` should resolve and when a literal session id should be
+   preserved
+2. `tasks` will still own its non-empty normalization and surface-specific error wording
+
+This keeps the refactor narrow and directly addresses the actual root cause: duplicated lookup
+logic across CLI surfaces.
+
+## Architecture
+
+Extend `crates/app/src/session/mod.rs` with one small shared selector helper surface.
+
+That helper should:
+
+1. stay behind the existing `memory-sqlite` feature gate
+2. build a `SessionRepository` from the provided `MemoryRuntimeConfig`
+3. reuse `latest_resumable_root_session_summary()`
+4. return `Option<String>` so each caller can preserve its own error text and policy decisions
+
+Then update callers:
+
+1. `crates/app/src/chat.rs` stops owning the selector token constant and repository lookup
+2. `crates/daemon/src/tasks_cli.rs` stops owning its own selector token constant and repository
+   lookup
+
+## Validation Strategy
+
+Minimum required validation for this refactor:
+
+1. add focused tests for the shared helper contract
+2. keep the existing app-layer `latest` runtime tests green
+3. keep the existing daemon `tasks` integration coverage green
+4. run workspace verification so the refactor proves it did not shift behavior elsewhere

--- a/docs/plans/2026-04-02-shared-cli-session-selector-implementation-plan.md
+++ b/docs/plans/2026-04-02-shared-cli-session-selector-implementation-plan.md
@@ -1,0 +1,155 @@
+# Shared CLI Session Selector Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move reusable CLI `latest` session-selector resolution into one shared app-session helper and route both `chat` and `tasks` through it without changing surrounding caller-specific policies.
+
+**Architecture:** Add one small helper surface in `crates/app/src/session/mod.rs` that owns the canonical selector token and the repository-backed `latest` lookup. Keep default-session handling, literal-session preservation, and caller-specific error messages in their existing surfaces.
+
+**Tech Stack:** Rust, Cargo, `loongclaw-app`, `loongclaw` daemon integration tests, sqlite-backed session repository
+
+---
+
+### Task 1: Add the shared session-selector helper contract tests
+
+**Files:**
+- Modify: `crates/app/src/session/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add focused tests that:
+
+1. seed multiple root sessions and verify the shared helper returns the newest resumable root
+   session id
+2. verify the shared helper returns `None` when no resumable root session exists
+
+**Step 2: Run the focused app test to verify failure**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app latest_cli_session_selector --locked
+```
+
+Expected: FAIL before the shared helper exists.
+
+### Task 2: Implement the shared helper
+
+**Files:**
+- Modify: `crates/app/src/session/mod.rs`
+
+**Step 1: Add the minimal shared surface**
+
+Implement:
+
+1. a shared `LATEST_SESSION_SELECTOR` constant
+2. a `latest_resumable_root_session_id(...)` helper that returns `CliResult<Option<String>>`
+
+**Step 2: Re-run the focused app test**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app latest_cli_session_selector --locked
+```
+
+Expected: PASS.
+
+### Task 3: Route chat through the shared helper
+
+**Files:**
+- Modify: `crates/app/src/chat.rs`
+- Test: `crates/app/src/chat/latest_session_selector_tests.rs`
+
+**Step 1: Replace the local selector token and repository lookup**
+
+Update `chat.rs` so it:
+
+1. imports the shared selector token
+2. imports the shared lookup helper
+3. preserves existing `CliSessionRequirement` behavior
+4. keeps the existing chat-specific missing-session error wording
+
+**Step 2: Run focused chat tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw-app cli_runtime_latest_session_selector --locked
+```
+
+Expected: PASS.
+
+### Task 4: Route tasks through the shared helper
+
+**Files:**
+- Modify: `crates/daemon/src/tasks_cli.rs`
+- Test: `crates/daemon/tests/integration/tasks_cli.rs`
+
+**Step 1: Replace the local selector token and repository lookup**
+
+Update `tasks_cli.rs` so it:
+
+1. imports the shared selector token
+2. imports the shared lookup helper
+3. keeps `tasks`-specific normalization and error text local
+
+**Step 2: Run focused daemon tests**
+
+Run:
+
+```bash
+cargo test -p loongclaw --test integration tasks_ --locked
+```
+
+Expected: PASS.
+
+### Task 5: Verify the cross-surface contract
+
+**Files:**
+- Modify only if test output exposes a real regression
+
+**Step 1: Re-run existing latest-selector coverage**
+
+Run:
+
+```bash
+cargo test -p loongclaw --test integration latest_session_selector --locked
+```
+
+Expected: PASS.
+
+**Step 2: Run repo-wide verification**
+
+Run:
+
+```bash
+git diff --check
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --locked
+cargo test --workspace --all-features --locked
+```
+
+Expected: all green.
+
+### Task 6: Prepare GitHub delivery artifacts
+
+**Files:**
+- Modify: issue and PR bodies only
+
+**Step 1: Reuse issue #809**
+
+Describe:
+
+1. the duplication problem across `chat` and `tasks`
+2. the scoped shared-helper solution
+3. the explicit non-goals around broader CLI abstraction
+
+**Step 2: Open the PR linked to that issue**
+
+Include:
+
+1. the ownership-boundary rationale
+2. the focused validation evidence
+3. the scope boundary that this change does not unify all session-hint policy


### PR DESCRIPTION
## Summary

- Problem: CLI `latest` session resolution still lived in more than one place. `chat` owned one repository-backed lookup path and `tasks` owned another, which left the selector contract vulnerable to future drift even though the current behavior matched.
- Why it matters: future selector changes could silently land in one CLI surface and miss the other, or change the canonical `latest` token in one path only.
- What changed:
  - added shared `LATEST_SESSION_SELECTOR` and `latest_resumable_root_session_id(...)` helpers in `crates/app/src/session/mod.rs`
  - updated `crates/app/src/chat.rs` to reuse the shared helper while preserving `CliSessionRequirement` behavior
  - updated `crates/daemon/src/tasks_cli.rs` to reuse the same shared helper while preserving `tasks`-specific normalization and error wording
  - added focused helper tests plus design and implementation-plan docs for the refactor
- What did not change (scope boundary):
  - no new selector variants or broader selector DSL
  - no change to repository ordering or resumable-root semantics
  - no change to `chat` implicit default-session behavior
  - no attempt to unify every CLI session-hint policy behind one generic abstraction

Closes #809

## Linked Issues

- Related #803

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --check
Passed.

cargo fmt --all -- --check
Passed after running cargo fmt --all once to normalize import ordering in the new session test module.

cargo test -p loongclaw-app latest_cli_session_selector --locked
Red: failed first with unresolved shared-helper imports before the helper existed.
Green: passed after adding the shared helper and focused tests.

cargo test -p loongclaw-app cli_runtime_latest_session_selector --locked
Passed.

cargo test -p loongclaw --test integration tasks_ --locked
Passed.

cargo test -p loongclaw --test integration latest_session_selector --locked
Passed.

cargo clippy --workspace --all-targets --all-features -- -D warnings
Passed.

cargo test --workspace --locked
Passed.

cargo test --workspace --all-features --locked
Passed.

Process-global env note: this change adds no new cross-process env serialization. Existing CLI tests continue to use the repository's guard-based harnesses and existing process-scoped restoration paths.
```

## User-visible / Operator-visible Changes

- No operator-facing selector behavior changes are intended.
- `chat` and `tasks` now resolve CLI `latest` through the same shared helper, which reduces future drift risk without changing current semantics.

## Failure Recovery

- Fast rollback or disable path: revert this PR to restore surface-local `latest` resolution logic.
- Observable failure symptoms reviewers should watch for: `chat` or `tasks` resolving `latest` differently from each other, preserving the literal token when they should select a root session, or returning the wrong missing-session error after the refactor.

## Reviewer Focus

- `crates/app/src/session/mod.rs`: confirm the shared helper is intentionally narrow and only wraps repository-backed `latest` resolution.
- `crates/app/src/chat.rs`: confirm `CliSessionRequirement` policy is unchanged and only the lookup path moved.
- `crates/daemon/src/tasks_cli.rs`: confirm `tasks` keeps its own normalization and error wording while reusing the shared helper.
- `crates/app/src/chat/latest_session_selector_tests.rs` and `crates/app/src/session/mod.rs`: confirm direct helper coverage plus existing runtime coverage are enough for this refactor.
- This PR is intentionally stacked on top of the base branch from #803 (`tasks-latest-selector-20260401`). Reviewer diff should be read against that base, not against `dev`.

