### PR TITLE
docs: add runtime convergence layer and sync roadmap/quality docs

### DIFF
--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -7,18 +7,18 @@ Domain grades for LoongClaw. Updated periodically to track gaps, prioritize clea
 | Domain | Grade | Last Reviewed | Gaps |
 |--------|-------|---------------|------|
 | Contracts (L0) | A | 2026-03-13 | `#[non_exhaustive]` applied; membrane field not yet enforced at runtime |
-| Kernel Security (L1) | B+ | 2026-03-13 | Policy only gates `shell.exec`; `file.read`/`file.write` bypass policy check |
+| Kernel Security (L1) | B+ | 2026-04-03 | Core tool execution now flows through capability checks and `PolicyExtensionChain`; remaining gaps are connector/ACP/runtime-only analytics and compatibility-seam closure |
 | Execution Planes (L2) | B | 2026-03-13 | Core/extension pattern solid; no WASM fuel metering yet |
 | Orchestration (L3) | B | 2026-03-13 | HarnessBroker routes correctly; context-engine selection is pluggable, but richer engine implementations and broader runtime coverage are still limited |
-| Observability (L4) | C+ | 2026-03-13 | Audit events in-memory only; no HMAC chain; no persistent sink |
+| Observability (L4) | B- | 2026-04-03 | Durable JSONL and fanout audit bootstraps exist; no tamper-evident chain, richer external sink adapters, or broader operator-facing audit evidence products yet |
 | Vertical Packs (L5) | B | 2026-03-13 | Pack validation works; namespace struct exists but not enforced |
 | Protocol (L5.5) | B+ | 2026-03-13 | Transport contracts and typed routing operational |
 | Integration (L6) | B | 2026-03-13 | Plugin scanning works; hotplug lifecycle incomplete |
 | Plugin IR (L7) | B- | 2026-03-13 | Bridge inference works; multi-language support limited |
-| Self-Awareness (L8) | B- | 2026-03-13 | Snapshots generated but not continuous; no drift detection agent |
+| Self-Awareness (L8) | B- | 2026-04-03 | Monthly drift review artifacts exist, but continuous drift detection and automated reviewer guidance are still limited |
 | Bootstrap (L9) | B | 2026-03-13 | Activation plans work; no policy-bounded bootstrap validation |
 | Context/Memory | C | 2026-03-29 | Typed scopes and staged retrieval substrate now exist, but built-in retrieval is still session-summary-only; no operator-visible provenance contract; no FTS5/local search surface |
-| Documentation | A- | 2026-03-13 | Strong coverage across design docs, security, product sense, and quality tracking |
+| Documentation | A- | 2026-04-03 | Strong coverage across design docs, security, product sense, quality tracking, and AGT comparison context; still needs more release-grade benchmark and governance evidence summaries |
 | CI/Enforcement | A | 2026-03-13 | 8 CI workflows, convention-engineering (14 files, 11 checks), check:harness mirror gate |
 | Contributor Experience | A- | 2026-03-13 | Clear tracks and recipes; could add more examples |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # LoongClaw Roadmap
 
-Last updated: 2026-03-29
+Last updated: 2026-04-03
 
 This roadmap is execution-focused. Every stage has:
 
@@ -25,6 +25,24 @@ Build a layered Agentic OS kernel that is:
 3. High-risk actions require human authorization under policy.
 4. Untrusted plugins default to strict scan + restricted runtime.
 5. Every security-critical decision must be auditable.
+
+## Current Comparison-Driven Priorities
+
+The convergence layer captured in
+`docs/plans/2026-04-03-runtime-convergence-design.md`
+and
+`docs/plans/2026-04-03-runtime-convergence-implementation-plan.md`
+reinforces five near-term priorities for the current branch:
+
+1. keep architecture-truth docs aligned with the governed-path reality that the
+   code now implements
+2. continue shrinking optional-context and direct-mode compatibility seams so
+   `Direct` remains explicit and narrow
+3. finish Stage 2 runtime-isolation closure for WASM and process bridge lanes
+4. productize governance evidence through benchmark, verification, and
+   release-facing artifacts
+5. sequence ecosystem-facing packaging after the kernel/runtime closure work
+   above
 
 ## Stage 0: Kernel Contract Freeze (Done)
 
