### PR TITLE
fix(install): improve missing-release fallback guidance

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -281,10 +281,14 @@ print_missing_release_guidance() {
   cat >&2 <<EOF
 error: no GitHub release is published for ${release_repo} yet.
 
-Install from a local checkout instead:
-  git clone https://github.com/${release_repo}.git
-  cd $(basename "${release_repo}")
-  bash scripts/install.sh --source --onboard
+Install from source instead:
+  1. Install Rust (if not already installed):
+     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+     source "\$HOME/.cargo/env"
+  2. Clone and build:
+     git clone https://github.com/${release_repo}.git
+     cd $(basename "${release_repo}")
+     bash scripts/install.sh --source --onboard
 EOF
 }
 

--- a/scripts/test_install_sh.sh
+++ b/scripts/test_install_sh.sh
@@ -794,6 +794,8 @@ run_missing_release_guidance_test() {
   fi
 
   assert_contains "$output_file" "no GitHub release is published for loongclaw-ai/loongclaw yet"
+  assert_contains "$output_file" "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+  assert_contains "$output_file" 'source "$HOME/.cargo/env"'
   assert_contains "$output_file" "git clone https://github.com/loongclaw-ai/loongclaw.git"
   assert_contains "$output_file" "bash scripts/install.sh --source --onboard"
 }


### PR DESCRIPTION
## Summary

- When no prebuilt release binary is available, the install script exits with a message telling users to clone and run `--source`, but omits the Rust toolchain prerequisite.
- Users who follow the guidance hit a second failure (`cargo not found`) and have to figure out rustup on their own.
- Updated `print_missing_release_guidance()` to include explicit rustup install and `source "$HOME/.cargo/env"` steps so the fallback instructions are self-contained.

## Discussion Points

We initially considered automating the full fallback chain (auto-install rustup, auto-fallback from release to source), but decided against it for now:

1. **Auto-installing rustup is invasive** — it modifies the user's shell profile (`.bashrc`/`.zshrc`), and in `curl | sh` pipe mode stdin is unavailable for interactive confirmation.
2. **Edge devices may not be supported by rustup** — architectures like MIPS and RISC-V are not rustup targets, and resource-constrained devices may lack the disk/memory to compile Rust. These cases likely need cross-compilation instead.
3. **Release binaries already cover the common platforms** — if a user lands in the no-release path, they are likely on an unusual device where source build may not work either.

We would like to discuss:

- **`--features` support for `--source` builds**: currently `--source` builds with default features only (`mvp`). Should we add a `--features` flag so edge-device users can build a minimal binary with only the channels/providers they need?
- **Auto-fallback from release to source**: should the script automatically attempt `install_from_source` when no release is found (for local checkout scenarios), instead of just printing guidance and exiting?

## Linked Issues

None.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
This is a shell script message-only change. No Rust code was modified.
Verified the updated guidance renders correctly by inspecting the diff.
```

## User-visible / Operator-visible Changes

- Users who hit the missing-release fallback now see complete instructions including Rust toolchain installation steps.

## Failure Recovery

- Fast rollback: revert this commit to restore the previous shorter guidance message.
- No runtime behavior change; this only affects a printed error message.

## Reviewer Focus

- `scripts/install.sh`: `print_missing_release_guidance()` — confirm the rustup command and env sourcing step are correct and the numbered steps are clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installation guidance now explicitly instructs users to install the Rust toolchain and initialize its environment before cloning the repo and running the installer when no pre-built release is available.
* **Tests**
  * Updated automated tests to verify the improved missing-release onboarding guidance includes the Rust setup and subsequent install steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->