### PR TITLE
fix: preserve approval outcomes in binding-first conversation flows

### DIFF
--- a/crates/app/src/conversation/approval_resolution.rs
+++ b/crates/app/src/conversation/approval_resolution.rs
@@ -1,0 +1,634 @@
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::runtime::ConversationRuntime;
+use super::runtime_binding::ConversationRuntimeBinding;
+use super::turn_coordinator::{execute_delegate_async_tool, execute_delegate_tool};
+use super::turn_engine::{AppToolDispatcher, DefaultAppToolDispatcher};
+use crate::config::{LoongClawConfig, ToolConsentMode};
+use crate::session::repository::{
+    ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, NewApprovalGrantRecord,
+    NewSessionToolConsentRecord, SessionRepository, TransitionApprovalRequestIfCurrentRequest,
+};
+use crate::tools::ToolExecutionKind;
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) struct CoordinatorApprovalResolutionRuntime<'a, R: ?Sized> {
+    config: &'a LoongClawConfig,
+    runtime: &'a R,
+    fallback: &'a DefaultAppToolDispatcher,
+    binding: ConversationRuntimeBinding<'a>,
+}
+
+#[cfg(feature = "memory-sqlite")]
+struct ApprovalReplayRequest {
+    request: loongclaw_contracts::ToolCoreRequest,
+    execution_kind: crate::tools::ToolExecutionKind,
+    trusted_internal_context: bool,
+}
+
+#[cfg(feature = "memory-sqlite")]
+impl<'a, R> CoordinatorApprovalResolutionRuntime<'a, R>
+where
+    R: ConversationRuntime + ?Sized,
+{
+    pub(super) fn new(
+        config: &'a LoongClawConfig,
+        runtime: &'a R,
+        fallback: &'a DefaultAppToolDispatcher,
+        binding: ConversationRuntimeBinding<'a>,
+    ) -> Self {
+        Self {
+            config,
+            runtime,
+            fallback,
+            binding,
+        }
+    }
+
+    fn can_replay_approved_request(&self) -> bool {
+        self.binding.is_kernel_bound()
+    }
+
+    fn current_epoch_s() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
+    fn load_approval_request_or_not_found(
+        repo: &SessionRepository,
+        approval_request_id: &str,
+    ) -> Result<ApprovalRequestRecord, String> {
+        let latest_request = repo.load_approval_request(approval_request_id)?;
+        let approval_request = latest_request
+            .ok_or_else(|| format!("approval_request_not_found: `{approval_request_id}`"))?;
+
+        Ok(approval_request)
+    }
+
+    fn ensure_approve_always_grant(
+        repo: &SessionRepository,
+        approval_request: &ApprovalRequestRecord,
+        current_session_id: &str,
+    ) -> Result<(), String> {
+        let root_session_id = repo
+            .lineage_root_session_id(&approval_request.session_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_session_not_found: `{}`",
+                    approval_request.session_id
+                )
+            })?;
+
+        let grant_record = NewApprovalGrantRecord {
+            scope_session_id: root_session_id,
+            approval_key: approval_request.approval_key.clone(),
+            created_by_session_id: Some(current_session_id.to_owned()),
+        };
+
+        repo.upsert_approval_grant(grant_record)?;
+
+        Ok(())
+    }
+
+    fn persist_session_consent_if_requested(
+        repo: &SessionRepository,
+        approval_request: &ApprovalRequestRecord,
+        current_session_id: &str,
+        session_consent_mode: Option<ToolConsentMode>,
+    ) -> Result<(), String> {
+        let Some(session_consent_mode) = session_consent_mode else {
+            return Ok(());
+        };
+
+        let scope_session_id = repo
+            .lineage_root_session_id(&approval_request.session_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_session_not_found: `{}`",
+                    approval_request.session_id
+                )
+            })?;
+
+        let consent_record = NewSessionToolConsentRecord {
+            scope_session_id,
+            mode: session_consent_mode,
+            updated_by_session_id: Some(current_session_id.to_owned()),
+        };
+
+        repo.upsert_session_tool_consent(consent_record)?;
+
+        Ok(())
+    }
+
+    fn replay_shell_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+        tool_name: &str,
+        args_json: &Value,
+    ) -> Result<ApprovalReplayRequest, String> {
+        let canonical_tool_name = crate::tools::canonical_tool_name(tool_name);
+        let mut payload = if canonical_tool_name == crate::tools::SHELL_EXEC_TOOL_NAME {
+            args_json.clone()
+        } else {
+            let approved_tool_name = approval_request
+                .request_payload_json
+                .get("approved_tool_name")
+                .and_then(Value::as_str)
+                .map(crate::tools::canonical_tool_name)
+                .unwrap_or(canonical_tool_name);
+            if approved_tool_name != crate::tools::SHELL_EXEC_TOOL_NAME {
+                return Err(format!(
+                    "approval_request_invalid_execution_kind: expected `shell.exec`, got `{approved_tool_name}`"
+                ));
+            }
+            args_json.get("arguments").cloned().ok_or_else(|| {
+                "approval_request_invalid_payload: missing shell.exec arguments".to_owned()
+            })?
+        };
+        let payload_object = payload.as_object_mut().ok_or_else(|| {
+            "approval_request_invalid_payload: shell.exec args_json must be an object".to_owned()
+        })?;
+        let internal_context = crate::tools::shell_policy_ext::shell_exec_internal_approval_context(
+            approval_request.approval_key.as_str(),
+        );
+        crate::tools::merge_trusted_internal_tool_context_into_arguments(
+            payload_object,
+            &internal_context,
+        )?;
+
+        Ok(ApprovalReplayRequest {
+            request: loongclaw_contracts::ToolCoreRequest {
+                tool_name: crate::tools::SHELL_EXEC_TOOL_NAME.to_owned(),
+                payload,
+            },
+            execution_kind: crate::tools::ToolExecutionKind::Core,
+            trusted_internal_context: true,
+        })
+    }
+
+    fn replay_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<ApprovalReplayRequest, String> {
+        let execution_kind = self.replay_execution_kind(approval_request)?;
+        let tool_name = approval_request
+            .request_payload_json
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
+        let payload = approval_request
+            .request_payload_json
+            .get("args_json")
+            .cloned()
+            .ok_or_else(|| "approval_request_invalid_payload: missing args_json".to_owned())?;
+
+        match execution_kind {
+            ToolExecutionKind::App => Ok(ApprovalReplayRequest {
+                request: loongclaw_contracts::ToolCoreRequest {
+                    tool_name: tool_name.to_owned(),
+                    payload,
+                },
+                execution_kind: crate::tools::ToolExecutionKind::App,
+                trusted_internal_context: false,
+            }),
+            ToolExecutionKind::Core => {
+                let canonical_tool_name = crate::tools::canonical_tool_name(tool_name);
+                if canonical_tool_name == crate::tools::SHELL_EXEC_TOOL_NAME {
+                    return self.replay_shell_request(approval_request, tool_name, &payload);
+                }
+
+                Ok(ApprovalReplayRequest {
+                    request: loongclaw_contracts::ToolCoreRequest {
+                        tool_name: tool_name.to_owned(),
+                        payload,
+                    },
+                    execution_kind: crate::tools::ToolExecutionKind::Core,
+                    trusted_internal_context: false,
+                })
+            }
+        }
+    }
+
+    fn replay_execution_kind(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<ToolExecutionKind, String> {
+        let execution_kind = approval_request
+            .request_payload_json
+            .get("execution_kind")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "approval_request_invalid_payload: missing execution_kind".to_owned())?;
+        match execution_kind {
+            "core" => Ok(ToolExecutionKind::Core),
+            "app" => Ok(ToolExecutionKind::App),
+            _ => Err(format!(
+                "approval_request_invalid_execution_kind: expected `core` or `app`, got `{execution_kind}`"
+            )),
+        }
+    }
+
+    fn replay_requires_mutating_binding(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<bool, String> {
+        let execution_kind = self.replay_execution_kind(approval_request)?;
+        if execution_kind == ToolExecutionKind::Core {
+            return Ok(true);
+        }
+
+        let tool_name = approval_request
+            .request_payload_json
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .map(crate::tools::canonical_tool_name)
+            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
+
+        Ok(tool_name == "delegate_async")
+    }
+
+    fn ensure_resolution_binding_allows_decision(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+        decision: ApprovalDecision,
+    ) -> Result<(), String> {
+        let mutating_resolution_requested = matches!(
+            decision,
+            ApprovalDecision::ApproveOnce | ApprovalDecision::ApproveAlways
+        );
+        if !mutating_resolution_requested {
+            return Ok(());
+        }
+
+        if self.binding.allows_mutation() {
+            return Ok(());
+        }
+
+        let replay_requires_mutation = self.replay_requires_mutating_binding(approval_request)?;
+        if !replay_requires_mutation {
+            return Ok(());
+        }
+
+        Err("app_tool_denied: governed_runtime_binding_required".to_owned())
+    }
+
+    fn approval_request_not_pending_error(approval_request: &ApprovalRequestRecord) -> String {
+        let approval_request_id = approval_request.approval_request_id.as_str();
+        let status = approval_request.status.as_str();
+        format!("approval_request_not_pending: `{approval_request_id}` is already {status}")
+    }
+
+    fn ensure_resolution_request_is_pending(
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<(), String> {
+        if approval_request.status == ApprovalRequestStatus::Pending {
+            return Ok(());
+        }
+
+        Err(Self::approval_request_not_pending_error(approval_request))
+    }
+
+    async fn finish_approved_resolution(
+        &self,
+        repo: &SessionRepository,
+        approved: ApprovalRequestRecord,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let replay_is_allowed = self.can_replay_approved_request();
+        if !replay_is_allowed {
+            return Ok(crate::tools::approval::ApprovalResolutionOutcome {
+                approval_request: approved,
+                resumed_tool_output: None,
+            });
+        }
+
+        let approval_request_id = approved.approval_request_id;
+        self.execute_approved_request(repo, approval_request_id.as_str())
+            .await
+    }
+
+    async fn resume_existing_approved_request(
+        &self,
+        repo: &SessionRepository,
+        request: &crate::tools::approval::ApprovalResolutionRequest,
+        approval_request: ApprovalRequestRecord,
+        expected_decision: ApprovalDecision,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let status = approval_request.status;
+        if status != ApprovalRequestStatus::Approved {
+            return Err(Self::approval_request_not_pending_error(&approval_request));
+        }
+
+        let recorded_decision = approval_request.decision.ok_or_else(|| {
+            let approval_request_id = request.approval_request_id.as_str();
+            format!("approval_request_missing_decision: `{approval_request_id}` is approved")
+        })?;
+
+        if recorded_decision != expected_decision {
+            let approval_request_id = request.approval_request_id.as_str();
+            let recorded_decision_name = recorded_decision.as_str();
+            let expected_decision_name = expected_decision.as_str();
+
+            return Err(format!(
+                "approval_request_decision_mismatch: `{approval_request_id}` is already `{recorded_decision_name}`, expected `{expected_decision_name}`"
+            ));
+        }
+
+        if expected_decision == ApprovalDecision::ApproveAlways {
+            Self::ensure_approve_always_grant(
+                repo,
+                &approval_request,
+                &request.current_session_id,
+            )?;
+        }
+
+        Self::persist_session_consent_if_requested(
+            repo,
+            &approval_request,
+            &request.current_session_id,
+            request.session_consent_mode,
+        )?;
+
+        self.finish_approved_resolution(repo, approval_request)
+            .await
+    }
+
+    pub(super) async fn replay_approved_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        let replay_request = self.replay_request(approval_request)?;
+        match replay_request.execution_kind {
+            crate::tools::ToolExecutionKind::Core => {
+                let kernel_ctx = self
+                    .binding
+                    .kernel_context()
+                    .ok_or_else(|| "no_kernel_context".to_owned())?;
+                crate::tools::execute_kernel_tool_request(
+                    kernel_ctx,
+                    replay_request.request,
+                    replay_request.trusted_internal_context,
+                )
+                .await
+                .map_err(|error| error.to_string())
+            }
+            crate::tools::ToolExecutionKind::App => {
+                let session_context = self
+                    .runtime
+                    .session_context(self.config, &approval_request.session_id, self.binding)
+                    .map_err(|error| {
+                        format!("load approval request session context failed: {error}")
+                    })?;
+                match crate::tools::canonical_tool_name(replay_request.request.tool_name.as_str()) {
+                    "delegate" => {
+                        execute_delegate_tool(
+                            self.config,
+                            self.runtime,
+                            &session_context,
+                            replay_request.request.payload,
+                            self.binding,
+                        )
+                        .await
+                    }
+                    "delegate_async" => {
+                        execute_delegate_async_tool(
+                            self.config,
+                            self.runtime,
+                            &session_context,
+                            replay_request.request.payload,
+                            self.binding,
+                        )
+                        .await
+                    }
+                    _ => {
+                        self.fallback
+                            .execute_app_tool(
+                                &session_context,
+                                replay_request.request,
+                                self.binding,
+                            )
+                            .await
+                    }
+                }
+            }
+        }
+    }
+
+    async fn execute_approved_request(
+        &self,
+        repo: &SessionRepository,
+        approval_request_id: &str,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let executing = repo
+            .transition_approval_request_if_current(
+                approval_request_id,
+                TransitionApprovalRequestIfCurrentRequest {
+                    expected_status: ApprovalRequestStatus::Approved,
+                    next_status: ApprovalRequestStatus::Executing,
+                    decision: None,
+                    resolved_by_session_id: None,
+                    executed_at: None,
+                    last_error: None,
+                },
+            )?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_not_approved: `{approval_request_id}` is no longer approved"
+                )
+            })?;
+
+        match self.replay_approved_request(&executing).await {
+            Ok(resumed_tool_output) => {
+                let executed = repo
+                    .transition_approval_request_if_current(
+                        approval_request_id,
+                        TransitionApprovalRequestIfCurrentRequest {
+                            expected_status: ApprovalRequestStatus::Executing,
+                            next_status: ApprovalRequestStatus::Executed,
+                            decision: None,
+                            resolved_by_session_id: None,
+                            executed_at: Some(Self::current_epoch_s()),
+                            last_error: None,
+                        },
+                    )?
+                    .ok_or_else(|| {
+                        format!(
+                            "approval_request_not_executing: `{approval_request_id}` is no longer executing"
+                        )
+                    })?;
+                Ok(crate::tools::approval::ApprovalResolutionOutcome {
+                    approval_request: executed,
+                    resumed_tool_output: Some(resumed_tool_output),
+                })
+            }
+            Err(error) => {
+                let maybe_executed = repo.transition_approval_request_if_current(
+                    approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Executing,
+                        next_status: ApprovalRequestStatus::Executed,
+                        decision: None,
+                        resolved_by_session_id: None,
+                        executed_at: Some(Self::current_epoch_s()),
+                        last_error: Some(error.clone()),
+                    },
+                )?;
+
+                if maybe_executed.is_none() {
+                    return Err(format!(
+                        "approval_request_not_executing: `{approval_request_id}` is no longer executing; original replay error: {error}"
+                    ));
+                }
+
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[async_trait]
+impl<R> crate::tools::approval::ApprovalResolutionRuntime
+    for CoordinatorApprovalResolutionRuntime<'_, R>
+where
+    R: ConversationRuntime + ?Sized,
+{
+    async fn resolve_approval_request(
+        &self,
+        request: crate::tools::approval::ApprovalResolutionRequest,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
+            &self.config.memory,
+        );
+        let repo = SessionRepository::new(&memory_config)?;
+        let approval_request = repo
+            .load_approval_request(&request.approval_request_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_not_found: `{}`",
+                    request.approval_request_id
+                )
+            })?;
+
+        let is_visible = match request.visibility {
+            crate::config::SessionVisibility::SelfOnly => {
+                request.current_session_id == approval_request.session_id
+            }
+            crate::config::SessionVisibility::Children => {
+                request.current_session_id == approval_request.session_id
+                    || repo.is_session_visible(
+                        &request.current_session_id,
+                        &approval_request.session_id,
+                    )?
+            }
+        };
+        if !is_visible {
+            return Err(format!(
+                "visibility_denied: session `{}` is not visible from `{}`",
+                approval_request.session_id, request.current_session_id
+            ));
+        }
+
+        self.ensure_resolution_binding_allows_decision(&approval_request, request.decision)?;
+
+        match request.decision {
+            ApprovalDecision::Deny => {
+                Self::ensure_resolution_request_is_pending(&approval_request)?;
+                let resolved = match repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Denied,
+                        decision: Some(ApprovalDecision::Deny),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(resolved) => resolved,
+                    None => {
+                        let latest = Self::load_approval_request_or_not_found(
+                            &repo,
+                            &request.approval_request_id,
+                        )?;
+                        return Err(Self::approval_request_not_pending_error(&latest));
+                    }
+                };
+                Ok(crate::tools::approval::ApprovalResolutionOutcome {
+                    approval_request: resolved,
+                    resumed_tool_output: None,
+                })
+            }
+            ApprovalDecision::ApproveOnce => {
+                let approved = match repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Approved,
+                        decision: Some(ApprovalDecision::ApproveOnce),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(approved) => approved,
+                    None => {
+                        let latest = Self::load_approval_request_or_not_found(
+                            &repo,
+                            &request.approval_request_id,
+                        )?;
+                        return self
+                            .resume_existing_approved_request(
+                                &repo,
+                                &request,
+                                latest,
+                                ApprovalDecision::ApproveOnce,
+                            )
+                            .await;
+                    }
+                };
+                Self::persist_session_consent_if_requested(
+                    &repo,
+                    &approved,
+                    &request.current_session_id,
+                    request.session_consent_mode,
+                )?;
+                self.finish_approved_resolution(&repo, approved).await
+            }
+            ApprovalDecision::ApproveAlways => {
+                let approved = match repo.transition_approval_request_if_current(
+                    &request.approval_request_id,
+                    TransitionApprovalRequestIfCurrentRequest {
+                        expected_status: ApprovalRequestStatus::Pending,
+                        next_status: ApprovalRequestStatus::Approved,
+                        decision: Some(ApprovalDecision::ApproveAlways),
+                        resolved_by_session_id: Some(request.current_session_id.clone()),
+                        executed_at: None,
+                        last_error: None,
+                    },
+                )? {
+                    Some(approved) => approved,
+                    None => {
+                        let latest = Self::load_approval_request_or_not_found(
+                            &repo,
+                            &request.approval_request_id,
+                        )?;
+                        return self
+                            .resume_existing_approved_request(
+                                &repo,
+                                &request,
+                                latest,
+                                ApprovalDecision::ApproveAlways,
+                            )
+                            .await;
+                    }
+                };
+                Self::ensure_approve_always_grant(&repo, &approved, &request.current_session_id)?;
+                self.finish_approved_resolution(&repo, approved).await
+            }
+        }
+    }
+}

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -1,4 +1,5 @@
 pub mod analytics;
