### PR TITLE
Canonicalize tool retry context across wrapped tool calls

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10031,6 +10031,194 @@ async fn handle_turn_with_runtime_tool_error_returns_natural_language_fallback()
     assert_eq!(visible_turns[1].2, reply);
 }
 
+#[cfg(feature = "tool-shell")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_repairable_shell_failure_followup_includes_failed_request_context()
+ {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::new();
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Trying the shell command now.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "shell.exec",
+                json!({"command": "/bin/echo", "args": ["hello"]}),
+                "session-shell-followup",
+                "turn-shell-followup",
+                "call-shell-followup",
+            )],
+            raw_meta: Value::Null,
+        }),
+        Ok("MODEL_SHELL_REPAIR_REPLY".to_owned()),
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-shell-followup",
+            "say hello in the shell",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+        )
+        .await
+        .expect("repairable shell failure should still return completion fallback");
+
+    assert_eq!(reply, "MODEL_SHELL_REPAIR_REPLY");
+
+    let completion_requests = runtime
+        .completion_requested_messages
+        .lock()
+        .expect("completion request lock")
+        .clone();
+    assert_eq!(completion_requests.len(), 1);
+
+    let followup_messages = &completion_requests[0];
+    assert!(
+        followup_messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_request]\n")
+                            && content.contains("\"tool\":\"shell.exec\"")
+                            && content.contains("\"command\":\"/bin/echo\"")
+                    })
+        }),
+        "completion followup should include the failed canonical request: {followup_messages:?}"
+    );
+    assert!(
+        followup_messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_failure]\n")
+                            && content.contains("tool input needs repair")
+                    })
+        }),
+        "completion followup should include the repairable failure reason: {followup_messages:?}"
+    );
+    assert!(
+        followup_messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("user")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.contains("Repair guidance for shell.exec:")
+                            && content.contains(
+                                "Use a bare lowercase executable name in `payload.command`.",
+                            )
+                            && content
+                                .contains("The failed request used `/bin/echo`; retry with `echo`")
+                    })
+        }),
+        "completion followup should include shell repair guidance: {followup_messages:?}"
+    );
+}
+
+#[cfg(feature = "tool-shell")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_multi_intent_shell_failure_followup_uses_failed_request_only() {
+    use crate::test_support::TurnTestHarness;
+
+    let harness = TurnTestHarness::with_tool_config(
+        std::collections::BTreeSet::from([
+            loongclaw_contracts::Capability::InvokeTool,
+            loongclaw_contracts::Capability::FilesystemRead,
+            loongclaw_contracts::Capability::FilesystemWrite,
+        ]),
+        crate::tools::runtime_config::ToolRuntimeConfig {
+            shell_allow: std::collections::BTreeSet::from(["ls".to_owned(), "echo".to_owned()]),
+            ..crate::tools::runtime_config::ToolRuntimeConfig::default()
+        },
+    );
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Trying both shell commands now.".to_owned(),
+            tool_intents: vec![
+                provider_tool_intent(
+                    "shell.exec",
+                    json!({"command": "ls", "args": ["."]}),
+                    "session-shell-followup-multi",
+                    "turn-shell-followup-multi",
+                    "call-shell-followup-multi-1",
+                ),
+                provider_tool_intent(
+                    "shell.exec",
+                    json!({"command": "/bin/echo", "args": ["hello"]}),
+                    "session-shell-followup-multi",
+                    "turn-shell-followup-multi",
+                    "call-shell-followup-multi-2",
+                ),
+            ],
+            raw_meta: Value::Null,
+        }),
+        Ok("MODEL_SHELL_MULTI_REPAIR_REPLY".to_owned()),
+    );
+    let mut config = test_config();
+    config.conversation.safe_lane_max_tool_steps_per_turn = 2;
+    config.conversation.fast_lane_max_tool_steps_per_turn = 2;
+    config.conversation.turn_loop.max_tool_steps_per_round = 2;
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "session-shell-followup-multi",
+            "say hello in the shell twice",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+        )
+        .await
+        .expect("repairable shell failure should still return completion fallback");
+
+    assert_eq!(reply, "MODEL_SHELL_MULTI_REPAIR_REPLY");
+
+    let completion_requests = runtime
+        .completion_requested_messages
+        .lock()
+        .expect("completion request lock")
+        .clone();
+    assert_eq!(completion_requests.len(), 1);
+
+    let followup_messages = &completion_requests[0];
+    assert!(
+        followup_messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("assistant")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.starts_with("[tool_request]\n")
+                            && content.contains("\"tool\":\"shell.exec\"")
+                            && content.contains("\"command\":\"/bin/echo\"")
+                            && !content.contains("\"command\":\"echo\",\"args\":[\"ok\"]")
+                    })
+        }),
+        "completion followup should include only the failed request: {followup_messages:?}"
+    );
+    assert!(
+        followup_messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("user")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| {
+                        content.contains("The failed request used `/bin/echo`; retry with `echo`")
+                    })
+        }),
+        "completion followup should use the failed shell command in repair guidance: {followup_messages:?}"
+    );
+}
 #[tokio::test]
 async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_without_markers() {
     let runtime = FakeRuntime::with_turn_and_completion(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -112,9 +112,10 @@ use super::turn_shared::{
     ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
     build_tool_loop_guard_tail, decide_provider_turn_request_action,
     format_approval_required_reply, next_conversation_turn_id, reduce_followup_payload_for_model,
-    request_completion_with_raw_fallback, tool_driven_followup_payload,
-    tool_loop_circuit_breaker_reply, tool_result_contains_truncation_signal,
-    user_requested_raw_tool_output,
+    request_completion_with_raw_fallback, summarize_single_tool_followup_request,
+    summarize_tool_followup_request, summarize_tool_followup_tool_names,
+    tool_driven_followup_payload, tool_loop_circuit_breaker_reply,
+    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
 };
 #[cfg(test)]
 use super::turn_shared::{ReplyResolutionMode, ToolDrivenFollowupKind};
@@ -2542,6 +2543,9 @@ fn build_provider_turn_tool_terminal_events(
     events
 }
 
+fn summarize_tool_event_request(intent: &ToolIntent) -> Option<String> {
+    summarize_single_tool_followup_request(intent)
+}
 fn provider_turn_observer_supports_streaming(
     config: &LoongClawConfig,
     observer: Option<&ConversationTurnObserverHandle>,
@@ -5149,9 +5153,10 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     ingress: Option<&ConversationIngressContext>,
 ) -> ProviderTurnLaneExecution {
     let had_tool_intents = !turn.tool_intents.is_empty();
-    let requires_provider_turn_followup = turn.tool_intents.iter().any(|intent| {
-        crate::tools::canonical_tool_name(intent.tool_name.as_str()) == "tool.search"
-    });
+    let requires_provider_turn_followup = turn
+        .tool_intents
+        .iter()
+        .any(|intent| effective_followup_tool_name(intent) == "tool.search");
     let assistant_preface = turn.assistant_text.clone();
     let lane = preparation.lane_plan.decision.lane;
     let session_context = match runtime.session_context(config, session_id, binding) {
@@ -5159,10 +5164,13 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         Err(error) => {
             let turn_result = TurnResult::non_retryable_tool_error("session_context_failed", error);
             let tool_events = build_provider_turn_tool_terminal_events(turn, &turn_result, None);
+            let tool_request_summary =
+                summarize_provider_lane_tool_request(turn, &turn_result, None);
             return ProviderTurnLaneExecution {
                 lane,
                 assistant_preface,
                 had_tool_intents,
+                tool_request_summary,
                 requires_provider_turn_followup,
                 raw_tool_output_requested: preparation.raw_tool_output_requested,
                 turn_result,
@@ -5288,6 +5296,11 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         &turn_result,
         fast_lane_tool_batch_trace.as_ref(),
     );
+    let tool_request_summary = summarize_provider_lane_tool_request(
+        turn,
+        &turn_result,
+        fast_lane_tool_batch_trace.as_ref(),
+    );
 
     ProviderTurnLaneExecution {
         lane,
@@ -5299,6 +5312,51 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         safe_lane_terminal_route,
         tool_events,
     }
+}
+
+fn summarize_provider_lane_tool_request(
+    turn: &ProviderTurn,
+    turn_result: &TurnResult,
+    trace: Option<&ToolBatchExecutionTrace>,
+) -> Option<String> {
+    match turn_result {
+        TurnResult::FinalText(_) | TurnResult::StreamingText(_) | TurnResult::StreamingDone(_) => {
+            summarize_tool_followup_request(&turn.tool_intents)
+        }
+        TurnResult::NeedsApproval(_)
+        | TurnResult::ToolDenied(_)
+        | TurnResult::ToolError(_)
+        | TurnResult::ProviderError(_) => summarize_failed_provider_lane_tool_request(turn, trace),
+    }
+}
+
+fn summarize_failed_provider_lane_tool_request(
+    turn: &ProviderTurn,
+    trace: Option<&ToolBatchExecutionTrace>,
+) -> Option<String> {
+    let failed_tool_call_id = trace.and_then(first_failed_provider_lane_tool_call_id);
+    if let Some(failed_tool_call_id) = failed_tool_call_id {
+        let failed_intent = turn
+            .tool_intents
+            .iter()
+            .find(|intent| intent.tool_call_id == failed_tool_call_id)?;
+        return summarize_single_tool_followup_request(failed_intent);
+    }
+
+    match turn.tool_intents.as_slice() {
+        [intent] => summarize_single_tool_followup_request(intent),
+        _ => None,
+    }
+}
+
+fn first_failed_provider_lane_tool_call_id(trace: &ToolBatchExecutionTrace) -> Option<&str> {
+    let failed_outcome = trace.intent_outcomes.iter().find(|intent_outcome| {
+        !matches!(
+            intent_outcome.status,
+            ToolBatchExecutionIntentStatus::Completed
+        )
+    })?;
+    Some(failed_outcome.tool_call_id.as_str())
 }
 
 async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
@@ -7954,6 +8012,44 @@ mod tests {
         assert_eq!(events[1].detail.as_deref(), Some("second tool failed"));
     }
 
+    #[test]
+    fn build_provider_turn_tool_terminal_events_attach_canonical_shell_request_summary() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "shell.exec".to_owned(),
+                args_json: json!({"command": "ls /root"}),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-a".to_owned(),
+                turn_id: "turn-a".to_owned(),
+                tool_call_id: "call-shell".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        };
+        let turn_result = TurnResult::ToolDenied(TurnFailure::policy_denied(
+            "shell_policy_denied",
+            "policy_denied: command contains embedded whitespace",
+        ));
+
+        let events = build_provider_turn_tool_terminal_events(&turn, &turn_result, None);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].tool_call_id, "call-shell");
+        assert_eq!(events[0].state, ConversationTurnToolState::Denied);
+        let request_summary = events[0]
+            .request_summary
+            .as_deref()
+            .expect("request summary should be present");
+        let request_summary_json: Value =
+            serde_json::from_str(request_summary).expect("request summary should be valid json");
+        assert_eq!(
+            request_summary_json,
+            json!({
+                "tool": "shell.exec",
+                "request": {"command": "ls", "args": ["/root"]}
+            })
+        );
+    }
     #[cfg(feature = "memory-sqlite")]
     fn finalize_recovered_child(
         repo: &SessionRepository,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -3074,10 +3074,11 @@ impl TurnEngine {
         ingress: Option<&ConversationIngressContext>,
     ) -> Result<PreparedToolIntent, PreparedToolIntentFailure> {
         let Some(resolved_tool) = crate::tools::resolve_tool_execution(&intent.tool_name) else {
-            let reason = format!("tool_not_found: {}", intent.tool_name);
+            let denied_tool_name = effective_denied_tool_name(intent);
+            let reason = format!("tool_not_found: {denied_tool_name}");
             let turn_result = TurnResult::policy_denied("tool_not_found", reason.clone());
             let decision =
-                ToolDecisionTelemetry::deny(intent.tool_name.as_str(), reason, "tool_not_found");
+                ToolDecisionTelemetry::deny(denied_tool_name.as_str(), reason, "tool_not_found");
             return Err(PreparedToolIntentFailure {
                 intent: intent.clone(),
                 turn_result,
@@ -3089,11 +3090,15 @@ impl TurnEngine {
             intent.args_json.clone(),
             ingress,
         );
-        let injected_payload_uses_reserved_internal_context =
-            crate::tools::payload_uses_reserved_internal_tool_context(&injected.payload);
-        let augmented_payload = augment_tool_payload_for_kernel(
+        let normalized_payload = crate::tools::normalize_shell_payload_for_request(
             resolved_tool.canonical_name,
             injected.payload,
+        );
+        let injected_payload_uses_reserved_internal_context =
+            crate::tools::payload_uses_reserved_internal_tool_context(&normalized_payload);
+        let augmented_payload = augment_tool_payload_for_kernel(
+            resolved_tool.canonical_name,
+            normalized_payload.clone(),
             session_context,
         );
         let augmented_payload_uses_reserved_internal_context =
@@ -3101,6 +3106,14 @@ impl TurnEngine {
         let request = ToolCoreRequest {
             tool_name: resolved_tool.canonical_name.to_owned(),
             payload: augmented_payload,
+        };
+        let normalized_intent = ToolIntent {
+            tool_name: resolved_tool.canonical_name.to_owned(),
+            args_json: normalized_payload,
+            source: intent.source.clone(),
+            session_id: intent.session_id.clone(),
+            turn_id: intent.turn_id.clone(),
+            tool_call_id: intent.tool_call_id.clone(),
         };
         let (effective_execution_kind, effective_request, effective_intent, effective_tool_name) =
             if resolved_tool.canonical_name == "tool.invoke" {
@@ -3136,7 +3149,7 @@ impl TurnEngine {
                     _ => (
                         resolved_tool.execution_kind,
                         request,
-                        intent.clone(),
+                        normalized_intent,
                         resolved_tool.canonical_name.to_owned(),
                     ),
                 }
@@ -3144,7 +3157,7 @@ impl TurnEngine {
                 (
                     resolved_tool.execution_kind,
                     request,
-                    intent.clone(),
+                    normalized_intent,
                     resolved_tool.canonical_name.to_owned(),
                 )
             };

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -2591,15 +2591,15 @@ impl TurnEngine {
                     ));
                 }
             } else {
+                if intent.source.starts_with("provider_") {
+                    return Err(concealed_provider_tool_denial());
+                }
                 if !session_context
                     .tool_view
                     .contains(resolved_tool.canonical_name)
                 {
                     let reason = format!("tool_not_visible: {}", intent.tool_name);
                     return Err(TurnFailure::policy_denied("tool_not_visible", reason));
-                }
-                if intent.source.starts_with("provider_") {
-                    return Err(concealed_provider_tool_denial());
                 }
             }
         }
@@ -3458,6 +3458,87 @@ mod tests {
 
     fn kernel_context(agent_id: &str) -> KernelContext {
         test_kernel_context(agent_id)
+    }
+
+    #[test]
+    fn validate_turn_in_context_conceals_provider_hidden_tool_invoke_alias_denial() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![ToolIntent {
+                tool_name: "tool_invoke".to_owned(),
+                args_json: json!({
+                    "tool_id": "shell.exec",
+                    "arguments": {"command": "echo hello"},
+                }),
+                source: "provider_tool_call".to_owned(),
+                session_id: "session-provider-hidden-tool-invoke".to_owned(),
+                turn_id: "turn-provider-hidden-tool-invoke".to_owned(),
+                tool_call_id: "call-provider-hidden-tool-invoke".to_owned(),
+            }],
+            raw_meta: Value::Null,
+        };
+        let session_context = SessionContext::root_with_tool_view(
+            "session-provider-hidden-tool-invoke",
+            crate::tools::ToolView::from_tool_names(std::iter::empty::<&str>()),
+        );
+
+        let failure = TurnEngine::new(4)
+            .validate_turn_in_context(&turn, &session_context)
+            .expect_err("provider hidden tool.invoke alias should be concealed");
+
+        assert_eq!(failure.code, "tool_not_found");
+        assert_eq!(
+            failure.reason,
+            "tool_not_found: requested tool is not available"
+        );
+    }
+
+    #[test]
+    fn prepare_tool_intent_uses_inner_shell_metadata_for_tool_invoke_core_requests() {
+        use crate::test_support::TurnTestHarness;
+
+        let harness = TurnTestHarness::new();
+        let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call(
+            "shell.exec",
+            json!({
+                "command": "/bin/echo",
+                "args": ["hello"],
+            }),
+        );
+        let intent = ToolIntent {
+            tool_name,
+            args_json,
+            source: "provider_tool_call".to_owned(),
+            session_id: "session-shell-invoke-trace".to_owned(),
+            turn_id: "turn-shell-invoke-trace".to_owned(),
+            tool_call_id: "call-shell-invoke-trace".to_owned(),
+        };
+        let session_context =
+            SessionContext::root_with_tool_view("session-shell-invoke-trace", runtime_tool_view());
+        let engine = TurnEngine::new(4);
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let prepared_intent = runtime.block_on(async {
+            engine
+                .prepare_tool_intent(
+                    &intent,
+                    &session_context,
+                    &DefaultAppToolDispatcher::runtime(),
+                    ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+                    None,
+                )
+                .await
+                .expect("tool.invoke shell request should prepare successfully")
+        });
+
+        assert_eq!(prepared_intent.request.tool_name, "tool.invoke");
+        assert_eq!(prepared_intent.intent.tool_name, "shell.exec");
+        assert_eq!(
+            prepared_intent.intent.args_json,
+            json!({
+                "command": "/bin/echo",
+                "args": ["hello"],
+            })
+        );
     }
 
     fn delegate_async_turn(session_id: &str, turn_id: &str, tool_call_id: &str) -> ProviderTurn {

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -15,7 +15,8 @@ use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_budget::{TurnRoundBudget, TurnRoundBudgetDecision};
 use super::turn_engine::{
-    DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnResult, TurnValidation,
+    DefaultAppToolDispatcher, ProviderTurn, ToolBatchExecutionIntentStatus,
+    ToolBatchExecutionTrace, ToolIntent, TurnEngine, TurnResult, TurnValidation,
 };
 use super::turn_observer::map_streaming_callback_data_to_token_event;
 use super::turn_shared::{
@@ -23,7 +24,9 @@ use super::turn_shared::{
     ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
     build_tool_loop_guard_tail, decide_provider_turn_request_action,
     reduce_followup_payload_for_model, request_completion_with_raw_fallback,
-    tool_loop_circuit_breaker_reply, user_requested_raw_tool_output,
+    summarize_single_tool_followup_request, summarize_tool_followup_request,
+    summarize_tool_followup_tool_names, tool_loop_circuit_breaker_reply,
+    user_requested_raw_tool_output,
 };
 
 #[derive(Default)]
@@ -43,6 +46,7 @@ struct TurnLoopSessionState {
 struct RoundKernelEvaluation {
     assistant_preface: String,
     had_tool_intents: bool,
+    tool_request_summary: Option<String>,
     turn_result: TurnResult,
     loop_verdict: Option<ToolLoopSupervisorVerdict>,
 }
@@ -394,12 +398,18 @@ async fn evaluate_round_kernel(
             .conversation
             .fast_lane_parallel_tool_execution_max_in_flight(),
     );
-    let turn_result = match engine.validate_turn_in_context(turn, session_context) {
-        Ok(TurnValidation::FinalText(text)) => TurnResult::FinalText(text),
-        Err(failure) => TurnResult::ToolDenied(failure),
+    let (turn_result, turn_trace) = match engine.validate_turn_in_context(turn, session_context) {
+        Ok(TurnValidation::FinalText(text)) => (TurnResult::FinalText(text), None),
+        Err(failure) => (TurnResult::ToolDenied(failure), None),
         Ok(TurnValidation::ToolExecutionRequired) => {
             engine
-                .execute_turn_in_context(turn, session_context, app_dispatcher, binding, None)
+                .execute_turn_in_context_with_trace(
+                    turn,
+                    session_context,
+                    app_dispatcher,
+                    binding,
+                    None,
+                )
                 .await
         }
     };
@@ -423,9 +433,56 @@ async fn evaluate_round_kernel(
     RoundKernelEvaluation {
         assistant_preface: turn.assistant_text.clone(),
         had_tool_intents,
+        tool_request_summary: summarize_round_tool_request(turn, &turn_result, turn_trace.as_ref()),
         turn_result,
         loop_verdict,
     }
+}
+
+fn summarize_round_tool_request(
+    turn: &ProviderTurn,
+    turn_result: &TurnResult,
+    turn_trace: Option<&ToolBatchExecutionTrace>,
+) -> Option<String> {
+    match turn_result {
+        TurnResult::FinalText(_) | TurnResult::StreamingText(_) | TurnResult::StreamingDone(_) => {
+            summarize_tool_followup_request(&turn.tool_intents)
+        }
+        TurnResult::NeedsApproval(_)
+        | TurnResult::ToolDenied(_)
+        | TurnResult::ToolError(_)
+        | TurnResult::ProviderError(_) => summarize_failed_round_tool_request(turn, turn_trace),
+    }
+}
+
+fn summarize_failed_round_tool_request(
+    turn: &ProviderTurn,
+    turn_trace: Option<&ToolBatchExecutionTrace>,
+) -> Option<String> {
+    let failed_tool_call_id = first_failed_tool_call_id(turn_trace);
+    if let Some(failed_tool_call_id) = failed_tool_call_id {
+        let failed_intent = turn
+            .tool_intents
+            .iter()
+            .find(|intent| intent.tool_call_id == failed_tool_call_id)?;
+        return summarize_single_tool_followup_request(failed_intent);
+    }
+
+    match turn.tool_intents.as_slice() {
+        [intent] => summarize_single_tool_followup_request(intent),
+        _ => None,
+    }
+}
+
+fn first_failed_tool_call_id(turn_trace: Option<&ToolBatchExecutionTrace>) -> Option<&str> {
+    let turn_trace = turn_trace?;
+    let failed_outcome = turn_trace.intent_outcomes.iter().find(|intent_outcome| {
+        !matches!(
+            intent_outcome.status,
+            ToolBatchExecutionIntentStatus::Completed
+        )
+    })?;
+    Some(failed_outcome.tool_call_id.as_str())
 }
 
 impl RoundKernelEvaluation {

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -5,8 +5,8 @@ use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::tool_result_compaction::compact_tool_search_payload_summary_str;
 use super::turn_engine::{
-    ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, ToolResultPayloadSemantics,
-    TurnResult,
+    ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, ToolIntent,
+    ToolResultPayloadSemantics, TurnResult,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -19,6 +19,7 @@ use crate::CliResult;
 
 pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const DISCOVERY_RESULT_FOLLOWUP_PROMPT: &str = "The tool result above is a discovery result, not the final evidence. Choose the best matching discovered tool, reuse its lease when invoking it, continue with the next tool call needed to satisfy the original user request, and only answer directly if the discovery results already contain the final user-facing information.";
+pub const TOOL_FAILURE_FOLLOWUP_PROMPT: &str = "A tool call failed. Inspect the attempted tool request and failure above before answering. If the failure is repairable, correct the tool arguments and retry with a materially different call. If the failure is a policy denial or cannot be repaired safely, explain the constraint and continue with the best possible answer.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "An external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
@@ -166,6 +167,80 @@ pub fn tool_driven_followup_payload(
     }
 }
 
+pub(crate) fn summarize_tool_followup_request(intents: &[ToolIntent]) -> Option<String> {
+    match intents {
+        [] => None,
+        [intent] => summarize_single_tool_followup_request(intent),
+        intents => serde_json::to_string(
+            &intents
+                .iter()
+                .map(tool_followup_request_entry)
+                .collect::<Vec<_>>(),
+        )
+        .ok(),
+    }
+}
+
+pub(crate) fn summarize_single_tool_followup_request(intent: &ToolIntent) -> Option<String> {
+    let entry = tool_followup_request_entry(intent);
+    serde_json::to_string(&entry).ok()
+}
+
+pub(crate) fn summarize_tool_followup_tool_names(intents: &[ToolIntent]) -> String {
+    intents
+        .iter()
+        .map(effective_followup_tool_name)
+        .collect::<Vec<_>>()
+        .join("||")
+}
+
+fn tool_followup_request_entry(intent: &ToolIntent) -> Value {
+    let tool_name = effective_followup_tool_name(intent);
+    let request = effective_followup_request(intent);
+    serde_json::json!({
+        "tool": tool_name,
+        "request": request,
+    })
+}
+
+pub(crate) fn effective_followup_tool_name(intent: &ToolIntent) -> String {
+    let canonical_tool_name = crate::tools::canonical_tool_name(intent.tool_name.as_str());
+    if canonical_tool_name != "tool.invoke" {
+        return canonical_tool_name.to_owned();
+    }
+
+    intent
+        .args_json
+        .get("tool_id")
+        .and_then(Value::as_str)
+        .map(crate::tools::canonical_tool_name)
+        .unwrap_or(canonical_tool_name)
+        .to_owned()
+}
+
+pub(crate) fn effective_followup_request(intent: &ToolIntent) -> Value {
+    let canonical_tool_name = crate::tools::canonical_tool_name(intent.tool_name.as_str());
+    if canonical_tool_name != "tool.invoke" {
+        return crate::tools::normalize_shell_payload_for_request(
+            canonical_tool_name,
+            intent.args_json.clone(),
+        );
+    }
+
+    let invoked_tool_name = intent
+        .args_json
+        .get("tool_id")
+        .and_then(Value::as_str)
+        .map(crate::tools::canonical_tool_name)
+        .unwrap_or(canonical_tool_name);
+    let request_payload = intent
+        .args_json
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| intent.args_json.clone());
+
+    crate::tools::normalize_shell_payload_for_request(invoked_tool_name, request_payload)
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolDrivenReplyBaseDecision {
     FinalizeDirect {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -431,6 +431,119 @@ const TOOL_LEASE_TOKEN_ID_FIELD: &str = "_lease_token_id";
 const TOOL_LEASE_SESSION_ID_FIELD: &str = "_lease_session_id";
 const TOOL_LEASE_TURN_ID_FIELD: &str = "_lease_turn_id";
 
+pub(crate) fn normalize_shell_payload_for_request(tool_name: &str, payload: Value) -> Value {
+    match canonical_tool_name(tool_name) {
+        "shell.exec" => normalize_shell_payload_object(payload),
+        "tool.invoke" => normalize_shell_invoke_payload(payload),
+        _ => payload,
+    }
+}
+
+pub(crate) fn normalize_shell_request_for_execution(
+    mut request: ToolCoreRequest,
+) -> ToolCoreRequest {
+    request.payload =
+        normalize_shell_payload_for_request(request.tool_name.as_str(), request.payload);
+    request
+}
+
+fn normalize_shell_invoke_payload(payload: Value) -> Value {
+    let mut outer = match payload {
+        Value::Object(outer) => outer,
+        other @ Value::Null
+        | other @ Value::Bool(_)
+        | other @ Value::Number(_)
+        | other @ Value::String(_)
+        | other @ Value::Array(_) => return other,
+    };
+    let Some(tool_id) = outer
+        .get("tool_id")
+        .and_then(Value::as_str)
+        .map(canonical_tool_name)
+    else {
+        return Value::Object(outer);
+    };
+    if tool_id != "shell.exec" {
+        return Value::Object(outer);
+    }
+    let arguments = outer
+        .remove("arguments")
+        .map(normalize_shell_payload_object)
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+    outer.insert("arguments".to_owned(), arguments);
+    Value::Object(outer)
+}
+
+fn normalize_shell_payload_object(payload: Value) -> Value {
+    let mut object = match payload {
+        Value::Object(object) => object,
+        other @ Value::Null
+        | other @ Value::Bool(_)
+        | other @ Value::Number(_)
+        | other @ Value::String(_)
+        | other @ Value::Array(_) => return other,
+    };
+    let args_missing = match object.get("args") {
+        None => true,
+        Some(Value::Array(values)) => values.is_empty(),
+        Some(_) => false,
+    };
+    if !args_missing {
+        return Value::Object(object);
+    }
+
+    let Some(command) = object.get("command").and_then(Value::as_str) else {
+        return Value::Object(object);
+    };
+    let Some((normalized_command, normalized_args)) = split_shell_command_if_safe(command) else {
+        return Value::Object(object);
+    };
+    object.insert("command".to_owned(), Value::String(normalized_command));
+    if normalized_args.is_empty() {
+        object.remove("args");
+    } else {
+        object.insert(
+            "args".to_owned(),
+            Value::Array(
+                normalized_args
+                    .into_iter()
+                    .map(Value::String)
+                    .collect::<Vec<_>>(),
+            ),
+        );
+    }
+    Value::Object(object)
+}
+
+fn split_shell_command_if_safe(command: &str) -> Option<(String, Vec<String>)> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let contains_newline = trimmed.chars().any(|ch| matches!(ch, '\n' | '\r'));
+    if contains_newline {
+        return None;
+    }
+    let contains_whitespace = trimmed.contains(char::is_whitespace);
+    if !contains_whitespace {
+        return None;
+    }
+    if trimmed.chars().any(|ch| {
+        matches!(
+            ch,
+            '\'' | '"' | '\\' | '`' | '|' | '&' | ';' | '<' | '>' | '(' | ')' | '$'
+        )
+    }) {
+        return None;
+    }
+    let mut parts = trimmed.split_whitespace();
+    let command = parts.next()?.to_owned();
+    let args = parts.map(str::to_owned).collect::<Vec<_>>();
+    if args.is_empty() {
+        return None;
+    }
+    Some((command, args))
+}
 pub(crate) fn prepare_kernel_tool_request(
     mut request: ToolCoreRequest,
     granted_capabilities: &BTreeSet<Capability>,
@@ -438,6 +551,7 @@ pub(crate) fn prepare_kernel_tool_request(
     session_id: Option<&str>,
     turn_id: Option<&str>,
 ) -> ToolCoreRequest {
+    request = normalize_shell_request_for_execution(request);
     let canonical_tool_name = canonical_tool_name(request.tool_name.as_str());
     if !matches!(canonical_tool_name, "tool.search" | "tool.invoke") {
         return request;
@@ -3315,19 +3429,97 @@ mod tests {
 
     #[cfg(feature = "tool-shell")]
     #[test]
-    fn shell_exec_rejects_embedded_whitespace_in_command() {
+    fn shell_exec_normalizes_embedded_whitespace_into_args_when_args_missing() {
+        #[cfg(unix)]
+        let config = test_tool_runtime_config(std::env::temp_dir());
+        #[cfg(windows)]
+        let mut config = test_tool_runtime_config(std::env::temp_dir());
+        #[cfg(windows)]
+        config.shell_allow.insert("cmd".to_owned());
+        #[cfg(unix)]
+        let command = "echo hello world";
+        #[cfg(windows)]
+        let command = "cmd /C echo hello world";
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "shell.exec".to_owned(),
+                payload: json!({"command": command}),
+            },
+            &config,
+        )
+        .expect("embedded whitespace should be normalized into args");
+        assert_eq!(outcome.status, "ok");
+        #[cfg(unix)]
+        assert_eq!(outcome.payload["command"], "echo");
+        #[cfg(unix)]
+        assert_eq!(outcome.payload["args"], json!(["hello", "world"]));
+        #[cfg(windows)]
+        assert_eq!(outcome.payload["command"], "cmd");
+        #[cfg(windows)]
+        assert_eq!(
+            outcome.payload["args"],
+            json!(["/C", "echo", "hello", "world"])
+        );
+        assert_eq!(outcome.payload["stdout"], json!("hello world"));
+    }
+
+    #[cfg(feature = "tool-shell")]
+    #[test]
+    fn tool_invoke_shell_exec_normalizes_embedded_whitespace_into_args_when_args_missing() {
+        #[cfg(unix)]
+        let config = test_tool_runtime_config(std::env::temp_dir());
+        #[cfg(windows)]
+        let mut config = test_tool_runtime_config(std::env::temp_dir());
+        #[cfg(windows)]
+        config.shell_allow.insert("cmd".to_owned());
+        #[cfg(unix)]
+        let command = "echo hello from invoke";
+        #[cfg(windows)]
+        let command = "cmd /C echo hello from invoke";
+        let lease = issue_tool_lease("shell.exec", &serde_json::Map::new());
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "tool.invoke".to_owned(),
+                payload: json!({
+                    "tool_id": "shell.exec",
+                    "lease": lease,
+                    "arguments": {"command": command}
+                }),
+            },
+            &config,
+        )
+        .expect("tool.invoke shell payload should be normalized into args");
+        assert_eq!(outcome.status, "ok");
+        #[cfg(unix)]
+        assert_eq!(outcome.payload["command"], "echo");
+        #[cfg(unix)]
+        assert_eq!(outcome.payload["args"], json!(["hello", "from", "invoke"]));
+        #[cfg(windows)]
+        assert_eq!(outcome.payload["command"], "cmd");
+        #[cfg(windows)]
+        assert_eq!(
+            outcome.payload["args"],
+            json!(["/C", "echo", "hello", "from", "invoke"])
+        );
+        assert_eq!(outcome.payload["stdout"], json!("hello from invoke"));
+    }
+
+    #[cfg(feature = "tool-shell")]
+    #[test]
+    fn shell_exec_does_not_normalize_multiline_command_into_args() {
         let config = test_tool_runtime_config(std::env::temp_dir());
         let error = execute_tool_core_with_config(
             ToolCoreRequest {
                 tool_name: "shell.exec".to_owned(),
-                payload: json!({"command": "ls -la"}),
+                payload: json!({"command": "echo hello\nworld"}),
             },
             &config,
         )
-        .expect_err("embedded whitespace should be denied");
+        .expect_err("multiline commands should stay repairable instead of executing");
+
         assert!(
-            error.contains("embedded whitespace"),
-            "expected whitespace rejection, got: {error}"
+            error.contains("payload.command"),
+            "expected payload.command validation failure, got: {error}"
         );
     }
 

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -55,7 +55,10 @@ impl ToolPolicyExtension {
 pub(crate) fn validate_shell_command_name(command: &str) -> Result<String, String> {
     let trimmed = command.trim();
     if trimmed.is_empty() {
-        return Err("shell.exec requires payload.command".to_owned());
+        let reason = repairable_tool_input_reason(
+            "shell.exec requires payload.command. Provide a bare executable in payload.command and move arguments into payload.args.".to_owned(),
+        );
+        return Err(reason);
     }
 
     if trimmed.contains(char::is_whitespace) {
@@ -576,6 +579,21 @@ mod tests {
         assert!(
             reason.contains("lowercase"),
             "expected lowercase rejection, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn empty_shell_command_reason_is_marked_repairable() {
+        let error =
+            validate_shell_command_name("   ").expect_err("blank shell command should be denied");
+
+        assert!(
+            is_repairable_tool_input_reason(error.as_str()),
+            "expected repairable prefix, got: {error}"
+        );
+        assert!(
+            strip_repairable_tool_input_prefix(error.as_str()).contains("payload.command"),
+            "expected payload.command guidance, got: {error}"
         );
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1306,6 +1306,95 @@ pub enum Commands {
     },
 }
 
+impl Commands {
+    pub(crate) fn command_kind_for_logging(&self) -> &'static str {
+        match self {
+            Self::Welcome => "welcome",
+            Self::Demo => "demo",
+            Self::RunTask { .. } => "run_task",
+            Self::InvokeConnector { .. } => "invoke_connector",
+            Self::AuditDemo => "audit_demo",
+            Self::InitSpec { .. } => "init_spec",
+            Self::RunSpec { .. } => "run_spec",
+            Self::BenchmarkProgrammaticPressure { .. } => "benchmark_programmatic_pressure",
+            Self::BenchmarkProgrammaticPressureLint { .. } => {
+                "benchmark_programmatic_pressure_lint"
+            }
+            Self::BenchmarkWasmCache { .. } => "benchmark_wasm_cache",
+            Self::BenchmarkMemoryContext { .. } => "benchmark_memory_context",
+            Self::ValidateConfig { .. } => "validate_config",
+            Self::Onboard { .. } => "onboard",
+            Self::Import { .. } => "import",
+            Self::Migrate { .. } => "migrate",
+            Self::Doctor { .. } => "doctor",
+            Self::Audit { .. } => "audit",
+            Self::Skills { .. } => "skills",
+            Self::Channels { .. } => "channels",
+            Self::ListModels { .. } => "list_models",
+            Self::RuntimeSnapshot { .. } => "runtime_snapshot",
+            Self::RuntimeRestore { .. } => "runtime_restore",
+            Self::RuntimeExperiment { .. } => "runtime_experiment",
+            Self::RuntimeCapability { .. } => "runtime_capability",
+            Self::ListContextEngines { .. } => "list_context_engines",
+            Self::ListMemorySystems { .. } => "list_memory_systems",
+            Self::ListAcpBackends { .. } => "list_acp_backends",
+            Self::ListAcpSessions { .. } => "list_acp_sessions",
+            Self::AcpStatus { .. } => "acp_status",
+            Self::AcpObservability { .. } => "acp_observability",
+            Self::AcpEventSummary { .. } => "acp_event_summary",
+            Self::AcpDispatch { .. } => "acp_dispatch",
+            Self::AcpDoctor { .. } => "acp_doctor",
+            Self::Ask { .. } => "ask",
+            Self::Chat { .. } => "chat",
+            Self::SafeLaneSummary { .. } => "safe_lane_summary",
+            Self::TelegramSend { .. } => "telegram_send",
+            Self::TelegramServe { .. } => "telegram_serve",
+            Self::FeishuSend { .. } => "feishu_send",
+            Self::FeishuServe { .. } => "feishu_serve",
+            Self::MatrixSend { .. } => "matrix_send",
+            Self::MatrixServe { .. } => "matrix_serve",
+            Self::WecomSend { .. } => "wecom_send",
+            Self::WecomServe { .. } => "wecom_serve",
+            Self::DiscordSend { .. } => "discord_send",
+            Self::DingtalkSend { .. } => "dingtalk_send",
+            Self::SlackSend { .. } => "slack_send",
+            Self::LineSend { .. } => "line_send",
+            Self::WhatsappSend { .. } => "whatsapp_send",
+            Self::EmailSend { .. } => "email_send",
+            Self::WebhookSend { .. } => "webhook_send",
+            Self::GoogleChatSend { .. } => "google_chat_send",
+            Self::TeamsSend { .. } => "teams_send",
+            Self::SignalSend { .. } => "signal_send",
+            Self::MattermostSend { .. } => "mattermost_send",
+            Self::NextcloudTalkSend { .. } => "nextcloud_talk_send",
+            Self::SynologyChatSend { .. } => "synology_chat_send",
+            Self::ImessageSend { .. } => "imessage_send",
+            Self::MultiChannelServe { .. } => "multi_channel_serve",
+            Self::Feishu { .. } => "feishu",
+            Self::Completions { .. } => "completions",
+        }
+    }
+}
+
+#[cfg(test)]
+mod command_kind_tests {
+    use super::Commands;
+
+    #[test]
+    fn command_kind_for_logging_uses_stable_variant_names() {
+        assert_eq!(Commands::Welcome.command_kind_for_logging(), "welcome");
+        assert_eq!(Commands::AuditDemo.command_kind_for_logging(), "audit_demo");
+        assert_eq!(
+            Commands::RunTask {
+                objective: "test".to_owned(),
+                payload: "{}".to_owned(),
+            }
+            .command_kind_for_logging(),
+            "run_task"
+        );
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum ValidateConfigOutput {
     Text,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -84,10 +84,10 @@ async fn main() {
     mvp::config::set_active_cli_command_name(mvp::config::detect_invoked_cli_command_name());
     let cli = parse_cli();
     let command = cli.command.unwrap_or_else(resolve_default_entry_command);
-    let command_kind = command_kind(&command);
+    let command_kind = command.command_kind_for_logging();
     tracing::debug!(
         target: "loongclaw.daemon",
-        command_kind = %command_kind,
+        command_kind,
         "parsed CLI command"
     );
     let result = match command {


### PR DESCRIPTION
## Summary

- Problem:
  canonical tool identity and request context drifted across retry follow-ups, loop guards, traces, and denial reasons whenever providers mixed direct calls, wrapped `tool.invoke` calls, or repairable shell failures.
- Why it matters:
  the runtime could warn about the wrong repeated request, hide the request details the provider needed to repair, and surface wrapper-oriented denial text instead of the effective tool the user experience actually depended on.
- What changed:
  canonicalized effective tool names and request summaries across shared follow-up helpers, the turn loop, the provider coordinator, the turn engine, shell request normalization, and daemon CLI command logging. repairable shell input denials now stay repairable, multiline shell payloads no longer auto-split, and failed multi-intent follow-ups keep the failed request instead of serializing the whole round.
- What did not change (scope boundary):
  this does not introduce new tool routing behavior or approval policy changes beyond fixing canonicalization, request summarization, and logging hygiene for existing paths.

## Linked Issues

- Closes #827
- Related #821

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Additional scenario, benchmark, or manual checks when behavior changed

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=.codex-target-pr828 cargo test -p loongclaw-daemon --lib command_kind_for_logging_uses_stable_variant_names --offline -- --exact
CARGO_TARGET_DIR=.codex-target-pr828 cargo test -p loongclaw-app --lib tools::tests::shell_exec_does_not_normalize_multiline_command_into_args --offline -- --exact
CARGO_TARGET_DIR=.codex-target-pr828 cargo test -p loongclaw-app --lib tools::shell_policy_ext::tests::empty_shell_command_reason_is_marked_repairable --offline -- --exact
CARGO_TARGET_DIR=.codex-target-pr828 cargo test -p loongclaw-app --lib conversation::turn_engine::tests::validate_turn_in_context_conceals_provider_hidden_tool_invoke_alias_denial --offline -- --exact
CARGO_TARGET_DIR=.codex-target-pr828 cargo test -p loongclaw-app --lib conversation::turn_engine::tests::prepare_tool_intent_uses_inner_shell_metadata_for_tool_invoke_core_requests --offline -- --exact
CARGO_TARGET_DIR=.codex-target-pr828 cargo test -p loongclaw-app --lib conversation::tests::handle_turn_with_runtime_multi_intent_shell_failure_followup_uses_failed_request_only --offline -- --exact
```

Note:
- `cargo test -p loongclaw-app --lib --offline` on this machine still hits an unrelated ACP fallback timeout test under current local load, so I did not mark the full workspace test boxes as complete from local evidence alone.
- CI is running on the rebased PR head and remains the authoritative merge gate.

## User-visible / Operator-visible Changes

- tool retry follow-ups now preserve canonical effective tool names and failed-request context more consistently across wrapped and direct calls.
- same-tool loop warnings no longer conflate an entire multi-intent round with one failed tool call.
- multiline shell payloads no longer auto-split into a different command, and empty `payload.command` denials now stay repairable.
- daemon debug logging now records a sanitized CLI command kind instead of the full parsed payload.

## Failure Recovery

- Fast rollback or disable path:
  revert commit `36dc66701f9651d30dc1ccddefbbb816ca6a4bbb`.
- Observable failure symptoms reviewers should watch for:
  missing failed-request context in follow-ups, leaked canonical tool names for concealed provider alias denials, multiline shell payloads executing after normalization, or daemon debug logs exposing full CLI payloads.

## Reviewer Focus

- `turn_shared.rs`, `turn_loop.rs`, and `turn_coordinator.rs` for failed-request summarization semantics.
- `turn_engine.rs` and `tools/mod.rs` for concealed denial ordering, wrapped core-call metadata, and shell normalization safety.
- `shell_policy_ext.rs`, `daemon/src/lib.rs`, and `daemon/src/main.rs` for repairable shell denial consistency and sanitized CLI logging.
