### PR TITLE
test(acpx): stabilize fake runtime startup deadlines

### DIFF
--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -1741,6 +1741,9 @@ mod tests {
     use crate::config::{AcpBackendProfilesConfig, AcpConfig, AcpxBackendConfig, LoongClawConfig};
 
     #[cfg(unix)]
+    const ACPX_FAKE_RUNTIME_STARTUP_TIMEOUT_MS: u64 = 60_000;
+
+    #[cfg(unix)]
     fn unique_temp_dir(prefix: &str) -> PathBuf {
         static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
         let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
@@ -2020,18 +2023,28 @@ exit 0
 
     #[cfg(unix)]
     fn fake_acpx_config(script_path: &Path, cwd: &Path) -> LoongClawConfig {
+        let command = script_path.display().to_string();
+        let working_directory = cwd.display().to_string();
+        let expected_version = "0.1.16".to_owned();
+        let permission_mode = "approve-reads".to_owned();
+        let non_interactive_permissions = "fail".to_owned();
+        let timeout_seconds = 12.5;
+        let queue_owner_ttl_seconds = 0.25;
+        let startup_timeout_ms = ACPX_FAKE_RUNTIME_STARTUP_TIMEOUT_MS;
+
         LoongClawConfig {
             acp: AcpConfig {
+                startup_timeout_ms: Some(startup_timeout_ms),
                 allow_mcp_server_injection: false,
                 backends: AcpBackendProfilesConfig {
                     acpx: Some(AcpxBackendConfig {
-                        command: Some(script_path.display().to_string()),
-                        expected_version: Some("0.1.16".to_owned()),
-                        cwd: Some(cwd.display().to_string()),
-                        permission_mode: Some("approve-reads".to_owned()),
-                        non_interactive_permissions: Some("fail".to_owned()),
-                        timeout_seconds: Some(12.5),
-                        queue_owner_ttl_seconds: Some(0.25),
+                        command: Some(command),
+                        expected_version: Some(expected_version),
+                        cwd: Some(working_directory),
+                        permission_mode: Some(permission_mode),
+                        non_interactive_permissions: Some(non_interactive_permissions),
+                        timeout_seconds: Some(timeout_seconds),
+                        queue_owner_ttl_seconds: Some(queue_owner_ttl_seconds),
                         ..AcpxBackendConfig::default()
                     }),
                 },
@@ -2039,6 +2052,18 @@ exit 0
             },
             ..LoongClawConfig::default()
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn fake_acpx_config_uses_explicit_process_test_startup_timeout() {
+        let temp_dir = unique_temp_dir("loongclaw-acpx-config-timeout");
+        let script_path = temp_dir.join("fake-acpx");
+
+        let config = fake_acpx_config(&script_path, &temp_dir);
+        let startup_timeout_ms = config.acp.startup_timeout_ms();
+
+        assert_eq!(startup_timeout_ms, ACPX_FAKE_RUNTIME_STARTUP_TIMEOUT_MS);
     }
 
     #[tokio::test]

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T12:07:16Z
+- Generated at: 2026-04-03T12:31:07Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -17,7 +17,7 @@
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.0% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 343 | 650 | 307 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -3.7% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
-| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2716 | 2800 | 84 | 56 | 65 | 9 | 97.0% | TIGHT | 2698 | 0.7% | PASS | 56 |
+| acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2741 | 2800 | 59 | 56 | 65 | 9 | 97.9% | TIGHT | 2698 | 1.6% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10464 | 10500 | 36 | 88 | 90 | 2 | 99.7% | TIGHT | 9922 | 5.5% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.8%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.8%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -62,7 +62,7 @@
 <!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=343 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
-<!-- arch-hotspot key=acpx_runtime lines=2716 functions=56 -->
+<!-- arch-hotspot key=acpx_runtime lines=2741 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=10464 functions=88 -->
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->


### PR DESCRIPTION
## Summary

- Problem:
  `cargo test --workspace --all-features --locked` was failing in three
  `acp::acpx` fake-runtime tests because the helper config inherited the
  production default ACP startup timeout, which was too optimistic for
  all-features process-test load.
- Why it matters:
  This created a false-negative validation gap in the ACPX control-plane
  coverage and made all-features CI-parity runs unreliable.
- What changed:
  The fake ACPX test helper now sets an explicit process-test startup timeout,
  and a guard test asserts that the helper keeps using that explicit timeout.
- What did not change (scope boundary):
  No production ACPX runtime behavior changed.
  No user-facing config default changed.

## Linked Issues

- Closes #850

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-acpx-fix-ci cargo clippy --workspace --all-targets --all-features -- -D warnings
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-acpx-fix-ci cargo test --workspace --locked
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-acpx-fix-ci cargo test --workspace --all-features --locked
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-acpx-fix-ci cargo test -p loongclaw-app --all-features runtime_backend_executes_session_turn_and_controls -- --nocapture --test-threads=1
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-acpx-fix-ci cargo test -p loongclaw-app --all-features ensure_session_falls_back_to_sessions_new_when_ensure_has_no_identifiers -- --nocapture --test-threads=1
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-acpx-fix-ci cargo test -p loongclaw-app --all-features runtime_backend_supports_local_abort_for_running_prompt -- --nocapture --test-threads=1
PASS
```

## User-visible / Operator-visible Changes

- None. This only stabilizes ACPX fake-runtime test coverage.

## Failure Recovery

- Fast rollback or disable path:
  Revert this test-only commit.
- Observable failure symptoms reviewers should watch for:
  ACPX fake-runtime tests timing out again under all-features validation.

## Reviewer Focus

- Check that the timeout widening is isolated to the fake ACPX test helper.
- Check that no production ACP config defaults changed.
- Check that the new guard test protects against future drift back to the default startup timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Tests**
- Added new test coverage for startup timeout configuration validation.
- Improved test helper organization to reduce code duplication and enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->