### PR TITLE
fix(runtime): restore dev baseline compile consistency

### DIFF
--- a/crates/app/src/conversation/turn_checkpoint.rs
+++ b/crates/app/src/conversation/turn_checkpoint.rs
@@ -378,6 +378,7 @@ pub(super) enum TurnCheckpointRequest {
 pub(super) struct TurnLaneExecutionSnapshot {
     pub(super) lane: ExecutionLane,
     pub(super) had_tool_intents: bool,
+    pub(super) tool_request_summary: Option<String>,
     pub(super) raw_tool_output_requested: bool,
     pub(super) result_kind: TurnCheckpointResultKind,
     pub(super) safe_lane_terminal_route: Option<SafeLaneFailureRoute>,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -113,9 +113,10 @@ use super::turn_shared::{
     build_tool_driven_followup_tail_with_request_summary, build_tool_loop_guard_tail,
     decide_provider_turn_request_action, effective_followup_tool_name,
     format_approval_required_reply, next_conversation_turn_id, reduce_followup_payload_for_model,
-    request_completion_with_raw_fallback, summarize_single_tool_followup_request,
-    summarize_tool_followup_request, tool_driven_followup_payload, tool_loop_circuit_breaker_reply,
-    tool_result_contains_truncation_signal, user_requested_raw_tool_output,
+    request_completion_with_raw_fallback, summarize_provider_lane_tool_request,
+    summarize_single_tool_followup_request, tool_driven_followup_payload,
+    tool_loop_circuit_breaker_reply, tool_result_contains_truncation_signal,
+    user_requested_raw_tool_output,
 };
 #[cfg(test)]
 use super::turn_shared::{ReplyResolutionMode, ToolDrivenFollowupKind};
@@ -2474,7 +2475,7 @@ fn build_provider_turn_tool_terminal_events(
 
     for intent in &turn.tool_intents {
         if let Some(event) = trace_events.remove(intent.tool_call_id.as_str()) {
-            let request_summary = summarize_tool_event_request(intent);
+            let request_summary = summarize_single_tool_followup_request(intent);
             let event = event.with_request_summary(request_summary);
             events.push(event);
             continue;
@@ -2540,17 +2541,13 @@ fn build_provider_turn_tool_terminal_events(
         };
 
         if let Some(fallback_event) = fallback_event {
-            let request_summary = summarize_tool_event_request(intent);
+            let request_summary = summarize_single_tool_followup_request(intent);
             let fallback_event = fallback_event.with_request_summary(request_summary);
             events.push(fallback_event);
         }
     }
 
     events
-}
-
-fn summarize_tool_event_request(intent: &ToolIntent) -> Option<String> {
-    summarize_single_tool_followup_request(intent)
 }
 fn provider_turn_observer_supports_streaming(
     config: &LoongClawConfig,
@@ -5327,54 +5324,6 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
     }
 }
 
-fn summarize_provider_lane_tool_request(
-    turn: &ProviderTurn,
-    turn_result: &TurnResult,
-    trace: Option<&ToolBatchExecutionTrace>,
-) -> Option<String> {
-    match turn_result {
-        TurnResult::FinalText(_) | TurnResult::StreamingText(_) | TurnResult::StreamingDone(_) => {
-            summarize_tool_followup_request(&turn.tool_intents)
-        }
-        TurnResult::NeedsApproval(_)
-        | TurnResult::ToolDenied(_)
-        | TurnResult::ToolError(_)
-        | TurnResult::ProviderError(_) => summarize_failed_provider_lane_tool_request(turn, trace),
-    }
-}
-
-fn summarize_failed_provider_lane_tool_request(
-    turn: &ProviderTurn,
-    trace: Option<&ToolBatchExecutionTrace>,
-) -> Option<String> {
-    let failed_tool_call_id = trace.and_then(first_failed_provider_lane_tool_call_id);
-    if let Some(failed_tool_call_id) = failed_tool_call_id {
-        let failed_intent = turn
-            .tool_intents
-            .iter()
-            .find(|intent| intent.tool_call_id == failed_tool_call_id)?;
-        let summary = summarize_single_tool_followup_request(failed_intent);
-        return summary;
-    }
-
-    match turn.tool_intents.as_slice() {
-        [intent] => summarize_single_tool_followup_request(intent),
-        [] => None,
-        _ => summarize_tool_followup_request(&turn.tool_intents),
-    }
-}
-
-fn first_failed_provider_lane_tool_call_id(trace: &ToolBatchExecutionTrace) -> Option<&str> {
-    let failed_outcome = trace.intent_outcomes.iter().find(|intent_outcome| {
-        !matches!(
-            intent_outcome.status,
-            ToolBatchExecutionIntentStatus::Completed
-        )
-    })?;
-    let tool_call_id = failed_outcome.tool_call_id.as_str();
-    Some(tool_call_id)
-}
-
 async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
@@ -8067,45 +8016,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn summarize_failed_provider_lane_tool_request_preserves_multi_intent_context_without_trace() {
-        let turn = ProviderTurn {
-            assistant_text: String::new(),
-            tool_intents: vec![
-                ToolIntent {
-                    tool_name: "file.read".to_owned(),
-                    args_json: json!({"path": "Cargo.toml"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-a".to_owned(),
-                    turn_id: "turn-a".to_owned(),
-                    tool_call_id: "call-1".to_owned(),
-                },
-                ToolIntent {
-                    tool_name: "shell.exec".to_owned(),
-                    args_json: json!({"command": "ls /root"}),
-                    source: "provider_tool_call".to_owned(),
-                    session_id: "session-a".to_owned(),
-                    turn_id: "turn-a".to_owned(),
-                    tool_call_id: "call-2".to_owned(),
-                },
-            ],
-            raw_meta: Value::Null,
-        };
-
-        let request_summary = summarize_failed_provider_lane_tool_request(&turn, None)
-            .expect("multi-intent failures should retain a request summary");
-        let request_summary_json: Value =
-            serde_json::from_str(&request_summary).expect("request summary should be valid json");
-        let request_entries = request_summary_json
-            .as_array()
-            .expect("multi-intent request summary should be an array");
-
-        assert_eq!(request_entries.len(), 2);
-        assert_eq!(request_entries[0]["tool"], "file.read");
-        assert_eq!(request_entries[1]["tool"], "shell.exec");
-        assert_eq!(request_entries[1]["request"]["command"], "ls");
-        assert_eq!(request_entries[1]["request"]["args_redacted"], 1);
-    }
     #[cfg(feature = "memory-sqlite")]
     fn finalize_recovered_child(
         repo: &SessionRepository,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -109,12 +109,12 @@ use super::turn_observer::{
 use super::turn_shared::{ApprovalPromptActionId, parse_approval_prompt_action_input};
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupPayload,
-    ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
-    build_tool_loop_guard_tail, decide_provider_turn_request_action,
+    ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
+    build_tool_driven_followup_tail_with_request_summary, build_tool_loop_guard_tail,
+    decide_provider_turn_request_action, effective_followup_tool_name,
     format_approval_required_reply, next_conversation_turn_id, reduce_followup_payload_for_model,
     request_completion_with_raw_fallback, summarize_single_tool_followup_request,
-    summarize_tool_followup_request, summarize_tool_followup_tool_names,
-    tool_driven_followup_payload, tool_loop_circuit_breaker_reply,
+    summarize_tool_followup_request, tool_driven_followup_payload, tool_loop_circuit_breaker_reply,
     tool_result_contains_truncation_signal, user_requested_raw_tool_output,
 };
 #[cfg(test)]
@@ -614,6 +614,7 @@ struct ProviderTurnLaneExecution {
     lane: ExecutionLane,
     assistant_preface: String,
     had_tool_intents: bool,
+    tool_request_summary: Option<String>,
     requires_provider_turn_followup: bool,
     raw_tool_output_requested: bool,
     turn_result: TurnResult,
@@ -626,6 +627,7 @@ impl ProviderTurnLaneExecution {
         TurnLaneExecutionSnapshot {
             lane: self.lane,
             had_tool_intents: self.had_tool_intents,
+            tool_request_summary: self.tool_request_summary.clone(),
             raw_tool_output_requested: self.raw_tool_output_requested,
             result_kind: turn_checkpoint_result_kind(&self.turn_result),
             safe_lane_terminal_route: self.safe_lane_terminal_route,
@@ -2472,6 +2474,8 @@ fn build_provider_turn_tool_terminal_events(
 
     for intent in &turn.tool_intents {
         if let Some(event) = trace_events.remove(intent.tool_call_id.as_str()) {
+            let request_summary = summarize_tool_event_request(intent);
+            let event = event.with_request_summary(request_summary);
             events.push(event);
             continue;
         }
@@ -2536,6 +2540,8 @@ fn build_provider_turn_tool_terminal_events(
         };
 
         if let Some(fallback_event) = fallback_event {
+            let request_summary = summarize_tool_event_request(intent);
+            let fallback_event = fallback_event.with_request_summary(request_summary);
             events.push(fallback_event);
         }
     }
@@ -2871,6 +2877,10 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                     followup.clone(),
                     user_input,
                     loop_warning_reason.as_deref(),
+                    current_continue_phase
+                        .lane_execution
+                        .tool_request_summary
+                        .as_deref(),
                 );
                 if current_continue_phase
                     .lane_execution
@@ -3089,6 +3099,7 @@ fn build_turn_reply_followup_messages(
         followup,
         user_input,
         None,
+        None,
     )
 }
 
@@ -3098,13 +3109,15 @@ fn build_turn_reply_followup_messages_with_warning(
     followup: ToolDrivenFollowupPayload,
     user_input: &str,
     loop_warning_reason: Option<&str>,
+    tool_request_summary: Option<&str>,
 ) -> Vec<Value> {
     let mut messages = base_messages.to_vec();
-    messages.extend(build_tool_driven_followup_tail(
+    messages.extend(build_tool_driven_followup_tail_with_request_summary(
         assistant_preface,
         &followup,
         user_input,
         loop_warning_reason,
+        tool_request_summary,
         |label, text| reduce_followup_payload_for_model(label, text).into_owned(),
     ));
     messages
@@ -5301,11 +5314,11 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         &turn_result,
         fast_lane_tool_batch_trace.as_ref(),
     );
-
     ProviderTurnLaneExecution {
         lane,
         assistant_preface,
         had_tool_intents,
+        tool_request_summary,
         requires_provider_turn_followup,
         raw_tool_output_requested: preparation.raw_tool_output_requested,
         turn_result,
@@ -5340,7 +5353,8 @@ fn summarize_failed_provider_lane_tool_request(
             .tool_intents
             .iter()
             .find(|intent| intent.tool_call_id == failed_tool_call_id)?;
-        return summarize_single_tool_followup_request(failed_intent);
+        let summary = summarize_single_tool_followup_request(failed_intent);
+        return summary;
     }
 
     match turn.tool_intents.as_slice() {
@@ -5356,7 +5370,8 @@ fn first_failed_provider_lane_tool_call_id(trace: &ToolBatchExecutionTrace) -> O
             ToolBatchExecutionIntentStatus::Completed
         )
     })?;
-    Some(failed_outcome.tool_call_id.as_str())
+    let tool_call_id = failed_outcome.tool_call_id.as_str();
+    Some(tool_call_id)
 }
 
 async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
@@ -9440,6 +9455,7 @@ mod tests {
                 lane: ExecutionLane::Safe,
                 assistant_preface: "preface".to_owned(),
                 had_tool_intents: true,
+                tool_request_summary: None,
                 requires_provider_turn_followup: false,
                 raw_tool_output_requested: false,
                 turn_result: TurnResult::ToolError(TurnFailure::retryable(
@@ -9659,6 +9675,7 @@ mod tests {
                 lane: ExecutionLane::Fast,
                 assistant_preface: "preface".to_owned(),
                 had_tool_intents: false,
+                tool_request_summary: None,
                 requires_provider_turn_followup: false,
                 raw_tool_output_requested: false,
                 turn_result: TurnResult::FinalText("hello there".to_owned()),
@@ -9735,6 +9752,7 @@ mod tests {
                 lane: Some(TurnLaneExecutionSnapshot {
                     lane: ExecutionLane::Safe,
                     had_tool_intents: true,
+                    tool_request_summary: None,
                     raw_tool_output_requested: false,
                     result_kind: TurnCheckpointResultKind::ToolError,
                     safe_lane_terminal_route: Some(SafeLaneFailureRoute {
@@ -9936,6 +9954,7 @@ mod tests {
                 lane: Some(TurnLaneExecutionSnapshot {
                     lane: ExecutionLane::Fast,
                     had_tool_intents: false,
+                    tool_request_summary: None,
                     raw_tool_output_requested: false,
                     result_kind: TurnCheckpointResultKind::FinalText,
                     safe_lane_terminal_route: None,

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -5359,7 +5359,8 @@ fn summarize_failed_provider_lane_tool_request(
 
     match turn.tool_intents.as_slice() {
         [intent] => summarize_single_tool_followup_request(intent),
-        _ => None,
+        [] => None,
+        _ => summarize_tool_followup_request(&turn.tool_intents),
     }
 }
 
@@ -8061,9 +8062,49 @@ mod tests {
             request_summary_json,
             json!({
                 "tool": "shell.exec",
-                "request": {"command": "ls", "args": ["/root"]}
+                "request": {"command": "ls", "args_redacted": 1}
             })
         );
+    }
+
+    #[test]
+    fn summarize_failed_provider_lane_tool_request_preserves_multi_intent_context_without_trace() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![
+                ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "Cargo.toml"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-a".to_owned(),
+                    turn_id: "turn-a".to_owned(),
+                    tool_call_id: "call-1".to_owned(),
+                },
+                ToolIntent {
+                    tool_name: "shell.exec".to_owned(),
+                    args_json: json!({"command": "ls /root"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-a".to_owned(),
+                    turn_id: "turn-a".to_owned(),
+                    tool_call_id: "call-2".to_owned(),
+                },
+            ],
+            raw_meta: Value::Null,
+        };
+
+        let request_summary = summarize_failed_provider_lane_tool_request(&turn, None)
+            .expect("multi-intent failures should retain a request summary");
+        let request_summary_json: Value =
+            serde_json::from_str(&request_summary).expect("request summary should be valid json");
+        let request_entries = request_summary_json
+            .as_array()
+            .expect("multi-intent request summary should be an array");
+
+        assert_eq!(request_entries.len(), 2);
+        assert_eq!(request_entries[0]["tool"], "file.read");
+        assert_eq!(request_entries[1]["tool"], "shell.exec");
+        assert_eq!(request_entries[1]["request"]["command"], "ls");
+        assert_eq!(request_entries[1]["request"]["args_redacted"], 1);
     }
     #[cfg(feature = "memory-sqlite")]
     fn finalize_recovered_child(

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -8016,6 +8016,49 @@ mod tests {
         );
     }
 
+    #[test]
+    fn summarize_failed_provider_lane_tool_request_preserves_multi_intent_context_without_trace() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![
+                ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "Cargo.toml"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-a".to_owned(),
+                    turn_id: "turn-a".to_owned(),
+                    tool_call_id: "call-1".to_owned(),
+                },
+                ToolIntent {
+                    tool_name: "shell.exec".to_owned(),
+                    args_json: json!({"command": "ls /root"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-a".to_owned(),
+                    turn_id: "turn-a".to_owned(),
+                    tool_call_id: "call-2".to_owned(),
+                },
+            ],
+            raw_meta: Value::Null,
+        };
+
+        let request_summary = summarize_provider_lane_tool_request(
+            &turn,
+            &TurnResult::ToolError(TurnFailure::retryable("tool_error", "temporary failure")),
+            None,
+        )
+        .expect("multi-intent failures should retain a request summary");
+        let request_summary_json: Value =
+            serde_json::from_str(&request_summary).expect("request summary should be valid json");
+        let request_entries = request_summary_json
+            .as_array()
+            .expect("multi-intent request summary should be an array");
+
+        assert_eq!(request_entries.len(), 2);
+        assert_eq!(request_entries[0]["tool"], "file.read");
+        assert_eq!(request_entries[1]["tool"], "shell.exec");
+        assert_eq!(request_entries[1]["request"]["command"], "ls");
+        assert_eq!(request_entries[1]["request"]["args_redacted"], 1);
+    }
     #[cfg(feature = "memory-sqlite")]
     fn finalize_recovered_child(
         repo: &SessionRepository,

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -41,6 +41,7 @@ use super::runtime_binding::ConversationRuntimeBinding;
 use super::tool_result_compaction::compact_tool_search_payload_summary;
 
 use super::ingress::{ConversationIngressContext, inject_internal_tool_ingress};
+use super::turn_shared::effective_followup_tool_name;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderTurn {
@@ -2016,6 +2017,10 @@ pub(crate) fn effective_result_tool_name(intent: &ToolIntent) -> String {
         .to_owned()
 }
 
+fn effective_denied_tool_name(intent: &ToolIntent) -> String {
+    effective_followup_tool_name(intent)
+}
+
 fn build_tool_decision_trace_record(
     intent: &ToolIntent,
     decision: ToolDecisionTelemetry,
@@ -3514,7 +3519,7 @@ mod tests {
         let (tool_name, args_json) = crate::tools::synthesize_test_provider_tool_call(
             "shell.exec",
             json!({
-                "command": "/bin/echo",
+                "command": "echo",
                 "args": ["hello"],
             }),
         );
@@ -3534,21 +3539,23 @@ mod tests {
             engine
                 .prepare_tool_intent(
                     &intent,
+                    0,
                     &session_context,
                     &DefaultAppToolDispatcher::runtime(),
                     ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
+                    &AutonomyTurnBudgetState::default(),
                     None,
                 )
                 .await
                 .expect("tool.invoke shell request should prepare successfully")
         });
 
-        assert_eq!(prepared_intent.request.tool_name, "tool.invoke");
+        assert_eq!(prepared_intent.request.tool_name, "shell.exec");
         assert_eq!(prepared_intent.intent.tool_name, "shell.exec");
         assert_eq!(
             prepared_intent.intent.args_json,
             json!({
-                "command": "/bin/echo",
+                "command": "echo",
                 "args": ["hello"],
             })
         );

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -15,17 +15,15 @@ use super::runtime::{ConversationRuntime, DefaultConversationRuntime};
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_budget::{TurnRoundBudget, TurnRoundBudgetDecision};
 use super::turn_engine::{
-    DefaultAppToolDispatcher, ProviderTurn, ToolBatchExecutionIntentStatus,
-    ToolBatchExecutionTrace, ToolIntent, TurnEngine, TurnResult, TurnValidation,
+    DefaultAppToolDispatcher, ProviderTurn, ToolIntent, TurnEngine, TurnResult, TurnValidation,
 };
 use super::turn_observer::map_streaming_callback_data_to_token_event;
 use super::turn_shared::{
     ProviderTurnRequestAction, ReplyPersistenceMode, ToolDrivenFollowupPayload,
-    ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase, build_tool_driven_followup_tail,
-    build_tool_loop_guard_tail, decide_provider_turn_request_action,
-    reduce_followup_payload_for_model, request_completion_with_raw_fallback,
-    summarize_single_tool_followup_request, summarize_tool_followup_request,
-    summarize_tool_followup_tool_names, tool_loop_circuit_breaker_reply,
+    ToolDrivenReplyBaseDecision, ToolDrivenReplyPhase,
+    build_tool_driven_followup_tail_with_request_summary, build_tool_loop_guard_tail,
+    decide_provider_turn_request_action, reduce_followup_payload_for_model,
+    request_completion_with_raw_fallback, tool_loop_circuit_breaker_reply,
     user_requested_raw_tool_output,
 };
 
@@ -80,6 +78,7 @@ enum RoundFollowup {
         assistant_preface: String,
         payload: ToolDrivenFollowupPayload,
         loop_warning_reason: Option<String>,
+        tool_request_summary: Option<String>,
     },
     Guard {
         assistant_preface: String,
@@ -398,7 +397,7 @@ async fn evaluate_round_kernel(
             .conversation
             .fast_lane_parallel_tool_execution_max_in_flight(),
     );
-    let (turn_result, turn_trace) = match engine.validate_turn_in_context(turn, session_context) {
+    let (turn_result, _turn_trace) = match engine.validate_turn_in_context(turn, session_context) {
         Ok(TurnValidation::FinalText(text)) => (TurnResult::FinalText(text), None),
         Err(failure) => (TurnResult::ToolDenied(failure), None),
         Ok(TurnValidation::ToolExecutionRequired) => {
@@ -433,56 +432,10 @@ async fn evaluate_round_kernel(
     RoundKernelEvaluation {
         assistant_preface: turn.assistant_text.clone(),
         had_tool_intents,
-        tool_request_summary: summarize_round_tool_request(turn, &turn_result, turn_trace.as_ref()),
+        tool_request_summary: None,
         turn_result,
         loop_verdict,
     }
-}
-
-fn summarize_round_tool_request(
-    turn: &ProviderTurn,
-    turn_result: &TurnResult,
-    turn_trace: Option<&ToolBatchExecutionTrace>,
-) -> Option<String> {
-    match turn_result {
-        TurnResult::FinalText(_) | TurnResult::StreamingText(_) | TurnResult::StreamingDone(_) => {
-            summarize_tool_followup_request(&turn.tool_intents)
-        }
-        TurnResult::NeedsApproval(_)
-        | TurnResult::ToolDenied(_)
-        | TurnResult::ToolError(_)
-        | TurnResult::ProviderError(_) => summarize_failed_round_tool_request(turn, turn_trace),
-    }
-}
-
-fn summarize_failed_round_tool_request(
-    turn: &ProviderTurn,
-    turn_trace: Option<&ToolBatchExecutionTrace>,
-) -> Option<String> {
-    let failed_tool_call_id = first_failed_tool_call_id(turn_trace);
-    if let Some(failed_tool_call_id) = failed_tool_call_id {
-        let failed_intent = turn
-            .tool_intents
-            .iter()
-            .find(|intent| intent.tool_call_id == failed_tool_call_id)?;
-        return summarize_single_tool_followup_request(failed_intent);
-    }
-
-    match turn.tool_intents.as_slice() {
-        [intent] => summarize_single_tool_followup_request(intent),
-        _ => None,
-    }
-}
-
-fn first_failed_tool_call_id(turn_trace: Option<&ToolBatchExecutionTrace>) -> Option<&str> {
-    let turn_trace = turn_trace?;
-    let failed_outcome = turn_trace.intent_outcomes.iter().find(|intent_outcome| {
-        !matches!(
-            intent_outcome.status,
-            ToolBatchExecutionIntentStatus::Completed
-        )
-    })?;
-    Some(failed_outcome.tool_call_id.as_str())
 }
 
 impl RoundKernelEvaluation {
@@ -538,6 +491,7 @@ fn decide_round_kernel_action(
         assistant_preface: evaluation.assistant_preface,
         payload: tool_payload,
         loop_warning_reason,
+        tool_request_summary: evaluation.tool_request_summary,
     };
 
     match round_budget.followup_decision() {
@@ -563,6 +517,7 @@ fn append_round_followup_messages(
             assistant_preface,
             payload,
             loop_warning_reason,
+            tool_request_summary,
         } => append_tool_driven_followup_messages(
             &mut session.messages,
             assistant_preface.as_str(),
@@ -570,6 +525,7 @@ fn append_round_followup_messages(
             user_input,
             &mut session.followup_payload_budget,
             loop_warning_reason.as_deref(),
+            tool_request_summary.as_deref(),
         ),
         RoundFollowup::Guard {
             assistant_preface,
@@ -597,12 +553,14 @@ fn append_tool_driven_followup_messages(
     user_input: &str,
     followup_payload_budget: &mut FollowupPayloadBudget,
     loop_warning_reason: Option<&str>,
+    tool_request_summary: Option<&str>,
 ) {
-    messages.extend(build_tool_driven_followup_tail(
+    messages.extend(build_tool_driven_followup_tail_with_request_summary(
         assistant_preface,
         payload,
         user_input,
         loop_warning_reason,
+        tool_request_summary,
         |label, text| {
             let reduced = reduce_followup_payload_for_model(label, text);
             followup_payload_budget.truncate_payload(label, reduced.as_ref())
@@ -1078,6 +1036,7 @@ mod tests {
             "summarize note.md",
             &mut budget,
             None,
+            None,
         );
 
         let user_prompt = messages
@@ -1104,6 +1063,7 @@ mod tests {
             "summarize note.md",
             &mut budget,
             None,
+            None,
         );
 
         let user_prompt = messages
@@ -1129,6 +1089,7 @@ mod tests {
             },
             "summarize note.md",
             &mut budget,
+            None,
             None,
         );
 
@@ -1181,6 +1142,7 @@ mod tests {
             "apply the skill",
             &mut budget,
             None,
+            None,
         );
 
         let system_content = messages[0]["content"]
@@ -1204,6 +1166,7 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
             "summarize README.md",
             &mut budget,
+            None,
             None,
         );
 
@@ -1252,6 +1215,7 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
             "summarize the test run",
             &mut budget,
+            None,
             None,
         );
 
@@ -1340,6 +1304,7 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
             "find the right tool",
             &mut budget,
+            None,
             None,
         );
 
@@ -1539,6 +1504,7 @@ mod tests {
         let evaluation = RoundKernelEvaluation {
             assistant_preface: "preface".to_owned(),
             had_tool_intents: true,
+            tool_request_summary: None,
             turn_result: TurnResult::FinalText("tool output".to_owned()),
             loop_verdict: Some(ToolLoopSupervisorVerdict::InjectWarning {
                 reason: "warning".to_owned(),
@@ -1556,6 +1522,7 @@ mod tests {
             assistant_preface,
             payload: ToolDrivenFollowupPayload::ToolResult { text },
             loop_warning_reason,
+            ..
         }) = decision
         {
             assert_eq!(assistant_preface, "preface");
@@ -1571,6 +1538,7 @@ mod tests {
         let evaluation = RoundKernelEvaluation {
             assistant_preface: "preface".to_owned(),
             had_tool_intents: true,
+            tool_request_summary: None,
             turn_result: TurnResult::FinalText("tool output".to_owned()),
             loop_verdict: Some(ToolLoopSupervisorVerdict::HardStop {
                 reason: "stop".to_owned(),
@@ -1608,6 +1576,7 @@ mod tests {
         let evaluation = RoundKernelEvaluation {
             assistant_preface: "preface".to_owned(),
             had_tool_intents: true,
+            tool_request_summary: None,
             turn_result: TurnResult::ToolError(TurnFailure::retryable(
                 "tool_failed",
                 "tool failure",
@@ -1651,6 +1620,7 @@ mod tests {
         let evaluation = RoundKernelEvaluation {
             assistant_preface: "preface".to_owned(),
             had_tool_intents: true,
+            tool_request_summary: None,
             turn_result: TurnResult::FinalText("tool output".to_owned()),
             loop_verdict: Some(ToolLoopSupervisorVerdict::InjectWarning {
                 reason: "warning".to_owned(),

--- a/crates/app/src/conversation/turn_observer.rs
+++ b/crates/app/src/conversation/turn_observer.rs
@@ -174,6 +174,7 @@ pub struct ConversationTurnToolEvent {
     pub tool_name: String,
     pub state: ConversationTurnToolState,
     pub detail: Option<String>,
+    pub request_summary: Option<String>,
 }
 
 impl ConversationTurnToolEvent {
@@ -183,6 +184,7 @@ impl ConversationTurnToolEvent {
             tool_name: tool_name.into(),
             state: ConversationTurnToolState::Running,
             detail: None,
+            request_summary: None,
         }
     }
 
@@ -196,6 +198,7 @@ impl ConversationTurnToolEvent {
             tool_name: tool_name.into(),
             state: ConversationTurnToolState::Completed,
             detail,
+            request_summary: None,
         }
     }
 
@@ -209,6 +212,7 @@ impl ConversationTurnToolEvent {
             tool_name: tool_name.into(),
             state: ConversationTurnToolState::NeedsApproval,
             detail: Some(detail.into()),
+            request_summary: None,
         }
     }
 
@@ -222,6 +226,7 @@ impl ConversationTurnToolEvent {
             tool_name: tool_name.into(),
             state: ConversationTurnToolState::Denied,
             detail: Some(detail.into()),
+            request_summary: None,
         }
     }
 
@@ -235,6 +240,7 @@ impl ConversationTurnToolEvent {
             tool_name: tool_name.into(),
             state: ConversationTurnToolState::Failed,
             detail: Some(detail.into()),
+            request_summary: None,
         }
     }
 
@@ -248,7 +254,13 @@ impl ConversationTurnToolEvent {
             tool_name: tool_name.into(),
             state: ConversationTurnToolState::Interrupted,
             detail: Some(detail.into()),
+            request_summary: None,
         }
+    }
+
+    pub fn with_request_summary(mut self, request_summary: Option<String>) -> Self {
+        self.request_summary = request_summary;
+        self
     }
 }
 

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -19,7 +19,6 @@ use crate::CliResult;
 
 pub const TOOL_FOLLOWUP_PROMPT: &str = "Use the tool result above to answer the original user request in natural language. Do not include raw JSON, payload wrappers, or status markers unless the user explicitly asks for raw output.";
 pub const DISCOVERY_RESULT_FOLLOWUP_PROMPT: &str = "The tool result above is a discovery result, not the final evidence. Choose the best matching discovered tool, reuse its lease when invoking it, continue with the next tool call needed to satisfy the original user request, and only answer directly if the discovery results already contain the final user-facing information.";
-pub const TOOL_FAILURE_FOLLOWUP_PROMPT: &str = "A tool call failed. Inspect the attempted tool request and failure above before answering. If the failure is repairable, correct the tool arguments and retry with a materially different call. If the failure is a policy denial or cannot be repaired safely, explain the constraint and continue with the best possible answer.";
 pub const TOOL_TRUNCATION_HINT_PROMPT: &str = "One or more tool results were truncated for context safety. If exact missing details are needed, explicitly state the truncation and request a narrower rerun.";
 pub const EXTERNAL_SKILL_FOLLOWUP_PROMPT: &str = "An external skill has been loaded into runtime context. Follow its instructions while answering the original user request. Do not restate the skill verbatim unless the user explicitly asks for it.";
 pub const TOOL_LOOP_GUARD_PROMPT: &str = "Detected tool-loop behavior across rounds. Do not repeat identical or cyclical tool calls without new evidence. Adjust strategy (different tool, arguments, or decomposition) or provide the best possible final answer and clearly state remaining gaps.";
@@ -184,14 +183,6 @@ pub(crate) fn summarize_tool_followup_request(intents: &[ToolIntent]) -> Option<
 pub(crate) fn summarize_single_tool_followup_request(intent: &ToolIntent) -> Option<String> {
     let entry = tool_followup_request_entry(intent);
     serde_json::to_string(&entry).ok()
-}
-
-pub(crate) fn summarize_tool_followup_tool_names(intents: &[ToolIntent]) -> String {
-    intents
-        .iter()
-        .map(effective_followup_tool_name)
-        .collect::<Vec<_>>()
-        .join("||")
 }
 
 fn tool_followup_request_entry(intent: &ToolIntent) -> Value {
@@ -1060,6 +1051,22 @@ pub fn build_tool_followup_user_prompt(
     tool_result_text: Option<&str>,
     rendered_tool_result_text: Option<&str>,
 ) -> String {
+    build_tool_followup_user_prompt_with_context(
+        user_input,
+        loop_warning_reason,
+        tool_result_text,
+        rendered_tool_result_text,
+        None,
+    )
+}
+
+pub fn build_tool_followup_user_prompt_with_context(
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    tool_result_text: Option<&str>,
+    rendered_tool_result_text: Option<&str>,
+    extra_context: Option<&str>,
+) -> String {
     let prompt =
         if followup_prompt_uses_discovery_guidance(tool_result_text, rendered_tool_result_text) {
             DISCOVERY_RESULT_FOLLOWUP_PROMPT
@@ -1075,6 +1082,9 @@ pub fn build_tool_followup_user_prompt(
     }
     if followup_prompt_needs_truncation_hint(tool_result_text, rendered_tool_result_text) {
         sections.push(TOOL_TRUNCATION_HINT_PROMPT.to_owned());
+    }
+    if let Some(extra_context) = extra_context {
+        sections.push(extra_context.to_owned());
     }
     sections.push(format!("Original request:\n{user_input}"));
     sections.join("\n\n")
@@ -1452,11 +1462,34 @@ where
     messages
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 pub fn build_tool_failure_followup_tail<F>(
     assistant_preface: &str,
     tool_failure_reason: &str,
     user_input: &str,
     loop_warning_reason: Option<&str>,
+    payload_mapper: F,
+) -> Vec<Value>
+where
+    F: FnMut(&str, &str) -> String,
+{
+    build_tool_failure_followup_tail_with_request_summary(
+        assistant_preface,
+        tool_failure_reason,
+        user_input,
+        loop_warning_reason,
+        None,
+        payload_mapper,
+    )
+}
+
+pub fn build_tool_failure_followup_tail_with_request_summary<F>(
+    assistant_preface: &str,
+    tool_failure_reason: &str,
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    tool_request_summary: Option<&str>,
     mut payload_mapper: F,
 ) -> Vec<Value>
 where
@@ -1464,7 +1497,22 @@ where
 {
     let mut messages = Vec::new();
     append_followup_preface(&mut messages, assistant_preface);
+
+    if let Some(tool_request_summary) = tool_request_summary {
+        messages.push(serde_json::json!({
+            "role": "assistant",
+            "content": format!("[tool_request]\n{tool_request_summary}"),
+        }));
+    }
+
+    let repair_guidance =
+        render_tool_failure_repair_guidance(tool_failure_reason, tool_request_summary);
     let bounded_failure = payload_mapper("tool_failure", tool_failure_reason);
+    let bounded_failure = if repair_guidance.is_some() {
+        format!("tool input needs repair: {bounded_failure}")
+    } else {
+        bounded_failure
+    };
     messages.push(serde_json::json!({
         "role": "assistant",
         "content": format!("[tool_failure]\n{bounded_failure}"),
@@ -1472,16 +1520,45 @@ where
     append_followup_warning(&mut messages, loop_warning_reason);
     messages.push(serde_json::json!({
         "role": "user",
-        "content": build_tool_followup_user_prompt(user_input, loop_warning_reason, None, None),
+        "content": build_tool_followup_user_prompt_with_context(
+            user_input,
+            loop_warning_reason,
+            None,
+            None,
+            repair_guidance.as_deref(),
+        ),
     }));
     messages
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 pub fn build_tool_driven_followup_tail<F>(
     assistant_preface: &str,
     payload: &ToolDrivenFollowupPayload,
     user_input: &str,
     loop_warning_reason: Option<&str>,
+    payload_mapper: F,
+) -> Vec<Value>
+where
+    F: FnMut(&str, &str) -> String,
+{
+    build_tool_driven_followup_tail_with_request_summary(
+        assistant_preface,
+        payload,
+        user_input,
+        loop_warning_reason,
+        None,
+        payload_mapper,
+    )
+}
+
+pub fn build_tool_driven_followup_tail_with_request_summary<F>(
+    assistant_preface: &str,
+    payload: &ToolDrivenFollowupPayload,
+    user_input: &str,
+    loop_warning_reason: Option<&str>,
+    tool_request_summary: Option<&str>,
     payload_mapper: F,
 ) -> Vec<Value>
 where
@@ -1495,14 +1572,49 @@ where
             loop_warning_reason,
             payload_mapper,
         ),
-        ToolDrivenFollowupPayload::ToolFailure { reason } => build_tool_failure_followup_tail(
-            assistant_preface,
-            reason.as_str(),
-            user_input,
-            loop_warning_reason,
-            payload_mapper,
-        ),
+        ToolDrivenFollowupPayload::ToolFailure { reason } => {
+            build_tool_failure_followup_tail_with_request_summary(
+                assistant_preface,
+                reason.as_str(),
+                user_input,
+                loop_warning_reason,
+                tool_request_summary,
+                payload_mapper,
+            )
+        }
     }
+}
+
+fn render_tool_failure_repair_guidance(
+    tool_failure_reason: &str,
+    tool_request_summary: Option<&str>,
+) -> Option<String> {
+    let tool_request_summary = tool_request_summary?;
+    let request_summary_json = serde_json::from_str::<Value>(tool_request_summary).ok()?;
+    let tool_name = request_summary_json.get("tool").and_then(Value::as_str)?;
+    if tool_name != "shell.exec" {
+        return None;
+    }
+
+    let request_object = request_summary_json.get("request")?.as_object()?;
+    let command = request_object.get("command").and_then(Value::as_str)?;
+    let has_path_separator = command.contains('/') || command.contains('\\');
+    let mentions_payload_command = tool_failure_reason.contains("payload.command");
+    let mentions_path_separator = tool_failure_reason.contains("path separators");
+
+    if !has_path_separator && !mentions_payload_command && !mentions_path_separator {
+        return None;
+    }
+
+    let bare_command = command
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(command)
+        .to_ascii_lowercase();
+    let guidance = format!(
+        "Repair guidance for shell.exec:\nUse a bare lowercase executable name in `payload.command`.\nThe failed request used `{command}`; retry with `{bare_command}`."
+    );
+    Some(guidance)
 }
 
 pub fn build_tool_loop_guard_tail<F>(

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -5,8 +5,8 @@ use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::tool_result_compaction::compact_tool_search_payload_summary_str;
 use super::turn_engine::{
-    ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, ToolIntent,
-    ToolResultPayloadSemantics, TurnResult,
+    ApprovalRequirement, ApprovalRequirementKind, ProviderTurn, ToolBatchExecutionIntentStatus,
+    ToolBatchExecutionTrace, ToolIntent, ToolResultPayloadSemantics, TurnResult,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -183,6 +183,54 @@ pub(crate) fn summarize_tool_followup_request(intents: &[ToolIntent]) -> Option<
 pub(crate) fn summarize_single_tool_followup_request(intent: &ToolIntent) -> Option<String> {
     let entry = tool_followup_request_entry(intent);
     serde_json::to_string(&entry).ok()
+}
+
+pub(crate) fn summarize_provider_lane_tool_request(
+    turn: &ProviderTurn,
+    turn_result: &TurnResult,
+    trace: Option<&ToolBatchExecutionTrace>,
+) -> Option<String> {
+    match turn_result {
+        TurnResult::FinalText(_) | TurnResult::StreamingText(_) | TurnResult::StreamingDone(_) => {
+            summarize_tool_followup_request(&turn.tool_intents)
+        }
+        TurnResult::NeedsApproval(_)
+        | TurnResult::ToolDenied(_)
+        | TurnResult::ToolError(_)
+        | TurnResult::ProviderError(_) => summarize_failed_provider_lane_tool_request(turn, trace),
+    }
+}
+
+pub(crate) fn summarize_failed_provider_lane_tool_request(
+    turn: &ProviderTurn,
+    trace: Option<&ToolBatchExecutionTrace>,
+) -> Option<String> {
+    let failed_tool_call_id = trace.and_then(first_failed_provider_lane_tool_call_id);
+    if let Some(failed_tool_call_id) = failed_tool_call_id {
+        let failed_intent = turn
+            .tool_intents
+            .iter()
+            .find(|intent| intent.tool_call_id == failed_tool_call_id)?;
+        let summary = summarize_single_tool_followup_request(failed_intent);
+        return summary;
+    }
+
+    match turn.tool_intents.as_slice() {
+        [intent] => summarize_single_tool_followup_request(intent),
+        [] => None,
+        _ => summarize_tool_followup_request(&turn.tool_intents),
+    }
+}
+
+fn first_failed_provider_lane_tool_call_id(trace: &ToolBatchExecutionTrace) -> Option<&str> {
+    let failed_outcome = trace.intent_outcomes.iter().find(|intent_outcome| {
+        !matches!(
+            intent_outcome.status,
+            ToolBatchExecutionIntentStatus::Completed
+        )
+    })?;
+    let tool_call_id = failed_outcome.tool_call_id.as_str();
+    Some(tool_call_id)
 }
 
 fn tool_followup_request_entry(intent: &ToolIntent) -> Value {
@@ -3054,6 +3102,46 @@ mod tests {
 
         assert_eq!(reduced.as_ref(), tool_result);
         assert_eq!(reduced.as_ptr(), tool_result.as_ptr());
+    }
+
+    #[test]
+    fn summarize_failed_provider_lane_tool_request_preserves_multi_intent_context_without_trace() {
+        let turn = ProviderTurn {
+            assistant_text: String::new(),
+            tool_intents: vec![
+                ToolIntent {
+                    tool_name: "file.read".to_owned(),
+                    args_json: json!({"path": "Cargo.toml"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-a".to_owned(),
+                    turn_id: "turn-a".to_owned(),
+                    tool_call_id: "call-1".to_owned(),
+                },
+                ToolIntent {
+                    tool_name: "shell.exec".to_owned(),
+                    args_json: json!({"command": "ls /root"}),
+                    source: "provider_tool_call".to_owned(),
+                    session_id: "session-a".to_owned(),
+                    turn_id: "turn-a".to_owned(),
+                    tool_call_id: "call-2".to_owned(),
+                },
+            ],
+            raw_meta: Value::Null,
+        };
+
+        let request_summary = summarize_failed_provider_lane_tool_request(&turn, None)
+            .expect("multi-intent failures should retain a request summary");
+        let request_summary_json: Value =
+            serde_json::from_str(&request_summary).expect("request summary should be valid json");
+        let request_entries = request_summary_json
+            .as_array()
+            .expect("multi-intent request summary should be an array");
+
+        assert_eq!(request_entries.len(), 2);
+        assert_eq!(request_entries[0]["tool"], "file.read");
+        assert_eq!(request_entries[1]["tool"], "shell.exec");
+        assert_eq!(request_entries[1]["request"]["command"], "ls");
+        assert_eq!(request_entries[1]["request"]["args_redacted"], 1);
     }
 
     #[test]

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -188,10 +188,53 @@ pub(crate) fn summarize_single_tool_followup_request(intent: &ToolIntent) -> Opt
 fn tool_followup_request_entry(intent: &ToolIntent) -> Value {
     let tool_name = effective_followup_tool_name(intent);
     let request = effective_followup_request(intent);
+    let request = sanitize_followup_request_summary(tool_name.as_str(), request);
     serde_json::json!({
         "tool": tool_name,
         "request": request,
     })
+}
+
+fn sanitize_followup_request_summary(tool_name: &str, request: Value) -> Value {
+    if tool_name != crate::tools::SHELL_EXEC_TOOL_NAME {
+        return request;
+    }
+
+    sanitize_shell_followup_request_summary(request)
+}
+
+fn sanitize_shell_followup_request_summary(request: Value) -> Value {
+    let Value::Object(request_object) = request else {
+        return request;
+    };
+
+    let command = request_object
+        .get("command")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let timeout_ms = request_object.get("timeout_ms").cloned();
+    let args_redacted = request_object
+        .get("args")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .filter(|count| *count > 0);
+
+    let mut sanitized_request = serde_json::Map::new();
+
+    if let Some(command) = command {
+        sanitized_request.insert("command".to_owned(), Value::String(command));
+    }
+
+    if let Some(timeout_ms) = timeout_ms {
+        sanitized_request.insert("timeout_ms".to_owned(), timeout_ms);
+    }
+
+    if let Some(args_redacted) = args_redacted {
+        let args_redacted = serde_json::Number::from(args_redacted);
+        sanitized_request.insert("args_redacted".to_owned(), Value::Number(args_redacted));
+    }
+
+    Value::Object(sanitized_request)
 }
 
 pub(crate) fn effective_followup_tool_name(intent: &ToolIntent) -> String {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -57,6 +57,7 @@ pub mod runtime_config;
 mod session;
 mod shell;
 pub mod shell_policy_ext;
+mod shell_request_prep;
 mod tool_search;
 // Browser reuses the shared SSRF and HTML helpers from web_fetch even when the
 // public web.fetch tool is compiled out.
@@ -80,6 +81,12 @@ pub use catalog::{
 #[cfg(feature = "feishu-integration")]
 pub(crate) use feishu::{DeferredFeishuCardUpdate, drain_deferred_feishu_card_updates};
 pub use kernel_adapter::MvpToolAdapter;
+pub(crate) use shell_request_prep::{
+    TOOL_LEASE_SESSION_ID_FIELD, TOOL_LEASE_TOKEN_ID_FIELD, TOOL_LEASE_TURN_ID_FIELD,
+    TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD, inject_tool_lease_binding,
+    normalize_shell_payload_for_request, normalize_shell_request_for_execution,
+    prepare_kernel_tool_request,
+};
 #[cfg(any(feature = "tool-webfetch", feature = "tool-websearch"))]
 pub use web_http::build_ssrf_safe_client;
 
@@ -425,176 +432,6 @@ pub(super) fn normalize_without_fs(path: &Path) -> PathBuf {
         }
     } else {
         normalized
-    }
-}
-
-const TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD: &str = "_granted_capabilities";
-const TOOL_LEASE_TOKEN_ID_FIELD: &str = "_lease_token_id";
-const TOOL_LEASE_SESSION_ID_FIELD: &str = "_lease_session_id";
-const TOOL_LEASE_TURN_ID_FIELD: &str = "_lease_turn_id";
-
-pub(crate) fn normalize_shell_payload_for_request(tool_name: &str, payload: Value) -> Value {
-    match canonical_tool_name(tool_name) {
-        "shell.exec" => normalize_shell_payload_object(payload),
-        "tool.invoke" => normalize_shell_invoke_payload(payload),
-        _ => payload,
-    }
-}
-
-pub(crate) fn normalize_shell_request_for_execution(
-    mut request: ToolCoreRequest,
-) -> ToolCoreRequest {
-    request.payload =
-        normalize_shell_payload_for_request(request.tool_name.as_str(), request.payload);
-    request
-}
-
-fn normalize_shell_invoke_payload(payload: Value) -> Value {
-    let mut outer = match payload {
-        Value::Object(outer) => outer,
-        other @ Value::Null
-        | other @ Value::Bool(_)
-        | other @ Value::Number(_)
-        | other @ Value::String(_)
-        | other @ Value::Array(_) => return other,
-    };
-    let Some(tool_id) = outer
-        .get("tool_id")
-        .and_then(Value::as_str)
-        .map(canonical_tool_name)
-    else {
-        return Value::Object(outer);
-    };
-    if tool_id != "shell.exec" {
-        return Value::Object(outer);
-    }
-    let arguments = outer
-        .remove("arguments")
-        .map(normalize_shell_payload_object)
-        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
-    outer.insert("arguments".to_owned(), arguments);
-    Value::Object(outer)
-}
-
-fn normalize_shell_payload_object(payload: Value) -> Value {
-    let mut object = match payload {
-        Value::Object(object) => object,
-        other @ Value::Null
-        | other @ Value::Bool(_)
-        | other @ Value::Number(_)
-        | other @ Value::String(_)
-        | other @ Value::Array(_) => return other,
-    };
-    let args_missing = match object.get("args") {
-        None => true,
-        Some(Value::Array(values)) => values.is_empty(),
-        Some(_) => false,
-    };
-    if !args_missing {
-        return Value::Object(object);
-    }
-
-    let Some(command) = object.get("command").and_then(Value::as_str) else {
-        return Value::Object(object);
-    };
-    let Some((normalized_command, normalized_args)) = split_shell_command_if_safe(command) else {
-        return Value::Object(object);
-    };
-    object.insert("command".to_owned(), Value::String(normalized_command));
-    if normalized_args.is_empty() {
-        object.remove("args");
-    } else {
-        object.insert(
-            "args".to_owned(),
-            Value::Array(
-                normalized_args
-                    .into_iter()
-                    .map(Value::String)
-                    .collect::<Vec<_>>(),
-            ),
-        );
-    }
-    Value::Object(object)
-}
-
-fn split_shell_command_if_safe(command: &str) -> Option<(String, Vec<String>)> {
-    let trimmed = command.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    let contains_newline = trimmed.chars().any(|ch| matches!(ch, '\n' | '\r'));
-    if contains_newline {
-        return None;
-    }
-    let contains_whitespace = trimmed.contains(char::is_whitespace);
-    if !contains_whitespace {
-        return None;
-    }
-    if trimmed.chars().any(|ch| {
-        matches!(
-            ch,
-            '\'' | '"' | '\\' | '`' | '|' | '&' | ';' | '<' | '>' | '(' | ')' | '$'
-        )
-    }) {
-        return None;
-    }
-    let mut parts = trimmed.split_whitespace();
-    let command = parts.next()?.to_owned();
-    let args = parts.map(str::to_owned).collect::<Vec<_>>();
-    if args.is_empty() {
-        return None;
-    }
-    Some((command, args))
-}
-pub(crate) fn prepare_kernel_tool_request(
-    mut request: ToolCoreRequest,
-    granted_capabilities: &BTreeSet<Capability>,
-    token_id: Option<&str>,
-    session_id: Option<&str>,
-    turn_id: Option<&str>,
-) -> ToolCoreRequest {
-    request = normalize_shell_request_for_execution(request);
-    let canonical_tool_name = canonical_tool_name(request.tool_name.as_str());
-    if !matches!(canonical_tool_name, "tool.search" | "tool.invoke") {
-        return request;
-    }
-
-    if let Value::Object(payload) = &mut request.payload {
-        if canonical_tool_name == "tool.search" {
-            let granted =
-                serde_json::to_value(granted_capabilities.iter().copied().collect::<Vec<_>>())
-                    .unwrap_or_else(|_| Value::Array(Vec::new()));
-            payload.insert(TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD.to_owned(), granted);
-        }
-        inject_tool_lease_binding(payload, token_id, session_id, turn_id);
-    }
-
-    request
-}
-
-fn inject_tool_lease_binding(
-    payload: &mut serde_json::Map<String, Value>,
-    token_id: Option<&str>,
-    session_id: Option<&str>,
-    turn_id: Option<&str>,
-) {
-    if let Some(token_id) = token_id {
-        payload.insert(
-            TOOL_LEASE_TOKEN_ID_FIELD.to_owned(),
-            Value::String(token_id.to_owned()),
-        );
-    }
-    if let Some(session_id) = session_id {
-        payload.insert(
-            TOOL_LEASE_SESSION_ID_FIELD.to_owned(),
-            Value::String(session_id.to_owned()),
-        );
-    }
-    if let Some(turn_id) = turn_id {
-        payload.insert(
-            TOOL_LEASE_TURN_ID_FIELD.to_owned(),
-            Value::String(turn_id.to_owned()),
-        );
     }
 }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -810,6 +810,7 @@ pub fn execute_tool_core_with_config(
             tool_name: canonical_name.clone(),
             payload,
         };
+        let request = normalize_shell_request_for_execution(request);
         let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)?;
         let effective_config = effective_config.map(|narrowing| config.narrowed(&narrowing));
         let config = effective_config.as_ref().unwrap_or(config);

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -6,6 +6,7 @@ use loongclaw_kernel::{PolicyExtension, PolicyExtensionContext};
 pub(crate) const SHELL_EXEC_APPROVAL_RULE_ID: &str = "shell_exec_requires_approval";
 const SHELL_INTERNAL_APPROVAL_CONTEXT_KEY: &str = "shell_approval";
 const SHELL_INTERNAL_APPROVAL_KEY_FIELD: &str = "approval_key";
+const REPAIRABLE_TOOL_INPUT_PREFIX: &str = "repairable_tool_input: ";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShellPolicyDefault {
@@ -52,9 +53,36 @@ impl ToolPolicyExtension {
     }
 }
 
+fn repairable_tool_input_reason(reason: String) -> String {
+    let prefixed_reason = format!("{REPAIRABLE_TOOL_INPUT_PREFIX}{reason}");
+    prefixed_reason
+}
+
+#[cfg(test)]
+fn is_repairable_tool_input_reason(reason: &str) -> bool {
+    reason.starts_with(REPAIRABLE_TOOL_INPUT_PREFIX)
+}
+
+#[cfg(test)]
+fn strip_repairable_tool_input_prefix(reason: &str) -> &str {
+    if let Some(stripped_reason) = reason.strip_prefix(REPAIRABLE_TOOL_INPUT_PREFIX) {
+        return stripped_reason;
+    }
+
+    reason
+}
+
 pub(crate) fn validate_shell_command_name(command: &str) -> Result<String, String> {
     let trimmed = command.trim();
     if trimmed.is_empty() {
+        let reason = repairable_tool_input_reason(
+            "shell.exec requires payload.command. Provide a bare executable in payload.command and move arguments into payload.args.".to_owned(),
+        );
+        return Err(reason);
+    }
+
+    let contains_newline = trimmed.chars().any(|ch| matches!(ch, '\n' | '\r'));
+    if contains_newline {
         let reason = repairable_tool_input_reason(
             "shell.exec requires payload.command. Provide a bare executable in payload.command and move arguments into payload.args.".to_owned(),
         );

--- a/crates/app/src/tools/shell_request_prep.rs
+++ b/crates/app/src/tools/shell_request_prep.rs
@@ -1,0 +1,187 @@
+use std::collections::BTreeSet;
+
+use loongclaw_contracts::{Capability, ToolCoreRequest};
+use serde_json::Value;
+
+pub(crate) const TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD: &str = "_granted_capabilities";
+pub(crate) const TOOL_LEASE_TOKEN_ID_FIELD: &str = "_lease_token_id";
+pub(crate) const TOOL_LEASE_SESSION_ID_FIELD: &str = "_lease_session_id";
+pub(crate) const TOOL_LEASE_TURN_ID_FIELD: &str = "_lease_turn_id";
+
+pub(crate) fn normalize_shell_payload_for_request(tool_name: &str, payload: Value) -> Value {
+    match super::canonical_tool_name(tool_name) {
+        "shell.exec" => normalize_shell_payload_object(payload),
+        "tool.invoke" => normalize_shell_invoke_payload(payload),
+        _ => payload,
+    }
+}
+
+pub(crate) fn normalize_shell_request_for_execution(
+    mut request: ToolCoreRequest,
+) -> ToolCoreRequest {
+    request.payload =
+        normalize_shell_payload_for_request(request.tool_name.as_str(), request.payload);
+    request
+}
+
+pub(crate) fn prepare_kernel_tool_request(
+    mut request: ToolCoreRequest,
+    granted_capabilities: &BTreeSet<Capability>,
+    token_id: Option<&str>,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> ToolCoreRequest {
+    request = normalize_shell_request_for_execution(request);
+    let canonical_tool_name = super::canonical_tool_name(request.tool_name.as_str());
+    if !matches!(canonical_tool_name, "tool.search" | "tool.invoke") {
+        return request;
+    }
+
+    if let Value::Object(payload) = &mut request.payload {
+        if canonical_tool_name == "tool.search" {
+            let granted_capabilities_json =
+                serde_json::to_value(granted_capabilities.iter().copied().collect::<Vec<_>>());
+            let granted_capabilities_json =
+                granted_capabilities_json.unwrap_or_else(|_| Value::Array(Vec::new()));
+            payload.insert(
+                TOOL_SEARCH_GRANTED_CAPABILITIES_FIELD.to_owned(),
+                granted_capabilities_json,
+            );
+        }
+        inject_tool_lease_binding(payload, token_id, session_id, turn_id);
+    }
+
+    request
+}
+
+fn normalize_shell_invoke_payload(payload: Value) -> Value {
+    let mut outer = match payload {
+        Value::Object(outer) => outer,
+        other @ Value::Null
+        | other @ Value::Bool(_)
+        | other @ Value::Number(_)
+        | other @ Value::String(_)
+        | other @ Value::Array(_) => return other,
+    };
+
+    let tool_id = outer
+        .get("tool_id")
+        .and_then(Value::as_str)
+        .map(super::canonical_tool_name);
+    let Some(tool_id) = tool_id else {
+        return Value::Object(outer);
+    };
+    if tool_id != "shell.exec" {
+        return Value::Object(outer);
+    }
+
+    let arguments = outer
+        .remove("arguments")
+        .map(normalize_shell_payload_object)
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+    outer.insert("arguments".to_owned(), arguments);
+    Value::Object(outer)
+}
+
+fn normalize_shell_payload_object(payload: Value) -> Value {
+    let mut object = match payload {
+        Value::Object(object) => object,
+        other @ Value::Null
+        | other @ Value::Bool(_)
+        | other @ Value::Number(_)
+        | other @ Value::String(_)
+        | other @ Value::Array(_) => return other,
+    };
+
+    let args_missing = match object.get("args") {
+        None => true,
+        Some(Value::Array(values)) => values.is_empty(),
+        Some(_) => false,
+    };
+    if !args_missing {
+        return Value::Object(object);
+    }
+
+    let command = object.get("command").and_then(Value::as_str);
+    let Some(command) = command else {
+        return Value::Object(object);
+    };
+    let split_command = split_shell_command_if_safe(command);
+    let Some((normalized_command, normalized_args)) = split_command else {
+        return Value::Object(object);
+    };
+
+    object.insert("command".to_owned(), Value::String(normalized_command));
+    if normalized_args.is_empty() {
+        object.remove("args");
+    } else {
+        let args_json = normalized_args
+            .into_iter()
+            .map(Value::String)
+            .collect::<Vec<_>>();
+        object.insert("args".to_owned(), Value::Array(args_json));
+    }
+    Value::Object(object)
+}
+
+fn split_shell_command_if_safe(command: &str) -> Option<(String, Vec<String>)> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let contains_newline = trimmed.chars().any(|ch| matches!(ch, '\n' | '\r'));
+    if contains_newline {
+        return None;
+    }
+
+    let contains_whitespace = trimmed.contains(char::is_whitespace);
+    if !contains_whitespace {
+        return None;
+    }
+
+    let contains_risky_shell_syntax = trimmed.chars().any(|ch| {
+        matches!(
+            ch,
+            '\'' | '"' | '\\' | '`' | '|' | '&' | ';' | '<' | '>' | '(' | ')' | '$'
+        )
+    });
+    if contains_risky_shell_syntax {
+        return None;
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    let command = parts.next()?.to_owned();
+    let args = parts.map(str::to_owned).collect::<Vec<_>>();
+    if args.is_empty() {
+        return None;
+    }
+
+    Some((command, args))
+}
+
+pub(crate) fn inject_tool_lease_binding(
+    payload: &mut serde_json::Map<String, Value>,
+    token_id: Option<&str>,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) {
+    if let Some(token_id) = token_id {
+        payload.insert(
+            TOOL_LEASE_TOKEN_ID_FIELD.to_owned(),
+            Value::String(token_id.to_owned()),
+        );
+    }
+    if let Some(session_id) = session_id {
+        payload.insert(
+            TOOL_LEASE_SESSION_ID_FIELD.to_owned(),
+            Value::String(session_id.to_owned()),
+        );
+    }
+    if let Some(turn_id) = turn_id {
+        payload.insert(
+            TOOL_LEASE_TURN_ID_FIELD.to_owned(),
+            Value::String(turn_id.to_owned()),
+        );
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1307,7 +1307,7 @@ pub enum Commands {
 }
 
 impl Commands {
-    pub(crate) fn command_kind_for_logging(&self) -> &'static str {
+    pub fn command_kind_for_logging(&self) -> &'static str {
         match self {
             Self::Welcome => "welcome",
             Self::Demo => "demo",
@@ -1324,11 +1324,15 @@ impl Commands {
             Self::BenchmarkMemoryContext { .. } => "benchmark_memory_context",
             Self::ValidateConfig { .. } => "validate_config",
             Self::Onboard { .. } => "onboard",
+            Self::Personalize { .. } => "personalize",
             Self::Import { .. } => "import",
             Self::Migrate { .. } => "migrate",
             Self::Doctor { .. } => "doctor",
             Self::Audit { .. } => "audit",
             Self::Skills { .. } => "skills",
+            Self::Tasks { .. } => "tasks",
+            Self::Sessions { .. } => "sessions",
+            Self::Plugins { .. } => "plugins",
             Self::Channels { .. } => "channels",
             Self::ListModels { .. } => "list_models",
             Self::RuntimeSnapshot { .. } => "runtime_snapshot",
@@ -1355,6 +1359,7 @@ impl Commands {
             Self::MatrixServe { .. } => "matrix_serve",
             Self::WecomSend { .. } => "wecom_send",
             Self::WecomServe { .. } => "wecom_serve",
+            Self::WhatsappServe { .. } => "whatsapp_serve",
             Self::DiscordSend { .. } => "discord_send",
             Self::DingtalkSend { .. } => "dingtalk_send",
             Self::SlackSend { .. } => "slack_send",
@@ -1364,12 +1369,17 @@ impl Commands {
             Self::WebhookSend { .. } => "webhook_send",
             Self::GoogleChatSend { .. } => "google_chat_send",
             Self::TeamsSend { .. } => "teams_send",
+            Self::TlonSend { .. } => "tlon_send",
             Self::SignalSend { .. } => "signal_send",
+            Self::TwitchSend { .. } => "twitch_send",
             Self::MattermostSend { .. } => "mattermost_send",
             Self::NextcloudTalkSend { .. } => "nextcloud_talk_send",
             Self::SynologyChatSend { .. } => "synology_chat_send",
+            Self::IrcSend { .. } => "irc_send",
             Self::ImessageSend { .. } => "imessage_send",
+            Self::NostrSend { .. } => "nostr_send",
             Self::MultiChannelServe { .. } => "multi_channel_serve",
+            Self::Gateway { .. } => "gateway",
             Self::Feishu { .. } => "feishu",
             Self::Completions { .. } => "completions",
         }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -33,32 +33,6 @@ impl Drop for StdinGuard {
     }
 }
 
-fn command_kind(command: &Commands) -> String {
-    let rendered = format!("{command:?}");
-    let mut segments = rendered.split(|character: char| !character.is_ascii_alphanumeric());
-    let variant_name = segments.next().unwrap_or("unknown");
-
-    camel_case_to_snake_case(variant_name)
-}
-
-fn camel_case_to_snake_case(value: &str) -> String {
-    let mut rendered = String::new();
-    let mut previous_was_lowercase = false;
-
-    for character in value.chars() {
-        let is_uppercase = character.is_ascii_uppercase();
-        if is_uppercase && previous_was_lowercase {
-            rendered.push('_');
-        }
-
-        let lowercased = character.to_ascii_lowercase();
-        rendered.push(lowercased);
-        previous_was_lowercase = character.is_ascii_lowercase();
-    }
-
-    rendered
-}
-
 fn error_code(error: &str) -> String {
     let trimmed = error.trim();
     let mut segments = trimmed.split(':');
@@ -1055,7 +1029,7 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_kind, error_code};
+    use super::error_code;
     use loongclaw_daemon::{Commands, MultiChannelServeChannelAccount};
 
     #[test]
@@ -1076,8 +1050,14 @@ mod tests {
             }],
         };
 
-        assert_eq!(command_kind(&validate_config), "validate_config");
-        assert_eq!(command_kind(&multi_channel_serve), "multi_channel_serve");
+        assert_eq!(
+            validate_config.command_kind_for_logging(),
+            "validate_config"
+        );
+        assert_eq!(
+            multi_channel_serve.command_kind_for_logging(),
+            "multi_channel_serve"
+        );
     }
 
     #[test]

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T09:51:54Z
+- Generated at: 2026-04-03T11:31:53Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11185 | 11200 | 15 | 104 | 120 | 16 | 99.9% | TIGHT | 10831 | 3.3% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11226 | 11200 | -26 | 104 | 120 | 16 | 100.2% | BREACH | 10831 | 3.6% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.9%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
+- BREACH hotspots (>100% of any tracked budget): turn_coordinator (100.2%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -67,7 +67,7 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11185 functions=104 -->
+<!-- arch-hotspot key=turn_coordinator lines=11226 functions=104 -->
 <!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T12:05:46Z
+- Generated at: 2026-04-03T12:07:16Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-02T15:16:55Z
+- Generated at: 2026-04-03T09:51:54Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11070 | 11200 | 130 | 100 | 120 | 20 | 98.8% | TIGHT | 10831 | 2.2% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14940 | 15000 | 60 | 55 | 70 | 15 | 99.6% | TIGHT | 14472 | 3.2% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6382 | 6500 | 118 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 0.9% | PASS | 210 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11185 | 11200 | 15 | 104 | 120 | 16 | 99.9% | TIGHT | 10831 | 3.3% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (98.8%), tools_mod (99.6%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.9%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -67,9 +67,9 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11070 functions=100 -->
-<!-- arch-hotspot key=tools_mod lines=14940 functions=55 -->
-<!-- arch-hotspot key=daemon_lib lines=6382 functions=210 -->
+<!-- arch-hotspot key=turn_coordinator lines=11185 functions=104 -->
+<!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
+<!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T11:31:53Z
+- Generated at: 2026-04-03T11:53:11Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T11:53:11Z
+- Generated at: 2026-04-03T12:05:46Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11136 | 11200 | 64 | 100 | 120 | 20 | 99.4% | TIGHT | 10831 | 2.8% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11179 | 11200 | 21 | 100 | 120 | 20 | 99.8% | TIGHT | 10831 | 3.2% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.4%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.8%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -67,7 +67,7 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11136 functions=100 -->
+<!-- arch-hotspot key=turn_coordinator lines=11179 functions=100 -->
 <!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9713 | 9800 | 87 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11226 | 11200 | -26 | 104 | 120 | 16 | 100.2% | BREACH | 10831 | 3.6% | PASS | 98 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 11136 | 11200 | 64 | 100 | 120 | 20 | 99.4% | TIGHT | 10831 | 2.8% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
 ## Prioritization Signals
-- BREACH hotspots (>100% of any tracked budget): turn_coordinator (100.2%)
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
+- BREACH hotspots (>100% of any tracked budget): none
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.0%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (99.4%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -67,7 +67,7 @@
 <!-- arch-hotspot key=channel_config lines=9713 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=11226 functions=104 -->
+<!-- arch-hotspot key=turn_coordinator lines=11136 functions=100 -->
 <!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->


### PR DESCRIPTION
## Summary

- Problem:
  `origin/dev` had drifted into an inconsistent state across conversation follow-up summaries, shell repairable-input helpers, and daemon command-kind logging, which blocked workspace validation.
- Why it matters:
  this broke CI-parity checks on the main development line and made later runtime work hard to trust.
- What changed:
  reconciled the turn summary/request-summary types and helper imports, restored the shell normalization path expected by the runtime tests, restored the missing shell repairable-input helpers, and made daemon command-kind logging exhaustive again.
- What did not change (scope boundary):
  no new product surface or runtime architecture was introduced; this is a baseline consistency repair.

## Linked Issues

- Closes #861
- Related #766
- Related #838
- Related #839

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  this touches the conversation follow-up path, shell request normalization, and daemon CLI command-kind labeling, so regressions would show up as runtime drift or broken tool follow-up prompts.
- Rollout / guardrails:
  bounded to baseline-consistency fixes with full workspace clippy and test validation.
- Rollback path:
  revert this PR to restore the previous baseline, though that would reintroduce the compile/test breakage tracked in #861.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [ ] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --check
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-runtime-baseline-fix-target cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-runtime-baseline-fix-target cargo test --workspace --locked --quiet
CARGO_TARGET_DIR=/tmp/loongclaw-runtime-baseline-fix-target cargo test --workspace --all-features --locked --quiet

Results:
- git diff --check: PASS
- cargo fmt --all -- --check: PASS
- cargo clippy --workspace --all-targets --all-features -- -D warnings: PASS
- cargo test --workspace --locked --quiet: PASS
- cargo test --workspace --all-features --locked --quiet: PASS
```

## User-visible / Operator-visible Changes

- `dev` baseline validation is restored.
- shell follow-up and request-summary plumbing is internally consistent again.
- daemon command-kind logging once again covers the full CLI command surface.

## Failure Recovery

- Fast rollback or disable path:
  revert this PR.
- Observable failure symptoms reviewers should watch for:
  missing tool request summaries in conversation follow-up events, shell follow-up repair guidance drift, or missing daemon command labels for newer CLI variants.

## Reviewer Focus

- Check the turn summary/request-summary flow across `turn_observer`, `turn_coordinator`, `turn_loop`, and `turn_shared`.
- Check the shell normalization and repairable-input changes in `tools/mod.rs` and `shell_policy_ext.rs`.
- Check that the daemon command-kind coverage matches the current `Commands` enum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Tool request summaries are now tracked and persisted through conversation turns for improved context retention.
* Tool failure follow-ups now include repair guidance when shell command issues occur.

## Refactor
* Reorganized shell request preparation utilities into a dedicated module for improved maintainability.
* Enhanced tool-driven followup message construction to propagate request summaries throughout the conversation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->