@@ -61,8 +79,9 @@ Delivered:
 - external profile integrity lock (`security_scan.profile_sha256`) with fail-closed behavior
 - external profile signature verification (`security_scan.profile_signature`, ed25519)
 - JSONL SIEM export lane (`security_scan.siem_export`) with optional fail-closed mode
-- kernel-level tool-call policy gate (`PolicyEngine::check_tool_call`) with explicit
-  deny/approval-required outcomes before tool dispatch (Rule of Two)
+- kernel-level tool-call policy gate through `authorize_pack_operation` and the
+  `PolicyExtensionChain`, with explicit deny/approval-required outcomes before
+  core tool dispatch (Rule of Two)
 - WASM static scan controls:
   - allowed artifact paths
   - module size cap
@@ -75,6 +94,8 @@ Remaining:
 
 - profile signing key lifecycle (rotation/revocation) and trust anchor management
 - SIEM transport adapters beyond file JSONL (HTTP/syslog/event bus)
+- connector/ACP/runtime-only analytics and remaining direct compatibility seams
+  still need to converge on the same L1 governance path
 
 Exit criteria:
 
@@ -481,7 +502,15 @@ Trade-off: wiring now locks in the API surface; waiting allows more usage patter
 
 ### D2: Persistent audit sink
 
-`InMemoryAuditSink` loses all audit events on process restart. For security-critical decisions (policy denials, token revocations) to be auditable post-incident, a durable sink is needed.
+Production app bootstraps now support durable JSONL retention and fanout audit
+mode, so the remaining observability gap is narrower than the earlier
+baseline.
+
+The next problem is:
+
+1. stronger tamper-evident audit retention
+2. richer query and export ergonomics
+3. consistent evidence behavior across non-app runtime seams
 
 Options:
 - SQLite audit table (reuse existing rusqlite dependency)
@@ -612,12 +641,28 @@ instead of preceding it.
 
 ## Current Priority Order
 
+This order is now described in more detail by:
+
+- `docs/plans/2026-04-03-runtime-convergence-design.md`
+- `docs/plans/2026-04-03-runtime-convergence-implementation-plan.md`
+
+Current order:
+
 1. Kernel-first runtime closure and direct-path retirement
+<<<<<<< HEAD
 2. Persistent audit sink and query baseline
 3. ACP control-plane hardening and recovery
 4. Local product control plane foundation
 5. Shared execution security tiers across process/browser/WASM lanes
 6. First-party workflow packs on hardened runtime primitives
+=======
+2. Durable session and memory runtime with stronger audit evidence
+3. ACP and app-layer control-plane hardening and recovery
+4. Tool productization and scheduling on top of truthful runtime evidence
+5. Approval surface unification
+6. Shared execution security tiers across process/browser/WASM lanes
+7. First-party workflow packs on hardened runtime primitives
+>>>>>>> d5fc7861 (docs: add runtime convergence layer)
 
 Execution package for this order:
 

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -30,7 +30,7 @@ Catalog of design documents and architectural decisions.
 |---------|-------------|----------------|
 | Core/Extension split | Every execution plane has a core adapter and optional extensions | `kernel/src/tool.rs`, `runtime.rs`, `memory.rs`, `connector.rs` |
 | Capability-gated access | Every resource access requires an explicit capability token | `kernel/src/policy.rs` |
-| Rule of Two | Tool calls require both LLM intent and deterministic policy approval | `kernel/src/policy.rs` |
+| Rule of Two | Tool calls require both LLM intent and deterministic policy approval through governed dispatch plus policy extensions | `kernel/src/policy_ext.rs`, `app/src/tools/*_policy_ext.rs` |
 | Registry pattern | Adapters registered by name into `BTreeMap<String, Arc<dyn Trait>>` | All execution planes |
 | Generation-based revocation | `AtomicU64` threshold invalidates all tokens with generation <= N | `kernel/src/kernel.rs` |
 | Policy extension chain | Chain-of-responsibility: multiple extensions evaluated in order, any can deny | `kernel/src/policy_ext.rs` |
