### PR TITLE
refactor(approval): centralize durable approval resolution

### DIFF
--- a/crates/app/src/conversation/approval_resolution.rs
+++ b/crates/app/src/conversation/approval_resolution.rs
@@ -5,11 +5,8 @@ use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_coordinator::{execute_delegate_async_tool, execute_delegate_tool};
 use super::turn_engine::{AppToolDispatcher, DefaultAppToolDispatcher};
-use crate::config::{LoongClawConfig, ToolConsentMode};
-use crate::session::repository::{
-    ApprovalDecision, ApprovalRequestRecord, ApprovalRequestStatus, NewApprovalGrantRecord,
-    NewSessionToolConsentRecord, SessionRepository, TransitionApprovalRequestIfCurrentRequest,
-};
+use crate::config::LoongClawConfig;
+use crate::session::repository::{ApprovalDecision, ApprovalRequestRecord};
 use crate::tools::ToolExecutionKind;
 
 #[cfg(feature = "memory-sqlite")]
@@ -50,79 +47,6 @@ where
         self.binding.is_kernel_bound()
     }
 
-    fn current_epoch_s() -> i64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|duration| duration.as_secs() as i64)
-            .unwrap_or(0)
-    }
-
-    fn load_approval_request_or_not_found(
-        repo: &SessionRepository,
-        approval_request_id: &str,
-    ) -> Result<ApprovalRequestRecord, String> {
-        let latest_request = repo.load_approval_request(approval_request_id)?;
-        let approval_request = latest_request
-            .ok_or_else(|| format!("approval_request_not_found: `{approval_request_id}`"))?;
-
-        Ok(approval_request)
-    }
-
-    fn ensure_approve_always_grant(
-        repo: &SessionRepository,
-        approval_request: &ApprovalRequestRecord,
-        current_session_id: &str,
-    ) -> Result<(), String> {
-        let root_session_id = repo
-            .lineage_root_session_id(&approval_request.session_id)?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_session_not_found: `{}`",
-                    approval_request.session_id
-                )
-            })?;
-
-        let grant_record = NewApprovalGrantRecord {
-            scope_session_id: root_session_id,
-            approval_key: approval_request.approval_key.clone(),
-            created_by_session_id: Some(current_session_id.to_owned()),
-        };
-
-        repo.upsert_approval_grant(grant_record)?;
-
-        Ok(())
-    }
-
-    fn persist_session_consent_if_requested(
-        repo: &SessionRepository,
-        approval_request: &ApprovalRequestRecord,
-        current_session_id: &str,
-        session_consent_mode: Option<ToolConsentMode>,
-    ) -> Result<(), String> {
-        let Some(session_consent_mode) = session_consent_mode else {
-            return Ok(());
-        };
-
-        let scope_session_id = repo
-            .lineage_root_session_id(&approval_request.session_id)?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_session_not_found: `{}`",
-                    approval_request.session_id
-                )
-            })?;
-
-        let consent_record = NewSessionToolConsentRecord {
-            scope_session_id,
-            mode: session_consent_mode,
-            updated_by_session_id: Some(current_session_id.to_owned()),
-        };
-
-        repo.upsert_session_tool_consent(consent_record)?;
-
-        Ok(())
-    }
-
     fn replay_shell_request(
         &self,
         approval_request: &ApprovalRequestRecord,
@@ -140,14 +64,17 @@ where
                 .map(crate::tools::canonical_tool_name)
                 .unwrap_or(canonical_tool_name);
             if approved_tool_name != crate::tools::SHELL_EXEC_TOOL_NAME {
-                return Err(format!(
+                let error = format!(
                     "approval_request_invalid_execution_kind: expected `shell.exec`, got `{approved_tool_name}`"
-                ));
+                );
+                return Err(error);
             }
+
             args_json.get("arguments").cloned().ok_or_else(|| {
                 "approval_request_invalid_payload: missing shell.exec arguments".to_owned()
             })?
         };
+
         let payload_object = payload.as_object_mut().ok_or_else(|| {
             "approval_request_invalid_payload: shell.exec args_json must be an object".to_owned()
         })?;
@@ -223,12 +150,16 @@ where
             .get("execution_kind")
             .and_then(Value::as_str)
             .ok_or_else(|| "approval_request_invalid_payload: missing execution_kind".to_owned())?;
+
         match execution_kind {
             "core" => Ok(ToolExecutionKind::Core),
             "app" => Ok(ToolExecutionKind::App),
-            _ => Err(format!(
-                "approval_request_invalid_execution_kind: expected `core` or `app`, got `{execution_kind}`"
-            )),
+            _ => {
+                let error = format!(
+                    "approval_request_invalid_execution_kind: expected `core` or `app`, got `{execution_kind}`"
+                );
+                Err(error)
+            }
         }
     }
 
@@ -276,91 +207,12 @@ where
         Err("app_tool_denied: governed_runtime_binding_required".to_owned())
     }
 
