### PR TITLE
test: resolve daemon env guard root aliases

### DIFF
--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -240,16 +240,9 @@ mod tests {
 
         fn resolve_path_aliases(&self, path_segments: &[String]) -> Vec<String> {
             let mut resolved_segments = path_segments.to_vec();
-            let mut seen_paths = BTreeSet::new();
+            let mut seen_alias_segments = BTreeSet::new();
 
             loop {
-                let inserted_new_path = seen_paths.insert(resolved_segments.clone());
-                let already_saw_path = !inserted_new_path;
-
-                if already_saw_path {
-                    break;
-                }
-
                 let mut alias_index = 0;
 
                 while let Some(segment) = resolved_segments.get(alias_index) {
@@ -270,10 +263,18 @@ mod tests {
                     Some(imported_path) => imported_path,
                     None => break,
                 };
-                let leading_segments = &resolved_segments[..alias_index];
+                let inserted_new_alias_segment = seen_alias_segments.insert(alias_segment.clone());
+                let already_saw_alias_segment = !inserted_new_alias_segment;
+
+                if already_saw_alias_segment {
+                    break;
+                }
+
                 let trailing_segments = &resolved_segments[(alias_index + 1)..];
-                let mut expanded_segments = leading_segments.to_vec();
-                expanded_segments.extend(imported_path);
+                // Replace the alias with its imported path directly.
+                // Carrying the original relative qualifier chain forward can
+                // create unbounded growth for imports like `use super::ScopedEnv;`.
+                let mut expanded_segments = imported_path;
 
                 for trailing_segment in trailing_segments {
                     expanded_segments.push(trailing_segment.clone());
@@ -988,6 +989,45 @@ mod tests {
         assert!(
             daemon_source_uses_forbidden_env_guard(sample_source),
             "daemon source guard should flag nested-module glob imports that resolve through a later root alias"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_flags_same_name_root_alias_without_unbounded_growth() {
+        let sample_source = r#"
+            use crate::mvp as mvp;
+
+            fn build_guard() {
+                let mut env = mvp::test_support::ScopedEnv::new();
+                drop(env);
+            }
+        "#;
+
+        assert!(
+            daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should resolve same-name root aliases without growing the expanded path without bound"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_allows_super_scoped_env_import_without_unbounded_growth() {
+        let sample_source = r#"
+            mod outer {
+                pub struct ScopedEnv;
+
+                mod inner {
+                    use super::ScopedEnv;
+
+                    fn build_guard() {
+                        let _env = ScopedEnv;
+                    }
+                }
+            }
+        "#;
+
+        assert!(
+            !daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should allow daemon-local super imports without growing alias resolution without bound"
         );
     }
 

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -175,6 +175,8 @@ mod tests {
     #[derive(Debug, Default)]
     struct ForbiddenAliasScope {
         imported_bindings: BTreeMap<String, Vec<String>>,
+        imported_paths: Vec<Vec<String>>,
+        glob_import_paths: Vec<Vec<String>>,
         scoped_env_visible_from_glob_import: bool,
     }
 
@@ -248,18 +250,33 @@ mod tests {
                     break;
                 }
 
-                let first_segment = match resolved_segments.first() {
-                    Some(first_segment) => first_segment,
+                let mut alias_index = 0;
+
+                while let Some(segment) = resolved_segments.get(alias_index) {
+                    let is_relative_qualifier = is_relative_path_qualifier(segment);
+
+                    if !is_relative_qualifier {
+                        break;
+                    }
+
+                    alias_index += 1;
+                }
+
+                let alias_segment = match resolved_segments.get(alias_index) {
+                    Some(alias_segment) => alias_segment,
                     None => break,
                 };
-                let imported_path = match self.lookup_alias(first_segment) {
+                let imported_path = match self.lookup_alias(alias_segment) {
                     Some(imported_path) => imported_path,
                     None => break,
                 };
-                let mut expanded_segments = imported_path;
+                let leading_segments = &resolved_segments[..alias_index];
+                let trailing_segments = &resolved_segments[(alias_index + 1)..];
+                let mut expanded_segments = leading_segments.to_vec();
+                expanded_segments.extend(imported_path);
 
-                for tail_segment in resolved_segments.iter().skip(1) {
-                    expanded_segments.push(tail_segment.clone());
+                for trailing_segment in trailing_segments {
+                    expanded_segments.push(trailing_segment.clone());
                 }
 
                 let expansion_changed = expanded_segments != resolved_segments;
@@ -274,22 +291,14 @@ mod tests {
             resolved_segments
         }
 
-        fn record_glob_import(&mut self, kind: ForbiddenImportKind) {
-            match kind {
-                ForbiddenImportKind::Module => {
-                    let current_scope = self.current_scope_mut();
-                    current_scope.scoped_env_visible_from_glob_import = true;
-                }
-                ForbiddenImportKind::ScopedEnv => {
-                    self.mark_forbidden_reference();
-                }
-            }
+        fn record_glob_import_path(&mut self, imported_path: Vec<String>) {
+            let current_scope = self.current_scope_mut();
+            current_scope.glob_import_paths.push(imported_path);
         }
 
         fn path_uses_glob_visible_scoped_env(path_segments: &[String]) -> bool {
             for qualifier_segment in path_segments {
-                let is_relative_qualifier =
-                    matches!(qualifier_segment.as_str(), "self" | "super" | "crate");
+                let is_relative_qualifier = is_relative_path_qualifier(qualifier_segment);
 
                 if is_relative_qualifier {
                     continue;
@@ -355,12 +364,7 @@ mod tests {
                 }
                 syn::UseTree::Glob(_) => {
                     let imported_path = prefix.clone();
-                    let resolved_imported_path = self.resolve_path_aliases(&imported_path);
-                    let import_kind = forbidden_import_kind_for_use_path(&resolved_imported_path);
-
-                    if let Some(import_kind) = import_kind {
-                        self.record_glob_import(import_kind);
-                    }
+                    self.record_glob_import_path(imported_path);
                 }
                 syn::UseTree::Group(use_group) => {
                     for child_tree in &use_group.items {
@@ -375,26 +379,103 @@ mod tests {
                 Some(alias_name) => alias_name,
                 None => imported_binding_name(&imported_path),
             };
-            let resolved_imported_path = self.resolve_path_aliases(&imported_path);
-            let import_kind = forbidden_import_kind_for_use_path(&resolved_imported_path);
-
-            self.record_alias(alias_name, resolved_imported_path);
-
-            let Some(import_kind) = import_kind else {
-                return;
-            };
-            let should_mark_forbidden_reference = match import_kind {
-                ForbiddenImportKind::Module => false,
-                ForbiddenImportKind::ScopedEnv => true,
-            };
-
-            if should_mark_forbidden_reference {
-                self.mark_forbidden_reference();
+            {
+                let current_scope = self.current_scope_mut();
+                current_scope.imported_paths.push(imported_path.clone());
             }
+            self.record_alias(alias_name, imported_path);
+        }
+
+        fn collect_item_uses(&mut self, items: &[syn::Item]) {
+            for item in items {
+                let syn::Item::Use(item_use) = item else {
+                    continue;
+                };
+                self.collect_single_item_use(item_use);
+            }
+        }
+
+        fn collect_single_item_use(&mut self, item_use: &syn::ItemUse) {
+            let mut prefix = Vec::new();
+            self.inspect_use_tree(&item_use.tree, &mut prefix);
+        }
+
+        fn current_scope_use_effect_counts(&self) -> (usize, usize) {
+            let current_scope = self
+                .alias_scopes
+                .last()
+                .expect("daemon source guard scope should exist");
+            let imported_path_count = current_scope.imported_paths.len();
+            let glob_import_path_count = current_scope.glob_import_paths.len();
+
+            (imported_path_count, glob_import_path_count)
+        }
+
+        fn refresh_current_scope_use_effects_since(
+            &mut self,
+            imported_path_start: usize,
+            glob_import_path_start: usize,
+        ) {
+            let (imported_paths, glob_import_paths, scoped_env_visible_from_glob_import) = {
+                let current_scope = self
+                    .alias_scopes
+                    .last()
+                    .expect("daemon source guard scope should exist");
+                let imported_paths = current_scope.imported_paths[imported_path_start..].to_vec();
+                let glob_import_paths =
+                    current_scope.glob_import_paths[glob_import_path_start..].to_vec();
+                let scoped_env_visible_from_glob_import =
+                    current_scope.scoped_env_visible_from_glob_import;
+
+                (
+                    imported_paths,
+                    glob_import_paths,
+                    scoped_env_visible_from_glob_import,
+                )
+            };
+            let mut scoped_env_visible_from_glob_import = scoped_env_visible_from_glob_import;
+
+            for imported_path in &imported_paths {
+                let resolved_imported_path = self.resolve_path_aliases(imported_path);
+                let import_kind = forbidden_import_kind_for_use_path(&resolved_imported_path);
+                let imports_scoped_env =
+                    matches!(import_kind, Some(ForbiddenImportKind::ScopedEnv));
+
+                if imports_scoped_env {
+                    self.mark_forbidden_reference();
+                }
+            }
+
+            for glob_import_path in &glob_import_paths {
+                let resolved_imported_path = self.resolve_path_aliases(glob_import_path);
+                let import_kind = forbidden_import_kind_for_use_path(&resolved_imported_path);
+
+                match import_kind {
+                    Some(ForbiddenImportKind::Module) => {
+                        scoped_env_visible_from_glob_import = true;
+                    }
+                    Some(ForbiddenImportKind::ScopedEnv) => {
+                        self.mark_forbidden_reference();
+                    }
+                    None => {}
+                }
+            }
+
+            let current_scope = self.current_scope_mut();
+            current_scope.scoped_env_visible_from_glob_import = scoped_env_visible_from_glob_import;
         }
     }
 
     impl<'ast> Visit<'ast> for DaemonSourceGuardInspector {
+        fn visit_file(&mut self, file: &'ast syn::File) {
+            self.collect_item_uses(&file.items);
+            self.refresh_current_scope_use_effects_since(0, 0);
+
+            for item in &file.items {
+                self.visit_item(item);
+            }
+        }
+
         fn visit_item_mod(&mut self, item_mod: &'ast syn::ItemMod) {
             let module_content = match &item_mod.content {
                 Some(module_content) => module_content,
@@ -403,6 +484,8 @@ mod tests {
             let (_, items) = module_content;
 
             self.push_scope();
+            self.collect_item_uses(items);
+            self.refresh_current_scope_use_effects_since(0, 0);
 
             for item in items {
                 self.visit_item(item);
@@ -413,14 +496,53 @@ mod tests {
 
         fn visit_block(&mut self, block: &'ast syn::Block) {
             self.push_scope();
-            visit::visit_block(self, block);
+            let mut pending_use_items = Vec::new();
+
+            for statement in &block.stmts {
+                if let syn::Stmt::Item(syn::Item::Use(item_use)) = statement {
+                    pending_use_items.push(item_use);
+                    continue;
+                }
+
+                let has_pending_use_items = !pending_use_items.is_empty();
+
+                if has_pending_use_items {
+                    let (imported_path_start, glob_import_path_start) =
+                        self.current_scope_use_effect_counts();
+
+                    for pending_use_item in pending_use_items.drain(..) {
+                        self.collect_single_item_use(pending_use_item);
+                    }
+
+                    self.refresh_current_scope_use_effects_since(
+                        imported_path_start,
+                        glob_import_path_start,
+                    );
+                }
+
+                self.visit_stmt(statement);
+            }
+
+            let has_pending_use_items = !pending_use_items.is_empty();
+
+            if has_pending_use_items {
+                let (imported_path_start, glob_import_path_start) =
+                    self.current_scope_use_effect_counts();
+
+                for pending_use_item in pending_use_items.drain(..) {
+                    self.collect_single_item_use(pending_use_item);
+                }
+
+                self.refresh_current_scope_use_effects_since(
+                    imported_path_start,
+                    glob_import_path_start,
+                );
+            }
+
             self.pop_scope();
         }
 
-        fn visit_item_use(&mut self, item_use: &'ast syn::ItemUse) {
-            let mut prefix = Vec::new();
-            self.inspect_use_tree(&item_use.tree, &mut prefix);
-        }
+        fn visit_item_use(&mut self, _item_use: &'ast syn::ItemUse) {}
 
         fn visit_path(&mut self, path: &'ast syn::Path) {
             let uses_forbidden_env_guard = self.path_uses_forbidden_scoped_env(path);
@@ -449,6 +571,10 @@ mod tests {
             .last()
             .cloned()
             .expect("forbidden import path should have a binding name")
+    }
+
+    fn is_relative_path_qualifier(segment: &str) -> bool {
+        matches!(segment, "self" | "super" | "crate")
     }
 
     fn forbidden_import_kind_for_use_path(imported_path: &[String]) -> Option<ForbiddenImportKind> {
@@ -811,6 +937,76 @@ mod tests {
         assert!(
             daemon_source_uses_forbidden_env_guard(sample_source),
             "daemon source guard should flag long alias chains that still resolve to the forbidden root module"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_flags_glob_import_from_later_root_alias_before_function_use() {
+        let sample_source = r#"
+            fn build_guard() {
+                let mut env = ScopedEnv::new();
+                drop(env);
+            }
+
+            use app_side::test_support::*;
+            use crate::mvp as app_side;
+        "#;
+
+        assert!(
+            daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should flag glob imports that resolve through a later root alias in the same scope"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_flags_import_only_scoped_env_from_later_root_alias() {
+        let sample_source = r#"
+            use app_side::test_support::ScopedEnv;
+            use crate::mvp as app_side;
+        "#;
+
+        assert!(
+            daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should flag import-only forbidden scoped env paths that resolve through a later root alias"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_flags_glob_import_from_later_root_alias_inside_nested_module() {
+        let sample_source = r#"
+            mod outer {
+                fn build_guard() {
+                    let mut env = ScopedEnv::new();
+                    drop(env);
+                }
+
+                use self::app_side::test_support::*;
+                use crate::mvp as app_side;
+            }
+        "#;
+
+        assert!(
+            daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should flag nested-module glob imports that resolve through a later root alias"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_flags_self_qualified_path_from_later_root_alias_inside_nested_module() {
+        let sample_source = r#"
+            mod outer {
+                fn build_guard() {
+                    let mut env = self::app_side::test_support::ScopedEnv::new();
+                    drop(env);
+                }
+
+                use crate::mvp as app_side;
+            }
+        "#;
+
+        assert!(
+            daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should flag self-qualified nested-module paths that resolve through a later root alias"
         );
     }
 

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -152,7 +152,7 @@ pub fn sign_security_scan_profile_for_test(profile: &SecurityScanProfile) -> (St
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -174,8 +174,7 @@ mod tests {
 
     #[derive(Debug, Default)]
     struct ForbiddenAliasScope {
-        module_aliases: BTreeSet<String>,
-        scoped_env_aliases: BTreeSet<String>,
+        imported_bindings: BTreeMap<String, Vec<String>>,
         scoped_env_visible_from_glob_import: bool,
     }
 
@@ -220,17 +219,59 @@ mod tests {
                 .expect("daemon source guard scope should exist")
         }
 
-        fn record_alias(&mut self, alias: String, kind: ForbiddenImportKind) {
+        fn record_alias(&mut self, alias: String, imported_path: Vec<String>) {
             let current_scope = self.current_scope_mut();
+            current_scope.imported_bindings.insert(alias, imported_path);
+        }
 
-            match kind {
-                ForbiddenImportKind::Module => {
-                    current_scope.module_aliases.insert(alias);
-                }
-                ForbiddenImportKind::ScopedEnv => {
-                    current_scope.scoped_env_aliases.insert(alias);
+        fn lookup_alias(&self, alias: &str) -> Option<Vec<String>> {
+            for scope in self.alias_scopes.iter().rev() {
+                let imported_path = scope.imported_bindings.get(alias);
+
+                if let Some(imported_path) = imported_path {
+                    return Some(imported_path.clone());
                 }
             }
+
+            None
+        }
+
+        fn resolve_path_aliases(&self, path_segments: &[String]) -> Vec<String> {
+            let mut resolved_segments = path_segments.to_vec();
+            let mut seen_paths = BTreeSet::new();
+
+            loop {
+                let inserted_new_path = seen_paths.insert(resolved_segments.clone());
+                let already_saw_path = !inserted_new_path;
+
+                if already_saw_path {
+                    break;
+                }
+
+                let first_segment = match resolved_segments.first() {
+                    Some(first_segment) => first_segment,
+                    None => break,
+                };
+                let imported_path = match self.lookup_alias(first_segment) {
+                    Some(imported_path) => imported_path,
+                    None => break,
+                };
+                let mut expanded_segments = imported_path;
+
+                for tail_segment in resolved_segments.iter().skip(1) {
+                    expanded_segments.push(tail_segment.clone());
+                }
+
+                let expansion_changed = expanded_segments != resolved_segments;
+
+                if !expansion_changed {
+                    break;
+                }
+
+                resolved_segments = expanded_segments;
+            }
+
+            resolved_segments
         }
 
         fn record_glob_import(&mut self, kind: ForbiddenImportKind) {
@@ -268,17 +309,12 @@ mod tests {
                 return true;
             }
 
-            let first_segment = match path_segments.first() {
-                Some(first_segment) => first_segment,
-                None => return false,
-            };
+            let resolved_path_segments = self.resolve_path_aliases(&path_segments);
+            let uses_resolved_path =
+                path_contains_forbidden_scoped_env_path(&resolved_path_segments);
 
-            for scope in self.alias_scopes.iter().rev() {
-                let uses_scoped_env_alias = scope.scoped_env_aliases.contains(first_segment);
-
-                if uses_scoped_env_alias {
-                    return true;
-                }
+            if uses_resolved_path {
+                return true;
             }
 
             let uses_glob_visible_scoped_env =
@@ -292,24 +328,6 @@ mod tests {
                     if scoped_env_visible_from_glob_import {
                         return true;
                     }
-                }
-            }
-
-            let second_segment = match path_segments.get(1) {
-                Some(second_segment) => second_segment,
-                None => return false,
-            };
-            let uses_module_alias_scoped_env = second_segment == "ScopedEnv";
-
-            if !uses_module_alias_scoped_env {
-                return false;
-            }
-
-            for scope in self.alias_scopes.iter().rev() {
-                let uses_module_alias = scope.module_aliases.contains(first_segment);
-
-                if uses_module_alias {
-                    return true;
                 }
             }
 
@@ -337,7 +355,8 @@ mod tests {
                 }
                 syn::UseTree::Glob(_) => {
                     let imported_path = prefix.clone();
-                    let import_kind = forbidden_import_kind_for_use_path(&imported_path);
+                    let resolved_imported_path = self.resolve_path_aliases(&imported_path);
+                    let import_kind = forbidden_import_kind_for_use_path(&resolved_imported_path);
 
                     if let Some(import_kind) = import_kind {
                         self.record_glob_import(import_kind);
@@ -352,11 +371,18 @@ mod tests {
         }
 
         fn record_import_path(&mut self, imported_path: Vec<String>, alias: Option<String>) {
-            let import_kind = forbidden_import_kind_for_use_path(&imported_path);
+            let alias_name = match alias {
+                Some(alias_name) => alias_name,
+                None => imported_binding_name(&imported_path),
+            };
+            let resolved_imported_path = self.resolve_path_aliases(&imported_path);
+            let import_kind = forbidden_import_kind_for_use_path(&resolved_imported_path);
+
+            self.record_alias(alias_name, resolved_imported_path);
+
             let Some(import_kind) = import_kind else {
                 return;
             };
-
             let should_mark_forbidden_reference = match import_kind {
                 ForbiddenImportKind::Module => false,
                 ForbiddenImportKind::ScopedEnv => true,
@@ -365,12 +391,6 @@ mod tests {
             if should_mark_forbidden_reference {
                 self.mark_forbidden_reference();
             }
-
-            let alias_name = match alias {
-                Some(alias_name) => alias_name,
-                None => imported_binding_name(&imported_path),
-            };
-            self.record_alias(alias_name, import_kind);
         }
     }
 
@@ -731,6 +751,66 @@ mod tests {
         assert!(
             daemon_source_uses_forbidden_env_guard(sample_source),
             "daemon source guard should flag aliases to forbidden scoped env items"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_flags_alias_to_forbidden_mvp_root_module() {
+        let sample_source = r#"
+            use crate::mvp as app_side;
+
+            fn build_guard() {
+                let mut env = app_side::test_support::ScopedEnv::new();
+                drop(env);
+            }
+        "#;
+
+        assert!(
+            daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should flag aliases to the forbidden mvp root module"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_flags_alias_to_forbidden_app_root_module() {
+        let sample_source = r#"
+            use loongclaw_app as app_side;
+
+            fn build_guard() {
+                let mut env = app_side::test_support::ScopedEnv::new();
+                drop(env);
+            }
+        "#;
+
+        assert!(
+            daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should flag aliases to the forbidden app root module"
+        );
+    }
+
+    #[test]
+    fn daemon_source_guard_flags_long_alias_chain_to_forbidden_root_module() {
+        let sample_source = r#"
+            use crate::mvp as app_side_0;
+            use app_side_0 as app_side_1;
+            use app_side_1 as app_side_2;
+            use app_side_2 as app_side_3;
+            use app_side_3 as app_side_4;
+            use app_side_4 as app_side_5;
+            use app_side_5 as app_side_6;
+            use app_side_6 as app_side_7;
+            use app_side_7 as app_side_8;
+            use app_side_8 as app_side_9;
+
+            fn build_guard() {
+                let mut env = app_side_9::test_support::ScopedEnv::new();
+                drop(env);
+            }
+        "#;
+
+        assert!(
+            daemon_source_uses_forbidden_env_guard(sample_source),
+            "daemon source guard should flag long alias chains that still resolve to the forbidden root module"
         );
     }
 


### PR DESCRIPTION
## Summary

- Problem:
  the daemon env regression guard merged in #805 still misses root-module aliases
  that resolve back to the forbidden app-side `ScopedEnv`.
- Why it matters:
  daemon tests can still route process-global env mutations through an app-side
  guard shape that looks structurally different but resolves to the same
  forbidden boundary escape hatch.
- What changed:
  replaced alias-kind tracking with imported-path tracking, added bounded alias
  resolution with cycle detection, and added regression coverage for both root
  module aliases and a longer alias chain.
- What did not change (scope boundary):
  no runtime behavior changed, no env-lock semantics changed, and the existing
  direct-path / module-alias / item-alias / glob-import guard behavior stayed in
  place.

## Linked Issues

- Closes #817
- Related #801

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
git diff --check
scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
CARGO_TARGET_DIR=/tmp/loongclaw-issue817-daemon cargo test -p loongclaw test_support::tests::daemon -- --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-issue817-lib cargo test -p loongclaw --lib -q
CARGO_TARGET_DIR=/tmp/loongclaw-issue817-workspace cargo test --workspace --locked --quiet
CARGO_TARGET_DIR=/tmp/loongclaw-issue817-allfeatures cargo test --workspace --all-features --locked --quiet
CARGO_TARGET_DIR=/tmp/loongclaw-issue817-clippy cargo clippy --workspace --all-targets --all-features -- -D warnings

All commands completed successfully on the follow-up branch based on origin/dev.
```

## User-visible / Operator-visible Changes

- None. This is daemon test-only hardening.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR to return to the pre-follow-up daemon env guard implementation.
- Observable failure symptoms reviewers should watch for:
  daemon env guard tests will fail when app-side `ScopedEnv` is reintroduced
  through root-module aliases or longer alias chains.

## Reviewer Focus

- `crates/daemon/src/test_support.rs`
- confirm imported-path tracking and alias resolution stay bounded and only
  affect forbidden app-side `ScopedEnv` detection
- confirm the new regression cases cover root-module aliases without changing
  accepted daemon-local helper usage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage to verify forbidden module usage detection across various import alias scenarios, including multi-step alias chains.

* **Refactor**
  * Streamlined internal validation logic to improve reliability and reduce code complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->