@@ -55,7 +55,7 @@ All decisions from the research repository. Status reflects implementation reali
 
 | ID | Decision | Implementation Status |
 |----|----------|---------------------|
-| D-003 | Append-only event log as single source of truth | Partial — audit events exist, in-memory only (TD-006) |
+| D-003 | Append-only event log as single source of truth | Partial — typed audit events exist with in-memory, JSONL, and fanout sinks; the event log is not yet the single query or materialization source |
 | D-004 | Materialized views from event log | Not started |
 | D-005 | Control/data plane separation | Partial — planes exist, not fully separated |
 | D-006 | Consensus-agnostic event log trait | Not started — no trait defined |

--- a/docs/plans/2026-04-03-runtime-convergence-design.md
+++ b/docs/plans/2026-04-03-runtime-convergence-design.md
@@ -1,0 +1,297 @@
+# Runtime Convergence Design
+
+Date: 2026-04-03
+
+Related:
+
+- issue `#837`
+- implementation package:
+  `docs/plans/2026-04-03-runtime-convergence-implementation-plan.md`
+
+## Goal
+
+Define one convergence layer above the current leaf plans so the next stage of
+LoongClaw runtime work is sequenced explicitly rather than inferred from many
+independent documents.
+
+This design uses the public `microsoft/agent-governance-toolkit` repository as
+an external reference point, not as a template to copy directly.
+
+## Why This Exists
+
+LoongClaw already has many strong plan documents across governed runtime
+closure, memory, approvals, tool surfaces, and protocol/runtime hardening.
+
+The missing artifact is not another leaf plan. The missing artifact is one
+explicit sequence layer that answers:
+
+1. which themes belong to the same next-stage runtime arc
+2. which existing plans remain authoritative within each theme
+3. what order reduces overlap in the app-layer hotspots
+4. what lessons from a mature public governance repository are worth borrowing
+   without weakening the kernel-first design
+
+## External Reference Summary
+
+The external repository is useful because it proves a different kind of
+strength:
+
+- governance as a consumable product surface
+- retrofit-style adoption paths
+- operator-facing evidence such as benchmarks, control mapping, and release
+  artifacts
+- ecosystem packaging across multiple adapters and SDKs
+
+LoongClaw should learn from those delivery patterns. It should not abandon its
+current architectural advantage:
+
+- typed contract surfaces
+- kernel-owned governance seams
+- explicit governed versus direct runtime bindings
+- stronger long-term runtime-isolation potential
+
+## Current Repo Truth
+
+The convergence layer is based on the current repository, not on old roadmap
+claims.
+
+### What Is Strong Today
+
+1. The workspace remains a strict 7-crate DAG.
+2. Core tool and memory execution already route through kernel policy and audit
+   seams.
+3. Conversation and provider paths now use explicit runtime bindings rather than
+   relying only on raw optional kernel context.
+4. Audit bootstrap is more truthful than some older docs imply: production
+   runtime can use durable JSONL and fanout sinks.
+5. Runtime evidence is converging across `process_stdio`, `http_json`, and WASM
+   lanes.
+
+### What Is Still Incomplete
+
+1. Architecture-truth docs still lag current code in a few places.
+2. Compatibility seams remain numerous around optional kernel authority and
+   direct-mode normalization.
+3. Runtime isolation remains partially delivered rather than fully closed.
+4. Governance evidence exists internally but is not yet packaged as an operator
+   product surface.
+
+## Convergence Themes
+
+The next stage should be sequenced around five themes.
+
+### Theme 1. Governed Path Closure
+
+Purpose:
+
+Make kernel-first execution more structurally true by continuing to narrow
+direct-mode and optional-context seams.
+
+Why it belongs first:
+
+- it protects the core architecture claim
+- it reduces ambiguity before later runtime or product-surface work
+- it lowers the chance that later features land on permissive compatibility
+  paths
+
+### Theme 2. Durable Session And Memory Runtime
+
+Purpose:
+
+Stabilize the memory/session substrate that governed runtime depends on.
+
+Why it comes early:
+
+- governed runtime hardening is less meaningful if session and memory behavior
+  still carry avoidable drift or runtime-specific inconsistencies
+- several later operator and evidence surfaces depend on stable memory and
+  history semantics
+
+### Theme 3. App-Layer Control-Plane Decomposition
+
+Purpose:
+
+Reduce hotspot overlap in the app layer by clarifying which responsibilities
+belong to conversation runtime, approval flow, operator/delegate control, and
+ACP-style orchestration.
+
+Why it must follow the first two themes:
+
+- otherwise control-plane cleanup can accidentally reopen authority drift
+- memory and governed-path truth should be stable before decomposing the higher
+  coordination layer
+
+### Theme 4. Tool Productization And Scheduling
+
+Purpose:
+
+Turn strong internal tool/runtime capabilities into more explicit product
+surfaces, benchmarked scheduling behavior, and operator-facing evidence.
+
+Why it comes after the earlier runtime closure work:
+
+- external productization works best after the execution contract is stable
+- otherwise operator-facing artifacts risk documenting transient behavior
+
+### Theme 5. Approval Surface Unification
+
+Purpose:
+
+Converge approval, consent, risk, and replay behavior into one clearer runtime
+surface.
+
+Why it is last in this convergence layer:
+
+- approval sits across governed execution, memory continuity, and control-plane
+  behavior
+- it benefits from earlier closure of authority seams and runtime decomposition
+
+## Existing Leaf Plans That Remain Authoritative
+
+The convergence layer does not replace the current leaf plans. It sequences
+them.
+
+### Theme 1. Governed Path Closure
+
+Primary references:
+
+- `docs/plans/2026-03-15-conversation-runtime-binding-design.md`
+- `docs/plans/2026-03-15-conversation-runtime-binding-implementation-plan.md`
+- `docs/plans/2026-03-15-provider-binding-normalization-design.md`
+- `docs/plans/2026-03-15-provider-binding-normalization-implementation-plan.md`
+- `docs/plans/2026-03-16-governed-runtime-path-hardening-design.md`
+- `docs/plans/2026-03-16-governed-runtime-path-hardening-implementation-plan.md`
+
+Active issue alignment:
+
+- `#766`
+- `#838`
+- `#839`
+
+### Theme 2. Durable Session And Memory Runtime
+
+Primary references:
+
+- `docs/plans/2026-03-11-loongclaw-memory-architecture-design.md`
+- `docs/plans/2026-03-11-loongclaw-memory-architecture-implementation.md`
+- `docs/plans/2026-03-12-memory-context-kernel-unification-design.md`
+- `docs/plans/2026-03-12-memory-context-kernel-unification-implementation-plan.md`
+- `docs/plans/2026-03-23-durable-recall-bootstrap-implementation-plan.md`
+- `docs/plans/2026-03-24-runtime-self-advisory-boundary-design.md`
+- `docs/plans/2026-03-24-runtime-self-advisory-boundary-implementation-plan.md`
+
+### Theme 3. App-Layer Control-Plane Decomposition
+
+Primary references:
+
+- `docs/plans/2026-03-17-constrained-delegate-subagent-design.md`
+- `docs/plans/2026-03-17-constrained-delegate-subagent-implementation-plan.md`
+- `docs/plans/2026-03-22-multi-session-concurrent-channel-dispatch-design.md`
+- `docs/plans/2026-03-22-multi-session-concurrent-channel-dispatch-implementation-plan.md`
+- `docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md`
+- `docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md`
+
+### Theme 4. Tool Productization And Scheduling
+
+Primary references:
+
+- `docs/plans/2026-03-15-tool-discovery-architecture.md`
+- `docs/plans/2026-03-15-product-surface-productization-design.md`
+- `docs/plans/2026-03-15-product-surface-productization-implementation-plan.md`
+- `docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-design.md`
+- `docs/plans/2026-03-17-conversation-fast-lane-parallel-tool-batch-implementation-plan.md`
+- `docs/plans/2026-03-18-runtime-capability-index-readiness-gate-design.md`
+- `docs/plans/2026-03-18-runtime-capability-index-readiness-gate-implementation-plan.md`
+- `docs/plans/2026-03-27-conversation-turn-tool-token-benchmark-design.md`
+- `docs/plans/2026-03-27-conversation-turn-tool-token-benchmark-implementation-plan.md`
+
+### Theme 5. Approval Surface Unification
+
+Primary references:
+
+- `docs/plans/2026-03-15-issue-128-approval-attention-rebuild-design.md`
+- `docs/plans/2026-03-15-issue-128-approval-attention-rebuild.md`
+- `docs/plans/2026-03-18-delegate-runtime-effective-contract-alignment-design.md`
+- `docs/plans/2026-03-18-delegate-runtime-effective-contract-alignment-implementation-plan.md`
+- `docs/plans/2026-03-26-autonomy-policy-kernel-architecture.md`
+- `docs/plans/2026-03-26-autonomy-policy-kernel-implementation-plan.md`
+
+## Recommended Execution Order
+
+The preferred order is:
+
+1. governed path closure
+2. durable session and memory runtime
+3. app-layer control-plane decomposition
+4. tool productization and scheduling
+5. approval surface unification
+
+## Why This Order Is Preferred
+
+### Governed Path Closure Before Memory And Control-Plane Work
+
+If the governed-path story is still semantically loose, later work risks
+landing on ambiguous authority seams.
+
+### Memory Before Control-Plane Decomposition
+
+Control-plane cleanup is easier when session persistence, memory assembly, and
+runtime self-continuity are already clearer and more stable.
+
+### Decomposition Before Productization
+
+Operator-facing product surfaces should describe stabilized runtime behavior,
+not transient hotspot internals.
+
+### Approval Unification After Earlier Closure
+
+Approval touches governance, runtime sequencing, and operator experience. It is
+best converged after the underlying execution and control-plane seams are
+clearer.
+
+## What The External Comparison Changes
+
+The comparison does not change LoongClaw's architectural direction.
+
+It does change emphasis in three ways:
+
+1. it raises the priority of architecture-truth sync and operator-facing
+   evidence
+2. it confirms that retrofit and product-surface packaging should happen after
+   core runtime closure, not before
+3. it strengthens the case for finishing runtime isolation because that is the
+   clearest area where LoongClaw can become stronger than application-layer
+   governance middleware
+
+## Non-Goals
+
+1. Do not replace all current leaf plans with this document.
+2. Do not turn the repo into a copy of another governance framework.
+3. Do not use this document to justify broad delete-first architecture work.
+4. Do not claim runtime behavior changed just because the planning layer is now
+   clearer.
+
+## Sources
+
+External:
+
+- https://github.com/microsoft/agent-governance-toolkit
+- https://raw.githubusercontent.com/microsoft/agent-governance-toolkit/main/docs/ARCHITECTURE.md
+- https://raw.githubusercontent.com/microsoft/agent-governance-toolkit/main/BENCHMARKS.md
+- https://raw.githubusercontent.com/microsoft/agent-governance-toolkit/main/CHANGELOG.md
+- https://raw.githubusercontent.com/microsoft/agent-governance-toolkit/main/docs/OWASP-COMPLIANCE.md
+- https://github.com/microsoft/agent-governance-toolkit/releases
+
+Internal:
+
+- `ARCHITECTURE.md`
+- `docs/ROADMAP.md`
+- `docs/SECURITY.md`
+- `docs/QUALITY_SCORE.md`
+- `crates/kernel/src/kernel.rs`
+- `crates/kernel/src/policy_ext.rs`
+- `crates/contracts/src/audit_types.rs`
+- `crates/app/src/context.rs`
+- `crates/app/src/conversation/runtime_binding.rs`
+- `crates/app/src/conversation/runtime.rs`
+- `crates/spec/src/spec_runtime.rs`

