### PR TITLE
fix(app): retry ETXTBSY process spawns

### DIFF
--- a/crates/app/src/tools/process_exec.rs
+++ b/crates/app/src/tools/process_exec.rs
@@ -3,6 +3,8 @@ use std::ffi::OsStr;
 #[cfg(feature = "tool-shell")]
 use std::future::Future;
 #[cfg(feature = "tool-shell")]
+use std::io::ErrorKind;
+#[cfg(feature = "tool-shell")]
 use std::path::Path;
 #[cfg(feature = "tool-shell")]
 use std::process::{Output, Stdio};
@@ -21,6 +23,10 @@ pub(super) const DEFAULT_TIMEOUT_MS: u64 = 120_000;
 pub(super) const MAX_TIMEOUT_MS: u64 = 600_000;
 #[cfg(feature = "tool-shell")]
 const OUTPUT_CAP_BYTES: usize = 1_048_576;
+#[cfg(feature = "tool-shell")]
+const EXECUTABLE_FILE_BUSY_SPAWN_RETRY_ATTEMPTS: usize = 20;
+#[cfg(feature = "tool-shell")]
+const EXECUTABLE_FILE_BUSY_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 #[cfg(feature = "tool-shell")]
 pub(super) fn run_tool_async<F>(future: F, tool_label: &str) -> Result<F::Output, String>
@@ -97,14 +103,8 @@ where
     P: AsRef<OsStr>,
     S: AsRef<OsStr>,
 {
-    let mut child = Command::new(program)
-        .args(args)
-        .current_dir(cwd)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdin(Stdio::null())
-        .kill_on_drop(true)
-        .spawn()
+    let mut child = spawn_process_with_retry(program.as_ref(), args, cwd)
+        .await
         .map_err(|error| format!("{error_prefix} spawn failed: {error}"))?;
 
     let duration = Duration::from_millis(timeout_ms.max(1));
@@ -158,5 +158,160 @@ where
             let _ = tokio::join!(stdout_task, stderr_task);
             Err(format!("{error_prefix} timed out after {timeout_ms}ms"))
         }
