### PR TITLE
feat(session): add FTS-backed session history search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2123,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
+ "tracing",
  "unicode-normalization",
  "unicode-segmentation",
  "wait-timeout",
@@ -2175,6 +2182,8 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "wat",
 ]
 
@@ -2251,6 +2260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3272,6 +3299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,7 +3413,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3768,6 +3803,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3902,6 +3980,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ wasmtime = { version = "43.0.0", default-features = false, features = ["std", "r
 rusqlite = { version = "0.39", features = ["bundled"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 which = "8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 [profile.release]
 lto = "thin"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -87,6 +87,7 @@ prost = { version = "0.14", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"], optional = true }
 libc = "0.2"
+tracing.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -1720,6 +1720,9 @@ mod tests {
     use crate::config::{AcpBackendProfilesConfig, AcpConfig, AcpxBackendConfig, LoongClawConfig};
 
     #[cfg(unix)]
+    const ACPX_FAKE_RUNTIME_STARTUP_TIMEOUT_MS: u64 = 60_000;
+
+    #[cfg(unix)]
     fn unique_temp_dir(prefix: &str) -> PathBuf {
         static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
         let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
@@ -1899,18 +1902,28 @@ mod tests {
 
     #[cfg(unix)]
     fn fake_acpx_config(script_path: &Path, cwd: &Path) -> LoongClawConfig {
+        let command = script_path.display().to_string();
+        let working_directory = cwd.display().to_string();
+        let expected_version = "0.1.16".to_owned();
+        let permission_mode = "approve-reads".to_owned();
+        let non_interactive_permissions = "fail".to_owned();
+        let timeout_seconds = 12.5;
+        let queue_owner_ttl_seconds = 0.25;
+        let startup_timeout_ms = ACPX_FAKE_RUNTIME_STARTUP_TIMEOUT_MS;
+
         LoongClawConfig {
             acp: AcpConfig {
+                startup_timeout_ms: Some(startup_timeout_ms),
                 allow_mcp_server_injection: false,
                 backends: AcpBackendProfilesConfig {
                     acpx: Some(AcpxBackendConfig {
-                        command: Some(script_path.display().to_string()),
-                        expected_version: Some("0.1.16".to_owned()),
-                        cwd: Some(cwd.display().to_string()),
-                        permission_mode: Some("approve-reads".to_owned()),
-                        non_interactive_permissions: Some("fail".to_owned()),
-                        timeout_seconds: Some(12.5),
-                        queue_owner_ttl_seconds: Some(0.25),
+                        command: Some(command),
+                        expected_version: Some(expected_version),
+                        cwd: Some(working_directory),
+                        permission_mode: Some(permission_mode),
+                        non_interactive_permissions: Some(non_interactive_permissions),
+                        timeout_seconds: Some(timeout_seconds),
+                        queue_owner_ttl_seconds: Some(queue_owner_ttl_seconds),
                         ..AcpxBackendConfig::default()
                     }),
                 },
@@ -1918,6 +1931,18 @@ mod tests {
             },
             ..LoongClawConfig::default()
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn fake_acpx_config_uses_explicit_process_test_startup_timeout() {
+        let temp_dir = unique_temp_dir("loongclaw-acpx-config-timeout");
+        let script_path = temp_dir.join("fake-acpx");
+
+        let config = fake_acpx_config(&script_path, &temp_dir);
+        let startup_timeout_ms = config.acp.startup_timeout_ms();
+
+        assert_eq!(startup_timeout_ms, ACPX_FAKE_RUNTIME_STARTUP_TIMEOUT_MS);
     }
 
     #[tokio::test]

--- a/crates/app/src/acp/manager.rs
+++ b/crates/app/src/acp/manager.rs
@@ -7,10 +7,10 @@ use crate::CliResult;
 use crate::config::LoongClawConfig;
 
 use super::backend::{
-    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, AcpAbortController, AcpConfigPatch, AcpDoctorReport,
-    AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle, AcpSessionMetadata, AcpSessionMode,
-    AcpSessionState, AcpSessionStatus, AcpTurnEventSink, AcpTurnRequest, AcpTurnResult,
-    BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
+    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, ACP_TURN_METADATA_TRACE_ID, AcpAbortController,
+    AcpConfigPatch, AcpDoctorReport, AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle,
+    AcpSessionMetadata, AcpSessionMode, AcpSessionState, AcpSessionStatus, AcpTurnEventSink,
+    AcpTurnRequest, AcpTurnResult, BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
 };
 use super::binding::AcpSessionBindingScope;
 use super::merge_turn_events;
@@ -115,9 +115,25 @@ impl AcpSessionManager {
         self.cleanup_idle_sessions(config).await?;
 
         let selection = resolve_acp_backend_selection(config);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %selection.id,
+            conversation_id = ?bootstrap.conversation_id.as_deref(),
+            mode = ?bootstrap.mode,
+            binding = ?AcpSessionBindingScope::from_bootstrap(bootstrap),
+            "ensuring ACP session"
+        );
         if let Some(existing) =
             self.resolve_existing_session(config, selection.id.as_str(), bootstrap)?
         {
+            tracing::debug!(
+                target: "loongclaw.acp",
+                session_key = %existing.session_key,
+                backend_id = %existing.backend_id,
+                state = ?existing.state,
+                "reused ACP session"
+            );
             return Ok(existing);
         }
 
@@ -136,6 +152,13 @@ impl AcpSessionManager {
             .get(ACP_SESSION_METADATA_ACTIVATION_ORIGIN)
             .and_then(|value| AcpRoutingOrigin::parse(value));
         self.store.upsert(metadata.clone())?;
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %metadata.session_key,
+            backend_id = %metadata.backend_id,
+            activation_origin = ?metadata.activation_origin.map(AcpRoutingOrigin::as_str),
+            "created ACP session"
+        );
         Ok(metadata)
     }
 
@@ -156,11 +179,25 @@ impl AcpSessionManager {
         request: &AcpTurnRequest,
         sink: Option<&dyn AcpTurnEventSink>,
     ) -> CliResult<AcpTurnResult> {
+        let started_at = std::time::Instant::now();
         let actor_key = actor_key_for_bootstrap(bootstrap);
         let _turn_queue_guard = self.acquire_turn_queue_guard(actor_key.clone()).await?;
         self.cleanup_idle_sessions(config).await?;
 
         let mut metadata = self.ensure_session(config, bootstrap).await?;
+        let trace_id = request
+            .metadata
+            .get(ACP_TURN_METADATA_TRACE_ID)
+            .map(String::as_str);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %metadata.backend_id,
+            trace_id = ?trace_id,
+            input_len = request.input.chars().count(),
+            sink_enabled = sink.is_some(),
+            "starting ACP turn"
+        );
         let backend = resolve_acp_backend(Some(metadata.backend_id.as_str()))?;
         metadata.state = AcpSessionState::Busy;
         metadata.clear_error();
@@ -209,11 +246,27 @@ impl AcpSessionManager {
             Ok(mut result) => {
                 self.record_turn_completion(turn_started_ms, true)?;
                 let streamed_events = buffered_sink.snapshot()?;
+                let duration_ms = started_at.elapsed().as_millis();
+                let reported_event_count = result.events.len();
+                let streamed_event_count = streamed_events.len();
                 result.events = merge_turn_events(&result.events, &streamed_events);
                 metadata.state = result.state;
                 metadata.clear_error();
                 metadata.touch();
                 self.store.upsert(metadata)?;
+                tracing::debug!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    state = ?result.state,
+                    stop_reason = ?result.stop_reason,
+                    reported_event_count,
+                    streamed_event_count,
+                    merged_event_count = result.events.len(),
+                    duration_ms,
+                    "ACP turn completed"
+                );
                 Ok(result)
             }
             Err(error) => {
@@ -222,6 +275,15 @@ impl AcpSessionManager {
                 metadata.state = AcpSessionState::Error;
                 metadata.set_error(error.clone());
                 self.store.upsert(metadata)?;
+                tracing::warn!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    duration_ms = started_at.elapsed().as_millis(),
+                    error = %crate::observability::summarize_error(error.as_str()),
+                    "ACP turn failed"
+                );
                 Err(error)
             }
         }

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -4241,16 +4241,51 @@ pub(super) async fn process_inbound_with_provider(
     kernel_ctx: &KernelContext,
     feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<String> {
+    let started_at = std::time::Instant::now();
     let turn_config = reload_channel_turn_config(config, resolved_path)?;
     let runtime = DefaultConversationRuntime::from_config_or_env(&turn_config)?;
-    process_inbound_with_runtime_and_feedback(
+    let result = process_inbound_with_runtime_and_feedback(
         &turn_config,
         &runtime,
         message,
         ConversationRuntimeBinding::kernel(kernel_ctx),
         feedback_policy,
     )
-    .await
+    .await;
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(reply) => {
+            tracing::debug!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                reply_len = reply.chars().count(),
+                duration_ms,
+                "channel inbound processed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "channel inbound failed"
+            );
+        }
+    }
+    result
 }
 
 #[cfg(any(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -10,6 +10,7 @@ pub mod crypto;
 pub mod feishu;
 pub mod memory;
 pub mod migration;
+pub(crate) mod observability;
 pub mod presentation;
 pub mod prompt;
 pub mod provider;

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -102,8 +102,8 @@ impl PromptWindowQueryDiagnostics {
 }
 
 const SUMMARY_FORMAT_VERSION: i64 = 1;
-const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 4;
-const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 9;
+const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 5;
+const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 13;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const SQLITE_PREPARED_STATEMENT_CACHE_CAPACITY: usize = 16;
 const SQL_INSERT_TURN: &str = "INSERT INTO turns(session_id, session_turn_index, role, content, ts) VALUES (?1, ?2, ?3, ?4, ?5)";
@@ -141,19 +141,21 @@ const SQL_SELECT_SESSION_TURN_COUNT: &str = "SELECT turn_count
              WHERE session_id = ?1";
 const SQL_COUNT_CURRENT_SCHEMA_OBJECTS: &str = "SELECT COUNT(*)
              FROM sqlite_master
-             WHERE (type = 'table' AND name IN (
-                        'turns',
-                        'memory_session_state',
-                        'memory_summary_checkpoints',
-                        'memory_summary_checkpoint_bodies',
-                        'approval_requests',
-                        'approval_grants'
-                    ))
-                OR (type = 'index' AND name IN (
-                        'idx_turns_session_id',
-                        'idx_turns_session_turn_index',
-                        'idx_approval_requests_session_status_requested_at'
-                    ))";
+             WHERE name IN (
+                 'turns',
+                 'memory_session_state',
+                 'memory_summary_checkpoints',
+                 'memory_summary_checkpoint_bodies',
+                 'approval_requests',
+                 'approval_grants',
+                 'turns_fts',
+                 'idx_turns_session_id',
+                 'idx_turns_session_turn_index',
+                 'idx_approval_requests_session_status_requested_at',
+                 'turns_fts_ai',
+                 'turns_fts_ad',
+                 'turns_fts_au'
+             )";
 const SQL_QUERY_RECENT_PROMPT_TURNS_WITH_CHECKPOINT_META: &str = "SELECT turns.id,
              turns.role,
              turns.content,
@@ -1329,6 +1331,7 @@ fn open_sqlite_connection_with_diagnostics(
         ensure_turn_session_index_and_state_metadata(&conn)?;
         ensure_approval_lifecycle_tables(&conn)?;
         ensure_summary_checkpoint_storage_layout(&conn)?;
+        ensure_turn_search_storage(&conn)?;
         write_sqlite_user_version(&conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
     }
     diagnostics.schema_upgrade_ms = elapsed_ms(schema_upgrade_started_at);
@@ -1499,6 +1502,44 @@ fn ensure_approval_lifecycle_tables(conn: &Connection) -> Result<(), String> {
         ",
     )
     .map_err(|error| format!("ensure approval lifecycle storage failed: {error}"))?;
+
+    Ok(())
+}
+
+fn ensure_turn_search_storage(conn: &Connection) -> Result<(), String> {
+    #[cfg(test)]
+    test_support::record_sqlite_schema_repair("turn_search");
+
+    conn.execute_batch(
+        "
+        CREATE VIRTUAL TABLE IF NOT EXISTS turns_fts
+          USING fts5(content, content='turns', content_rowid='id');
+        CREATE TRIGGER IF NOT EXISTS turns_fts_ai
+          AFTER INSERT ON turns
+        BEGIN
+          INSERT INTO turns_fts(rowid, content)
+          VALUES (new.id, new.content);
+        END;
+        CREATE TRIGGER IF NOT EXISTS turns_fts_ad
+          AFTER DELETE ON turns
+        BEGIN
+          INSERT INTO turns_fts(turns_fts, rowid, content)
+          VALUES ('delete', old.id, old.content);
+        END;
+        CREATE TRIGGER IF NOT EXISTS turns_fts_au
+          AFTER UPDATE ON turns
+        BEGIN
+          INSERT INTO turns_fts(turns_fts, rowid, content)
+          VALUES ('delete', old.id, old.content);
+          INSERT INTO turns_fts(rowid, content)
+          VALUES (new.id, new.content);
+        END;
+        ",
+    )
+    .map_err(|error| format!("ensure turn search storage failed: {error}"))?;
+
+    conn.execute("INSERT INTO turns_fts(turns_fts) VALUES ('rebuild')", [])
+        .map_err(|error| format!("rebuild turn search index failed: {error}"))?;
 
     Ok(())
 }

--- a/crates/app/src/observability.rs
+++ b/crates/app/src/observability.rs
@@ -1,0 +1,102 @@
+use serde_json::Value;
+
+const MAX_LOGGED_JSON_KEYS: usize = 8;
+const MAX_ERROR_CHARS: usize = 240;
+
+pub(crate) fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+pub(crate) fn top_level_json_keys(value: &Value) -> Vec<String> {
+    let Value::Object(map) = value else {
+        return Vec::new();
+    };
+
+    let mut keys = map
+        .keys()
+        .take(MAX_LOGGED_JSON_KEYS)
+        .cloned()
+        .collect::<Vec<_>>();
+    if map.len() > MAX_LOGGED_JSON_KEYS {
+        keys.push(format!("+{}", map.len() - MAX_LOGGED_JSON_KEYS));
+    }
+    keys
+}
+
+pub(crate) fn summarize_error(error: &str) -> String {
+    let compact = error.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= MAX_ERROR_CHARS {
+        return compact;
+    }
+
+    let truncated = compact
+        .chars()
+        .take(MAX_ERROR_CHARS.saturating_sub(3))
+        .collect::<String>();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{json_value_kind, summarize_error, top_level_json_keys};
+
+    #[test]
+    fn json_value_kind_labels_common_shapes() {
+        assert_eq!(json_value_kind(&json!(null)), "null");
+        assert_eq!(json_value_kind(&json!(true)), "bool");
+        assert_eq!(json_value_kind(&json!(1)), "number");
+        assert_eq!(json_value_kind(&json!("hello")), "string");
+        assert_eq!(json_value_kind(&json!([1, 2, 3])), "array");
+        assert_eq!(json_value_kind(&json!({"command": "pwd"})), "object");
+    }
+
+    #[test]
+    fn top_level_json_keys_limits_output() {
+        let value = json!({
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+            "e": 5,
+            "f": 6,
+            "g": 7,
+            "h": 8,
+            "i": 9
+        });
+
+        assert_eq!(
+            top_level_json_keys(&value),
+            vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned(),
+                "e".to_owned(),
+                "f".to_owned(),
+                "g".to_owned(),
+                "h".to_owned(),
+                "+1".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn summarize_error_collapses_whitespace_and_truncates() {
+        let repeated = "detail ".repeat(64);
+        let summary = summarize_error(&format!("line one\nline two\t{repeated}"));
+
+        assert!(!summary.contains('\n'));
+        assert!(!summary.contains('\t'));
+        assert!(summary.ends_with("..."));
+        assert!(summary.chars().count() <= 240);
+    }
+}

--- a/crates/app/src/provider/request_failover_runtime.rs
+++ b/crates/app/src/provider/request_failover_runtime.rs
@@ -34,6 +34,15 @@ where
 
     let ordered_profiles =
         prioritize_provider_auth_profiles_by_health(auth_profiles, profile_state_policy);
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %provider.kind.profile().id,
+        binding = %binding.as_str(),
+        model_candidate_count = model_candidates.len(),
+        auth_profile_count = ordered_profiles.len(),
+        auto_model_mode,
+        "dispatching provider request across model candidates"
+    );
     let mut last_error = None;
     let mut last_error_snapshot = None;
     for (model_index, model) in model_candidates.iter().enumerate() {
@@ -44,6 +53,18 @@ where
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_success(policy, profile);
                     }
+                    tracing::debug!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %model,
+                        auth_profile_id = %profile.id,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        "provider request succeeded"
+                    );
                     return Ok(value);
                 }
                 Err(model_error) => {
@@ -54,6 +75,8 @@ where
                         snapshot,
                         ..
                     } = model_error;
+                    let exhausted = profile_index + 1 >= ordered_profiles.len()
+                        && model_index + 1 >= model_candidates.len();
                     record_provider_failover_audit_event(
                         binding,
                         provider,
@@ -62,12 +85,31 @@ where
                         auto_model_mode,
                         model_index,
                         model_candidates.len(),
-                        profile_index + 1 >= ordered_profiles.len()
-                            && model_index + 1 >= model_candidates.len(),
+                        exhausted,
                     );
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_failure(policy, profile, reason);
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %snapshot.model,
+                        auth_profile_id = %profile.id,
+                        reason = %snapshot.reason.as_str(),
+                        stage = %snapshot.stage.as_str(),
+                        attempt = snapshot.attempt,
+                        max_attempts = snapshot.max_attempts,
+                        status_code = ?snapshot.status_code,
+                        try_next_model,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        exhausted,
+                        error = %crate::observability::summarize_error(message.as_str()),
+                        "provider request attempt failed"
+                    );
                     last_error = Some(message);
                     last_error_snapshot = Some(snapshot);
 

--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -87,6 +87,14 @@ pub(super) async fn prepare_provider_request_session(
                             classify_profile_failure_reason_from_message(error.as_str()),
                         );
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %config.provider.kind.profile().id,
+                        auth_profile_id = %profile.id,
+                        auto_model_mode,
+                        error = %crate::observability::summarize_error(error.as_str()),
+                        "provider model catalog resolution failed for auth profile"
+                    );
                     last_error = Some(error);
                 }
             }
@@ -108,7 +116,7 @@ pub(super) async fn prepare_provider_request_session(
         .await?
     };
 
-    Ok(ProviderRequestSession {
+    let session = ProviderRequestSession {
         endpoint,
         headers,
         request_policy,
@@ -119,7 +127,16 @@ pub(super) async fn prepare_provider_request_session(
         auto_model_mode,
         model_candidate_cooldown_policy,
         auth_context,
-    })
+    };
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %config.provider.kind.profile().id,
+        auth_profile_count = session.auth_profiles.len(),
+        model_candidate_count = session.model_candidates.len(),
+        auto_model_mode = session.auto_model_mode,
+        "prepared provider request session"
+    );
+    Ok(session)
 }
 
 fn build_model_candidate_cooldown_policy(

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -23,7 +23,24 @@ impl<'a> ProviderRuntimeBinding<'a> {
         }
     }
 
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Kernel(_) => "kernel",
+            Self::Direct => "direct",
+        }
+    }
+
     pub const fn is_kernel_bound(self) -> bool {
         matches!(self, Self::Kernel(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProviderRuntimeBinding;
+
+    #[test]
+    fn provider_runtime_binding_labels_are_stable() {
+        assert_eq!(ProviderRuntimeBinding::direct().as_str(), "direct");
     }
 }

--- a/crates/app/src/session/repository.rs
+++ b/crates/app/src/session/repository.rs
@@ -230,6 +230,15 @@ pub struct SessionSummaryRecord {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct SessionSearchHitRecord {
+    pub turn_id: i64,
+    pub session_id: String,
+    pub role: String,
+    pub content_snippet: String,
+    pub ts: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct SessionObservationRecord {
     pub session: SessionSummaryRecord,
     pub terminal_outcome: Option<SessionTerminalOutcomeRecord>,
@@ -736,6 +745,32 @@ impl SessionRepository {
             sort_session_summaries(&mut sessions);
         }
         Ok(sessions)
+    }
+
+    pub fn search_turns_for_session_ids(
+        &self,
+        session_ids: &[String],
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SessionSearchHitRecord>, String> {
+        let normalized_query = normalize_required_text(query, "query")?;
+        if session_ids.is_empty() || limit == 0 {
+            return Ok(Vec::new());
+        }
+        let match_query = build_turn_search_match_query(&normalized_query);
+
+        let normalized_session_ids = session_ids
+            .iter()
+            .map(|session_id| normalize_required_text(session_id, "session_id"))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let conn = self.open_connection()?;
+        Self::search_turns_for_session_ids_with_conn(
+            &conn,
+            normalized_session_ids.as_slice(),
+            match_query.as_str(),
+            limit,
+        )
     }
 
     pub fn is_session_visible(
@@ -1632,6 +1667,77 @@ impl SessionRepository {
         raw.map(SessionSummaryRecord::try_from_raw).transpose()
     }
 
+    fn search_turns_for_session_ids_with_conn(
+        conn: &Connection,
+        session_ids: &[String],
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SessionSearchHitRecord>, String> {
+        if session_ids.is_empty() || limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut sql = String::from(
+            "SELECT
+                turns.id,
+                turns.session_id,
+                turns.role,
+                snippet(turns_fts, 0, '[', ']', ' ... ', 16) AS content_snippet,
+                turns.ts
+             FROM turns_fts
+             JOIN turns ON turns_fts.rowid = turns.id
+             WHERE turns.session_id IN (",
+        );
+
+        for index in 0..session_ids.len() {
+            if index > 0 {
+                sql.push_str(", ");
+            }
+
+            let placeholder = format!("?{}", index + 1);
+            sql.push_str(&placeholder);
+        }
+        sql.push_str(") AND turns_fts MATCH ?");
+        let limit_placeholder_index = session_ids.len() + 2;
+        let order_clause = format!(
+            " ORDER BY bm25(turns_fts), turns.ts DESC, turns.id DESC LIMIT ?{limit_placeholder_index}"
+        );
+        sql.push_str(&order_clause);
+
+        let mut bind_values = Vec::with_capacity(session_ids.len() + 2);
+        for session_id in session_ids {
+            let value = rusqlite::types::Value::from(session_id.clone());
+            bind_values.push(value);
+        }
+        bind_values.push(rusqlite::types::Value::from(query.to_owned()));
+        bind_values.push(rusqlite::types::Value::from(limit as i64));
+
+        let mut statement = conn
+            .prepare(&sql)
+            .map_err(|error| format!("prepare session search query failed: {error}"))?;
+        let bind_params = rusqlite::params_from_iter(bind_values.iter());
+        let rows = statement
+            .query_map(bind_params, |row| {
+                Ok(RawSessionSearchHitRecord {
+                    turn_id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role: row.get(2)?,
+                    content_snippet: row.get(3)?,
+                    ts: row.get(4)?,
+                })
+            })
+            .map_err(|error| format!("query session search failed: {error}"))?;
+
+        let mut hits = Vec::new();
+        for row in rows {
+            let raw = row.map_err(|error| format!("decode session search row failed: {error}"))?;
+            let hit = SessionSearchHitRecord::from_raw(raw);
+            hits.push(hit);
+        }
+
+        Ok(hits)
+    }
+
     fn load_session_summary_with_legacy_fallback_with_conn(
         conn: &Connection,
         session_id: &str,
@@ -1913,6 +2019,15 @@ struct RawSessionSummaryRecord {
 }
 
 #[derive(Debug)]
+struct RawSessionSearchHitRecord {
+    turn_id: i64,
+    session_id: String,
+    role: String,
+    content_snippet: String,
+    ts: i64,
+}
+
+#[derive(Debug)]
 struct RawSessionEventRecord {
     id: i64,
     session_id: String,
@@ -1988,6 +2103,18 @@ impl SessionSummaryRecord {
             last_turn_at: raw.last_turn_at,
             last_error: raw.last_error,
         })
+    }
+}
+
+impl SessionSearchHitRecord {
+    fn from_raw(raw: RawSessionSearchHitRecord) -> Self {
+        Self {
+            turn_id: raw.turn_id,
+            session_id: raw.session_id,
+            role: raw.role,
+            content_snippet: raw.content_snippet,
+            ts: raw.ts,
+        }
     }
 }
 
@@ -2071,6 +2198,28 @@ fn normalize_optional_text(value: Option<String>) -> Option<String> {
         let trimmed = raw.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_owned())
     })
+}
+
+fn build_turn_search_match_query(raw_query: &str) -> String {
+    let mut terms = Vec::new();
+
+    for part in raw_query.split_whitespace() {
+        let trimmed_part = part.trim();
+        if trimmed_part.is_empty() {
+            continue;
+        }
+
+        let escaped_part = trimmed_part.replace('"', "\"\"");
+        let term = format!("\"{escaped_part}\"");
+        terms.push(term);
+    }
+
+    if terms.is_empty() {
+        let escaped_query = raw_query.trim().replace('"', "\"\"");
+        return format!("\"{escaped_query}\"");
+    }
+
+    terms.join(" AND ")
 }
 
 fn unix_ts_now() -> i64 {
@@ -2334,6 +2483,84 @@ mod tests {
         assert_eq!(second.parent_session_id, None);
         assert_eq!(second.label.as_deref(), Some("Root"));
         assert_eq!(repo.list_sessions().expect("list sessions").len(), 1);
+    }
+
+    #[test]
+    fn session_repository_search_turns_filters_to_requested_sessions() {
+        let config = isolated_memory_config("session-search-scope");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-a".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child A".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create child a");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-b".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child B".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create child b");
+
+        append_turn_direct("child-a", "user", "deploy freeze window", &config)
+            .expect("append child a turn");
+        append_turn_direct("child-b", "user", "release note draft", &config)
+            .expect("append child b turn");
+
+        let session_ids = vec!["child-a".to_owned()];
+        let hits = repo
+            .search_turns_for_session_ids(&session_ids, "deploy freeze", 10)
+            .expect("search turns");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].session_id, "child-a");
+        assert_eq!(hits[0].role, "user");
+        assert!(hits[0].content_snippet.contains("deploy"));
+    }
+
+    #[test]
+    fn session_repository_search_turns_escapes_query_text() {
+        let config = isolated_memory_config("session-search-query");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+
+        append_turn_direct(
+            "root-session",
+            "assistant",
+            "quoted \"release\" note",
+            &config,
+        )
+        .expect("append root turn");
+
+        let session_ids = vec!["root-session".to_owned()];
+        let hits = repo
+            .search_turns_for_session_ids(&session_ids, "\"release\" note", 10)
+            .expect("search turns with quoted query");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].session_id, "root-session");
+        assert!(hits[0].content_snippet.contains("release"));
     }
 
     #[test]

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -722,6 +722,19 @@ fn build_tool_catalog() -> ToolCatalog {
             provider_definition_builder: sessions_history_definition,
         },
         ToolDescriptor {
+            name: "sessions_search",
+            provider_name: "sessions_search",
+            aliases: &[],
+            description: "Search visible session history using bounded full-text lookup",
+            execution_kind: ToolExecutionKind::App,
+            availability: runtime_session_tool_availability(),
+            exposure: ToolExposureClass::Discoverable,
+            visibility_gate: ToolVisibilityGate::Sessions,
+            capability_action_class: CapabilityActionClass::ExecuteExisting,
+            policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
+            provider_definition_builder: sessions_search_definition,
+        },
+        ToolDescriptor {
             name: "sessions_list",
             provider_name: "sessions_list",
             aliases: &[],
@@ -2269,6 +2282,41 @@ fn sessions_history_definition(descriptor: &ToolDescriptor) -> Value {
     })
 }
 
