### PR TITLE
refactor: restore owned binding for detached async delegate transport

### DIFF
--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -27,7 +27,7 @@ use super::context_engine_registry::{
 };
 use super::prompt_orchestrator::seed_prompt_fragments_from_context;
 use super::prompt_orchestrator::sync_prompt_fragments_into_context;
-use super::runtime_binding::ConversationRuntimeBinding;
+use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
 use super::subagent::ConstrainedSubagentExecution;
 use super::turn_engine::ProviderTurn;
 use super::turn_middleware::{
@@ -315,7 +315,7 @@ pub struct AsyncDelegateSpawnRequest {
     pub execution: ConstrainedSubagentExecution,
     pub(crate) runtime_self_continuity: Option<RuntimeSelfContinuity>,
     pub timeout_seconds: u64,
-    pub kernel_context: Option<KernelContext>,
+    pub binding: OwnedConversationRuntimeBinding,
 }
 
 #[async_trait]
@@ -350,7 +350,7 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
             execution,
             runtime_self_continuity,
             timeout_seconds,
-            kernel_context,
+            binding,
         } = request;
 
         let execution_timeout_seconds = execution.timeout_seconds;
@@ -368,14 +368,13 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
         let runtime_ref = &runtime;
         let child_session_id_for_spawn = child_session_id.clone();
         let parent_session_id_for_spawn = parent_session_id.clone();
-        let binding =
-            ConversationRuntimeBinding::from_optional_kernel_context(kernel_context.as_ref());
-        let child_kernel_context = kernel_context.clone();
+        let borrowed_binding = binding.as_borrowed();
+        let child_binding = binding.clone();
         super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime_ref,
             &parent_session_id,
             &child_session_id,
-            binding,
+            borrowed_binding,
             move || async move {
                 let started = repo.transition_session_with_event_if_current(
                     &child_session_id_for_spawn,
@@ -408,9 +407,7 @@ impl AsyncDelegateSpawner for DefaultAsyncDelegateSpawner {
                     &task,
                     execution,
                     execution_timeout_seconds,
-                    ConversationRuntimeBinding::from_optional_kernel_context(
-                        child_kernel_context.as_ref(),
-                    ),
+                    child_binding.as_borrowed(),
                 )
                 .await;
                 Ok(())

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -248,13 +248,12 @@ impl crate::conversation::AsyncDelegateSpawner for PostPrepareFailingAsyncDelega
             .runtime
             .get()
             .ok_or_else(|| "test_post_prepare_runtime_missing".to_owned())?;
+        let binding = request.binding.as_borrowed();
         super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime.as_ref(),
             &request.parent_session_id,
             &request.child_session_id,
-            crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
-                request.kernel_context.as_ref(),
-            ),
+            binding,
             || async { Err("synthetic_post_prepare_async_spawn_failure".to_owned()) },
         )
         .await
@@ -282,7 +281,7 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
             execution,
             runtime_self_continuity: _,
             timeout_seconds,
-            kernel_context,
+            binding,
         } = request;
         let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
         let repo = crate::session::repository::SessionRepository::new(&memory_config)?;
@@ -292,15 +291,13 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
             .ok_or_else(|| "test_local_delegate_runtime_missing".to_owned())?;
         let child_session_id_for_spawn = child_session_id.clone();
         let parent_session_id_for_spawn = parent_session_id.clone();
