### PR TITLE
Require kernel-bound runtime for delegate_async

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -19989,6 +19989,305 @@ async fn spawn_background_delegate_with_runtime_uses_default_timeout_when_omitte
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
+async fn handle_turn_with_runtime_delegate_async_direct_binding_fails_before_persisting_approval() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-async", "direct-preflight-denied")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Delegating async.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
+                    "task": "child async task",
+                    "label": "async-child"
+                }),
+                "root-session",
+                "turn-delegate-async-direct",
+                "call-delegate-async-direct",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_async_delegate_spawner(spawner.clone())
+    .with_durable_memory_config(memory_config.clone());
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("delegate_async direct denial reply");
+
+    assert!(
+        reply.contains("governed_runtime_binding_required"),
+        "expected governed runtime binding denial, got: {reply}"
+    );
+    assert_eq!(
+        repo.list_sessions()
+            .expect("list sessions after direct denial")
+            .len(),
+        1,
+        "direct delegate_async denial should not create a child session"
+    );
+    assert_eq!(
+        spawner
+            .requests
+            .lock()
+            .expect("async delegate requests lock")
+            .len(),
+        0,
+        "direct delegate_async denial should not dispatch the async spawner"
+    );
+    assert!(
+        repo.list_approval_requests_for_session("root-session", None)
+            .expect("list approval requests after direct denial")
+            .is_empty(),
+        "direct delegate_async denial should happen before approval request persistence"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_delegate_async_direct_binding_still_fails_when_preapproved() {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id("conversation-delegate-async", "direct-preapproved-denied")
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    enable_guided_autonomy(&mut config);
+    preapprove_tool_call(&mut config, "delegate_async");
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "Delegating async.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "delegate_async",
+                json!({
+                    "task": "child async task",
+                    "label": "async-child"
+                }),
+                "root-session",
+                "turn-delegate-async-preapproved",
+                "call-delegate-async-preapproved",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_async_delegate_spawner(spawner.clone())
+    .with_durable_memory_config(memory_config.clone());
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("delegate_async preapproved direct denial reply");
+
+    assert!(
+        reply.contains("governed_runtime_binding_required"),
+        "expected governed runtime binding denial, got: {reply}"
+    );
+    assert_eq!(
+        repo.list_visible_sessions("root-session")
+            .expect("list visible sessions after preapproved denial")
+            .into_iter()
+            .filter(|session| session.parent_session_id.as_deref() == Some("root-session"))
+            .count(),
+        0,
+        "preapproved direct delegate_async denial should not create a child session"
+    );
+    assert_eq!(
+        spawner
+            .requests
+            .lock()
+            .expect("async delegate requests lock")
+            .len(),
+        0,
+        "preapproved direct delegate_async denial should not dispatch the async spawner"
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
+async fn handle_turn_with_runtime_approval_request_resolve_keeps_delegate_async_pending_without_kernel_binding()
+ {
+    let db_path = std::env::temp_dir().join(format!(
+        "{}.sqlite3",
+        unique_acp_test_id(
+            "conversation-approval-resolve",
+            "delegate-async-direct-pending"
+        )
+    ));
+    let _ = std::fs::remove_file(&db_path);
+
+    let mut config = test_config();
+    config.memory.sqlite_path = db_path.display().to_string();
+    let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
+        approval_request_id: "apr-delegate-async-direct".to_owned(),
+        session_id: "root-session".to_owned(),
+        turn_id: "turn-delegate-async-parent".to_owned(),
+        tool_call_id: "call-delegate-async-parent".to_owned(),
+        tool_name: "delegate_async".to_owned(),
+        approval_key: "tool:delegate_async".to_owned(),
+        request_payload_json: json!({
+            "session_id": "root-session",
+            "parent_session_id": Value::Null,
+            "turn_id": "turn-delegate-async-parent",
+            "tool_call_id": "call-delegate-async-parent",
+            "tool_name": "delegate_async",
+            "args_json": {
+                "task": "child async task",
+                "label": "async-child"
+            },
+            "source": "provider_tool_call",
+            "execution_kind": "app"
+        }),
+        governance_snapshot_json: json!({
+            "governance_scope": "topology_mutation",
+            "risk_class": "high",
+            "approval_mode": "policy_driven",
+            "rule_id": "governed_tool_requires_approval",
+            "reason": "operator approval required before running `delegate_async`"
+        }),
+    })
+    .expect("seed approval request");
+
+    let spawner = Arc::new(FakeAsyncDelegateSpawner::default());
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![Ok(ProviderTurn {
+            assistant_text: "resolving async approval".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "approval_request_resolve",
+                json!({
+                    "approval_request_id": "apr-delegate-async-direct",
+                    "decision": "approve_once"
+                }),
+                "root-session",
+                "turn-approval-resolve",
+                "call-approval-resolve",
+            )],
+            raw_meta: Value::Null,
+        })],
+        vec![],
+    )
+    .with_async_delegate_spawner(spawner.clone())
+    .with_durable_memory_config(memory_config.clone());
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("approval resolve direct denial reply");
+
+    assert!(
+        reply.contains("governed_runtime_binding_required"),
+        "expected governed runtime binding denial, got: {reply}"
+    );
+    assert_eq!(
+        repo.list_visible_sessions("root-session")
+            .expect("list visible sessions after approval replay denial")
+            .into_iter()
+            .filter(|session| session.parent_session_id.as_deref() == Some("root-session"))
+            .count(),
+        0,
+        "direct approval replay should not create a delegate_async child session"
+    );
+    assert_eq!(
+        spawner
+            .requests
+            .lock()
+            .expect("async delegate requests lock")
+            .len(),
+        0,
+        "direct approval replay should not dispatch the async spawner"
+    );
+
+    let request = repo
+        .load_approval_request("apr-delegate-async-direct")
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(
+        request.status,
+        crate::session::repository::ApprovalRequestStatus::Pending
+    );
+    assert_eq!(request.decision, None);
+    assert_eq!(request.resolved_by_session_id, None);
+    assert!(request.executed_at.is_none(), "request={request:?}");
+    assert!(request.last_error.is_none(), "request={request:?}");
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[tokio::test]
 async fn handle_turn_with_runtime_delegate_async_queue_failure_rolls_back_child_creation() {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3813,7 +3813,18 @@ where
         approval_request: &ApprovalRequestRecord,
     ) -> Result<bool, String> {
         let execution_kind = self.replay_execution_kind(approval_request)?;
-        Ok(execution_kind == ToolExecutionKind::Core)
+        if execution_kind == ToolExecutionKind::Core {
+            return Ok(true);
+        }
+
+        let tool_name = approval_request
+            .request_payload_json
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .map(crate::tools::canonical_tool_name)
+            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
+
+        Ok(tool_name == "delegate_async")
     }
 
     fn ensure_resolution_binding_allows_decision(
@@ -4601,6 +4612,10 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
     payload: Value,
     binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+    if !binding.allows_mutation() {
+        return Err("app_tool_denied: governed_runtime_binding_required".to_owned());
+    }
+
     let delegate_request = crate::tools::delegate::parse_delegate_request_with_default_timeout(
         &payload,
         config.tools.delegate.timeout_seconds,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -440,6 +440,10 @@ fn governed_runtime_binding_denied_outcome(
     ToolPreflightOutcome::Denied { failure, decision }
 }
 
+fn requires_kernel_bound_runtime_for_preflight(descriptor: &crate::tools::ToolDescriptor) -> bool {
+    descriptor.name == "delegate_async"
+}
+
 #[async_trait]
 pub trait AppToolDispatcher: Send + Sync {
     async fn preflight_tool_intent_with_binding(
@@ -1302,6 +1306,13 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
         binding: ConversationRuntimeBinding<'_>,
         budget_state: &AutonomyTurnBudgetState,
     ) -> Result<ToolPreflightOutcome, String> {
+        let requires_kernel_bound_runtime = requires_kernel_bound_runtime_for_preflight(descriptor);
+        let allows_mutation = binding.allows_mutation();
+        if requires_kernel_bound_runtime && !allows_mutation {
+            let denied = governed_runtime_binding_denied_outcome(descriptor);
+            return Ok(denied);
+        }
+
         let policy_snapshot = self.autonomy_policy_snapshot();
         let action_class = descriptor.capability_action_class();
         let policy_input = PolicyDecisionInput {

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T12:31:07Z
+- Generated at: 2026-04-03T12:52:08Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11179 | 11200 | 21 | 100 | 120 | 20 | 99.8% | TIGHT | 10831 | 3.2% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11194 | 11200 | 6 | 100 | 120 | 20 | 99.9% | TIGHT | 10831 | 3.4% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.8%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.9%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -67,7 +67,7 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11179 functions=100 -->
+<!-- arch-hotspot key=turn_coordinator lines=11194 functions=100 -->
 <!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->


### PR DESCRIPTION
## Summary

- Problem: `delegate_async` could enter the app-tool path from a direct-bound conversation runtime.
- Why it matters: async delegate child-session orchestration should fail closed when the parent turn does not carry kernel authority.
- What changed: added a kernel-context gate in `delegate_async` preflight and execution, added a direct-bound approval replay fail-closed regression, and updated delegate-async regression tests to keep queueing and spawn-failure coverage on kernel-bound paths.
- What did not change (scope boundary): request schema, synchronous `delegate`, ACP routing behavior, and unrelated conversation/tool paths.

## Linked Issues

- Closes #844
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: this tightens a governed execution entry point and blocks direct-bound `delegate_async` calls that previously reached approval or queueing paths.
- Rollout / guardrails: scope the fail-closed behavior to `delegate_async` only; keep kernel-bound queueing and failure-recovery behavior unchanged.
- Rollback path: revert the `delegate_async` kernel-context guard and its test updates.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-delegate-async-governed-target cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-delegate-async-governed-target cargo test -p loongclaw-app turn_engine_fails_closed_before_governed_approval_for_later_app_intent -- --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-delegate-async-governed-target cargo test -p loongclaw-app delegate_async -- --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-delegate-async-governed-target cargo test --workspace --locked
CARGO_TARGET_DIR=/tmp/loongclaw-delegate-async-governed-target cargo test --workspace --all-features --locked
CARGO_TARGET_DIR=/tmp/loongclaw-delegate-async-governed-target cargo test -p loongclaw-daemon browser_companion_doctor_checks_warn_when_runtime_gate_is_closed -- --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-delegate-async-governed-target cargo test -p loongclaw-daemon browser_companion_onboard_preflight_warns_when_runtime_gate_is_closed -- --nocapture
CARGO_TARGET_DIR=/tmp/loongclaw-delegate-async-governed-target cargo test -p loongclaw-daemon collect_browser_companion_diagnostics_rejects_partial_expected_version_matches -- --nocapture

Notes:
- `delegate_async`-focused regression coverage passed, including direct denial, approval replay denial, kernel-bound queueing, nested denial, and spawn failure / panic / recovery paths.
- The first attempt at `cargo test --workspace --all-features --locked` hit browser companion timeout flakes under concurrent load in daemon tests. Re-running the exact daemon tests individually and then re-running the full command succeeded.
- Browser companion env-mutating tests rely on scoped env guards inside the test harness; no production config/env defaults changed in this patch.
```

## User-visible / Operator-visible Changes

- `delegate_async` now rejects direct-bound conversation runtimes with `no_kernel_context` instead of queuing an async child session.
- Direct-bound approval replay for `delegate_async` also fails closed and records `last_error=no_kernel_context` on the approval request instead of silently queuing a child session.
- Kernel-bound `delegate_async` flows still queue child sessions and preserve the inherited kernel context.

## Failure Recovery

- Fast rollback or disable path: revert this patch.
- Observable failure symptoms reviewers should watch for: direct-bound `delegate_async` unexpectedly still queueing child sessions, or kernel-bound async delegate queueing/regression paths no longer producing child-session state transitions.

## Reviewer Focus

- `crates/app/src/conversation/turn_engine.rs`: preflight guard location relative to `tool.invoke` unwrapping and approval lookup.
- `crates/app/src/conversation/turn_coordinator.rs`: early fail-closed execution guard and inherited kernel context propagation.
- `crates/app/src/conversation/tests.rs`: direct-denial regression, direct-bound approval replay denial, and kernel-bound queue/spawn-failure coverage.
