### PR TITLE
Fix shell.exec approval routing under default-deny policy

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2001,6 +2001,32 @@ fn provider_tool_intent(
     }
 }
 
+#[cfg(all(feature = "memory-sqlite", feature = "tool-shell"))]
+fn shell_exec_test_command() -> (&'static str, Vec<&'static str>, &'static str) {
+    #[cfg(unix)]
+    {
+        (
+            "echo",
+            vec!["approved-shell-output"],
+            "approved-shell-output",
+        )
+    }
+
+    #[cfg(windows)]
+    {
+        (
+            "cmd",
+            vec!["/C", "echo", "approved-shell-output"],
+            "approved-shell-output",
+        )
+    }
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "tool-shell"))]
+fn shell_exec_approval_key(command: &str) -> String {
+    format!("tool:shell.exec:{command}")
+}
+
 fn effective_tool_request(request: &ToolCoreRequest) -> (String, &Value) {
     let tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
     if tool_name != "tool.invoke" {
@@ -18502,6 +18528,553 @@ async fn handle_turn_with_runtime_approval_request_resolve_reports_not_pending_b
     assert_eq!(
         request.decision,
         Some(crate::session::repository::ApprovalDecision::Deny)
+    );
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "tool-shell"))]
+#[tokio::test]
+async fn handle_turn_with_runtime_requires_approval_before_shell_exec_execution() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-shell-approval", "request")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let kernel_ctx =
+        crate::context::bootstrap_kernel_context_with_config("shell-approval-request", 60, &config)
+            .expect("bootstrap kernel context");
+    let (command, args, _expected_stdout) = shell_exec_test_command();
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Running a shell command.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "shell.exec",
+                    json!({
+                        "command": command,
+                        "args": args
+                    }),
+                    "root-session",
+                    "turn-shell-parent",
+                    "call-shell-parent",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "approval pending".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "run the command",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("shell approval reply");
+
+    let requests = repo
+        .list_approval_requests_for_session("root-session", None)
+        .expect("list approval requests");
+    let approval_key = shell_exec_approval_key(command);
+
+    assert!(
+        reply.contains("[tool_approval_required]"),
+        "expected approval marker, got: {reply}"
+    );
+    assert!(
+        reply.contains("tool: shell.exec"),
+        "expected shell.exec tool detail, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].tool_name, "shell.exec");
+    assert_eq!(requests[0].approval_key, approval_key);
+    assert!(
+        reply.contains(requests[0].approval_request_id.as_str()),
+        "reply should surface approval request id, got: {reply}"
+    );
+
+    let stored = repo
+        .load_approval_request(&requests[0].approval_request_id)
+        .expect("load approval request")
+        .expect("approval request row");
+    let payload_tool_name = stored.request_payload_json["tool_name"]
+        .as_str()
+        .expect("request payload tool name");
+    let payload_command = stored.request_payload_json["args_json"]["command"]
+        .as_str()
+        .expect("request payload command");
+
+    assert_eq!(payload_tool_name, "shell.exec");
+    assert_eq!(payload_command, command);
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "tool-shell"))]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_replays_shell_exec_for_approve_once() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-shell-approval", "approve-once")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let kernel_ctx =
+        crate::context::bootstrap_kernel_context_with_config("shell-approval-once", 60, &config)
+            .expect("bootstrap kernel context");
+    let (command, args, expected_stdout) = shell_exec_test_command();
+    let args_json = json!({
+        "command": command,
+        "args": args
+    });
+    let approval_key = shell_exec_approval_key(command);
+
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-shell-1".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-shell-parent".to_owned(),
+        tool_call_id: "call-shell-parent".to_owned(),
+        tool_name: "shell.exec".to_owned(),
+        approval_key,
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-shell-parent",
+            "tool_call_id": "call-shell-parent",
+            "tool_name": "shell.exec",
+            "args_json": args_json,
+            "source": "provider_tool_call",
+            "execution_kind": "core"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "routine",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "shell_exec_requires_approval",
+            "reason": format!(
+                "operator approval required before running shell command `{command}` via `shell.exec`"
+            )
+        }),
+    })
+    .expect("seed shell approval request");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "resolving shell approval".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
+                        "approval_request_id": "apr-shell-1",
+                        "decision": "approve_once"
+                    }),
+                    "root-session",
+                    "turn-approval-resolve",
+                    "call-approval-resolve",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "shell approval resolved".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("shell approval resolve reply");
+
+    let request = repo
+        .load_approval_request("apr-shell-1")
+        .expect("load approval request")
+        .expect("approval request row");
+
+    assert!(
+        reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {reply}"
+    );
+    assert!(
+        reply.contains(expected_stdout),
+        "expected resumed shell output, got: {reply}"
+    );
+    assert_eq!(
+        request.status,
+        crate::session::repository::ApprovalRequestStatus::Executed
+    );
+    assert_eq!(
+        request.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveOnce)
+    );
+    assert!(request.last_error.is_none(), "request={request:?}");
+    assert!(
+        repo.load_approval_grant("root-session", &request.approval_key)
+            .expect("load shell grant")
+            .is_none()
+    );
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "tool-shell"))]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_approve_always_reuses_shell_grant() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-shell-approval", "approve-always")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let kernel_ctx =
+        crate::context::bootstrap_kernel_context_with_config("shell-approval-always", 60, &config)
+            .expect("bootstrap kernel context");
+    let (command, args, expected_stdout) = shell_exec_test_command();
+    let command_payload = json!({
+        "command": command,
+        "args": args
+    });
+    let args_json = command_payload.clone();
+    let approval_key = shell_exec_approval_key(command);
+
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-shell-always".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-shell-parent".to_owned(),
+        tool_call_id: "call-shell-parent".to_owned(),
+        tool_name: "shell.exec".to_owned(),
+        approval_key: approval_key.clone(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-shell-parent",
+            "tool_call_id": "call-shell-parent",
+            "tool_name": "shell.exec",
+            "args_json": args_json,
+            "source": "provider_tool_call",
+            "execution_kind": "core"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "routine",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "shell_exec_requires_approval",
+            "reason": format!(
+                "operator approval required before running shell command `{command}` via `shell.exec`"
+            )
+        }),
+    })
+    .expect("seed shell approval request");
+
+    let approval_runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "resolving shell approval".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
+                        "approval_request_id": "apr-shell-always",
+                        "decision": "approve_always"
+                    }),
+                    "root-session",
+                    "turn-shell-approval",
+                    "call-shell-approval",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "shell approval persisted".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let approval_reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &approval_runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("shell approval persist reply");
+
+    let resolved = repo
+        .load_approval_request("apr-shell-always")
+        .expect("load approval request")
+        .expect("approval request row");
+
+    assert!(
+        approval_reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {approval_reply}"
+    );
+    assert_eq!(
+        resolved.decision,
+        Some(crate::session::repository::ApprovalDecision::ApproveAlways)
+    );
+    assert!(
+        repo.load_approval_grant("root-session", &approval_key)
+            .expect("load shell grant")
+            .is_some()
+    );
+
+    let granted_runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "running granted shell command".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "shell.exec",
+                    command_payload,
+                    "root-session",
+                    "turn-after-grant",
+                    "call-after-grant",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "granted shell completed".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+
+    let granted_reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &granted_runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("granted shell reply");
+
+    let requests = repo
+        .list_approval_requests_for_session("root-session", None)
+        .expect("list shell approval requests");
+
+    assert!(
+        !granted_reply.contains("[tool_approval_required]"),
+        "grant-backed shell call should not request approval again, got: {granted_reply}"
+    );
+    assert!(
+        granted_reply.contains(expected_stdout),
+        "expected granted shell output, got: {granted_reply}"
+    );
+    assert_eq!(
+        requests.len(),
+        1,
+        "grant-backed shell call should not create a second approval request"
+    );
+}
+
+#[cfg(all(feature = "memory-sqlite", feature = "tool-shell"))]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_shell_exec() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-shell-approval", "deny")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    config.tools.approval.mode = crate::config::GovernedToolApprovalMode::Strict;
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let (command, args, _expected_stdout) = shell_exec_test_command();
+    let args_json = json!({
+        "command": command,
+        "args": args
+    });
+    let approval_key = shell_exec_approval_key(command);
+
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-shell-deny".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-shell-parent".to_owned(),
+        tool_call_id: "call-shell-parent".to_owned(),
+        tool_name: "shell.exec".to_owned(),
+        approval_key: approval_key.clone(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-shell-parent",
+            "tool_call_id": "call-shell-parent",
+            "tool_name": "shell.exec",
+            "args_json": args_json,
+            "source": "provider_tool_call",
+            "execution_kind": "core"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "routine",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "shell_exec_requires_approval",
+            "reason": format!(
+                "operator approval required before running shell command `{command}` via `shell.exec`"
+            )
+        }),
+    })
+    .expect("seed shell approval request");
+
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "denying shell approval".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
+                        "approval_request_id": "apr-shell-deny",
+                        "decision": "deny"
+                    }),
+                    "root-session",
+                    "turn-shell-deny",
+                    "call-shell-deny",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "shell denied".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let coordinator = ConversationTurnCoordinator::new();
+
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("shell approval deny reply");
+
+    assert!(
+        reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {reply}"
+    );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
+
+    let request = repo
+        .load_approval_request("apr-shell-deny")
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(
+        request.status,
+        crate::session::repository::ApprovalRequestStatus::Denied
+    );
+    assert_eq!(
+        request.decision,
+        Some(crate::session::repository::ApprovalDecision::Deny)
+    );
+    assert_eq!(
+        request.resolved_by_session_id.as_deref(),
+        Some("root-session")
+    );
+    assert!(request.executed_at.is_none(), "request={request:?}");
+    assert!(request.last_error.is_none(), "request={request:?}");
+    assert!(
+        repo.load_approval_grant("root-session", approval_key.as_str())
+            .expect("load shell grant")
+            .is_none()
     );
 }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -98,8 +98,8 @@ use super::turn_checkpoint::{
 };
 use super::turn_engine::{
     AppToolDispatcher, DefaultAppToolDispatcher, ProviderTurn, ToolBatchExecutionIntentStatus,
-    ToolBatchExecutionTrace, ToolIntent, TurnEngine, TurnFailure, TurnFailureKind, TurnResult,
-    TurnValidation, effective_result_tool_name,
+    ToolBatchExecutionTrace, ToolExecutionPreflight, ToolIntent, TurnEngine, TurnFailure,
+    TurnFailureKind, TurnResult, TurnValidation, effective_result_tool_name,
 };
 use super::turn_observer::{
     ConversationTurnObserverHandle, ConversationTurnPhase, ConversationTurnPhaseEvent,
@@ -3667,6 +3667,13 @@ struct CoordinatorApprovalResolutionRuntime<'a, R: ?Sized> {
 }
 
 #[cfg(feature = "memory-sqlite")]