-        let binding = crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
-            kernel_context.as_ref(),
-        );
-        let child_kernel_context = kernel_context.clone();
+        let borrowed_binding = binding.as_borrowed();
+        let child_binding = binding.clone();
         super::turn_coordinator::with_prepared_subagent_spawn_cleanup_if_kernel_bound(
             runtime.as_ref(),
             &parent_session_id,
             &child_session_id,
-            binding,
+            borrowed_binding,
             move || async move {
                 let started = repo.transition_session_with_event_if_current(
                     &child_session_id_for_spawn,
@@ -330,9 +327,7 @@ impl crate::conversation::AsyncDelegateSpawner for LocalChildRuntimeAsyncDelegat
                     &task,
                     execution,
                     timeout_seconds,
-                    crate::conversation::ConversationRuntimeBinding::from_optional_kernel_context(
-                        child_kernel_context.as_ref(),
-                    ),
+                    child_binding.as_borrowed(),
                 )
                 .await;
                 Ok(())
@@ -19525,8 +19520,11 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
     assert_eq!(spawn_request.label.as_deref(), Some("async-child"));
     assert_eq!(spawn_request.timeout_seconds, 9);
     assert!(
-        spawn_request.kernel_context.is_some(),
-        "kernel-bound parent turns should preserve kernel context for async delegates"
+        matches!(
+            &spawn_request.binding,
+            crate::conversation::OwnedConversationRuntimeBinding::Kernel(_)
+        ),
+        "kernel-bound parent turns should preserve owned governed binding for async delegates"
     );
     assert_eq!(child.state, crate::session::repository::SessionState::Ready);
     assert_eq!(child.label.as_deref(), Some("async-child"));
@@ -19556,7 +19554,7 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_delegate_async_preserves_kernel_context_in_spawn_request() {
+async fn handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
         unique_acp_test_id("conversation-delegate-async", "kernel-binding")
@@ -19637,11 +19635,14 @@ async fn handle_turn_with_runtime_delegate_async_preserves_kernel_context_in_spa
         reply.contains("\"tool\":\"delegate_async\""),
         "expected raw delegate_async tool output, got: {reply}"
     );
-    assert!(spawn_request.kernel_context.is_some());
+    assert!(matches!(
+        &spawn_request.binding,
+        crate::conversation::OwnedConversationRuntimeBinding::Kernel(_)
+    ));
     let child_kernel_ctx = spawn_request
-        .kernel_context
-        .as_ref()
-        .expect("spawn request should carry kernel context");
+        .binding
+        .kernel_context()
+        .expect("spawn request should carry owned governed binding");
     assert_eq!(child_kernel_ctx.token, expected_kernel_ctx.token);
     assert!(
         Arc::ptr_eq(&child_kernel_ctx.kernel, &expected_kernel_ctx.kernel),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -62,7 +62,7 @@ use super::runtime::{
     AsyncDelegateSpawnRequest, AsyncDelegateSpawner, ConversationRuntime,
     DefaultConversationRuntime, SessionContext,
 };
-use super::runtime_binding::ConversationRuntimeBinding;
+use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
 use super::safe_lane_failure::{
     SafeLaneFailureCode, SafeLaneFailureRouteDecision, SafeLaneFailureRouteSource,
     classify_safe_lane_plan_failure,
@@ -4427,7 +4427,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         execution,
         runtime_self_continuity,
         timeout_seconds,
-        kernel_context: binding.kernel_context().cloned(),
+        binding: OwnedConversationRuntimeBinding::from_borrowed(binding),
     };
     spawn_async_delegate_detached(runtime_handle, memory_config, spawner, request);
 

--- a/docs/plans/2026-04-01-async-delegate-owned-binding-restoration-design.md
+++ b/docs/plans/2026-04-01-async-delegate-owned-binding-restoration-design.md
@@ -1,0 +1,161 @@
+# Async Delegate Owned Binding Restoration Design
+
+Date: 2026-04-01
+Branch: `feat/async-delegate-owned-binding-restoration-20260401`
+Scope: restore an explicit owned runtime-binding contract at the detached async delegate seam
+
+## Problem
+
+The current conversation runtime exposes explicit borrowed binding semantics
+through `ConversationRuntimeBinding<'_>`, but detached async delegate transport
+still falls back to raw optional kernel-state storage:
+
+1. `AsyncDelegateSpawnRequest` stores `kernel_context: Option<KernelContext>`
+2. async delegate spawners reconstruct borrowed binding through
+   `ConversationRuntimeBinding::from_optional_kernel_context(...)`
+3. the detach boundary therefore speaks in storage terms rather than runtime
+   contract terms
+
+This is exactly the kind of governed/direct drift tracked by roadmap item `D6`.
+The detach seam crosses an ownership boundary, so it is the place where the
+runtime should be most explicit about whether authority is governed or
+advisory-only.
+
+## Goals
+
+1. Make detached async delegate requests carry explicit owned binding semantics.
+2. Preserve the current governed-versus-advisory behavior without broadening
+   delegate eligibility.
+3. Keep the patch narrow and local to async delegate transport, spawners, and
+   focused regression tests.
+
+## Non-goals
+
+1. Do not sweep the repository for every
+   `ConversationRuntimeBinding::from_optional_kernel_context(...)` use.
+2. Do not redesign synchronous `delegate` execution.
+3. Do not bundle `session_history`, approval routing, or chat diagnostics into
+   this slice.
+4. Do not change the high-risk policy rule that advisory parents cannot reach
+   `delegate_async`.
+
+## Alternatives Considered
+
+### A. Keep `Option<KernelContext>` in `AsyncDelegateSpawnRequest`
+
+Rejected. That preserves the current ambiguity and keeps the ownership boundary
+describing raw storage instead of the execution contract.
+
+### B. Convert the whole conversation runtime to owned bindings
+
+Rejected. That would widen the patch from one detached seam into a broad API
+refactor with much higher merge risk.
+
+### C. Introduce a narrow owned binding type for detached async delegate flow
+
+Recommended. It keeps the immediate execution API borrowed, but makes the
+detached transport contract explicit and auditable.
+
+## Decision
+
+Introduce `OwnedConversationRuntimeBinding` as the detached transport shape and
+thread it through `AsyncDelegateSpawnRequest`.
+
+The boundary will be:
+
+1. parent turn execution uses borrowed `ConversationRuntimeBinding<'_>`
+2. `turn_coordinator.rs` converts that borrowed binding into an owned binding
+   when enqueuing async delegate work
+3. async spawners borrow from the owned binding only when entering cleanup and
+   child-turn execution helpers
+
+This keeps the current behavior while removing raw optional-kernel authority
+from the detached request contract.
+
+## Proposed Design
+
+### 1. Add `OwnedConversationRuntimeBinding`
+
+`crates/app/src/conversation/runtime_binding.rs` should define an owned mirror
+of the borrowed binding enum:
+
+1. `OwnedConversationRuntimeBinding::Kernel(KernelContext)`
+2. `OwnedConversationRuntimeBinding::Direct`
+
+The owned type should provide:
+
+1. `from_borrowed(...)`
+2. `as_borrowed(&self)`
+3. `kernel_context()`
+4. `is_kernel_bound()`
+
+The names and helpers should stay intentionally boring. This slice is about
+contract truthfulness, not abstraction cleverness.
+
+### 2. Change detached request storage
+
+`AsyncDelegateSpawnRequest` in `crates/app/src/conversation/runtime.rs` should
+replace:
+
+1. `kernel_context: Option<KernelContext>`
+
+with:
+
+1. `binding: OwnedConversationRuntimeBinding`
+
+That makes the detached request state the intended runtime authority directly.
+
+### 3. Borrow only at execution seams
+
+The default async delegate spawner and test spawners should stop reconstructing
+binding from optional kernel context. They should instead call
+`request.binding.as_borrowed()` only at the helper boundary:
+
+1. `with_prepared_subagent_spawn_cleanup_if_kernel_bound(...)`
+2. `run_started_delegate_child_turn_with_runtime(...)`
+
+This keeps the borrowed API where it still fits, without leaking raw optional
+authority into detached transport.
+
+### 4. Tighten regression coverage
+
+Tests should assert the explicit contract:
+
+1. queued governed async delegate requests carry
+   `OwnedConversationRuntimeBinding::Kernel(...)`
+2. direct/advisory round-tripping still behaves correctly at the binding-type
+   level
+3. child execution still receives the correct borrowed view derived from the
+   owned request binding
+
+## Expected Behavioral Outcome
+
+1. Detached async delegate requests preserve runtime authority as an explicit
+   owned binding contract.
+2. Governed parent turns still spawn governed child turns.
+3. Advisory/direct parents remain denied before async spawn, matching the
+   existing policy contract.
+4. No unrelated runtime behavior changes.
+
+## Test Strategy
+
+Add focused regression coverage for:
+
+1. owned binding round-trips between borrowed and owned views
+2. async delegate queueing preserves governed binding explicitly
+3. local child execution continues to work when the request stores owned
+   binding instead of raw `KernelContext`
+4. existing deny paths still fail closed for advisory parents
+
+## Rollout Notes
+
+This should land as a follow-up slice after `#768`, or as an explicit stacked
+branch if review timing requires that. It should not be folded back into the
+already-ready delivery PR.
+
+## Why This Slice Matters
+
+This is a small but important contract repair. The async delegate detach point
+is one of the few places where authority crosses an ownership boundary. If that
+seam still speaks in raw optional-kernel terms, the rest of the binding-first
+story remains less truthful than the surrounding runtime already is.

--- a/docs/plans/2026-04-01-async-delegate-owned-binding-restoration-implementation-plan.md
+++ b/docs/plans/2026-04-01-async-delegate-owned-binding-restoration-implementation-plan.md
@@ -1,7 +1,5 @@
 # Async Delegate Owned Binding Restoration Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Restore an explicit owned runtime-binding contract for detached async delegate requests.
 
 **Architecture:** Keep `ConversationRuntimeBinding<'_>` as the borrowed execution API for immediate runtime helpers, but add an owned mirror for detached transport. The detach point in `turn_coordinator.rs` should own the binding, and spawners should borrow it back only when they actually execute cleanup or child turns.
@@ -10,7 +8,7 @@
 
 ---
 
-### Task 1: Add the owned binding type
+## Task 1: Add the owned binding type
 
 **Files:**
 - Modify: `crates/app/src/conversation/runtime_binding.rs`
@@ -65,7 +63,7 @@ git add crates/app/src/conversation/runtime_binding.rs crates/app/src/conversati
 git commit -m "refactor: add owned conversation runtime binding"
 ```
 
-### Task 2: Move async delegate requests onto the owned binding contract
+## Task 2: Move async delegate requests onto the owned binding contract
 
 **Files:**
 - Modify: `crates/app/src/conversation/runtime.rs`
@@ -126,7 +124,7 @@ git add crates/app/src/conversation/runtime.rs crates/app/src/conversation/turn_
 git commit -m "refactor: store owned binding in async delegate requests"
 ```
 
-### Task 3: Borrow the owned binding only at child execution seams
+## Task 3: Borrow the owned binding only at child execution seams
 
 **Files:**
 - Modify: `crates/app/src/conversation/runtime.rs`
@@ -169,7 +167,7 @@ git add crates/app/src/conversation/runtime.rs crates/app/src/conversation/tests
 git commit -m "test: align async delegate spawners with owned binding"
 ```
 
-### Task 4: Verify the bounded slice end-to-end
+## Task 4: Verify the bounded slice end-to-end
 
 **Files:**
 - Modify: `docs/plans/2026-04-01-async-delegate-owned-binding-restoration-design.md`

--- a/docs/plans/2026-04-01-async-delegate-owned-binding-restoration-implementation-plan.md
+++ b/docs/plans/2026-04-01-async-delegate-owned-binding-restoration-implementation-plan.md
@@ -1,0 +1,220 @@
+# Async Delegate Owned Binding Restoration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restore an explicit owned runtime-binding contract for detached async delegate requests.
+
+**Architecture:** Keep `ConversationRuntimeBinding<'_>` as the borrowed execution API for immediate runtime helpers, but add an owned mirror for detached transport. The detach point in `turn_coordinator.rs` should own the binding, and spawners should borrow it back only when they actually execute cleanup or child turns.
+
+**Tech Stack:** Rust, Tokio, async-trait, cargo test, cargo fmt, cargo clippy
+
+---
+
+### Task 1: Add the owned binding type
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime_binding.rs`
+- Modify: `crates/app/src/conversation/mod.rs`
+- Test: `crates/app/src/conversation/runtime_binding.rs`
+
+**Step 1: Write the failing test**
+
+Add a focused unit test in `crates/app/src/conversation/runtime_binding.rs`
+that:
+
+```rust
+let owned = OwnedConversationRuntimeBinding::from_borrowed(
+    ConversationRuntimeBinding::kernel(&kernel_ctx),
+);
+assert!(owned.is_kernel_bound());
+assert!(matches!(
+    owned.as_borrowed(),
+    ConversationRuntimeBinding::Kernel(_)
+));
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test --workspace --locked owned_conversation_runtime_binding`
+Expected: FAIL because `OwnedConversationRuntimeBinding` does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+```rust
+pub enum OwnedConversationRuntimeBinding {
+    Kernel(KernelContext),
+    Direct,
+}
+```
+
+Implement only the helpers needed by detached async delegate flow:
+`from_borrowed(...)`, `as_borrowed(...)`, `kernel_context()`, and
+`is_kernel_bound()`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test --workspace --locked owned_conversation_runtime_binding`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/runtime_binding.rs crates/app/src/conversation/mod.rs
+git commit -m "refactor: add owned conversation runtime binding"
+```
+
+### Task 2: Move async delegate requests onto the owned binding contract
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/turn_coordinator.rs`
+- Test: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Update the async delegate queue tests in
+`crates/app/src/conversation/tests.rs` to assert:
+
+```rust
+assert!(matches!(
+    &spawn_request.binding,
+    crate::conversation::OwnedConversationRuntimeBinding::Kernel(_)
+));
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `cargo test --workspace --locked handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request`
+- `cargo test --workspace --locked handle_turn_with_runtime_executes_delegate_async_via_coordinator_without_waiting`
+
+Expected: FAIL because `AsyncDelegateSpawnRequest` still stores
+`kernel_context`.
+
+**Step 3: Write minimal implementation**
+
+Replace:
+
+```rust
+pub kernel_context: Option<KernelContext>,
+```
+
+with:
+
+```rust
+pub binding: OwnedConversationRuntimeBinding,
+```
+
+At the detach seam in `turn_coordinator.rs`, convert the parent borrowed
+binding into the owned form:
+
+```rust
+binding: OwnedConversationRuntimeBinding::from_borrowed(binding),
+```
+
+**Step 4: Run test to verify it passes**
+
+Run the same targeted tests.
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/runtime.rs crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs
+git commit -m "refactor: store owned binding in async delegate requests"
+```
+
+### Task 3: Borrow the owned binding only at child execution seams
+
+**Files:**
+- Modify: `crates/app/src/conversation/runtime.rs`
+- Modify: `crates/app/src/conversation/tests.rs`
+
+**Step 1: Write the failing test**
+
+Tighten local async delegate child execution coverage so the spawner path still
+works when the request carries owned binding and no longer exposes
+`request.kernel_context`.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `cargo test --workspace --locked handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_by_default`
+- `cargo test --workspace --locked handle_turn_with_runtime_delegate_async_preserves_kernel_context_in_spawn_request`
+
+Expected: FAIL if the spawner path still reads `request.kernel_context`.
+
+**Step 3: Write minimal implementation**
+
+In runtime and test helper spawners, derive the borrowed binding only at the
+helper call sites:
+
+```rust
+let binding = request.binding.as_borrowed();
+```
+
+Use that borrowed view for cleanup and child-turn execution helpers.
+
+**Step 4: Run test to verify it passes**
+
+Run the same targeted tests.
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/app/src/conversation/runtime.rs crates/app/src/conversation/tests.rs
+git commit -m "test: align async delegate spawners with owned binding"
+```
+
+### Task 4: Verify the bounded slice end-to-end
+
+**Files:**
+- Modify: `docs/plans/2026-04-01-async-delegate-owned-binding-restoration-design.md`
+- Modify: `docs/plans/2026-04-01-async-delegate-owned-binding-restoration-implementation-plan.md`
+
+**Step 1: Run formatting verification**
+
+Run: `cargo fmt --all -- --check`
+Expected: PASS
+
+**Step 2: Run strict lint verification**
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+Expected: PASS
+
+**Step 3: Run targeted regression coverage**
+
+Run:
+- `cargo test -p loongclaw-app governed_runtime_binding --features memory-sqlite`
+- `cargo test -p loongclaw-app approval_request_resolve --features memory-sqlite`
+- `cargo test -p loongclaw-app handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request --features memory-sqlite`
+- `cargo test -p loongclaw-app handle_turn_with_runtime_delegate_async_preserves_kernel_context_in_spawn_request --features memory-sqlite`
+
+Expected: PASS
+
+**Step 4: Run workspace tests**
+
+Run:
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+Expected: PASS
+
+**Step 5: Inspect final diff**
+
+Run:
+- `git status --short`
+- `git diff --stat`
+
+Expected: only the owned-binding restoration slice and its design docs are
+present.
+
+**Step 6: Commit**
+
+```bash
+git add docs/plans/2026-04-01-async-delegate-owned-binding-restoration-design.md docs/plans/2026-04-01-async-delegate-owned-binding-restoration-implementation-plan.md crates/app/src/conversation/runtime_binding.rs crates/app/src/conversation/mod.rs crates/app/src/conversation/runtime.rs crates/app/src/conversation/turn_coordinator.rs crates/app/src/conversation/tests.rs
+git commit -m "refactor: restore owned binding for async delegate transport"
+```

--- a/docs/plans/2026-04-01-async-delegate-owned-binding-restoration-implementation-plan.md
+++ b/docs/plans/2026-04-01-async-delegate-owned-binding-restoration-implementation-plan.md
@@ -142,7 +142,7 @@ works when the request carries owned binding and no longer exposes
 
 Run:
 - `cargo test --workspace --locked handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_by_default`
-- `cargo test --workspace --locked handle_turn_with_runtime_delegate_async_preserves_kernel_context_in_spawn_request`
+- `cargo test --workspace --locked handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request`
 
 Expected: FAIL if the spawner path still reads `request.kernel_context`.
 
@@ -191,7 +191,7 @@ Run:
 - `cargo test -p loongclaw-app governed_runtime_binding --features memory-sqlite`
 - `cargo test -p loongclaw-app approval_request_resolve --features memory-sqlite`
 - `cargo test -p loongclaw-app handle_turn_with_runtime_delegate_async_preserves_kernel_binding_in_spawn_request --features memory-sqlite`
-- `cargo test -p loongclaw-app handle_turn_with_runtime_delegate_async_preserves_kernel_context_in_spawn_request --features memory-sqlite`
+- `cargo test -p loongclaw-app handle_turn_with_runtime_delegate_child_cannot_reenter_delegate_async_by_default --features memory-sqlite`
 
 Expected: PASS
 


### PR DESCRIPTION
## Summary

- Problem:
  The binding-first runtime landed in `#768`, but detached async delegate transport still stored raw optional kernel state in `AsyncDelegateSpawnRequest`, leaving that seam on the older optional-kernel dialect instead of the explicit runtime-authority contract used elsewhere.
- Why it matters:
  Detached async delegate flow is one of the clearest ownership boundaries in conversation runtime. Keeping it storage-shaped instead of authority-shaped makes the binding-first contract less truthful and easier to drift again.
- What changed:
  Replaced detached async delegate request storage with owned runtime binding semantics, converted borrowed runtime binding into owned binding only at the detach boundary, borrowed back only at child execution helper seams, and updated focused regression coverage for queued async delegate requests and child execution helpers.
- What did not change (scope boundary):
  No repo-wide runtime binding refactor, no synchronous `delegate` redesign, no approval-policy redesign, and no unrelated ACP, session-history, or provider cleanup.

## Linked Issues

- Closes #774
- Related #766

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes detached async delegate request transport for governed versus direct runtime binding and affects how child delegate execution restores runtime authority.
- Rollout / guardrails:
  Guarded by focused async delegate regressions plus fresh full-workspace verification on the clean `origin/dev`-based branch.
- Rollback path:
  Revert this PR to restore the prior detached request transport shape.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  PASS

cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS

cargo test --workspace --locked --quiet
  PASS

cargo test --workspace --all-features --locked
  PASS

scripts/check-docs.sh
  PASS with the same existing non-blocking release-artifact warnings already present on dev

python3 scripts/sync_github_labels.py --check
  PASS

bash scripts/test_sync_github_labels.sh
  PASS

cargo deny check advisories bans licenses sources
  PASS with the same existing non-blocking duplicate/advisory policy warnings already present on dev

git diff --check
  PASS

diff CLAUDE.md AGENTS.md
  PASS

LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
  PASS

scripts/check_dep_graph.sh
  PASS

Additional focused regressions:
- cargo test -p loongclaw-app delegate_async --features memory-sqlite
  PASS
- cargo test -p loongclaw-app governed_runtime_binding --features memory-sqlite
  PASS
- cargo test -p loongclaw-app approval_request_resolve --features memory-sqlite
  PASS
```

## User-visible / Operator-visible Changes

- Detached `delegate_async` requests now carry explicit owned runtime binding semantics instead of raw optional kernel state.
- Child async delegate execution restores the same governed versus advisory authority contract without ad hoc reconstruction from request storage.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to restore the previous detached transport contract.
- Observable failure symptoms reviewers should watch for:
  Async delegate requests losing governed binding semantics, child delegate execution unexpectedly falling back to advisory behavior, or approval-related regressions on queued delegate paths.

## Reviewer Focus

- `crates/app/src/conversation/turn_coordinator.rs`: verify the detach boundary is the only place that converts borrowed binding into owned request storage.
- `crates/app/src/conversation/runtime.rs`: verify child execution borrows back from owned binding without reintroducing optional-kernel reconstruction drift.
- `crates/app/src/conversation/tests.rs`: verify queued async delegate and child execution regressions directly assert owned binding behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced optional kernel-context with an owned runtime binding for async delegate requests, ensuring the conversation binding is preserved and correctly borrowed during async execution.

* **Tests**
  * Updated and renamed tests to validate owned binding preservation and adjusted assertions accordingly.

* **Documentation**
  * Added design and implementation plans describing the owned binding approach and verification strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->