### PR TITLE
docs: align top-level governance docs with live policy and audit seams

### DIFF
--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -7,10 +7,10 @@ Domain grades for LoongClaw. Updated periodically to track gaps, prioritize clea
 | Domain | Grade | Last Reviewed | Gaps |
 |--------|-------|---------------|------|
 | Contracts (L0) | A | 2026-03-13 | `#[non_exhaustive]` applied; membrane field not yet enforced at runtime |
-| Kernel Security (L1) | B+ | 2026-03-13 | Policy only gates `shell.exec`; `file.read`/`file.write` bypass policy check |
+| Kernel Security (L1) | B+ | 2026-04-03 | Core tool paths now route through policy extensions; remaining gaps are non-uniform L1 coverage for connector/ACP/runtime-only analytics and explicit `Direct` compatibility lanes |
 | Execution Planes (L2) | B | 2026-03-13 | Core/extension pattern solid; no WASM fuel metering yet |
 | Orchestration (L3) | B | 2026-03-13 | HarnessBroker routes correctly; context-engine selection is pluggable, but richer engine implementations and broader runtime coverage are still limited |
-| Observability (L4) | C+ | 2026-03-13 | Audit events in-memory only; no HMAC chain; no persistent sink |
+| Observability (L4) | C+ | 2026-04-03 | Durable JSONL/fanout audit exists; remaining gaps are tamper-evident verification, query baseline, and richer export lanes |
 | Vertical Packs (L5) | B | 2026-03-13 | Pack validation works; namespace struct exists but not enforced |
 | Protocol (L5.5) | B+ | 2026-03-13 | Transport contracts and typed routing operational |
 | Integration (L6) | B | 2026-03-13 | Plugin scanning works; hotplug lifecycle incomplete |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,8 +61,9 @@ Delivered:
 - external profile integrity lock (`security_scan.profile_sha256`) with fail-closed behavior
 - external profile signature verification (`security_scan.profile_signature`, ed25519)
 - JSONL SIEM export lane (`security_scan.siem_export`) with optional fail-closed mode
-- kernel-level tool-call policy gate (`PolicyEngine::check_tool_call`) with explicit
-  deny/approval-required outcomes before tool dispatch (Rule of Two)
+- kernel-level request-policy gate for tool calls through `PolicyEngine::authorize(...)`
+  plus `PolicyExtensionChain`, with explicit deny/approval-required outcomes before
+  tool dispatch (Rule of Two)
 - WASM static scan controls:
   - allowed artifact paths
   - module size cap

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -75,7 +75,7 @@ Tool-specific request approval currently lives in the `PolicyExtensionChain`; th
 
 ### Audit System
 
-- 7 event kinds with atomic sequencing
+- 10 event kinds with atomic sequencing
 - Production app runtimes default to durable JSONL retention via `[audit].mode = "fanout"`
 - Default journal path: `~/.loongclaw/audit/events.jsonl`
 - `LoongClawKernel::new()` and spec/test/demo helpers may still opt into explicit in-memory audit seams when side-effect-free snapshot reporting is required

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -55,7 +55,7 @@ All decisions from the research repository. Status reflects implementation reali
 
 | ID | Decision | Implementation Status |
 |----|----------|---------------------|
-| D-003 | Append-only event log as single source of truth | Partial — audit events exist, in-memory only (TD-006) |
+| D-003 | Append-only event log as single source of truth | Partial — audit events exist, JSONL/fanout retention exists, no tamper-evident verification or query baseline yet |
 | D-004 | Materialized views from event log | Not started |
 | D-005 | Control/data plane separation | Partial — planes exist, not fully separated |
 | D-006 | Consensus-agnostic event log trait | Not started — no trait defined |

--- a/docs/design-docs/layered-kernel-design.md
+++ b/docs/design-docs/layered-kernel-design.md
@@ -37,8 +37,12 @@ Scope:
 Rules:
 
 - Every external action must pass L1.
-- Tool plane core/extension execution must call `PolicyEngine::check_tool_call` before dispatch
-  (Rule of Two: model intent plus deterministic policy decision).
+- Tool plane core/extension execution must route deterministic request-policy approval through the
+  kernel authorization stack before dispatch: token/capability validation in `PolicyEngine::authorize`
+  plus tool-specific tightening in `PolicyExtensionChain` (Rule of Two: model intent plus
+  deterministic policy decision).
+- The deprecated `PolicyEngine::check_tool_call` hook remains compatibility-only and must not be
+  treated as the live request-policy seam.
 - Policy extensions can only tighten behavior, never weaken core policy.
 - Denials are auditable and deterministic.
 - Human approval gate should default to medium-balanced mode:

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -315,6 +315,11 @@ elif ! grep -Fq "${EXPECTED_ADVISORY_URL}" "$ISSUE_TEMPLATE_CONFIG"; then
     ERRORS=$((ERRORS + 1))
 fi
 
