### PR TITLE
fix(personalize): preserve suppress metadata and saved preferences

### DIFF
--- a/crates/app/src/memory/context.rs
+++ b/crates/app/src/memory/context.rs
@@ -176,18 +176,9 @@ pub fn load_prompt_context(
 ) -> Result<Vec<MemoryContextEntry>, String> {
     let mut entries = Vec::new();
 
-    let profile_section = runtime_identity::render_session_profile_section(
-        config.profile_note.as_deref(),
-        config.personalization.as_ref(),
-    );
-    if matches!(config.mode, MemoryMode::ProfilePlusWindow)
-        && let Some(profile_section) = profile_section
-    {
-        entries.push(MemoryContextEntry {
-            kind: MemoryContextKind::Profile,
-            role: "system".to_owned(),
-            content: profile_section,
-        });
+    let profile_entry = build_profile_entry(config);
+    if let Some(profile_entry) = profile_entry {
+        entries.push(profile_entry);
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -220,6 +211,24 @@ pub fn load_prompt_context(
     }
 
     Ok(entries)
+}
+
+pub(super) fn build_profile_entry(config: &MemoryRuntimeConfig) -> Option<MemoryContextEntry> {
+    let profile_plus_window_mode = matches!(config.mode, MemoryMode::ProfilePlusWindow);
+    if !profile_plus_window_mode {
+        return None;
+    }
+
+    let profile_note = config.profile_note.as_deref();
+    let personalization = config.personalization.as_ref();
+    let profile_section =
+        runtime_identity::render_session_profile_section(profile_note, personalization)?;
+
+    Some(MemoryContextEntry {
+        kind: MemoryContextKind::Profile,
+        role: "system".to_owned(),
+        content: profile_section,
+    })
 }
 
 #[cfg(test)]
@@ -335,6 +344,8 @@ mod tests {
         let _ = std::fs::create_dir_all(&tmp);
         let db_path = tmp.join("personalization.sqlite3");
         let _ = std::fs::remove_file(&db_path);
+        let default_personalization = crate::config::PersonalizationConfig::default();
+        let schema_version = default_personalization.schema_version;
         let personalization = crate::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
             response_density: Some(crate::config::ResponseDensity::Thorough),
@@ -343,7 +354,7 @@ mod tests {
             timezone: Some("Asia/Shanghai".to_owned()),
             locale: None,
             prompt_state: crate::config::PersonalizationPromptState::Configured,
-            schema_version: 1,
+            schema_version,
             updated_at_epoch_seconds: Some(1_775_095_200),
         };
         let config = MemoryRuntimeConfig {
@@ -390,6 +401,8 @@ mod tests {
         let _ = std::fs::create_dir_all(&tmp);
         let db_path = tmp.join("window-only-personalization.sqlite3");
         let _ = std::fs::remove_file(&db_path);
+        let default_personalization = crate::config::PersonalizationConfig::default();
+        let schema_version = default_personalization.schema_version;
         let personalization = crate::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
             response_density: Some(crate::config::ResponseDensity::Balanced),
@@ -398,7 +411,7 @@ mod tests {
             timezone: Some("Asia/Shanghai".to_owned()),
             locale: None,
             prompt_state: crate::config::PersonalizationPromptState::Configured,
-            schema_version: 1,
+            schema_version,
             updated_at_epoch_seconds: Some(1_775_095_200),
         };
         let config = MemoryRuntimeConfig {

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -10,8 +10,6 @@ use loongclaw_contracts::{MemoryCoreOutcome, MemoryCoreRequest};
 use serde_json::json;
 
 use crate::config::MemoryBackendKind;
-use crate::runtime_identity;
-
 mod canonical;
 mod context;
 #[cfg(feature = "memory-sqlite")]
@@ -257,20 +255,7 @@ pub fn load_prompt_context_with_diagnostics(
     session_id: &str,
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<(Vec<MemoryContextEntry>, SqliteContextLoadDiagnostics), String> {
-    let mut profile_entry = None;
-    let profile_section = runtime_identity::render_session_profile_section(
-        config.profile_note.as_deref(),
-        config.personalization.as_ref(),
-    );
-    if matches!(config.mode, crate::config::MemoryMode::ProfilePlusWindow)
-        && let Some(profile_section) = profile_section
-    {
-        profile_entry = Some(MemoryContextEntry {
-            kind: MemoryContextKind::Profile,
-            role: "system".to_owned(),
-            content: profile_section,
-        });
-    }
+    let mut profile_entry = context::build_profile_entry(config);
 
     let (snapshot, diagnostics) =
         sqlite::load_context_snapshot_with_diagnostics(session_id, config)?;

--- a/crates/app/src/memory/runtime_config.rs
+++ b/crates/app/src/memory/runtime_config.rs
@@ -301,6 +301,33 @@ mod tests {
     }
 
     #[test]
+    fn runtime_config_from_memory_config_carries_personalization() {
+        let _env = ScopedEnv::new();
+        let default_personalization = PersonalizationConfig::default();
+        let schema_version = default_personalization.schema_version;
+        let personalization = PersonalizationConfig {
+            preferred_name: Some("Chum".to_owned()),
+            response_density: Some(crate::config::ResponseDensity::Balanced),
+            initiative_level: Some(crate::config::InitiativeLevel::AskBeforeActing),
+            standing_boundaries: Some("Ask before destructive actions.".to_owned()),
+            timezone: Some("Asia/Shanghai".to_owned()),
+            locale: Some("zh-CN".to_owned()),
+            prompt_state: crate::config::PersonalizationPromptState::Suppressed,
+            schema_version,
+            updated_at_epoch_seconds: Some(1_775_095_200),
+        };
+        let config = MemoryConfig {
+            personalization: Some(personalization),
+            ..MemoryConfig::default()
+        };
+
+        let runtime = MemoryRuntimeConfig::from_memory_config(&config);
+        let expected_personalization = config.trimmed_personalization();
+
+        assert_eq!(runtime.personalization, expected_personalization);
+    }
+
+    #[test]
     fn hydrated_memory_runtime_config_carries_system_policy() {
         let _env = ScopedEnv::new();
         let config = MemoryConfig {

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -25,6 +25,13 @@ fn isolated_memory_workspace(prefix: &str) -> (PathBuf, runtime_config::MemoryRu
     (root, config)
 }
 
+#[cfg(feature = "memory-sqlite")]
+fn cleanup_memory_workspace(workspace_root: &std::path::Path, db_path: &std::path::Path) {
+    let _ = drop_cached_sqlite_runtime(db_path);
+    let _ = std::fs::remove_file(db_path);
+    let _ = std::fs::remove_dir(workspace_root);
+}
+
 #[test]
 fn fallback_memory_operation_stays_compatible() {
     let outcome = execute_memory_core(MemoryCoreRequest {
@@ -293,7 +300,7 @@ fn load_prompt_context_with_diagnostics_projects_typed_personalization_without_p
     let config = runtime_config::MemoryRuntimeConfig {
         profile: MemoryProfile::ProfilePlusWindow,
         mode: MemoryMode::ProfilePlusWindow,
-        sqlite_path: Some(db_path),
+        sqlite_path: Some(db_path.clone()),
         sliding_window: 2,
         profile_note: None,
         personalization: Some(personalization),
@@ -328,7 +335,7 @@ fn load_prompt_context_with_diagnostics_projects_typed_personalization_without_p
     assert!(profile_content.contains("Timezone: Asia/Shanghai"));
     assert!(!profile_content.contains("## Resolved Runtime Identity"));
 
-    std::fs::remove_dir_all(&workspace_root).expect("remove diagnostics workspace");
+    cleanup_memory_workspace(&workspace_root, &db_path);
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/tests.rs
+++ b/crates/app/src/memory/tests.rs
@@ -268,6 +268,71 @@ fn load_prompt_context_with_diagnostics_omits_legacy_identity_from_profile_proje
 
 #[cfg(feature = "memory-sqlite")]
 #[test]
+fn load_prompt_context_with_diagnostics_projects_typed_personalization_without_profile_note() {
+    use crate::config::{MemoryMode, MemoryProfile};
+
+    let workspace_root = crate::test_support::unique_temp_dir(
+        "loongclaw-test-memory-profile-diagnostics-personalization",
+    );
+    std::fs::create_dir_all(&workspace_root).expect("create diagnostics workspace");
+
+    let db_path = workspace_root.join("profile-diagnostics-personalization.sqlite3");
+    let default_personalization = crate::config::PersonalizationConfig::default();
+    let schema_version = default_personalization.schema_version;
+    let personalization = crate::config::PersonalizationConfig {
+        preferred_name: Some("Chum".to_owned()),
+        response_density: Some(crate::config::ResponseDensity::Balanced),
+        initiative_level: Some(crate::config::InitiativeLevel::AskBeforeActing),
+        standing_boundaries: Some("Ask before destructive actions.".to_owned()),
+        timezone: Some("Asia/Shanghai".to_owned()),
+        locale: None,
+        prompt_state: crate::config::PersonalizationPromptState::Configured,
+        schema_version,
+        updated_at_epoch_seconds: Some(1_775_095_200),
+    };
+    let config = runtime_config::MemoryRuntimeConfig {
+        profile: MemoryProfile::ProfilePlusWindow,
+        mode: MemoryMode::ProfilePlusWindow,
+        sqlite_path: Some(db_path),
+        sliding_window: 2,
+        profile_note: None,
+        personalization: Some(personalization),
+        ..runtime_config::MemoryRuntimeConfig::default()
+    };
+
+    append_turn_direct(
+        "profile-diagnostics-personalization-session",
+        "user",
+        "recent turn",
+        &config,
+    )
+    .expect("append_turn_direct should succeed");
+
+    let diagnostics_context = load_prompt_context_with_diagnostics(
+        "profile-diagnostics-personalization-session",
+        &config,
+    );
+    let (entries, _diagnostics) =
+        diagnostics_context.expect("load_prompt_context_with_diagnostics should succeed");
+    let profile_entry = entries
+        .iter()
+        .find(|entry| entry.kind == MemoryContextKind::Profile)
+        .expect("profile entry");
+    let profile_content = profile_entry.content.as_str();
+
+    assert!(profile_content.contains("## Session Profile"));
+    assert!(profile_content.contains("Preferred name: Chum"));
+    assert!(profile_content.contains("Response density: balanced"));
+    assert!(profile_content.contains("Initiative level: ask_before_acting"));
+    assert!(profile_content.contains("Ask before destructive actions."));
+    assert!(profile_content.contains("Timezone: Asia/Shanghai"));
+    assert!(!profile_content.contains("## Resolved Runtime Identity"));
+
+    std::fs::remove_dir_all(&workspace_root).expect("remove diagnostics workspace");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
 fn pre_compaction_durable_flush_deduplicates_repeated_summary_exports() {
     let durable_flush_lock = crate::test_support::durable_memory_flush_test_lock();
     let _durable_flush_guard = durable_flush_lock.blocking_lock();

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -5101,7 +5101,7 @@ mod tests {
     }
 
     #[test]
-    fn build_doctor_next_steps_keeps_browser_preview_visible_when_channels_are_enabled() {
+    fn build_doctor_next_steps_prioritizes_personalization_when_channels_are_enabled() {
         let checks = vec![DoctorCheck {
             name: "provider credentials".to_owned(),
             level: DoctorCheckLevel::Pass,

--- a/crates/daemon/src/personalize_cli.rs
+++ b/crates/daemon/src/personalize_cli.rs
@@ -69,9 +69,13 @@ pub(crate) fn run_personalize_cli_with_ui(
             ui.print_line("No changes saved.")?;
             Ok(PersonalizeCliOutcome::Skipped)
         }
-        PersonalizeReviewAction::SuppressFutureSuggestions => {
-            suppress_personalization(ui, &resolved_path, &mut config, now)
-        }
+        PersonalizeReviewAction::SuppressFutureSuggestions => suppress_personalization(
+            ui,
+            &resolved_path,
+            &mut config,
+            existing_personalization.as_ref(),
+            now,
+        ),
     }
 }
 
@@ -348,7 +352,9 @@ fn select_review_action(
         SelectOption {
             label: "suppress future suggestions".to_owned(),
             slug: "suppress".to_owned(),
-            description: "persist a do-not-suggest state without saving preferences".to_owned(),
+            description:
+                "stop proactive suggestions without saving this draft; keep any existing saved preferences"
+                    .to_owned(),
             recommended: false,
         },
     ];
@@ -483,17 +489,10 @@ fn suppress_personalization(
     ui: &mut impl OperatorPromptUi,
     resolved_path: &Path,
     config: &mut mvp::config::LoongClawConfig,
+    existing_personalization: Option<&mvp::config::PersonalizationConfig>,
     now: OffsetDateTime,
 ) -> CliResult<PersonalizeCliOutcome> {
-    let updated_at_epoch_seconds = u64::try_from(now.unix_timestamp()).ok();
-    let default_personalization = mvp::config::PersonalizationConfig::default();
-    let schema_version = default_personalization.schema_version;
-    let personalization = mvp::config::PersonalizationConfig {
-        prompt_state: mvp::config::PersonalizationPromptState::Suppressed,
-        schema_version,
-        updated_at_epoch_seconds,
-        ..default_personalization
-    };
+    let personalization = build_suppressed_personalization(existing_personalization, now);
 
     config.memory.personalization = Some(personalization);
     let saved_path = write_personalization_config(config, resolved_path)?;
@@ -507,6 +506,38 @@ fn suppress_personalization(
     )?;
 
     Ok(PersonalizeCliOutcome::Suppressed)
+}
+
+fn build_suppressed_personalization(
+    existing_personalization: Option<&mvp::config::PersonalizationConfig>,
+    now: OffsetDateTime,
+) -> mvp::config::PersonalizationConfig {
+    let updated_at_epoch_seconds = u64::try_from(now.unix_timestamp()).ok();
+    let default_personalization = mvp::config::PersonalizationConfig::default();
+    let schema_version = default_personalization.schema_version;
+    let preserved_personalization = existing_personalization
+        .cloned()
+        .unwrap_or(default_personalization);
+
+    let preferred_name = preserved_personalization.preferred_name;
+    let response_density = preserved_personalization.response_density;
+    let initiative_level = preserved_personalization.initiative_level;
+    let standing_boundaries = preserved_personalization.standing_boundaries;
+    let timezone = preserved_personalization.timezone;
+    let locale = preserved_personalization.locale;
+    let prompt_state = mvp::config::PersonalizationPromptState::Suppressed;
+
+    mvp::config::PersonalizationConfig {
+        preferred_name,
+        response_density,
+        initiative_level,
+        standing_boundaries,
+        timezone,
+        locale,
+        prompt_state,
+        schema_version,
+        updated_at_epoch_seconds,
+    }
 }
 
 fn write_personalization_config(
@@ -622,8 +653,13 @@ mod tests {
         mvp::config::write(Some(path_string.as_str()), config, true).expect("write config");
     }
 
+    fn personalization_schema_version_for_tests() -> u32 {
+        let default_personalization = mvp::config::PersonalizationConfig::default();
+        default_personalization.schema_version
+    }
+
     fn configured_personalization_for_tests() -> mvp::config::PersonalizationConfig {
-        let schema_version = mvp::config::PersonalizationConfig::default().schema_version;
+        let schema_version = personalization_schema_version_for_tests();
         mvp::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
             response_density: Some(mvp::config::ResponseDensity::Balanced),
@@ -650,6 +686,7 @@ mod tests {
         let config_path = unique_config_path("save");
         let config_path_string = config_path.display().to_string();
         write_default_config(&config_path);
+        let expected_schema_version = personalization_schema_version_for_tests();
         let mut ui = TestPromptUi::with_inputs([
             "Chum",
             "3",
@@ -671,7 +708,6 @@ mod tests {
             .memory
             .personalization
             .expect("saved personalization");
-        let schema_version = mvp::config::PersonalizationConfig::default().schema_version;
 
         assert_eq!(
             outcome,
@@ -702,7 +738,7 @@ mod tests {
             personalization.prompt_state,
             mvp::config::PersonalizationPromptState::Configured
         );
-        assert_eq!(personalization.schema_version, schema_version);
+        assert_eq!(personalization.schema_version, expected_schema_version);
         assert_eq!(
             personalization.updated_at_epoch_seconds,
             Some(1_775_095_200)
@@ -740,6 +776,7 @@ mod tests {
         let config_path = unique_config_path("suppress");
         let config_path_string = config_path.display().to_string();
         write_default_config(&config_path);
+        let expected_schema_version = personalization_schema_version_for_tests();
         let mut ui = TestPromptUi::with_inputs(["", "", "", "", "", "", "3"]);
 
         let outcome =
@@ -752,7 +789,6 @@ mod tests {
             .memory
             .personalization
             .expect("suppressed personalization state");
-        let schema_version = mvp::config::PersonalizationConfig::default().schema_version;
 
         assert_eq!(outcome, PersonalizeCliOutcome::Suppressed);
         assert_eq!(personalization.preferred_name, None);
@@ -765,7 +801,7 @@ mod tests {
             personalization.prompt_state,
             mvp::config::PersonalizationPromptState::Suppressed
         );
-        assert_eq!(personalization.schema_version, schema_version);
+        assert_eq!(personalization.schema_version, expected_schema_version);
         assert_eq!(
             personalization.updated_at_epoch_seconds,
             Some(1_775_095_200)
@@ -775,12 +811,14 @@ mod tests {
     }
 
     #[test]
-    fn personalize_cli_suppress_clears_existing_preferences() {
-        let config_path = unique_config_path("suppress-clears-existing");
+    fn personalize_cli_suppress_preserves_existing_preferences() {
+        let config_path = unique_config_path("suppress-preserve");
         let config_path_string = config_path.display().to_string();
         let config = configured_personalize_config_for_tests();
         write_config(&config_path, &config);
-        let mut ui = TestPromptUi::with_inputs(["", "", "", "", "", "", "3"]);
+        let expected_schema_version = personalization_schema_version_for_tests();
+        let mut ui =
+            TestPromptUi::with_inputs(["New Name", "3", "3", "New boundary", "UTC", "en-US", "3"]);
 
         let outcome =
             run_personalize_cli_with_ui(Some(config_path_string.as_str()), &mut ui, fixed_now())
@@ -792,20 +830,32 @@ mod tests {
             .memory
             .personalization
             .expect("suppressed personalization state");
-        let schema_version = mvp::config::PersonalizationConfig::default().schema_version;
 
         assert_eq!(outcome, PersonalizeCliOutcome::Suppressed);
-        assert_eq!(personalization.preferred_name, None);
-        assert_eq!(personalization.response_density, None);
-        assert_eq!(personalization.initiative_level, None);
-        assert_eq!(personalization.standing_boundaries, None);
-        assert_eq!(personalization.timezone, None);
-        assert_eq!(personalization.locale, None);
+        assert_eq!(personalization.preferred_name.as_deref(), Some("Chum"));
+        assert_eq!(
+            personalization.response_density,
+            Some(mvp::config::ResponseDensity::Balanced)
+        );
+        assert_eq!(
+            personalization.initiative_level,
+            Some(mvp::config::InitiativeLevel::AskBeforeActing)
+        );
+        assert_eq!(
+            personalization.standing_boundaries.as_deref(),
+            Some("Ask before destructive actions.")
+        );
+        assert_eq!(personalization.timezone.as_deref(), Some("Asia/Shanghai"));
+        assert_eq!(personalization.locale.as_deref(), Some("zh-CN"));
         assert_eq!(
             personalization.prompt_state,
             mvp::config::PersonalizationPromptState::Suppressed
         );
-        assert_eq!(personalization.schema_version, schema_version);
+        assert_eq!(personalization.schema_version, expected_schema_version);
+        assert_eq!(
+            personalization.updated_at_epoch_seconds,
+            Some(1_775_095_200)
+        );
 
         let _ = std::fs::remove_file(config_path);
     }
@@ -903,7 +953,7 @@ mod tests {
         let config_path = unique_config_path("clear-enum");
         let config_path_string = config_path.display().to_string();
         let mut config = configured_personalize_config_for_tests();
-        let schema_version = mvp::config::PersonalizationConfig::default().schema_version;
+        let schema_version = personalization_schema_version_for_tests();
         config.memory.personalization = Some(mvp::config::PersonalizationConfig {
             preferred_name: Some("Chum".to_owned()),
             response_density: Some(mvp::config::ResponseDensity::Balanced),
@@ -966,7 +1016,7 @@ mod tests {
         let config_path = unique_config_path("suppressed-recovery");
         let config_path_string = config_path.display().to_string();
         let mut config = mvp::config::LoongClawConfig::default();
-        let schema_version = mvp::config::PersonalizationConfig::default().schema_version;
+        let schema_version = personalization_schema_version_for_tests();
         config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
         config.memory.personalization = Some(mvp::config::PersonalizationConfig {
             preferred_name: None,
@@ -1040,7 +1090,7 @@ mod tests {
         let config_path = unique_config_path("suppressed-empty-save");
         let config_path_string = config_path.display().to_string();
         let mut config = mvp::config::LoongClawConfig::default();
-        let schema_version = mvp::config::PersonalizationConfig::default().schema_version;
+        let schema_version = personalization_schema_version_for_tests();
         config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
         config.memory.personalization = Some(mvp::config::PersonalizationConfig {
             preferred_name: None,

--- a/crates/daemon/src/personalize_cli.rs
+++ b/crates/daemon/src/personalize_cli.rs
@@ -514,30 +514,18 @@ fn build_suppressed_personalization(
 ) -> mvp::config::PersonalizationConfig {
     let updated_at_epoch_seconds = u64::try_from(now.unix_timestamp()).ok();
     let default_personalization = mvp::config::PersonalizationConfig::default();
-    let schema_version = default_personalization.schema_version;
-    let preserved_personalization = existing_personalization
-        .cloned()
-        .unwrap_or(default_personalization);
+    let preserved_personalization = existing_personalization.cloned();
+    let has_existing_personalization = preserved_personalization.is_some();
+    let mut suppressed_personalization =
+        preserved_personalization.unwrap_or(default_personalization);
 
-    let preferred_name = preserved_personalization.preferred_name;
-    let response_density = preserved_personalization.response_density;
-    let initiative_level = preserved_personalization.initiative_level;
-    let standing_boundaries = preserved_personalization.standing_boundaries;
-    let timezone = preserved_personalization.timezone;
-    let locale = preserved_personalization.locale;
-    let prompt_state = mvp::config::PersonalizationPromptState::Suppressed;
+    suppressed_personalization.prompt_state = mvp::config::PersonalizationPromptState::Suppressed;
 
-    mvp::config::PersonalizationConfig {
-        preferred_name,
-        response_density,
-        initiative_level,
-        standing_boundaries,
-        timezone,
-        locale,
-        prompt_state,
-        schema_version,
-        updated_at_epoch_seconds,
+    if !has_existing_personalization {
+        suppressed_personalization.updated_at_epoch_seconds = updated_at_epoch_seconds;
     }
+
+    suppressed_personalization
 }
 
 fn write_personalization_config(
@@ -814,9 +802,23 @@ mod tests {
     fn personalize_cli_suppress_preserves_existing_preferences() {
         let config_path = unique_config_path("suppress-preserve");
         let config_path_string = config_path.display().to_string();
-        let config = configured_personalize_config_for_tests();
+        let custom_schema_version = personalization_schema_version_for_tests() + 7;
+        let preserved_updated_at_epoch_seconds = Some(1_700_000_000);
+        let personalization = mvp::config::PersonalizationConfig {
+            preferred_name: Some("Chum".to_owned()),
+            response_density: Some(mvp::config::ResponseDensity::Balanced),
+            initiative_level: Some(mvp::config::InitiativeLevel::AskBeforeActing),
+            standing_boundaries: Some("Ask before destructive actions.".to_owned()),
+            timezone: Some("Asia/Shanghai".to_owned()),
+            locale: Some("zh-CN".to_owned()),
+            prompt_state: mvp::config::PersonalizationPromptState::Configured,
+            schema_version: custom_schema_version,
+            updated_at_epoch_seconds: preserved_updated_at_epoch_seconds,
+        };
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.memory.profile = mvp::config::MemoryProfile::ProfilePlusWindow;
+        config.memory.personalization = Some(personalization);
         write_config(&config_path, &config);
-        let expected_schema_version = personalization_schema_version_for_tests();
         let mut ui =
             TestPromptUi::with_inputs(["New Name", "3", "3", "New boundary", "UTC", "en-US", "3"]);
 
@@ -851,10 +853,10 @@ mod tests {
             personalization.prompt_state,
             mvp::config::PersonalizationPromptState::Suppressed
         );
-        assert_eq!(personalization.schema_version, expected_schema_version);
+        assert_eq!(personalization.schema_version, custom_schema_version);
         assert_eq!(
             personalization.updated_at_epoch_seconds,
-            Some(1_775_095_200)
+            preserved_updated_at_epoch_seconds
         );
 
         let _ = std::fs::remove_file(config_path);

--- a/docs/product-specs/personalization.md
+++ b/docs/product-specs/personalization.md
@@ -24,7 +24,8 @@ down the first-run path or mutating runtime identity authority.
       deferred, suppressed, or rerun explicitly later.
 - [ ] Operators can rerun `loong personalize` to update or clear saved
       preferences, and suppression only persists an advisory do-not-suggest
-      state until the command is run explicitly again.
+      state until operators explicitly rerun and save updated preferences,
+      without erasing already saved preferences.
 - [ ] Persisted personalization state remains advisory and is projected through
       the session-profile lane rather than becoming a second runtime identity
       authority.

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -15,7 +15,7 @@
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3568 | 3700 | 132 | 48 | 80 | 32 | 96.4% | TIGHT | 3547 | 0.6% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.0% | PASS | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 358 | 650 | 292 | 14 | 16 | 2 | 87.5% | WATCH | 356 | 0.6% | PASS | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 343 | 650 | 307 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -3.7% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2716 | 2800 | 84 | 56 | 65 | 9 | 97.0% | TIGHT | 2698 | 0.7% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10464 | 10500 | 36 | 88 | 90 | 2 | 99.7% | TIGHT | 9922 | 5.5% | PASS | 88 |
@@ -60,7 +60,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3568 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=358 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=343 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2716 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=10464 functions=88 -->


### PR DESCRIPTION
## Summary

- Problem:
  The current `dev` branch still treats `suppress future suggestions` as a destructive rewrite of the saved personalization record. Operators who only want to mute future reminders lose previously saved advisory preferences, and existing personalization metadata is rewritten instead of preserved.
- Why it matters:
  Suppression is supposed to be a non-destructive do-not-suggest state, not an implicit reset. Rewriting the saved record drifts from the product spec and weakens the session-profile projection path that depends on durable personalization state.
- What changed:
  The suppress path now preserves an existing personalization record, including its saved fields and metadata, and only flips `prompt_state` to `Suppressed`. The suppress action continues to ignore the in-progress draft. This PR also deduplicates profile-entry assembly across the normal and diagnostics-aware memory loaders, adds runtime-config coverage for personalization propagation, and tightens the product spec wording so the intended semantics are explicit.
- What did not change (scope boundary):
  This PR does not introduce a new governed prompt lane, does not change first-chat behavior, does not change authority files such as `AGENTS.md` or `IDENTITY.md`, and does not alter the browser companion probe implementation already present on `dev`.

## Linked Issues

- Closes #824
- Related #811

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-target-personalize-followup cargo clippy --workspace --all-targets --all-features -- -D warnings
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-target-personalize-followup cargo test -p loongclaw personalize_cli::tests::personalize_cli_suppress_preserves_existing_preferences -- --exact --nocapture
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-target-personalize-followup cargo test -p loongclaw browser_companion_diagnostics::tests::collect_browser_companion_diagnostics_rejects_partial_expected_version_matches -- --exact --nocapture
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-target-personalize-followup cargo test -p loongclaw doctor_cli::tests::browser_companion_doctor_checks_warn_when_expected_version_mismatches -- --exact --nocapture
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-target-personalize-followup cargo test --workspace --locked
  PASS

CARGO_TARGET_DIR=/tmp/loongclaw-target-personalize-followup cargo test --workspace --all-features --locked
  PASS

scripts/check_architecture_boundaries.sh
  PASS

scripts/check_dep_graph.sh
  PASS

scripts/check-docs.sh
  PASS with existing non-blocking release-artifact warnings only

diff CLAUDE.md AGENTS.md
  PASS
```

Not run as an actual gate in this environment:

- `task check:conventions`
  The repository Taskfile depends on `~/.claude/skills/convention-engineering`, which is not installed on this machine, so I am not claiming that gate passed.

Before / after behavior covered by regression tests:

- Before: suppress rebuilt an existing personalization record from defaults, which cleared saved preference fields and rewrote metadata.
- After: suppress preserves existing saved fields and existing metadata, and only changes `prompt_state` to `Suppressed`.
- Before: suppress and save semantics were too close together, because suppress still behaved like a destructive persistence path.
- After: suppress continues to ignore the in-progress draft, while save remains the only path that writes the new draft.
- Before: profile-entry assembly lived in two memory-loading paths and could drift over time.
- After: both paths use the same helper, and runtime-config coverage explicitly proves personalization reaches the runtime projection.
- Tests that touch process-global environment in this area continue to use `ScopedEnv` or the daemon environment lock helpers so state is restored or serialized instead of leaking across tests.

## User-visible / Operator-visible Changes

- Operators can suppress future personalization suggestions without losing previously saved advisory preferences.
- Existing personalization metadata stays stable when suppression is applied to a saved record.
- Session-profile projection stays aligned between the normal and diagnostics-aware memory loaders.

## Failure Recovery

- Fast rollback or disable path:
  Revert this PR to restore the previous behavior, or rerun `loongclaw personalize` and explicitly save or clear the desired preferences.
- Observable failure symptoms reviewers should watch for:
  Suppress clearing saved preferences, suppress rewriting existing metadata, or the normal and diagnostics-aware memory paths rendering different profile sections for the same personalization state.

## Reviewer Focus

- `crates/daemon/src/personalize_cli.rs` for the suppress persistence semantics and the separation between saved state and in-progress draft state.
- `crates/app/src/memory/context.rs` and `crates/app/src/memory/mod.rs` for parity between normal and diagnostics-aware profile projection.
- `crates/app/src/memory/runtime_config.rs` and `docs/product-specs/personalization.md` for runtime propagation coverage and spec alignment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppression of proactive suggestions now preserves previously saved personalization preferences and timestamps; the suppression option text was updated to state saved preferences are kept.
* **Tests**
  * Added/updated tests validating personalization propagation, suppression-preserves-existing-preferences behavior, and context loading with typed personalization (including when profile notes are absent); one test identifier was renamed for clarity.
* **Documentation**
  * Clarified personalization acceptance criteria and refreshed an architecture report timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->