-    fn approval_request_not_pending_error(approval_request: &ApprovalRequestRecord) -> String {
-        let approval_request_id = approval_request.approval_request_id.as_str();
-        let status = approval_request.status.as_str();
-        format!("approval_request_not_pending: `{approval_request_id}` is already {status}")
-    }
-
-    fn ensure_resolution_request_is_pending(
-        approval_request: &ApprovalRequestRecord,
-    ) -> Result<(), String> {
-        if approval_request.status == ApprovalRequestStatus::Pending {
-            return Ok(());
-        }
-
-        Err(Self::approval_request_not_pending_error(approval_request))
-    }
-
-    async fn finish_approved_resolution(
-        &self,
-        repo: &SessionRepository,
-        approved: ApprovalRequestRecord,
-    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let replay_is_allowed = self.can_replay_approved_request();
-        if !replay_is_allowed {
-            return Ok(crate::tools::approval::ApprovalResolutionOutcome {
-                approval_request: approved,
-                resumed_tool_output: None,
-            });
-        }
-
-        let approval_request_id = approved.approval_request_id;
-        self.execute_approved_request(repo, approval_request_id.as_str())
-            .await
-    }
-
-    async fn resume_existing_approved_request(
-        &self,
-        repo: &SessionRepository,
-        request: &crate::tools::approval::ApprovalResolutionRequest,
-        approval_request: ApprovalRequestRecord,
-        expected_decision: ApprovalDecision,
-    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let status = approval_request.status;
-        if status != ApprovalRequestStatus::Approved {
-            return Err(Self::approval_request_not_pending_error(&approval_request));
-        }
-
-        let recorded_decision = approval_request.decision.ok_or_else(|| {
-            let approval_request_id = request.approval_request_id.as_str();
-            format!("approval_request_missing_decision: `{approval_request_id}` is approved")
-        })?;
-
-        if recorded_decision != expected_decision {
-            let approval_request_id = request.approval_request_id.as_str();
-            let recorded_decision_name = recorded_decision.as_str();
-            let expected_decision_name = expected_decision.as_str();
-
-            return Err(format!(
-                "approval_request_decision_mismatch: `{approval_request_id}` is already `{recorded_decision_name}`, expected `{expected_decision_name}`"
-            ));
-        }
-
-        if expected_decision == ApprovalDecision::ApproveAlways {
-            Self::ensure_approve_always_grant(
-                repo,
-                &approval_request,
-                &request.current_session_id,
-            )?;
-        }
-
-        Self::persist_session_consent_if_requested(
-            repo,
-            &approval_request,
-            &request.current_session_id,
-            request.session_consent_mode,
-        )?;
-
-        self.finish_approved_resolution(repo, approval_request)
-            .await
-    }
-
     pub(super) async fn replay_approved_request(
         &self,
         approval_request: &ApprovalRequestRecord,
     ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
         let replay_request = self.replay_request(approval_request)?;
+
         match replay_request.execution_kind {
             crate::tools::ToolExecutionKind::Core => {
                 let kernel_ctx = self
@@ -382,6 +234,7 @@ where
                     .map_err(|error| {
                         format!("load approval request session context failed: {error}")
                     })?;
+
                 match crate::tools::canonical_tool_name(replay_request.request.tool_name.as_str()) {
                     "delegate" => {
                         execute_delegate_tool(
@@ -416,77 +269,6 @@ where
             }
         }
     }
-
-    async fn execute_approved_request(
-        &self,
-        repo: &SessionRepository,
-        approval_request_id: &str,
-    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let executing = repo
-            .transition_approval_request_if_current(
-                approval_request_id,
-                TransitionApprovalRequestIfCurrentRequest {
-                    expected_status: ApprovalRequestStatus::Approved,
-                    next_status: ApprovalRequestStatus::Executing,
-                    decision: None,
-                    resolved_by_session_id: None,
-                    executed_at: None,
-                    last_error: None,
-                },
-            )?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_not_approved: `{approval_request_id}` is no longer approved"
-                )
-            })?;
-
-        match self.replay_approved_request(&executing).await {
-            Ok(resumed_tool_output) => {
-                let executed = repo
-                    .transition_approval_request_if_current(
-                        approval_request_id,
-                        TransitionApprovalRequestIfCurrentRequest {
-                            expected_status: ApprovalRequestStatus::Executing,
-                            next_status: ApprovalRequestStatus::Executed,
-                            decision: None,
-                            resolved_by_session_id: None,
-                            executed_at: Some(Self::current_epoch_s()),
-                            last_error: None,
-                        },
-                    )?
-                    .ok_or_else(|| {
-                        format!(
-                            "approval_request_not_executing: `{approval_request_id}` is no longer executing"
-                        )
-                    })?;
-                Ok(crate::tools::approval::ApprovalResolutionOutcome {
-                    approval_request: executed,
-                    resumed_tool_output: Some(resumed_tool_output),
-                })
-            }
-            Err(error) => {
-                let maybe_executed = repo.transition_approval_request_if_current(
-                    approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Executing,
-                        next_status: ApprovalRequestStatus::Executed,
-                        decision: None,
-                        resolved_by_session_id: None,
-                        executed_at: Some(Self::current_epoch_s()),
-                        last_error: Some(error.clone()),
-                    },
-                )?;
-
-                if maybe_executed.is_none() {
-                    return Err(format!(
-                        "approval_request_not_executing: `{approval_request_id}` is no longer executing; original replay error: {error}"
-                    ));
-                }
-
-                Err(error)
-            }
-        }
-    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -496,139 +278,26 @@ impl<R> crate::tools::approval::ApprovalResolutionRuntime
 where
     R: ConversationRuntime + ?Sized,
 {
-    async fn resolve_approval_request(
+    fn can_replay_approved_request(&self) -> bool {
+        CoordinatorApprovalResolutionRuntime::can_replay_approved_request(self)
+    }
+
+    fn ensure_resolution_binding_allows_decision(
         &self,
-        request: crate::tools::approval::ApprovalResolutionRequest,
-    ) -> Result<crate::tools::approval::ApprovalResolutionOutcome, String> {
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(
-            &self.config.memory,
-        );
-        let repo = SessionRepository::new(&memory_config)?;
-        let approval_request = repo
-            .load_approval_request(&request.approval_request_id)?
-            .ok_or_else(|| {
-                format!(
-                    "approval_request_not_found: `{}`",
-                    request.approval_request_id
-                )
-            })?;
+        approval_request: &ApprovalRequestRecord,
+        decision: ApprovalDecision,
+    ) -> Result<(), String> {
+        CoordinatorApprovalResolutionRuntime::ensure_resolution_binding_allows_decision(
+            self,
+            approval_request,
+            decision,
+        )
+    }
 
-        let is_visible = match request.visibility {
-            crate::config::SessionVisibility::SelfOnly => {
-                request.current_session_id == approval_request.session_id
-            }
-            crate::config::SessionVisibility::Children => {
-                request.current_session_id == approval_request.session_id
-                    || repo.is_session_visible(
-                        &request.current_session_id,
-                        &approval_request.session_id,
-                    )?
-            }
-        };
-        if !is_visible {
-            return Err(format!(
-                "visibility_denied: session `{}` is not visible from `{}`",
-                approval_request.session_id, request.current_session_id
-            ));
-        }
-
-        self.ensure_resolution_binding_allows_decision(&approval_request, request.decision)?;
-
-        match request.decision {
-            ApprovalDecision::Deny => {
-                Self::ensure_resolution_request_is_pending(&approval_request)?;
-                let resolved = match repo.transition_approval_request_if_current(
-                    &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Denied,
-                        decision: Some(ApprovalDecision::Deny),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(resolved) => resolved,
-                    None => {
-                        let latest = Self::load_approval_request_or_not_found(
-                            &repo,
-                            &request.approval_request_id,
-                        )?;
-                        return Err(Self::approval_request_not_pending_error(&latest));
-                    }
-                };
-                Ok(crate::tools::approval::ApprovalResolutionOutcome {
-                    approval_request: resolved,
-                    resumed_tool_output: None,
-                })
-            }
-            ApprovalDecision::ApproveOnce => {
-                let approved = match repo.transition_approval_request_if_current(
-                    &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Approved,
-                        decision: Some(ApprovalDecision::ApproveOnce),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(approved) => approved,
-                    None => {
-                        let latest = Self::load_approval_request_or_not_found(
-                            &repo,
-                            &request.approval_request_id,
-                        )?;
-                        return self
-                            .resume_existing_approved_request(
-                                &repo,
-                                &request,
-                                latest,
-                                ApprovalDecision::ApproveOnce,
-                            )
-                            .await;
-                    }
-                };
-                Self::persist_session_consent_if_requested(
-                    &repo,
-                    &approved,
-                    &request.current_session_id,
-                    request.session_consent_mode,
-                )?;
-                self.finish_approved_resolution(&repo, approved).await
-            }
-            ApprovalDecision::ApproveAlways => {
-                let approved = match repo.transition_approval_request_if_current(
-                    &request.approval_request_id,
-                    TransitionApprovalRequestIfCurrentRequest {
-                        expected_status: ApprovalRequestStatus::Pending,
-                        next_status: ApprovalRequestStatus::Approved,
-                        decision: Some(ApprovalDecision::ApproveAlways),
-                        resolved_by_session_id: Some(request.current_session_id.clone()),
-                        executed_at: None,
-                        last_error: None,
-                    },
-                )? {
-                    Some(approved) => approved,
-                    None => {
-                        let latest = Self::load_approval_request_or_not_found(
-                            &repo,
-                            &request.approval_request_id,
-                        )?;
-                        return self
-                            .resume_existing_approved_request(
-                                &repo,
-                                &request,
-                                latest,
-                                ApprovalDecision::ApproveAlways,
-                            )
-                            .await;
-                    }
-                };
-                Self::ensure_approve_always_grant(&repo, &approved, &request.current_session_id)?;
-                self.finish_approved_resolution(&repo, approved).await
-            }
-        }
+    async fn replay_approved_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
+        CoordinatorApprovalResolutionRuntime::replay_approved_request(self, approval_request).await
     }
 }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -8698,22 +8698,23 @@ mod tests {
             &fallback,
             ConversationRuntimeBinding::direct(),
         );
