### PR TITLE
fix: stabilize browser companion version probes in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2123,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
+ "tracing",
  "unicode-normalization",
  "unicode-segmentation",
  "wait-timeout",
@@ -2175,6 +2182,8 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "wat",
 ]
 
@@ -2251,6 +2260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3272,6 +3299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,7 +3413,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3768,6 +3803,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3902,6 +3980,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,6 +2184,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "wait-timeout",
  "wat",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ wasmtime = { version = "43.0.0", default-features = false, features = ["std", "r
 rusqlite = { version = "0.39", features = ["bundled"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 which = "8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 [profile.release]
 lto = "thin"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -87,6 +87,7 @@ prost = { version = "0.14", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"], optional = true }
 libc = "0.2"
+tracing.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/app/src/acp/manager.rs
+++ b/crates/app/src/acp/manager.rs
@@ -7,10 +7,10 @@ use crate::CliResult;
 use crate::config::LoongClawConfig;
 
 use super::backend::{
-    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, AcpAbortController, AcpConfigPatch, AcpDoctorReport,
-    AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle, AcpSessionMetadata, AcpSessionMode,
-    AcpSessionState, AcpSessionStatus, AcpTurnEventSink, AcpTurnRequest, AcpTurnResult,
-    BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
+    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, ACP_TURN_METADATA_TRACE_ID, AcpAbortController,
+    AcpConfigPatch, AcpDoctorReport, AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle,
+    AcpSessionMetadata, AcpSessionMode, AcpSessionState, AcpSessionStatus, AcpTurnEventSink,
+    AcpTurnRequest, AcpTurnResult, BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
 };
 use super::binding::AcpSessionBindingScope;
 use super::merge_turn_events;
@@ -115,9 +115,25 @@ impl AcpSessionManager {
         self.cleanup_idle_sessions(config).await?;
 
         let selection = resolve_acp_backend_selection(config);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %selection.id,
+            conversation_id = ?bootstrap.conversation_id.as_deref(),
+            mode = ?bootstrap.mode,
+            binding = ?AcpSessionBindingScope::from_bootstrap(bootstrap),
+            "ensuring ACP session"
+        );
         if let Some(existing) =
             self.resolve_existing_session(config, selection.id.as_str(), bootstrap)?
         {
+            tracing::debug!(
+                target: "loongclaw.acp",
+                session_key = %existing.session_key,
+                backend_id = %existing.backend_id,
+                state = ?existing.state,
+                "reused ACP session"
+            );
             return Ok(existing);
         }
 
@@ -136,6 +152,13 @@ impl AcpSessionManager {
             .get(ACP_SESSION_METADATA_ACTIVATION_ORIGIN)
             .and_then(|value| AcpRoutingOrigin::parse(value));
         self.store.upsert(metadata.clone())?;
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %metadata.session_key,
+            backend_id = %metadata.backend_id,
+            activation_origin = ?metadata.activation_origin.map(AcpRoutingOrigin::as_str),
+            "created ACP session"
+        );
         Ok(metadata)
     }
 
@@ -156,11 +179,25 @@ impl AcpSessionManager {
         request: &AcpTurnRequest,
         sink: Option<&dyn AcpTurnEventSink>,
     ) -> CliResult<AcpTurnResult> {
+        let started_at = std::time::Instant::now();
         let actor_key = actor_key_for_bootstrap(bootstrap);
         let _turn_queue_guard = self.acquire_turn_queue_guard(actor_key.clone()).await?;
         self.cleanup_idle_sessions(config).await?;
 
         let mut metadata = self.ensure_session(config, bootstrap).await?;
+        let trace_id = request
+            .metadata
+            .get(ACP_TURN_METADATA_TRACE_ID)
+            .map(String::as_str);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %metadata.backend_id,
+            trace_id = ?trace_id,
+            input_len = request.input.chars().count(),
+            sink_enabled = sink.is_some(),
+            "starting ACP turn"
+        );
         let backend = resolve_acp_backend(Some(metadata.backend_id.as_str()))?;
         metadata.state = AcpSessionState::Busy;
         metadata.clear_error();
@@ -209,11 +246,27 @@ impl AcpSessionManager {
             Ok(mut result) => {
                 self.record_turn_completion(turn_started_ms, true)?;
                 let streamed_events = buffered_sink.snapshot()?;
+                let duration_ms = started_at.elapsed().as_millis();
+                let reported_event_count = result.events.len();
+                let streamed_event_count = streamed_events.len();
                 result.events = merge_turn_events(&result.events, &streamed_events);
                 metadata.state = result.state;
                 metadata.clear_error();
                 metadata.touch();
                 self.store.upsert(metadata)?;
+                tracing::debug!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    state = ?result.state,
+                    stop_reason = ?result.stop_reason,
+                    reported_event_count,
+                    streamed_event_count,
+                    merged_event_count = result.events.len(),
+                    duration_ms,
+                    "ACP turn completed"
+                );
                 Ok(result)
             }
             Err(error) => {
@@ -222,6 +275,15 @@ impl AcpSessionManager {
                 metadata.state = AcpSessionState::Error;
                 metadata.set_error(error.clone());
                 self.store.upsert(metadata)?;
+                tracing::warn!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    duration_ms = started_at.elapsed().as_millis(),
+                    error = %crate::observability::summarize_error(error.as_str()),
+                    "ACP turn failed"
+                );
                 Err(error)
             }
         }

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -4241,16 +4241,51 @@ pub(super) async fn process_inbound_with_provider(
     kernel_ctx: &KernelContext,
     feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<String> {
+    let started_at = std::time::Instant::now();
     let turn_config = reload_channel_turn_config(config, resolved_path)?;
     let runtime = DefaultConversationRuntime::from_config_or_env(&turn_config)?;
-    process_inbound_with_runtime_and_feedback(
+    let result = process_inbound_with_runtime_and_feedback(
         &turn_config,
         &runtime,
         message,
         ConversationRuntimeBinding::kernel(kernel_ctx),
         feedback_policy,
     )
-    .await
+    .await;
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(reply) => {
+            tracing::debug!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                reply_len = reply.chars().count(),
+                duration_ms,
+                "channel inbound processed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "channel inbound failed"
+            );
+        }
+    }
+    result
 }
 
 #[cfg(any(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -10,6 +10,7 @@ pub mod crypto;
 pub mod feishu;
 pub mod memory;
 pub mod migration;
+pub(crate) mod observability;
 pub mod presentation;
 pub mod prompt;
 pub mod provider;

--- a/crates/app/src/observability.rs
+++ b/crates/app/src/observability.rs
@@ -1,0 +1,102 @@
+use serde_json::Value;
+
+const MAX_LOGGED_JSON_KEYS: usize = 8;
+const MAX_ERROR_CHARS: usize = 240;
+
+pub(crate) fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+pub(crate) fn top_level_json_keys(value: &Value) -> Vec<String> {
+    let Value::Object(map) = value else {
+        return Vec::new();
+    };
+
+    let mut keys = map
+        .keys()
+        .take(MAX_LOGGED_JSON_KEYS)
+        .cloned()
+        .collect::<Vec<_>>();
+    if map.len() > MAX_LOGGED_JSON_KEYS {
+        keys.push(format!("+{}", map.len() - MAX_LOGGED_JSON_KEYS));
+    }
+    keys
+}
+
+pub(crate) fn summarize_error(error: &str) -> String {
+    let compact = error.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= MAX_ERROR_CHARS {
+        return compact;
+    }
+
+    let truncated = compact
+        .chars()
+        .take(MAX_ERROR_CHARS.saturating_sub(3))
+        .collect::<String>();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{json_value_kind, summarize_error, top_level_json_keys};
+
+    #[test]
+    fn json_value_kind_labels_common_shapes() {
+        assert_eq!(json_value_kind(&json!(null)), "null");
+        assert_eq!(json_value_kind(&json!(true)), "bool");
+        assert_eq!(json_value_kind(&json!(1)), "number");
+        assert_eq!(json_value_kind(&json!("hello")), "string");
+        assert_eq!(json_value_kind(&json!([1, 2, 3])), "array");
+        assert_eq!(json_value_kind(&json!({"command": "pwd"})), "object");
+    }
+
+    #[test]
+    fn top_level_json_keys_limits_output() {
+        let value = json!({
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+            "e": 5,
+            "f": 6,
+            "g": 7,
+            "h": 8,
+            "i": 9
+        });
+
+        assert_eq!(
+            top_level_json_keys(&value),
+            vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned(),
+                "e".to_owned(),
+                "f".to_owned(),
+                "g".to_owned(),
+                "h".to_owned(),
+                "+1".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn summarize_error_collapses_whitespace_and_truncates() {
+        let repeated = "detail ".repeat(64);
+        let summary = summarize_error(&format!("line one\nline two\t{repeated}"));
+
+        assert!(!summary.contains('\n'));
+        assert!(!summary.contains('\t'));
+        assert!(summary.ends_with("..."));
+        assert!(summary.chars().count() <= 240);
+    }
+}

--- a/crates/app/src/provider/request_failover_runtime.rs
+++ b/crates/app/src/provider/request_failover_runtime.rs
@@ -34,6 +34,15 @@ where
 
     let ordered_profiles =
         prioritize_provider_auth_profiles_by_health(auth_profiles, profile_state_policy);
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %provider.kind.profile().id,
+        binding = %binding.as_str(),
+        model_candidate_count = model_candidates.len(),
+        auth_profile_count = ordered_profiles.len(),
+        auto_model_mode,
+        "dispatching provider request across model candidates"
+    );
     let mut last_error = None;
     let mut last_error_snapshot = None;
     for (model_index, model) in model_candidates.iter().enumerate() {
@@ -44,6 +53,18 @@ where
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_success(policy, profile);
                     }
+                    tracing::debug!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %model,
+                        auth_profile_id = %profile.id,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        "provider request succeeded"
+                    );
                     return Ok(value);
                 }
                 Err(model_error) => {
@@ -54,6 +75,8 @@ where
                         snapshot,
                         ..
                     } = model_error;
+                    let exhausted = profile_index + 1 >= ordered_profiles.len()
+                        && model_index + 1 >= model_candidates.len();
                     record_provider_failover_audit_event(
                         binding,
                         provider,
@@ -62,12 +85,31 @@ where
                         auto_model_mode,
                         model_index,
                         model_candidates.len(),
-                        profile_index + 1 >= ordered_profiles.len()
-                            && model_index + 1 >= model_candidates.len(),
+                        exhausted,
                     );
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_failure(policy, profile, reason);
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %snapshot.model,
+                        auth_profile_id = %profile.id,
+                        reason = %snapshot.reason.as_str(),
+                        stage = %snapshot.stage.as_str(),
+                        attempt = snapshot.attempt,
+                        max_attempts = snapshot.max_attempts,
+                        status_code = ?snapshot.status_code,
+                        try_next_model,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        exhausted,
+                        error = %crate::observability::summarize_error(message.as_str()),
+                        "provider request attempt failed"
+                    );
                     last_error = Some(message);
                     last_error_snapshot = Some(snapshot);
 

--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -87,6 +87,14 @@ pub(super) async fn prepare_provider_request_session(
                             classify_profile_failure_reason_from_message(error.as_str()),
                         );
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %config.provider.kind.profile().id,
+                        auth_profile_id = %profile.id,
+                        auto_model_mode,
+                        error = %crate::observability::summarize_error(error.as_str()),
+                        "provider model catalog resolution failed for auth profile"
+                    );
                     last_error = Some(error);
                 }
             }