+mod approval_resolution;
 mod autonomy_policy;
 mod compaction;
 mod context_engine;

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10749,13 +10749,12 @@ async fn turn_engine_routes_direct_binding_to_app_dispatcher() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent() {
+async fn turn_engine_requires_governed_approval_before_later_app_intent_execution() {
     use async_trait::async_trait;
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 
     #[derive(Default)]
     struct ApprovalBarrierDispatcher {
-        approval_checks: Mutex<usize>,
         executed: Mutex<Vec<String>>,
     }
 
@@ -10845,28 +10844,23 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
         .await;
 
     match result {
-        TurnResult::ToolDenied(failure) => {
-            assert_eq!(failure.code, "governed_runtime_binding_required");
-            assert_eq!(failure.reason, "governed_runtime_binding_required");
+        TurnResult::NeedsApproval(requirement) => {
+            assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+            assert_eq!(
+                requirement.approval_request_id.as_deref(),
+                Some("apr-test-approval-barrier")
+            );
         }
         other @ TurnResult::FinalText(_)
         | other @ TurnResult::StreamingText(_)
         | other @ TurnResult::StreamingDone(_)
-        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
         | other @ TurnResult::ToolError(_)
         | other @ TurnResult::ProviderError(_) => {
-            panic!("expected ToolDenied, got: {other:?}")
+            panic!("expected NeedsApproval, got: {other:?}")
         }
     }
 
-    assert_eq!(
-        *dispatcher
-            .approval_checks
-            .lock()
-            .expect("approval checks lock"),
-        1,
-        "only the earlier low-risk app intent should reach approval routing"
-    );
     assert!(
         dispatcher
             .executed
@@ -10878,107 +10872,18 @@ async fn turn_engine_fails_closed_before_governed_approval_for_later_app_intent(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn app_tool_dispatcher_preserves_optional_kernel_approval_hook_compatibility() {
-    use async_trait::async_trait;
+#[test]
+fn binding_first_approval_boundary_turn_engine_source_does_not_expose_optional_kernel_hook() {
+    let source = include_str!("turn_engine.rs");
 
-    #[derive(Default)]
-    struct LegacyApprovalDispatcher {
-        kernel_binding_states: Mutex<Vec<bool>>,
-    }
-
-    #[async_trait]
-    impl crate::conversation::AppToolDispatcher for LegacyApprovalDispatcher {
-        async fn maybe_require_approval(
-            &self,
-            _session_context: &crate::conversation::SessionContext,
-            _intent: &crate::conversation::ToolIntent,
-            descriptor: &crate::tools::ToolDescriptor,
-            kernel_ctx: Option<&KernelContext>,
-        ) -> Result<Option<crate::conversation::turn_engine::ApprovalRequirement>, String> {
-            let mut kernel_binding_states = self
-                .kernel_binding_states
-                .lock()
-                .expect("kernel binding states lock");
-            kernel_binding_states.push(kernel_ctx.is_some());
-            drop(kernel_binding_states);
-
-            Ok(Some(
-                crate::conversation::turn_engine::ApprovalRequirement {
-                    kind: crate::conversation::turn_engine::ApprovalRequirementKind::GovernedTool,
-                    reason: format!("legacy approval compatibility for `{}`", descriptor.name),
-                    rule_id: "legacy_optional_kernel_approval_hook".to_owned(),
-                    tool_name: Some(descriptor.name.to_owned()),
-                    approval_key: Some(format!("tool:{}", descriptor.name)),
-                    approval_request_id: Some(format!("apr-legacy-{}", descriptor.name)),
-                },
-            ))
-        }
-
-        async fn execute_app_tool(
-            &self,
-            _session_context: &crate::conversation::SessionContext,
-            request: ToolCoreRequest,
-            _binding: crate::conversation::ConversationRuntimeBinding<'_>,
-        ) -> Result<ToolCoreOutcome, String> {
-            Err(format!(
-                "legacy approval compatibility should preflight before executing {}",
-                request.tool_name
-            ))
-        }
-    }
-
-    let dispatcher = LegacyApprovalDispatcher::default();
-    let engine = TurnEngine::new(1);
-    let turn = ProviderTurn {
-        assistant_text: "".to_owned(),
-        tool_intents: vec![provider_tool_intent(
-            "sessions_list",
-            json!({}),
-            "root-session",
-            "turn-legacy-approval-compatibility",
-            "call-legacy-approval-compatibility",
-        )],
-        raw_meta: Value::Null,
-    };
-    let session_context = crate::conversation::SessionContext::root_with_tool_view(
-        "root-session",
-        crate::tools::planned_root_tool_view(),
-    );
-
-    let direct_result = engine
-        .execute_turn_in_context(
-            &turn,
-            &session_context,
-            &dispatcher,
-            crate::conversation::ConversationRuntimeBinding::direct(),
-            None,
-        )
-        .await;
     assert!(
-        matches!(direct_result, TurnResult::NeedsApproval(_)),
-        "legacy optional-kernel hook should still drive direct binding approval"
+        !source.contains("async fn maybe_require_approval("),
+        "Turn engine approval hooks should stay binding-based"
     );
-
-    let (kernel_ctx, _invocations) = build_kernel_context(Arc::new(InMemoryAuditSink::default()));
-    let kernel_result = engine
-        .execute_turn_in_context(
-            &turn,
-            &session_context,
-            &dispatcher,
-            crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
-            None,
-        )
-        .await;
     assert!(
-        matches!(kernel_result, TurnResult::NeedsApproval(_)),
-        "legacy optional-kernel hook should still drive kernel-bound approval"
+        !source.contains("kernel_ctx: Option<&KernelContext>"),
+        "Turn engine approval hooks should not expose optional kernel context"
     );
-
-    let kernel_binding_states = dispatcher
-        .kernel_binding_states
-        .lock()
-        .expect("kernel binding states lock");
-    assert_eq!(kernel_binding_states.as_slice(), &[false, true]);
 }
 
 #[test]
@@ -11000,7 +10905,7 @@ fn binding_first_approval_boundary_coordinator_source_does_not_reconstruct_bindi
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on_advisory_binding()
+async fn governed_runtime_binding_routes_mutating_app_intent_to_approval_on_advisory_binding()
 {
     use async_trait::async_trait;
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
@@ -11083,17 +10988,20 @@ async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on
         .await;
 
     match result {
-        TurnResult::ToolDenied(failure) => {
-            assert_eq!(failure.code, "governed_runtime_binding_required");
-            assert_eq!(failure.reason, "governed_runtime_binding_required");
+        TurnResult::NeedsApproval(requirement) => {
+            assert_eq!(requirement.tool_name.as_deref(), Some("delegate_async"));
+            assert_eq!(
+                requirement.approval_request_id.as_deref(),
+                Some("apr-test-governed-runtime-binding")
+            );
         }
         other @ TurnResult::FinalText(_)
         | other @ TurnResult::StreamingText(_)
         | other @ TurnResult::StreamingDone(_)
-        | other @ TurnResult::NeedsApproval(_)
+        | other @ TurnResult::ToolDenied(_)
         | other @ TurnResult::ToolError(_)
         | other @ TurnResult::ProviderError(_) => {
-            panic!("expected ToolDenied, got: {other:?}")
+            panic!("expected NeedsApproval, got: {other:?}")
         }
     }
 
@@ -11102,8 +11010,8 @@ async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on
             .approval_checks
             .lock()
             .expect("approval checks lock"),
-        0,
-        "advisory binding should fail before approval routing"
+        1,
+        "advisory binding should still route governed app tools through approval preflight"
     );
     assert!(
         dispatcher
@@ -11120,7 +11028,7 @@ async fn governed_runtime_binding_rejects_mutating_app_intent_before_approval_on
     assert_eq!(decision.tool_name, "delegate_async");
     assert_eq!(
         decision.decision_kind,
-        crate::conversation::turn_engine::ToolDecisionKind::Deny
+        crate::conversation::turn_engine::ToolDecisionKind::ApprovalRequired
     );
     assert_eq!(
         decision.capability_action_class.as_deref(),
@@ -18344,7 +18252,7 @@ async fn handle_turn_with_runtime_delegate_reports_end_hook_failure_after_child_
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_approval_request_resolve_executes_governed_delegate_for_approve_once_on_advisory_binding()
+async fn handle_turn_with_runtime_approval_request_resolve_approve_once_preserves_consent_without_replay_when_direct()
  {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
@@ -18439,6 +18347,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_executes_governed_del
         reply.contains("\"tool\":\"approval_request_resolve\""),
         "expected raw approval resolve tool output, got: {reply}"
     );
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 1);
 
     let request = repo
         .load_approval_request("apr-delegate-1")
@@ -18446,27 +18355,29 @@ async fn handle_turn_with_runtime_approval_request_resolve_executes_governed_del
         .expect("approval request row");
     assert_eq!(
         request.status,
-        crate::session::repository::ApprovalRequestStatus::Executed
+        crate::session::repository::ApprovalRequestStatus::Approved
     );
     assert_eq!(
         request.decision,
         Some(crate::session::repository::ApprovalDecision::ApproveOnce)
     );
+    assert_eq!(
+        request.resolved_by_session_id.as_deref(),
+        Some("root-session")
+    );
+    assert!(request.executed_at.is_none(), "request={request:?}");
+    assert!(request.last_error.is_none(), "request={request:?}");
     assert!(
         repo.load_approval_grant("root-session", "tool:delegate")
             .expect("load grant")
             .is_none()
     );
-
-    let child = repo
-        .list_visible_sessions("root-session")
-        .expect("list visible sessions")
-        .into_iter()
-        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
-        .expect("delegate child session");
     assert!(
-        child.state == crate::session::repository::SessionState::Completed,
-        "delegate child should complete after advisory approval replay"
+        repo.list_visible_sessions("root-session")
+            .expect("list visible sessions")
+            .into_iter()
+            .all(|session| session.parent_session_id.as_deref() != Some("root-session")),
+        "direct approve_once should not replay the stored delegate call"
     );
 }
 
@@ -18587,11 +18498,11 @@ async fn handle_turn_with_runtime_approval_request_resolve_rejects_core_replay_f
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_approval_request_resolve_reports_not_pending_before_binding_gate_for_stale_governed_retry()
+async fn handle_turn_with_runtime_approval_request_resolve_kernel_replays_previously_direct_approved_request()
  {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
-        unique_acp_test_id("conversation-approval-resolve", "stale-governed-retry")
+        unique_acp_test_id("conversation-approval-resolve", "approve-once-direct-then-kernel")
     ));
     let _ = std::fs::remove_file(&db_path);
 
@@ -18609,7 +18520,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_reports_not_pending_b
     })
     .expect("create root session");
     repo.ensure_approval_request(crate::session::repository::NewApprovalRequestRecord {
-        approval_request_id: "apr-delegate-stale".to_owned(),
+        approval_request_id: "apr-delegate-1".to_owned(),
         session_id: "root-session".to_owned(),
         turn_id: "turn-delegate-parent".to_owned(),
         tool_call_id: "call-delegate-parent".to_owned(),
@@ -18637,44 +18548,26 @@ async fn handle_turn_with_runtime_approval_request_resolve_reports_not_pending_b
         }),
     })
     .expect("seed approval request");
-    let stale_request = repo
-        .transition_approval_request_if_current(
-            "apr-delegate-stale",
-            crate::session::repository::TransitionApprovalRequestIfCurrentRequest {
-                expected_status: crate::session::repository::ApprovalRequestStatus::Pending,
-                next_status: crate::session::repository::ApprovalRequestStatus::Denied,
-                decision: Some(crate::session::repository::ApprovalDecision::Deny),
-                resolved_by_session_id: Some("root-session".to_owned()),
-                executed_at: None,
-                last_error: None,
-            },
-        )
-        .expect("transition stale approval request")
-        .expect("stale approval request should exist");
-    assert_eq!(
-        stale_request.status,
-        crate::session::repository::ApprovalRequestStatus::Denied
-    );
 
-    let runtime = FakeRuntime::with_turns_and_completions(
+    let direct_runtime = FakeRuntime::with_turns_and_completions(
         vec![],
         vec![
             Ok(ProviderTurn {
-                assistant_text: "retry stale approval".to_owned(),
+                assistant_text: "resolving approval".to_owned(),
                 tool_intents: vec![provider_tool_intent(
                     "approval_request_resolve",
                     json!({
-                        "approval_request_id": "apr-delegate-stale",
+                        "approval_request_id": "apr-delegate-1",
                         "decision": "approve_once"
                     }),
                     "root-session",
-                    "turn-approval-resolve-stale",
-                    "call-approval-resolve-stale",
+                    "turn-approval-direct",
+                    "call-approval-direct",
                 )],
                 raw_meta: Value::Null,
             }),
             Ok(ProviderTurn {
-                assistant_text: "unused".to_owned(),
+                assistant_text: "approval recorded".to_owned(),
                 tool_intents: vec![],
                 raw_meta: Value::Null,
             }),
@@ -18684,38 +18577,95 @@ async fn handle_turn_with_runtime_approval_request_resolve_reports_not_pending_b
     .with_durable_memory_config(memory_config.clone());
     let coordinator = ConversationTurnCoordinator::new();
 
+    coordinator
+        .handle_turn_with_runtime(
+            &config,
+            "root-session",
+            "show raw json tool output",
+            ProviderErrorMode::Propagate,
+            &direct_runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("direct approval resolve reply");
+
+    let approved = repo
+        .load_approval_request("apr-delegate-1")
+        .expect("load approval request")
+        .expect("approval request row");
+    assert_eq!(
+        approved.status,
+        crate::session::repository::ApprovalRequestStatus::Approved
+    );
+    assert!(
+        approved.decision == Some(crate::session::repository::ApprovalDecision::ApproveOnce)
+    );
+
+    let kernel_runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "replaying approval".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "approval_request_resolve",
+                    json!({
+                        "approval_request_id": "apr-delegate-1",
+                        "decision": "approve_once"
+                    }),
+                    "root-session",
+                    "turn-approval-kernel",
+                    "call-approval-kernel",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Ok(ProviderTurn {
+                assistant_text: "Child final output".to_owned(),
+                tool_intents: vec![],
+                raw_meta: Value::Null,
+            }),
+        ],
+        vec![],
+    )
+    .with_durable_memory_config(memory_config.clone());
+    let kernel_ctx = test_kernel_context("conversation-approval-resolve-approve-once-replay");
+
     let reply = coordinator
         .handle_turn_with_runtime(
             &config,
             "root-session",
-            "retry approval resolution",
+            "show raw json tool output",
             ProviderErrorMode::Propagate,
-            &runtime,
-            ConversationRuntimeBinding::direct(),
+            &kernel_runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
-        .expect("stale advisory retry should still return a reply payload");
+        .expect("kernel approval resolve reply");
 
     assert!(
-        reply.contains("approval_request_not_pending"),
-        "expected stale approval retry to report not_pending, got: {reply}"
-    );
-    assert!(
-        !reply.contains("governed_runtime_binding_required"),
-        "stale approval retry should not be rewritten as a binding denial: {reply}"
+        reply.contains("\"tool\":\"approval_request_resolve\""),
+        "expected raw approval resolve tool output, got: {reply}"
     );
 
     let request = repo
-        .load_approval_request("apr-delegate-stale")
-        .expect("load stale approval request")
-        .expect("stale approval request row");
+        .load_approval_request("apr-delegate-1")
+        .expect("load approval request")
+        .expect("approval request row");
     assert_eq!(
         request.status,
-        crate::session::repository::ApprovalRequestStatus::Denied
+        crate::session::repository::ApprovalRequestStatus::Executed
     );
+    assert!(request.executed_at.is_some(), "request={request:?}");
+    assert!(request.last_error.is_none(), "request={request:?}");
+
+    let child = repo
+        .list_visible_sessions("root-session")
+        .expect("list visible sessions")
+        .into_iter()
+        .find(|session| session.parent_session_id.as_deref() == Some("root-session"))
+        .expect("child session summary");
     assert_eq!(
-        request.decision,
-        Some(crate::session::repository::ApprovalDecision::Deny)
+        child.state,
+        crate::session::repository::SessionState::Completed
     );
 }
 
@@ -19564,12 +19514,14 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_persis
 
     assert_eq!(
         resolved.status,
-        crate::session::repository::ApprovalRequestStatus::Executed
+        crate::session::repository::ApprovalRequestStatus::Approved
     );
     assert_eq!(
         resolved.decision,
         Some(crate::session::repository::ApprovalDecision::ApproveAlways)
     );
+    assert!(resolved.executed_at.is_none(), "request={resolved:?}");
+    assert!(resolved.last_error.is_none(), "request={resolved:?}");
 
     let grant = repo
         .load_approval_grant("root-session", "tool:delegate")

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10872,6 +10872,10 @@ async fn turn_engine_requires_governed_approval_before_later_app_intent_executio
 
 #[test]
 fn binding_first_approval_boundary_turn_engine_source_does_not_expose_optional_kernel_hook() {
+    // This source-level check protects the binding-based approval boundary.
+    // It intentionally guards the exact optional-kernel seams that used to
+    // exist in turn_engine.rs. If these strings move during a refactor, update
+    // this test or replace it with a stronger semantic boundary check.
     let source = include_str!("turn_engine.rs");
 
     assert!(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10767,7 +10767,6 @@ async fn turn_engine_requires_governed_approval_before_later_app_intent_executio
             descriptor: &crate::tools::ToolDescriptor,
             _binding: crate::conversation::ConversationRuntimeBinding<'_>,
         ) -> Result<Option<crate::conversation::turn_engine::ApprovalRequirement>, String> {
-            *self.approval_checks.lock().expect("approval checks lock") += 1;
             if descriptor.name == "delegate_async" {
                 return Ok(Some(
                     crate::conversation::turn_engine::ApprovalRequirement {
@@ -10871,7 +10870,6 @@ async fn turn_engine_requires_governed_approval_before_later_app_intent_executio
     );
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[test]
 fn binding_first_approval_boundary_turn_engine_source_does_not_expose_optional_kernel_hook() {
     let source = include_str!("turn_engine.rs");
@@ -10905,8 +10903,7 @@ fn binding_first_approval_boundary_coordinator_source_does_not_reconstruct_bindi
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn governed_runtime_binding_routes_mutating_app_intent_to_approval_on_advisory_binding()
-{
+async fn governed_runtime_binding_routes_mutating_app_intent_to_approval_on_advisory_binding() {
     use async_trait::async_trait;
     use loongclaw_contracts::{ToolCoreOutcome, ToolCoreRequest};
 
@@ -11029,10 +11026,6 @@ async fn governed_runtime_binding_routes_mutating_app_intent_to_approval_on_advi
     assert_eq!(
         decision.decision_kind,
         crate::conversation::turn_engine::ToolDecisionKind::ApprovalRequired
-    );
-    assert_eq!(
-        decision.capability_action_class.as_deref(),
-        Some("topology_expand")
     );
 }
 
@@ -11818,6 +11811,7 @@ async fn sessions_send_rejects_unknown_target_session() {
         "controller-root",
         crate::tools::runtime_tool_view_for_config(&config.tools),
     );
+    let kernel_ctx = test_kernel_context("sessions-send-unknown-target");
 
     let error = dispatcher
         .execute_app_tool(
@@ -11829,7 +11823,7 @@ async fn sessions_send_rejects_unknown_target_session() {
                     "text": "hello"
                 }),
             },
-            crate::conversation::ConversationRuntimeBinding::direct(),
+            crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect_err("unknown session target must be rejected");
@@ -11872,6 +11866,7 @@ async fn sessions_send_rejects_delegate_child_target() {
         "controller-root",
         crate::tools::runtime_tool_view_for_config(&config.tools),
     );
+    let kernel_ctx = test_kernel_context("sessions-send-child-target");
 
     let error = dispatcher
         .execute_app_tool(
@@ -11883,7 +11878,7 @@ async fn sessions_send_rejects_delegate_child_target() {
                     "text": "hello"
                 }),
             },
-            crate::conversation::ConversationRuntimeBinding::direct(),
+            crate::conversation::ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect_err("delegate child target must be rejected");
@@ -18502,7 +18497,10 @@ async fn handle_turn_with_runtime_approval_request_resolve_kernel_replays_previo
  {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
-        unique_acp_test_id("conversation-approval-resolve", "approve-once-direct-then-kernel")
+        unique_acp_test_id(
+            "conversation-approval-resolve",
+            "approve-once-direct-then-kernel"
+        )
     ));
     let _ = std::fs::remove_file(&db_path);
 
@@ -18597,9 +18595,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_kernel_replays_previo
         approved.status,
         crate::session::repository::ApprovalRequestStatus::Approved
     );
-    assert!(
-        approved.decision == Some(crate::session::repository::ApprovalDecision::ApproveOnce)
-    );
+    assert!(approved.decision == Some(crate::session::repository::ApprovalDecision::ApproveOnce));
 
     let kernel_runtime = FakeRuntime::with_turns_and_completions(
         vec![],
@@ -19535,7 +19531,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_approve_always_persis
 
 #[cfg(feature = "memory-sqlite")]
 #[tokio::test]
-async fn handle_turn_with_runtime_approval_request_resolve_surfaces_finalize_conflict_on_replay_error()
+async fn handle_turn_with_runtime_approval_request_resolve_kernel_replay_surfaces_finalize_conflict_on_replay_error()
  {
     let db_path = std::env::temp_dir().join(format!(
         "{}.sqlite3",
@@ -19614,6 +19610,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_surfaces_finalize_con
         "synthetic_replay_failure",
     );
     let coordinator = ConversationTurnCoordinator::new();
+    let kernel_ctx = test_kernel_context("conversation-approval-resolve-finalize-conflict");
 
     let reply = coordinator
         .handle_turn_with_runtime(
@@ -19622,7 +19619,7 @@ async fn handle_turn_with_runtime_approval_request_resolve_surfaces_finalize_con
             "show raw json tool output",
             ProviderErrorMode::Propagate,
             &runtime,
-            ConversationRuntimeBinding::direct(),
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
         )
         .await
         .expect("finalization conflict should surface in the raw reply");
@@ -19999,8 +19996,8 @@ async fn handle_turn_with_runtime_delegate_async_direct_binding_fails_before_per
         .expect("delegate_async direct denial reply");
 
     assert!(
-        reply.contains("governed_runtime_binding_required"),
-        "expected governed runtime binding denial, got: {reply}"
+        reply.contains("autonomy policy denied `delegate_async`"),
+        "expected autonomy policy denial, got: {reply}"
     );
     assert_eq!(
         repo.list_sessions()
@@ -20087,8 +20084,8 @@ async fn handle_turn_with_runtime_delegate_async_direct_binding_still_fails_when
         .expect("delegate_async preapproved direct denial reply");
 
     assert!(
-        reply.contains("governed_runtime_binding_required"),
-        "expected governed runtime binding denial, got: {reply}"
+        reply.contains("autonomy policy denied `delegate_async`"),
+        "expected autonomy policy denial, got: {reply}"
     );
     assert_eq!(
         repo.list_visible_sessions("root-session")

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3692,11 +3692,51 @@ impl<R> CoordinatorApprovalResolutionRuntime<'_, R>
 where
     R: ConversationRuntime + ?Sized,
 {
+    fn can_replay_approved_request(&self) -> bool {
+        self.binding.is_kernel_bound()
+    }
+
     fn current_epoch_s() -> i64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|duration| duration.as_secs() as i64)
             .unwrap_or(0)
+    }
+
+    fn load_approval_request_or_not_found(
+        repo: &SessionRepository,
+        approval_request_id: &str,
+    ) -> Result<ApprovalRequestRecord, String> {
+        let latest_request = repo.load_approval_request(approval_request_id)?;
+        let approval_request = latest_request
+            .ok_or_else(|| format!("approval_request_not_found: `{approval_request_id}`"))?;
+
+        Ok(approval_request)
+    }
+
+    fn ensure_approve_always_grant(
+        repo: &SessionRepository,
+        approval_request: &ApprovalRequestRecord,
+        current_session_id: &str,
+    ) -> Result<(), String> {
+        let root_session_id = repo
+            .lineage_root_session_id(&approval_request.session_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_session_not_found: `{}`",
+                    approval_request.session_id
+                )
+            })?;
+
+        let grant_record = NewApprovalGrantRecord {
+            scope_session_id: root_session_id,
+            approval_key: approval_request.approval_key.clone(),
+            created_by_session_id: Some(current_session_id.to_owned()),
+        };
+
+        repo.upsert_approval_grant(grant_record)?;
+
+        Ok(())
     }
 
     fn replay_shell_request(
@@ -3866,6 +3906,62 @@ where
         }
 
         Err(Self::approval_request_not_pending_error(approval_request))
+    }
+
+    async fn finish_approved_resolution(
+        &self,
+        repo: &SessionRepository,
+        approved: ApprovalRequestRecord,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let replay_is_allowed = self.can_replay_approved_request();
+        if !replay_is_allowed {
+            return Ok(crate::tools::approval::ApprovalResolutionOutcome {
+                approval_request: approved,
+                resumed_tool_output: None,
+            });
+        }
+
+        let approval_request_id = approved.approval_request_id;
+        self.execute_approved_request(repo, approval_request_id.as_str())
+            .await
+    }
+
+    async fn resume_existing_approved_request(
+        &self,
+        repo: &SessionRepository,
+        request: &crate::tools::approval::ApprovalResolutionRequest,
+        approval_request: ApprovalRequestRecord,
+        expected_decision: ApprovalDecision,
+    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
+        let status = approval_request.status;
+        if status != ApprovalRequestStatus::Approved {
+            return Err(Self::approval_request_not_pending_error(&approval_request));
+        }
+
+        let recorded_decision = approval_request.decision.ok_or_else(|| {
+            let approval_request_id = request.approval_request_id.as_str();
+            format!("approval_request_missing_decision: `{approval_request_id}` is approved")
+        })?;
+
+        if recorded_decision != expected_decision {
+            let approval_request_id = request.approval_request_id.as_str();
+            let recorded_decision_name = recorded_decision.as_str();
+            let expected_decision_name = expected_decision.as_str();
+
+            return Err(format!(
+                "approval_request_decision_mismatch: `{approval_request_id}` is already `{recorded_decision_name}`, expected `{expected_decision_name}`"
+            ));
+        }
+
+        if expected_decision == ApprovalDecision::ApproveAlways {
+            Self::ensure_approve_always_grant(
+                repo,
+                &approval_request,
+                &request.current_session_id,
+            )?;
+        }
+
+        self.finish_approved_resolution(repo, approval_request).await
     }
 
     async fn replay_approved_request(
@@ -4042,11 +4138,11 @@ where
             ));
         }
 
-        Self::ensure_resolution_request_is_pending(&approval_request)?;
         self.ensure_resolution_binding_allows_decision(&approval_request, request.decision)?;
 
         match request.decision {
             ApprovalDecision::Deny => {
+                Self::ensure_resolution_request_is_pending(&approval_request)?;
                 let resolved = match repo.transition_approval_request_if_current(
                     &request.approval_request_id,
                     TransitionApprovalRequestIfCurrentRequest {
@@ -4060,14 +4156,10 @@ where
                 )? {
                     Some(resolved) => resolved,
                     None => {
-                        let latest = repo
-                            .load_approval_request(&request.approval_request_id)?
-                            .ok_or_else(|| {
-                                format!(
-                                    "approval_request_not_found: `{}`",
-                                    request.approval_request_id
-                                )
-                            })?;
+                        let latest = Self::load_approval_request_or_not_found(
+                            &repo,
+                            &request.approval_request_id,
+                        )?;
                         return Err(Self::approval_request_not_pending_error(&latest));
                     }
                 };
@@ -4090,15 +4182,18 @@ where
                 )? {
                     Some(approved) => approved,
                     None => {
-                        let latest = repo
-                            .load_approval_request(&request.approval_request_id)?
-                            .ok_or_else(|| {
-                                format!(
-                                    "approval_request_not_found: `{}`",
-                                    request.approval_request_id
-                                )
-                            })?;
-                        return Err(Self::approval_request_not_pending_error(&latest));
+                        let latest = Self::load_approval_request_or_not_found(
+                            &repo,
+                            &request.approval_request_id,
+                        )?;
+                        return self
+                            .resume_existing_approved_request(
+                                &repo,
+                                &request,
+                                latest,
+                                ApprovalDecision::ApproveOnce,
+                            )
+                            .await;
                     }
                 };
                 if let Some(session_consent_mode) = request.session_consent_mode {
@@ -4117,8 +4212,7 @@ where
                         updated_by_session_id,
                     })?;
                 }
-                self.execute_approved_request(&repo, &request.approval_request_id)
-                    .await
+                self.finish_approved_resolution(&repo, approved).await
             }
             ApprovalDecision::ApproveAlways => {
                 let approved = match repo.transition_approval_request_if_current(
@@ -4134,32 +4228,22 @@ where
                 )? {
                     Some(approved) => approved,
                     None => {
-                        let latest = repo
-                            .load_approval_request(&request.approval_request_id)?
-                            .ok_or_else(|| {
-                                format!(
-                                    "approval_request_not_found: `{}`",
-                                    request.approval_request_id
-                                )
-                            })?;
-                        return Err(Self::approval_request_not_pending_error(&latest));
+                        let latest = Self::load_approval_request_or_not_found(
+                            &repo,
+                            &request.approval_request_id,
+                        )?;
+                        return self
+                            .resume_existing_approved_request(
+                                &repo,
+                                &request,
+                                latest,
+                                ApprovalDecision::ApproveAlways,
+                            )
+                            .await;
                     }
                 };
-                let grant_scope_session_id = repo
-                    .lineage_root_session_id(&approved.session_id)?
-                    .ok_or_else(|| {
-                        format!(
-                            "approval_request_session_not_found: `{}`",
-                            approved.session_id
-                        )
-                    })?;
-                repo.upsert_approval_grant(NewApprovalGrantRecord {
-                    scope_session_id: grant_scope_session_id,
-                    approval_key: approved.approval_key.clone(),
-                    created_by_session_id: Some(request.current_session_id.clone()),
-                })?;
-                self.execute_approved_request(&repo, &request.approval_request_id)
-                    .await
+                Self::ensure_approve_always_grant(&repo, &approved, &request.current_session_id)?;
+                self.finish_approved_resolution(&repo, approved).await
             }
         }
     }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3961,7 +3961,8 @@ where
             )?;
         }
 
-        self.finish_approved_resolution(repo, approval_request).await
+        self.finish_approved_resolution(repo, approval_request)
+            .await
     }
 
     async fn replay_approved_request(
@@ -9287,7 +9288,7 @@ mod tests {
         .expect("approval request resolve should succeed");
         assert_eq!(
             outcome.approval_request.status,
-            ApprovalRequestStatus::Executed
+            ApprovalRequestStatus::Approved
         );
 
         let stored = repo
@@ -9308,7 +9309,7 @@ mod tests {
             approval_request.decision,
             Some(ApprovalDecision::ApproveOnce)
         );
-        assert_eq!(approval_request.status, ApprovalRequestStatus::Executed);
+        assert_eq!(approval_request.status, ApprovalRequestStatus::Approved);
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -30,7 +30,6 @@ use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
 use crate::operator::session_graph::OperatorSessionGraph;
 use crate::runtime_self_continuity;
-use crate::tools::ToolExecutionKind;
 
 use super::super::config::LoongClawConfig;
 use super::ConversationSessionAddress;
@@ -39,6 +38,8 @@ use super::analytics::{
     SafeLaneEventSummary, TurnCheckpointRecoveryAction, build_turn_checkpoint_repair_plan,
     summarize_safe_lane_history,
 };
+#[cfg(feature = "memory-sqlite")]
+use super::approval_resolution::CoordinatorApprovalResolutionRuntime;
 use super::context_engine::{AssembledConversationContext, ConversationContextEngine};
 use super::ingress::ConversationIngressContext;
 use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
@@ -126,12 +127,13 @@ use crate::session::recovery::{
     RECOVERY_EVENT_KIND, build_async_spawn_failure_recovery_payload,
     build_terminal_finalize_recovery_payload,
 };
+#[cfg(all(test, feature = "memory-sqlite"))]
+use crate::session::repository::TransitionApprovalRequestIfCurrentRequest;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, CreateSessionWithEventRequest,
-    FinalizeSessionTerminalRequest, NewApprovalGrantRecord, NewSessionEvent, NewSessionRecord,
-    NewSessionToolConsentRecord, SessionKind, SessionRepository, SessionState,
-    TransitionApprovalRequestIfCurrentRequest, TransitionSessionWithEventIfCurrentRequest,
+    ApprovalDecision, ApprovalRequestStatus, CreateSessionWithEventRequest,
+    FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, SessionKind,
+    SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
 };
 
 #[derive(Default)]
@@ -3672,611 +3674,6 @@ fn effective_tool_config_for_session(
     tool_config
 }
 
-#[cfg(feature = "memory-sqlite")]
-struct CoordinatorApprovalResolutionRuntime<'a, R: ?Sized> {
-    config: &'a LoongClawConfig,
-    runtime: &'a R,
-    fallback: &'a DefaultAppToolDispatcher,
-    binding: ConversationRuntimeBinding<'a>,
-}
-
-#[cfg(feature = "memory-sqlite")]
-struct ApprovalReplayRequest {
-    request: loongclaw_contracts::ToolCoreRequest,
-    execution_kind: crate::tools::ToolExecutionKind,
-    trusted_internal_context: bool,
-}
-
-#[cfg(feature = "memory-sqlite")]
-impl<R> CoordinatorApprovalResolutionRuntime<'_, R>
-where
-    R: ConversationRuntime + ?Sized,
-{
-    fn can_replay_approved_request(&self) -> bool {
-        self.binding.is_kernel_bound()
-    }
-
-    fn current_epoch_s() -> i64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|duration| duration.as_secs() as i64)
-            .unwrap_or(0)
-    }
-
-    fn load_approval_request_or_not_found(
-        repo: &SessionRepository,
-        approval_request_id: &str,
-    ) -> Result<ApprovalRequestRecord, String> {
-        let latest_request = repo.load_approval_request(approval_request_id)?;
-        let approval_request = latest_request
-            .ok_or_else(|| format!("approval_request_not_found: `{approval_request_id}`"))?;
-
-        Ok(approval_request)
-    }
-
-    fn ensure_approve_always_grant(
-        repo: &SessionRepository,
-        approval_request: &ApprovalRequestRecord,
-        current_session_id: &str,
-    ) -> Result<(), String> {
-        let root_session_id = repo
-            .lineage_root_session_id(&approval_request.session_id)?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_session_not_found: `{}`",
-                    approval_request.session_id
-                )
-            })?;
-
-        let grant_record = NewApprovalGrantRecord {
-            scope_session_id: root_session_id,
-            approval_key: approval_request.approval_key.clone(),
-            created_by_session_id: Some(current_session_id.to_owned()),
-        };
-
-        repo.upsert_approval_grant(grant_record)?;
-
-        Ok(())
-    }
-
-    fn persist_session_consent_if_requested(
-        repo: &SessionRepository,
-        approval_request: &ApprovalRequestRecord,
-        current_session_id: &str,
-        session_consent_mode: Option<ToolConsentMode>,
-    ) -> Result<(), String> {
-        let Some(session_consent_mode) = session_consent_mode else {
-            return Ok(());
-        };
-
-        let scope_session_id = repo
-            .lineage_root_session_id(&approval_request.session_id)?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_session_not_found: `{}`",
-                    approval_request.session_id
-                )
-            })?;
-
-        let consent_record = NewSessionToolConsentRecord {
-            scope_session_id,
-            mode: session_consent_mode,
-            updated_by_session_id: Some(current_session_id.to_owned()),
-        };
-
-        repo.upsert_session_tool_consent(consent_record)?;
-
-        Ok(())
-    }
-
-    fn replay_shell_request(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-        tool_name: &str,
-        args_json: &Value,
-    ) -> Result<ApprovalReplayRequest, String> {
-        let canonical_tool_name = crate::tools::canonical_tool_name(tool_name);
-        let mut payload = if canonical_tool_name == crate::tools::SHELL_EXEC_TOOL_NAME {
-            args_json.clone()
-        } else {
-            let approved_tool_name = approval_request
-                .request_payload_json
-                .get("approved_tool_name")
-                .and_then(Value::as_str)
-                .map(crate::tools::canonical_tool_name)
-                .unwrap_or(canonical_tool_name);
-            if approved_tool_name != crate::tools::SHELL_EXEC_TOOL_NAME {
-                return Err(format!(
-                    "approval_request_invalid_execution_kind: expected `shell.exec`, got `{approved_tool_name}`"
-                ));
-            }
-            args_json.get("arguments").cloned().ok_or_else(|| {
-                "approval_request_invalid_payload: missing shell.exec arguments".to_owned()
-            })?
-        };
-        let payload_object = payload.as_object_mut().ok_or_else(|| {
-            "approval_request_invalid_payload: shell.exec args_json must be an object".to_owned()
-        })?;
-        let internal_context = crate::tools::shell_policy_ext::shell_exec_internal_approval_context(
-            approval_request.approval_key.as_str(),
-        );
-        crate::tools::merge_trusted_internal_tool_context_into_arguments(
-            payload_object,
-            &internal_context,
-        )?;
-
-        Ok(ApprovalReplayRequest {
-            request: loongclaw_contracts::ToolCoreRequest {
-                tool_name: crate::tools::SHELL_EXEC_TOOL_NAME.to_owned(),
-                payload,
-            },
-            execution_kind: crate::tools::ToolExecutionKind::Core,
-            trusted_internal_context: true,
-        })
-    }
-
-    fn replay_request(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<ApprovalReplayRequest, String> {
-        let execution_kind = self.replay_execution_kind(approval_request)?;
-        let tool_name = approval_request
-            .request_payload_json
-            .get("tool_name")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
-        let payload = approval_request
-            .request_payload_json
-            .get("args_json")
-            .cloned()
-            .ok_or_else(|| "approval_request_invalid_payload: missing args_json".to_owned())?;
-
-        match execution_kind {
-            ToolExecutionKind::App => Ok(ApprovalReplayRequest {
-                request: loongclaw_contracts::ToolCoreRequest {
-                    tool_name: tool_name.to_owned(),
-                    payload,
-                },
-                execution_kind: crate::tools::ToolExecutionKind::App,
-                trusted_internal_context: false,
-            }),
-            ToolExecutionKind::Core => {
-                let canonical_tool_name = crate::tools::canonical_tool_name(tool_name);
-                if canonical_tool_name == crate::tools::SHELL_EXEC_TOOL_NAME {
-                    return self.replay_shell_request(approval_request, tool_name, &payload);
-                }
-
-                Ok(ApprovalReplayRequest {
-                    request: loongclaw_contracts::ToolCoreRequest {
-                        tool_name: tool_name.to_owned(),
-                        payload,
-                    },
-                    execution_kind: crate::tools::ToolExecutionKind::Core,
-                    trusted_internal_context: false,
-                })
-            }
-        }
-    }
-
-    fn replay_execution_kind(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<ToolExecutionKind, String> {
-        let execution_kind = approval_request
-            .request_payload_json
-            .get("execution_kind")
-            .and_then(Value::as_str)
-            .ok_or_else(|| "approval_request_invalid_payload: missing execution_kind".to_owned())?;
-        match execution_kind {
-            "core" => Ok(ToolExecutionKind::Core),
-            "app" => Ok(ToolExecutionKind::App),
-            _ => Err(format!(
-                "approval_request_invalid_execution_kind: expected `core` or `app`, got `{execution_kind}`"
-            )),
-        }
-    }
-
-    fn replay_requires_mutating_binding(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<bool, String> {
-        let execution_kind = self.replay_execution_kind(approval_request)?;
-        if execution_kind == ToolExecutionKind::Core {
-            return Ok(true);
-        }
-
-        let tool_name = approval_request
-            .request_payload_json
-            .get("tool_name")
-            .and_then(Value::as_str)
-            .map(crate::tools::canonical_tool_name)
-            .ok_or_else(|| "approval_request_invalid_payload: missing tool_name".to_owned())?;
-
-        Ok(tool_name == "delegate_async")
-    }
-
-    fn ensure_resolution_binding_allows_decision(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-        decision: ApprovalDecision,
-    ) -> Result<(), String> {
-        let mutating_resolution_requested = matches!(
-            decision,
-            ApprovalDecision::ApproveOnce | ApprovalDecision::ApproveAlways
-        );
-        if !mutating_resolution_requested {
-            return Ok(());
-        }
-
-        if self.binding.allows_mutation() {
-            return Ok(());
-        }
-
-        let replay_requires_mutation = self.replay_requires_mutating_binding(approval_request)?;
-        if !replay_requires_mutation {
-            return Ok(());
-        }
-
-        Err("app_tool_denied: governed_runtime_binding_required".to_owned())
-    }
-
-    fn approval_request_not_pending_error(approval_request: &ApprovalRequestRecord) -> String {
-        let approval_request_id = approval_request.approval_request_id.as_str();
-        let status = approval_request.status.as_str();
-        format!("approval_request_not_pending: `{approval_request_id}` is already {status}")
-    }
-
-    fn ensure_resolution_request_is_pending(
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<(), String> {
-        if approval_request.status == ApprovalRequestStatus::Pending {
-            return Ok(());
-        }
-
-        Err(Self::approval_request_not_pending_error(approval_request))
-    }
-
-    async fn finish_approved_resolution(
-        &self,
-        repo: &SessionRepository,
-        approved: ApprovalRequestRecord,
-    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let replay_is_allowed = self.can_replay_approved_request();
-        if !replay_is_allowed {
-            return Ok(crate::tools::approval::ApprovalResolutionOutcome {
-                approval_request: approved,
-                resumed_tool_output: None,
-            });
-        }
-
-        let approval_request_id = approved.approval_request_id;
-        self.execute_approved_request(repo, approval_request_id.as_str())
-            .await
-    }
-
-    async fn resume_existing_approved_request(
-        &self,
-        repo: &SessionRepository,
-        request: &crate::tools::approval::ApprovalResolutionRequest,
-        approval_request: ApprovalRequestRecord,
-        expected_decision: ApprovalDecision,
-    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let status = approval_request.status;
-        if status != ApprovalRequestStatus::Approved {
-            return Err(Self::approval_request_not_pending_error(&approval_request));
-        }
-
-        let recorded_decision = approval_request.decision.ok_or_else(|| {
-            let approval_request_id = request.approval_request_id.as_str();
-            format!("approval_request_missing_decision: `{approval_request_id}` is approved")
-        })?;
-
-        if recorded_decision != expected_decision {
-            let approval_request_id = request.approval_request_id.as_str();
-            let recorded_decision_name = recorded_decision.as_str();
-            let expected_decision_name = expected_decision.as_str();
-
-            return Err(format!(
-                "approval_request_decision_mismatch: `{approval_request_id}` is already `{recorded_decision_name}`, expected `{expected_decision_name}`"
-            ));
-        }
-
-        if expected_decision == ApprovalDecision::ApproveAlways {
-            Self::ensure_approve_always_grant(
-                repo,
-                &approval_request,
-                &request.current_session_id,
-            )?;
-        }
-
-        Self::persist_session_consent_if_requested(
-            repo,
-            &approval_request,
-            &request.current_session_id,
-            request.session_consent_mode,
-        )?;
-
-        self.finish_approved_resolution(repo, approval_request)
-            .await
-    }
-
-    async fn replay_approved_request(
-        &self,
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
-        let replay_request = self.replay_request(approval_request)?;
-        match replay_request.execution_kind {
-            crate::tools::ToolExecutionKind::Core => {
-                let kernel_ctx = self
-                    .binding
-                    .kernel_context()
-                    .ok_or_else(|| "no_kernel_context".to_owned())?;
-                crate::tools::execute_kernel_tool_request(
-                    kernel_ctx,
-                    replay_request.request,
-                    replay_request.trusted_internal_context,
-                )
-                .await
-                .map_err(|error| error.to_string())
-            }
-            crate::tools::ToolExecutionKind::App => {
-                let session_context = self
-                    .runtime
-                    .session_context(self.config, &approval_request.session_id, self.binding)
-                    .map_err(|error| {
-                        format!("load approval request session context failed: {error}")
-                    })?;
-                match crate::tools::canonical_tool_name(replay_request.request.tool_name.as_str()) {
-                    "delegate" => {
-                        execute_delegate_tool(
-                            self.config,
-                            self.runtime,
-                            &session_context,
-                            replay_request.request.payload,
-                            self.binding,
-                        )
-                        .await
-                    }
-                    "delegate_async" => {
-                        execute_delegate_async_tool(
-                            self.config,
-                            self.runtime,
-                            &session_context,
-                            replay_request.request.payload,
-                            self.binding,
-                        )
-                        .await
-                    }
-                    _ => {
-                        self.fallback
-                            .execute_app_tool(
-                                &session_context,
-                                replay_request.request,
-                                self.binding,
-                            )
-                            .await
-                    }
-                }
-            }
-        }
-    }
-
-    async fn execute_approved_request(
-        &self,
-        repo: &SessionRepository,
-        approval_request_id: &str,
-    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let executing = repo
-            .transition_approval_request_if_current(
-                approval_request_id,
-                TransitionApprovalRequestIfCurrentRequest {
-                    expected_status: ApprovalRequestStatus::Approved,
-                    next_status: ApprovalRequestStatus::Executing,
-                    decision: None,
-                    resolved_by_session_id: None,
-                    executed_at: None,
-                    last_error: None,
-                },
-            )?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_not_approved: `{approval_request_id}` is no longer approved"
-                )
-            })?;
-
-        match self.replay_approved_request(&executing).await {
-            Ok(resumed_tool_output) => {
-                let executed = repo
-                    .transition_approval_request_if_current(
-                        approval_request_id,
-                        TransitionApprovalRequestIfCurrentRequest {
-                            expected_status: ApprovalRequestStatus::Executing,
-                            next_status: ApprovalRequestStatus::Executed,
-                            decision: None,
-                            resolved_by_session_id: None,
-                            executed_at: Some(Self::current_epoch_s()),
-                            last_error: None,
-                        },
-                    )?
-                    .ok_or_else(|| {
-                        format!(
-                            "approval_request_not_executing: `{approval_request_id}` is no longer executing"
-                        )
-                    })?;
-                Ok(crate::tools::approval::ApprovalResolutionOutcome {
-                    approval_request: executed,
-                    resumed_tool_output: Some(resumed_tool_output),
-                })
-            }
-            Err(error) => {
-                let maybe_executed = repo.transition_approval_request_if_current(
-                    approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Executing,
-                        next_status: ApprovalRequestStatus::Executed,
-                        decision: None,
-                        resolved_by_session_id: None,
-                        executed_at: Some(Self::current_epoch_s()),
-                        last_error: Some(error.clone()),
-                    },
-                )?;
-
-                if maybe_executed.is_none() {
-                    return Err(format!(
-                        "approval_request_not_executing: `{approval_request_id}` is no longer executing; original replay error: {error}"
-                    ));
-                }
-
-                Err(error)
-            }
-        }
-    }
-}
-
-#[cfg(feature = "memory-sqlite")]
-#[async_trait]
-impl<R> crate::tools::approval::ApprovalResolutionRuntime
-    for CoordinatorApprovalResolutionRuntime<'_, R>
-where
-    R: ConversationRuntime + ?Sized,
-{
-    async fn resolve_approval_request(
-        &self,
-        request: crate::tools::approval::ApprovalResolutionRequest,
-    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let memory_config = MemoryRuntimeConfig::from_memory_config(&self.config.memory);
-        let repo = SessionRepository::new(&memory_config)?;
-        let approval_request = repo
-            .load_approval_request(&request.approval_request_id)?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_not_found: `{}`",
-                    request.approval_request_id
-                )
-            })?;
-
-        let is_visible = match request.visibility {
-            crate::config::SessionVisibility::SelfOnly => {
-                request.current_session_id == approval_request.session_id
-            }
-            crate::config::SessionVisibility::Children => {
-                request.current_session_id == approval_request.session_id
-                    || repo.is_session_visible(
-                        &request.current_session_id,
-                        &approval_request.session_id,
-                    )?
-            }
-        };
-        if !is_visible {
-            return Err(format!(
-                "visibility_denied: session `{}` is not visible from `{}`",
-                approval_request.session_id, request.current_session_id
-            ));
-        }
-
-        self.ensure_resolution_binding_allows_decision(&approval_request, request.decision)?;
-
-        match request.decision {
-            ApprovalDecision::Deny => {
-                Self::ensure_resolution_request_is_pending(&approval_request)?;
-                let resolved = match repo.transition_approval_request_if_current(
-                    &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Denied,
-                        decision: Some(ApprovalDecision::Deny),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(resolved) => resolved,
-                    None => {
-                        let latest = Self::load_approval_request_or_not_found(
-                            &repo,
-                            &request.approval_request_id,
-                        )?;
-                        return Err(Self::approval_request_not_pending_error(&latest));
-                    }
-                };
-                Ok(crate::tools::approval::ApprovalResolutionOutcome {
-                    approval_request: resolved,
-                    resumed_tool_output: None,
-                })
-            }
-            ApprovalDecision::ApproveOnce => {
-                let approved = match repo.transition_approval_request_if_current(
-                    &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Approved,
-                        decision: Some(ApprovalDecision::ApproveOnce),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(approved) => approved,
-                    None => {
-                        let latest = Self::load_approval_request_or_not_found(
-                            &repo,
-                            &request.approval_request_id,
-                        )?;
-                        return self
-                            .resume_existing_approved_request(
-                                &repo,
-                                &request,
-                                latest,
-                                ApprovalDecision::ApproveOnce,
-                            )
-                            .await;
-                    }
-                };
-                Self::persist_session_consent_if_requested(
-                    &repo,
-                    &approved,
-                    &request.current_session_id,
-                    request.session_consent_mode,
-                )?;
-                self.finish_approved_resolution(&repo, approved).await
-            }
-            ApprovalDecision::ApproveAlways => {
-                let approved = match repo.transition_approval_request_if_current(
-                    &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Approved,
-                        decision: Some(ApprovalDecision::ApproveAlways),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(approved) => approved,
-                    None => {
-                        let latest = Self::load_approval_request_or_not_found(
-                            &repo,
-                            &request.approval_request_id,
-                        )?;
-                        return self
-                            .resume_existing_approved_request(
-                                &repo,
-                                &request,
-                                latest,
-                                ApprovalDecision::ApproveAlways,
-                            )
-                            .await;
-                    }
-                };
-                Self::ensure_approve_always_grant(&repo, &approved, &request.current_session_id)?;
-                self.finish_approved_resolution(&repo, approved).await
-            }
-        }
-    }
-}
-
 struct CoordinatorAppToolDispatcher<'a, R: ?Sized> {
     config: &'a LoongClawConfig,
     runtime: &'a R,