-        let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
-            &approval_runtime,
-            crate::tools::approval::ApprovalResolutionRequest {
-                current_session_id: "root-session".to_owned(),
-                approval_request_id: "apr-auto-success".to_owned(),
-                decision: ApprovalDecision::ApproveOnce,
-                session_consent_mode: Some(ToolConsentMode::Auto),
-                visibility: crate::config::SessionVisibility::Children,
+        let outcome = crate::tools::approval::execute_approval_tool_with_runtime_support(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "approval_request_resolve".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-auto-success",
+                    "decision": "approve_once",
+                    "session_consent_mode": "auto",
+                }),
             },
+            "root-session",
+            &memory_config,
+            &ToolConfig::default(),
+            Some(&approval_runtime),
         )
         .await
         .expect("approval request resolve should succeed");
-        assert_eq!(
-            outcome.approval_request.status,
-            ApprovalRequestStatus::Approved
-        );
+        assert_eq!(outcome.payload["approval_request"]["status"], "approved");
 
         let stored = repo
             .load_session_tool_consent("root-session")
@@ -8786,23 +8787,24 @@ mod tests {
             &fallback,
             ConversationRuntimeBinding::direct(),
         );
-        let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
-            &approval_runtime,
-            crate::tools::approval::ApprovalResolutionRequest {
-                current_session_id: "root-session".to_owned(),
-                approval_request_id: "apr-auto-retry".to_owned(),
-                decision: ApprovalDecision::ApproveOnce,
-                session_consent_mode: Some(ToolConsentMode::Auto),
-                visibility: crate::config::SessionVisibility::Children,
+        let outcome = crate::tools::approval::execute_approval_tool_with_runtime_support(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "approval_request_resolve".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-auto-retry",
+                    "decision": "approve_once",
+                    "session_consent_mode": "auto",
+                }),
             },
+            "root-session",
+            &memory_config,
+            &ToolConfig::default(),
+            Some(&approval_runtime),
         )
         .await
         .expect("approval request retry should succeed");
 