+fn sessions_search_definition(descriptor: &ToolDescriptor) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": descriptor.provider_name,
+            "description": descriptor.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Text to search for in visible session turns."
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional visible session identifier to narrow the search scope."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 200,
+                        "description": "Maximum search hits to return."
+                    },
+                    "include_archived": {
+                        "type": "boolean",
+                        "description": "When true, archived visible sessions remain searchable."
+                    }
+                },
+                "required": ["query"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
 fn session_events_definition(descriptor: &ToolDescriptor) -> Value {
     json!({
         "type": "function",
@@ -2605,6 +2653,9 @@ fn tool_argument_hint(name: &str) -> &'static str {
         "delegate" | "delegate_async" => "task:string,label?:string,timeout_seconds?:integer",
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => "session_id:string",
+        "sessions_search" => {
+            "query:string,session_id?:string,limit?:integer,include_archived?:boolean"
+        }
         "sessions_list" => "limit?:integer,state?:string",
         "sessions_send" => "session_id:string,text:string",
         "web.search" => "query:string,provider?:string,max_results?:integer",
@@ -2694,6 +2745,12 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
         ],
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => &[("session_id", "string")],
+        "sessions_search" => &[
+            ("query", "string"),
+            ("session_id", "string"),
+            ("limit", "integer"),
+            ("include_archived", "boolean"),
+        ],
         "sessions_list" => &[("limit", "integer"), ("state", "string")],
         "sessions_send" => &[("session_id", "string"), ("text", "string")],
         "web.search" => &[
@@ -2731,6 +2788,7 @@ fn tool_required_fields(name: &str) -> &'static [&'static str] {
         "delegate" | "delegate_async" => &["task"],
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
         | "session_status" | "session_wait" | "sessions_history" => &["session_id"],
+        "sessions_search" => &["query"],
         "sessions_send" => &["session_id", "text"],
         "web.search" => &["query"],
         _ => &[],
@@ -2766,9 +2824,8 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
         "provider.switch" => &["provider", "switch", "model", "runtime"],
         "delegate" | "delegate_async" => &["session", "delegate", "child"],
         "session_archive" | "session_cancel" | "session_events" | "session_recover"
-        | "session_status" | "session_wait" | "sessions_history" | "sessions_list" => {
-            &["session", "history", "runtime"]
-        }
+        | "session_status" | "session_wait" | "sessions_history" | "sessions_list"
+        | "sessions_search" => &["session", "history", "runtime"],
         "sessions_send" => &["session", "message", "channel"],
         "web.search" => &["web", "search", "discover", "external"],
         _ => &[],

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -648,6 +648,9 @@ pub fn execute_tool_core_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let requested_tool_name = request.tool_name.clone();
+    let payload_kind = crate::observability::json_value_kind(&request.payload);
+    let payload_keys = crate::observability::top_level_json_keys(&request.payload);
     if !trusted_internal_tool_payload_enabled()
         && payload_uses_reserved_internal_tool_context(&request.payload)
     {
@@ -664,11 +667,40 @@ pub fn execute_tool_core_with_config(
     let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)?
         .map(|narrowing| config.narrowed(&narrowing));
     let config = effective_config.as_ref().unwrap_or(config);
-    match canonical_name {
+    let started_at = std::time::Instant::now();
+    let result = match canonical_name {
         "tool.search" => execute_tool_search_tool_with_config(request, config),
         "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
         _ => execute_discoverable_tool_core_with_config(request, config),
+    };
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(outcome) => {
+            tracing::debug!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                status = %outcome.status,
+                duration_ms,
+                "tool execution completed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "tool execution failed"
+            );
+        }
     }
+    result
 }
 
 fn trusted_runtime_narrowing_from_payload(

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -281,8 +281,8 @@ fn execute_app_tool_with_browser_companion_readiness(
                 tool_config,
             )
         }
-        "sessions_list" | "sessions_history" | "session_status" | "session_events"
-        | "session_archive" | "session_cancel" | "session_recover" => {
+        "sessions_list" | "sessions_history" | "sessions_search" | "session_status"
+        | "session_events" | "session_archive" | "session_cancel" | "session_recover" => {
             session::execute_session_tool_with_policies(
                 request,
                 current_session_id,
@@ -1792,6 +1792,7 @@ mod tests {
             "session_wait",
             "sessions_history",
             "sessions_list",
+            "sessions_search",
             "web.fetch",
             "web.search",
         ]);

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -31,8 +31,8 @@ use crate::session::{
 
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    SessionEventRecord, SessionKind, SessionObservationRecord, SessionRepository, SessionState,
-    SessionSummaryRecord, SessionTerminalOutcomeRecord,
+    SessionEventRecord, SessionKind, SessionObservationRecord, SessionRepository,
+    SessionSearchHitRecord, SessionState, SessionSummaryRecord, SessionTerminalOutcomeRecord,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -111,6 +111,15 @@ struct SessionsListRequest {
     overdue_only: bool,
     include_archived: bool,
     include_delegate_lifecycle: bool,
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionsSearchRequest {
+    query: String,
+    session_id: Option<String>,
+    limit: usize,
+    include_archived: bool,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -280,6 +289,9 @@ pub fn execute_session_tool_with_policies(
             }
             "sessions_history" => {
                 execute_sessions_history(payload, current_session_id, config, tool_config)
+            }
+            "sessions_search" => {
+                execute_sessions_search(payload, current_session_id, config, tool_config)
             }
             "session_status" => {
                 execute_session_status(payload, current_session_id, config, tool_config)
@@ -490,6 +502,120 @@ fn execute_sessions_history(
             "session_id": target_session_id,
             "limit": limit,
             "turns": turns,
+        }),
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn parse_sessions_search_request(
+    payload: &Value,
+    tool_config: &ToolConfig,
+) -> Result<SessionsSearchRequest, String> {
+    let query = required_payload_string(payload, "query", "session tool")?;
+    let session_id = optional_payload_string(payload, "session_id");
+    let default_limit = tool_config.sessions.history_limit.min(20);
+    let limit = optional_payload_limit(
+        payload,
+        "limit",
+        default_limit,
+        tool_config.sessions.history_limit,
+    );
+    let include_archived = payload
+        .get("include_archived")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    Ok(SessionsSearchRequest {
+        query,
+        session_id,
+        limit,
+        include_archived,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn session_search_hit_json(
+    hit: SessionSearchHitRecord,
+    session_by_id: &BTreeMap<String, SessionSummaryRecord>,
+) -> Value {
+    let session_summary = session_by_id.get(&hit.session_id);
+    let session_label = session_summary.and_then(|session| session.label.clone());
+    let session_state = session_summary
+        .map(|session| session.state.as_str().to_owned())
+        .unwrap_or_else(|| "unknown".to_owned());
+    let session_archived = session_summary
+        .map(|session| session.archived_at.is_some())
+        .unwrap_or(false);
+
+    json!({
+        "turn_id": hit.turn_id,
+        "session_id": hit.session_id,
+        "session_label": session_label,
+        "session_state": session_state,
+        "session_archived": session_archived,
+        "role": hit.role,
+        "ts": hit.ts,
+        "snippet": hit.content_snippet,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn execute_sessions_search(
+    payload: Value,
+    current_session_id: &str,
+    config: &MemoryRuntimeConfig,
+    tool_config: &ToolConfig,
+) -> Result<ToolCoreOutcome, String> {
+    let request = parse_sessions_search_request(&payload, tool_config)?;
+    let repo = SessionRepository::new(config)?;
+    let mut visible_sessions = repo.list_visible_sessions(current_session_id)?;
+
+    if tool_config.sessions.visibility == SessionVisibility::SelfOnly {
+        visible_sessions.retain(|session| session.session_id == current_session_id);
+    }
+    if !request.include_archived {
+        visible_sessions.retain(|session| session.archived_at.is_none());
+    }
+
+    if let Some(target_session_id) = request.session_id.as_deref() {
+        ensure_visible(
+            &repo,
+            current_session_id,
+            target_session_id,
+            tool_config.sessions.visibility,
+        )?;
+        visible_sessions.retain(|session| session.session_id == target_session_id);
+    }
+
+    let mut session_by_id = BTreeMap::new();
+    for session in visible_sessions {
+        let session_id = session.session_id.clone();
+        session_by_id.insert(session_id, session);
+    }
+
+    let searchable_session_ids = session_by_id.keys().cloned().collect::<Vec<_>>();
+    let hits = repo.search_turns_for_session_ids(
+        searchable_session_ids.as_slice(),
+        request.query.as_str(),
+        request.limit,
+    )?;
+    let matched_count = hits.len();
+    let results = hits
+        .into_iter()
+        .map(|hit| session_search_hit_json(hit, &session_by_id))
+        .collect::<Vec<_>>();
+    let returned_count = results.len();
+
+    Ok(ToolCoreOutcome {
+        status: "ok".to_owned(),
+        payload: json!({
+            "current_session_id": current_session_id,
+            "query": request.query,
+            "session_id": request.session_id,
+            "include_archived": request.include_archived,
+            "matched_count": matched_count,
+            "returned_count": returned_count,
+            "results": results,
         }),
     })
 }
@@ -3176,6 +3302,129 @@ mod tests {
         assert_eq!(turns[0]["content"], "hello");
         assert_eq!(turns[1]["role"], "assistant");
         assert_eq!(turns[1]["content"], "world");
+    }
+
+    #[test]
+    fn sessions_search_returns_hits_for_visible_sessions() {
+        let config = isolated_memory_config("sessions-search");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "child-session".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Child".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create child");
+
+        append_turn_direct("child-session", "user", "deploy freeze window", &config)
+            .expect("append user turn");
+        append_turn_direct(
+            "child-session",
+            "assistant",
+            "draft the release note",
+            &config,
+        )
+        .expect("append assistant turn");
+
+        let outcome = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_search".to_owned(),
+                payload: json!({
+                    "query": "deploy freeze",
+                    "limit": 10
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_search outcome");
+
+        let results = outcome.payload["results"]
+            .as_array()
+            .expect("results array");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["session_id"], "child-session");
+        assert_eq!(results[0]["session_label"], "Child");
+        assert_eq!(results[0]["role"], "user");
+        assert!(
+            results[0]["snippet"]
+                .as_str()
+                .expect("snippet should exist")
+                .contains("deploy")
+        );
+    }
+
+    #[test]
+    fn sessions_search_excludes_archived_sessions_by_default() {
+        let config = isolated_memory_config("sessions-search-archived");
+        let repo = SessionRepository::new(&config).expect("repository");
+        repo.create_session(NewSessionRecord {
+            session_id: "root-session".to_owned(),
+            kind: SessionKind::Root,
+            parent_session_id: None,
+            label: Some("Root".to_owned()),
+            state: SessionState::Ready,
+        })
+        .expect("create root");
+        repo.create_session(NewSessionRecord {
+            session_id: "archived-child".to_owned(),
+            kind: SessionKind::DelegateChild,
+            parent_session_id: Some("root-session".to_owned()),
+            label: Some("Archived".to_owned()),
+            state: SessionState::Completed,
+        })
+        .expect("create child");
+        repo.append_event(NewSessionEvent {
+            session_id: "archived-child".to_owned(),
+            event_kind: "session_archived".to_owned(),
+            actor_session_id: Some("root-session".to_owned()),
+            payload_json: json!({"reason": "done"}),
+        })
+        .expect("archive child");
+        append_turn_direct(
+            "archived-child",
+            "assistant",
+            "deploy freeze window",
+            &config,
+        )
+        .expect("append archived turn");
+
+        let hidden = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_search".to_owned(),
+                payload: json!({
+                    "query": "deploy freeze"
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_search outcome");
+        assert_eq!(hidden.payload["matched_count"], 0);
+
+        let included = execute_session_tool_with_config(
+            ToolCoreRequest {
+                tool_name: "sessions_search".to_owned(),
+                payload: json!({
+                    "query": "deploy freeze",
+                    "include_archived": true
+                }),
+            },
+            "root-session",
+            &config,
+        )
+        .expect("sessions_search include archived outcome");
+        assert_eq!(included.payload["matched_count"], 1);
+        assert_eq!(included.payload["results"][0]["session_archived"], true);
     }
 
     #[test]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -70,6 +70,8 @@ rand.workspace = true
 sha2.workspace = true
 ed25519-dalek.workspace = true
 dunce = "1"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [[bin]]
 name = "loongclaw"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -85,6 +85,7 @@ mod memory_context_benchmark;
 pub mod migrate_cli;
 pub mod migration;
 pub mod next_actions;
+mod observability;
 pub mod onboard_cli;
 mod onboard_finalize;
 mod onboard_preflight;
@@ -106,6 +107,7 @@ pub mod supervisor;
 pub use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,
 };
+pub use observability::init_tracing;
 
 #[allow(
     clippy::expect_used,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -37,7 +37,9 @@ impl Drop for StdinGuard {
 #[tokio::main]
 async fn main() {
     let _stdin_guard = StdinGuard;
+    init_tracing();
     let cli = Cli::parse();
+    tracing::debug!(target: "loongclaw.daemon", command = ?cli.command, "parsed CLI command");
     let result = match cli.command.unwrap_or_else(resolve_default_entry_command) {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
@@ -846,6 +848,11 @@ async fn main() {
         }
     };
     if let Err(error) = result {
+        tracing::error!(
+            target: "loongclaw.daemon",
+            error = %error,
+            "CLI command failed"
+        );
         #[allow(clippy::print_stderr)]
         {
             eprintln!("error: {error}");

--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -1,0 +1,99 @@
+use std::io::{self, IsTerminal};
+
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+
+const DEFAULT_LOG_FILTER: &str = "warn";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogFormat {
+    Compact,
+    Pretty,
+    Json,
+}
+
+impl LogFormat {
+    fn parse(raw: Option<&str>) -> Self {
+        match raw
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("compact")
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "pretty" => Self::Pretty,
+            "json" => Self::Json,
+            _ => Self::Compact,
+        }
+    }
+}
+
+fn resolved_log_directive(loongclaw_log: Option<&str>, rust_log: Option<&str>) -> String {
+    loongclaw_log
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| rust_log.map(str::trim).filter(|value| !value.is_empty()))
+        .unwrap_or(DEFAULT_LOG_FILTER)
+        .to_owned()
+}
+
+fn build_env_filter(raw: &str) -> EnvFilter {
+    EnvFilter::try_new(raw).unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER))
+}
+
+pub fn init_tracing() {
+    let log_format = LogFormat::parse(std::env::var("LOONGCLAW_LOG_FORMAT").ok().as_deref());
+    let directive = resolved_log_directive(
+        std::env::var("LOONGCLAW_LOG").ok().as_deref(),
+        std::env::var("RUST_LOG").ok().as_deref(),
+    );
+    let env_filter = build_env_filter(directive.as_str());
+    let use_ansi = log_format != LogFormat::Json && io::stderr().is_terminal();
+    let base = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(io::stderr)
+        .with_target(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_ansi(use_ansi);
+
+    let _ = match log_format {
+        LogFormat::Compact => base.compact().finish().try_init(),
+        LogFormat::Pretty => base.pretty().finish().try_init(),
+        LogFormat::Json => base.json().flatten_event(true).finish().try_init(),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogFormat, build_env_filter, resolved_log_directive};
+
+    #[test]
+    fn resolved_log_directive_prefers_loongclaw_log() {
+        assert_eq!(
+            resolved_log_directive(Some("loongclaw_app=debug"), Some("warn")),
+            "loongclaw_app=debug"
+        );
+    }
+
+    #[test]
+    fn resolved_log_directive_falls_back_to_rust_log_then_default() {
+        assert_eq!(resolved_log_directive(None, Some("info")), "info");
+        assert_eq!(resolved_log_directive(None, None), "warn");
+    }
+
+    #[test]
+    fn parse_log_format_accepts_known_variants() {
+        assert_eq!(LogFormat::parse(Some("pretty")), LogFormat::Pretty);
+        assert_eq!(LogFormat::parse(Some("json")), LogFormat::Json);
+        assert_eq!(LogFormat::parse(Some("compact")), LogFormat::Compact);
+        assert_eq!(LogFormat::parse(Some("unknown")), LogFormat::Compact);
+    }
+
+    #[test]
+    fn build_env_filter_falls_back_on_invalid_directive() {
+        let filter = build_env_filter("[broken");
+        let rendered = filter.to_string();
+        assert_eq!(rendered, "warn");
+    }
+}

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -17,7 +17,7 @@ Domain grades for LoongClaw. Updated periodically to track gaps, prioritize clea
 | Plugin IR (L7) | B- | 2026-03-13 | Bridge inference works; multi-language support limited |
 | Self-Awareness (L8) | B- | 2026-03-13 | Snapshots generated but not continuous; no drift detection agent |
 | Bootstrap (L9) | B | 2026-03-13 | Activation plans work; no policy-bounded bootstrap validation |
-| Context/Memory | C | 2026-03-13 | SQLite turns only; no scopes, no provenance, no FTS5 |
+| Context/Memory | C+ | 2026-04-03 | SQLite canonical/session substrate now includes FTS-backed session search; scope/provenance remain partial and semantic retrieval is still absent |
 | Documentation | A- | 2026-03-13 | Strong coverage across design docs, security, product sense, and quality tracking |
 | CI/Enforcement | A | 2026-03-13 | 8 CI workflows, convention-engineering (14 files, 11 checks), check:harness mirror gate |
 | Contributor Experience | A- | 2026-03-13 | Clear tracks and recipes; could add more examples |


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw already persisted session turns and session metadata in SQLite, but
  it still lacked a database-native search capability over session history.
- Why it matters:
  Without substrate-level history search, operators can inspect sessions and
  fetch recent transcripts, but cannot do bounded historical lookup across
  visible sessions. This leaves the session/memory runtime less mature than it
  should be.
- What changed:
  Added SQLite FTS-backed indexing for `turns`, repository search helpers,
  and a new read-only `sessions_search` app tool. The tool respects session
  visibility and archive filtering. Updated `docs/QUALITY_SCORE.md` to reflect
  the new FTS-backed session search capability.
- What did not change (scope boundary):
  No semantic/vector retrieval was added.
  Existing `sessions_history`, `session_events`, and session mutation tools were
  not replaced.

## Linked Issues

- Closes #867
- Related #850

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-session-memory-ci cargo clippy --workspace --all-targets --all-features -- -D warnings
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-session-memory-ci cargo test --workspace --locked
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-session-memory-ci cargo test --workspace --all-features --locked
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-session-memory-ci cargo test -p loongclaw-app session_repository_search_turns_filters_to_requested_sessions -- --nocapture
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-session-memory-ci cargo test -p loongclaw-app session_repository_search_turns_escapes_query_text -- --nocapture
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-session-memory-ci cargo test -p loongclaw-app sessions_search_returns_hits_for_visible_sessions -- --nocapture
PASS

env CARGO_TARGET_DIR=/tmp/loongclaw-session-memory-ci cargo test -p loongclaw-app sessions_search_excludes_archived_sessions_by_default -- --nocapture
PASS
```

## User-visible / Operator-visible Changes

- Added a new read-only `sessions_search` session tool for bounded full-text
  lookup across visible session history.

## Failure Recovery

- Fast rollback or disable path:
  Revert this slice.
- Observable failure symptoms reviewers should watch for:
  `sessions_search` returning hits from invisible sessions, archived-session
  filtering drifting, or SQLite schema reopen/migration regressions.

## Reviewer Focus

- Check the FTS schema setup and migration order in `memory/sqlite.rs`.
- Check that repository search remains scoped to explicitly provided visible session ids.
- Check that `sessions_search` complements rather than changes existing session-history behavior.