--- a/docs/plans/2026-04-03-runtime-convergence-implementation-plan.md
+++ b/docs/plans/2026-04-03-runtime-convergence-implementation-plan.md
@@ -1,0 +1,176 @@
+# Runtime Convergence Implementation Plan
+
+Date: 2026-04-03
+
+## Goal
+
+Translate `docs/plans/2026-04-03-runtime-convergence-design.md` into a bounded
+execution plan that sequences the next runtime stage without replacing the
+existing leaf plans.
+
+This is a documentation-only implementation plan. It defines order, ownership
+of themes, and verification expectations. It does not claim runtime behavior
+changes.
+
+## Requirements Summary
+
+The convergence layer should produce these outcomes:
+
+1. maintainers can see one explicit next-stage execution order
+2. existing leaf plans remain authoritative within their narrow seams
+3. runtime work stops overlapping casually in the same app-layer hotspots
+4. external-reference lessons are captured without changing LoongClaw's
+   kernel-first architecture
+5. the repository truth sources stay aligned with the actual governed-path
+   reality
+
+## Acceptance Criteria
+
+1. The repository contains one convergence design note and one convergence
+   implementation plan in `docs/plans/`.
+2. The convergence docs identify the five runtime themes and explain why they
+   must be sequenced together.
+3. Each theme maps to the existing leaf plans that remain authoritative.
+4. The docs state a recommended execution order and explain why that order is
+   preferred.
+5. The resulting PR is documentation-only and does not claim runtime behavior
+   changed.
+
+## Workstreams
+
+### Workstream 1. Truth-Sync Artifacts
+
+Scope:
+
+- align `docs/ROADMAP.md` with current governed-path reality
+- align `docs/QUALITY_SCORE.md` with current security and observability state
+- add the convergence design and implementation plan documents
+
+Why first:
+
+- all other work depends on truthful baseline docs
+
+Exit condition:
+
+- repo-facing docs no longer describe retired tool-policy and audit defaults as
+  if they were current
+
+### Workstream 2. Governed Path Closure
+
+Scope:
+
+- continue work under the existing governed-path and binding-first plans
+- treat `#766`, `#838`, and `#839` as the most immediate active issue lane
+
+Required closure before advancing:
+
+- direct-mode and optional-context behavior is narrower and more explicit at
+  production entrypoints
+- new work does not reintroduce ambiguous authority semantics deeper in the
+  runtime
+
+### Workstream 3. Durable Session And Memory Runtime
+
+Scope:
+
+- continue the memory and durable recall tracks after governed-path closure is
+  stable enough to stop reopening authority questions
+
+Required closure before advancing:
+
+- session and memory runtime behavior is stable enough that later control-plane
+  cleanup is not fighting persistence ambiguity
+
+### Workstream 4. App-Layer Control-Plane Decomposition
+
+Scope:
+
+- decompose conversation/operator/delegate/control-plane hotspots only after the
+  first two workstreams are materially settled
+
+Required closure before advancing:
+
+- hotspot reduction is happening without reintroducing governance drift
+
+### Workstream 5. Tool Productization And Scheduling
+
+Scope:
+
+- convert mature internal runtime/tool behavior into clearer product and
+  benchmark surfaces
+
+Required closure before advancing:
+
+- artifacts describe stabilized behavior rather than in-flight churn
+
+### Workstream 6. Approval Surface Unification
+
+Scope:
+
+- unify approval and consent semantics after the earlier runtime and
+  control-plane seams are clearer
+
+Required closure for this stage:
+
+- approval no longer has to compensate for unresolved authority and lifecycle
+  drift in deeper runtime layers
+
+## Sequencing Rules
+
+1. Do not start broad control-plane decomposition before governed-path closure
+   and memory stabilization have stopped moving the authority contract.
+2. Do not lead with ecosystem/product packaging before the runtime contract is
+   stable enough to document honestly.
+3. Do not use approval work as a substitute for missing governed-path closure.
+4. Keep each later PR linked back to both the convergence layer and the narrow
+   leaf plan it is actually implementing.
+
+## Issue Mapping
+
+The current active or relevant issues already show where the first execution
+pressure exists:
+
+- `#766` for binding-first seam tightening
+- `#838` for fail-closed app-tool execution under missing kernel context
+- `#839` for production conversation entrypoint hardening
+- `#48` for the long-term handle-model discussion that remains separate from
+  this convergence layer
+- `#458` for governance-simplification classification, which remains adjacent
+  context rather than the execution parent for this runtime sequence
+
+## Deliverable Shape For Later PRs
+
+Each later implementation PR under this convergence layer should do four
+things:
+
+1. name the specific theme it belongs to
+2. reference the narrow leaf plan it implements
+3. state what changed and what did not change
+4. provide verification evidence proportionate to the touched runtime seam
+
+## Verification Plan
+
+For this documentation-only slice:
+
+1. verify the new convergence docs are present and internally consistent
+2. verify roadmap and quality-score edits match the current code and security
+   docs
+3. run repo checks appropriate for a documentation-only commit, plus the
+   repository's required CI-parity gates before commit
+
+For later implementation slices:
+
+1. governed-path changes require runtime regression tests
+2. memory/runtime work requires persistence and history-path validation
+3. control-plane decomposition requires hotspot and behavior regression checks
+4. productization work requires artifact generation and documentation truth
+   validation
+5. approval work requires explicit negative and replay-path controls
+
+## Non-Goals
+
+1. This plan does not replace the existing leaf plans.
+2. This plan does not introduce new product goals outside the current
+   LoongClaw direction.
+3. This plan does not authorize broad runtime rewrites without a narrow parent
+   issue and evidence-backed scope.


