### PR TITLE
docs: add cross-repo runtime architecture convergence roadmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2123,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
+ "tracing",
  "unicode-normalization",
  "unicode-segmentation",
  "wait-timeout",
@@ -2175,6 +2182,8 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "wat",
 ]
 
@@ -2251,6 +2260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3272,6 +3299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,7 +3413,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3768,6 +3803,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3902,6 +3980,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ wasmtime = { version = "43.0.0", default-features = false, features = ["std", "r
 rusqlite = { version = "0.39", features = ["bundled"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 which = "8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 [profile.release]
 lto = "thin"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -87,6 +87,7 @@ prost = { version = "0.14", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"], optional = true }
 libc = "0.2"
+tracing.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/app/src/acp/manager.rs
+++ b/crates/app/src/acp/manager.rs
@@ -7,10 +7,10 @@ use crate::CliResult;
 use crate::config::LoongClawConfig;
 
 use super::backend::{
-    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, AcpAbortController, AcpConfigPatch, AcpDoctorReport,
-    AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle, AcpSessionMetadata, AcpSessionMode,
-    AcpSessionState, AcpSessionStatus, AcpTurnEventSink, AcpTurnRequest, AcpTurnResult,
-    BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
+    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, ACP_TURN_METADATA_TRACE_ID, AcpAbortController,
+    AcpConfigPatch, AcpDoctorReport, AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle,
+    AcpSessionMetadata, AcpSessionMode, AcpSessionState, AcpSessionStatus, AcpTurnEventSink,
+    AcpTurnRequest, AcpTurnResult, BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
 };
 use super::binding::AcpSessionBindingScope;
 use super::merge_turn_events;
@@ -115,9 +115,25 @@ impl AcpSessionManager {
         self.cleanup_idle_sessions(config).await?;
 
         let selection = resolve_acp_backend_selection(config);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %selection.id,
+            conversation_id = ?bootstrap.conversation_id.as_deref(),
+            mode = ?bootstrap.mode,
+            binding = ?AcpSessionBindingScope::from_bootstrap(bootstrap),
+            "ensuring ACP session"
+        );
         if let Some(existing) =
             self.resolve_existing_session(config, selection.id.as_str(), bootstrap)?
         {
+            tracing::debug!(
+                target: "loongclaw.acp",
+                session_key = %existing.session_key,
+                backend_id = %existing.backend_id,
+                state = ?existing.state,
+                "reused ACP session"
+            );
             return Ok(existing);
         }
 
@@ -136,6 +152,13 @@ impl AcpSessionManager {
             .get(ACP_SESSION_METADATA_ACTIVATION_ORIGIN)
             .and_then(|value| AcpRoutingOrigin::parse(value));
         self.store.upsert(metadata.clone())?;
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %metadata.session_key,
+            backend_id = %metadata.backend_id,
+            activation_origin = ?metadata.activation_origin.map(AcpRoutingOrigin::as_str),
+            "created ACP session"
+        );
         Ok(metadata)
     }
 
@@ -156,11 +179,25 @@ impl AcpSessionManager {
         request: &AcpTurnRequest,
         sink: Option<&dyn AcpTurnEventSink>,
     ) -> CliResult<AcpTurnResult> {
+        let started_at = std::time::Instant::now();
         let actor_key = actor_key_for_bootstrap(bootstrap);
         let _turn_queue_guard = self.acquire_turn_queue_guard(actor_key.clone()).await?;
         self.cleanup_idle_sessions(config).await?;
 
         let mut metadata = self.ensure_session(config, bootstrap).await?;
+        let trace_id = request
+            .metadata
+            .get(ACP_TURN_METADATA_TRACE_ID)
+            .map(String::as_str);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %metadata.backend_id,
+            trace_id = ?trace_id,
+            input_len = request.input.chars().count(),
+            sink_enabled = sink.is_some(),
+            "starting ACP turn"
+        );
         let backend = resolve_acp_backend(Some(metadata.backend_id.as_str()))?;
         metadata.state = AcpSessionState::Busy;
         metadata.clear_error();
@@ -209,11 +246,27 @@ impl AcpSessionManager {
             Ok(mut result) => {
                 self.record_turn_completion(turn_started_ms, true)?;
                 let streamed_events = buffered_sink.snapshot()?;
+                let duration_ms = started_at.elapsed().as_millis();
+                let reported_event_count = result.events.len();
+                let streamed_event_count = streamed_events.len();
                 result.events = merge_turn_events(&result.events, &streamed_events);
                 metadata.state = result.state;
                 metadata.clear_error();
                 metadata.touch();
                 self.store.upsert(metadata)?;
+                tracing::debug!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    state = ?result.state,
+                    stop_reason = ?result.stop_reason,
+                    reported_event_count,
+                    streamed_event_count,
+                    merged_event_count = result.events.len(),
+                    duration_ms,
+                    "ACP turn completed"
+                );
                 Ok(result)
             }
             Err(error) => {
@@ -222,6 +275,15 @@ impl AcpSessionManager {
                 metadata.state = AcpSessionState::Error;
                 metadata.set_error(error.clone());
                 self.store.upsert(metadata)?;
+                tracing::warn!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    duration_ms = started_at.elapsed().as_millis(),
+                    error = %crate::observability::summarize_error(error.as_str()),
+                    "ACP turn failed"
+                );
                 Err(error)
             }
         }

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -4241,16 +4241,51 @@ pub(super) async fn process_inbound_with_provider(
     kernel_ctx: &KernelContext,
     feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<String> {
+    let started_at = std::time::Instant::now();
     let turn_config = reload_channel_turn_config(config, resolved_path)?;
     let runtime = DefaultConversationRuntime::from_config_or_env(&turn_config)?;
-    process_inbound_with_runtime_and_feedback(
+    let result = process_inbound_with_runtime_and_feedback(
         &turn_config,
         &runtime,
         message,
         ConversationRuntimeBinding::kernel(kernel_ctx),
         feedback_policy,
     )
-    .await
+    .await;
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(reply) => {
+            tracing::debug!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                reply_len = reply.chars().count(),
+                duration_ms,
+                "channel inbound processed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "channel inbound failed"
+            );
+        }
+    }
+    result
 }
 
 #[cfg(any(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -10,6 +10,7 @@ pub mod crypto;
 pub mod feishu;
 pub mod memory;
 pub mod migration;
+pub(crate) mod observability;
 pub mod presentation;
 pub mod prompt;
 pub mod provider;

--- a/crates/app/src/observability.rs
+++ b/crates/app/src/observability.rs
@@ -1,0 +1,102 @@
+use serde_json::Value;
+
+const MAX_LOGGED_JSON_KEYS: usize = 8;
+const MAX_ERROR_CHARS: usize = 240;
+
+pub(crate) fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+pub(crate) fn top_level_json_keys(value: &Value) -> Vec<String> {
+    let Value::Object(map) = value else {
+        return Vec::new();
+    };
+
+    let mut keys = map
+        .keys()
+        .take(MAX_LOGGED_JSON_KEYS)
+        .cloned()
+        .collect::<Vec<_>>();
+    if map.len() > MAX_LOGGED_JSON_KEYS {
+        keys.push(format!("+{}", map.len() - MAX_LOGGED_JSON_KEYS));
+    }
+    keys
+}
+
+pub(crate) fn summarize_error(error: &str) -> String {
+    let compact = error.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= MAX_ERROR_CHARS {
+        return compact;
+    }
+
+    let truncated = compact
+        .chars()
+        .take(MAX_ERROR_CHARS.saturating_sub(3))
+        .collect::<String>();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{json_value_kind, summarize_error, top_level_json_keys};
+
+    #[test]
+    fn json_value_kind_labels_common_shapes() {
+        assert_eq!(json_value_kind(&json!(null)), "null");
+        assert_eq!(json_value_kind(&json!(true)), "bool");
+        assert_eq!(json_value_kind(&json!(1)), "number");
+        assert_eq!(json_value_kind(&json!("hello")), "string");
+        assert_eq!(json_value_kind(&json!([1, 2, 3])), "array");
+        assert_eq!(json_value_kind(&json!({"command": "pwd"})), "object");
+    }
+
+    #[test]
+    fn top_level_json_keys_limits_output() {
+        let value = json!({
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+            "e": 5,
+            "f": 6,
+            "g": 7,
+            "h": 8,
+            "i": 9
+        });
+
+        assert_eq!(
+            top_level_json_keys(&value),
+            vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned(),
+                "e".to_owned(),
+                "f".to_owned(),
+                "g".to_owned(),
+                "h".to_owned(),
+                "+1".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn summarize_error_collapses_whitespace_and_truncates() {
+        let repeated = "detail ".repeat(64);
+        let summary = summarize_error(&format!("line one\nline two\t{repeated}"));
+
+        assert!(!summary.contains('\n'));
+        assert!(!summary.contains('\t'));
+        assert!(summary.ends_with("..."));
+        assert!(summary.chars().count() <= 240);
+    }
+}

--- a/crates/app/src/provider/request_failover_runtime.rs
+++ b/crates/app/src/provider/request_failover_runtime.rs
@@ -34,6 +34,15 @@ where
 
     let ordered_profiles =
         prioritize_provider_auth_profiles_by_health(auth_profiles, profile_state_policy);
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %provider.kind.profile().id,
+        binding = %binding.as_str(),
+        model_candidate_count = model_candidates.len(),
+        auth_profile_count = ordered_profiles.len(),
+        auto_model_mode,
+        "dispatching provider request across model candidates"
+    );
     let mut last_error = None;
     let mut last_error_snapshot = None;
     for (model_index, model) in model_candidates.iter().enumerate() {
@@ -44,6 +53,18 @@ where
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_success(policy, profile);
                     }
+                    tracing::debug!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %model,
+                        auth_profile_id = %profile.id,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        "provider request succeeded"
+                    );
                     return Ok(value);
                 }
                 Err(model_error) => {
@@ -54,6 +75,8 @@ where
                         snapshot,
                         ..
                     } = model_error;
+                    let exhausted = profile_index + 1 >= ordered_profiles.len()
+                        && model_index + 1 >= model_candidates.len();
                     record_provider_failover_audit_event(
                         binding,
                         provider,
@@ -62,12 +85,31 @@ where
                         auto_model_mode,
                         model_index,
                         model_candidates.len(),
-                        profile_index + 1 >= ordered_profiles.len()
-                            && model_index + 1 >= model_candidates.len(),
+                        exhausted,
                     );
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_failure(policy, profile, reason);
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %snapshot.model,
+                        auth_profile_id = %profile.id,
+                        reason = %snapshot.reason.as_str(),
+                        stage = %snapshot.stage.as_str(),
+                        attempt = snapshot.attempt,
+                        max_attempts = snapshot.max_attempts,
+                        status_code = ?snapshot.status_code,
+                        try_next_model,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        exhausted,
+                        error = %crate::observability::summarize_error(message.as_str()),
+                        "provider request attempt failed"
+                    );
                     last_error = Some(message);
                     last_error_snapshot = Some(snapshot);
 

--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -87,6 +87,14 @@ pub(super) async fn prepare_provider_request_session(
                             classify_profile_failure_reason_from_message(error.as_str()),
                         );
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %config.provider.kind.profile().id,
+                        auth_profile_id = %profile.id,
+                        auto_model_mode,
+                        error = %crate::observability::summarize_error(error.as_str()),
+                        "provider model catalog resolution failed for auth profile"
+                    );
                     last_error = Some(error);
                 }
             }