+    }
+}
+
+#[cfg(feature = "tool-shell")]
+async fn spawn_process_with_retry<S>(
+    program: &OsStr,
+    args: &[S],
+    cwd: &Path,
+) -> std::io::Result<tokio::process::Child>
+where
+    S: AsRef<OsStr>,
+{
+    retry_executable_file_busy(|| {
+        let mut command = Command::new(program);
+        command.args(args);
+        command.current_dir(cwd);
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        command.stdin(Stdio::null());
+        command.kill_on_drop(true);
+        command.spawn()
+    })
+    .await
+}
+
+#[cfg(feature = "tool-shell")]
+async fn retry_executable_file_busy<T, F>(operation: F) -> std::io::Result<T>
+where
+    F: FnMut() -> std::io::Result<T>,
+{
+    retry_executable_file_busy_with_pause(operation, pause_before_spawn_retry).await
+}
+
+#[cfg(feature = "tool-shell")]
+async fn retry_executable_file_busy_with_pause<T, F, P, Fut>(
+    mut operation: F,
+    mut pause: P,
+) -> std::io::Result<T>
+where
+    F: FnMut() -> std::io::Result<T>,
+    P: FnMut() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let mut attempt_count = 0;
+
+    loop {
+        attempt_count += 1;
+
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(error)
+                if should_retry_spawn_error(&error)
+                    && attempt_count < EXECUTABLE_FILE_BUSY_SPAWN_RETRY_ATTEMPTS =>
+            {
+                pause().await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(feature = "tool-shell")]
+async fn pause_before_spawn_retry() {
+    tokio::time::sleep(EXECUTABLE_FILE_BUSY_SPAWN_RETRY_DELAY).await;
+}
+
+#[cfg(feature = "tool-shell")]
+fn should_retry_spawn_error(error: &std::io::Error) -> bool {
+    error.kind() == ErrorKind::ExecutableFileBusy
+}
+
+#[cfg(all(test, feature = "tool-shell"))]
+mod tests {
+    use super::*;
+    use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn retry_executable_file_busy_retries_until_success() {
+        let attempts = AtomicUsize::new(0);
+
+        let result = retry_executable_file_busy(|| {
+            let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+
+            if attempt < 2 {
+                return Err(io::Error::from(std::io::ErrorKind::ExecutableFileBusy));
+            }
+
+            Ok("spawned")
+        })
+        .await
+        .expect("retry should recover once the executable is no longer busy");
+
+        assert_eq!(result, "spawned");
+        assert_eq!(attempts.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_executable_file_busy_surfaces_non_retryable_error_immediately() {
+        let attempts = AtomicUsize::new(0);
+
+        let error = retry_executable_file_busy::<(), _>(|| {
+            attempts.fetch_add(1, Ordering::Relaxed);
+            Err(io::Error::other("boom"))
+        })
+        .await
+        .expect_err("non-retryable errors should surface immediately");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(attempts.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_executable_file_busy_stops_after_retry_budget() {
+        let attempts = AtomicUsize::new(0);
+
+        let error = retry_executable_file_busy::<(), _>(|| {
+            attempts.fetch_add(1, Ordering::Relaxed);
+            Err(io::Error::from(std::io::ErrorKind::ExecutableFileBusy))
+        })
+        .await
+        .expect_err("retry should stop after exhausting the executable-busy budget");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::ExecutableFileBusy);
+        assert_eq!(
+            attempts.load(Ordering::Relaxed),
+            EXECUTABLE_FILE_BUSY_SPAWN_RETRY_ATTEMPTS
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_executable_file_busy_pauses_between_retryable_failures() {
+        let attempts = AtomicUsize::new(0);
+        let pauses = AtomicUsize::new(0);
+
+        let result = retry_executable_file_busy_with_pause(
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+
+                if attempt < 2 {
+                    return Err(io::Error::from(std::io::ErrorKind::ExecutableFileBusy));
+                }
+
+                Ok("spawned")
+            },
+            || async {
+                pauses.fetch_add(1, Ordering::Relaxed);
+            },
+        )
+        .await
+        .expect("retry should pause between retryable executable-busy failures");
+
+        assert_eq!(result, "spawned");
+        assert_eq!(attempts.load(Ordering::Relaxed), 3);
+        assert_eq!(pauses.load(Ordering::Relaxed), 2);
     }
 }


### PR DESCRIPTION
## Summary

- Problem:
  intermittent `bash.exec` CI failures could surface `Text file busy (os error 26)` while spawning the fake bash runtime on ubuntu.
- Why it matters:
  the failure blocks or delays merges and creates noisy red CI unrelated to the actual tool behavior under test.
- What changed:
  route `process_exec` spawns through a bounded retry helper for `ErrorKind::ExecutableFileBusy`, then add focused regression tests for success recovery, non-retryable failures, retry-budget exhaustion, and retry pauses.
- What did not change (scope boundary):
  no bash governance rules, no runtime config defaults, and no user-facing tool contract changes.

## Linked Issues

- Closes #829
- Related: none

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-target-issue-829 cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-target-issue-829 cargo test -p loongclaw-app process_exec --all-features -- --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-target-issue-829 cargo test -p loongclaw-app tools::tests::bash_exec_tests::bash_exec_runs_command_string_via_bash_runtime --all-features -- --exact --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-target-issue-829 cargo test -p loongclaw-app tools::tests::shell_exec_succeeds_when_fast_command_receives_timeout_ms --all-features -- --exact --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-target-issue-829 cargo test --workspace --locked
CARGO_TARGET_DIR=/tmp/loongclaw-target-issue-829 cargo test --workspace --all-features --locked

additional regression proof:
- temporarily disabled the executable-file-busy retry predicate and re-ran the focused `process_exec` tests.
- observed the new recovery, pause, and retry-budget tests fail before restoring the final implementation.
```

## User-visible / Operator-visible Changes

- None at the API level.
- Internal process spawning is now resilient to transient `ETXTBSY` races for shared shell process execution paths.

## Failure Recovery

- Fast rollback or disable path:
  revert commit `45b1ed8b4e28c9be23a45249a46001463cab8ee0`.
- Observable failure symptoms reviewers should watch for:
  unexpected spawn latency regressions or repeated `spawn failed` errors that are not `ExecutableFileBusy`.

## Reviewer Focus

- Confirm the retry scope stays limited to transient `ExecutableFileBusy` spawn errors in `crates/app/src/tools/process_exec.rs`.
- Check that the new helper tests prove both recovery and non-retryable passthrough behavior.
- Verify the shared `process_exec` path is the right abstraction layer for both `bash.exec` and `shell.exec`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Process execution now includes automatic retry logic for transient failures, improving reliability when encountering temporary file access conflicts.

* **Tests**
  * Added comprehensive unit tests validating retry behavior, including success scenarios, immediate error surfacing, retry budget exhaustion, and delay mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->