@@ -108,7 +116,7 @@ pub(super) async fn prepare_provider_request_session(
         .await?
     };
 
-    Ok(ProviderRequestSession {
+    let session = ProviderRequestSession {
         endpoint,
         headers,
         request_policy,
@@ -119,7 +127,16 @@ pub(super) async fn prepare_provider_request_session(
         auto_model_mode,
         model_candidate_cooldown_policy,
         auth_context,
-    })
+    };
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %config.provider.kind.profile().id,
+        auth_profile_count = session.auth_profiles.len(),
+        model_candidate_count = session.model_candidates.len(),
+        auto_model_mode = session.auto_model_mode,
+        "prepared provider request session"
+    );
+    Ok(session)
 }
 
 fn build_model_candidate_cooldown_policy(

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -23,7 +23,24 @@ impl<'a> ProviderRuntimeBinding<'a> {
         }
     }
 
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Kernel(_) => "kernel",
+            Self::Direct => "direct",
+        }
+    }
+
     pub const fn is_kernel_bound(self) -> bool {
         matches!(self, Self::Kernel(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProviderRuntimeBinding;
+
+    #[test]
+    fn provider_runtime_binding_labels_are_stable() {
+        assert_eq!(ProviderRuntimeBinding::direct().as_str(), "direct");
     }
 }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -648,6 +648,9 @@ pub fn execute_tool_core_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let requested_tool_name = request.tool_name.clone();
+    let payload_kind = crate::observability::json_value_kind(&request.payload);
+    let payload_keys = crate::observability::top_level_json_keys(&request.payload);
     if !trusted_internal_tool_payload_enabled()
         && payload_uses_reserved_internal_tool_context(&request.payload)
     {
@@ -664,11 +667,40 @@ pub fn execute_tool_core_with_config(
     let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)?
         .map(|narrowing| config.narrowed(&narrowing));
     let config = effective_config.as_ref().unwrap_or(config);
-    match canonical_name {
+    let started_at = std::time::Instant::now();
+    let result = match canonical_name {
         "tool.search" => execute_tool_search_tool_with_config(request, config),
         "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
         _ => execute_discoverable_tool_core_with_config(request, config),
+    };
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(outcome) => {
+            tracing::debug!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                status = %outcome.status,
+                duration_ms,
+                "tool execution completed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "tool execution failed"
+            );
+        }
     }
+    result
 }
 
 fn trusted_runtime_narrowing_from_payload(

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -70,6 +70,8 @@ rand.workspace = true
 sha2.workspace = true
 ed25519-dalek.workspace = true
 dunce = "1"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [[bin]]
 name = "loongclaw"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -72,6 +72,7 @@ ed25519-dalek.workspace = true
 dunce = "1"
 tracing.workspace = true
 tracing-subscriber.workspace = true
+wait-timeout = "0.2"
 
 [[bin]]
 name = "loongclaw"

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -1,15 +1,14 @@
 use std::io::ErrorKind;
+use std::process::{Command, Output, Stdio};
 use std::time::Duration;
 
 use loongclaw_app as mvp;
-use tokio::process::Command;
-use tokio::time::timeout;
+use wait_timeout::ChildExt;
 
 pub(crate) const BROWSER_COMPANION_INSTALL_CHECK_NAME: &str = "browser companion install";
 pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser companion runtime gate";
 
 const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
-const BROWSER_COMPANION_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,10 +34,13 @@ impl BrowserCompanionDiagnostics {
             BrowserCompanionInstallStatus::MissingBinary { command } => {
                 format!("command `{command}` was not found on PATH")
             }
-            BrowserCompanionInstallStatus::ProbeTimedOut { command } => {
+            BrowserCompanionInstallStatus::ProbeTimedOut {
+                command,
+                timeout_seconds,
+            } => {
                 format!(
                     "command `{command} {BROWSER_COMPANION_VERSION_ARG}` timed out after {}s",
-                    BROWSER_COMPANION_PROBE_TIMEOUT.as_secs()
+                    timeout_seconds
                 )
             }
             BrowserCompanionInstallStatus::ProbeFailed { command, error } => {
@@ -98,6 +100,7 @@ pub(crate) enum BrowserCompanionInstallStatus {
     },
     ProbeTimedOut {
         command: String,
+        timeout_seconds: u64,
     },
     ProbeFailed {
         command: String,
@@ -139,6 +142,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
 
     let runtime_ready = runtime.is_runtime_ready();
     let expected_version = runtime.expected_version;
+    let probe_timeout_seconds = runtime.timeout_seconds;
     let Some(command) = runtime.command else {
         return Some(BrowserCompanionDiagnostics {
             command: None,
@@ -149,7 +153,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
         });
     };
 
-    match probe_browser_companion_version(&command).await {
+    match probe_browser_companion_version(&command, probe_timeout_seconds).await {
         Ok(observed_version) => {
             let install_status = match expected_version.as_deref() {
                 Some(expected_version)
@@ -178,13 +182,20 @@ pub(crate) async fn collect_browser_companion_diagnostics(
             runtime_ready,
             install_status: BrowserCompanionInstallStatus::MissingBinary { command },
         }),
-        Err(BrowserCompanionProbeError::TimedOut) => Some(BrowserCompanionDiagnostics {
-            command: Some(command.clone()),
-            expected_version,
-            observed_version: None,
-            runtime_ready,
-            install_status: BrowserCompanionInstallStatus::ProbeTimedOut { command },
-        }),
+        Err(BrowserCompanionProbeError::TimedOut) => {
+            let timed_out_command = command.clone();
+            let install_status = BrowserCompanionInstallStatus::ProbeTimedOut {
+                command,
+                timeout_seconds: probe_timeout_seconds,
+            };
+            Some(BrowserCompanionDiagnostics {
+                command: Some(timed_out_command),
+                expected_version,
+                observed_version: None,
+                runtime_ready,
+                install_status,
+            })
+        }
         Err(BrowserCompanionProbeError::SpawnFailed(error)) => Some(BrowserCompanionDiagnostics {
             command: Some(command.clone()),
             expected_version,
@@ -211,32 +222,91 @@ pub(crate) async fn collect_browser_companion_diagnostics(
 
 async fn probe_browser_companion_version(
     command: &str,
+    timeout_seconds: u64,
 ) -> Result<String, BrowserCompanionProbeError> {
-    let mut probe = Command::new(command);
-    probe.arg(BROWSER_COMPANION_VERSION_ARG);
-    probe.kill_on_drop(true);
+    let command = command.to_owned();
+    let join_result = tokio::task::spawn_blocking(move || {
+        probe_browser_companion_version_blocking(command.as_str(), timeout_seconds)
+    })
+    .await;
 
-    match timeout(BROWSER_COMPANION_PROBE_TIMEOUT, probe.output()).await {
-        Ok(Ok(output)) => {
-            let observed = observed_output(&output.stdout, &output.stderr);
-            if output.status.success() {
-                Ok(observed)
-            } else {
-                Err(BrowserCompanionProbeError::Exited {
-                    observed,
-                    exit_status: output.status.code(),
-                })
-            }
-        }
-        Ok(Err(error)) => {
-            if error.kind() == ErrorKind::NotFound {
-                Err(BrowserCompanionProbeError::MissingBinary)
-            } else {
-                Err(BrowserCompanionProbeError::SpawnFailed(error.to_string()))
-            }
-        }
-        Err(_) => Err(BrowserCompanionProbeError::TimedOut),
+    match join_result {
+        Ok(result) => result,
+        Err(error) => Err(BrowserCompanionProbeError::SpawnFailed(error.to_string())),
     }
+}
+
+fn probe_browser_companion_version_blocking(
+    command: &str,
+    timeout_seconds: u64,
+) -> Result<String, BrowserCompanionProbeError> {
+    let child = spawn_browser_companion_probe_process(command)?;
+    let output = wait_for_browser_companion_probe_output(child, timeout_seconds)?;
+    interpret_browser_companion_probe_output(output)
+}
+
+fn spawn_browser_companion_probe_process(
+    command: &str,
+) -> Result<std::process::Child, BrowserCompanionProbeError> {
+    let mut process = Command::new(command);
+    process.arg(BROWSER_COMPANION_VERSION_ARG);
+    process.stdin(Stdio::null());
+    process.stdout(Stdio::piped());
+    process.stderr(Stdio::piped());
+
+    let spawn_result = process.spawn();
+    match spawn_result {
+        Ok(child) => Ok(child),
+        Err(error) => {
+            if error.kind() == ErrorKind::NotFound {
+                return Err(BrowserCompanionProbeError::MissingBinary);
+            }
+
+            let error_message = error.to_string();
+            Err(BrowserCompanionProbeError::SpawnFailed(error_message))
+        }
+    }
+}
+
+fn wait_for_browser_companion_probe_output(
+    mut child: std::process::Child,
+    timeout_seconds: u64,
+) -> Result<Output, BrowserCompanionProbeError> {
+    let timeout_duration = Duration::from_secs(timeout_seconds.max(1));
+    let wait_result = child.wait_timeout(timeout_duration);
+    let status_option = wait_result.map_err(|error| {
+        let error_message = error.to_string();
+        BrowserCompanionProbeError::SpawnFailed(error_message)
+    })?;
+
+    if status_option.is_some() {
+        let output_result = child.wait_with_output();
+        return output_result.map_err(|error| {
+            let error_message = error.to_string();
+            BrowserCompanionProbeError::SpawnFailed(error_message)
+        });
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Err(BrowserCompanionProbeError::TimedOut)
+}
+
+fn interpret_browser_companion_probe_output(
+    output: Output,
+) -> Result<String, BrowserCompanionProbeError> {
+    let observed = observed_output(&output.stdout, &output.stderr);
+    let status = output.status;
+
+    if status.success() {
+        return Ok(observed);
+    }
+
+    let exit_status = status.code();
+    Err(BrowserCompanionProbeError::Exited {
+        observed,
+        exit_status,
+    })
 }
 
 fn observed_output(stdout: &[u8], stderr: &[u8]) -> String {
@@ -261,15 +331,11 @@ fn observed_version_matches_expected(observed_version: &str, expected_version: &
 mod tests {
     use super::*;
     #[cfg(unix)]
-    use std::ffi::OsString;
-    #[cfg(unix)]
     use std::io::Write;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     #[cfg(unix)]
     use std::path::{Path, PathBuf};
-    #[cfg(unix)]
-    use std::sync::MutexGuard;
     #[cfg(unix)]
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -301,55 +367,17 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn set_browser_companion_env_var(key: &str, value: &str) {
-        // SAFETY: daemon tests serialize process env mutations behind
-        // `lock_daemon_test_environment`, so no concurrent env readers/writers
-        // observe racy updates while these tests run.
-        #[allow(unsafe_code, clippy::disallowed_methods)]
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-
-    #[cfg(unix)]
-    fn remove_browser_companion_env_var(key: &str) {
-        // SAFETY: daemon tests serialize process env mutations behind
-        // `lock_daemon_test_environment`, so removing the variable here is
-        // coordinated with all other env-mutating daemon tests.
-        #[allow(unsafe_code, clippy::disallowed_methods)]
-        unsafe {
-            std::env::remove_var(key);
-        }
-    }
-
-    #[cfg(unix)]
     struct BrowserCompanionEnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        saved_ready: Option<OsString>,
+        _env: crate::test_support::ScopedEnv,
     }
 
     #[cfg(unix)]
     impl BrowserCompanionEnvGuard {
         fn runtime_gate_closed() -> Self {
-            let lock = crate::test_support::lock_daemon_test_environment();
             let key = "LOONGCLAW_BROWSER_COMPANION_READY";
-            let saved_ready = std::env::var_os(key);
-            remove_browser_companion_env_var(key);
-            Self {
-                _lock: lock,
-                saved_ready,
-            }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for BrowserCompanionEnvGuard {
-        fn drop(&mut self) {
-            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
-            match self.saved_ready.take() {
-                Some(value) => set_browser_companion_env_var(key, &value.to_string_lossy()),
-                None => remove_browser_companion_env_var(key),
-            }
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.remove(key);
+            Self { _env: env }
         }
     }
 
@@ -368,6 +396,7 @@ mod tests {
         config.tools.browser_companion.enabled = true;
         config.tools.browser_companion.command = Some(script_path.display().to_string());
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+        config.tools.browser_companion.timeout_seconds = 3;
 
         let diagnostics = collect_browser_companion_diagnostics(&config)
             .await
@@ -384,6 +413,39 @@ mod tests {
                     && observed_version == "loongclaw-browser-companion 11.5.0"
             ),
             "partial version matches should still warn as mismatches: {diagnostics:#?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_browser_companion_diagnostics_times_out_stalled_probe() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let temp_dir = browser_companion_temp_dir("stalled-probe");
+        let script_path = temp_dir.join("browser-companion");
+        write_browser_companion_script(
+            &script_path,
+            "#!/bin/sh\n/bin/sleep 5\necho 'loongclaw-browser-companion 1.5.0'\n",
+        );
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+        config.tools.browser_companion.timeout_seconds = 3;
+
+        let diagnostics = collect_browser_companion_diagnostics(&config)
+            .await
+            .expect("diagnostics should be collected");
+
+        let install_status = &diagnostics.install_status;
+        let timed_out = matches!(
+            install_status,
+            BrowserCompanionInstallStatus::ProbeTimedOut { .. }
+        );
+
+        assert!(
+            timed_out,
+            "stalled probes should time out deterministically: {diagnostics:#?}"
         );
     }
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -1887,16 +1887,12 @@ fn push_unique_step(steps: &mut Vec<String>, step: String) {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(unix)]
-    use std::ffi::OsString;
     use std::fs::Permissions;
     #[cfg(unix)]
     use std::io::Write;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
-    #[cfg(unix)]
-    use std::sync::MutexGuard;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1925,15 +1921,19 @@ mod tests {
         let mut file = std::fs::File::create(script_path).expect("create browser companion script");
         file.write_all(body.as_bytes())
             .expect("write browser companion script");
-        let mut permissions = file.metadata().expect("script metadata").permissions();
+        file.sync_all()
+            .expect("sync browser companion script to disk");
+        drop(file);
+
+        let metadata = std::fs::metadata(script_path).expect("script metadata");
+        let mut permissions = metadata.permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(script_path, permissions).expect("chmod browser companion script");
     }
 
     #[cfg(unix)]
     struct BrowserCompanionEnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        saved_ready: Option<OsString>,
+        _env: ScopedEnv,
     }
 
     struct PermissionRestore {
@@ -1954,28 +1954,6 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn set_browser_companion_env_var(key: &str, value: &str) {
-        // SAFETY: daemon tests serialize process env mutations behind
-        // `lock_daemon_test_environment`, so no concurrent env readers/writers
-        // observe racy updates while these tests run.
-        #[allow(unsafe_code, clippy::disallowed_methods)]
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-
-    #[cfg(unix)]
-    fn remove_browser_companion_env_var(key: &str) {
-        // SAFETY: daemon tests serialize process env mutations behind
-        // `lock_daemon_test_environment`, so removing the variable here is
-        // coordinated with all other env-mutating daemon tests.
-        #[allow(unsafe_code, clippy::disallowed_methods)]
-        unsafe {
-            std::env::remove_var(key);
-        }
-    }
-
-    #[cfg(unix)]
     impl BrowserCompanionEnvGuard {
         fn runtime_gate_closed() -> Self {
             Self::set_ready(None)
@@ -1986,28 +1964,13 @@ mod tests {
         }
 
         fn set_ready(value: Option<&str>) -> Self {
-            let lock = crate::test_support::lock_daemon_test_environment();
             let key = "LOONGCLAW_BROWSER_COMPANION_READY";
-            let saved_ready = std::env::var_os(key);
+            let mut env = ScopedEnv::new();
             match value {
-                Some(value) => set_browser_companion_env_var(key, value),
-                None => remove_browser_companion_env_var(key),
+                Some(value) => env.set(key, value),
+                None => env.remove(key),
             }
-            Self {
-                _lock: lock,
-                saved_ready,
-            }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for BrowserCompanionEnvGuard {
-        fn drop(&mut self) {
-            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
-            match self.saved_ready.take() {
-                Some(value) => set_browser_companion_env_var(key, &value.to_string_lossy()),
-                None => remove_browser_companion_env_var(key),
-            }
+            Self { _env: env }
         }
     }
 

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -85,6 +85,7 @@ mod memory_context_benchmark;
 pub mod migrate_cli;
 pub mod migration;
 pub mod next_actions;
+mod observability;
 pub mod onboard_cli;
 mod onboard_finalize;
 mod onboard_preflight;
@@ -106,6 +107,7 @@ pub mod supervisor;
 pub use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,
 };
+pub use observability::init_tracing;
 
 #[allow(
     clippy::expect_used,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -37,7 +37,9 @@ impl Drop for StdinGuard {
 #[tokio::main]
 async fn main() {
     let _stdin_guard = StdinGuard;
+    init_tracing();
     let cli = Cli::parse();
+    tracing::debug!(target: "loongclaw.daemon", command = ?cli.command, "parsed CLI command");
     let result = match cli.command.unwrap_or_else(resolve_default_entry_command) {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
@@ -846,6 +848,11 @@ async fn main() {
         }
     };
     if let Err(error) = result {
+        tracing::error!(
+            target: "loongclaw.daemon",
+            error = %error,
+            "CLI command failed"
+        );
         #[allow(clippy::print_stderr)]
         {
             eprintln!("error: {error}");

--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -1,0 +1,99 @@
+use std::io::{self, IsTerminal};
+
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+
+const DEFAULT_LOG_FILTER: &str = "warn";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogFormat {
+    Compact,
+    Pretty,
+    Json,
+}
+
+impl LogFormat {
+    fn parse(raw: Option<&str>) -> Self {
+        match raw
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("compact")
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "pretty" => Self::Pretty,
+            "json" => Self::Json,
+            _ => Self::Compact,
+        }
+    }
+}
+
+fn resolved_log_directive(loongclaw_log: Option<&str>, rust_log: Option<&str>) -> String {
+    loongclaw_log
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| rust_log.map(str::trim).filter(|value| !value.is_empty()))
+        .unwrap_or(DEFAULT_LOG_FILTER)
+        .to_owned()
+}
+
+fn build_env_filter(raw: &str) -> EnvFilter {
+    EnvFilter::try_new(raw).unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER))
+}
+
+pub fn init_tracing() {
+    let log_format = LogFormat::parse(std::env::var("LOONGCLAW_LOG_FORMAT").ok().as_deref());
+    let directive = resolved_log_directive(
+        std::env::var("LOONGCLAW_LOG").ok().as_deref(),
+        std::env::var("RUST_LOG").ok().as_deref(),
+    );
+    let env_filter = build_env_filter(directive.as_str());
+    let use_ansi = log_format != LogFormat::Json && io::stderr().is_terminal();
+    let base = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(io::stderr)
+        .with_target(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_ansi(use_ansi);
+
+    let _ = match log_format {
+        LogFormat::Compact => base.compact().finish().try_init(),
+        LogFormat::Pretty => base.pretty().finish().try_init(),
+        LogFormat::Json => base.json().flatten_event(true).finish().try_init(),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogFormat, build_env_filter, resolved_log_directive};
+
+    #[test]
+    fn resolved_log_directive_prefers_loongclaw_log() {
+        assert_eq!(
+            resolved_log_directive(Some("loongclaw_app=debug"), Some("warn")),
+            "loongclaw_app=debug"
+        );
+    }
+
+    #[test]
+    fn resolved_log_directive_falls_back_to_rust_log_then_default() {
+        assert_eq!(resolved_log_directive(None, Some("info")), "info");
+        assert_eq!(resolved_log_directive(None, None), "warn");
+    }
+
+    #[test]
+    fn parse_log_format_accepts_known_variants() {
+        assert_eq!(LogFormat::parse(Some("pretty")), LogFormat::Pretty);
+        assert_eq!(LogFormat::parse(Some("json")), LogFormat::Json);
+        assert_eq!(LogFormat::parse(Some("compact")), LogFormat::Compact);
+        assert_eq!(LogFormat::parse(Some("unknown")), LogFormat::Compact);
+    }
+
+    #[test]
+    fn build_env_filter_falls_back_on_invalid_directive() {
+        let filter = build_env_filter("[broken");
+        let rendered = filter.to_string();
+        assert_eq!(rendered, "warn");
+    }
+}

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -5974,11 +5974,10 @@ fn resolve_write_plan(
 mod tests {
     use super::*;
     use std::collections::VecDeque;
-    use std::ffi::OsString;
     use std::io::Write;
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-    use std::sync::{Arc, MutexGuard};
 
     use crate::test_support::ScopedEnv;
 
@@ -6296,28 +6295,7 @@ mod tests {
     }
 
     struct BrowserCompanionEnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        saved_ready: Option<OsString>,
-    }
-
-    fn set_browser_companion_env_var(key: &str, value: &str) {
-        // SAFETY: daemon tests serialize process env mutations behind
-        // `lock_daemon_test_environment`, so no concurrent env readers/writers
-        // observe racy updates while these tests run.
-        #[allow(unsafe_code, clippy::disallowed_methods)]
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-
-    fn remove_browser_companion_env_var(key: &str) {
-        // SAFETY: daemon tests serialize process env mutations behind
-        // `lock_daemon_test_environment`, so removing the variable here is
-        // coordinated with all other env-mutating daemon tests.
-        #[allow(unsafe_code, clippy::disallowed_methods)]
-        unsafe {
-            std::env::remove_var(key);
-        }
+        _env: ScopedEnv,
     }
 
     impl BrowserCompanionEnvGuard {
@@ -6330,61 +6308,28 @@ mod tests {
         }
 
         fn set_ready(value: Option<&str>) -> Self {
-            let lock = crate::test_support::lock_daemon_test_environment();
             let key = "LOONGCLAW_BROWSER_COMPANION_READY";
-            let saved_ready = std::env::var_os(key);
+            let mut env = ScopedEnv::new();
             match value {
-                Some(value) => set_browser_companion_env_var(key, value),
-                None => remove_browser_companion_env_var(key),
+                Some(value) => env.set(key, value),
+                None => env.remove(key),
             }
-            Self {
-                _lock: lock,
-                saved_ready,
-            }
+            Self { _env: env }
         }
     }
 
     struct PasteDrainWindowEnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        saved_value: Option<OsString>,
+        _env: ScopedEnv,
     }
 
     impl PasteDrainWindowEnvGuard {
         fn set(value: Option<&str>) -> Self {
-            let lock = crate::test_support::lock_daemon_test_environment();
-            let saved_value = std::env::var_os(ONBOARD_PASTE_DRAIN_WINDOW_ENV);
+            let mut env = ScopedEnv::new();
             match value {
-                Some(value) => set_browser_companion_env_var(ONBOARD_PASTE_DRAIN_WINDOW_ENV, value),
-                None => remove_browser_companion_env_var(ONBOARD_PASTE_DRAIN_WINDOW_ENV),
+                Some(value) => env.set(ONBOARD_PASTE_DRAIN_WINDOW_ENV, value),
+                None => env.remove(ONBOARD_PASTE_DRAIN_WINDOW_ENV),
             }
-            Self {
-                _lock: lock,
-                saved_value,
-            }
-        }
-    }
-
-    impl Drop for PasteDrainWindowEnvGuard {
-        fn drop(&mut self) {
-            match &self.saved_value {
-                Some(value) => {
-                    set_browser_companion_env_var(
-                        ONBOARD_PASTE_DRAIN_WINDOW_ENV,
-                        &value.to_string_lossy(),
-                    );
-                }
-                None => remove_browser_companion_env_var(ONBOARD_PASTE_DRAIN_WINDOW_ENV),
-            }
-        }
-    }
-
-    impl Drop for BrowserCompanionEnvGuard {
-        fn drop(&mut self) {
-            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
-            match self.saved_ready.take() {
-                Some(value) => set_browser_companion_env_var(key, &value.to_string_lossy()),
-                None => remove_browser_companion_env_var(key),
-            }
+            Self { _env: env }
         }
     }
 

--- a/crates/daemon/src/test_support.rs
+++ b/crates/daemon/src/test_support.rs
@@ -1,12 +1,11 @@
-use std::ffi::{OsStr, OsString};
-use std::path::Path;
-use std::sync::{Mutex, MutexGuard};
-
 use crate::mvp;
 use crate::{Capability, OperationSpec};
 use serde_json::Value;
 use std::collections::BTreeSet;
+use std::ffi::{OsStr, OsString};
 use std::fs;
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
 
 pub use crate::SecurityScanProfile;
 
@@ -19,9 +18,8 @@ pub fn lock_daemon_test_environment() -> MutexGuard<'static, ()> {
 }
 
 fn set_test_env_var(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
-    // SAFETY: daemon tests serialize process env mutations behind
-    // `lock_daemon_test_environment`, so no concurrent env readers or writers
-    // observe racy updates while these helpers are active.
+    // SAFETY: daemon tests hold `mvp::test_support::ScopedEnv` inside this
+    // wrapper, so daemon-side env mutations serialize with app-side env tests.
     #[allow(unsafe_code, clippy::disallowed_methods)]
     unsafe {
         std::env::set_var(key, value);
@@ -29,9 +27,8 @@ fn set_test_env_var(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
 }
 
 fn remove_test_env_var(key: impl AsRef<OsStr>) {
-    // SAFETY: daemon tests serialize process env mutations behind
-    // `lock_daemon_test_environment`, so removals are coordinated with all
-    // other daemon-side env mutation helpers.
+    // SAFETY: daemon tests hold `mvp::test_support::ScopedEnv` inside this
+    // wrapper, so daemon-side env removals serialize with app-side env tests.
     #[allow(unsafe_code, clippy::disallowed_methods)]
     unsafe {
         std::env::remove_var(key);
@@ -40,12 +37,12 @@ fn remove_test_env_var(key: impl AsRef<OsStr>) {
 
 pub struct ScopedEnv {
     saved: Vec<(String, Option<OsString>)>,
-    _lock: MutexGuard<'static, ()>,
+    _lock: mvp::test_support::ScopedEnv,
 }
 
 impl ScopedEnv {
     pub fn new() -> Self {
-        let lock = lock_daemon_test_environment();
+        let lock = mvp::test_support::ScopedEnv::new();
         let saved = Vec::new();
         Self { saved, _lock: lock }
     }


### PR DESCRIPTION
## Summary

- Problem:
  Browser companion diagnostics, doctor, and onboard validation used a scheduler-sensitive version probe path, and the daemon test env lock was separate from the app test env lock. Under workspace validation this could surface probe timeouts and flaky browser companion test failures.
- Why it matters:
  `cargo test --workspace --locked` and `cargo test --workspace --all-features --locked` need to stay green on `dev`. Flaky browser companion probes block unrelated work and make the diagnostics surface harder to trust.
- What changed:
  Moved the browser companion version probe onto a blocking child-process path with explicit timeout handling, reused the same `wait-timeout` style as the main companion execution path, hardened doctor test script persistence, unified daemon-side env guards with the app test env lock through `ScopedEnv`, and made the stalled-probe regression test use an explicit 3-second timeout plus `/bin/sleep` to avoid `PATH`-dependent behavior.
- What did not change (scope boundary):
  No user-facing browser companion protocol behavior changed. This PR only hardens diagnostics and test infrastructure around the version probe path.

## Linked Issues

- Closes #848
- Related #837

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [ ] Tools
- [x] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo test -p loongclaw-daemon browser_companion_diagnostics::tests::collect_browser_companion_diagnostics_rejects_partial_expected_version_matches -- --nocapture
cargo test -p loongclaw-daemon browser_companion_diagnostics::tests::collect_browser_companion_diagnostics_times_out_stalled_probe -- --nocapture
cargo test -p loongclaw-daemon browser_companion_doctor_checks -- --nocapture
cargo test -p loongclaw-daemon browser_companion_onboard_preflight -- --nocapture
cargo test -p loongclaw-daemon --lib -- --nocapture
cargo fmt --all -- --check
cargo clippy -p loongclaw-daemon --all-targets --all-features -- -D warnings
cargo test --workspace --all-features --locked
cargo test --workspace --locked
cargo clippy --workspace --all-targets --all-features -- -D warnings
git diff --check

Results:
- targeted browser companion regressions: PASS
- loongclaw-daemon --lib: PASS
- cargo fmt: PASS
- package clippy (loongclaw-daemon, all targets, all features): PASS
- cargo test --workspace --all-features --locked: PASS
- cargo test --workspace --locked: PASS
- cargo clippy --workspace --all-targets --all-features -- -D warnings: PASS
- git diff --check: PASS
```

## User-visible / Operator-visible Changes

- Browser companion diagnostics, doctor, and onboarding checks are now stable under full workspace validation.
- The version probe timeout message now reflects the active browser companion timeout contract instead of an independent hardcoded probe timeout.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `61a7d05f`.
- Observable failure symptoms reviewers should watch for:
  Browser companion diagnostics reverting to `ProbeTimedOut` in `doctor` / `onboard` tests under all-features validation.

## Reviewer Focus

- Review the new probe path in `crates/daemon/src/browser_companion_diagnostics.rs`, especially the shift from async process output to blocking child wait with explicit timeout.
- Review the env-guard unification in daemon test helpers to confirm it now shares the app-side env serialization lane.
- Review the stalled-probe regression test to confirm it is deterministic and no longer depends on ambient `PATH`.