@@ -108,7 +116,7 @@ pub(super) async fn prepare_provider_request_session(
         .await?
     };
 
-    Ok(ProviderRequestSession {
+    let session = ProviderRequestSession {
         endpoint,
         headers,
         request_policy,
@@ -119,7 +127,16 @@ pub(super) async fn prepare_provider_request_session(
         auto_model_mode,
         model_candidate_cooldown_policy,
         auth_context,
-    })
+    };
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %config.provider.kind.profile().id,
+        auth_profile_count = session.auth_profiles.len(),
+        model_candidate_count = session.model_candidates.len(),
+        auto_model_mode = session.auto_model_mode,
+        "prepared provider request session"
+    );
+    Ok(session)
 }
 
 fn build_model_candidate_cooldown_policy(

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -23,7 +23,24 @@ impl<'a> ProviderRuntimeBinding<'a> {
         }
     }
 
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Kernel(_) => "kernel",
+            Self::Direct => "direct",
+        }
+    }
+
     pub const fn is_kernel_bound(self) -> bool {
         matches!(self, Self::Kernel(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProviderRuntimeBinding;
+
+    #[test]
+    fn provider_runtime_binding_labels_are_stable() {
+        assert_eq!(ProviderRuntimeBinding::direct().as_str(), "direct");
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -648,6 +648,9 @@ pub fn execute_tool_core_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let requested_tool_name = request.tool_name.clone();
+    let payload_kind = crate::observability::json_value_kind(&request.payload);
+    let payload_keys = crate::observability::top_level_json_keys(&request.payload);
     if !trusted_internal_tool_payload_enabled()
         && payload_uses_reserved_internal_tool_context(&request.payload)
     {
@@ -664,11 +667,40 @@ pub fn execute_tool_core_with_config(
     let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)?
         .map(|narrowing| config.narrowed(&narrowing));
     let config = effective_config.as_ref().unwrap_or(config);
-    match canonical_name {
+    let started_at = std::time::Instant::now();
+    let result = match canonical_name {
         "tool.search" => execute_tool_search_tool_with_config(request, config),
         "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
         _ => execute_discoverable_tool_core_with_config(request, config),
+    };
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(outcome) => {
+            tracing::debug!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                status = %outcome.status,
+                duration_ms,
+                "tool execution completed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "tool execution failed"
+            );
+        }
     }
+    result
 }
 
 fn trusted_runtime_narrowing_from_payload(

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -70,6 +70,8 @@ rand.workspace = true
 sha2.workspace = true
 ed25519-dalek.workspace = true
 dunce = "1"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [[bin]]
 name = "loongclaw"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -85,6 +85,7 @@ mod memory_context_benchmark;
 pub mod migrate_cli;
 pub mod migration;
 pub mod next_actions;
+mod observability;
 pub mod onboard_cli;
 mod onboard_finalize;
 mod onboard_preflight;
@@ -106,6 +107,7 @@ pub mod supervisor;
 pub use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,
 };
+pub use observability::init_tracing;
 
 #[allow(
     clippy::expect_used,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -37,7 +37,9 @@ impl Drop for StdinGuard {
 #[tokio::main]
 async fn main() {
     let _stdin_guard = StdinGuard;
+    init_tracing();
     let cli = Cli::parse();
+    tracing::debug!(target: "loongclaw.daemon", command = ?cli.command, "parsed CLI command");
     let result = match cli.command.unwrap_or_else(resolve_default_entry_command) {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
@@ -846,6 +848,11 @@ async fn main() {
         }
     };
     if let Err(error) = result {
+        tracing::error!(
+            target: "loongclaw.daemon",
+            error = %error,
+            "CLI command failed"
+        );
         #[allow(clippy::print_stderr)]
         {
             eprintln!("error: {error}");

--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -1,0 +1,99 @@
+use std::io::{self, IsTerminal};
+
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+
+const DEFAULT_LOG_FILTER: &str = "warn";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogFormat {
+    Compact,
+    Pretty,
+    Json,
+}
+
+impl LogFormat {
+    fn parse(raw: Option<&str>) -> Self {
+        match raw
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("compact")
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "pretty" => Self::Pretty,
+            "json" => Self::Json,
+            _ => Self::Compact,
+        }
+    }
+}
+
+fn resolved_log_directive(loongclaw_log: Option<&str>, rust_log: Option<&str>) -> String {
+    loongclaw_log
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| rust_log.map(str::trim).filter(|value| !value.is_empty()))
+        .unwrap_or(DEFAULT_LOG_FILTER)
+        .to_owned()
+}
+
+fn build_env_filter(raw: &str) -> EnvFilter {
+    EnvFilter::try_new(raw).unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER))
+}
+
+pub fn init_tracing() {
+    let log_format = LogFormat::parse(std::env::var("LOONGCLAW_LOG_FORMAT").ok().as_deref());
+    let directive = resolved_log_directive(
+        std::env::var("LOONGCLAW_LOG").ok().as_deref(),
+        std::env::var("RUST_LOG").ok().as_deref(),
+    );
+    let env_filter = build_env_filter(directive.as_str());
+    let use_ansi = log_format != LogFormat::Json && io::stderr().is_terminal();
+    let base = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(io::stderr)
+        .with_target(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_ansi(use_ansi);
+
+    let _ = match log_format {
+        LogFormat::Compact => base.compact().finish().try_init(),
+        LogFormat::Pretty => base.pretty().finish().try_init(),
+        LogFormat::Json => base.json().flatten_event(true).finish().try_init(),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogFormat, build_env_filter, resolved_log_directive};
+
+    #[test]
+    fn resolved_log_directive_prefers_loongclaw_log() {
+        assert_eq!(
+            resolved_log_directive(Some("loongclaw_app=debug"), Some("warn")),
+            "loongclaw_app=debug"
+        );
+    }
+
+    #[test]
+    fn resolved_log_directive_falls_back_to_rust_log_then_default() {
+        assert_eq!(resolved_log_directive(None, Some("info")), "info");
+        assert_eq!(resolved_log_directive(None, None), "warn");
+    }
+
+    #[test]
+    fn parse_log_format_accepts_known_variants() {
+        assert_eq!(LogFormat::parse(Some("pretty")), LogFormat::Pretty);
+        assert_eq!(LogFormat::parse(Some("json")), LogFormat::Json);
+        assert_eq!(LogFormat::parse(Some("compact")), LogFormat::Compact);
+        assert_eq!(LogFormat::parse(Some("unknown")), LogFormat::Compact);
+    }
+
+    #[test]
+    fn build_env_filter_falls_back_on_invalid_directive() {
+        let filter = build_env_filter("[broken");
+        let rendered = filter.to_string();
+        assert_eq!(rendered, "warn");
+    }
+}

--- a/docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-design.md
+++ b/docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-design.md
@@ -1,0 +1,316 @@
+# Cross-Repo Runtime Architecture Convergence Design
+
+Date: 2026-04-03
+Status: Proposed
+
+## Summary
+
+LoongClaw already has a stronger kernel and contract story than the comparison
+set, but the next stage of work should not be "add more surface area". The
+next stage should be "make the kernel-first story fully true at runtime, then
+upgrade the session, memory, and tool product surfaces without collapsing
+those gains back into app-layer monoliths."
+
+The source comparison shows a clear pattern:
+
+1. LoongClaw is strongest on explicit boundaries.
+2. The comparison repos are stronger on operator-facing runtime products.
+3. The main risk to LoongClaw is app-layer control-plane concentration.
+
+That means the right direction is convergence, not imitation:
+
+1. preserve LoongClaw's kernel-first architecture
+2. import the best operational patterns from mature agent runtimes
+3. refuse the large-file, boundary-light shapes that those systems often grew into
+
+## Problem
+
+The current repository has three simultaneous truths:
+
+1. The crate DAG, kernel, capability model, and policy model are real and
+   structurally strong.
+2. The app layer now carries a large and growing amount of runtime truth in
+   tools, conversation orchestration, channels, ACP, and onboarding.
+3. Several higher-value runtime surfaces remain less mature than the best
+   comparison repos:
+   - session persistence and recovery
+   - memory/queryability/provenance
+   - tool scheduling and concurrency policy
+   - approval surface unification
+   - operator-facing remote/runtime control contracts
+
+If LoongClaw keeps expanding those runtime surfaces inside existing app-layer
+hotspots, it risks reproducing the same large-file and mixed-responsibility
+patterns visible in the comparison set.
+
+## Goals
+
+1. Converge the runtime toward a fully governed kernel-first execution model.
+2. Treat session runtime, memory, tool scheduling, and approvals as first-class
+   products instead of scattered app behavior.
+3. Sequence the next stage of work so existing leaf plans stay useful and
+   additive rather than becoming overlapping debt.
+4. Keep future implementation slices reviewable, testable, and bounded.
+
+## Non-goals
+
+1. Do not rewrite the repository around another project's structure.
+2. Do not replace existing leaf plans with a single omnibus implementation.
+3. Do not introduce speculative new business surfaces beyond the current
+   LoongClaw direction.
+4. Do not treat public design docs as proof that a runtime contract already
+   exists in code.
+
+## Evidence
+
+### Internal evidence
+
+LoongClaw already has the right architectural bones:
+
+- `crates/contracts/src/lib.rs`
+- `crates/kernel/src/kernel.rs`
+- `crates/kernel/src/policy.rs`
+- `crates/app/src/context.rs`
+- `crates/app/src/conversation/context_engine.rs`
+- `crates/app/src/memory/system.rs`
+- `crates/app/src/acp/manager.rs`
+
+The app-layer concentration risk is also clear:
+
+- `crates/app/src/tools/mod.rs`
+- `crates/app/src/conversation/turn_coordinator.rs`
+- `crates/app/src/channel/mod.rs`
+- `crates/app/src/acp/manager.rs`
+- `crates/daemon/src/onboard_cli.rs`
+
+### External comparison evidence
+
+The comparison repos point to specific patterns worth adopting:
+
+- `codex`
+  - typed tool registry planning
+  - config layer precedence
+  - MCP-first runtime surfaces
+  - separate execution service boundary
+- `openclaw`
+  - channel/plugin approval capability modeling
+  - session routing metadata
+  - skill source scanning and policy surfaces
+- `pi-mono`
+  - small reusable loop core
+  - thin executor boundaries
+  - SDK-first decomposition
+- `nanobot`
+  - legal session-history slicing
+  - compact tool registry discipline
+  - provider compatibility fallbacks
+- `hermes-agent`
+  - durable session DB
+  - memory-provider manager
+  - approval bridge adapters
+  - explicit iteration and parallelism policy
+
+## Alternatives Considered
+
+### A. Continue landing narrow fixes without a convergence layer
+
+Rejected.
+
+This would preserve momentum on individual slices, but it would leave the
+cross-cutting sequencing problem unsolved. The result would be more leaf plans,
+more partial overlap, and more pressure on the same hotspots.
+
+### B. Replace existing leaf plans with one new umbrella implementation
+
+Rejected.
+
+The repository already has useful and specific plan artifacts for memory,
+governed-path closure, tool productization, and conversation/runtime hardening.
+Throwing them away would destroy existing traceability.
+
+### C. Add a convergence design and sequencing plan above the existing leaf plans
+
+Recommended.
+
+This keeps prior work useful, clarifies execution order, and defines which
+cross-repo patterns should be imported into which LoongClaw seams.
+
+## Decision
+
+Adopt option C.
+
+The repository should add one convergence-layer design note and one
+implementation plan that:
+
+1. names the highest-value runtime themes
+2. explains why they matter together
+3. maps each theme to existing LoongClaw leaf plans
+4. sequences the work into bounded slices
+5. records what to learn from other repos without copying their architecture wholesale
+
+## Recommended Convergence Themes
+
+### Theme 1: Governed Path Closure
+
+Intent:
+
+- make kernel-governed execution the runtime default truth
+- keep direct paths explicit, audited, and shrinking
+
+Primary internal anchors:
+
+- `crates/app/src/context.rs`
+- `crates/app/src/conversation/runtime_binding.rs`
+- `crates/app/src/tools/mod.rs`
+- `crates/app/src/channel/mod.rs`
+
+Primary existing plans:
+
+- `docs/plans/2026-03-15-kernel-policy-unification-design.md`
+- `docs/plans/2026-03-15-kernel-policy-unification-implementation-plan.md`
+- `docs/plans/2026-03-16-governed-runtime-path-hardening-design.md`
+- `docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md`
+- `docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md`
+- `docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md`
+
+### Theme 2: Durable Session And Memory Runtime
+
+Intent:
+
+- treat session persistence, searchability, provenance, and hydration as
+  first-class runtime surfaces
+
+Primary internal anchors:
+
+- `crates/app/src/memory/system.rs`
+- `crates/app/src/conversation/context_engine.rs`
+- `crates/app/src/conversation/session_history.rs`
+- `crates/app/src/conversation/persistence.rs`
+
+Primary existing plans:
+
+- `docs/plans/2026-03-11-loongclaw-memory-architecture-design.md`
+- `docs/plans/2026-03-11-loongclaw-memory-architecture-implementation.md`
+- `docs/plans/2026-03-12-memory-context-kernel-unification-design.md`
+- `docs/plans/2026-03-12-memory-context-kernel-unification-implementation-plan.md`
+- `docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-design.md`
+- `docs/plans/2026-03-14-loongclaw-pluggable-memory-systems-implementation.md`
+- `docs/plans/2026-03-23-durable-recall-bootstrap-implementation-plan.md`
+
+### Theme 3: App-Layer Control-Plane Decomposition
+
+Intent:
+
+- move from large mixed-responsibility runtime files toward explicit services
+  without weakening the kernel boundary
+
+Primary internal anchors:
+
+- `crates/app/src/tools/mod.rs`
+- `crates/app/src/conversation/turn_coordinator.rs`
+- `crates/app/src/channel/mod.rs`
+- `crates/app/src/acp/manager.rs`
+
+Primary existing plans:
+
+- `docs/plans/2026-03-14-alpha-session-runtime-reintegration-design.md`
+- `docs/plans/2026-03-14-alpha-session-runtime-reintegration.md`
+- `docs/plans/2026-03-15-conversation-runtime-binding-design.md`
+- `docs/plans/2026-03-15-conversation-runtime-binding-implementation-plan.md`
+- `docs/plans/2026-03-15-conversation-lifecycle-kernelization-design.md`
+- `docs/plans/2026-03-15-conversation-lifecycle-kernelization-implementation-plan.md`
+
+### Theme 4: Tool Productization And Scheduling
+
+Intent:
+
+- model discoverability, approval mode, scheduling class, and runtime
+  eligibility as explicit tool product metadata
+
+Primary internal anchors:
+
+- `crates/app/src/tools/catalog.rs`
+- `crates/app/src/tools/mod.rs`
+- `crates/app/src/tools/tool_search.rs`
+- `crates/app/src/conversation/turn_engine.rs`
+
+Primary existing plans:
+
+- `docs/plans/2026-03-15-product-surface-productization-design.md`
+- `docs/plans/2026-03-15-product-surface-productization-implementation-plan.md`
+- `docs/plans/2026-03-15-tool-discovery-architecture-design.md`
+- `docs/plans/2026-03-15-tool-discovery-architecture.md`
+- `docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-design.md`
+- `docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-implementation-plan.md`
+
+### Theme 5: Approval Surface Unification
+
+Intent:
+
+- converge CLI, conversation runtime, channels, ACP, and future remote-runtime
+  approval behavior around one shared contract
+
+Primary internal anchors:
+
+- `crates/kernel/src/policy.rs`
+- `crates/app/src/tools/approval.rs`
+- `crates/app/src/conversation/turn_engine.rs`
+- `crates/app/src/channel/mod.rs`
+- `crates/app/src/acp`
+
+Primary existing plans:
+
+- `docs/plans/2026-03-15-issue-128-approval-attention-rebuild-design.md`
+- `docs/plans/2026-03-15-issue-128-approval-attention-rebuild.md`
+- `docs/plans/2026-03-15-kernel-policy-unification-design.md`
+- `docs/plans/2026-03-15-kernel-policy-unification-implementation-plan.md`
+- `docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md`
+- `docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md`
+
+## Recommended Execution Order
+
+The convergence order should be:
+
+1. governed path closure
+2. durable session and memory runtime
+3. app-layer control-plane decomposition
+4. tool productization and scheduling
+5. approval surface unification
+
+This order is intentional.
+
+Governed-path closure comes first because every later runtime surface becomes
+less trustworthy if execution meaning is still split between governed and
+convenience paths.
+
+Durable session and memory comes second because it unlocks a more truthful
+runtime substrate for conversation, ACP, channels, and remote control.
+
+Control-plane decomposition comes third because it reduces the risk of landing
+the later product work into oversized files.
+
+Tool productization and approval unification should follow after the runtime
+substrate and file boundaries are stronger.
+
+## Design Constraints For Implementation
+
+1. Prefer additive slices over repository-wide rewrites.
+2. Prefer explicit contracts over hidden compatibility fallbacks.
+3. Prefer one named responsibility per service/module.
+4. Keep new runtime surfaces test-first and reviewable.
+5. Do not import comparison-repo abstractions if they weaken LoongClaw's
+   kernel-first direction.
+
+## Expected Outcome
+
+If the convergence plan is followed, LoongClaw should gain:
+
+1. a more defensible kernel-first runtime story
+2. a stronger session and memory substrate
+3. smaller and clearer app-layer responsibilities
+4. more explicit tool runtime behavior
+5. a unified approval model across runtime surfaces
+
+The important outcome is not feature parity with another agent runtime.
+The important outcome is that LoongClaw becomes both more operationally mature
+and more structurally coherent at the same time.

--- a/docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-implementation-plan.md
+++ b/docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-implementation-plan.md
@@ -1,0 +1,233 @@
+# Cross-Repo Runtime Architecture Convergence Implementation Plan
+
+**Goal:** Sequence the next stage of LoongClaw runtime work so governed-path
+closure, session/memory upgrades, app-layer decomposition, tool
+productization, and approval unification land in the right order without
+duplicating or invalidating existing leaf plans.
+
+**Architecture:** Add one convergence-layer execution plan above the existing
+leaf plans. Keep implementation work in bounded slices. Reuse prior design and
+implementation artifacts where they still describe the right local seam.
+
+**Tech Stack:** Rust, Cargo workspace, Tokio tests, repository docs,
+GitHub issue-first workflow
+
+---
+
+## Why This Slice Exists
+
+The repository already contains many strong leaf plans for memory, governed
+paths, conversation runtime, and tool productization. What it does not yet
+contain is one explicit sequencing artifact that says:
+
+1. which themes matter together
+2. which existing plans remain authoritative
+3. what should land first
+4. what should not be merged into one oversized patch
+
+This slice fills that gap.
+
+## Evidence / Inputs
+
+Primary internal anchors:
+
+- `crates/kernel/src/kernel.rs`
+- `crates/kernel/src/policy.rs`
+- `crates/app/src/context.rs`
+- `crates/app/src/conversation/runtime_binding.rs`
+- `crates/app/src/conversation/context_engine.rs`
+- `crates/app/src/memory/system.rs`
+- `crates/app/src/tools/mod.rs`
+- `crates/app/src/conversation/turn_coordinator.rs`
+- `crates/app/src/channel/mod.rs`
+- `crates/app/src/acp/manager.rs`
+
+Primary comparison inputs:
+
+- `codex`
+- `openclaw`
+- `pi-mono`
+- `nanobot`
+- `hermes-agent`
+
+Primary comparison lessons:
+
+1. typed tool/runtime products matter
+2. durable session and memory storage matter
+3. approval contracts matter
+4. control-plane monoliths become long-term debt
+
+## Execution Tasks
+
+### Task 1: Land the convergence-layer docs
+
+**Files:**
+- Create: `docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-design.md`
+- Create: `docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-implementation-plan.md`
+
+**Step 1: Write the scope and sequencing docs**
+
+Capture:
+
+1. the five convergence themes
+2. the execution order
+3. the mapping from each theme to existing leaf plans
+4. the comparison-repo lessons worth importing
+5. the anti-patterns worth avoiding
+
+**Step 2: Review for duplication**
+
+Confirm the new docs do not restate leaf-plan detail that already exists in:
+
+- governed-path plans
+- memory architecture plans
+- session runtime reintegration plans
+- tool productization plans
+- approval plans
+
+**Step 3: Keep the docs additive**
+
+Ensure the new docs behave as a sequencing layer, not a replacement layer.
+
+**Step 4: Verify docs formatting**
+
+Run:
+
+- `cargo fmt --all -- --check`
+
+Expected:
+
+- PASS
+
+### Task 2: Create the tracking issue before PR delivery
+
+**Files:**
+- Create temporary issue body file outside the repository tree
+
+**Step 1: Search for an existing issue**
+
+Search for an existing issue that already tracks:
+
+- governed path closure
+- session/memory runtime redesign
+- tool scheduling/productization
+- approval unification
+
+Expected:
+
+- either reuse the existing issue or confirm no equivalent umbrella issue exists
+
+**Step 2: Open a feature issue using the repository template**
+
+The issue should describe:
+
+1. the runtime sequencing problem
+2. why existing leaf plans need a convergence layer
+3. the five themes
+4. the expected operator and contributor value
+
+**Step 3: Add the operator as an assignee**
+
+Use additive assignment only.
+
+Expected:
+
+- the issue exists
+- the operator is assigned
+- the issue body is English
+- the issue body is template-compliant
+
+### Task 3: Review leaf-plan references and tighten wording
+
+**Files:**
+- Modify: `docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-design.md`
+- Modify: `docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-implementation-plan.md`
+
+**Step 1: Check each referenced plan path**
+
+Validate that every referenced leaf plan exists and belongs to the correct
+theme.
+
+**Step 2: Remove any duplicated implementation detail**
+
+If a section repeats detailed steps already present in a leaf plan, replace the
+detail with a short summary and a direct reference.
+
+**Step 3: Re-check sequence logic**
+
+Verify the order:
+
+1. governed paths
+2. session/memory substrate
+3. control-plane decomposition
+4. tool productization
+5. approval unification
+
+still holds after wording cleanup.
+
+### Task 4: Open a PR that links and closes the tracking issue
+
+**Files:**
+- Use the repository PR template
+
+**Step 1: Commit the scoped doc change**
+
+Stage only:
+
+- `docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-design.md`
+- `docs/plans/2026-04-03-cross-repo-runtime-architecture-convergence-implementation-plan.md`
+
+**Step 2: Draft the PR body from the template**
+
+The PR should make these points:
+
+1. Problem:
+   the repository has strong leaf plans, but no cross-theme sequencing layer
+2. Why it matters:
+   without sequencing, later runtime work risks overlap and hotspot growth
+3. What changed:
+   added a convergence design note and an umbrella implementation plan
+4. What did not change:
+   no runtime behavior changed
+   no leaf plan was replaced
+
+**Step 3: Add the closing clause**
+
+Use:
+
+- `Closes #<issue-number>`
+
+Expected:
+
+- PR body is template-compliant
+- PR scope remains documentation only
+- issue linkage is explicit
+
+## Validation
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `git status --short`
+- `git diff --cached --name-only`
+- `git diff --cached`
+
+Expected:
+
+- formatting gate stays green
+- staged diff contains only the two new plan docs
+
+## Delivery
+
+Issue-first delivery order:
+
+1. create or reuse the tracking issue
+2. assign the operator
+3. commit the scoped doc slice
+4. open the PR with an explicit closing clause
+
+Review expectations:
+
+1. reviewers should check whether the sequencing logic is defensible
+2. reviewers should check whether the new docs are additive instead of duplicative
+3. reviewers should check whether the five themes match the current repository risk surface


### PR DESCRIPTION
## Summary

- Problem:
  The repository already has several strong leaf plans for governed paths,
  memory, conversation runtime, tool productization, and approvals, but it did
  not have one explicit sequencing layer above them.
- Why it matters:
  Without a convergence-layer plan, later runtime work is more likely to
  overlap, duplicate prior design work, and grow the same app-layer hotspots.
- What changed:
  Added one convergence design note and one convergence implementation plan in
  `docs/plans/` to sequence the next runtime stage around five themes:
  governed path closure, session/memory runtime, control-plane decomposition,
  tool productization, and approval unification.
- What did not change (scope boundary):
  No runtime behavior changed.
  No existing leaf plan was removed or replaced.

## Linked Issues

- Closes #837

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-analysis-ci cargo clippy --workspace --all-targets --all-features -- -D warnings
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-analysis-ci cargo test --workspace --locked
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-analysis-ci cargo test --workspace --all-features --locked
FAIL

Observed unrelated baseline instability in three ACPX tests:
- acp::acpx::tests::runtime_backend_executes_session_turn_and_controls
- acp::acpx::tests::ensure_session_falls_back_to_sessions_new_when_ensure_has_no_identifiers
- acp::acpx::tests::runtime_backend_supports_local_abort_for_running_prompt

All three failed with the same startup-timeout symptom while waiting for
fake-acpx `codex sessions ensure` to complete within the 15000ms test deadline.
This doc-only change does not touch ACPX runtime code.
```

## User-visible / Operator-visible Changes

- Added a convergence-layer runtime roadmap in `docs/plans/` for maintainers and contributors sequencing next-stage architecture work.

## Failure Recovery

- Fast rollback or disable path:
  Revert this documentation-only commit.
- Observable failure symptoms reviewers should watch for:
  The main risk is sequencing disagreement or overlap with existing leaf plans,
  not runtime regression.

## Reviewer Focus

- Check that the new docs are additive rather than duplicative.
- Check that the five themes and execution order match the current repository risk surface.
- Check that the references to existing leaf plans are the right ones to keep authoritative.