+# --- 6. Governance architecture doc consistency checks ---
+if ! "$REPO_ROOT/scripts/check_governance_docs_consistency.sh"; then
+    ERRORS=$((ERRORS + 1))
+fi
+
 # --- Summary ---
 if [ "$ERRORS" -gt 0 ]; then
     echo ""

--- a/scripts/check_governance_docs_consistency.sh
+++ b/scripts/check_governance_docs_consistency.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ERRORS=0
+
+fail() {
+    local message="$1"
+    echo "FAIL: ${message}"
+    ERRORS=$((ERRORS + 1))
+}
+
+check_file_exists() {
+    local file="$1"
+
+    if [ -f "$file" ]; then
+        return
+    fi
+
+    fail "missing required governance doc or source file: ${file#"$REPO_ROOT/"}"
+}
+
+check_absent_fixed_string() {
+    local file="$1"
+    local needle="$2"
+    local message="$3"
+
+    if grep -Fq "$needle" "$file"; then
+        fail "$message"
+    fi
+}
+
+check_present_fixed_string() {
+    local file="$1"
+    local needle="$2"
+    local message="$3"
+
+    if grep -Fq "$needle" "$file"; then
+        return
+    fi
+
+    fail "$message"
+}
+
+count_audit_event_kinds() {
+    local file="$1"
+
+    awk '
+        /pub enum AuditEventKind \{/ {
+            in_enum = 1
+            next
+        }
+
+        in_enum && /^}/ {
+            in_enum = 0
+        }
+
+        in_enum && /^[[:space:]]{4}[A-Za-z0-9_]+[[:space:]]*(\{|,)/ {
+            count += 1
+        }
+
+        END {
+            print count + 0
+        }
+    ' "$file"
+}
+
+read_documented_audit_event_kind_count() {
+    local file="$1"
+
+    sed -n -E 's/^- ([0-9]+) event kinds with atomic sequencing$/\1/p' "$file" | head -n 1
+}
+
+ROADMAP_FILE="$REPO_ROOT/docs/ROADMAP.md"
+SECURITY_FILE="$REPO_ROOT/docs/SECURITY.md"
+QUALITY_SCORE_FILE="$REPO_ROOT/docs/QUALITY_SCORE.md"
+LAYERED_DESIGN_FILE="$REPO_ROOT/docs/design-docs/layered-kernel-design.md"
+DESIGN_INDEX_FILE="$REPO_ROOT/docs/design-docs/index.md"
+AUDIT_TYPES_FILE="$REPO_ROOT/crates/contracts/src/audit_types.rs"
+
+check_file_exists "$ROADMAP_FILE"
+check_file_exists "$SECURITY_FILE"
+check_file_exists "$QUALITY_SCORE_FILE"
+check_file_exists "$LAYERED_DESIGN_FILE"
+check_file_exists "$DESIGN_INDEX_FILE"
+check_file_exists "$AUDIT_TYPES_FILE"
+
+check_absent_fixed_string \
+    "$ROADMAP_FILE" \
+    'kernel-level tool-call policy gate (`PolicyEngine::check_tool_call`)' \
+    "docs/ROADMAP.md still describes PolicyEngine::check_tool_call as the live tool-policy seam"
+
+check_absent_fixed_string \
+    "$LAYERED_DESIGN_FILE" \
+    'must call `PolicyEngine::check_tool_call` before dispatch' \
+    "docs/design-docs/layered-kernel-design.md still describes PolicyEngine::check_tool_call as the live tool-policy seam"
+
+check_present_fixed_string \
+    "$SECURITY_FILE" \
+    'PolicyExtensionChain' \
+    "docs/SECURITY.md must describe the live PolicyExtensionChain tool-policy seam"
+
+check_present_fixed_string \
+    "$LAYERED_DESIGN_FILE" \
+    'PolicyExtensionChain' \
+    "docs/design-docs/layered-kernel-design.md must describe the policy extension chain as the live request-policy seam"
+
+check_absent_fixed_string \
+    "$QUALITY_SCORE_FILE" \
+    'file.read`/`file.write` bypass policy check' \
+    "docs/QUALITY_SCORE.md still claims file tools bypass policy checks"
+
+check_absent_fixed_string \
+    "$QUALITY_SCORE_FILE" \
+    'Audit events in-memory only' \
+    "docs/QUALITY_SCORE.md still claims observability is in-memory only"
+
+check_absent_fixed_string \
+    "$DESIGN_INDEX_FILE" \
+    'audit events exist, in-memory only' \
+    "docs/design-docs/index.md still claims the audit system is in-memory only"
+
+implemented_audit_event_kinds="$(count_audit_event_kinds "$AUDIT_TYPES_FILE")"
+documented_audit_event_kinds="$(read_documented_audit_event_kind_count "$SECURITY_FILE")"
+
+if [ -z "$documented_audit_event_kinds" ]; then
+    fail "docs/SECURITY.md must declare the number of audit event kinds"
+elif [ "$implemented_audit_event_kinds" != "$documented_audit_event_kinds" ]; then
+    fail \
+        "docs/SECURITY.md says there are ${documented_audit_event_kinds} audit event kinds, but crates/contracts/src/audit_types.rs defines ${implemented_audit_event_kinds}"
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+    echo ""
+    echo "FAILED: $ERRORS governance doc consistency error(s)"
+    exit 1
+fi
+
+echo "Governance doc consistency checks passed."

--- a/scripts/test_bootstrap_release_local_artifacts.sh
+++ b/scripts/test_bootstrap_release_local_artifacts.sh
@@ -91,15 +91,22 @@ make_fixture_repo() {
   fixture="$(mktemp -d)"
   mkdir -p \
     "$fixture/scripts" \
+    "$fixture/docs/design-docs" \
     "$fixture/docs/releases" \
+    "$fixture/crates/contracts/src" \
     "$fixture/.github/ISSUE_TEMPLATE" \
     "$fixture/.github/workflows"
 
   cp "$REPO_ROOT/scripts/check-docs.sh" "$fixture/scripts/check-docs.sh"
+  cp "$REPO_ROOT/scripts/check_governance_docs_consistency.sh" \
+    "$fixture/scripts/check_governance_docs_consistency.sh"
   cp "$REPO_ROOT/scripts/release_artifact_lib.sh" "$fixture/scripts/release_artifact_lib.sh"
   chmod +x "$fixture/scripts/check-docs.sh"
+  chmod +x "$fixture/scripts/check_governance_docs_consistency.sh"
   cp "$REPO_ROOT/docs/releases/README.md" "$fixture/docs/releases/README.md"
   cp "$REPO_ROOT/docs/releases/TEMPLATE.md" "$fixture/docs/releases/TEMPLATE.md"
+  cp "$REPO_ROOT/crates/contracts/src/audit_types.rs" \
+    "$fixture/crates/contracts/src/audit_types.rs"
   cp "$REPO_ROOT/.github/ISSUE_TEMPLATE/config.yml" "$fixture/.github/ISSUE_TEMPLATE/config.yml"
   cp "$REPO_ROOT/.github/workflows/release.yml" "$fixture/.github/workflows/release.yml"
 
@@ -140,6 +147,50 @@ EOF
 EOF
   cp "$fixture/AGENTS.md" "$fixture/CLAUDE.md"
 
+  cat >"$fixture/docs/ROADMAP.md" <<'EOF'
+# LoongClaw Roadmap
+
+- kernel-level request-policy gate for tool calls through `PolicyEngine::authorize(...)`
+  plus `PolicyExtensionChain`, with explicit deny/approval-required outcomes before
+  tool dispatch (Rule of Two)
+EOF
+
+  cat >"$fixture/docs/SECURITY.md" <<'EOF'
+# Security
+
+CapabilityToken → PolicyEngine.authorize(...) → PolicyExtensionChain → Execution → Audit
+
+- 10 event kinds with atomic sequencing
+EOF
+
+  cat >"$fixture/docs/QUALITY_SCORE.md" <<'EOF'
+# Quality Score
+
+| Domain | Grade | Last Reviewed | Gaps |
+|--------|-------|---------------|------|
+| Kernel Security (L1) | B+ | 2026-04-03 | Core tool paths now route through policy extensions; remaining gaps are non-uniform L1 coverage for connector/ACP/runtime-only analytics and explicit `Direct` compatibility lanes |
+| Observability (L4) | C+ | 2026-04-03 | Durable JSONL/fanout audit exists; remaining gaps are tamper-evident verification, query baseline, and richer export lanes |
+EOF
+
+  cat >"$fixture/docs/design-docs/index.md" <<'EOF'
+# Design Documents Index
+
+| ID | Decision | Implementation Status |
+|----|----------|---------------------|
+| D-003 | Append-only event log as single source of truth | Partial — audit events exist, JSONL/fanout retention exists, no tamper-evident verification or query baseline yet |
+EOF
+
+  cat >"$fixture/docs/design-docs/layered-kernel-design.md" <<'EOF'
+# Layered Kernel Design
+
+- Tool plane core/extension execution must route deterministic request-policy approval through the
+  kernel authorization stack before dispatch: token/capability validation in `PolicyEngine::authorize`
+  plus tool-specific tightening in `PolicyExtensionChain` (Rule of Two: model intent plus
+  deterministic policy decision).
+- The deprecated `PolicyEngine::check_tool_call` hook remains compatibility-only and must not be
+  treated as the live request-policy seam.
+EOF
+
   printf '%s\n' "$fixture"
 }
 
@@ -148,15 +199,22 @@ make_prerelease_fixture_repo() {
   fixture="$(mktemp -d)"
   mkdir -p \
     "$fixture/scripts" \
+    "$fixture/docs/design-docs" \
     "$fixture/docs/releases" \
+    "$fixture/crates/contracts/src" \
     "$fixture/.github/ISSUE_TEMPLATE" \
     "$fixture/.github/workflows"
 
   cp "$REPO_ROOT/scripts/check-docs.sh" "$fixture/scripts/check-docs.sh"
+  cp "$REPO_ROOT/scripts/check_governance_docs_consistency.sh" \
+    "$fixture/scripts/check_governance_docs_consistency.sh"
   cp "$REPO_ROOT/scripts/release_artifact_lib.sh" "$fixture/scripts/release_artifact_lib.sh"
   chmod +x "$fixture/scripts/check-docs.sh"
+  chmod +x "$fixture/scripts/check_governance_docs_consistency.sh"
   cp "$REPO_ROOT/docs/releases/README.md" "$fixture/docs/releases/README.md"
   cp "$REPO_ROOT/docs/releases/TEMPLATE.md" "$fixture/docs/releases/TEMPLATE.md"
+  cp "$REPO_ROOT/crates/contracts/src/audit_types.rs" \
+    "$fixture/crates/contracts/src/audit_types.rs"
   cp "$REPO_ROOT/.github/ISSUE_TEMPLATE/config.yml" "$fixture/.github/ISSUE_TEMPLATE/config.yml"
   cp "$REPO_ROOT/.github/workflows/release.yml" "$fixture/.github/workflows/release.yml"
 
@@ -221,6 +279,50 @@ EOF
 # Mirror
 EOF
   cp "$fixture/AGENTS.md" "$fixture/CLAUDE.md"
+
+  cat >"$fixture/docs/ROADMAP.md" <<'EOF'
+# LoongClaw Roadmap
+
+- kernel-level request-policy gate for tool calls through `PolicyEngine::authorize(...)`
+  plus `PolicyExtensionChain`, with explicit deny/approval-required outcomes before
+  tool dispatch (Rule of Two)
+EOF
+
+  cat >"$fixture/docs/SECURITY.md" <<'EOF'
+# Security
+
+CapabilityToken → PolicyEngine.authorize(...) → PolicyExtensionChain → Execution → Audit
+
+- 10 event kinds with atomic sequencing
+EOF
+
+  cat >"$fixture/docs/QUALITY_SCORE.md" <<'EOF'
+# Quality Score
+
+| Domain | Grade | Last Reviewed | Gaps |
+|--------|-------|---------------|------|
+| Kernel Security (L1) | B+ | 2026-04-03 | Core tool paths now route through policy extensions; remaining gaps are non-uniform L1 coverage for connector/ACP/runtime-only analytics and explicit `Direct` compatibility lanes |
+| Observability (L4) | C+ | 2026-04-03 | Durable JSONL/fanout audit exists; remaining gaps are tamper-evident verification, query baseline, and richer export lanes |
+EOF
+
+  cat >"$fixture/docs/design-docs/index.md" <<'EOF'
+# Design Documents Index
+
+| ID | Decision | Implementation Status |
+|----|----------|---------------------|
+| D-003 | Append-only event log as single source of truth | Partial — audit events exist, JSONL/fanout retention exists, no tamper-evident verification or query baseline yet |
+EOF
+
+  cat >"$fixture/docs/design-docs/layered-kernel-design.md" <<'EOF'
+# Layered Kernel Design
+
+- Tool plane core/extension execution must route deterministic request-policy approval through the
+  kernel authorization stack before dispatch: token/capability validation in `PolicyEngine::authorize`
+  plus tool-specific tightening in `PolicyExtensionChain` (Rule of Two: model intent plus
+  deterministic policy decision).
+- The deprecated `PolicyEngine::check_tool_call` hook remains compatibility-only and must not be
+  treated as the live request-policy seam.
+EOF
 
   printf '%s\n' "$fixture"
 }

--- a/scripts/test_check_governance_docs_consistency.sh
+++ b/scripts/test_check_governance_docs_consistency.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+assert_contains() {
+    local file="$1"
+    local needle="$2"
+
+    if grep -Fq "$needle" "$file"; then
+        return
+    fi
+
+    echo "expected to find '$needle' in $file" >&2
+    cat "$file" >&2
+    exit 1
+}
+
+make_fixture_repo() {
+    local fixture
+    fixture="$(mktemp -d)"
+
+    mkdir -p \
+        "$fixture/scripts" \
+        "$fixture/docs/design-docs" \
+        "$fixture/crates/contracts/src"
+
+    cp "$REPO_ROOT/scripts/check_governance_docs_consistency.sh" \
+        "$fixture/scripts/check_governance_docs_consistency.sh"
+    cp "$REPO_ROOT/docs/ROADMAP.md" "$fixture/docs/ROADMAP.md"
+    cp "$REPO_ROOT/docs/SECURITY.md" "$fixture/docs/SECURITY.md"
+    cp "$REPO_ROOT/docs/QUALITY_SCORE.md" "$fixture/docs/QUALITY_SCORE.md"
+    cp "$REPO_ROOT/docs/design-docs/layered-kernel-design.md" \
+        "$fixture/docs/design-docs/layered-kernel-design.md"
+    cp "$REPO_ROOT/docs/design-docs/index.md" \
+        "$fixture/docs/design-docs/index.md"
+    cp "$REPO_ROOT/crates/contracts/src/audit_types.rs" \
+        "$fixture/crates/contracts/src/audit_types.rs"
+
+    chmod +x "$fixture/scripts/check_governance_docs_consistency.sh"
+
+    printf '%s\n' "$fixture"
+}
+
+run_happy_path_test() {
+    local fixture
+    local output_file
+
+    fixture="$(make_fixture_repo)"
+    output_file="$fixture/happy.out"
+    trap 'rm -rf "$fixture"' RETURN
+
+    (
+        cd "$fixture"
+        scripts/check_governance_docs_consistency.sh >"$output_file"
+    )
+
+    assert_contains "$output_file" "Governance doc consistency checks passed."
+}
+
+run_stale_policy_hook_test() {
+    local fixture
+    local output_file
+
+    fixture="$(make_fixture_repo)"
+    output_file="$fixture/stale-policy.out"
+    trap 'rm -rf "$fixture"' RETURN
+
+    cat <<'EOF_APPEND' >> "$fixture/docs/ROADMAP.md"
+- kernel-level tool-call policy gate (`PolicyEngine::check_tool_call`) with explicit deny/approval-required outcomes before tool dispatch
+EOF_APPEND
+
+    if (
+        cd "$fixture"
+        scripts/check_governance_docs_consistency.sh >"$output_file" 2>&1
+    ); then
+        echo "expected governance doc consistency check to fail on stale policy-hook wording" >&2
+        cat "$output_file" >&2
+        exit 1
+    fi
+
+    assert_contains "$output_file" "docs/ROADMAP.md still describes PolicyEngine::check_tool_call as the live tool-policy seam"
+}
+
+run_audit_event_count_mismatch_test() {
+    local fixture
+    local output_file
+
+    fixture="$(make_fixture_repo)"
+    output_file="$fixture/audit-count.out"
+    trap 'rm -rf "$fixture"' RETURN
+
+    python3 - "$fixture/docs/SECURITY.md" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+updated = text.replace("- 10 event kinds with atomic sequencing", "- 7 event kinds with atomic sequencing")
+path.write_text(updated)
+PY
+
+    if (
+        cd "$fixture"
+        scripts/check_governance_docs_consistency.sh >"$output_file" 2>&1
+    ); then
+        echo "expected governance doc consistency check to fail on audit event count mismatch" >&2
+        cat "$output_file" >&2
+        exit 1
+    fi
+
+    assert_contains "$output_file" "docs/SECURITY.md says there are 7 audit event kinds"
+}
+
+run_happy_path_test
+run_stale_policy_hook_test
+run_audit_event_count_mismatch_test
+
+echo "governance doc consistency script checks passed"


### PR DESCRIPTION
## Summary

- Problem:
  Top-level governance docs had drifted away from the live request-policy and audit-retention seams, and the public repo had no mechanical check preventing that drift from returning.
- Why it matters:
  LoongClaw treats the repository as the system of record. If the top-level policy and audit story is stale, later work starts from the wrong implementation truth.
- What changed:
  Reconciled the live policy/audit narrative in the roadmap, security, quality, and architecture docs, and added a dedicated docs-consistency gate plus regression script for the highest-risk governance claims.
- What did not change (scope boundary):
  No runtime behavior changed in this slice.
  The broader runtime-convergence assessment remains archived outside the public source repo.

## Linked Issues

- Closes #837
- Related #196
- Related #420
- Related #421
- Related #440
- Related loongclaw-ai/knowledge-base#18

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [x] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This PR changes the documented source of truth for live governance seams and adds a docs gate that will fail future PRs if those high-risk claims drift.
- Rollout / guardrails:
  The new gate is narrow and evidence-backed. It checks only the living top-level docs and compares the audit event count against the current contracts enum.
- Rollback path:
  Revert this PR.

## Validation

- [x] `bash -n scripts/check_governance_docs_consistency.sh scripts/test_check_governance_docs_consistency.sh`
- [x] `scripts/test_check_governance_docs_consistency.sh`
- [x] `bash scripts/test_bootstrap_release_local_artifacts.sh`
- [x] `scripts/check_governance_docs_consistency.sh`
- [x] `scripts/check-docs.sh`
- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked --quiet`
- [ ] `cargo test --workspace --all-features --locked --quiet`

Commands and evidence:

```text
bash -n scripts/check_governance_docs_consistency.sh scripts/test_check_governance_docs_consistency.sh
PASS

scripts/test_check_governance_docs_consistency.sh
PASS

scripts/check_governance_docs_consistency.sh
PASS

git diff --check
PASS

scripts/check-docs.sh
PASS, with the existing non-blocking local release-artifact warnings from .docs/ release traces

cargo fmt --all -- --check
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-pr-849-target cargo clippy --workspace --all-targets --all-features -- -D warnings
FAIL on the current origin/dev baseline in loongclaw-app

env CARGO_TARGET_DIR=/tmp/loongclaw-pr-849-target cargo test --workspace --locked --quiet
FAIL on the same current origin/dev baseline in loongclaw-app

env CARGO_TARGET_DIR=/tmp/loongclaw-pr-849-target cargo test --workspace --all-features --locked --quiet
FAIL on the same current origin/dev baseline in loongclaw-app

Observed baseline compile failures include:
- missing followup/denied tool helper symbols in conversation runtime code
- missing tool_request_summary fields in conversation runtime structs
- prepare_tool_intent callsite drift in conversation tests
- missing repairable shell-policy helper functions in shell policy extensions
```

## User-visible / Operator-visible Changes

- Top-level governance docs now describe the live tool-policy and audit-retention seams accurately.
- Future PRs will fail doc governance checks if they reintroduce stale request-policy or in-memory-audit claims.
- The source-repo slice stays docs-only and leaves the broader runtime-convergence assessment archived outside this repository.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `0078a6f0`.
- Observable failure symptoms reviewers should watch for:
  `scripts/check-docs.sh` will fail if the living docs bring back stale `check_tool_call` live-path wording, stale in-memory-audit claims, or an incorrect audit-event count.

## Reviewer Focus

- Review the top-level wording changes in `docs/ROADMAP.md`, `docs/SECURITY.md`, `docs/QUALITY_SCORE.md`, `docs/design-docs/index.md`, and `docs/design-docs/layered-kernel-design.md`.
- Review the new `scripts/check_governance_docs_consistency.sh` scope to confirm it is narrow, evidence-backed, and does not overfit beyond the intended living docs.
- Confirm that this branch is docs-only and that the broader runtime-convergence assessment remains archived outside the public source repo.