-        assert_eq!(
-            outcome.approval_request.status,
-            ApprovalRequestStatus::Approved
-        );
+        assert_eq!(outcome.payload["approval_request"]["status"], "approved");
 
         let stored = repo
             .load_session_tool_consent("root-session")

--- a/crates/app/src/tools/approval.rs
+++ b/crates/app/src/tools/approval.rs
@@ -15,7 +15,8 @@ use crate::operator::approval_runtime::OperatorApprovalRuntime;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     ApprovalDecision, ApprovalGrantRecord, ApprovalRequestRecord, ApprovalRequestStatus,
-    SessionRepository,
+    NewApprovalGrantRecord, NewSessionToolConsentRecord, SessionRepository,
+    TransitionApprovalRequestIfCurrentRequest,
 };
 
 #[cfg(feature = "memory-sqlite")]
@@ -55,10 +56,24 @@ pub(crate) struct ApprovalResolutionOutcome {
 #[cfg(feature = "memory-sqlite")]
 #[async_trait]
 pub(crate) trait ApprovalResolutionRuntime: Send + Sync {
-    async fn resolve_approval_request(
+    fn can_replay_approved_request(&self) -> bool {
+        true
+    }
+
+    fn ensure_resolution_binding_allows_decision(
         &self,
-        request: ApprovalResolutionRequest,
-    ) -> Result<ApprovalResolutionOutcome, String>;
+        approval_request: &ApprovalRequestRecord,
+        decision: ApprovalDecision,
+    ) -> Result<(), String> {
+        let _ = approval_request;
+        let _ = decision;
+        Ok(())
+    }
+
+    async fn replay_approved_request(
+        &self,
+        approval_request: &ApprovalRequestRecord,
+    ) -> Result<ToolCoreOutcome, String>;
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -532,15 +547,15 @@ async fn execute_approval_request_resolve(
     runtime: &(dyn ApprovalResolutionRuntime + '_),
 ) -> Result<ToolCoreOutcome, String> {
     let request = parse_approval_request_resolve_request(&payload)?;
-    let outcome = runtime
-        .resolve_approval_request(ApprovalResolutionRequest {
-            current_session_id: current_session_id.to_owned(),
-            approval_request_id: request.approval_request_id,
-            decision: request.decision,
-            session_consent_mode: request.session_consent_mode,
-            visibility: tool_config.sessions.visibility,
-        })
-        .await?;
+    let resolution_request = ApprovalResolutionRequest {
+        current_session_id: current_session_id.to_owned(),
+        approval_request_id: request.approval_request_id,
+        decision: request.decision,
+        session_consent_mode: request.session_consent_mode,
+        visibility: tool_config.sessions.visibility,
+    };
+    let outcome =
+        resolve_approval_request_with_runtime(config, runtime, resolution_request).await?;
     let repo = SessionRepository::new(config)?;
     let attention = derive_attention_view(&repo, &outcome.approval_request)?;
 
@@ -552,6 +567,379 @@ async fn execute_approval_request_resolve(
             "resumed_tool_output": outcome.resumed_tool_output,
         }),
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn resolve_approval_request_with_runtime(
+    config: &MemoryRuntimeConfig,
+    runtime: &(dyn ApprovalResolutionRuntime + '_),
+    request: ApprovalResolutionRequest,
+) -> Result<ApprovalResolutionOutcome, String> {
+    let repo = SessionRepository::new(config)?;
+    let approval_request = load_visible_approval_request(&repo, &request)?;
+
+    runtime.ensure_resolution_binding_allows_decision(&approval_request, request.decision)?;
+
+    match request.decision {
+        ApprovalDecision::Deny => {
+            resolve_denied_approval_request(&repo, &request, &approval_request)
+        }
+        ApprovalDecision::ApproveOnce => {
+            let approved = transition_approval_request_to_approved(
+                &repo,
+                &request,
+                ApprovalDecision::ApproveOnce,
+                approval_request,
+            )?;
+            persist_session_consent_if_requested(
+                &repo,
+                &approved,
+                &request.current_session_id,
+                request.session_consent_mode,
+            )?;
+            finish_approved_resolution(&repo, runtime, approved).await
+        }
+        ApprovalDecision::ApproveAlways => {
+            let approved = transition_approval_request_to_approved(
+                &repo,
+                &request,
+                ApprovalDecision::ApproveAlways,
+                approval_request,
+            )?;
+            persist_runtime_grant_for_approved_request(
+                &repo,
+                &approved,
+                &request.current_session_id,
+            )?;
+            finish_approved_resolution(&repo, runtime, approved).await
+        }
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_visible_approval_request(
+    repo: &SessionRepository,
+    request: &ApprovalResolutionRequest,
+) -> Result<ApprovalRequestRecord, String> {
+    let approval_request = repo
+        .load_approval_request(&request.approval_request_id)?
+        .ok_or_else(|| {
+            format!(
+                "approval_request_not_found: `{}`",
+                request.approval_request_id
+            )
+        })?;
+
+    let is_visible = match request.visibility {
+        SessionVisibility::SelfOnly => request.current_session_id == approval_request.session_id,
+        SessionVisibility::Children => {
+            let current_session_id = request.current_session_id.as_str();
+            let target_session_id = approval_request.session_id.as_str();
+            let same_session = current_session_id == target_session_id;
+            if same_session {
+                true
+            } else {
+                repo.is_session_visible(current_session_id, target_session_id)?
+            }
+        }
+    };
+
+    if !is_visible {
+        let current_session_id = request.current_session_id.as_str();
+        let target_session_id = approval_request.session_id.as_str();
+        let error = format!(
+            "visibility_denied: session `{target_session_id}` is not visible from `{current_session_id}`"
+        );
+        return Err(error);
+    }
+
+    Ok(approval_request)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_not_pending_error(approval_request: &ApprovalRequestRecord) -> String {
+    let approval_request_id = approval_request.approval_request_id.as_str();
+    let status = approval_request.status.as_str();
+    format!("approval_request_not_pending: `{approval_request_id}` is already {status}")
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn transition_approval_request_to_approved(
+    repo: &SessionRepository,
+    request: &ApprovalResolutionRequest,
+    expected_decision: ApprovalDecision,
+    approval_request: ApprovalRequestRecord,
+) -> Result<ApprovalRequestRecord, String> {
+    let approval_request_id = request.approval_request_id.as_str();
+    let resolved_by_session_id = request.current_session_id.clone();
+    let updated = repo.transition_approval_request_if_current(
+        approval_request_id,
+        TransitionApprovalRequestIfCurrentRequest {
+            expected_status: ApprovalRequestStatus::Pending,
+            next_status: ApprovalRequestStatus::Approved,
+            decision: Some(expected_decision),
+            resolved_by_session_id: Some(resolved_by_session_id),
+            executed_at: None,
+            last_error: None,
+        },
+    )?;
+
+    let Some(approved) = updated else {
+        return resume_existing_approved_request(
+            repo,
+            request,
+            approval_request,
+            expected_decision,
+        );
+    };
+
+    Ok(approved)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resume_existing_approved_request(
+    repo: &SessionRepository,
+    request: &ApprovalResolutionRequest,
+    approval_request: ApprovalRequestRecord,
+    expected_decision: ApprovalDecision,
+) -> Result<ApprovalRequestRecord, String> {
+    if approval_request.status != ApprovalRequestStatus::Approved {
+        let error = approval_request_not_pending_error(&approval_request);
+        return Err(error);
+    }
+
+    let recorded_decision = approval_request.decision.ok_or_else(|| {
+        let approval_request_id = request.approval_request_id.as_str();
+        format!("approval_request_missing_decision: `{approval_request_id}` is approved")
+    })?;
+
+    if recorded_decision != expected_decision {
+        let approval_request_id = request.approval_request_id.as_str();
+        let recorded_decision_name = recorded_decision.as_str();
+        let expected_decision_name = expected_decision.as_str();
+        let error = format!(
+            "approval_request_decision_mismatch: `{approval_request_id}` is already `{recorded_decision_name}`, expected `{expected_decision_name}`"
+        );
+        return Err(error);
+    }
+
+    if expected_decision == ApprovalDecision::ApproveAlways {
+        persist_runtime_grant_for_approved_request(
+            repo,
+            &approval_request,
+            &request.current_session_id,
+        )?;
+    }
+
+    persist_session_consent_if_requested(
+        repo,
+        &approval_request,
+        &request.current_session_id,
+        request.session_consent_mode,
+    )?;
+
+    Ok(approval_request)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_denied_approval_request(
+    repo: &SessionRepository,
+    request: &ApprovalResolutionRequest,
+    approval_request: &ApprovalRequestRecord,
+) -> Result<ApprovalResolutionOutcome, String> {
+    if approval_request.status != ApprovalRequestStatus::Pending {
+        let error = approval_request_not_pending_error(approval_request);
+        return Err(error);
+    }
+
+    let approval_request_id = request.approval_request_id.as_str();
+    let resolved_by_session_id = request.current_session_id.clone();
+    let denied = repo.transition_approval_request_if_current(
+        approval_request_id,
+        TransitionApprovalRequestIfCurrentRequest {
+            expected_status: ApprovalRequestStatus::Pending,
+            next_status: ApprovalRequestStatus::Denied,
+            decision: Some(ApprovalDecision::Deny),
+            resolved_by_session_id: Some(resolved_by_session_id),
+            executed_at: None,
+            last_error: None,
+        },
+    )?;
+
+    let Some(denied) = denied else {
+        let latest = repo
+            .load_approval_request(approval_request_id)?
+            .ok_or_else(|| {
+                format!(
+                    "approval_request_not_found: `{}`",
+                    request.approval_request_id
+                )
+            })?;
+        let error = approval_request_not_pending_error(&latest);
+        return Err(error);
+    };
+
+    Ok(ApprovalResolutionOutcome {
+        approval_request: denied,
+        resumed_tool_output: None,
+    })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn persist_runtime_grant_for_approved_request(
+    repo: &SessionRepository,
+    approval_request: &ApprovalRequestRecord,
+    current_session_id: &str,
+) -> Result<(), String> {
+    let scope_session_id = approval_request_scope_session_id(repo, approval_request)?;
+
+    let grant_record = NewApprovalGrantRecord {
+        scope_session_id,
+        approval_key: approval_request.approval_key.clone(),
+        created_by_session_id: Some(current_session_id.to_owned()),
+    };
+
+    repo.upsert_approval_grant(grant_record)?;
+
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn persist_session_consent_if_requested(
+    repo: &SessionRepository,
+    approval_request: &ApprovalRequestRecord,
+    current_session_id: &str,
+    session_consent_mode: Option<ToolConsentMode>,
+) -> Result<(), String> {
+    let Some(session_consent_mode) = session_consent_mode else {
+        return Ok(());
+    };
+
+    let scope_session_id = approval_request_scope_session_id(repo, approval_request)?;
+
+    let consent_record = NewSessionToolConsentRecord {
+        scope_session_id,
+        mode: session_consent_mode,
+        updated_by_session_id: Some(current_session_id.to_owned()),
+    };
+
+    repo.upsert_session_tool_consent(consent_record)?;
+
+    Ok(())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_parent_session_id(approval_request: &ApprovalRequestRecord) -> Option<&str> {
+    let parent_session_value = approval_request
+        .request_payload_json
+        .get("parent_session_id")
+        .and_then(Value::as_str);
+    let parent_session_value = parent_session_value.map(str::trim);
+
+    parent_session_value.filter(|parent_session_id| !parent_session_id.is_empty())
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_scope_session_id(
+    repo: &SessionRepository,
+    approval_request: &ApprovalRequestRecord,
+) -> Result<String, String> {
+    let approval_runtime = OperatorApprovalRuntime::new(repo);
+    let parent_session_id = approval_request_parent_session_id(approval_request);
+    approval_runtime.grant_scope_session_id(&approval_request.session_id, parent_session_id)
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn finish_approved_resolution(
+    repo: &SessionRepository,
+    runtime: &(dyn ApprovalResolutionRuntime + '_),
+    approved: ApprovalRequestRecord,
+) -> Result<ApprovalResolutionOutcome, String> {
+    if !runtime.can_replay_approved_request() {
+        return Ok(ApprovalResolutionOutcome {
+            approval_request: approved,
+            resumed_tool_output: None,
+        });
+    }
+
+    let approval_request_id = approved.approval_request_id;
+    execute_approved_request(repo, runtime, approval_request_id.as_str()).await
+}
+
+#[cfg(feature = "memory-sqlite")]
+async fn execute_approved_request(
+    repo: &SessionRepository,
+    runtime: &(dyn ApprovalResolutionRuntime + '_),
+    approval_request_id: &str,
+) -> Result<ApprovalResolutionOutcome, String> {
+    let executing = repo.transition_approval_request_if_current(
+        approval_request_id,
+        TransitionApprovalRequestIfCurrentRequest {
+            expected_status: ApprovalRequestStatus::Approved,
+            next_status: ApprovalRequestStatus::Executing,
+            decision: None,
+            resolved_by_session_id: None,
+            executed_at: None,
+            last_error: None,
+        },
+    )?;
+
+    let Some(executing) = executing else {
+        let error =
+            format!("approval_request_not_approved: `{approval_request_id}` is no longer approved");
+        return Err(error);
+    };
+
+    let replay_result = runtime.replay_approved_request(&executing).await;
+    match replay_result {
+        Ok(resumed_tool_output) => {
+            let executed = repo.transition_approval_request_if_current(
+                approval_request_id,
+                TransitionApprovalRequestIfCurrentRequest {
+                    expected_status: ApprovalRequestStatus::Executing,
+                    next_status: ApprovalRequestStatus::Executed,
+                    decision: None,
+                    resolved_by_session_id: None,
+                    executed_at: Some(unix_ts_now()),
+                    last_error: None,
+                },
+            )?;
+
+            let Some(executed) = executed else {
+                let error = format!(
+                    "approval_request_not_executing: `{approval_request_id}` is no longer executing"
+                );
+                return Err(error);
+            };
+
+            Ok(ApprovalResolutionOutcome {
+                approval_request: executed,
+                resumed_tool_output: Some(resumed_tool_output),
+            })
+        }
+        Err(error) => {
+            let executed = repo.transition_approval_request_if_current(
+                approval_request_id,
+                TransitionApprovalRequestIfCurrentRequest {
+                    expected_status: ApprovalRequestStatus::Executing,
+                    next_status: ApprovalRequestStatus::Executed,
+                    decision: None,
+                    resolved_by_session_id: None,
+                    executed_at: Some(unix_ts_now()),
+                    last_error: Some(error.clone()),
+                },
+            )?;
+
+            if executed.is_none() {
+                let combined_error = format!(
+                    "approval_request_not_executing: `{approval_request_id}` is no longer executing; original replay error: {error}"
+                );
+                return Err(combined_error);
+            }
+
+            Err(error)
+        }
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -948,13 +1336,17 @@ fn parse_approval_decision(value: &str) -> Result<ApprovalDecision, String> {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::{Arc, Mutex};
 
+    use async_trait::async_trait;
+    use loongclaw_contracts::ToolCoreOutcome;
     use loongclaw_contracts::ToolCoreRequest;
     #[cfg(feature = "memory-sqlite")]
     use rusqlite::{Connection, params};
     use serde_json::Value;
     use serde_json::json;
 
+    use super::*;
     use crate::config::ToolConfig;
     use crate::memory::runtime_config::MemoryRuntimeConfig;
     use crate::session::repository::{
@@ -1113,6 +1505,78 @@ mod tests {
             params![session_id],
         )
         .expect("delete session row");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[derive(Clone)]
+    struct MockApprovalResolutionRuntime {
+        binding_error: Option<String>,
+        can_replay: bool,
+        replay_result: Result<ToolCoreOutcome, String>,
+        replayed_request_ids: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    impl MockApprovalResolutionRuntime {
+        fn succeeds_with(payload: Value) -> Self {
+            let outcome = ToolCoreOutcome {
+                status: "ok".to_owned(),
+                payload,
+            };
+            Self {
+                binding_error: None,
+                can_replay: true,
+                replay_result: Ok(outcome),
+                replayed_request_ids: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn without_replay(mut self) -> Self {
+            self.can_replay = false;
+            self
+        }
+
+        fn replayed_request_ids(&self) -> Vec<String> {
+            let guard = self
+                .replayed_request_ids
+                .lock()
+                .expect("replayed request ids lock");
+            guard.clone()
+        }
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[async_trait]
+    impl ApprovalResolutionRuntime for MockApprovalResolutionRuntime {
+        fn can_replay_approved_request(&self) -> bool {
+            self.can_replay
+        }
+
+        fn ensure_resolution_binding_allows_decision(
+            &self,
+            _approval_request: &ApprovalRequestRecord,
+            _decision: ApprovalDecision,
+        ) -> Result<(), String> {
+            match &self.binding_error {
+                Some(binding_error) => Err(binding_error.clone()),
+                None => Ok(()),
+            }
+        }
+
+        async fn replay_approved_request(
+            &self,
+            approval_request: &ApprovalRequestRecord,
+        ) -> Result<ToolCoreOutcome, String> {
+            let approval_request_id = approval_request.approval_request_id.clone();
+            let mut guard = self
+                .replayed_request_ids
+                .lock()
+                .expect("replayed request ids lock");
+            guard.push(approval_request_id);
+            drop(guard);
+
+            self.replay_result.clone()
+        }
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -1772,5 +2236,207 @@ mod tests {
         assert_eq!(grant_review["scope_session_id"], "root-session");
         assert_eq!(grant_review["grant_exists"], true);
         assert_eq!(grant_attention["needs_attention"], false);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn approval_request_resolve_approve_once_transitions_and_replays_in_tools_runtime() {
+        let config = isolated_memory_config("approval-resolve-once");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-resolve-once",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_approval",
+        );
+
+        let runtime = MockApprovalResolutionRuntime::succeeds_with(json!({
+            "tool": "delegate_async",
+            "ok": true,
+        }));
+        let outcome = resolve_approval_request_with_runtime(
+            &config,
+            &runtime,
+            ApprovalResolutionRequest {
+                current_session_id: "root-session".to_owned(),
+                approval_request_id: "apr-resolve-once".to_owned(),
+                decision: ApprovalDecision::ApproveOnce,
+                session_consent_mode: None,
+                visibility: SessionVisibility::Children,
+            },
+        )
+        .await
+        .expect("approval request resolve outcome");
+
+        assert_eq!(
+            outcome.approval_request.status,
+            ApprovalRequestStatus::Executed
+        );
+        assert_eq!(
+            outcome
+                .resumed_tool_output
+                .as_ref()
+                .map(|outcome| outcome.payload["tool"].clone()),
+            Some(json!("delegate_async"))
+        );
+        assert_eq!(
+            runtime.replayed_request_ids(),
+            vec!["apr-resolve-once".to_owned()]
+        );
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn approval_request_resolve_approve_always_persists_runtime_grant_without_session_row() {
+        let config = isolated_memory_config("approval-resolve-always-missing-session-row");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-resolve-always",
+            "root-session",
+            "delegate",
+            "governed_tool_requires_approval",
+        );
+        delete_session_row(&config, "root-session");
+
+        let runtime = MockApprovalResolutionRuntime::succeeds_with(json!({
+            "tool": "delegate",
+            "ok": true,
+        }))
+        .without_replay();
+        let outcome = resolve_approval_request_with_runtime(
+            &config,
+            &runtime,
+            ApprovalResolutionRequest {
+                current_session_id: "root-session".to_owned(),
+                approval_request_id: "apr-resolve-always".to_owned(),
+                decision: ApprovalDecision::ApproveAlways,
+                session_consent_mode: None,
+                visibility: SessionVisibility::Children,
+            },
+        )
+        .await
+        .expect("approval request resolve outcome");
+
+        let grant = repo
+            .load_approval_grant("root-session", "tool:delegate")
+            .expect("load approval grant");
+
+        assert_eq!(
+            outcome.approval_request.status,
+            ApprovalRequestStatus::Approved
+        );
+        assert!(
+            grant.is_some(),
+            "expected root-session grant to be persisted"
+        );
+        assert!(runtime.replayed_request_ids().is_empty());
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn approval_request_resolve_approve_once_retries_existing_approved_request_and_persists_consent()
+     {
+        let config = isolated_memory_config("approval-resolve-existing-approved");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-resolve-retry",
+            "root-session",
+            "sessions_list",
+            "governed_tool_requires_approval",
+        );
+        repo.transition_approval_request_if_current(
+            "apr-resolve-retry",
+            TransitionApprovalRequestIfCurrentRequest {
+                expected_status: ApprovalRequestStatus::Pending,
+                next_status: ApprovalRequestStatus::Approved,
+                decision: Some(ApprovalDecision::ApproveOnce),
+                resolved_by_session_id: Some("root-session".to_owned()),
+                executed_at: None,
+                last_error: None,
+            },
+        )
+        .expect("transition approval request")
+        .expect("approval request should be pending");
+
+        let runtime = MockApprovalResolutionRuntime::succeeds_with(json!({
+            "tool": "sessions_list",
+            "ok": true,
+        }))
+        .without_replay();
+        let outcome = resolve_approval_request_with_runtime(
+            &config,
+            &runtime,
+            ApprovalResolutionRequest {
+                current_session_id: "root-session".to_owned(),
+                approval_request_id: "apr-resolve-retry".to_owned(),
+                decision: ApprovalDecision::ApproveOnce,
+                session_consent_mode: Some(ToolConsentMode::Auto),
+                visibility: SessionVisibility::Children,
+            },
+        )
+        .await
+        .expect("approval request resolve retry outcome");
+
+        let stored = repo
+            .load_session_tool_consent("root-session")
+            .expect("load session tool consent")
+            .expect("session tool consent row");
+
+        assert_eq!(
+            outcome.approval_request.status,
+            ApprovalRequestStatus::Approved
+        );
+        assert_eq!(stored.mode, ToolConsentMode::Auto);
+        assert!(runtime.replayed_request_ids().is_empty());
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[tokio::test]
+    async fn approval_request_resolve_deny_stays_terminal_without_replay() {
+        let config = isolated_memory_config("approval-resolve-deny");
+        let repo = SessionRepository::new(&config).expect("repository");
+
+        seed_session(&repo, "root-session", SessionKind::Root, None);
+        seed_request(
+            &repo,
+            "apr-resolve-deny",
+            "root-session",
+            "delegate_async",
+            "governed_tool_requires_approval",
+        );
+
+        let runtime = MockApprovalResolutionRuntime::succeeds_with(json!({
+            "tool": "delegate_async",
+            "ok": true,
+        }));
+        let outcome = resolve_approval_request_with_runtime(
+            &config,
+            &runtime,
+            ApprovalResolutionRequest {
+                current_session_id: "root-session".to_owned(),
+                approval_request_id: "apr-resolve-deny".to_owned(),
+                decision: ApprovalDecision::Deny,
+                session_consent_mode: None,
+                visibility: SessionVisibility::Children,
+            },
+        )
+        .await
+        .expect("approval request resolve outcome");
+
+        assert_eq!(
+            outcome.approval_request.status,
+            ApprovalRequestStatus::Denied
+        );
+        assert!(outcome.resumed_tool_output.is_none());
+        assert!(runtime.replayed_request_ids().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Problem:
  `approval_request_resolve` still owned durable approval state transitions inside the conversation runtime, so approval lifecycle storage and replay policy stayed split across `turn_coordinator` and the approval tool runtime.
- Why it matters:
  That split made approval behavior harder to reason about, harder to test in isolation, and easier to regress when durable state transitions and replay policy drifted apart.
- What changed:
  Moved durable approval resolution into `crates/app/src/tools/approval.rs`, including visibility checks, pending-to-approved and pending-to-denied transitions, executing-to-executed finalization, approve-always grant persistence, approve-once consent persistence, and approved-request retry handling. Reduced `crates/app/src/conversation/approval_resolution.rs` to binding-policy and replay adapters only. Restacked this branch onto `dev` so the PR is reviewable without the closed session-memory base branch.
- What did not change (scope boundary):
  This PR does not change approval policy semantics, request payload shape, session visibility rules, or replay dispatch targets. It keeps current `dev` behavior, including session consent persistence, direct-binding replay deferral, core/app replay handling, and missing-session-row grant scope recovery.

## Linked Issues

- Closes #873
- Related #867

## Change Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  Regressions would show up as incorrect approval status transitions, missed durable grants or consent persistence, binding-gate drift, or replay/finalization mismatches.
- Rollout / guardrails:
  Guarded by focused approval-runtime tests, conversation approval regressions, app-scope linting, and architecture plus dep-graph checks.
- Rollback path:
  Revert commit `1d8b14ca`.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace --locked`
- [ ] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
  PASS

env CARGO_TARGET_DIR=<redacted-target-dir> cargo check -p loongclaw-app --tests -j 1
  PASS

env CARGO_TARGET_DIR=<redacted-target-dir> cargo clippy -p loongclaw-app --tests --all-features -- -D warnings
  PASS

env CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app approval_request_resolve -- --nocapture
  PASS

env CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app approval_request_status_uses_request_session_scope_when_session_row_is_missing -- --nocapture
  PASS

env CARGO_TARGET_DIR=<redacted-target-dir> cargo test -p loongclaw-app approval_request_status_uses_root_scope_for_child_request_when_root_row_is_missing -- --nocapture
  PASS

./scripts/check_architecture_boundaries.sh
  PASS

./scripts/check_dep_graph.sh
  PASS
```

Additional scenario checks:

```text
approval_request_resolve_approve_once_transitions_and_replays_in_tools_runtime
approval_request_resolve_approve_always_persists_runtime_grant_without_session_row
approval_request_resolve_approve_once_retries_existing_approved_request_and_persists_consent
approval_request_resolve_deny_stays_terminal_without_replay
approval_request_resolve_persists_session_mode_on_success
approval_request_resolve_retries_missing_session_mode_after_approval
handle_turn_with_runtime_approval_request_resolve_approve_once_preserves_consent_without_replay_when_direct
handle_turn_with_runtime_approval_request_resolve_rejects_core_replay_for_approve_once_on_advisory_binding
handle_turn_with_runtime_approval_request_resolve_kernel_replays_previously_direct_approved_request
handle_turn_with_runtime_approval_request_resolve_replays_shell_exec_for_approve_once
handle_turn_with_runtime_approval_request_resolve_approve_always_reuses_shell_grant
handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_shell_exec
handle_turn_with_runtime_approval_request_resolve_approve_always_reuses_root_grant
handle_turn_with_runtime_approval_request_resolve_approve_always_persists_grant_without_session_row
handle_turn_with_runtime_approval_request_resolve_kernel_replay_surfaces_finalize_conflict_on_replay_error
handle_turn_with_runtime_approval_request_resolve_deny_does_not_replay_delegate
handle_turn_with_runtime_approval_request_resolve_keeps_delegate_async_pending_without_kernel_binding
approval_request_status_uses_request_session_scope_when_session_row_is_missing
approval_request_status_uses_root_scope_for_child_request_when_root_row_is_missing
```

## User-visible / Operator-visible Changes

- None. Approval behavior stays the same, but the durable state machine now has a single runtime owner and keeps current `dev` replay semantics.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `1d8b14ca`.
- Observable failure symptoms reviewers should watch for:
  Approval requests stuck in `approved` or `executing`, missing `approve_always` grants or session consent persistence, direct binding unexpectedly replaying governed work, or replayed tool output missing after an otherwise successful resolution.

## Reviewer Focus

- Review `crates/app/src/tools/approval.rs` for the durable approval lifecycle ownership, retry handling, and missing-session-row scope persistence.
- Review `crates/app/src/conversation/approval_resolution.rs` to confirm it now only enforces binding policy and replay adapters.
- Review `crates/app/src/conversation/turn_coordinator.rs` for the updated approval resolution tests and runtime entrypoint wiring.