### PR DESCRIPTION
## Summary

- Problem:
  the next runtime stage was spread across many leaf plans, and the repo lacked one explicit convergence layer that sequences that work above the existing narrow docs.
- Why it matters:
  LoongClaw treats the repository as the system of record. If the top-level runtime roadmap and quality summaries drift away from the live governed-path reality, later implementation work starts from the wrong architecture truth.
- What changed:
  added a runtime convergence design note, added a matching implementation plan, updated `docs/ROADMAP.md`, updated `docs/QUALITY_SCORE.md`, and refreshed the relevant design-doc index entries to reflect the current policy and audit story.
- What did not change (scope boundary):
  no runtime behavior, policy behavior, or production code path changed in this PR.

## Linked Issues

- Closes #837
- Related #48
- Related #458

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --check
./scripts/check-docs.sh
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-docs-runtime-convergence-clean-target cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-docs-runtime-convergence-clean-target cargo test --workspace --locked --quiet
CARGO_TARGET_DIR=/tmp/loongclaw-docs-runtime-convergence-clean-target cargo test --workspace --all-features --locked --quiet

Results:
- git diff --check: PASS
- scripts/check-docs.sh: PASS, with the existing non-blocking local release-artifact warnings from .docs/ release traces
- cargo fmt --all -- --check: PASS
- cargo clippy --workspace --all-targets --all-features -- -D warnings: FAIL on the current origin/dev baseline in loongclaw-app
- cargo test --workspace --locked --quiet: FAIL on the same current origin/dev baseline compile errors in loongclaw-app
- cargo test --workspace --all-features --locked --quiet: FAIL on the same current origin/dev baseline compile errors in loongclaw-app