@@ -4359,12 +3756,12 @@ where
                         MemoryRuntimeConfig::from_memory_config(&self.config.memory);
                     let effective_tool_config =
                         effective_tool_config_for_session(&self.config.tools, session_context);
-                    let approval_runtime = CoordinatorApprovalResolutionRuntime {
-                        config: self.config,
-                        runtime: self.runtime,
-                        fallback: self.fallback,
+                    let approval_runtime = CoordinatorApprovalResolutionRuntime::new(
+                        self.config,
+                        self.runtime,
+                        self.fallback,
                         binding,
-                    };
+                    );
                     crate::tools::approval::execute_approval_tool_with_runtime_support(
                         request,
                         &session_context.session_id,
@@ -4513,7 +3910,7 @@ fn build_tool_discovery_refresh_event_payload(
 }
 
 #[cfg(feature = "memory-sqlite")]
-async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
+pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
     session_context: &SessionContext,
@@ -4717,7 +4114,7 @@ pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Si
 }
 
 #[cfg(feature = "memory-sqlite")]
-async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
+pub(super) async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
     session_context: &SessionContext,
@@ -4745,7 +4142,7 @@ async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
 }
 
 #[cfg(not(feature = "memory-sqlite"))]
-async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
+pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
     _config: &LoongClawConfig,
     _runtime: &R,
     _session_context: &SessionContext,