+struct ApprovalReplayRequest {
+    request: loongclaw_contracts::ToolCoreRequest,
+    execution_kind: crate::tools::ToolExecutionKind,
+    trusted_internal_context: bool,
+}
+
+#[cfg(feature = "memory-sqlite")]
 impl<R> CoordinatorApprovalResolutionRuntime<'_, R>
 where
     R: ConversationRuntime + ?Sized,
@@ -3678,12 +3685,57 @@ where
             .unwrap_or(0)
     }
 
+    fn replay_shell_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+        tool_name: &str,
+        args_json: &Value,
+    ) -> Result<ApprovalReplayRequest, String> {
+        let canonical_tool_name = crate::tools::canonical_tool_name(tool_name);
+        let mut payload = if canonical_tool_name == crate::tools::SHELL_EXEC_TOOL_NAME {
+            args_json.clone()
+        } else {
+            let approved_tool_name = approval_request
+                .request_payload_json
+                .get("approved_tool_name")
+                .and_then(Value::as_str)
+                .map(crate::tools::canonical_tool_name)
+                .unwrap_or(canonical_tool_name);
+            if approved_tool_name != crate::tools::SHELL_EXEC_TOOL_NAME {
+                return Err(format!(
+                    "approval_request_invalid_execution_kind: expected `shell.exec`, got `{approved_tool_name}`"
+                ));
+            }
+            args_json.get("arguments").cloned().ok_or_else(|| {
+                "approval_request_invalid_payload: missing shell.exec arguments".to_owned()
+            })?
+        };
+        let payload_object = payload.as_object_mut().ok_or_else(|| {
+            "approval_request_invalid_payload: shell.exec args_json must be an object".to_owned()
+        })?;
+        let internal_context = crate::tools::shell_policy_ext::shell_exec_internal_approval_context(
+            approval_request.approval_key.as_str(),
+        );
+        crate::tools::merge_trusted_internal_tool_context_into_arguments(
+            payload_object,
+            &internal_context,
+        )?;
+
+        Ok(ApprovalReplayRequest {
+            request: loongclaw_contracts::ToolCoreRequest {
+                tool_name: crate::tools::SHELL_EXEC_TOOL_NAME.to_owned(),
+                payload,
+            },
+            execution_kind: crate::tools::ToolExecutionKind::Core,
+            trusted_internal_context: true,
+        })
+    }
+
     fn replay_request(
         &self,
         approval_request: &ApprovalRequestRecord,
-    ) -> Result<loongclaw_contracts::ToolCoreRequest, String> {
-        let _ = self.replay_execution_kind(approval_request)?;
-
+    ) -> Result<ApprovalReplayRequest, String> {
+        let execution_kind = self.replay_execution_kind(approval_request)?;
         let tool_name = approval_request
             .request_payload_json
             .get("tool_name")
@@ -3697,10 +3749,31 @@ where
             .cloned()
             .ok_or_else(|| "approval_request_invalid_payload: missing args_json".to_owned())?;
 
-        Ok(loongclaw_contracts::ToolCoreRequest {
-            tool_name: tool_name.to_owned(),
-            payload,
-        })
+        match execution_kind {
+            ToolExecutionKind::App => Ok(ApprovalReplayRequest {
+                request: loongclaw_contracts::ToolCoreRequest {
+                    tool_name: tool_name.to_owned(),
+                    payload,
+                },
+                execution_kind: crate::tools::ToolExecutionKind::App,
+                trusted_internal_context: false,
+            }),
+            ToolExecutionKind::Core => {
+                let canonical_tool_name = crate::tools::canonical_tool_name(tool_name);
+                if canonical_tool_name == crate::tools::SHELL_EXEC_TOOL_NAME {
+                    return self.replay_shell_request(approval_request, tool_name, &payload);
+                }
+
+                Ok(ApprovalReplayRequest {
+                    request: loongclaw_contracts::ToolCoreRequest {
+                        tool_name: tool_name.to_owned(),
+                        payload,
+                    },
+                    execution_kind: crate::tools::ToolExecutionKind::Core,
+                    trusted_internal_context: false,
+                })
+            }
+        }
     }
 
     fn replay_execution_kind(
@@ -3774,32 +3847,35 @@ where
         &self,
         approval_request: &ApprovalRequestRecord,
     ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
-        let execution_kind = self.replay_execution_kind(approval_request)?;
         let replay_request = self.replay_request(approval_request)?;
-
-        match execution_kind {
-            ToolExecutionKind::Core => {
+        match replay_request.execution_kind {
+            crate::tools::ToolExecutionKind::Core => {
                 let kernel_ctx = self
                     .binding
                     .kernel_context()
-                    .ok_or_else(|| "approval_request_replay_missing_kernel_context".to_owned())?;
-                crate::tools::execute_tool(replay_request, kernel_ctx).await
+                    .ok_or_else(|| "no_kernel_context".to_owned())?;
+                crate::tools::execute_kernel_tool_request(
+                    kernel_ctx,
+                    replay_request.request,
+                    replay_request.trusted_internal_context,
+                )
+                .await
+                .map_err(|error| error.to_string())
             }
-            ToolExecutionKind::App => {
+            crate::tools::ToolExecutionKind::App => {
                 let session_context = self
                     .runtime
                     .session_context(self.config, &approval_request.session_id, self.binding)
                     .map_err(|error| {
                         format!("load approval request session context failed: {error}")
                     })?;
-
-                match crate::tools::canonical_tool_name(replay_request.tool_name.as_str()) {
+                match crate::tools::canonical_tool_name(replay_request.request.tool_name.as_str()) {
                     "delegate" => {
                         execute_delegate_tool(
                             self.config,
                             self.runtime,
                             &session_context,
-                            replay_request.payload,
+                            replay_request.request.payload,
                             self.binding,
                         )
                         .await
@@ -3809,14 +3885,18 @@ where
                             self.config,
                             self.runtime,
                             &session_context,
-                            replay_request.payload,
+                            replay_request.request.payload,
                             self.binding,
                         )
                         .await
                     }
                     _ => {
                         self.fallback
-                            .execute_app_tool(&session_context, replay_request, self.binding)
+                            .execute_app_tool(
+                                &session_context,
+                                replay_request.request,
+                                self.binding,
+                            )
                             .await
                     }
                 }
@@ -4099,6 +4179,25 @@ where
     ) -> Result<Option<super::turn_engine::ApprovalRequirement>, String> {
         self.fallback
             .maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
+            .await
+    }
+
+    async fn preflight_tool_execution_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        request: loongclaw_contracts::ToolCoreRequest,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<ToolExecutionPreflight, String> {
+        self.fallback
+            .preflight_tool_execution_with_binding(
+                session_context,
+                intent,
+                request,
+                descriptor,
+                binding,
+            )
             .await
     }
 

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures_util::stream::{self, StreamExt};
 use loongclaw_contracts::{KernelError, ToolCoreOutcome, ToolCoreRequest, ToolPlaneError};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::config::{
@@ -497,6 +497,17 @@ pub trait AppToolDispatcher: Send + Sync {
         Ok(None)
     }
 
+    async fn preflight_tool_execution_with_binding(
+        &self,
+        _session_context: &SessionContext,
+        _intent: &ToolIntent,
+        request: ToolCoreRequest,
+        _descriptor: &crate::tools::ToolDescriptor,
+        _binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<ToolExecutionPreflight, String> {
+        Ok(ToolExecutionPreflight::ready(request))
+    }
+
     async fn execute_app_tool(
         &self,
         session_context: &SessionContext,
@@ -527,6 +538,23 @@ impl AppToolDispatcher for NoopAppToolDispatcher {
         _binding: ConversationRuntimeBinding<'_>,
     ) -> Result<ToolCoreOutcome, String> {
         Err(format!("app_tool_not_implemented: {}", request.tool_name))
+    }
+}
+
+pub enum ToolExecutionPreflight {
+    Ready {
+        request: ToolCoreRequest,
+        trusted_internal_context: bool,
+    },
+    NeedsApproval(ApprovalRequirement),
+}
+
+impl ToolExecutionPreflight {
+    fn ready(request: ToolCoreRequest) -> Self {
+        Self::Ready {
+            request,
+            trusted_internal_context: false,
+        }
     }
 }
 
@@ -924,6 +952,293 @@ impl DefaultAppToolDispatcher {
         let _ = (session_context, intent, descriptor);
         Ok(None)
     }
+
+    fn governed_tool_requires_operator_approval(
+        &self,
+        descriptor: &crate::tools::ToolDescriptor,
+    ) -> bool {
+        let governance = governance_profile_for_descriptor(descriptor);
+        match self.tool_config.approval.mode {
+            GovernedToolApprovalMode::Disabled => false,
+            GovernedToolApprovalMode::MediumBalanced => {
+                governance.risk_class == crate::tools::ToolRiskClass::High
+            }
+            GovernedToolApprovalMode::Strict => {
+                governance.approval_mode == ToolApprovalMode::PolicyDriven
+            }
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn ensure_governed_tool_session_scope(
+        &self,
+        repo: &SessionRepository,
+        session_context: &SessionContext,
+    ) -> Result<String, String> {
+        let session_kind = if session_context.parent_session_id.is_some() {
+            SessionKind::DelegateChild
+        } else {
+            SessionKind::Root
+        };
+        let session_record = NewSessionRecord {
+            session_id: session_context.session_id.clone(),
+            kind: session_kind,
+            parent_session_id: session_context.parent_session_id.clone(),
+            label: None,
+            state: SessionState::Ready,
+        };
+        let _ = repo.ensure_session(session_record)?;
+        Self::lineage_root_session_id(repo, session_context)
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn governed_app_tool_preflight(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        descriptor: &crate::tools::ToolDescriptor,
+    ) -> Result<GovernedToolPreflight, String> {
+        let governance = governance_profile_for_descriptor(descriptor);
+        if descriptor.execution_kind != ToolExecutionKind::App
+            || governance.approval_mode != ToolApprovalMode::PolicyDriven
+        {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+
+        let requires_approval = self.governed_tool_requires_operator_approval(descriptor);
+        if !requires_approval {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+
+        let approval_key = format!("tool:{}", descriptor.name);
+        let approved_calls = &self.tool_config.approval.approved_calls;
+        let approved_by_policy = approved_calls.iter().any(|entry| entry == &approval_key);
+        if approved_by_policy {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+
+        let denied_calls = &self.tool_config.approval.denied_calls;
+        let denied_by_policy = denied_calls.iter().any(|entry| entry == &approval_key);
+        if denied_by_policy {
+            let reason = format!(
+                "app_tool_denied: governed tool `{approval_key}` is denied by approval policy"
+            );
+            return Err(reason);
+        }
+
+        let repo = SessionRepository::new(&self.memory_config)?;
+        let scope_session_id = self.ensure_governed_tool_session_scope(&repo, session_context)?;
+        let grant_record = repo.load_approval_grant(&scope_session_id, &approval_key)?;
+        if grant_record.is_some() {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+
+        let approval_request_id =
+            governed_approval_request_id(session_context, descriptor.name, intent);
+        let reason = format!(
+            "operator approval required before running `{}`",
+            descriptor.name
+        );
+        let rule_id = "governed_tool_requires_approval";
+        let request_payload_json = json!({
+            "session_id": session_context.session_id,
+            "parent_session_id": session_context.parent_session_id,
+            "turn_id": intent.turn_id,
+            "tool_call_id": intent.tool_call_id,
+            "tool_name": descriptor.name,
+            "args_json": intent.args_json,
+            "source": intent.source,
+            "execution_kind": match descriptor.execution_kind {
+                ToolExecutionKind::Core => "core",
+                ToolExecutionKind::App => "app",
+            },
+        });
+        let governance_snapshot_json = json!({
+            "governance_scope": governance.scope.as_str(),
+            "risk_class": governance.risk_class.as_str(),
+            "approval_mode": governance.approval_mode.as_str(),
+            "rule_id": rule_id,
+            "reason": reason,
+        });
+        let stored = repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id,
+            session_id: session_context.session_id.clone(),
+            turn_id: intent.turn_id.clone(),
+            tool_call_id: intent.tool_call_id.clone(),
+            tool_name: descriptor.name.to_owned(),
+            approval_key: approval_key.clone(),
+            request_payload_json,
+            governance_snapshot_json,
+        })?;
+        let requirement = ApprovalRequirement::governed_tool(
+            descriptor.name,
+            approval_key,
+            reason,
+            rule_id,
+            Some(stored.approval_request_id),
+        );
+        Ok(GovernedToolPreflight::NeedsApproval(requirement))
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn governed_shell_tool_preflight(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        request: &ToolCoreRequest,
+        descriptor: &crate::tools::ToolDescriptor,
+    ) -> Result<GovernedToolPreflight, String> {
+        if descriptor.name != crate::tools::SHELL_EXEC_TOOL_NAME {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+
+        let payload = request.payload.as_object();
+        let Some(payload) = payload else {
+            return Ok(GovernedToolPreflight::Allowed);
+        };
+        let command = payload.get("command").and_then(Value::as_str);
+        let Some(command) = command else {
+            return Ok(GovernedToolPreflight::Allowed);
+        };
+        let trimmed_command = command.trim();
+        if trimmed_command.is_empty() {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+        let normalized_command =
+            crate::tools::shell_policy_ext::validate_shell_command_name(trimmed_command)
+                .map_err(|reason| format!("tool_preflight_denied: {reason}"))?;
+
+        let shell_deny = &self.tool_config.shell_deny;
+        let hard_denied = shell_deny
+            .iter()
+            .any(|entry| entry.eq_ignore_ascii_case(&normalized_command));
+        if hard_denied {
+            let reason = format!(
+                "tool_preflight_denied: shell command `{normalized_command}` is blocked by shell policy"
+            );
+            return Err(reason);
+        }
+
+        let shell_allow = &self.tool_config.shell_allow;
+        let explicitly_allowed = shell_allow
+            .iter()
+            .any(|entry| entry.eq_ignore_ascii_case(&normalized_command));
+        let default_allows = self.tool_config.shell_default_mode == "allow";
+        if explicitly_allowed || default_allows {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+
+        let requires_approval = self.governed_tool_requires_operator_approval(descriptor);
+        if !requires_approval {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+
+        let approval_key =
+            crate::tools::shell_policy_ext::shell_exec_approval_key_for_normalized_command(
+                normalized_command.as_str(),
+            );
+        let approved_calls = &self.tool_config.approval.approved_calls;
+        let approved_by_policy = approved_calls.iter().any(|entry| entry == &approval_key);
+        if approved_by_policy {
+            let internal_context =
+                crate::tools::shell_policy_ext::shell_exec_internal_approval_context(
+                    approval_key.as_str(),
+                );
+            return Ok(GovernedToolPreflight::AllowedWithTrustedInternalContext(
+                internal_context,
+            ));
+        }
+
+        let denied_calls = &self.tool_config.approval.denied_calls;
+        let denied_by_policy = denied_calls.iter().any(|entry| entry == &approval_key);
+        if denied_by_policy {
+            let reason = format!(
+                "tool_preflight_denied: governed tool `{approval_key}` is denied by approval policy"
+            );
+            return Err(reason);
+        }
+
+        let repo = SessionRepository::new(&self.memory_config)?;
+        let scope_session_id = self.ensure_governed_tool_session_scope(&repo, session_context)?;
+        let grant_record = repo.load_approval_grant(&scope_session_id, &approval_key)?;
+        if grant_record.is_some() {
+            let internal_context =
+                crate::tools::shell_policy_ext::shell_exec_internal_approval_context(
+                    approval_key.as_str(),
+                );
+            return Ok(GovernedToolPreflight::AllowedWithTrustedInternalContext(
+                internal_context,
+            ));
+        }
+
+        let approval_request_id =
+            governed_approval_request_id(session_context, descriptor.name, intent);
+        let reason = format!(
+            "operator approval required before running shell command `{normalized_command}` via `shell.exec`"
+        );
+        let rule_id = crate::tools::shell_policy_ext::SHELL_EXEC_APPROVAL_RULE_ID;
+        let request_payload_json = json!({
+            "session_id": session_context.session_id,
+            "parent_session_id": session_context.parent_session_id,
+            "turn_id": intent.turn_id,
+            "tool_call_id": intent.tool_call_id,
+            "tool_name": descriptor.name,
+            "args_json": request.payload,
+            "source": intent.source,
+            "execution_kind": "core",
+        });
+        let governance = governance_profile_for_descriptor(descriptor);
+        let governance_snapshot_json = json!({
+            "governance_scope": governance.scope.as_str(),
+            "risk_class": governance.risk_class.as_str(),
+            "approval_mode": governance.approval_mode.as_str(),
+            "rule_id": rule_id,
+            "reason": reason,
+        });
+        let stored = repo.ensure_approval_request(NewApprovalRequestRecord {
+            approval_request_id,
+            session_id: session_context.session_id.clone(),
+            turn_id: intent.turn_id.clone(),
+            tool_call_id: intent.tool_call_id.clone(),
+            tool_name: descriptor.name.to_owned(),
+            approval_key: approval_key.clone(),
+            request_payload_json,
+            governance_snapshot_json,
+        })?;
+        let requirement = ApprovalRequirement::governed_tool(
+            descriptor.name,
+            approval_key,
+            reason,
+            rule_id,
+            Some(stored.approval_request_id),
+        );
+        Ok(GovernedToolPreflight::NeedsApproval(requirement))
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    fn governed_tool_preflight(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        request: &ToolCoreRequest,
+        descriptor: &crate::tools::ToolDescriptor,
+    ) -> Result<GovernedToolPreflight, String> {
+        let governance = governance_profile_for_descriptor(descriptor);
+        if governance.approval_mode != ToolApprovalMode::PolicyDriven {
+            return Ok(GovernedToolPreflight::Allowed);
+        }
+
+        if descriptor.name == crate::tools::SHELL_EXEC_TOOL_NAME {
+            return self.governed_shell_tool_preflight(
+                session_context,
+                intent,
+                request,
+                descriptor,
+            );
+        }
+
+        self.governed_app_tool_preflight(session_context, intent, descriptor)
+    }
 }
 
 fn governed_approval_request_id(
@@ -962,6 +1277,12 @@ fn requires_mutating_runtime_binding(descriptor: &crate::tools::ToolDescriptor) 
     let governance = governance_profile_for_descriptor(descriptor);
     descriptor.execution_kind == ToolExecutionKind::App
         && governance.approval_mode == ToolApprovalMode::PolicyDriven
+}
+
+enum GovernedToolPreflight {
+    Allowed,
+    AllowedWithTrustedInternalContext(Value),
+    NeedsApproval(ApprovalRequirement),
 }
 
 impl Default for DefaultAppToolDispatcher {
@@ -1251,6 +1572,55 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
             )?;
 
             Ok(Some(requirement))
+        }
+    }
+
+    async fn preflight_tool_execution_with_binding(
+        &self,
+        session_context: &SessionContext,
+        intent: &ToolIntent,
+        request: ToolCoreRequest,
+        descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
+    ) -> Result<ToolExecutionPreflight, String> {
+        #[cfg(not(feature = "memory-sqlite"))]
+        {
+            let _ = (session_context, intent, descriptor, binding);
+            Ok(ToolExecutionPreflight::ready(request))
+        }
+
+        #[cfg(feature = "memory-sqlite")]
+        {
+            let _ = binding;
+            if descriptor.name != crate::tools::SHELL_EXEC_TOOL_NAME {
+                return Ok(ToolExecutionPreflight::ready(request));
+            }
+
+            let preflight =
+                self.governed_tool_preflight(session_context, intent, &request, descriptor)?;
+            match preflight {
+                GovernedToolPreflight::Allowed => Ok(ToolExecutionPreflight::ready(request)),
+                GovernedToolPreflight::NeedsApproval(requirement) => {
+                    Ok(ToolExecutionPreflight::NeedsApproval(requirement))
+                }
+                GovernedToolPreflight::AllowedWithTrustedInternalContext(internal_context) => {
+                    let mut request = request;
+                    let payload = request.payload.as_object_mut().ok_or_else(|| {
+                        format!(
+                            "tool_preflight_invalid_payload: `{}` payload must be an object",
+                            descriptor.name
+                        )
+                    })?;
+                    crate::tools::merge_trusted_internal_tool_context_into_arguments(
+                        payload,
+                        &internal_context,
+                    )?;
+                    Ok(ToolExecutionPreflight::Ready {
+                        request,
+                        trusted_internal_context: true,
+                    })
+                }
+            }
         }
     }
 
@@ -2744,9 +3114,12 @@ impl TurnEngine {
                             turn_id: intent.turn_id.clone(),
                             tool_call_id: intent.tool_call_id.clone(),
                         };
-                        if inner_resolved.execution_kind == ToolExecutionKind::App {
+                        let should_rebind_request = inner_resolved.execution_kind
+                            == ToolExecutionKind::App
+                            || inner_resolved.canonical_name == crate::tools::SHELL_EXEC_TOOL_NAME;
+                        if should_rebind_request {
                             (
-                                ToolExecutionKind::App,
+                                inner_resolved.execution_kind,
                                 inner_request,
                                 inner_intent,
                                 inner_resolved.canonical_name.to_owned(),
@@ -2760,7 +3133,7 @@ impl TurnEngine {
                             )
                         }
                     }
-                    Err(_) => (
+                    _ => (
                         resolved_tool.execution_kind,
                         request,
                         intent.clone(),
@@ -2839,7 +3212,7 @@ impl TurnEngine {
                 let human_reason = render_app_tool_denied_reason(reason.as_str());
                 let turn_result =
                     TurnResult::policy_denied("app_tool_denied", human_reason.clone());
-                let decision = ToolDecisionTelemetry::deny(
+                let denial_decision = ToolDecisionTelemetry::deny(
                     effective_tool_name.as_str(),
                     human_reason,
                     "app_tool_denied",
@@ -2847,13 +3220,13 @@ impl TurnEngine {
                 return Err(PreparedToolIntentFailure {
                     intent: effective_intent,
                     turn_result,
-                    decision,
+                    decision: denial_decision,
                 });
             }
             Err(reason) => {
                 let turn_result =
                     TurnResult::non_retryable_tool_error("tool_preflight_failed", reason.clone());
-                let decision = ToolDecisionTelemetry::deny(
+                let denial_decision = ToolDecisionTelemetry::deny(
                     effective_tool_name.as_str(),
                     reason,
                     "tool_preflight_failed",
@@ -2861,17 +3234,17 @@ impl TurnEngine {
                 return Err(PreparedToolIntentFailure {
                     intent: effective_intent,
                     turn_result,
-                    decision,
+                    decision: denial_decision,
                 });
             }
         };
 
-        match effective_execution_kind {
+        let preflight = match effective_execution_kind {
             ToolExecutionKind::Core => {
                 if binding.kernel_context().is_none() {
                     let turn_result =
                         TurnResult::policy_denied("no_kernel_context", "no_kernel_context");
-                    let decision = ToolDecisionTelemetry::deny(
+                    let denial_decision = ToolDecisionTelemetry::deny(
                         effective_tool_name.as_str(),
                         "no_kernel_context",
                         "no_kernel_context",
@@ -2879,12 +3252,99 @@ impl TurnEngine {
                     return Err(PreparedToolIntentFailure {
                         intent: effective_intent,
                         turn_result,
-                        decision,
+                        decision: denial_decision,
                     });
                 }
+
+                app_dispatcher
+                    .preflight_tool_execution_with_binding(
+                        session_context,
+                        &effective_intent,
+                        effective_request,
+                        descriptor,
+                        binding,
+                    )
+                    .await
             }
-            ToolExecutionKind::App => {}
-        }
+            ToolExecutionKind::App => {
+                app_dispatcher
+                    .preflight_tool_execution_with_binding(
+                        session_context,
+                        &effective_intent,
+                        effective_request,
+                        descriptor,
+                        binding,
+                    )
+                    .await
+            }
+        };
+
+        let (effective_request, trusted_preflight_context) = match preflight {
+            Ok(ToolExecutionPreflight::Ready {
+                request,
+                trusted_internal_context,
+            }) => (request, trusted_internal_context),
+            Ok(ToolExecutionPreflight::NeedsApproval(requirement)) => {
+                let turn_result = TurnResult::NeedsApproval(requirement.clone());
+                let approval_decision =
+                    approval_required_tool_decision(effective_tool_name.as_str(), &requirement);
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision: approval_decision,
+                });
+            }
+            Err(reason) if reason.starts_with("app_tool_denied:") => {
+                let human_reason = render_app_tool_denied_reason(reason.as_str());
+                let turn_result =
+                    TurnResult::policy_denied("app_tool_denied", human_reason.clone());
+                let denial_decision = ToolDecisionTelemetry::deny(
+                    effective_tool_name.as_str(),
+                    human_reason,
+                    "app_tool_denied",
+                );
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision: denial_decision,
+                });
+            }
+            Err(reason) if reason.starts_with("tool_preflight_denied:") => {
+                let turn_result =
+                    TurnResult::policy_denied("tool_preflight_denied", reason.clone());
+                let denial_decision = ToolDecisionTelemetry::deny(
+                    effective_tool_name.as_str(),
+                    reason,
+                    "tool_preflight_denied",
+                );
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision: denial_decision,
+                });
+            }
+            Err(reason) => {
+                let turn_result = TurnResult::non_retryable_tool_error(
+                    "app_tool_preflight_failed",
+                    reason.clone(),
+                );
+                let denial_decision = ToolDecisionTelemetry::deny(
+                    effective_tool_name.as_str(),
+                    reason,
+                    "app_tool_preflight_failed",
+                );
+                return Err(PreparedToolIntentFailure {
+                    intent: effective_intent,
+                    turn_result,
+                    decision: denial_decision,
+                });
+            }
+        };
+        let injected_trusted_internal_context = injected.trusted_internal_context
+            || (!injected_payload_uses_reserved_internal_context
+                && augmented_payload_uses_reserved_internal_context);
+        let trusted_internal_context =
+            injected_trusted_internal_context || trusted_preflight_context;
 
         Ok(PreparedToolIntent {
             intent_sequence,
@@ -2893,9 +3353,7 @@ impl TurnEngine {
             execution_kind: effective_execution_kind,
             capability_action_class,
             scheduling_class,
-            trusted_internal_context: injected.trusted_internal_context
-                || (!injected_payload_uses_reserved_internal_context
-                    && augmented_payload_uses_reserved_internal_context),
+            trusted_internal_context,
             decision,
         })
     }
@@ -2964,6 +3422,7 @@ fn session_context_from_turn(turn: &ProviderTurn, tool_view: ToolView) -> Sessio
 
 #[cfg(test)]
 mod tests {
+    use crate::context::bootstrap_test_kernel_context;
     use crate::test_support::unique_temp_dir;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -3048,6 +3507,34 @@ mod tests {
         );
         ProviderTurn {
             assistant_text: "reading external skills policy".to_owned(),
+            tool_intents: vec![ToolIntent {
+                tool_name,
+                args_json,
+                source: "assistant".to_owned(),
+                session_id: session_id.to_owned(),
+                turn_id: turn_id.to_owned(),
+                tool_call_id: tool_call_id.to_owned(),
+            }],
+            raw_meta: json!({}),
+        }
+    }
+
+    fn discovered_shell_exec_turn(
+        session_id: &str,
+        turn_id: &str,
+        tool_call_id: &str,
+    ) -> ProviderTurn {
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call_with_scope(
+            "shell.exec",
+            json!({
+                "command": "cargo",
+                "args": ["--version"]
+            }),
+            Some(session_id),
+            Some(turn_id),
+        );
+        ProviderTurn {
+            assistant_text: "checking cargo version".to_owned(),
             tool_intents: vec![ToolIntent {
                 tool_name,
                 args_json,
@@ -3986,6 +4473,160 @@ mod tests {
             .list_approval_requests_for_session("root-session", None)
             .expect("list approval requests");
         assert!(requests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn governed_tool_approval_request_is_persisted_for_discovered_shell_exec() {
+        let memory_config = isolated_memory_config("persist-shell");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = bootstrap_test_kernel_context("turn-engine-governed-shell-approval", 60)
+            .expect("kernel context");
+
+        let result = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &discovered_shell_exec_turn(
+                    "root-session",
+                    "turn-shell-discovered",
+                    "call-shell-discovered",
+                ),
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
+                None,
+            )
+            .await;
+
+        let approval_request_id = match result {
+            TurnResult::NeedsApproval(requirement) => {
+                assert_eq!(requirement.tool_name.as_deref(), Some("shell.exec"));
+                assert_eq!(
+                    requirement.approval_key.as_deref(),
+                    Some("tool:shell.exec:cargo")
+                );
+                requirement
+                    .approval_request_id
+                    .expect("approval request id should be present")
+            }
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::StreamingText(_)
+            | other @ TurnResult::StreamingDone(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected NeedsApproval, got {other:?}")
+            }
+        };
+
+        let stored = repo
+            .load_approval_request(&approval_request_id)
+            .expect("load approval request")
+            .expect("approval request row");
+        assert_eq!(stored.status, ApprovalRequestStatus::Pending);
+        assert_eq!(stored.tool_name, "shell.exec");
+        assert_eq!(stored.turn_id, "turn-shell-discovered");
+        assert_eq!(stored.tool_call_id, "call-shell-discovered");
+        assert_eq!(stored.approval_key, "tool:shell.exec:cargo");
+        assert_eq!(stored.request_payload_json["tool_name"], "shell.exec");
+        assert_eq!(stored.request_payload_json["execution_kind"], "core");
+        assert_eq!(
+            stored.request_payload_json["args_json"],
+            json!({
+                "command": "cargo",
+                "args": ["--version"]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn governed_tool_approval_request_reuses_deterministic_id_for_same_blocked_call() {
+        let memory_config = isolated_memory_config("reuse-shell");
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+
+        let mut tool_config = ToolConfig::default();
+        tool_config.approval.mode = GovernedToolApprovalMode::Strict;
+
+        let tool_view = runtime_tool_view_for_config(&tool_config);
+        let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
+        let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
+        let kernel_ctx = bootstrap_test_kernel_context("turn-engine-governed-shell-reuse", 60)
+            .expect("kernel context");
+        let turn = discovered_shell_exec_turn("root-session", "turn-reuse", "call-reuse");
+
+        let first = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
+                None,
+            )
+            .await;
+        let second = TurnEngine::new(4)
+            .execute_turn_in_context(
+                &turn,
+                &session_context,
+                &dispatcher,
+                ConversationRuntimeBinding::kernel(&kernel_ctx),
+                None,
+            )
+            .await;
+
+        let first_request_id = match first {
+            TurnResult::NeedsApproval(requirement) => requirement
+                .approval_request_id
+                .expect("first approval request id"),
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::StreamingText(_)
+            | other @ TurnResult::StreamingDone(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected first NeedsApproval, got {other:?}")
+            }
+        };
+        let second_request_id = match second {
+            TurnResult::NeedsApproval(requirement) => requirement
+                .approval_request_id
+                .expect("second approval request id"),
+            other @ TurnResult::FinalText(_)
+            | other @ TurnResult::StreamingText(_)
+            | other @ TurnResult::StreamingDone(_)
+            | other @ TurnResult::ToolDenied(_)
+            | other @ TurnResult::ToolError(_)
+            | other @ TurnResult::ProviderError(_) => {
+                panic!("expected second NeedsApproval, got {other:?}")
+            }
+        };
+
+        assert_eq!(first_request_id, second_request_id);
+
+        let requests = repo
+            .list_approval_requests_for_session("root-session", None)
+            .expect("list approval requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].approval_request_id, first_request_id);
     }
 
     #[tokio::test]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -749,7 +749,7 @@ fn trusted_runtime_narrowing_from_payload(
         .map_err(|error| format!("invalid_internal_runtime_narrowing: {error}"))
 }
 
-fn merge_trusted_internal_tool_context_into_arguments(
+pub(crate) fn merge_trusted_internal_tool_context_into_arguments(
     arguments: &mut serde_json::Map<String, Value>,
     internal_context: &Value,
 ) -> Result<(), String> {
@@ -1111,7 +1111,10 @@ fn runtime_discoverable_tool_entries(
         .iter()
         .filter(|descriptor| descriptor.is_discoverable())
         .filter(|descriptor| visible_tool_view.contains(descriptor.name))
-        .filter(|descriptor| tool_search_entry_is_runtime_usable(descriptor.name, config))
+        .filter(|descriptor| {
+            descriptor.name == SHELL_EXEC_TOOL_NAME
+                || tool_search_entry_is_runtime_usable(descriptor.name, config)
+        })
         .map(searchable_entry_from_descriptor)
         .collect::<Vec<_>>()
 }
@@ -3128,7 +3131,7 @@ mod tests {
 
     #[cfg(feature = "tool-shell")]
     #[test]
-    fn tool_search_hides_shell_exec_when_runtime_allowlist_is_empty() {
+    fn tool_search_includes_shell_exec_when_runtime_allowlist_is_empty() {
         let root = std::env::temp_dir().join(format!(
             "loongclaw-tool-search-shell-filter-{}",
             std::process::id()
@@ -3151,7 +3154,15 @@ mod tests {
         .expect("tool search should succeed");
 
         let results = outcome.payload["results"].as_array().expect("results");
-        assert!(results.iter().all(|entry| entry["tool_id"] != "shell.exec"));
+        let shell_entry = results
+            .iter()
+            .find(|entry| entry["tool_id"] == "shell.exec")
+            .expect("shell.exec should remain discoverable");
+        let lease = shell_entry["lease"]
+            .as_str()
+            .expect("shell.exec should include a lease");
+
+        assert!(!lease.is_empty(), "lease should not be empty");
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -3140,18 +3140,18 @@ mod tests {
 
         let config = runtime_config::ToolRuntimeConfig {
             shell_allow: BTreeSet::new(),
+            shell_default_mode: shell_policy_ext::ShellPolicyDefault::Deny,
             file_root: Some(root.clone()),
             messages_enabled: true,
             ..Default::default()
         };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "tool.search".to_owned(),
-                payload: json!({"query": "shell command"}),
-            },
-            &config,
-        )
-        .expect("tool search should succeed");
+
+        let request = ToolCoreRequest {
+            tool_name: "tool.search".to_owned(),
+            payload: json!({"exact_tool_id": "shell.exec"}),
+        };
+        let outcome =
+            execute_tool_core_with_config(request, &config).expect("tool search should succeed");
 
         let results = outcome.payload["results"].as_array().expect("results");
         let shell_entry = results

--- a/crates/app/src/tools/process_exec.rs
+++ b/crates/app/src/tools/process_exec.rs
@@ -3,6 +3,8 @@ use std::ffi::OsStr;
 #[cfg(feature = "tool-shell")]
 use std::future::Future;
 #[cfg(feature = "tool-shell")]
+use std::io::ErrorKind;
+#[cfg(feature = "tool-shell")]
 use std::path::Path;
 #[cfg(feature = "tool-shell")]
 use std::process::{Output, Stdio};
@@ -21,6 +23,10 @@ pub(super) const DEFAULT_TIMEOUT_MS: u64 = 120_000;
 pub(super) const MAX_TIMEOUT_MS: u64 = 600_000;
 #[cfg(feature = "tool-shell")]
 const OUTPUT_CAP_BYTES: usize = 1_048_576;
+#[cfg(feature = "tool-shell")]
+const SPAWN_RETRY_ATTEMPTS: usize = 5;
+#[cfg(feature = "tool-shell")]
+const SPAWN_RETRY_DELAY: Duration = Duration::from_millis(25);
 
 #[cfg(feature = "tool-shell")]
 pub(super) fn run_tool_async<F>(future: F, tool_label: &str) -> Result<F::Output, String>
@@ -86,6 +92,31 @@ where
 }
 
 #[cfg(feature = "tool-shell")]
+async fn retry_executable_file_busy<T, F>(mut operation: F) -> std::io::Result<T>
+where
+    F: FnMut() -> std::io::Result<T>,
+{
+    let mut attempt = 0;
+
+    loop {
+        attempt += 1;
+
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(error) if should_retry_spawn_error(&error) && attempt < SPAWN_RETRY_ATTEMPTS => {
+                tokio::time::sleep(SPAWN_RETRY_DELAY).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(feature = "tool-shell")]
+fn should_retry_spawn_error(error: &std::io::Error) -> bool {
+    error.kind() == ErrorKind::ExecutableFileBusy
+}
+
+#[cfg(feature = "tool-shell")]
 pub(super) async fn run_process_with_timeout<P, S>(
     program: P,
     args: &[S],
@@ -97,14 +128,16 @@ where
     P: AsRef<OsStr>,
     S: AsRef<OsStr>,
 {
-    let mut child = Command::new(program)
-        .args(args)
-        .current_dir(cwd)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdin(Stdio::null())
-        .kill_on_drop(true)
-        .spawn()
+    let mut command = Command::new(program);
+    command.args(args);
+    command.current_dir(cwd);
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    command.stdin(Stdio::null());
+    command.kill_on_drop(true);
+
+    let mut child = retry_executable_file_busy(|| command.spawn())
+        .await
         .map_err(|error| format!("{error_prefix} spawn failed: {error}"))?;
 
     let duration = Duration::from_millis(timeout_ms.max(1));
@@ -158,5 +191,43 @@ where
             let _ = tokio::join!(stdout_task, stderr_task);
             Err(format!("{error_prefix} timed out after {timeout_ms}ms"))
         }
+    }
+}
+
+#[cfg(all(test, feature = "tool-shell"))]
+mod tests {
+    use super::{retry_executable_file_busy, should_retry_spawn_error};
+    use std::io::{Error, ErrorKind};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn should_retry_spawn_error_matches_executable_file_busy() {
+        let busy_error = Error::from(ErrorKind::ExecutableFileBusy);
+        let missing_error = Error::from(ErrorKind::NotFound);
+
+        assert!(should_retry_spawn_error(&busy_error));
+        assert!(!should_retry_spawn_error(&missing_error));
+    }
+
+    #[tokio::test]
+    async fn retry_executable_file_busy_retries_until_success() {
+        let attempts = AtomicUsize::new(0);
+
+        let result = retry_executable_file_busy(|| {
+            let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+
+            if attempt < 2 {
+                return Err(Error::from(ErrorKind::ExecutableFileBusy));
+            }
+
+            Ok("spawned")
+        })
+        .await
+        .expect("executable-file-busy errors should retry");
+
+        let total_attempts = attempts.load(Ordering::Relaxed);
+
+        assert_eq!(result, "spawned");
+        assert_eq!(total_attempts, 3);
     }
 }

--- a/crates/app/src/tools/shell.rs
+++ b/crates/app/src/tools/shell.rs
@@ -63,7 +63,16 @@ pub(super) fn execute_shell_tool_with_config(
             config.shell_default_mode,
             crate::tools::shell_policy_ext::ShellPolicyDefault::Allow
         );
-        if !explicitly_allowed && !default_allows {
+        let approval_key =
+            crate::tools::shell_policy_ext::shell_exec_approval_key_for_normalized_command(
+                basename,
+            );
+        let approved_by_internal_context =
+            crate::tools::shell_policy_ext::shell_exec_matches_trusted_internal_approval(
+                payload,
+                approval_key.as_str(),
+            );
+        if !explicitly_allowed && !default_allows && !approved_by_internal_context {
             return Err(format!(
                 "policy_denied: shell command `{basename}` is not in the allow list (default-deny policy)"
             ));

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -3,6 +3,10 @@ use std::collections::BTreeSet;
 use loongclaw_contracts::PolicyError;
 use loongclaw_kernel::{PolicyExtension, PolicyExtensionContext};
 
+pub(crate) const SHELL_EXEC_APPROVAL_RULE_ID: &str = "shell_exec_requires_approval";
+const SHELL_INTERNAL_APPROVAL_CONTEXT_KEY: &str = "shell_approval";
+const SHELL_INTERNAL_APPROVAL_KEY_FIELD: &str = "approval_key";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShellPolicyDefault {
     Deny,
@@ -77,6 +81,41 @@ pub(crate) fn validate_shell_command_name(command: &str) -> Result<String, Strin
     Ok(normalized)
 }
 
+#[cfg(test)]
+pub(crate) fn shell_exec_approval_key(command: &str) -> Result<String, String> {
+    let normalized_command = validate_shell_command_name(command)?;
+    Ok(shell_exec_approval_key_for_normalized_command(
+        normalized_command.as_str(),
+    ))
+}
+
+pub(crate) fn shell_exec_approval_key_for_normalized_command(normalized_command: &str) -> String {
+    format!("tool:shell.exec:{normalized_command}")
+}
+
+pub(crate) fn shell_exec_internal_approval_context(approval_key: &str) -> serde_json::Value {
+    serde_json::json!({
+        SHELL_INTERNAL_APPROVAL_CONTEXT_KEY: {
+            SHELL_INTERNAL_APPROVAL_KEY_FIELD: approval_key,
+        }
+    })
+}
+
+pub(crate) fn shell_exec_matches_trusted_internal_approval(
+    payload: &serde_json::Map<String, serde_json::Value>,
+    approval_key: &str,
+) -> bool {
+    let trusted_context = payload.get(super::LOONGCLAW_INTERNAL_TOOL_CONTEXT_KEY);
+    let trusted_context = trusted_context.and_then(serde_json::Value::as_object);
+    let trusted_context =
+        trusted_context.and_then(|value| value.get(SHELL_INTERNAL_APPROVAL_CONTEXT_KEY));
+    let trusted_context = trusted_context.and_then(serde_json::Value::as_object);
+    let trusted_approval_key =
+        trusted_context.and_then(|value| value.get(SHELL_INTERNAL_APPROVAL_KEY_FIELD));
+    let trusted_approval_key = trusted_approval_key.and_then(serde_json::Value::as_str);
+    trusted_approval_key == Some(approval_key)
+}
+
 impl PolicyExtension for ToolPolicyExtension {
     fn name(&self) -> &str {
         "tool-policy"
@@ -92,25 +131,23 @@ impl PolicyExtension for ToolPolicyExtension {
             return Ok(());
         }
 
-        let command = payload
-            .and_then(|payload| payload.get("command"))
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|s| !s.is_empty());
-
+        let Some(payload) = payload.and_then(serde_json::Value::as_object) else {
+            return Ok(());
+        };
+        let command = payload.get("command").and_then(serde_json::Value::as_str);
         let Some(command) = command else {
             return Ok(());
         };
-
-        let basename = match validate_shell_command_name(command) {
-            Ok(command) => command,
-            Err(reason) => {
-                return Err(PolicyError::ToolCallDenied {
-                    tool_name: tool_name.to_owned(),
-                    reason,
-                });
+        let trimmed_command = command.trim();
+        if trimmed_command.is_empty() {
+            return Ok(());
+        }
+        let basename = validate_shell_command_name(trimmed_command).map_err(|reason| {
+            PolicyError::ToolCallDenied {
+                tool_name: tool_name.to_owned(),
+                reason,
             }
-        };
+        })?;
 
         if self.hard_deny.contains(basename.as_str()) {
             return Err(PolicyError::ToolCallDenied {
@@ -120,6 +157,13 @@ impl PolicyExtension for ToolPolicyExtension {
         }
 
         if self.allow.contains(basename.as_str()) {
+            return Ok(());
+        }
+
+        let approval_key = shell_exec_approval_key_for_normalized_command(basename.as_str());
+        let approved_by_internal_context =
+            shell_exec_matches_trusted_internal_approval(payload, approval_key.as_str());
+        if approved_by_internal_context {
             return Ok(());
         }
 
@@ -293,6 +337,52 @@ mod tests {
         });
         let allowed_ctx = make_context(&pack, &token, &caps, Some(&allowed));
         assert!(ext.authorize_extension(&allowed_ctx).is_ok());
+    }
+
+    #[test]
+    fn allows_trusted_shell_approval_context_when_default_policy_denies() {
+        let ext =
+            ToolPolicyExtension::new(BTreeSet::new(), BTreeSet::new(), ShellPolicyDefault::Deny);
+        let pack = test_pack();
+        let token = test_token();
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let approval_key = shell_exec_approval_key("cargo").expect("approval key");
+        let params = json!({
+            "tool_name": "shell.exec",
+            "payload": {
+                "command": "cargo",
+                "_loongclaw": shell_exec_internal_approval_context(approval_key.as_str()),
+            }
+        });
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+
+        assert!(ext.authorize_extension(&ctx).is_ok());
+    }
+
+    #[test]
+    fn hard_deny_overrides_trusted_shell_approval_context() {
+        let ext = ToolPolicyExtension::new(
+            BTreeSet::from(["cargo".to_owned()]),
+            BTreeSet::new(),
+            ShellPolicyDefault::Deny,
+        );
+        let pack = test_pack();
+        let token = test_token();
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let approval_key = shell_exec_approval_key("cargo").expect("approval key");
+        let params = json!({
+            "tool_name": "shell.exec",
+            "payload": {
+                "command": "cargo",
+                "_loongclaw": shell_exec_internal_approval_context(approval_key.as_str()),
+            }
+        });
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+
+        assert!(matches!(
+            ext.authorize_extension(&ctx).unwrap_err(),
+            PolicyError::ToolCallDenied { .. }
+        ));
     }
 
     #[test]

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-02T12:05:09Z
+- Generated at: 2026-04-02T15:16:55Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10971 | 11200 | 229 | 100 | 120 | 20 | 98.0% | TIGHT | 10831 | 1.3% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14929 | 15000 | 71 | 56 | 70 | 14 | 99.5% | TIGHT | 14472 | 3.2% | PASS | 54 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11070 | 11200 | 130 | 100 | 120 | 20 | 98.8% | TIGHT | 10831 | 2.2% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14940 | 15000 | 60 | 55 | 70 | 15 | 99.6% | TIGHT | 14472 | 3.2% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6382 | 6500 | 118 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.9% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (98.0%), tools_mod (99.5%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (98.8%), tools_mod (99.6%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -67,8 +67,8 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10971 functions=100 -->
-<!-- arch-hotspot key=tools_mod lines=14929 functions=56 -->
+<!-- arch-hotspot key=turn_coordinator lines=11070 functions=100 -->
+<!-- arch-hotspot key=tools_mod lines=14940 functions=55 -->
 <!-- arch-hotspot key=daemon_lib lines=6382 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem: `shell.exec` disappeared from `tool.search` under a default-deny shell policy, and approved shell calls could still fail to replay through the same policy.
- Why it matters: operators who intentionally keep `shell_allow = []` got a misleading “shell unavailable” experience, and explicit approvals did not reliably unblock the requested command.
- What changed:
  - kept `shell.exec` discoverable in `tool.search` even when the runtime allowlist is empty
  - routed discovered `shell.exec` requests into the existing governed approval flow with a command-scoped approval key
  - replayed approved shell requests through the existing kernel execution path by attaching trusted internal approval context
  - preserved hard-deny precedence and preserved generic core approval replay for non-shell tools
  - added regression coverage for discovery, approval persistence, `approve_once`, `approve_always`, deny handling, and core replay compatibility
- What did not change (scope boundary): this does not add a new global yes/auto/full/esc-style permission mode machine, does not relax `shell_default_mode = "deny"`, and does not widen non-shell tool permissions.

## Linked Issues

- Closes #821
- Related #787

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: approval routing now treats `shell.exec` as discoverable-but-governed under default-deny, and approval replay injects trusted internal context only for approved `shell.exec` requests.
- Rollout / guardrails: hard-deny still wins, the trusted context is command-scoped (`tool:shell.exec:<normalized-command>`), and non-shell core tools keep the generic replay path.
- Rollback path: revert commit `05f76ab1199d4518c7fbbb8e9bc11281d4b6266d`, or immediately disable shell execution with `tool-shell` off / `shell_deny` if unexpected behavior appears.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p loongclaw-app shell_exec
cargo test -p loongclaw-app reuses_shell_grant
cargo test -p loongclaw-app autonomy_policy_
cargo test -p loongclaw-app turn_engine_fails_closed_before_governed_approval_for_later_app_intent
cargo test -p loongclaw-app core_approval_replay_skips_app_session_context_loading
cargo test -p loongclaw-app auto_mode_requires_approval_for_high_risk_core_tool
cargo test -p loongclaw-app governed_tool_approval_request_reuses_deterministic_id_for_same_blocked_call
cargo test --workspace --locked
cargo test --workspace --all-features --locked
scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh

Results:
- All listed cargo commands exited 0.
- `scripts/check_architecture_boundaries.sh` passed.
- `scripts/check_dep_graph.sh` passed.
- `task check:conventions` was not runnable in this environment because the required local `~/.claude/skills/convention-engineering` dependency was missing.
```

Before / after behavior and regression coverage:

- Before: `tool.search` could hide `shell.exec` completely when `shell_allow = []`, so shell execution looked unavailable instead of governed.
- Before: an approved default-deny `shell.exec` request could still fail replay because the execution path did not bridge approval through trusted internal context.
- After: `tool.search` keeps `shell.exec` visible, discovered shell calls request approval through the existing governance flow, and approved `approve_once` / `approve_always` replays execute through the kernel path.
- Regression coverage: discovery visibility, approval persistence, deterministic approval IDs, approve-once replay, approve-always grant reuse, deny behavior, and non-shell core replay compatibility.

## User-visible / Operator-visible Changes

- Under a safe default-deny shell policy, `shell.exec` remains discoverable instead of disappearing from tool search.
- Approved shell commands now resume through the existing approval flow instead of looking permanently blocked by the same policy that required approval.

## Failure Recovery

- Fast rollback or disable path: revert `05f76ab1199d4518c7fbbb8e9bc11281d4b6266d`, or block shell execution explicitly with `shell_deny` / a build without `tool-shell`.
- Observable failure symptoms reviewers should watch for: duplicate approval requests for the same shell command, approved shell calls still failing default-deny, or non-shell core approvals being misrouted through the shell replay path.

## Reviewer Focus

- Review the hybrid `tool.invoke` handling and preflight binding path in `crates/app/src/conversation/turn_engine.rs`.
- Review shell-only approval replay and trusted internal context injection in `crates/app/src/conversation/turn_coordinator.rs`.
- Review hard-deny precedence and trusted approval matching in `crates/app/src/tools/shell_policy_ext.rs` and `crates/app/src/tools/shell.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Governed approval and preflight checks for shell command execution, including single-use, persistent-grant reuse, and deny handling; shell.exec remains discoverable and can use a trusted internal approval context to permit execution under default-deny policies.

* **Tests**
  * Added comprehensive tests for approval-required flows: approval request creation, approve-once replay, approve-always grant reuse, deny behavior, persistence, and deterministic approval IDs.

* **Documentation**
  * Updated architecture hotspot metrics and report timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->