Observed baseline compile failures:
- missing or mismatched turn-summary symbols in crates/app/src/conversation/turn_coordinator.rs and crates/app/src/conversation/turn_loop.rs
- missing helper symbols in crates/app/src/tools/shell_policy_ext.rs
- prepare_tool_intent callsite drift in crates/app/src/conversation/turn_engine.rs

This PR does not touch those runtime files.
```

## User-visible / Operator-visible Changes

- Added a docs-only convergence layer that sequences the next runtime stage into five themes.
- Updated roadmap and quality-score language to match the current governed-path and audit evidence story more closely.
- Kept the slice additive and tied to the existing issue and leaf-plan structure.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR only.
- Observable failure symptoms reviewers should watch for:
  stale or overclaimed roadmap language, convergence sequencing that replaces rather than reuses leaf plans, or quality-score wording that no longer matches the current security docs.

## Reviewer Focus

- Check that the convergence layer stays additive and does not replace the existing leaf plans.
- Check that the truth-sync updates match the current policy and audit narrative without overstating implementation.
- Check that the validation section clearly distinguishes docs checks that passed from current origin/dev baseline build failures unrelated to this docs-only slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quality score documentation with revised security, observability, and governance assessments reflecting current system capabilities.
  * Refreshed roadmap with new near-term convergence priorities and implementation sequencing.
  * Added runtime convergence design and implementation planning documents to clarify the next stage of development priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->