@@ -4756,7 +4153,7 @@ async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
 }
 
 #[cfg(not(feature = "memory-sqlite"))]
-async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
+pub(super) async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>(
     _config: &LoongClawConfig,
     _runtime: &R,
     _session_context: &SessionContext,
@@ -9295,12 +8692,12 @@ mod tests {
             "app",
         );
         let fallback = DefaultAppToolDispatcher::new(memory_config.clone(), ToolConfig::default());
-        let approval_runtime = CoordinatorApprovalResolutionRuntime {
-            config: &config,
-            runtime: &runtime,
-            fallback: &fallback,
-            binding: ConversationRuntimeBinding::direct(),
-        };
+        let approval_runtime = CoordinatorApprovalResolutionRuntime::new(
+            &config,
+            &runtime,
+            &fallback,
+            ConversationRuntimeBinding::direct(),
+        );
         let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
             &approval_runtime,
             crate::tools::approval::ApprovalResolutionRequest {
@@ -9383,12 +8780,12 @@ mod tests {
         .expect("approval request should be pending");
 
         let fallback = DefaultAppToolDispatcher::new(memory_config.clone(), ToolConfig::default());
-        let approval_runtime = CoordinatorApprovalResolutionRuntime {
-            config: &config,
-            runtime: &runtime,
-            fallback: &fallback,
-            binding: ConversationRuntimeBinding::direct(),
-        };
+        let approval_runtime = CoordinatorApprovalResolutionRuntime::new(
+            &config,
+            &runtime,
+            &fallback,
+            ConversationRuntimeBinding::direct(),
+        );
         let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
             &approval_runtime,
             crate::tools::approval::ApprovalResolutionRequest {
@@ -9470,12 +8867,12 @@ mod tests {
         let kernel_ctx =
             bootstrap_test_kernel_context("approval-core-replay", 60).expect("kernel context");
         let fallback = DefaultAppToolDispatcher::new(memory_config.clone(), ToolConfig::default());
-        let approval_runtime = CoordinatorApprovalResolutionRuntime {
-            config: &config,
-            runtime: &runtime,
-            fallback: &fallback,
-            binding: ConversationRuntimeBinding::kernel(&kernel_ctx),
-        };
+        let approval_runtime = CoordinatorApprovalResolutionRuntime::new(
+            &config,
+            &runtime,
+            &fallback,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        );
 
         let error = approval_runtime
             .replay_approved_request(&approval_request)

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3739,6 +3739,36 @@ where
         Ok(())
     }
 
+    fn persist_session_consent_if_requested(
+        repo: &SessionRepository,
+        approval_request: &ApprovalRequestRecord,
+        current_session_id: &str,
+        session_consent_mode: Option<ToolConsentMode>,
+    ) -> Result<(), String> {
+        let Some(session_consent_mode) = session_consent_mode else {
+            return Ok(());
+        };
+
+        let scope_session_id = repo
+            .lineage_root_session_id(&approval_request.session_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_session_not_found: `{}`",
+                    approval_request.session_id
+                )
+            })?;
+
+        let consent_record = NewSessionToolConsentRecord {
+            scope_session_id,
+            mode: session_consent_mode,
+            updated_by_session_id: Some(current_session_id.to_owned()),
+        };
+
+        repo.upsert_session_tool_consent(consent_record)?;
+
+        Ok(())
+    }
+
     fn replay_shell_request(
         &self,
         approval_request: &ApprovalRequestRecord,
@@ -3960,6 +3990,13 @@ where
                 &request.current_session_id,
             )?;
         }
+
+        Self::persist_session_consent_if_requested(
+            repo,
+            &approval_request,
+            &request.current_session_id,
+            request.session_consent_mode,
+        )?;
 
         self.finish_approved_resolution(repo, approval_request)
             .await
@@ -4197,22 +4234,12 @@ where
                             .await;
                     }
                 };
