### PR TITLE
feat: harden runtime security boundaries and audit verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,11 +2737,13 @@ version = "0.1.0-alpha.3"
 dependencies = [
  "async-trait",
  "futures-util",
+ "hex",
  "loongclaw-contracts",
  "proptest",
  "semver",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/crates/app/src/channel/feishu/api/client.rs
+++ b/crates/app/src/channel/feishu/api/client.rs
@@ -474,13 +474,15 @@ impl FeishuClient {
         path: &str,
         bearer_token: Option<&str>,
         query_pairs: &[(String, String)],
+        max_bytes: usize,
     ) -> CliResult<FeishuBinaryResponse> {
         let url = self.build_open_api_url_with_query(path, query_pairs)?;
         let request = self.authorized(self.http.get(url), bearer_token).header(
             reqwest::header::CONTENT_TYPE,
             "application/json; charset=utf-8",
         );
-        self.send_binary_request_with_retry(request).await
+        self.send_binary_request_with_retry(request, max_bytes)
+            .await
     }
 
     fn authorized(
@@ -605,6 +607,7 @@ impl FeishuClient {
     async fn send_binary_request_with_retry(
         &self,
         request: RequestBuilder,
+        max_bytes: usize,
     ) -> CliResult<FeishuBinaryResponse> {
         let max_attempts = self.retry_policy.max_attempts.max(1);
         let mut current_request = Some(request);
@@ -620,16 +623,29 @@ impl FeishuClient {
             };
 
             match request.send().await {
-                Ok(response) => {
+                Ok(mut response) => {
                     let status = response.status();
                     let headers = response.headers().clone();
-                    let bytes = response
-                        .bytes()
+                    let mut budget = crate::tools::download_guard::ByteBudget::new(max_bytes);
+
+                    budget.reject_if_content_length_exceeds(
+                        response.content_length(),
+                        "feishu http binary response",
+                    )?;
+
+                    let mut bytes = Vec::new();
+                    while let Some(chunk) = response
+                        .chunk()
                         .await
-                        .map_err(|error| format!("feishu http response decode failed: {error}"))?;
+                        .map_err(|error| format!("feishu http response decode failed: {error}"))?
+                    {
+                        budget.try_consume(chunk.len(), "feishu http binary response")?;
+                        bytes.extend_from_slice(&chunk);
+                    }
+
                     if status.is_success() {
                         return Ok(FeishuBinaryResponse {
-                            bytes: bytes.to_vec(),
+                            bytes,
                             content_type: header_value(headers.get(reqwest::header::CONTENT_TYPE)),
                             content_disposition: header_value(
                                 headers.get(reqwest::header::CONTENT_DISPOSITION),
@@ -1115,7 +1131,7 @@ mod tests {
         client.retry_policy.max_backoff_ms = 0;
 
         let payload = client
-            .get_binary("/open-apis/test", Some("tenant-token"), &[])
+            .get_binary("/open-apis/test", Some("tenant-token"), &[], 1_024)
             .await
             .expect("binary request should retry and succeed");
 

--- a/crates/app/src/channel/feishu/api/resources/media.rs
+++ b/crates/app/src/channel/feishu/api/resources/media.rs
@@ -10,6 +10,7 @@ use super::types::{
 };
 
 pub const FEISHU_DEFAULT_MESSAGE_FILE_TYPE: &str = "stream";
+pub const FEISHU_MESSAGE_RESOURCE_DOWNLOAD_MAX_BYTES: usize = 32 * 1024 * 1024;
 
 pub async fn upload_message_image(
     client: &FeishuClient,
@@ -81,6 +82,7 @@ pub async fn download_message_resource(
     message_id: &str,
     file_key: &str,
     resource_type: FeishuMessageResourceType,
+    max_bytes: usize,
 ) -> CliResult<FeishuDownloadedMessageResource> {
     let message_id =
         require_non_empty("feishu message resource download", "message_id", message_id)?;
@@ -90,6 +92,7 @@ pub async fn download_message_resource(
             format!("/open-apis/im/v1/messages/{message_id}/resources/{file_key}").as_str(),
             Some(tenant_access_token),
             &[("type".to_owned(), resource_type.as_api_value().to_owned())],
+            max_bytes,
         )
         .await?;
     Ok(FeishuDownloadedMessageResource {
@@ -441,6 +444,7 @@ mod tests {
             "om_123",
             "file_456",
             FeishuMessageResourceType::File,
+            1_024,
         )
         .await
         .expect("download resource should retry and succeed");
@@ -451,6 +455,38 @@ mod tests {
         assert_eq!(resource.file_name.as_deref(), Some("spec-sheet.pdf"));
         assert_eq!(resource.content_type.as_deref(), Some("application/pdf"));
         assert_eq!(resource.bytes, b"demo-pdf".to_vec());
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn download_message_resource_rejects_payload_exceeding_max_bytes_limit() {
+        let router = Router::new().route(
+            "/open-apis/im/v1/messages/om_oversize/resources/file_oversize",
+            get(|| async move {
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "application/octet-stream")
+                    .header("content-length", "10")
+                    .body(Body::from(b"0123456789".to_vec()))
+                    .expect("build binary response")
+            }),
+        );
+        let (base_url, server) = spawn_mock_feishu_server(router).await;
+        let client = FeishuClient::new(base_url, "cli_xxx", "secret_xxx", 20).expect("client");
+
+        let error = download_message_resource(
+            &client,
+            "tenant-token",
+            "om_oversize",
+            "file_oversize",
+            FeishuMessageResourceType::File,
+            4,
+        )
+        .await
+        .expect_err("oversize download should fail closed");
+
+        assert!(error.contains("max_bytes limit"));
 
         server.abort();
     }

--- a/crates/app/src/tools/browser.rs
+++ b/crates/app/src/tools/browser.rs
@@ -358,15 +358,26 @@ fn fetch_browser_page(
             .get(CONTENT_TYPE)
             .and_then(|value| value.to_str().ok())
             .map(|value| value.to_owned());
+        let mut budget = super::download_guard::ByteBudget::new(max_bytes);
+
+        budget.reject_if_content_length_exceeds(response.content_length(), "browser response")?;
         let mut body = Vec::new();
         let mut limited_reader = response.take((max_bytes as u64).saturating_add(1));
-        limited_reader
-            .read_to_end(&mut body)
-            .map_err(|error| format!("failed to read browser response body: {error}"))?;
-        if body.len() > max_bytes {
-            return Err(format!(
-                "browser response exceeded max_bytes limit ({max_bytes} bytes)"
-            ));
+        let mut buffer = [0_u8; 8_192];
+
+        loop {
+            let read = limited_reader
+                .read(&mut buffer)
+                .map_err(|error| format!("failed to read browser response body: {error}"))?;
+            if read == 0 {
+                break;
+            }
+
+            budget.try_consume(read, "browser response")?;
+            let chunk = buffer
+                .get(..read)
+                .ok_or_else(|| "failed to slice browser response buffer".to_owned())?;
+            body.extend_from_slice(chunk);
         }
 
         let raw_text = String::from_utf8_lossy(&body).into_owned();
@@ -408,7 +419,7 @@ fn fetch_browser_page(
             raw_html: raw_text,
             page_text,
             links,
-            bytes_downloaded: body.len(),
+            bytes_downloaded: budget.consumed(),
             redirect_count,
         });
     }
@@ -918,6 +929,35 @@ mod tests {
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["title"], json!("Fixture Home"));
+        handle.join().expect("server thread");
+    }
+
+    #[test]
+    fn browser_open_rejects_declared_content_length_above_limit() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let address = listener.local_addr().expect("listener addr");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept stream");
+            let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: 10\r\nConnection: close\r\n\r\ntiny";
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+
+        let mut config = local_browser_config();
+        config.web_fetch.max_bytes = 4;
+
+        let error = execute_browser_tool_with_config(
+            scoped_request(
+                "browser.open",
+                json!({"url": format!("http://127.0.0.1:{}/", address.port())}),
+                "test-open-content-length",
+            ),
+            &config,
+        )
+        .expect_err("oversize declared content length should fail closed");
+
+        assert!(error.contains("Content-Length"));
         handle.join().expect("server thread");
     }
 

--- a/crates/app/src/tools/browser.rs
+++ b/crates/app/src/tools/browser.rs
@@ -938,14 +938,21 @@ mod tests {
         let address = listener.local_addr().expect("listener addr");
         let handle = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("accept stream");
-            let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: 10\r\nConnection: close\r\n\r\ntiny";
+            let body = "<html><body>too large</body></html>";
+            let response = build_http_response("200 OK", "text/html; charset=utf-8", body, None);
+            let mut request_buffer = [0_u8; 4_096];
+
+            stream
+                .set_read_timeout(Some(Duration::from_millis(200)))
+                .expect("set read timeout");
+            let _ = stream.read(&mut request_buffer);
             stream
                 .write_all(response.as_bytes())
                 .expect("write response");
         });
 
         let mut config = local_browser_config();
-        config.web_fetch.max_bytes = 4;
+        config.web_fetch.max_bytes = 8;
 
         let error = execute_browser_tool_with_config(
             scoped_request(
@@ -957,7 +964,7 @@ mod tests {
         )
         .expect_err("oversize declared content length should fail closed");
 
-        assert!(error.contains("Content-Length"));
+        assert!(error.contains("max_bytes limit"));
         handle.join().expect("server thread");
     }
 

--- a/crates/app/src/tools/download_guard.rs
+++ b/crates/app/src/tools/download_guard.rs
@@ -1,0 +1,51 @@
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ByteBudget {
+    max_bytes: usize,
+    consumed: usize,
+}
+
+impl ByteBudget {
+    pub(crate) fn new(max_bytes: usize) -> Self {
+        Self {
+            max_bytes,
+            consumed: 0,
+        }
+    }
+
+    pub(crate) fn reject_if_content_length_exceeds(
+        &self,
+        content_length: Option<u64>,
+        surface_name: &str,
+    ) -> Result<(), String> {
+        let Some(content_length) = content_length else {
+            return Ok(());
+        };
+
+        if content_length <= self.max_bytes as u64 {
+            return Ok(());
+        }
+
+        Err(format!(
+            "{surface_name} Content-Length ({content_length}) exceeds max_bytes limit ({} bytes)",
+            self.max_bytes
+        ))
+    }
+
+    pub(crate) fn try_consume(&mut self, bytes: usize, surface_name: &str) -> Result<(), String> {
+        let next_consumed = self.consumed.saturating_add(bytes);
+
+        if next_consumed > self.max_bytes {
+            return Err(format!(
+                "{surface_name} exceeded max_bytes limit ({} bytes)",
+                self.max_bytes
+            ));
+        }
+
+        self.consumed = next_consumed;
+        Ok(())
+    }
+
+    pub(crate) fn consumed(&self) -> usize {
+        self.consumed
+    }
+}

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
     fs,
-    io::{ErrorKind, Read},
+    io::{BufWriter, ErrorKind, Read, Write},
     path::{Path, PathBuf},
     sync::{OnceLock, RwLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -16,6 +16,7 @@ use serde_json::{Map, Value, json};
 use serde_yaml::Value as YamlValue;
 use sha2::{Digest, Sha256};
 use tar::Archive;
+use tempfile::Builder as TempFileBuilder;
 
 use super::external_skills_scan::{
     ExternalSkillSecurityDecision, parse_external_skill_security_decision, scan_external_skill_tree,
@@ -483,18 +484,8 @@ pub(super) fn execute_external_skills_fetch_tool_with_config(
         "download",
     )?;
     let response = send_external_skill_get_request(&client, &validated_download_url, "download")?;
-
-    let mut body = Vec::new();
-    let mut limited_reader = response.take((max_bytes as u64).saturating_add(1));
-    limited_reader
-        .read_to_end(&mut body)
-        .map_err(|error| format!("failed to read external skills download body: {error}"))?;
-
-    if body.len() > max_bytes {
-        return Err(format!(
-            "external skills download exceeded max_bytes limit ({max_bytes} bytes)"
-        ));
-    }
+    let content_length = response.content_length();
+    let mut response = response;
 
     let output_dir = resolve_download_dir(config);
     fs::create_dir_all(&output_dir).map_err(|error| {
@@ -510,16 +501,14 @@ pub(super) fn execute_external_skills_fetch_tool_with_config(
         .filter(|value| !value.is_empty());
     let derived_name = requested_name
         .unwrap_or_else(|| derive_filename_from_url(&validated_download_url.parsed_url));
-    let output_path = unique_output_path(&output_dir, &derived_name);
-
-    fs::write(&output_path, &body).map_err(|error| {
-        format!(
-            "failed to write downloaded external skill artifact {}: {error}",
-            output_path.display()
-        )
-    })?;
-
-    let sha256 = hex::encode(Sha256::digest(&body));
+    let download = stream_download_to_unique_path(
+        &mut response,
+        content_length,
+        max_bytes,
+        &output_dir,
+        &derived_name,
+        "external skills download",
+    )?;
 
     Ok(ToolCoreOutcome {
         status: "ok".to_owned(),
@@ -529,9 +518,9 @@ pub(super) fn execute_external_skills_fetch_tool_with_config(
             "reference": reference,
             "url": download_plan.artifact_url,
             "host": validated_download_url.host,
-            "saved_path": output_path.display().to_string(),
-            "bytes_downloaded": body.len(),
-            "sha256": sha256,
+            "saved_path": download.path.display().to_string(),
+            "bytes_downloaded": download.bytes_downloaded,
+            "sha256": download.sha256,
             "approval_required": policy.require_download_approval,
             "approval_granted": approval_granted,
             "max_bytes": max_bytes,
@@ -2572,6 +2561,80 @@ fn unique_output_path(dir: &Path, filename: &str) -> PathBuf {
     }
 }
 
+#[derive(Debug)]
+struct StreamedDownload {
+    path: PathBuf,
+    bytes_downloaded: usize,
+    sha256: String,
+}
+
+fn stream_download_to_unique_path<R: Read>(
+    reader: &mut R,
+    content_length: Option<u64>,
+    max_bytes: usize,
+    output_dir: &Path,
+    filename: &str,
+    surface_name: &str,
+) -> Result<StreamedDownload, String> {
+    let mut budget = super::download_guard::ByteBudget::new(max_bytes);
+
+    budget.reject_if_content_length_exceeds(content_length, surface_name)?;
+
+    let target_path = unique_output_path(output_dir, filename);
+    let mut temp_file = TempFileBuilder::new()
+        .prefix(".download-")
+        .tempfile_in(output_dir)
+        .map_err(|error| {
+            format!(
+                "failed to create temporary download file in {}: {error}",
+                output_dir.display()
+            )
+        })?;
+    let mut writer = BufWriter::new(temp_file.as_file_mut());
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8_192];
+
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| format!("failed to read {surface_name} body: {error}"))?;
+        if read == 0 {
+            break;
+        }
+
+        budget.try_consume(read, surface_name)?;
+        let chunk = buffer
+            .get(..read)
+            .ok_or_else(|| format!("failed to slice {surface_name} buffer"))?;
+
+        writer
+            .write_all(chunk)
+            .map_err(|error| format!("failed to write {surface_name} body: {error}"))?;
+        hasher.update(chunk);
+    }
+
+    writer
+        .flush()
+        .map_err(|error| format!("failed to flush {surface_name} body: {error}"))?;
+    drop(writer);
+
+    temp_file.persist(&target_path).map_err(|error| {
+        format!(
+            "failed to persist downloaded artifact {}: {}",
+            target_path.display(),
+            error.error
+        )
+    })?;
+
+    let sha256 = hex::encode(hasher.finalize());
+
+    Ok(StreamedDownload {
+        path: target_path,
+        bytes_downloaded: budget.consumed(),
+        sha256,
+    })
+}
+
 fn unique_managed_install_transition_path(
     install_root: &Path,
     skill_id: &str,
@@ -4375,6 +4438,27 @@ mod tests {
         std::env::temp_dir().join(format!("{prefix}-{nanos}"))
     }
 
+    struct CountingReader {
+        inner: std::io::Cursor<Vec<u8>>,
+        reads: usize,
+    }
+
+    impl CountingReader {
+        fn new(bytes: &[u8]) -> Self {
+            Self {
+                inner: std::io::Cursor::new(bytes.to_vec()),
+                reads: 0,
+            }
+        }
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.reads += 1;
+            self.inner.read(buf)
+        }
+    }
+
     struct ScopedHomeFixture {
         _env: crate::test_support::ScopedEnv,
         path: PathBuf,
@@ -4511,6 +4595,83 @@ mod tests {
             "https://wry-manatee-359.convex.site/api/v1/download?slug=hybrid-deep-search"
         );
         assert_eq!(plan.source_skill_id.as_deref(), Some("hybrid-deep-search"));
+    }
+
+    #[test]
+    fn stream_download_to_unique_path_rejects_declared_content_length_before_reading() {
+        let output_dir = unique_temp_dir("ext-skills-download-precheck");
+        fs::create_dir_all(&output_dir).expect("create output dir");
+        let mut reader = CountingReader::new(b"tiny");
+
+        let error = stream_download_to_unique_path(
+            &mut reader,
+            Some(10),
+            4,
+            &output_dir,
+            "demo.tgz",
+            "external skills download",
+        )
+        .expect_err("declared oversize content length should fail closed");
+
+        assert!(error.contains("Content-Length"));
+        assert_eq!(reader.reads, 0);
+        assert!(
+            fs::read_dir(&output_dir)
+                .expect("list output dir")
+                .next()
+                .is_none()
+        );
+        fs::remove_dir_all(output_dir).ok();
+    }
+
+    #[test]
+    fn stream_download_to_unique_path_rejects_streamed_body_past_limit() {
+        let output_dir = unique_temp_dir("ext-skills-download-stream-limit");
+        fs::create_dir_all(&output_dir).expect("create output dir");
+        let mut reader = CountingReader::new(b"0123456789");
+
+        let error = stream_download_to_unique_path(
+            &mut reader,
+            None,
+            4,
+            &output_dir,
+            "demo.tgz",
+            "external skills download",
+        )
+        .expect_err("streamed oversize body should fail closed");
+
+        assert!(error.contains("exceeded max_bytes limit"));
+        assert!(
+            fs::read_dir(&output_dir)
+                .expect("list output dir")
+                .next()
+                .is_none()
+        );
+        fs::remove_dir_all(output_dir).ok();
+    }
+
+    #[test]
+    fn stream_download_to_unique_path_writes_file_and_computes_digest() {
+        let output_dir = unique_temp_dir("ext-skills-download-success");
+        fs::create_dir_all(&output_dir).expect("create output dir");
+        let mut reader = CountingReader::new(b"skill-bytes");
+
+        let download = stream_download_to_unique_path(
+            &mut reader,
+            Some(11),
+            32,
+            &output_dir,
+            "demo.tgz",
+            "external skills download",
+        )
+        .expect("streamed download should succeed");
+
+        let persisted = fs::read(&download.path).expect("read persisted artifact");
+
+        assert_eq!(download.bytes_downloaded, 11);
+        assert_eq!(persisted, b"skill-bytes");
+        assert_eq!(download.sha256, hex::encode(Sha256::digest(b"skill-bytes")));
+        fs::remove_dir_all(output_dir).ok();
     }
 
     #[test]

--- a/crates/app/src/tools/external_skills.rs
+++ b/crates/app/src/tools/external_skills.rs
@@ -2576,11 +2576,13 @@ fn stream_download_to_unique_path<R: Read>(
     filename: &str,
     surface_name: &str,
 ) -> Result<StreamedDownload, String> {
+    const MAX_PERSIST_COLLISION_RETRIES: usize = 16;
+
     let mut budget = super::download_guard::ByteBudget::new(max_bytes);
 
     budget.reject_if_content_length_exceeds(content_length, surface_name)?;
 
-    let target_path = unique_output_path(output_dir, filename);
+    let mut target_path = unique_output_path(output_dir, filename);
     let mut temp_file = TempFileBuilder::new()
         .prefix(".download-")
         .tempfile_in(output_dir)
@@ -2618,13 +2620,38 @@ fn stream_download_to_unique_path<R: Read>(
         .map_err(|error| format!("failed to flush {surface_name} body: {error}"))?;
     drop(writer);
 
-    temp_file.persist(&target_path).map_err(|error| {
-        format!(
-            "failed to persist downloaded artifact {}: {}",
-            target_path.display(),
-            error.error
-        )
-    })?;
+    // Claim the final name without clobbering a sibling download that won the
+    // same derived filename race first.
+    for attempt in 0..MAX_PERSIST_COLLISION_RETRIES {
+        let persist_result = temp_file.persist_noclobber(&target_path);
+
+        match persist_result {
+            Ok(_) => {
+                break;
+            }
+            Err(error) if error.error.kind() == ErrorKind::AlreadyExists => {
+                let is_last_attempt = attempt + 1 == MAX_PERSIST_COLLISION_RETRIES;
+
+                if is_last_attempt {
+                    return Err(format!(
+                        "failed to persist downloaded artifact {} after {} name collisions",
+                        target_path.display(),
+                        MAX_PERSIST_COLLISION_RETRIES
+                    ));
+                }
+
+                temp_file = error.file;
+                target_path = unique_output_path(output_dir, filename);
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to persist downloaded artifact {}: {}",
+                    target_path.display(),
+                    error.error
+                ));
+            }
+        }
+    }
 
     let sha256 = hex::encode(hasher.finalize());
 

--- a/crates/app/src/tools/feishu.rs
+++ b/crates/app/src/tools/feishu.rs
@@ -4789,6 +4789,7 @@ fn execute_feishu_messages_resource_get_tool_with_config(
                 &message_id,
                 &file_key,
                 resource_type,
+                media::FEISHU_MESSAGE_RESOURCE_DOWNLOAD_MAX_BYTES,
             )
             .await?;
             if let Some(parent) = save_path.parent() {

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -40,6 +40,7 @@ mod catalog;
 mod claw_migrate;
 pub(crate) mod delegate;
 mod direct_policy_preflight;
+pub(crate) mod download_guard;
 mod external_skills;
 mod external_skills_scan;
 mod external_skills_sources;

--- a/crates/app/src/tools/process_exec.rs
+++ b/crates/app/src/tools/process_exec.rs
@@ -129,6 +129,10 @@ where
     S: AsRef<OsStr>,
 {
     let mut command = Command::new(program);
+    let sanitized_env = loongclaw_contracts::sanitized_child_process_env();
+
+    command.env_clear();
+    command.envs(sanitized_env);
     command.args(args);
     command.current_dir(cwd);
     command.stdout(Stdio::piped());

--- a/crates/app/src/tools/web_fetch.rs
+++ b/crates/app/src/tools/web_fetch.rs
@@ -65,6 +65,7 @@ fn execute_web_fetch_tool_enabled(
 
     super::web_http::run_async(async {
         loop {
+            let mut budget = super::download_guard::ByteBudget::new(max_bytes);
             let response = client
                 .get(current_url.clone())
                 .send()
@@ -115,30 +116,18 @@ fn execute_web_fetch_tool_enabled(
                 .get(reqwest::header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
                 .map(|value| value.to_owned());
+            budget.reject_if_content_length_exceeds(
+                response.content_length(),
+                "web.fetch response",
+            )?;
 
-            // Short-circuit on Content-Length when the server advertises it.
-            if let Some(content_length) = response.content_length()
-                && content_length > max_bytes as u64
-            {
-                return Err(format!(
-                    "web.fetch response Content-Length ({content_length}) exceeds max_bytes limit ({max_bytes} bytes)"
-                ));
-            }
-
-            // Stream the body with a hard cap at max_bytes + 1 to detect
-            // oversize responses without unbounded memory allocation.
-            let limit = (max_bytes as u64).saturating_add(1);
             let mut body = Vec::new();
             let mut stream = response.bytes_stream();
             use futures_util::StreamExt;
             while let Some(chunk) = stream.next().await {
                 let chunk = chunk
                     .map_err(|error| format!("failed to read web.fetch response body: {error}"))?;
-                if body.len() as u64 + chunk.len() as u64 > limit {
-                    return Err(format!(
-                        "web.fetch response exceeded max_bytes limit ({max_bytes} bytes)"
-                    ));
-                }
+                budget.try_consume(chunk.len(), "web.fetch response")?;
                 body.extend_from_slice(&chunk);
             }
 
@@ -174,7 +163,7 @@ fn execute_web_fetch_tool_enabled(
                     "mode": mode.as_str(),
                     "content": content,
                     "title": title,
-                    "bytes_downloaded": body.len(),
+                    "bytes_downloaded": budget.consumed(),
                     "redirect_count": redirect_count,
                 }),
             });

--- a/crates/contracts/src/audit_types.rs
+++ b/crates/contracts/src/audit_types.rs
@@ -110,9 +110,18 @@ pub enum AuditEventKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditIntegrity {
+    pub algorithm: String,
+    pub prev_hash: Option<String>,
+    pub entry_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuditEvent {
     pub event_id: String,
     pub timestamp_epoch_s: u64,
     pub agent_id: Option<String>,
     pub kind: AuditEventKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<AuditIntegrity>,
 }

--- a/crates/contracts/src/audit_types.rs
+++ b/crates/contracts/src/audit_types.rs
@@ -110,18 +110,9 @@ pub enum AuditEventKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuditIntegrity {
-    pub algorithm: String,
-    pub prev_hash: Option<String>,
-    pub entry_hash: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuditEvent {
     pub event_id: String,
     pub timestamp_epoch_s: u64,
     pub agent_id: Option<String>,
     pub kind: AuditEventKind,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub integrity: Option<AuditIntegrity>,
 }

--- a/crates/contracts/src/child_process_env.rs
+++ b/crates/contracts/src/child_process_env.rs
@@ -1,0 +1,116 @@
+use std::ffi::{OsStr, OsString};
+
+pub const HIGH_RISK_CHILD_PROCESS_ENV_VARS: &[&str] = &[
+    "CC",
+    "CXX",
+    "CARGO_BUILD_RUSTC",
+    "CMAKE_C_COMPILER",
+    "CMAKE_CXX_COMPILER",
+    "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
+    "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "PYTHONPATH",
+];
+
+const ESSENTIAL_CHILD_PROCESS_ENV_VARS: &[&str] = &[
+    "APPDATA",
+    "COLORTERM",
+    "COMSPEC",
+    "HOME",
+    "LANG",
+    "LOCALAPPDATA",
+    "LOGNAME",
+    "NO_COLOR",
+    "PATH",
+    "PATHEXT",
+    "PWD",
+    "SHELL",
+    "SYSTEMROOT",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "USERPROFILE",
+    "WINDIR",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_RUNTIME_DIR",
+];
+
+const ESSENTIAL_CHILD_PROCESS_ENV_PREFIXES: &[&str] = &["LC_"];
+
+#[must_use]
+pub fn child_process_env_var_is_allowed(name: &OsStr) -> bool {
+    let rendered = name.to_string_lossy();
+
+    let is_blocked = HIGH_RISK_CHILD_PROCESS_ENV_VARS
+        .iter()
+        .any(|blocked| rendered.eq_ignore_ascii_case(blocked));
+
+    if is_blocked {
+        return false;
+    }
+
+    let is_allowed = ESSENTIAL_CHILD_PROCESS_ENV_VARS
+        .iter()
+        .any(|allowed| rendered.eq_ignore_ascii_case(allowed));
+
+    if is_allowed {
+        return true;
+    }
+
+    let normalized = rendered.to_ascii_uppercase();
+
+    ESSENTIAL_CHILD_PROCESS_ENV_PREFIXES
+        .iter()
+        .any(|prefix| normalized.starts_with(prefix))
+}
+
+#[must_use]
+pub fn sanitized_child_process_env() -> Vec<(OsString, OsString)> {
+    std::env::vars_os()
+        .filter(|(name, _)| child_process_env_var_is_allowed(name))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn child_process_env_blocks_high_risk_toolchain_and_index_overrides() {
+        assert!(!child_process_env_var_is_allowed(OsStr::new(
+            "UV_INDEX_URL"
+        )));
+        assert!(!child_process_env_var_is_allowed(OsStr::new(
+            "PIP_EXTRA_INDEX_URL"
+        )));
+        assert!(!child_process_env_var_is_allowed(OsStr::new("PYTHONPATH")));
+        assert!(!child_process_env_var_is_allowed(OsStr::new(
+            "CMAKE_C_COMPILER"
+        )));
+    }
+
+    #[test]
+    fn child_process_env_keeps_essential_runtime_variables() {
+        assert!(child_process_env_var_is_allowed(OsStr::new("PATH")));
+        assert!(child_process_env_var_is_allowed(OsStr::new("HOME")));
+        assert!(child_process_env_var_is_allowed(OsStr::new("TMPDIR")));
+    }
+
+    #[test]
+    fn child_process_env_keeps_loongclaw_prefixed_variables() {
+        assert!(child_process_env_var_is_allowed(OsStr::new("LC_TEST_FLAG")));
+        assert!(child_process_env_var_is_allowed(OsStr::new("lc_test_flag")));
+    }
+
+    #[test]
+    fn child_process_env_drops_unrecognized_variables() {
+        assert!(!child_process_env_var_is_allowed(OsStr::new(
+            "RANDOM_CUSTOM_FLAG"
+        )));
+    }
+}

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 mod audit_types;
+mod child_process_env;
 mod clock;
 mod contracts;
 mod errors;
@@ -18,7 +19,10 @@ mod task_state;
 mod tool_types;
 mod workflow_types;
 
-pub use audit_types::{AuditEvent, AuditEventKind, ExecutionPlane, PlaneTier};
+pub use audit_types::{AuditEvent, AuditEventKind, AuditIntegrity, ExecutionPlane, PlaneTier};
+pub use child_process_env::{
+    HIGH_RISK_CHILD_PROCESS_ENV_VARS, child_process_env_var_is_allowed, sanitized_child_process_env,
+};
 pub use clock::{Clock, FixedClock, SystemClock};
 pub use contracts::{
     Capability, CapabilityToken, ConnectorCommand, ConnectorOutcome, ExecutionRoute, HarnessKind,

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -19,7 +19,7 @@ mod task_state;
 mod tool_types;
 mod workflow_types;
 
-pub use audit_types::{AuditEvent, AuditEventKind, AuditIntegrity, ExecutionPlane, PlaneTier};
+pub use audit_types::{AuditEvent, AuditEventKind, ExecutionPlane, PlaneTier};
 pub use child_process_env::{
     HIGH_RISK_CHILD_PROCESS_ENV_VARS, child_process_env_var_is_allowed, sanitized_child_process_env,
 };

--- a/crates/daemon/src/audit_cli.rs
+++ b/crates/daemon/src/audit_cli.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use clap::Subcommand;
 
-use crate::kernel::{AuditEvent, AuditEventKind, PluginTrustTier};
+use crate::kernel::{AuditEvent, AuditEventKind, PluginTrustTier, verify_jsonl_audit_journal};
 use loongclaw_spec::CliResult;
 use serde_json::{Map, Value, json};
 
@@ -101,6 +101,8 @@ pub enum AuditCommands {
         #[arg(long, value_parser = parse_audit_identity_filter)]
         agent_id: Option<String>,
     },
+    /// Verify the integrity chain of the durable audit journal
+    Verify,
 }
 
 #[derive(Debug, Clone)]
@@ -257,6 +259,14 @@ pub enum AuditCommandResult {
         revoked_agent_id: Option<String>,
         timeline: Vec<AuditEvent>,
     },
+    Verify {
+        loaded_events: usize,
+        verified_events: usize,
+        valid: bool,
+        last_entry_hash: Option<String>,
+        first_invalid_line: Option<usize>,
+        reason: Option<String>,
+    },
 }
 
 pub fn run_audit_cli(options: AuditCommandOptions) -> CliResult<()> {
@@ -392,9 +402,29 @@ pub fn execute_audit_command(options: AuditCommandOptions) -> CliResult<AuditCom
             None,
             "audit token-trail",
         ),
+        AuditCommands::Verify => (
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "audit verify",
+        ),
     };
-    let limit = validate_audit_limit(limit, command_name)?;
-    validate_audit_time_range(since_epoch_s_filter, until_epoch_s_filter, command_name)?;
+    let _limit = if matches!(command, AuditCommands::Verify) {
+        0
+    } else {
+        validate_audit_limit(limit, command_name)?
+    };
+    if !matches!(command, AuditCommands::Verify) {
+        validate_audit_time_range(since_epoch_s_filter, until_epoch_s_filter, command_name)?;
+    }
     let filter = AuditEventFilter {
         since_epoch_s: since_epoch_s_filter,
         until_epoch_s: until_epoch_s_filter,
@@ -410,17 +440,27 @@ pub fn execute_audit_command(options: AuditCommandOptions) -> CliResult<AuditCom
 
     let (resolved_path, config) = crate::mvp::config::load(config.as_deref())?;
     let journal_path = config.audit.resolved_path();
-    let audit_window = load_audit_event_window(&config.audit, &journal_path, limit, &filter)?;
-    let total_matching_events = audit_window.total_matching_events;
-    let events = audit_window.events;
     let result = match command {
-        AuditCommands::Recent { limit, .. } => AuditCommandResult::Recent { limit, events },
+        AuditCommands::Recent { limit, .. } => {
+            let audit_window =
+                load_audit_event_window(&config.audit, &journal_path, limit, &filter)?;
+            let events = audit_window.events;
+            AuditCommandResult::Recent { limit, events }
+        }
         AuditCommands::Summary {
             limit, group_by, ..
-        } => summarize_audit_events(limit, group_by, &events),
+        } => {
+            let audit_window =
+                load_audit_event_window(&config.audit, &journal_path, limit, &filter)?;
+            let events = audit_window.events;
+            summarize_audit_events(limit, group_by, &events)
+        }
         AuditCommands::Discovery {
             limit, group_by, ..
         } => {
+            let audit_window =
+                load_audit_event_window(&config.audit, &journal_path, limit, &filter)?;
+            let events = audit_window.events;
             let correlated_summary_groups = if group_by.is_some() {
                 let broader_window = load_audit_event_window(
                     &config.audit,
@@ -442,7 +482,25 @@ pub fn execute_audit_command(options: AuditCommandOptions) -> CliResult<AuditCom
         }
         AuditCommands::TokenTrail {
             limit, token_id, ..
-        } => summarize_token_trail(limit, token_id, events, total_matching_events),
+        } => {
+            let audit_window =
+                load_audit_event_window(&config.audit, &journal_path, limit, &filter)?;
+            let total_matching_events = audit_window.total_matching_events;
+            let events = audit_window.events;
+            summarize_token_trail(limit, token_id, events, total_matching_events)
+        }
+        AuditCommands::Verify => {
+            let report = verify_jsonl_audit_journal(&journal_path)
+                .map_err(|error| format!("verify audit journal failed: {error}"))?;
+            AuditCommandResult::Verify {
+                loaded_events: report.total_events,
+                verified_events: report.verified_events,
+                valid: report.valid,
+                last_entry_hash: report.last_entry_hash,
+                first_invalid_line: report.first_invalid_line,
+                reason: report.reason,
+            }
+        }
     };
 
     Ok(AuditCommandExecution {
@@ -762,6 +820,23 @@ pub fn audit_cli_json(execution: &AuditCommandExecution) -> Value {
             );
             payload.insert("revoked_agent_id".to_owned(), json!(revoked_agent_id));
             payload.insert("timeline".to_owned(), json!(timeline));
+            Value::Object(payload)
+        }
+        AuditCommandResult::Verify {
+            loaded_events,
+            verified_events,
+            valid,
+            last_entry_hash,
+            first_invalid_line,
+            reason,
+        } => {
+            let mut payload = audit_cli_base_json(execution, "verify");
+            payload.insert("loaded_events".to_owned(), json!(loaded_events));
+            payload.insert("verified_events".to_owned(), json!(verified_events));
+            payload.insert("valid".to_owned(), json!(valid));
+            payload.insert("last_entry_hash".to_owned(), json!(last_entry_hash));
+            payload.insert("first_invalid_line".to_owned(), json!(first_invalid_line));
+            payload.insert("reason".to_owned(), json!(reason));
             Value::Object(payload)
         }
     }
@@ -1632,6 +1707,31 @@ pub fn render_audit_cli_text(execution: &AuditCommandExecution) -> CliResult<Str
                     detail
                 ));
             }
+        }
+        AuditCommandResult::Verify {
+            loaded_events,
+            verified_events,
+            valid,
+            last_entry_hash,
+            first_invalid_line,
+            reason,
+        } => {
+            lines.push(format!(
+                "audit verify config={} journal={} loaded_events={} verified_events={} valid={}",
+                execution.resolved_config_path,
+                execution.journal_path,
+                loaded_events,
+                verified_events,
+                valid
+            ));
+            lines.push(format!(
+                "last_entry_hash={} first_invalid_line={} reason={}",
+                last_entry_hash.as_deref().unwrap_or("-"),
+                first_invalid_line
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_owned()),
+                reason.as_deref().unwrap_or("-")
+            ));
         }
     }
     Ok(lines.join("\n"))
@@ -2936,7 +3036,8 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use crate::kernel::{
-        AuditEvent, AuditEventKind, Capability, CapabilityToken, ExecutionPlane, PlaneTier,
+        AuditEvent, AuditEventKind, AuditSink, Capability, CapabilityToken, ExecutionPlane,
+        PlaneTier,
     };
     use crate::test_support::ScopedEnv;
 
@@ -2983,6 +3084,7 @@ mod tests {
             timestamp_epoch_s,
             agent_id: agent_id.map(str::to_owned),
             kind,
+            integrity: None,
         }
     }
 
@@ -6269,6 +6371,103 @@ mod tests {
             payload["last_triage_hint"],
             "grant the required capability or retry with a token scoped for the requested operation"
         );
+    }
+
+    #[test]
+    fn audit_verify_reports_valid_chain_for_fresh_journal() {
+        let root = unique_temp_dir("loongclaw-audit-cli-verify");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        let sink =
+            crate::kernel::JsonlAuditSink::new(journal_path).expect("jsonl sink should initialize");
+
+        sink.record(sample_audit_event(
+            "evt-verify-1",
+            1_700_010_300,
+            Some("agent-verify"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-verify-1".to_owned(),
+            },
+        ))
+        .expect("record first event");
+
+        sink.record(sample_audit_event(
+            "evt-verify-2",
+            1_700_010_301,
+            Some("agent-verify"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-verify-2".to_owned(),
+            },
+        ))
+        .expect("record second event");
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Verify,
+        })
+        .expect("execute audit verify");
+
+        match execution.result {
+            AuditCommandResult::Verify {
+                loaded_events,
+                verified_events,
+                valid,
+                ..
+            } => {
+                assert_eq!(loaded_events, 2);
+                assert_eq!(verified_events, 2);
+                assert!(valid);
+            }
+            other => panic!("unexpected audit verify result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_verify_reports_first_invalid_line_for_tampered_chain() {
+        let root = unique_temp_dir("loongclaw-audit-cli-verify-tamper");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        let sink = crate::kernel::JsonlAuditSink::new(journal_path.clone())
+            .expect("jsonl sink should initialize");
+
+        sink.record(sample_audit_event(
+            "evt-tamper-1",
+            1_700_010_310,
+            Some("agent-tamper"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-tamper-1".to_owned(),
+            },
+        ))
+        .expect("record first event");
+
+        sink.record(sample_audit_event(
+            "evt-tamper-2",
+            1_700_010_311,
+            Some("agent-tamper"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-tamper-2".to_owned(),
+            },
+        ))
+        .expect("record second event");
+
+        let contents = fs::read_to_string(&journal_path).expect("read audit journal");
+        let tampered = contents.replacen("token-tamper-2", "token-tamper-x", 1);
+        fs::write(&journal_path, tampered).expect("rewrite tampered journal");
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: true,
+            command: AuditCommands::Verify,
+        })
+        .expect("execute audit verify");
+
+        let payload = audit_cli_json(&execution);
+
+        assert_eq!(payload["command"], "verify");
+        assert_eq!(payload["valid"], json!(false));
+        assert_eq!(payload["first_invalid_line"], json!(2));
+        assert_eq!(payload["reason"], json!("entry_hash mismatch"));
     }
 
     #[test]

--- a/crates/daemon/src/audit_cli.rs
+++ b/crates/daemon/src/audit_cli.rs
@@ -490,6 +490,7 @@ pub fn execute_audit_command(options: AuditCommandOptions) -> CliResult<AuditCom
             summarize_token_trail(limit, token_id, events, total_matching_events)
         }
         AuditCommands::Verify => {
+            ensure_audit_journal_preflight(&config.audit, &journal_path)?;
             let report = verify_jsonl_audit_journal(&journal_path)
                 .map_err(|error| format!("verify audit journal failed: {error}"))?;
             AuditCommandResult::Verify {
@@ -1783,18 +1784,20 @@ struct AuditEventWindow {
     total_matching_events: usize,
 }
 
-fn load_audit_event_window(
+fn audit_journal_missing_hint(audit: &crate::mvp::config::AuditConfig) -> &'static str {
+    if audit.mode == crate::mvp::config::AuditMode::InMemory {
+        return "durable audit retention is disabled because [audit].mode = \"in_memory\"";
+    }
+
+    "journal is created on first audit write"
+}
+
+fn ensure_audit_journal_preflight(
     audit: &crate::mvp::config::AuditConfig,
     journal_path: &Path,
-    limit: usize,
-    filter: &AuditEventFilter,
-) -> CliResult<AuditEventWindow> {
+) -> CliResult<()> {
     if !journal_path.exists() {
-        let hint = if audit.mode == crate::mvp::config::AuditMode::InMemory {
-            "durable audit retention is disabled because [audit].mode = \"in_memory\""
-        } else {
-            "journal is created on first audit write"
-        };
+        let hint = audit_journal_missing_hint(audit);
         return Err(format!(
             "audit journal not found at {} ({hint})",
             journal_path.display()
@@ -1806,6 +1809,17 @@ fn load_audit_event_window(
             journal_path.display()
         ));
     }
+
+    Ok(())
+}
+
+fn load_audit_event_window(
+    audit: &crate::mvp::config::AuditConfig,
+    journal_path: &Path,
+    limit: usize,
+    filter: &AuditEventFilter,
+) -> CliResult<AuditEventWindow> {
+    ensure_audit_journal_preflight(audit, journal_path)?;
 
     let file = File::open(journal_path).map_err(|error| {
         format!(
@@ -3084,7 +3098,6 @@ mod tests {
             timestamp_epoch_s,
             agent_id: agent_id.map(str::to_owned),
             kind,
-            integrity: None,
         }
     }
 
@@ -5541,6 +5554,45 @@ mod tests {
     }
 
     #[test]
+    fn audit_verify_reports_missing_journal_with_first_write_hint() {
+        let root = unique_temp_dir("loongclaw-audit-cli-verify-missing");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+
+        let error = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Verify,
+        })
+        .expect_err("missing journal should fail");
+
+        assert!(error.contains("audit journal not found"));
+        assert!(error.contains("first audit write"));
+    }
+
+    #[test]
+    fn audit_verify_reports_in_memory_mode_when_journal_is_missing() {
+        let root = unique_temp_dir("loongclaw-audit-cli-verify-in-memory");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config_with_mode(
+            &root,
+            &journal_path,
+            crate::mvp::config::AuditMode::InMemory,
+        );
+
+        let error = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: false,
+            command: AuditCommands::Verify,
+        })
+        .expect_err("missing in-memory journal should fail");
+
+        assert!(error.contains("audit journal not found"));
+        assert!(error.contains("durable audit retention is disabled"));
+        assert!(error.contains("[audit].mode = \"in_memory\""));
+    }
+
+    #[test]
     fn audit_summary_rolls_up_event_kinds_and_last_seen_fields() {
         let root = unique_temp_dir("loongclaw-audit-cli-summary");
         let journal_path = root.join("audit").join("events.jsonl");
@@ -6468,6 +6520,49 @@ mod tests {
         assert_eq!(payload["valid"], json!(false));
         assert_eq!(payload["first_invalid_line"], json!(2));
         assert_eq!(payload["reason"], json!("entry_hash mismatch"));
+    }
+
+    #[test]
+    fn audit_verify_accepts_legacy_prefix_and_verifies_protected_tail() {
+        let root = unique_temp_dir("loongclaw-audit-cli-verify-legacy-prefix");
+        let journal_path = root.join("audit").join("events.jsonl");
+        let config_path = write_audit_config(&root, &journal_path);
+        let legacy_event = sample_audit_event(
+            "evt-legacy-1",
+            1_700_010_320,
+            Some("agent-legacy"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-legacy-1".to_owned(),
+            },
+        );
+        write_journal(&journal_path, &[legacy_event]);
+        let sink =
+            crate::kernel::JsonlAuditSink::new(journal_path).expect("jsonl sink should initialize");
+
+        sink.record(sample_audit_event(
+            "evt-verify-legacy-tail",
+            1_700_010_321,
+            Some("agent-legacy"),
+            AuditEventKind::TokenRevoked {
+                token_id: "token-legacy-2".to_owned(),
+            },
+        ))
+        .expect("record protected event");
+
+        let execution = execute_audit_command(AuditCommandOptions {
+            config: Some(config_path.display().to_string()),
+            json: true,
+            command: AuditCommands::Verify,
+        })
+        .expect("execute audit verify");
+
+        let payload = audit_cli_json(&execution);
+
+        assert_eq!(payload["command"], "verify");
+        assert_eq!(payload["loaded_events"], json!(2));
+        assert_eq!(payload["verified_events"], json!(1));
+        assert_eq!(payload["valid"], json!(true));
+        assert_eq!(payload["first_invalid_line"], Value::Null);
     }
 
     #[test]

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -509,10 +509,12 @@ mod tests {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
         let temp_dir = browser_companion_temp_dir("double-transient-timeout");
         let script_path = temp_dir.join("browser-companion");
-        let state_path = temp_dir.join("probe-state");
+        let first_timeout_path = temp_dir.join("probe-timeout-1");
+        let second_timeout_path = temp_dir.join("probe-timeout-2");
         let script_body = format!(
-            "#!/bin/sh\nstate_path='{}'\nattempt=0\nif [ -f \"$state_path\" ]; then\n  attempt=$(cat \"$state_path\")\nfi\nnext_attempt=$((attempt + 1))\nprintf '%s' \"$next_attempt\" > \"$state_path\"\nif [ \"$next_attempt\" -le 2 ]; then\n  /bin/sleep 6\nfi\necho 'loongclaw-browser-companion 1.5.0'\n",
-            state_path.display()
+            "#!/bin/sh\nfirst_timeout_path='{}'\nsecond_timeout_path='{}'\nif [ ! -f \"$first_timeout_path\" ]; then\n  touch \"$first_timeout_path\"\n  /bin/sleep 6\nfi\nif [ ! -f \"$second_timeout_path\" ]; then\n  touch \"$second_timeout_path\"\n  /bin/sleep 6\nfi\necho 'loongclaw-browser-companion 1.5.0'\n",
+            first_timeout_path.display(),
+            second_timeout_path.display()
         );
         write_browser_companion_script(&script_path, script_body.as_str());
 

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
-use kernel::probe_jsonl_audit_journal_runtime_ready;
+use kernel::{probe_jsonl_audit_journal_runtime_ready, verify_jsonl_audit_journal};
 use loongclaw_app as mvp;
 use loongclaw_contracts::SecretRef;
 use loongclaw_spec::CliResult;
@@ -138,6 +138,7 @@ pub async fn run_doctor_cli(options: DoctorCommandOptions) -> CliResult<()> {
         "create memory directory",
     ));
     checks.push(audit_retention_doctor_check(&config.audit));
+    checks.push(audit_integrity_doctor_check(&config.audit));
     if matches!(
         config.audit.mode,
         mvp::config::AuditMode::Jsonl | mvp::config::AuditMode::Fanout
@@ -439,6 +440,59 @@ fn durable_audit_runtime_probe(path: &Path) -> Result<(), String> {
         (Err(error), _) => Err(error),
         (Ok(()), Err(error)) => Err(error),
         (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn audit_integrity_doctor_check(audit: &mvp::config::AuditConfig) -> DoctorCheck {
+    if matches!(audit.mode, mvp::config::AuditMode::InMemory) {
+        return DoctorCheck {
+            name: "audit integrity".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: "audit integrity verification is unavailable while audit.mode=in_memory"
+                .to_owned(),
+        };
+    }
+
+    let journal_path = audit.resolved_path();
+    if !journal_path.exists() {
+        return DoctorCheck {
+            name: "audit integrity".to_owned(),
+            level: DoctorCheckLevel::Warn,
+            detail: format!(
+                "audit journal {} has not been created yet, so integrity verification is not available until the first durable write",
+                journal_path.display()
+            ),
+        };
+    }
+
+    match verify_jsonl_audit_journal(&journal_path) {
+        Ok(report) if report.valid => DoctorCheck {
+            name: "audit integrity".to_owned(),
+            level: DoctorCheckLevel::Pass,
+            detail: format!(
+                "verified {} of {} audit events (last_entry_hash={})",
+                report.verified_events,
+                report.total_events,
+                report.last_entry_hash.as_deref().unwrap_or("-")
+            ),
+        },
+        Ok(report) => DoctorCheck {
+            name: "audit integrity".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: format!(
+                "audit journal integrity failed at line {} ({})",
+                report
+                    .first_invalid_line
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_owned()),
+                report.reason.as_deref().unwrap_or("unknown reason")
+            ),
+        },
+        Err(error) => DoctorCheck {
+            name: "audit integrity".to_owned(),
+            level: DoctorCheckLevel::Fail,
+            detail: format!("audit integrity verification failed: {error}"),
+        },
     }
 }
 
@@ -2668,6 +2722,7 @@ mod tests {
 
     use super::*;
     use crate::test_support::ScopedEnv;
+    use kernel::AuditSink;
     use mvp::channel::{
         ChannelOperationHealth, ChannelOperationRuntime, ChannelOperationStatus,
         ChannelStatusSnapshot,
@@ -2682,6 +2737,21 @@ mod tests {
         ));
         std::fs::create_dir_all(&temp_dir).expect("create browser companion temp dir");
         temp_dir
+    }
+
+    fn sample_audit_event(
+        event_id: &str,
+        timestamp_epoch_s: u64,
+        agent_id: Option<&str>,
+        kind: kernel::AuditEventKind,
+    ) -> kernel::AuditEvent {
+        kernel::AuditEvent {
+            event_id: event_id.to_owned(),
+            timestamp_epoch_s,
+            agent_id: agent_id.map(str::to_owned),
+            kind,
+            integrity: None,
+        }
     }
 
     fn managed_bridge_manifest(
@@ -3898,6 +3968,90 @@ mod tests {
         assert_eq!(check.name, "audit retention");
         assert_eq!(check.level, DoctorCheckLevel::Warn);
         assert!(check.detail.contains("lost on restart"));
+    }
+
+    #[test]
+    fn audit_integrity_doctor_check_warns_for_in_memory_mode() {
+        let check = audit_integrity_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::InMemory,
+            ..mvp::config::AuditConfig::default()
+        });
+
+        assert_eq!(check.name, "audit integrity");
+        assert_eq!(check.level, DoctorCheckLevel::Warn);
+        assert!(
+            check
+                .detail
+                .contains("unavailable while audit.mode=in_memory")
+        );
+    }
+
+    #[test]
+    fn audit_integrity_doctor_check_passes_for_valid_chain() {
+        let temp_dir = browser_companion_temp_dir("audit-integrity-valid");
+        let journal_path = temp_dir.join("events.jsonl");
+        let sink = kernel::JsonlAuditSink::new(journal_path.clone()).expect("create jsonl sink");
+
+        sink.record(sample_audit_event(
+            "evt-integrity-1",
+            1_700_010_400,
+            Some("agent-a"),
+            kernel::AuditEventKind::TokenRevoked {
+                token_id: "token-a".to_owned(),
+            },
+        ))
+        .expect("record event");
+
+        let check = audit_integrity_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::Jsonl,
+            path: journal_path.display().to_string(),
+            retain_in_memory: false,
+        });
+
+        assert_eq!(check.name, "audit integrity");
+        assert_eq!(check.level, DoctorCheckLevel::Pass);
+        assert!(check.detail.contains("verified 1 of 1 audit events"));
+    }
+
+    #[test]
+    fn audit_integrity_doctor_check_fails_for_tampered_chain() {
+        let temp_dir = browser_companion_temp_dir("audit-integrity-tampered");
+        let journal_path = temp_dir.join("events.jsonl");
+        let sink = kernel::JsonlAuditSink::new(journal_path.clone()).expect("create jsonl sink");
+
+        sink.record(sample_audit_event(
+            "evt-integrity-1",
+            1_700_010_410,
+            Some("agent-a"),
+            kernel::AuditEventKind::TokenRevoked {
+                token_id: "token-a".to_owned(),
+            },
+        ))
+        .expect("record event");
+
+        sink.record(sample_audit_event(
+            "evt-integrity-2",
+            1_700_010_411,
+            Some("agent-b"),
+            kernel::AuditEventKind::TokenRevoked {
+                token_id: "token-b".to_owned(),
+            },
+        ))
+        .expect("record event");
+
+        let contents = std::fs::read_to_string(&journal_path).expect("read audit journal");
+        let tampered = contents.replacen("token-b", "token-x", 1);
+        std::fs::write(&journal_path, tampered).expect("rewrite tampered journal");
+
+        let check = audit_integrity_doctor_check(&mvp::config::AuditConfig {
+            mode: mvp::config::AuditMode::Jsonl,
+            path: journal_path.display().to_string(),
+            retain_in_memory: false,
+        });
+
+        assert_eq!(check.name, "audit integrity");
+        assert_eq!(check.level, DoctorCheckLevel::Fail);
+        assert!(check.detail.contains("failed at line 2"));
     }
 
     #[test]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -2750,7 +2750,6 @@ mod tests {
             timestamp_epoch_s,
             agent_id: agent_id.map(str::to_owned),
             kind,
-            integrity: None,
         }
     }
 

--- a/crates/daemon/src/feishu_cli.rs
+++ b/crates/daemon/src/feishu_cli.rs
@@ -1632,6 +1632,7 @@ pub async fn execute_feishu_messages_resource(
         &args.message_id,
         &args.file_key,
         args.resource_type.as_resource_type(),
+        mvp::channel::feishu::api::resources::media::FEISHU_MESSAGE_RESOURCE_DOWNLOAD_MAX_BYTES,
     )
     .await?;
     let output = args.output.trim();

--- a/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
+++ b/crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs
@@ -383,6 +383,125 @@ async fn execute_spec_process_stdio_bridge_fails_on_invalid_json_line_response()
 
 #[cfg(not(target_os = "windows"))]
 #[tokio::test]
+async fn execute_spec_process_stdio_bridge_strips_high_risk_env_vars_from_child_process() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let mut env = loongclaw_daemon::test_support::ScopedEnv::new();
+    env.set("CC", "malicious-cc");
+    env.set("PYTHONPATH", "/tmp/malicious-pythonpath");
+    env.set("LC_CHILD_TEST", "keep-me");
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be monotonic")
+        .as_nanos();
+    let plugin_root = std::env::temp_dir().join(format!(
+        "loongclaw-plugin-process-stdio-env-sanitized-{unique}"
+    ));
+    fs::create_dir_all(&plugin_root).expect("create plugin root");
+
+    fs::write(
+        plugin_root.join("stdio_plugin.py"),
+        r#"
+# LOONGCLAW_PLUGIN_START
+# {
+#   "plugin_id": "stdio-env-sanitized-plugin",
+#   "provider_id": "stdio-env-sanitized-provider",
+#   "connector_name": "stdio-env-sanitized-provider",
+#   "channel_id": "primary",
+#   "endpoint": "local://stdio-env-sanitized-provider",
+#   "capabilities": ["InvokeConnector"],
+#   "metadata": {
+#     "bridge_kind":"process_stdio",
+#     "command":"python3",
+#     "process_timeout_ms":"15000",
+#     "args_json":"[\"-c\",\"import json, os, sys; request=json.loads(sys.stdin.readline()); payload={'cc': os.environ.get('CC', 'unset'), 'pythonpath': os.environ.get('PYTHONPATH', 'unset'), 'lc_child_test': os.environ.get('LC_CHILD_TEST', 'unset'), 'path': 'set' if os.environ.get('PATH') else 'unset'}; response={'method': request['method'], 'id': request['id'], 'payload': payload}; sys.stdout.write(json.dumps(response)+'\\\\n'); sys.stdout.flush()\"]",
+#     "version":"1.0.0"
+#   }
+# }
+# LOONGCLAW_PLUGIN_END
+"#,
+    )
+    .expect("write stdio plugin");
+
+    let spec = RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id: "spec-process-stdio-env-sanitized".to_owned(),
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::new(),
+            metadata: BTreeMap::new(),
+        },
+        agent_id: "agent-process-stdio-env-sanitized".to_owned(),
+        ttl_s: 120,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: Some(PluginScanSpec {
+            enabled: true,
+            roots: vec![plugin_root.display().to_string()],
+        }),
+        bridge_support: Some(BridgeSupportSpec {
+            enabled: true,
+            supported_bridges: vec![PluginBridgeKind::ProcessStdio],
+            supported_adapter_families: Vec::new(),
+            supported_compatibility_modes: vec![PluginCompatibilityMode::Native],
+            supported_compatibility_shims: Vec::new(),
+            supported_compatibility_shim_profiles: Vec::new(),
+            enforce_supported: true,
+            policy_version: None,
+            expected_checksum: None,
+            expected_sha256: None,
+            execute_process_stdio: true,
+            execute_http_json: false,
+            allowed_process_commands: vec!["python3".to_owned()],
+            enforce_execution_success: true,
+            security_scan: None,
+        }),
+        bootstrap: Some(BootstrapSpec {
+            enabled: true,
+            allow_http_json_auto_apply: Some(false),
+            allow_process_stdio_auto_apply: Some(true),
+            allow_native_ffi_auto_apply: Some(false),
+            allow_wasm_component_auto_apply: Some(false),
+            allow_mcp_server_auto_apply: Some(false),
+            allow_acp_bridge_auto_apply: Some(false),
+            allow_acp_runtime_auto_apply: Some(false),
+            block_unverified_high_risk_auto_apply: None,
+            enforce_ready_execution: Some(true),
+            max_tasks: Some(10),
+        }),
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
+        operation: OperationSpec::ConnectorLegacy {
+            connector_name: "stdio-env-sanitized-provider".to_owned(),
+            operation: "invoke".to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeConnector]),
+            payload: json!({"question":"ping"}),
+        },
+    };
+
+    let report = execute_spec(&spec, true).await;
+    let bridge_execution = &report.outcome["outcome"]["payload"]["bridge_execution"];
+    let response_payload = &bridge_execution["runtime"]["stdout_json"];
+
+    assert_eq!(report.operation_kind, "connector_legacy");
+    assert_eq!(report.outcome["outcome"]["status"], "ok");
+    assert_eq!(bridge_execution["status"], "executed");
+    assert_eq!(response_payload["cc"], "unset");
+    assert_eq!(response_payload["pythonpath"], "unset");
+    assert_eq!(response_payload["lc_child_test"], "keep-me");
+    assert_eq!(response_payload["path"], "set");
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
 async fn execute_spec_process_stdio_bridge_fails_on_response_id_mismatch() {
     use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -12,9 +12,11 @@ homepage.workspace = true
 loongclaw-contracts = { version = "0.1.0-alpha.3", path = "../contracts" }
 async-trait.workspace = true
 futures-util.workspace = true
+hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 semver.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 
 [features]

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -1,10 +1,13 @@
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 // Re-export data types from contracts
-pub use loongclaw_contracts::{AuditEvent, AuditEventKind, ExecutionPlane, PlaneTier};
+pub use loongclaw_contracts::{
+    AuditEvent, AuditEventKind, AuditIntegrity, ExecutionPlane, PlaneTier,
+};
+use sha2::{Digest, Sha256};
 
 use crate::errors::AuditError;
 
@@ -47,9 +50,25 @@ impl AuditSink for InMemoryAuditSink {
 }
 
 #[derive(Debug)]
+struct JsonlAuditJournalState {
+    file: File,
+    last_entry_hash: Option<String>,
+}
+
+#[derive(Debug)]
 pub struct JsonlAuditSink {
     path: PathBuf,
-    journal: Mutex<File>,
+    journal: Mutex<JsonlAuditJournalState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditVerificationReport {
+    pub total_events: usize,
+    pub verified_events: usize,
+    pub valid: bool,
+    pub last_entry_hash: Option<String>,
+    pub first_invalid_line: Option<usize>,
+    pub reason: Option<String>,
 }
 
 fn prepare_audit_journal_parent(path: &Path) -> Result<(), AuditError> {
@@ -111,12 +130,219 @@ pub fn probe_jsonl_audit_journal_runtime_ready(path: &Path) -> Result<(), AuditE
 impl JsonlAuditSink {
     pub fn new(path: PathBuf) -> Result<Self, AuditError> {
         let journal = open_jsonl_audit_journal(&path)?;
+        let last_entry_hash = load_last_audit_entry_hash(&path)?;
 
         Ok(Self {
             path,
-            journal: Mutex::new(journal),
+            journal: Mutex::new(JsonlAuditJournalState {
+                file: journal,
+                last_entry_hash,
+            }),
         })
     }
+}
+
+fn serialize_audit_event_chain_material(
+    event: &AuditEvent,
+    prev_hash: Option<&str>,
+    journal_path: &Path,
+) -> Result<Vec<u8>, AuditError> {
+    serde_json::to_vec(&serde_json::json!({
+        "event_id": event.event_id,
+        "timestamp_epoch_s": event.timestamp_epoch_s,
+        "agent_id": event.agent_id,
+        "kind": event.kind,
+        "prev_hash": prev_hash,
+    }))
+    .map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to serialize audit chain material for `{}`: {error}",
+            journal_path.display()
+        ))
+    })
+}
+
+fn compute_audit_event_entry_hash(
+    event: &AuditEvent,
+    prev_hash: Option<&str>,
+    journal_path: &Path,
+) -> Result<String, AuditError> {
+    let material = serialize_audit_event_chain_material(event, prev_hash, journal_path)?;
+    let digest = Sha256::digest(material);
+    let encoded = hex::encode(digest);
+    Ok(encoded)
+}
+
+fn event_with_integrity(
+    mut event: AuditEvent,
+    prev_hash: Option<String>,
+    entry_hash: String,
+) -> AuditEvent {
+    event.integrity = Some(AuditIntegrity {
+        algorithm: "sha256".to_owned(),
+        prev_hash,
+        entry_hash,
+    });
+    event
+}
+
+fn load_last_audit_entry_hash(path: &Path) -> Result<Option<String>, AuditError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let file = File::open(path).map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to inspect audit journal `{}`: {error}",
+            path.display()
+        ))
+    })?;
+    let reader = BufReader::new(file);
+    let mut last_non_empty_line = None;
+
+    for line_result in reader.lines() {
+        let line = line_result.map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to read audit journal `{}` while loading tail hash: {error}",
+                path.display()
+            ))
+        })?;
+        if !line.trim().is_empty() {
+            last_non_empty_line = Some(line);
+        }
+    }
+
+    let Some(line) = last_non_empty_line else {
+        return Ok(None);
+    };
+
+    let event = serde_json::from_str::<AuditEvent>(&line).map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to decode audit journal tail `{}`: {error}",
+            path.display()
+        ))
+    })?;
+
+    let integrity = event.integrity;
+    let last_hash = integrity.and_then(|value| {
+        let hash = value.entry_hash;
+        let trimmed_hash = hash.trim();
+        if trimmed_hash.is_empty() {
+            return None;
+        }
+        Some(hash)
+    });
+
+    Ok(last_hash)
+}
+
+pub fn verify_jsonl_audit_journal(path: &Path) -> Result<AuditVerificationReport, AuditError> {
+    if !path.exists() {
+        return Ok(AuditVerificationReport {
+            total_events: 0,
+            verified_events: 0,
+            valid: true,
+            last_entry_hash: None,
+            first_invalid_line: None,
+            reason: None,
+        });
+    }
+
+    let file = File::open(path).map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to open audit journal `{}` for verification: {error}",
+            path.display()
+        ))
+    })?;
+    let reader = BufReader::new(file);
+    let mut total_events = 0usize;
+    let mut verified_events = 0usize;
+    let mut previous_hash: Option<String> = None;
+
+    for (index, line_result) in reader.lines().enumerate() {
+        let line_number = index + 1;
+        let line = line_result.map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to read audit journal `{}` at line {}: {error}",
+                path.display(),
+                line_number
+            ))
+        })?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        total_events += 1;
+        let event = serde_json::from_str::<AuditEvent>(&line).map_err(|error| {
+            AuditError::Sink(format!(
+                "failed to decode audit journal `{}` at line {}: {error}",
+                path.display(),
+                line_number
+            ))
+        })?;
+
+        let Some(integrity) = event.integrity.as_ref() else {
+            return Ok(AuditVerificationReport {
+                total_events,
+                verified_events,
+                valid: false,
+                last_entry_hash: previous_hash,
+                first_invalid_line: Some(line_number),
+                reason: Some("missing integrity envelope".to_owned()),
+            });
+        };
+
+        if integrity.algorithm.trim() != "sha256" {
+            return Ok(AuditVerificationReport {
+                total_events,
+                verified_events,
+                valid: false,
+                last_entry_hash: previous_hash,
+                first_invalid_line: Some(line_number),
+                reason: Some(format!(
+                    "unsupported integrity algorithm `{}`",
+                    integrity.algorithm
+                )),
+            });
+        }
+
+        if integrity.prev_hash != previous_hash {
+            return Ok(AuditVerificationReport {
+                total_events,
+                verified_events,
+                valid: false,
+                last_entry_hash: previous_hash,
+                first_invalid_line: Some(line_number),
+                reason: Some("prev_hash mismatch".to_owned()),
+            });
+        }
+
+        let expected_hash =
+            compute_audit_event_entry_hash(&event, integrity.prev_hash.as_deref(), path)?;
+
+        if integrity.entry_hash != expected_hash {
+            return Ok(AuditVerificationReport {
+                total_events,
+                verified_events,
+                valid: false,
+                last_entry_hash: previous_hash,
+                first_invalid_line: Some(line_number),
+                reason: Some("entry_hash mismatch".to_owned()),
+            });
+        }
+
+        previous_hash = Some(integrity.entry_hash.clone());
+        verified_events += 1;
+    }
+
+    Ok(AuditVerificationReport {
+        total_events,
+        verified_events,
+        valid: true,
+        last_entry_hash: previous_hash,
+        first_invalid_line: None,
+        reason: None,
+    })
 }
 
 fn serialize_audit_event_line(
@@ -139,11 +365,16 @@ impl AuditSink for JsonlAuditSink {
             .journal
             .lock()
             .map_err(|_error| AuditError::Sink("audit journal mutex poisoned".to_owned()))?;
+        let previous_hash = guard.last_entry_hash.clone();
+        let entry_hash =
+            compute_audit_event_entry_hash(&event, previous_hash.as_deref(), &self.path)?;
+        let event = event_with_integrity(event, previous_hash, entry_hash.clone());
         let encoded = serialize_audit_event_line(&event, &self.path)?;
 
-        lock_audit_journal(&guard, &self.path)?;
+        lock_audit_journal(&guard.file, &self.path)?;
 
         let write_result = guard
+            .file
             .write_all(&encoded)
             .map_err(|error| {
                 AuditError::Sink(format!(
@@ -152,7 +383,7 @@ impl AuditSink for JsonlAuditSink {
                 ))
             })
             .and_then(|()| {
-                guard.flush().map_err(|error| {
+                guard.file.flush().map_err(|error| {
                     AuditError::Sink(format!(
                         "failed to flush audit journal `{}`: {error}",
                         self.path.display()
@@ -160,12 +391,15 @@ impl AuditSink for JsonlAuditSink {
                 })
             });
 
-        let unlock_result = unlock_audit_journal(&guard, &self.path);
+        let unlock_result = unlock_audit_journal(&guard.file, &self.path);
 
         match (write_result, unlock_result) {
             (Err(error), _) => Err(error),
             (Ok(()), Err(error)) => Err(error),
-            (Ok(()), Ok(())) => Ok(()),
+            (Ok(()), Ok(())) => {
+                guard.last_entry_hash = Some(entry_hash);
+                Ok(())
+            }
         }
     }
 }

--- a/crates/kernel/src/audit.rs
+++ b/crates/kernel/src/audit.rs
@@ -4,9 +4,8 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 // Re-export data types from contracts
-pub use loongclaw_contracts::{
-    AuditEvent, AuditEventKind, AuditIntegrity, ExecutionPlane, PlaneTier,
-};
+pub use loongclaw_contracts::{AuditEvent, AuditEventKind, ExecutionPlane, PlaneTier};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::errors::AuditError;
@@ -69,6 +68,21 @@ pub struct AuditVerificationReport {
     pub last_entry_hash: Option<String>,
     pub first_invalid_line: Option<usize>,
     pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PersistedAuditIntegrity {
+    algorithm: String,
+    prev_hash: Option<String>,
+    entry_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PersistedAuditEvent {
+    #[serde(flatten)]
+    event: AuditEvent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    integrity: Option<PersistedAuditIntegrity>,
 }
 
 fn prepare_audit_journal_parent(path: &Path) -> Result<(), AuditError> {
@@ -174,16 +188,34 @@ fn compute_audit_event_entry_hash(
 }
 
 fn event_with_integrity(
-    mut event: AuditEvent,
+    event: AuditEvent,
     prev_hash: Option<String>,
     entry_hash: String,
-) -> AuditEvent {
-    event.integrity = Some(AuditIntegrity {
+) -> PersistedAuditEvent {
+    let integrity = PersistedAuditIntegrity {
         algorithm: "sha256".to_owned(),
         prev_hash,
         entry_hash,
-    });
-    event
+    };
+
+    PersistedAuditEvent {
+        event,
+        integrity: Some(integrity),
+    }
+}
+
+fn decode_persisted_audit_event_line(
+    line: &str,
+    journal_path: &Path,
+    line_number: &str,
+) -> Result<PersistedAuditEvent, AuditError> {
+    serde_json::from_str::<PersistedAuditEvent>(line).map_err(|error| {
+        AuditError::Sink(format!(
+            "failed to decode audit journal `{}` at {}: {error}",
+            journal_path.display(),
+            line_number
+        ))
+    })
 }
 
 fn load_last_audit_entry_hash(path: &Path) -> Result<Option<String>, AuditError> {
@@ -216,15 +248,8 @@ fn load_last_audit_entry_hash(path: &Path) -> Result<Option<String>, AuditError>
         return Ok(None);
     };
 
-    let event = serde_json::from_str::<AuditEvent>(&line).map_err(|error| {
-        AuditError::Sink(format!(
-            "failed to decode audit journal tail `{}`: {error}",
-            path.display()
-        ))
-    })?;
-
-    let integrity = event.integrity;
-    let last_hash = integrity.and_then(|value| {
+    let persisted_event = decode_persisted_audit_event_line(&line, path, "tail line")?;
+    let last_hash = persisted_event.integrity.and_then(|value| {
         let hash = value.entry_hash;
         let trimmed_hash = hash.trim();
         if trimmed_hash.is_empty() {
@@ -258,6 +283,7 @@ pub fn verify_jsonl_audit_journal(path: &Path) -> Result<AuditVerificationReport
     let mut total_events = 0usize;
     let mut verified_events = 0usize;
     let mut previous_hash: Option<String> = None;
+    let mut protected_chain_started = false;
 
     for (index, line_result) in reader.lines().enumerate() {
         let line_number = index + 1;
@@ -273,23 +299,22 @@ pub fn verify_jsonl_audit_journal(path: &Path) -> Result<AuditVerificationReport
         }
 
         total_events += 1;
-        let event = serde_json::from_str::<AuditEvent>(&line).map_err(|error| {
-            AuditError::Sink(format!(
-                "failed to decode audit journal `{}` at line {}: {error}",
-                path.display(),
-                line_number
-            ))
-        })?;
+        let line_label = format!("line {line_number}");
+        let persisted_event = decode_persisted_audit_event_line(&line, path, &line_label)?;
+        let event = persisted_event.event;
+        let Some(integrity) = persisted_event.integrity.as_ref() else {
+            if protected_chain_started {
+                return Ok(AuditVerificationReport {
+                    total_events,
+                    verified_events,
+                    valid: false,
+                    last_entry_hash: previous_hash,
+                    first_invalid_line: Some(line_number),
+                    reason: Some("missing integrity envelope".to_owned()),
+                });
+            }
 
-        let Some(integrity) = event.integrity.as_ref() else {
-            return Ok(AuditVerificationReport {
-                total_events,
-                verified_events,
-                valid: false,
-                last_entry_hash: previous_hash,
-                first_invalid_line: Some(line_number),
-                reason: Some("missing integrity envelope".to_owned()),
-            });
+            continue;
         };
 
         if integrity.algorithm.trim() != "sha256" {
@@ -305,6 +330,8 @@ pub fn verify_jsonl_audit_journal(path: &Path) -> Result<AuditVerificationReport
                 )),
             });
         }
+
+        protected_chain_started = true;
 
         if integrity.prev_hash != previous_hash {
             return Ok(AuditVerificationReport {
@@ -346,7 +373,7 @@ pub fn verify_jsonl_audit_journal(path: &Path) -> Result<AuditVerificationReport
 }
 
 fn serialize_audit_event_line(
-    event: &AuditEvent,
+    event: &PersistedAuditEvent,
     journal_path: &Path,
 ) -> Result<Vec<u8>, AuditError> {
     let mut encoded = serde_json::to_vec(event).map_err(|error| {
@@ -368,8 +395,8 @@ impl AuditSink for JsonlAuditSink {
         let previous_hash = guard.last_entry_hash.clone();
         let entry_hash =
             compute_audit_event_entry_hash(&event, previous_hash.as_deref(), &self.path)?;
-        let event = event_with_integrity(event, previous_hash, entry_hash.clone());
-        let encoded = serialize_audit_event_line(&event, &self.path)?;
+        let persisted_event = event_with_integrity(event, previous_hash, entry_hash.clone());
+        let encoded = serialize_audit_event_line(&persisted_event, &self.path)?;
 
         lock_audit_journal(&guard.file, &self.path)?;
 

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -859,6 +859,7 @@ impl<P: PolicyEngine> LoongClawKernel<P> {
             timestamp_epoch_s,
             agent_id,
             kind,
+            integrity: None,
         }
     }
 }

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -859,7 +859,6 @@ impl<P: PolicyEngine> LoongClawKernel<P> {
             timestamp_epoch_s,
             agent_id,
             kind,
-            integrity: None,
         }
     }
 }

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -26,8 +26,9 @@ pub use architecture::{
     ArchitecturePathReport,
 };
 pub use audit::{
-    AuditEvent, AuditEventKind, AuditSink, ExecutionPlane, FanoutAuditSink, InMemoryAuditSink,
-    JsonlAuditSink, NoopAuditSink, PlaneTier, probe_jsonl_audit_journal_runtime_ready,
+    AuditEvent, AuditEventKind, AuditSink, AuditVerificationReport, ExecutionPlane,
+    FanoutAuditSink, InMemoryAuditSink, JsonlAuditSink, NoopAuditSink, PlaneTier,
+    probe_jsonl_audit_journal_runtime_ready, verify_jsonl_audit_journal,
 };
 pub use awareness::{CodebaseAwarenessConfig, CodebaseAwarenessEngine, CodebaseAwarenessSnapshot};
 pub use bootstrap::{

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 
 use crate::audit::{
     AuditEvent, AuditEventKind, AuditSink, FanoutAuditSink, InMemoryAuditSink, JsonlAuditSink,
-    probe_jsonl_audit_journal_runtime_ready,
+    probe_jsonl_audit_journal_runtime_ready, verify_jsonl_audit_journal,
 };
 use crate::clock::FixedClock;
 use crate::contracts::{Capability, HarnessOutcome, TaskIntent};
@@ -48,6 +48,7 @@ fn sample_audit_event(event_id: &str, timestamp_epoch_s: u64) -> AuditEvent {
             operation: "shell.exec".to_owned(),
             required_capabilities: vec![Capability::InvokeTool],
         },
+        integrity: None,
     }
 }
 
@@ -71,6 +72,51 @@ fn jsonl_audit_sink_appends_one_json_line_per_event() {
         serde_json::from_str(lines[1]).expect("second JSON line should decode into AuditEvent");
     assert_eq!(first.event_id, "evt-1");
     assert_eq!(second.event_id, "evt-2");
+    assert!(first.integrity.is_some());
+    assert!(second.integrity.is_some());
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn verify_jsonl_audit_journal_accepts_freshly_written_chain() {
+    let path = fresh_audit_temp_path("jsonl-verify");
+    let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
+
+    sink.record(sample_audit_event("evt-verify-1", 300))
+        .expect("first event should record");
+    sink.record(sample_audit_event("evt-verify-2", 301))
+        .expect("second event should record");
+
+    let report = verify_jsonl_audit_journal(&path).expect("verification should succeed");
+
+    assert!(report.valid);
+    assert_eq!(report.total_events, 2);
+    assert_eq!(report.verified_events, 2);
+    assert!(report.last_entry_hash.is_some());
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn verify_jsonl_audit_journal_rejects_tampered_chain_entry() {
+    let path = fresh_audit_temp_path("jsonl-tamper");
+    let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
+
+    sink.record(sample_audit_event("evt-tamper-1", 400))
+        .expect("first event should record");
+    sink.record(sample_audit_event("evt-tamper-2", 401))
+        .expect("second event should record");
+
+    let contents = fs::read_to_string(&path).expect("read audit journal");
+    let tampered = contents.replacen("evt-tamper-2", "evt-tamper-x", 1);
+    fs::write(&path, tampered).expect("rewrite tampered audit journal");
+
+    let report = verify_jsonl_audit_journal(&path).expect("verification should run");
+
+    assert!(!report.valid);
+    assert_eq!(report.first_invalid_line, Some(2));
+    assert_eq!(report.reason.as_deref(), Some("entry_hash mismatch"));
 
     let _ = fs::remove_file(path);
 }

--- a/crates/kernel/src/tests.rs
+++ b/crates/kernel/src/tests.rs
@@ -48,7 +48,6 @@ fn sample_audit_event(event_id: &str, timestamp_epoch_s: u64) -> AuditEvent {
             operation: "shell.exec".to_owned(),
             required_capabilities: vec![Capability::InvokeTool],
         },
-        integrity: None,
     }
 }
 
@@ -70,10 +69,14 @@ fn jsonl_audit_sink_appends_one_json_line_per_event() {
         serde_json::from_str(lines[0]).expect("first JSON line should decode into AuditEvent");
     let second: AuditEvent =
         serde_json::from_str(lines[1]).expect("second JSON line should decode into AuditEvent");
+    let first_payload = serde_json::from_str::<serde_json::Value>(lines[0])
+        .expect("first JSON line should decode into a JSON payload");
+    let second_payload = serde_json::from_str::<serde_json::Value>(lines[1])
+        .expect("second JSON line should decode into a JSON payload");
     assert_eq!(first.event_id, "evt-1");
     assert_eq!(second.event_id, "evt-2");
-    assert!(first.integrity.is_some());
-    assert!(second.integrity.is_some());
+    assert!(first_payload.get("integrity").is_some());
+    assert!(second_payload.get("integrity").is_some());
 
     let _ = fs::remove_file(path);
 }
@@ -117,6 +120,30 @@ fn verify_jsonl_audit_journal_rejects_tampered_chain_entry() {
     assert!(!report.valid);
     assert_eq!(report.first_invalid_line, Some(2));
     assert_eq!(report.reason.as_deref(), Some("entry_hash mismatch"));
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn verify_jsonl_audit_journal_accepts_legacy_prefix_before_protected_entries() {
+    let path = fresh_audit_temp_path("jsonl-legacy-prefix");
+    let legacy_event = sample_audit_event("evt-legacy-1", 500);
+    let legacy_line = serde_json::to_string(&legacy_event).expect("serialize legacy audit event");
+    let legacy_contents = format!("{legacy_line}\n");
+
+    fs::write(&path, legacy_contents).expect("write legacy audit journal");
+
+    let sink = JsonlAuditSink::new(path.clone()).expect("jsonl sink should initialize");
+
+    sink.record(sample_audit_event("evt-verify-legacy-tail", 501))
+        .expect("protected event should record");
+
+    let report = verify_jsonl_audit_journal(&path).expect("verification should succeed");
+
+    assert!(report.valid);
+    assert_eq!(report.total_events, 2);
+    assert_eq!(report.verified_events, 1);
+    assert!(report.last_entry_hash.is_some());
 
     let _ = fs::remove_file(path);
 }

--- a/crates/spec/src/spec_runtime/process_stdio_bridge.rs
+++ b/crates/spec/src/spec_runtime/process_stdio_bridge.rs
@@ -128,11 +128,17 @@ pub async fn run_process_stdio_json_line_exchange(
     timeout_ms: u64,
     frame: OutboundFrame,
 ) -> Result<ProcessStdioExchangeOutcome, String> {
-    let mut child = TokioCommand::new(program)
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+    let sanitized_env = loongclaw_contracts::sanitized_child_process_env();
+    let mut process = TokioCommand::new(program);
+
+    process.env_clear();
+    process.envs(sanitized_env);
+    process.args(args);
+    process.stdin(Stdio::piped());
+    process.stdout(Stdio::piped());
+    process.stderr(Stdio::piped());
+
+    let mut child = process
         .spawn()
         .map_err(|error| format!("failed to spawn process command {program}: {error}"))?;
 


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw still lacked a tamper-evident integrity contract for the durable
  audit journal, enforced remote byte limits through partially duplicated code
  paths, and allowed model-driven child-process surfaces to inherit a broader
  ambient environment than necessary.
- Why it matters:
  Those gaps weakened operator trust in local audit evidence, made download
  guardrails easier to drift across surfaces, and expanded the runtime boundary
  exposed to subprocess execution.
- What changed:
  Added a kernel-owned audit integrity chain plus `audit verify`; introduced a
  shared byte-budget guard and applied it to `web.fetch`, `browser.open`,
  `external_skills.fetch`, and Feishu binary downloads; switched model-driven
  subprocess execution to a minimal inherited environment; added focused
  regression coverage and full-suite validation on latest `dev`.
- What did not change (scope boundary):
  This PR does not redesign the kernel crate DAG, add a new sandbox subsystem,
  or change unrelated provider / conversation routing behavior.

## Linked Issues

- Closes #858
- Closes #878
- Related #196

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [x] Browser automation
- [x] Channels / integrations
- [ ] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes durable audit semantics, remote byte-stream enforcement, and
  model-driven subprocess environment inheritance.
- Rollout / guardrails:
  The audit integrity field is additive and optional for readers. Existing
  `audit recent` and `audit summary` flows remain intact, and the new
  `audit verify` surface is read-only. Download limits remain fail-closed and
  are now enforced through one shared budget model. Process-stdio and shell
  child processes inherit only the minimal runtime environment needed for
  execution.
- Rollback path:
  Revert the PR commits on `security/openclaw-audit` to remove the audit
  integrity chain, shared byte-budget guard, minimal child-process
  environment changes, and the refreshed April drift report.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test --workspace --locked
CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test --workspace --all-features --locked
bash scripts/check_architecture_boundaries.sh
bash scripts/check_dep_graph.sh

Focused regressions also exercised:
- CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test -p loongclaw-contracts child_process_env
- CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test -p loongclaw-app stream_download_to_unique_path_
- CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test -p loongclaw-app browser_open_rejects_declared_content_length_above_limit
- CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test -p loongclaw-app download_message_resource_rejects_payload_exceeding_max_bytes_limit
- CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test -p loongclaw --test integration execute_spec_process_stdio_bridge_strips_high_risk_env_vars_from_child_process
- CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test -p loongclaw audit_verify_reports_valid_chain_for_fresh_journal
- CARGO_TARGET_DIR=/tmp/loongclaw-devrebase-target cargo test -p loongclaw audit_integrity_doctor_check_fails_for_tampered_chain
```

## User-visible / Operator-visible Changes

- Added `audit verify` for durable journal integrity validation.
- Durable audit journals now carry a chained integrity envelope that can detect
  tampering in appended JSONL entries.
- Remote byte-stream limits now behave consistently across `web.fetch`,
  `browser.open`, external skill downloads, and Feishu binary fetches.
- Model-driven child processes now inherit a minimal environment instead of the
  broader ambient process environment.

## Failure Recovery

- Fast rollback or disable path:
  Revert the PR commits on `security/openclaw-audit`.
- Observable failure symptoms reviewers should watch for:
  unexpected download limit denials, missing expected essential child-process
  env vars in approved runtime paths, or `audit verify` reporting invalid
  chains for freshly written journals.

## Reviewer Focus

- `crates/kernel/src/audit.rs`
- `crates/daemon/src/audit_cli.rs`
- `crates/daemon/src/doctor_cli.rs`
- `crates/app/src/tools/download_guard.rs`
- `crates/app/src/tools/external_skills.rs`
- `crates/app/src/tools/browser.rs`
- `crates/app/src/tools/web_fetch.rs`
- `crates/contracts/src/child_process_env.rs`
- `crates/spec/src/spec_runtime/process_stdio_bridge.rs`
- `crates/daemon/tests/integration/spec_runtime_bridge/process_stdio.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit journal integrity verification and a new "verify" audit command
  * Enforced download byte limits with streaming checks across file/network operations
  * Child process environment is now sanitized to exclude high-risk variables

* **Bug Fixes**
  * Improved download size enforcement by validating declared content length and during transfer
<!-- end of auto-generated comment: release notes by coderabbit.ai -->