### PR TITLE
docs: add threat model and agent-risk mapping baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This file is the **map** — keep it short (~100 lines). Deeper context lives in
 - [Core Beliefs](docs/design-docs/core-beliefs.md) — kernel and engineering principles
 - [Layered Kernel Design](docs/design-docs/layered-kernel-design.md) — layered model and boundary rules
 - [Roadmap](docs/ROADMAP.md) — stage-based milestones and acceptance criteria
+- [Threat Model](docs/THREAT_MODEL.md) — trust boundaries, attack surfaces, and residual risks
+- [Agent Risk Mapping](docs/AGENT_RISK_MAPPING.md) — current control coverage across common agent-risk areas
 - [Reliability](docs/RELIABILITY.md) — invariants and operating expectations
 - [Product Specs](docs/product-specs/index.md) — user-facing requirements
 - [Contributing Guide](CONTRIBUTING.md) — contributor workflow and recipes
@@ -78,6 +80,8 @@ Use `task verify` for the stricter local superset (architecture, conventions, do
 | Roadmap | `docs/ROADMAP.md` |
 | Reliability invariants | `docs/RELIABILITY.md` |
 | Security model & gaps | `docs/SECURITY.md` |
+| Threat boundaries & residual risks | `docs/THREAT_MODEL.md` |
+| Agent-risk control coverage | `docs/AGENT_RISK_MAPPING.md` |
 | Quality scores & gaps | `docs/QUALITY_SCORE.md` |
 | Product sense & principles | `docs/PRODUCT_SENSE.md` |
 | Release process docs | `docs/releases/` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -117,6 +117,8 @@ mechanically where possible.
 | Harness engineering & backpressure | [Harness Engineering](docs/design-docs/harness-engineering.md) |
 | Design decisions, patterns & catalog | [Design Docs Index](docs/design-docs/index.md) |
 | Security model & gaps | [Security](docs/SECURITY.md) |
+| Threat boundaries and residual risks | [Threat Model](docs/THREAT_MODEL.md) |
+| Agent-risk control coverage baseline | [Agent Risk Mapping](docs/AGENT_RISK_MAPPING.md) |
 | Stage-based roadmap | [Roadmap](docs/ROADMAP.md) |
 | Build and kernel invariants | [Reliability](docs/RELIABILITY.md) |
 | Domain quality grades | [Quality Score](docs/QUALITY_SCORE.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ This file is the **map** — keep it short (~100 lines). Deeper context lives in
 - [Core Beliefs](docs/design-docs/core-beliefs.md) — kernel and engineering principles
 - [Layered Kernel Design](docs/design-docs/layered-kernel-design.md) — layered model and boundary rules
 - [Roadmap](docs/ROADMAP.md) — stage-based milestones and acceptance criteria
+- [Threat Model](docs/THREAT_MODEL.md) — trust boundaries, attack surfaces, and residual risks
+- [Agent Risk Mapping](docs/AGENT_RISK_MAPPING.md) — current control coverage across common agent-risk areas
 - [Reliability](docs/RELIABILITY.md) — invariants and operating expectations
 - [Product Specs](docs/product-specs/index.md) — user-facing requirements
 - [Contributing Guide](CONTRIBUTING.md) — contributor workflow and recipes
@@ -78,6 +80,8 @@ Use `task verify` for the stricter local superset (architecture, conventions, do
 | Roadmap | `docs/ROADMAP.md` |
 | Reliability invariants | `docs/RELIABILITY.md` |
 | Security model & gaps | `docs/SECURITY.md` |
+| Threat boundaries & residual risks | `docs/THREAT_MODEL.md` |
+| Agent-risk control coverage | `docs/AGENT_RISK_MAPPING.md` |
 | Quality scores & gaps | `docs/QUALITY_SCORE.md` |
 | Product sense & principles | `docs/PRODUCT_SENSE.md` |
 | Release process docs | `docs/releases/` |

--- a/docs/AGENT_RISK_MAPPING.md
+++ b/docs/AGENT_RISK_MAPPING.md
@@ -1,0 +1,67 @@
+# Agent Risk Mapping
+
+Date: 2026-04-03
+Issue: #851
+Status: Active
+
+This document maps common agent-risk categories to LoongClaw's current
+repository-visible controls.
+
+It is a control-mapping baseline, not a compliance certification.
+Statuses in this document mean:
+
+- `Enforced`: the repository already documents or implements this as an active
+  runtime control
+- `Partial`: meaningful controls exist, but important gaps remain
+- `Planned`: the roadmap or design direction is clear, but current coverage is
+  not yet sufficient to rely on the control as active protection
+
+This document should be read together with:
+
+- [Threat Model](THREAT_MODEL.md)
+- [Security](SECURITY.md)
+- [Roadmap](ROADMAP.md)
+- [Architecture](../ARCHITECTURE.md)
+
+## Control Mapping
+
+| Risk area | Current LoongClaw controls | Status | Main evidence | Main gaps |
+|-----------|----------------------------|--------|---------------|-----------|
+| Goal or instruction hijack leading to unsafe action | kernel-mediated tool execution, policy extension chain, approval gates, explicit runtime binding | Partial | `docs/SECURITY.md`, `ARCHITECTURE.md`, `docs/design-docs/layered-kernel-design.md` | direct-mode compatibility still exists in some outer seams; not every runtime path is fully converged |
+| Excessive capability or privilege | capability tokens, pack boundaries, denylist precedence, TTL-based authorization, tool-specific approval | Enforced to partial | `ARCHITECTURE.md`, `docs/SECURITY.md` | `membrane` not enforced; namespace confinement incomplete |
+| Identity or provenance abuse | runtime identity separation, connector caller provenance, channel account identity handling, plugin attestation metadata | Partial | `docs/SECURITY.md`, `docs/product-specs/runtime-self-continuity.md` | no first-class trust plane, no explicit trust decay or delegation contract |
+| Plugin or package supply-chain compromise | manifest validation, compatibility checks, ownership checks, structured diagnostics, preflight governance, checksum and signature support | Partial | `docs/SECURITY.md`, `docs/design-docs/plugin-package-manifest-contract.md`, `docs/ROADMAP.md` | trust tiers and reproducible verification are not fully closed yet |
+| Unexpected code execution or unsafe runtime expansion | WASM guardrails, runtime execution tiers, bridge support matrix, activation attestation, allowlisted process lanes | Partial | `docs/SECURITY.md`, `docs/ROADMAP.md`, `docs/design-docs/layered-kernel-design.md` | process isolation is not fully implemented; runtime resource guarantees are still under Stage 2 |
+| Memory or context poisoning | runtime identity boundary, kernel-bound history fail-closed behavior, staged memory architecture, session-profile separation | Partial | `docs/SECURITY.md`, `docs/product-specs/runtime-self-continuity.md`, `docs/QUALITY_SCORE.md` | provenance, scoped retrieval, deletion governance, and poisoning-resistant operator surfaces are incomplete |
+| Insecure inter-system or protocol communication | typed protocol routes, route authorization, bounded transports, SSRF-safe web and browser clients, outbound HTTP host restrictions | Partial | `docs/SECURITY.md`, `ARCHITECTURE.md`, `crates/protocol` references in docs | broader trust semantics across channels, connectors, and future multi-agent paths are still incomplete |
+| Cascading failures or uncontrolled fanout | retry and backoff controls, rate shaping, connector circuit breakers, adaptive concurrency, scheduler telemetry | Partial | `docs/ROADMAP.md` | reliability primitives are not yet packaged as one explicit operator-facing SRE lane |
+| Unsafe human trust or approval misuse | explicit approval surfaces, policy-bound high-risk actions, operator security audit surface | Partial | `docs/SECURITY.md`, `docs/ROADMAP.md` | stronger review guidance, approval evidence packaging, and trust-plane linkage remain future work |
+| Rogue or drifted runtime behavior | audit trail, plugin preflight, activation attestation, release-doc governance, architecture and dependency gates | Partial | `docs/SECURITY.md`, `docs/releases/README.md`, `.github/workflows/ci.yml` | continuous drift detection and tamper-evident audit chain are not fully closed |
+
+## Summary
+
+The main conclusion from this first mapping is straightforward:
+
+- LoongClaw already has meaningful governance controls in the core runtime
+- the current gaps are mostly about closure, trust modeling, and evidence
+  packaging rather than total absence of governance work
+
+The highest-leverage next improvements remain:
+
+1. stronger governance evidence
+2. a first-class trust and identity plane
+3. runtime isolation completion
+4. memory provenance and retention governance
+5. plugin supply-chain trust closure
+
+## Non-Claims
+
+This document does not claim:
+
+- complete compliance with any external framework
+- uniform enforcement across every future channel or plugin ecosystem
+- finished tamper-evident audit guarantees
+- complete memory-governance closure
+
+Those areas should move from `Partial` toward `Enforced` only when repository
+evidence and tests support the claim.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -126,5 +126,7 @@ Current evidence surfaces that emit or expose this vocabulary:
 ## See Also
 
 - [Design Docs Index](design-docs/index.md) — security-related design decisions
+- [Threat Model](THREAT_MODEL.md) — trust boundaries, attack surfaces, mitigations, and residual risks
+- [Agent Risk Mapping](AGENT_RISK_MAPPING.md) — current control coverage baseline across common agent-risk areas
 - [Layered Kernel Design](design-docs/layered-kernel-design.md) — L1 security layer specification
 - [Core Beliefs](design-docs/core-beliefs.md) — principle #3: capability-gated by default

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,259 @@
+# Threat Model
+
+Date: 2026-04-03
+Issue: #851
+Status: Active
+
+This document provides a repository-local threat model for LoongClaw's current
+governed runtime posture.
+
+It is intentionally bounded.
+It describes current trust boundaries, attack surfaces, mitigations, and
+residual risks based on repository evidence today.
+
+It is not a certification document.
+It does not claim complete coverage of every agent-risk framework.
+It should be read together with:
+
+- [Architecture](../ARCHITECTURE.md)
+- [Security](SECURITY.md)
+- [Roadmap](ROADMAP.md)
+- [Agent Risk Mapping](AGENT_RISK_MAPPING.md)
+
+## Scope
+
+This threat model focuses on the runtime-governance layer that LoongClaw
+already exposes through:
+
+- capability-gated kernel execution
+- policy and approval enforcement
+- audit and observability
+- runtime bridge execution
+- plugin intake and activation
+- protocol and channel integration
+- memory and context assembly
+
+It does not attempt to model:
+
+- model-provider safety training
+- prompt-content moderation as a standalone product surface
+- hardware or robotics deployment
+- future trust planes that are not yet implemented
+
+## Trust Boundaries
+
+### 1. Human Or Operator To Runtime
+
+Humans provide prompts, approvals, configuration, policies, and release-facing
+artifacts.
+
+Main risks:
+
+- unsafe approvals
+- over-broad policy settings
+- configuration drift
+- release-doc or trace mismatch
+
+Current mitigations:
+
+- explicit approval surfaces
+- policy-owned execution path
+- structured release-doc governance checks
+- operator-facing security posture audit
+
+### 2. Model Or Conversation Loop To Kernel-Governed Actions
+
+This is the core LoongClaw governance boundary.
+The runtime may continue conversation orchestration in direct mode, but
+kernel-mediated tool execution requires explicit authority.
+
+Main risks:
+
+- hidden kernel bypasses
+- accidental direct-mode fallback
+- missing approval checks
+
+Current mitigations:
+
+- `ConversationRuntimeBinding`
+- `ProviderRuntimeBinding`
+- capability and policy checks before governed execution
+- binding-first fail-closed behavior for missing authority in kernel-only paths
+
+### 3. Agent To Tool Or Connector
+
+This is the highest-value action boundary because successful abuse can produce:
+
+- shell execution
+- file mutation
+- network egress
+- external side effects
+
+Current mitigations:
+
+- capability tokens
+- policy extension chain
+- tool-specific approval requirements
+- filesystem path confinement
+- SSRF-safe web and browser URL validation
+- connector caller provenance for programmatic calls
+
+### 4. Agent To Plugin Or Runtime Bridge
+
+Plugins, foreign packages, and runtime bridges create a supply-chain and
+execution-expansion boundary.
+
+Main risks:
+
+- malicious or malformed manifests
+- incompatible host contracts
+- unsafe bridge widening
+- runtime expansion without trustworthy provenance
+
+Current mitigations:
+
+- plugin manifest validation
+- ownership and compatibility checks
+- structured preflight diagnostics
+- policy integrity pinning and signature support
+- activation attestation for loaded plugin runtime compatibility
+
+### 5. Agent To Memory And Context
+
+Memory and context are long-lived influence surfaces.
+If they are poisoned, mis-scoped, or silently de-governed, future turns can
+drift without obvious operator visibility.
+
+Main risks:
+
+- poisoned summaries
+- provenance loss
+- accidental authority bleed between runtime identity and advisory context
+- destructive deletion without clear ownership
+
+Current mitigations:
+
+- explicit runtime identity separation
+- binding-first history access for kernel-bound flows
+- staged memory architecture direction
+- fail-closed kernel-bound history loading
+
+### 6. Agent To Channel, Protocol, Or External Endpoint
+
+LoongClaw now spans CLI, browser, providers, channels, and protocol bridges.
+That expands the communication boundary.
+
+Main risks:
+
+- untrusted outbound endpoints
+- redirect-based trust widening
+- protocol mismatch
+- ambiguous account identity
+- unsafe bridge execution or runtime routing drift
+
+Current mitigations:
+
+- typed protocol routes
+- route authorization gates
+- bounded transport primitives
+- outbound HTTP host restrictions
+- no ambient proxy trust for governed web lanes
+- explicit channel/runtime account identity handling
+
+### 7. Agent To Repository And Release Control Plane
+
+The repository itself is part of the runtime trust story because release docs,
+trace artifacts, CI, and package workflows influence operator trust.
+
+Main risks:
+
+- release metadata drift
+- missing traceability
+- undocumented contract changes
+- supply-chain ambiguity
+
+Current mitigations:
+
+- release-doc conventions
+- local release-artifact bootstrap
+- doc governance checks
+- architecture and dependency-graph gates
+
+## High-Level Data Flow
+
+```text
+Human / Operator
+    |
+    v
+Conversation / Provider Runtime
+    |
+    v
+Kernel capability + policy + approval boundary
+    |
+    +--> Tool plane
+    +--> Connector plane
+    +--> Runtime bridge plane
+    +--> Memory / context path
+    +--> Plugin intake / activation path
+    |
+    v
+Audit + observability + release / trace evidence
+```
+
+## Primary Attack Surfaces
+
+| Surface | Example threats | Current posture |
+|---------|-----------------|-----------------|
+| Prompts, approvals, operator input | unsafe approval, social engineering, over-broad settings | Partial |
+| Governed tool execution | shell abuse, file mutation, unsafe network access | Enforced to partial, depending on tool and path |
+| Plugin manifests and bridge execution | supply-chain drift, host incompatibility, bridge widening | Partial with strong preflight direction |
+| Memory and context assembly | poisoned summaries, provenance loss, identity bleed | Partial |
+| Channel and protocol edges | SSRF, untrusted endpoints, route drift, account confusion | Partial |
+| Release and trace artifacts | missing debug linkage, trace mismatch, documentation drift | Partial |
+
+## STRIDE View
+
+| Category | Example LoongClaw risk | Main mitigations today | Residual gaps |
+|----------|------------------------|------------------------|---------------|
+| Spoofing | connector or channel caller identity ambiguity | caller provenance, account identity normalization, binding-first execution | no full trust plane yet |
+| Tampering | plugin metadata drift, audit evidence manipulation, release trace mismatch | manifest validation, attestation, release-doc checks, durable audit JSONL | no HMAC chain, limited tamper-evidence story |
+| Repudiation | operator or runtime cannot prove what happened | structured audit events, approval records, release trace linkage | audit chain integrity still partial |
+| Information disclosure | web or browser escape, outbound endpoint misuse, context leakage | SSRF guardrails, host restrictions, tool policy, path confinement | namespace confinement not fully enforced |
+| Denial of service | runaway bridge execution, cascading retries, expensive fanout | bounded queues, rate shaping, circuit-breaker and concurrency controls in runtime planning | not yet packaged as one explicit reliability plane |
+| Elevation of privilege | direct-mode drift, unsafe capability growth, plugin or bridge expansion | capability tokens, policy chain, approval gates, runtime binding, activation checks | membrane not enforced; process isolation incomplete |
+
+## Residual Risks
+
+The main currently documented residual risks are:
+
+- namespace confinement exists as a concept but is not fully enforced
+- the capability `membrane` field is not enforced at runtime
+- durable audit exists, but tamper-evidence is still incomplete
+- WASM and process isolation are still mid-journey rather than fully closed
+- no first-class trust and identity plane exists yet for delegation and trust
+  decay
+- memory provenance and deletion governance remain incomplete
+
+These are not hidden caveats.
+They are active roadmap items and should remain explicit in future security and
+adoption discussions.
+
+## Operator Assumptions
+
+LoongClaw's current threat posture assumes:
+
+- operators keep policy scope narrow
+- high-risk actions keep approval or allowlist boundaries
+- plugin and bridge expansion are treated as governance events, not convenience
+  steps
+- release and trace artifacts are regenerated before strict docs governance
+  checks
+- deployment-specific isolation stronger than the current runtime baseline may
+  still be needed for higher-trust environments
+
+## See Also
+
+- [Security](SECURITY.md)
+- [Agent Risk Mapping](AGENT_RISK_MAPPING.md)
+- [Architecture](../ARCHITECTURE.md)
+- [Roadmap](ROADMAP.md)


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw had roadmap-level guidance to improve governance evidence, but it
  still lacked the first concrete repository-local artifacts that describe
  trust boundaries and map current controls to common agent-risk areas.
- Why it matters:
  Without those baseline docs, external review and future planning have to
  reconstruct the threat model and control-coverage story from scattered
  architecture, security, and roadmap material.
- What changed:
  Added `docs/THREAT_MODEL.md` and `docs/AGENT_RISK_MAPPING.md`, then linked
  them from the existing architecture, security, and repo navigation entry
  points.
- What did not change (scope boundary):
  No runtime code, policies, configs, or benchmarks changed. This is a docs-only
  evidence slice.

## Linked Issues

- Closes #851
- Related #842

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --check
cargo fmt --all -- --check
scripts/bootstrap_release_local_artifacts.sh
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
CARGO_BUILD_JOBS=1 cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_BUILD_JOBS=1 cargo test --workspace --locked
CARGO_BUILD_JOBS=1 cargo test --workspace --all-features --locked

Observed results:
- `git diff --check`: PASS
- `cargo fmt --all -- --check`: PASS
- `scripts/bootstrap_release_local_artifacts.sh`: PASS
- `LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh`: PASS
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: FAIL on current `origin/dev` baseline with compile errors in `crates/app/src/conversation/turn_coordinator.rs`, `crates/app/src/conversation/turn_engine.rs`, and `crates/app/src/tools/shell_policy_ext.rs`
- `cargo test --workspace --locked`: FAIL on the same baseline compile errors
- `cargo test --workspace --all-features --locked`: FAIL on the same baseline compile errors
```

## User-visible / Operator-visible Changes

- Added a repository-local threat model for the current governed runtime.
- Added a first-pass agent-risk control mapping that distinguishes current
  enforced, partial, and planned coverage.
- Added navigation links so maintainers can find these docs from existing
  architecture and security entry points.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `566adc11`.
- Observable failure symptoms reviewers should watch for:
  Documentation over-claims, duplicated security guidance, or navigation links
  that drift from current runtime reality.

## Reviewer Focus

- Check that the new docs stay implementation-truthful and do not imply
  complete compliance or complete coverage.
- Check that the risk mapping correctly distinguishes enforced versus partial
  controls.
- Check that the new navigation links are sufficient without bloating the repo
  entry surfaces.