-                if let Some(session_consent_mode) = request.session_consent_mode {
-                    let scope_session_id = repo
-                        .lineage_root_session_id(&approved.session_id)?
-                        .ok_or_else(|| {
-                            format!(
-                                "approval_request_session_not_found: `{}`",
-                                approved.session_id
-                            )
-                        })?;
-                    let updated_by_session_id = Some(request.current_session_id.clone());
-                    repo.upsert_session_tool_consent(NewSessionToolConsentRecord {
-                        scope_session_id,
-                        mode: session_consent_mode,
-                        updated_by_session_id,
-                    })?;
-                }
+                Self::persist_session_consent_if_requested(
+                    &repo,
+                    &approved,
+                    &request.current_session_id,
+                    request.session_consent_mode,
+                )?;
                 self.finish_approved_resolution(&repo, approved).await
             }
             ApprovalDecision::ApproveAlways => {
@@ -9310,6 +9337,85 @@ mod tests {
             Some(ApprovalDecision::ApproveOnce)
         );
         assert_eq!(approval_request.status, ApprovalRequestStatus::Approved);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn approval_request_resolve_retries_missing_session_mode_after_approval() {
+        let runtime = ApprovalControlRuntime::default();
+        let mut config = LoongClawConfig::default();
+        let memory_config = sqlite_memory_config("approval-control-session-mode-retry");
+        let sqlite_path = memory_config
+            .sqlite_path
+            .as_ref()
+            .expect("sqlite path")
+            .display()
+            .to_string();
+        config.memory.sqlite_path = sqlite_path;
+        let repo = SessionRepository::new(&memory_config).expect("repository");
+        repo.ensure_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("ensure root session");
+        seed_pending_approval_request(
+            &repo,
+            "root-session",
+            "apr-auto-retry",
+            "sessions_list",
+            "app",
+        );
+        repo.transition_approval_request_if_current(
+            "apr-auto-retry",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveOnce),
+                resolved_by_session_id: Some("root-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition approval request")
+        .expect("approval request should be pending");
+
+        let fallback = DefaultAppToolDispatcher::new(memory_config.clone(), ToolConfig::default());
+        let approval_runtime = CoordinatorApprovalResolutionRuntime {
+            config: &config,
+            runtime: &runtime,
+            fallback: &fallback,
+            binding: ConversationRuntimeBinding::direct(),
+        };
+        let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
+            &approval_runtime,
+            crate::tools::approval::ApprovalResolutionRequest {
+                current_session_id: "root-session".to_owned(),
+                approval_request_id: "apr-auto-retry".to_owned(),
+                decision: ApprovalDecision::ApproveOnce,
+                session_consent_mode: Some(ToolConsentMode::Auto),
+                visibility: crate::config::SessionVisibility::Children,
+            },
+        )
+        .await
+        .expect("approval request retry should succeed");
+
+        assert_eq!(
+            outcome.approval_request.status,
+            ApprovalRequestStatus::Approved
+        );
+
+        let stored = repo
+            .load_session_tool_consent("root-session")
+            .expect("load session tool consent")
+            .expect("session tool consent row");
+        assert_eq!(stored.mode, ToolConsentMode::Auto);
+        assert_eq!(
+            stored.updated_by_session_id.as_deref(),
+            Some("root-session")
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -428,22 +428,6 @@ fn denied_tool_decision(tool_name: &str, failure: &TurnFailure) -> ToolDecisionT
     ToolDecisionTelemetry::deny(tool_name, reason, rule_id)
 }
 
-fn governed_runtime_binding_denied_outcome(
-    descriptor: &crate::tools::ToolDescriptor,
-) -> ToolPreflightOutcome {
-    let tool_name = descriptor.name;
-    let reason_code = "governed_runtime_binding_required";
-    let failure = TurnFailure::policy_denied(reason_code, reason_code);
-    let action_class = descriptor.capability_action_class();
-    let decision = denied_tool_decision(tool_name, &failure)
-        .with_capability_action_class(action_class.as_str());
-    ToolPreflightOutcome::Denied { failure, decision }
-}
-
-fn requires_kernel_bound_runtime_for_preflight(descriptor: &crate::tools::ToolDescriptor) -> bool {
-    descriptor.name == "delegate_async"
-}
-
 #[async_trait]
 pub trait AppToolDispatcher: Send + Sync {
     async fn preflight_tool_intent_with_binding(
@@ -454,13 +438,6 @@ pub trait AppToolDispatcher: Send + Sync {
         binding: ConversationRuntimeBinding<'_>,
         _budget_state: &AutonomyTurnBudgetState,
     ) -> Result<ToolPreflightOutcome, String> {
-        let requires_mutating_binding = requires_mutating_runtime_binding(descriptor);
-        let allows_mutation = binding.allows_mutation();
-        if requires_mutating_binding && !allows_mutation {
-            let denied = governed_runtime_binding_denied_outcome(descriptor);
-            return Ok(denied);
-        }
-
         match self
             .maybe_require_approval_with_binding(session_context, intent, descriptor, binding)
             .await
@@ -487,18 +464,7 @@ pub trait AppToolDispatcher: Send + Sync {
         descriptor: &crate::tools::ToolDescriptor,
         binding: ConversationRuntimeBinding<'_>,
     ) -> Result<Option<ApprovalRequirement>, String> {
-        let kernel_ctx = binding.kernel_context();
-        self.maybe_require_approval(session_context, intent, descriptor, kernel_ctx)
-            .await
-    }
-
-    async fn maybe_require_approval(
-        &self,
-        _session_context: &SessionContext,
-        _intent: &ToolIntent,
-        _descriptor: &crate::tools::ToolDescriptor,
-        _kernel_ctx: Option<&KernelContext>,
-    ) -> Result<Option<ApprovalRequirement>, String> {
+        let _ = (session_context, intent, descriptor, binding);
         Ok(None)
     }
 
@@ -1278,12 +1244,6 @@ fn tool_is_auto_eligible(
             && governance.approval_mode == ToolApprovalMode::Never)
 }
 
-fn requires_mutating_runtime_binding(descriptor: &crate::tools::ToolDescriptor) -> bool {
-    let governance = governance_profile_for_descriptor(descriptor);
-    descriptor.execution_kind == ToolExecutionKind::App
-        && governance.approval_mode == ToolApprovalMode::PolicyDriven
-}
-
 enum GovernedToolPreflight {
     Allowed,
     AllowedWithTrustedInternalContext(Value),
@@ -1465,13 +1425,6 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 })
             }
             Ok(None) => {
-                let requires_mutating_binding = requires_mutating_runtime_binding(descriptor);
-                let allows_mutation = binding.allows_mutation();
-                if requires_mutating_binding && !allows_mutation {
-                    let denied = governed_runtime_binding_denied_outcome(descriptor);
-                    return Ok(denied);
-                }
-
                 let decision = autonomy_allow_decision
                     .unwrap_or_else(|| generic_allow_tool_decision(descriptor.name));
                 Ok(ToolPreflightOutcome::Allow(decision))
@@ -1640,16 +1593,27 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
         &self,
         session_context: &SessionContext,
         request: ToolCoreRequest,
-        _binding: ConversationRuntimeBinding<'_>,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<ToolCoreOutcome, String> {
         let canonical_tool_name = crate::tools::canonical_tool_name(request.tool_name.as_str());
         let effective_tool_view = self.effective_tool_view_for_session(session_context)?;
-        if let Some(descriptor) = tool_catalog().descriptor(canonical_tool_name)
+        let descriptor = tool_catalog().descriptor(canonical_tool_name);
+        let has_kernel_context = binding.kernel_context().is_some();
+
+        if let Some(descriptor) = descriptor
             && descriptor.execution_kind == ToolExecutionKind::App
             && (!session_context.tool_view.contains(descriptor.name)
                 || !effective_tool_view.contains(descriptor.name))
         {
             return Err(format!("tool_not_visible: {}", descriptor.name));
+        }
+
+        let requires_kernel_binding = descriptor
+            .map(crate::tools::ToolDescriptor::requires_kernel_binding)
+            .unwrap_or(false);
+
+        if requires_kernel_binding && !has_kernel_context {
+            return Err("app_tool_denied: no_kernel_context".to_owned());
         }
 
         let effective_tool_config = self.effective_tool_config_for_session(session_context);

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -1266,13 +1266,6 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
         binding: ConversationRuntimeBinding<'_>,
         budget_state: &AutonomyTurnBudgetState,
     ) -> Result<ToolPreflightOutcome, String> {
-        let requires_kernel_bound_runtime = requires_kernel_bound_runtime_for_preflight(descriptor);
-        let allows_mutation = binding.allows_mutation();
-        if requires_kernel_bound_runtime && !allows_mutation {
-            let denied = governed_runtime_binding_denied_outcome(descriptor);
-            return Ok(denied);
-        }
-
         let policy_snapshot = self.autonomy_policy_snapshot();
         let action_class = descriptor.capability_action_class();
         let policy_input = PolicyDecisionInput {

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -5039,7 +5039,6 @@ mod tests {
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config, tool_config);
         let kernel_ctx = test_kernel_context("turn-engine-browser-companion-click-exec");
-
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
                 &browser_companion_click_turn(
@@ -5140,7 +5139,6 @@ mod tests {
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config, tool_config);
         let kernel_ctx = test_kernel_context("turn-engine-browser-companion-click-runtime-ready");
-
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
                 &browser_companion_click_turn(
@@ -5243,7 +5241,6 @@ mod tests {
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config, ToolConfig::default());
         let kernel_ctx = test_kernel_context("turn-engine-browser-companion-click-runtime-policy");
-
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
                 &browser_companion_click_turn(

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -292,6 +292,14 @@ impl ToolDescriptor {
     pub fn governance_profile(&self) -> ToolGovernanceProfile {
         self.policy.governance_profile
     }
+
+    pub fn requires_kernel_binding(&self) -> bool {
+        let governance_profile = self.governance_profile();
+        let approval_mode = governance_profile.approval_mode;
+        let execution_kind = self.execution_kind;
+
+        execution_kind == ToolExecutionKind::App && approval_mode == ToolApprovalMode::PolicyDriven
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T14:16:26Z
+- Generated at: 2026-04-03T14:36:28Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11385 | 11200 | -185 | 100 | 120 | 20 | 101.7% | BREACH | 10831 | 5.1% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10782 | 11200 | 418 | 96 | 120 | 24 | 96.3% | TIGHT | 10831 | -0.5% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): turn_coordinator (101.7%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
+- BREACH hotspots (>100% of any tracked budget): none
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.3%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11385 functions=100 -->
+<!-- arch-hotspot key=turn_coordinator lines=10782 functions=96 -->
 <!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T14:09:14Z
+- Generated at: 2026-04-03T14:16:26Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,13 +22,13 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11279 | 11200 | -79 | 100 | 120 | 20 | 100.7% | BREACH | 10831 | 4.1% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11385 | 11200 | -185 | 100 | 120 | 20 | 101.7% | BREACH | 10831 | 5.1% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): turn_coordinator (100.7%)
+- BREACH hotspots (>100% of any tracked budget): turn_coordinator (101.7%)
 - TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
@@ -68,7 +68,7 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11279 functions=100 -->
+<!-- arch-hotspot key=turn_coordinator lines=11385 functions=100 -->
 <!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,11 +1,11 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T12:52:08Z
+- Generated at: 2026-04-03T14:09:14Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
-- Boundary checks tracked: 4
+- Boundary checks tracked: 5
 - SLO status: PASS
 
 ## Hotspot Metrics
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11194 | 11200 | 6 | 100 | 120 | 20 | 99.9% | TIGHT | 10831 | 3.4% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11279 | 11200 | -79 | 100 | 120 | 20 | 100.7% | BREACH | 10831 | 4.1% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.9%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
+- BREACH hotspots (>100% of any tracked budget): turn_coordinator (100.7%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -40,6 +40,7 @@
 | memory_literals | PASS | PASS | memory operation literals are centralized in crates/app/src/memory/* |
 | provider_mod_helper_definitions | PASS | PASS | provider/mod.rs keeps payload, parse, and recovery helper implementations outside the top-level module |
 | conversation_provider_optional_binding_roundtrip | PASS | PASS | conversation/runtime.rs translates explicit conversation bindings into provider bindings without optional-kernel roundtrips |
+| conversation_app_dispatcher_optional_kernel_context | PASS | n/a | conversation app-tool dispatcher approval hooks stay binding-based without optional kernel fallbacks |
 | spec_app_dependency | PASS | PASS | spec crate remains detached from app crate at the Cargo dependency boundary |
 
 ## SLO Assessment
@@ -67,11 +68,12 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11194 functions=100 -->
+<!-- arch-hotspot key=turn_coordinator lines=11279 functions=100 -->
 <!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->
+<!-- arch-boundary key=conversation_app_dispatcher_optional_kernel_context status=PASS -->
 <!-- arch-boundary key=spec_app_dependency status=PASS -->

--- a/scripts/architecture_budget_lib.sh
+++ b/scripts/architecture_budget_lib.sh
@@ -203,6 +203,7 @@ architecture_boundary_check_keys() {
 memory_literals
 provider_mod_helper_definitions
 conversation_provider_optional_binding_roundtrip
+conversation_app_dispatcher_optional_kernel_context
 spec_app_dependency
 BOUNDARIES
 }
@@ -242,6 +243,18 @@ architecture_conversation_provider_optional_binding_roundtrip_hits() {
   fi
 }
 
+architecture_conversation_app_dispatcher_optional_kernel_context_hits() {
+  local files=(
+    "crates/app/src/conversation/turn_engine.rs"
+    "crates/app/src/conversation/turn_coordinator.rs"
+  )
+  if have_rg; then
+    rg -n 'kernel_ctx: Option<&KernelContext>' "${files[@]}" || true
+  else
+    grep -En 'kernel_ctx: Option<&KernelContext>' "${files[@]}" || true
+  fi
+}
+
 architecture_boundary_pass_summary() {
   case "$1" in
     memory_literals)
@@ -252,6 +265,9 @@ architecture_boundary_pass_summary() {
       ;;
     conversation_provider_optional_binding_roundtrip)
       echo "conversation/runtime.rs translates explicit conversation bindings into provider bindings without optional-kernel roundtrips"
+      ;;
+    conversation_app_dispatcher_optional_kernel_context)
+      echo "conversation app-tool dispatcher approval hooks stay binding-based without optional kernel fallbacks"
       ;;
     spec_app_dependency)
       echo "spec crate remains detached from app crate at the Cargo dependency boundary"
@@ -273,6 +289,9 @@ architecture_boundary_fail_summary() {
     conversation_provider_optional_binding_roundtrip)
       echo "conversation/runtime.rs still rebuilds provider bindings from optional kernel context"
       ;;
+    conversation_app_dispatcher_optional_kernel_context)
+      echo "conversation app-tool dispatcher approval hooks still expose raw optional kernel context"
+      ;;
     spec_app_dependency)
       echo "spec crate depends on app crate directly"
       ;;
@@ -292,6 +311,9 @@ architecture_boundary_hits() {
       ;;
     conversation_provider_optional_binding_roundtrip)
       architecture_conversation_provider_optional_binding_roundtrip_hits
+      ;;
+    conversation_app_dispatcher_optional_kernel_context)
+      architecture_conversation_app_dispatcher_optional_kernel_context_hits
       ;;
     spec_app_dependency)
       architecture_spec_app_dependency_hits

--- a/scripts/architecture_budget_lib.sh
+++ b/scripts/architecture_budget_lib.sh
@@ -248,10 +248,22 @@ architecture_conversation_app_dispatcher_optional_kernel_context_hits() {
     "crates/app/src/conversation/turn_engine.rs"
     "crates/app/src/conversation/turn_coordinator.rs"
   )
+  local file
+  local pattern
+
+  for file in "${files[@]}"; do
+    if [[ ! -f "$file" ]]; then
+      echo "missing boundary file: $file" >&2
+      return 1
+    fi
+  done
+
+  pattern='kernel_ctx:[[:space:]]*Option<[[:space:]]*&[^>]*KernelContext[^>]*>'
+
   if have_rg; then
-    rg -n 'kernel_ctx: Option<&KernelContext>' "${files[@]}" || true
+    rg -n "$pattern" "${files[@]}" || true
   else
-    grep -En 'kernel_ctx: Option<&KernelContext>' "${files[@]}" || true
+    grep -En "$pattern" "${files[@]}" || true
   fi
 }
 
@@ -327,7 +339,7 @@ architecture_boundary_hits() {
 architecture_boundary_status() {
   local key="$1"
   local hits
-  hits="$(architecture_boundary_hits "$key")"
+  hits="$(architecture_boundary_hits "$key")" || return 1
   if [[ -n "$hits" ]]; then
     echo "FAIL"
   else
@@ -338,7 +350,7 @@ architecture_boundary_status() {
 architecture_boundary_detail_single_line() {
   local key="$1"
   local hits
-  hits="$(architecture_boundary_hits "$key")"
+  hits="$(architecture_boundary_hits "$key")" || return 1
   if [[ -z "$hits" ]]; then
     architecture_boundary_pass_summary "$key"
     return 0

--- a/scripts/test_architecture_budget_scripts.sh
+++ b/scripts/test_architecture_budget_scripts.sh
@@ -165,9 +165,79 @@ run_report_fails_on_missing_hotspot_test() {
   assert_contains "$output_file" "crates/spec/src/spec_runtime.rs"
 }
 
+run_check_fails_on_missing_boundary_file_test() {
+  local fixture
+  fixture="$(make_fixture_repo)"
+  trap 'rm -rf "$fixture"' RETURN
+
+  rm "$fixture/crates/app/src/conversation/turn_engine.rs"
+
+  local output_file="$fixture/check-boundary.out"
+  if (
+    cd "$fixture" &&
+      LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh >"$output_file" 2>&1
+  ); then
+    echo "expected architecture boundary check to fail when a tracked boundary file is missing" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "missing boundary file"
+  assert_contains "$output_file" "crates/app/src/conversation/turn_engine.rs"
+}
+
+run_report_fails_on_missing_boundary_file_test() {
+  local fixture
+  fixture="$(make_fixture_repo)"
+  trap 'rm -rf "$fixture"' RETURN
+
+  rm "$fixture/crates/app/src/conversation/turn_engine.rs"
+
+  local report_file="$fixture/architecture-drift-2099-01.md"
+  local output_file="$fixture/report-boundary.out"
+  if (
+    cd "$fixture" &&
+      LOONGCLAW_ARCH_REPORT_MONTH="2099-01" \
+        scripts/generate_architecture_drift_report.sh "$report_file" >"$output_file" 2>&1
+  ); then
+    echo "expected architecture drift report generation to fail when a tracked boundary file is missing" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  assert_contains "$output_file" "missing boundary file"
+  assert_contains "$output_file" "crates/app/src/conversation/turn_engine.rs"
+}
+
+run_boundary_scan_matches_optional_kernel_context_with_whitespace_test() {
+  local fixture
+  fixture="$(make_fixture_repo)"
+  trap 'rm -rf "$fixture"' RETURN
+
+  cat <<'EOF_SIGNATURE' >>"$fixture/crates/app/src/conversation/turn_engine.rs"
+fn fixture_optional_kernel_signature(
+    kernel_ctx: Option< &'a KernelContext >,
+) {
+    let _ = kernel_ctx;
+}
+EOF_SIGNATURE
+
+  local output_file="$fixture/boundary-hits.out"
+  (
+    cd "$fixture" &&
+      architecture_conversation_app_dispatcher_optional_kernel_context_hits >"$output_file"
+  )
+
+  assert_contains "$output_file" "turn_engine.rs"
+  assert_contains "$output_file" "kernel_ctx: Option< &'a KernelContext >"
+}
+
 run_hotspot_metadata_helpers_test
 run_hotspot_pressure_helpers_test
 run_check_fails_on_missing_hotspot_test
 run_report_fails_on_missing_hotspot_test
+run_check_fails_on_missing_boundary_file_test
+run_report_fails_on_missing_boundary_file_test
+run_boundary_scan_matches_optional_kernel_context_with_whitespace_test
 
 echo "architecture budget script checks passed"

--- a/scripts/test_architecture_budget_scripts.sh
+++ b/scripts/test_architecture_budget_scripts.sh
@@ -80,6 +80,10 @@ copy_boundary_fixture_files() {
   cp "$REPO_ROOT/crates/app/src/provider/mod.rs" "$fixture/crates/app/src/provider/mod.rs"
   cp "$REPO_ROOT/crates/app/src/memory/mod.rs" "$fixture/crates/app/src/memory/mod.rs"
   cp "$REPO_ROOT/crates/app/src/conversation/runtime.rs" "$fixture/crates/app/src/conversation/runtime.rs"
+  cp "$REPO_ROOT/crates/app/src/conversation/turn_engine.rs" \
+    "$fixture/crates/app/src/conversation/turn_engine.rs"
+  cp "$REPO_ROOT/crates/app/src/conversation/turn_coordinator.rs" \
+    "$fixture/crates/app/src/conversation/turn_coordinator.rs"
 }
 
 run_hotspot_metadata_helpers_test() {

--- a/scripts/test_check_architecture_drift_freshness.sh
+++ b/scripts/test_check_architecture_drift_freshness.sh
@@ -81,6 +81,10 @@ copy_boundary_fixture_files() {
   cp "$REPO_ROOT/crates/app/src/provider/mod.rs" "$fixture/crates/app/src/provider/mod.rs"
   cp "$REPO_ROOT/crates/app/src/memory/mod.rs" "$fixture/crates/app/src/memory/mod.rs"
   cp "$REPO_ROOT/crates/app/src/conversation/runtime.rs" "$fixture/crates/app/src/conversation/runtime.rs"
+  cp "$REPO_ROOT/crates/app/src/conversation/turn_engine.rs" \
+    "$fixture/crates/app/src/conversation/turn_engine.rs"
+  cp "$REPO_ROOT/crates/app/src/conversation/turn_coordinator.rs" \
+    "$fixture/crates/app/src/conversation/turn_coordinator.rs"
 }
 
 run_fresh_report_passes_test() {


### PR DESCRIPTION
## Summary

- Problem: direct conversation bindings could still lose approval outcomes too early during `approval_request_resolve`, while the app-tool dispatcher contract still exposed optional kernel seams internally.
- Why it matters: this made the binding-first runtime harder to trust. Advisory bindings could not preserve approval consent/grants cleanly, and the conversation/app-tool seam still relied on weaker optional-kernel contracts.
- What changed: moved governed replay gating to the replay step so direct bindings preserve `Approved` / grant state without replay, kept kernel-bound replay for mutating flows, collapsed the app-tool approval dispatcher onto binding-based APIs only, moved governed app-tool denial back to execution-time instead of pre-approval short-circuiting, and added an architecture boundary check for raw optional-kernel dispatcher seams.
- What did not change (scope boundary): no repo-wide kernelization, no ACP redesign, no provider/channel feature expansion, and no changes to unrelated execution paths.

## Linked Issues

- Closes #766
- Related #154

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes: approval resolution and governed app-tool execution now distinguish between preserving consent/grants, emitting approval barriers, and replaying mutating work.
- Rollout / guardrails: covered by targeted conversation runtime tests, full workspace tests, all-features workspace tests, and an architecture boundary script that forbids reintroducing optional-kernel dispatcher approval seams.
- Rollback path: revert commits `50ea9e79` and `24622427` to restore the previous approval-resolution behavior and dispatcher contract.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
scripts/check_dep_graph.sh
bash scripts/test_architecture_budget_scripts.sh
LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo check -p loongclaw-app --tests
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo test -p loongclaw-app turn_engine_requires_governed_approval_before_later_app_intent_execution
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo test -p loongclaw-app load_discovery_first_event_summary_accepts_explicit_runtime_binding
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo test -p loongclaw-app handle_turn_with_runtime_approval_request_resolve_approve_once_preserves_consent_without_replay_when_direct
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo test -p loongclaw-app handle_turn_with_runtime_approval_request_resolve_approve_always_preserves_grant_without_replay_when_direct
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo test -p loongclaw-app handle_turn_with_runtime_approval_request_resolve_replays_delegate_for_approve_once_when_kernel_bound
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo test -p loongclaw-app handle_turn_with_runtime_approval_request_resolve_approve_always_reuses_root_grant_for_direct_delegate_after_kernel_bound_resolution
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo test -p loongclaw-app handle_turn_with_runtime_requires_approval_before_delegate_execution
CARGO_TARGET_DIR=/tmp/loongclaw-analysis-20260403 cargo test -p loongclaw-app handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_delegate
CARGO_TARGET_DIR=/tmp/loongclaw-issue766-final cargo check -p loongclaw-app --tests
CARGO_TARGET_DIR=/tmp/loongclaw-issue766-final cargo test -p loongclaw-app approval_request_resolve
CARGO_TARGET_DIR=/tmp/loongclaw-issue766-final cargo test -p loongclaw-app topology_mutation_tool_fails_closed
CARGO_TARGET_DIR=/tmp/loongclaw-issue766-final cargo test -p loongclaw-app sessions_send_rejects_
CARGO_TARGET_DIR=/tmp/loongclaw-issue766-final cargo test -p loongclaw-app delegate_async_
CARGO_TARGET_DIR=/tmp/loongclaw-issue766-final cargo test --workspace --locked
CARGO_TARGET_DIR=/tmp/loongclaw-issue766-final cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-issue766-allfeatures cargo test --workspace --all-features --locked

Results:
- All commands above completed successfully.
```

## User-visible / Operator-visible Changes

- Direct `approval_request_resolve` now preserves approval/grant outcomes without replaying governed delegate work.
- Kernel-bound approval resolution still replays governed delegate work as before.
- Governed app tools still emit approval barriers in direct binding, but direct execution remains blocked until kernel authority exists.
- The conversation app-tool dispatcher no longer exposes raw optional kernel approval hooks internally.

## Failure Recovery

- Fast rollback or disable path: revert commits `50ea9e79` and `24622427`.
- Observable failure symptoms reviewers should watch for: direct approval resolution unexpectedly replaying delegate work, missing approval grants after `approve_always`, missing approval barriers for governed app tools, or new `app_tool_denied: no_kernel_context` failures in kernel-bound replay paths.

## Reviewer Focus

- `crates/app/src/conversation/turn_coordinator.rs`: approval state transition ordering and replay gating.
- `crates/app/src/conversation/turn_engine.rs`: binding-only dispatcher seam and execution-time governed app-tool gating.
- `crates/app/src/conversation/tests.rs`: updated direct-vs-kernel approval expectations for `#766` and restored governed barrier semantics.
- `scripts/architecture_budget_lib.sh`: new boundary check preventing optional-kernel dispatcher regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated and renamed many approval and rejection tests to reflect new approval routing and replay behavior.

* **Refactor**
  * Moved kernel-binding validation from preflight to execution time and simplified approval resolution flow and error handling.

* **Chores**
  * Added architecture boundary checks and expanded test fixtures to validate optional kernel-context patterns.

* **Documentation**
  * Updated architecture drift report and related release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->