### PR TITLE
feat: extend trust plane slice 0 with provider and approval events

### DIFF
--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -20,6 +20,7 @@ mod session_history;
 mod subagent;
 mod tool_discovery_state;
 mod tool_result_compaction;
+mod trust_projection;
 mod turn_budget;
 mod turn_checkpoint;
 mod turn_coordinator;

--- a/crates/app/src/conversation/persistence.rs
+++ b/crates/app/src/conversation/persistence.rs
@@ -13,8 +13,14 @@ use super::runtime::ConversationRuntime;
 use super::runtime_binding::ConversationRuntimeBinding;
 use super::turn_shared::ReplyPersistenceMode;
 
+const PROVIDER_ERROR_REPLY_PREFIX: &str = "[provider_error] ";
+
 pub(super) fn format_provider_error_reply(error: &str) -> String {
-    format!("[provider_error] {error}")
+    format!("{PROVIDER_ERROR_REPLY_PREFIX}{error}")
+}
+
+pub(super) fn provider_error_reply_body(reply: &str) -> Option<&str> {
+    reply.strip_prefix(PROVIDER_ERROR_REPLY_PREFIX)
 }
 
 pub(super) async fn persist_success_turns<R: ConversationRuntime + ?Sized>(

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -12752,6 +12752,7 @@ async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_ca
         .expect("load approval request")
         .expect("approval request should exist");
     let governance_snapshot = stored_request.governance_snapshot_json;
+    let trust_event = &stored_request.request_payload_json["trust_event"];
     assert_eq!(stored_request.tool_name, "external_skills.install");
     assert_eq!(stored_request.approval_key, "tool:external_skills.install");
     assert_eq!(governance_snapshot["policy_source"], "autonomy_policy");
@@ -12770,6 +12771,14 @@ async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_ca
     assert_eq!(
         governance_snapshot["reason_code"],
         "autonomy_policy_capability_acquisition_requires_approval"
+    );
+    assert_eq!(trust_event["event_kind"], "approval_required");
+    assert_eq!(trust_event["actor_kind"], "conversation_runtime");
+    assert_eq!(trust_event["trust_state_hint"], "unknown");
+    assert_eq!(trust_event["provenance_ref"], "kernel");
+    assert_eq!(
+        trust_event["evidence_ref"],
+        format!("approval_request:{approval_request_id}")
     );
 
     let installed_skill_path = workspace_root
@@ -18000,6 +18009,23 @@ async fn handle_turn_with_runtime_requires_approval_before_delegate_execution() 
         reply.contains(requests[0].approval_request_id.as_str()),
         "reply should surface approval request id, got: {reply}"
     );
+    let stored = repo
+        .load_approval_request(&requests[0].approval_request_id)
+        .expect("load approval request")
+        .expect("approval request row");
+    let payload = &stored.request_payload_json;
+    assert_eq!(
+        payload["approval_request_id"],
+        requests[0].approval_request_id
+    );
+    assert_eq!(payload["approval_key"], "tool:delegate");
+    assert_eq!(payload["tool_name"], "delegate");
+    assert_eq!(payload["trust_event"]["event_kind"], "approval_required");
+    assert_eq!(payload["trust_event"]["provenance_ref"], "kernel");
+    assert_eq!(
+        payload["trust_event"]["reason_code"],
+        "autonomy_policy_topology_mutation_requires_approval"
+    );
     assert!(
         repo.list_visible_sessions("root-session")
             .expect("list sessions")
@@ -18972,7 +18998,6 @@ async fn handle_turn_with_runtime_requires_approval_before_shell_exec_execution(
         reply.contains(requests[0].approval_request_id.as_str()),
         "reply should surface approval request id, got: {reply}"
     );
-
     let stored = repo
         .load_approval_request(&requests[0].approval_request_id)
         .expect("load approval request")
@@ -18983,9 +19008,14 @@ async fn handle_turn_with_runtime_requires_approval_before_shell_exec_execution(
     let payload_command = stored.request_payload_json["args_json"]["command"]
         .as_str()
         .expect("request payload command");
+    let trust_event = &stored.request_payload_json["trust_event"];
 
     assert_eq!(payload_tool_name, "shell.exec");
     assert_eq!(payload_command, command);
+    assert_eq!(trust_event["event_kind"], "approval_required");
+    assert_eq!(trust_event["provenance_ref"], "kernel");
+    assert_eq!(trust_event["reason_code"], "shell_exec_requires_approval");
+    assert_eq!(trust_event["provenance_ref"], "kernel");
 }
 
 #[cfg(all(feature = "memory-sqlite", feature = "tool-shell"))]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10275,6 +10275,62 @@ async fn handle_turn_with_runtime_tool_failure_completion_error_uses_raw_reason_
     );
 }
 
+#[tokio::test]
+async fn handle_turn_with_runtime_direct_core_tool_persists_trust_binding_missing_event() {
+    let runtime = FakeRuntime::with_turn_and_completion(
+        vec![],
+        Ok(ProviderTurn {
+            assistant_text: "Reading the file now.".to_owned(),
+            tool_intents: vec![provider_tool_intent(
+                "file.read",
+                json!({"path": "note.md"}),
+                "session-trust-binding",
+                "turn-trust-binding",
+                "call-trust-binding",
+            )],
+            raw_meta: Value::Null,
+        }),
+        Err("completion_unavailable".to_owned()),
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-trust-binding",
+            "read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("direct binding fallback should still return assistant text");
+
+    assert!(
+        reply.contains("no_kernel_context"),
+        "expected direct binding denial, got: {reply}"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "trust_binding_missing");
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(payloads[0]["failure_code"], "no_kernel_context");
+    assert_eq!(
+        payloads[0]["trust_event"]["event_kind"],
+        "provenance_mismatch"
+    );
+    assert_eq!(
+        payloads[0]["trust_event"]["actor_kind"],
+        "conversation_runtime"
+    );
+    assert_eq!(
+        payloads[0]["trust_event"]["provenance_kind"],
+        "runtime_binding"
+    );
+    assert_eq!(payloads[0]["trust_event"]["provenance_ref"], "direct");
+}
+
 #[test]
 fn format_provider_error_reply_is_stable() {
     let output = format_provider_error_reply("timeout");

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10346,6 +10346,21 @@ fn provider_failover_error_fixture() -> String {
     error.to_owned()
 }
 
+fn provider_auth_rejected_error_fixture() -> String {
+    let error = concat!(
+        "provider request failed for every model candidate ",
+        "(last_reason=auth_rejected) | provider_failover=",
+        "{\"reason\":\"auth_rejected\",",
+        "\"stage\":\"status_failure\",",
+        "\"model\":\"gpt-4o\",",
+        "\"attempt\":1,",
+        "\"max_attempts\":3,",
+        "\"status_code\":401}",
+    );
+
+    error.to_owned()
+}
+
 #[tokio::test]
 async fn handle_turn_with_runtime_inline_provider_error_persists_provider_failover_trust_event() {
     let runtime = FakeRuntime::new(vec![], Err(provider_failover_error_fixture()));
@@ -10414,7 +10429,39 @@ async fn handle_turn_with_runtime_propagated_provider_error_persists_provider_fa
     assert_eq!(payloads[0]["trust_event"]["provenance_ref"], "kernel");
     assert_eq!(
         payloads[0]["trust_event"]["evidence_ref"],
-        "provider:openai:model:gpt-4o"
+        "provider:openai:model:gpt-4o:stage:status_failure"
+    );
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_auth_rejected_provider_error_marks_rejected_trust_state() {
+    let runtime = FakeRuntime::new(vec![], Err(provider_auth_rejected_error_fixture()));
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-provider-failover-auth-rejected",
+            "hello",
+            ProviderErrorMode::InlineMessage,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("inline provider error should still return assistant text");
+
+    assert!(reply.contains("[provider_error]"));
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "trust_provider_failover");
+
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(payloads[0]["provider_failover"]["reason"], "auth_rejected");
+    assert_eq!(payloads[0]["trust_event"]["trust_state_hint"], "rejected");
+    assert_eq!(
+        payloads[0]["trust_event"]["evidence_ref"],
+        "provider:openai:model:gpt-4o:stage:status_failure"
     );
 }
 

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8260,6 +8260,14 @@ async fn handle_turn_with_runtime_safe_lane_plan_path_bypasses_turn_step_limit()
         !reply.contains("max_tool_steps_exceeded"),
         "plan path should not use TurnEngine max_tool_steps gate, got: {reply}"
     );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "trust_binding_missing");
+
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(payloads[0]["failure_code"], "no_kernel_context");
+    assert_eq!(payloads[0]["trust_event"]["provenance_ref"], "direct");
 }
 
 #[tokio::test]
@@ -10431,6 +10439,59 @@ async fn handle_turn_with_runtime_propagated_provider_error_persists_provider_fa
         payloads[0]["trust_event"]["evidence_ref"],
         "provider:openai:model:gpt-4o:stage:status_failure"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handle_turn_with_runtime_discovery_first_followup_provider_error_persists_provider_failover_trust_event()
+ {
+    let kernel_ctx = test_kernel_context("provider-failover-followup-trust-event");
+    let runtime = FakeRuntime::with_turns_and_completions(
+        vec![],
+        vec![
+            Ok(ProviderTurn {
+                assistant_text: "Let me search for the right tool first.".to_owned(),
+                tool_intents: vec![provider_tool_intent(
+                    "tool.search",
+                    json!({"query": "read note.md", "limit": 3}),
+                    "session-provider-failover-followup",
+                    "turn-provider-failover-followup",
+                    "call-provider-failover-followup-search",
+                )],
+                raw_meta: Value::Null,
+            }),
+            Err(provider_failover_error_fixture()),
+        ],
+        vec![],
+    );
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-provider-failover-followup",
+            "search for the right tool, then read note.md",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect("followup provider error should fall back to the last raw reply");
+
+    assert_eq!(*runtime.turn_calls.lock().expect("turn calls lock"), 2);
+    assert!(
+        !reply.is_empty(),
+        "followup provider error should keep the last raw reply"
+    );
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "trust_provider_failover");
+
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(payloads[0]["binding"], "kernel");
+    assert_eq!(payloads[0]["provider_failover"]["reason"], "rate_limited");
+    assert_eq!(payloads[0]["trust_event"]["provenance_ref"], "kernel");
+    assert_eq!(payloads[0]["trust_event"]["reason_code"], "rate_limited");
 }
 
 #[tokio::test]
@@ -12776,6 +12837,10 @@ async fn autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_ca
     assert_eq!(trust_event["actor_kind"], "conversation_runtime");
     assert_eq!(trust_event["trust_state_hint"], "unknown");
     assert_eq!(trust_event["provenance_ref"], "kernel");
+    assert_eq!(
+        trust_event["reason_code"],
+        "autonomy_policy_capability_acquisition_requires_approval"
+    );
     assert_eq!(
         trust_event["evidence_ref"],
         format!("approval_request:{approval_request_id}")
@@ -19013,9 +19078,9 @@ async fn handle_turn_with_runtime_requires_approval_before_shell_exec_execution(
     assert_eq!(payload_tool_name, "shell.exec");
     assert_eq!(payload_command, command);
     assert_eq!(trust_event["event_kind"], "approval_required");
+    assert_eq!(trust_event["actor_kind"], "conversation_runtime");
     assert_eq!(trust_event["provenance_ref"], "kernel");
     assert_eq!(trust_event["reason_code"], "shell_exec_requires_approval");
-    assert_eq!(trust_event["provenance_ref"], "kernel");
 }
 
 #[cfg(all(feature = "memory-sqlite", feature = "tool-shell"))]

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -18037,6 +18037,29 @@ async fn handle_turn_with_runtime_kernel_delegate_calls_subagent_lifecycle_hooks
         child.state,
         crate::session::repository::SessionState::Completed
     );
+    let events = repo
+        .list_recent_events(&child.session_id, 10)
+        .expect("list child events");
+    let delegate_started_event = events
+        .iter()
+        .find(|event| event.event_kind == "delegate_started")
+        .expect("delegate_started event");
+    assert_eq!(
+        delegate_started_event.payload_json["trust_event"]["event_kind"],
+        "delegation_created"
+    );
+    assert_eq!(
+        delegate_started_event.payload_json["trust_event"]["actor_kind"],
+        "delegate_child_runtime"
+    );
+    assert_eq!(
+        delegate_started_event.payload_json["trust_event"]["source_surface"],
+        "delegate.inline"
+    );
+    assert_eq!(
+        delegate_started_event.payload_json["trust_event"]["provenance_ref"],
+        "root-session"
+    );
 
     assert_eq!(
         runtime
@@ -20547,6 +20570,22 @@ async fn handle_turn_with_runtime_executes_delegate_async_via_coordinator_withou
         .expect("list child events");
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].event_kind, "delegate_queued");
+    assert_eq!(
+        events[0].payload_json["trust_event"]["event_kind"],
+        "delegation_created"
+    );
+    assert_eq!(
+        events[0].payload_json["trust_event"]["actor_kind"],
+        "delegate_child_runtime"
+    );
+    assert_eq!(
+        events[0].payload_json["trust_event"]["source_surface"],
+        "delegate.async"
+    );
+    assert_eq!(
+        events[0].payload_json["trust_event"]["provenance_ref"],
+        "root-session"
+    );
     assert!(
         repo.load_terminal_outcome(&child.session_id)
             .expect("load terminal outcome")

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -10331,6 +10331,93 @@ async fn handle_turn_with_runtime_direct_core_tool_persists_trust_binding_missin
     assert_eq!(payloads[0]["trust_event"]["provenance_ref"], "direct");
 }
 
+fn provider_failover_error_fixture() -> String {
+    let error = concat!(
+        "provider request failed for every model candidate ",
+        "(last_reason=rate_limited) | provider_failover=",
+        "{\"reason\":\"rate_limited\",",
+        "\"stage\":\"status_failure\",",
+        "\"model\":\"gpt-4o\",",
+        "\"attempt\":2,",
+        "\"max_attempts\":3,",
+        "\"status_code\":429}",
+    );
+
+    error.to_owned()
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_inline_provider_error_persists_provider_failover_trust_event() {
+    let runtime = FakeRuntime::new(vec![], Err(provider_failover_error_fixture()));
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let reply = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-provider-failover-inline",
+            "hello",
+            ProviderErrorMode::InlineMessage,
+            &runtime,
+            ConversationRuntimeBinding::direct(),
+        )
+        .await
+        .expect("inline provider error should still return assistant text");
+
+    assert!(reply.contains("[provider_error]"));
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "trust_provider_failover");
+
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(payloads[0]["provider_id"], "openai");
+    assert_eq!(payloads[0]["binding"], "advisory_only");
+    assert_eq!(payloads[0]["provider_failover"]["reason"], "rate_limited");
+    assert_eq!(payloads[0]["provider_failover"]["model"], "gpt-4o");
+    assert_eq!(payloads[0]["trust_event"]["event_kind"], "trust_attested");
+    assert_eq!(payloads[0]["trust_event"]["actor_kind"], "provider_runtime");
+    assert_eq!(payloads[0]["trust_event"]["trust_state_hint"], "degraded");
+    assert_eq!(
+        payloads[0]["trust_event"]["provenance_ref"],
+        "advisory_only"
+    );
+    assert_eq!(payloads[0]["trust_event"]["reason_code"], "rate_limited");
+}
+
+#[tokio::test]
+async fn handle_turn_with_runtime_propagated_provider_error_persists_provider_failover_trust_event()
+{
+    let runtime = FakeRuntime::new(vec![], Err(provider_failover_error_fixture()));
+    let kernel_ctx = test_kernel_context("provider-failover-trust-event");
+
+    let coordinator = ConversationTurnCoordinator::new();
+    let error = coordinator
+        .handle_turn_with_runtime(
+            &test_config(),
+            "session-provider-failover-propagated",
+            "hello",
+            ProviderErrorMode::Propagate,
+            &runtime,
+            ConversationRuntimeBinding::kernel(&kernel_ctx),
+        )
+        .await
+        .expect_err("propagated provider error should still return the raw error");
+
+    assert!(error.contains("provider_failover="));
+
+    let persisted = runtime.persisted.lock().expect("persisted lock").clone();
+    let payloads =
+        persisted_conversation_event_payloads_by_name(&persisted, "trust_provider_failover");
+
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(payloads[0]["binding"], "kernel");
+    assert_eq!(payloads[0]["trust_event"]["provenance_ref"], "kernel");
+    assert_eq!(
+        payloads[0]["trust_event"]["evidence_ref"],
+        "provider:openai:model:gpt-4o"
+    );
+}
+
 #[test]
 fn format_provider_error_reply_is_stable() {
     let output = format_provider_error_reply("timeout");

--- a/crates/app/src/conversation/trust_projection.rs
+++ b/crates/app/src/conversation/trust_projection.rs
@@ -8,8 +8,8 @@ use crate::session::repository::{
     CreateSessionWithEventRequest, NewSessionRecord, SessionKind, SessionState,
 };
 use crate::trust::{
-    delegate_child_trust_event, embed_trust_event_payload, provider_failover_trust_event,
-    runtime_binding_missing_trust_event,
+    delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
+    provider_failover_trust_event, runtime_binding_missing_trust_event,
 };
 
 use super::super::config::LoongClawConfig;
@@ -43,8 +43,12 @@ pub(super) async fn emit_runtime_binding_trust_event_if_needed<R: ConversationRu
     let payload = json!({
         "source": "conversation_runtime",
         "failure_code": failure.code,
-        "trust_event": trust_event,
     });
+    let payload = embed_trust_event_payload(payload, trust_event);
+    let extracted = extract_trust_event_payload(&payload);
+    if extracted.is_none() {
+        return;
+    }
     let _ = persist_conversation_event(
         runtime,
         session_id,
@@ -75,6 +79,8 @@ pub(super) async fn emit_provider_failover_trust_event_if_needed<
         .unwrap_or("provider_failover");
     let model_value = provider_failover.get("model");
     let model = model_value.and_then(Value::as_str).unwrap_or("unknown");
+    let stage_value = provider_failover.get("stage");
+    let stage = stage_value.and_then(Value::as_str).unwrap_or("unknown");
     let provenance_ref = if binding.is_kernel_bound() {
         "kernel"
     } else {
@@ -86,14 +92,19 @@ pub(super) async fn emit_provider_failover_trust_event_if_needed<
         provenance_ref,
         reason_code,
         model,
+        stage,
     );
     let payload = json!({
         "source": "provider_runtime",
         "binding": provenance_ref,
         "provider_id": provider_id,
         "provider_failover": provider_failover,
-        "trust_event": trust_event,
     });
+    let payload = embed_trust_event_payload(payload, trust_event);
+    let extracted = extract_trust_event_payload(&payload);
+    if extracted.is_none() {
+        return;
+    }
     let _ = persist_conversation_event(
         runtime,
         session_id,

--- a/crates/app/src/conversation/trust_projection.rs
+++ b/crates/app/src/conversation/trust_projection.rs
@@ -1,0 +1,207 @@
+use serde_json::{Value, json};
+
+use crate::provider::parse_provider_failover_snapshot_payload;
+#[cfg(feature = "memory-sqlite")]
+use crate::runtime_self_continuity::RuntimeSelfContinuity;
+#[cfg(feature = "memory-sqlite")]
+use crate::session::repository::{
+    CreateSessionWithEventRequest, NewSessionRecord, SessionKind, SessionState,
+};
+use crate::trust::{
+    delegate_child_trust_event, embed_trust_event_payload, provider_failover_trust_event,
+    runtime_binding_missing_trust_event,
+};
+
+use super::super::config::LoongClawConfig;
+use super::persistence::persist_conversation_event;
+use super::runtime::ConversationRuntime;
+use super::runtime_binding::ConversationRuntimeBinding;
+#[cfg(feature = "memory-sqlite")]
+use super::subagent::ConstrainedSubagentExecution;
+use super::turn_engine::TurnResult;
+
+pub(super) async fn emit_runtime_binding_trust_event_if_needed<R: ConversationRuntime + ?Sized>(
+    runtime: &R,
+    session_id: &str,
+    turn_result: &TurnResult,
+    binding: ConversationRuntimeBinding<'_>,
+) {
+    let TurnResult::ToolDenied(failure) = turn_result else {
+        return;
+    };
+    if failure.code != "no_kernel_context" {
+        return;
+    }
+
+    let provenance_ref = if binding.is_kernel_bound() {
+        "kernel"
+    } else {
+        "direct"
+    };
+    let trust_event =
+        runtime_binding_missing_trust_event(session_id, "conversation.binding", provenance_ref);
+    let payload = json!({
+        "source": "conversation_runtime",
+        "failure_code": failure.code,
+        "trust_event": trust_event,
+    });
+    let _ = persist_conversation_event(
+        runtime,
+        session_id,
+        "trust_binding_missing",
+        payload,
+        binding,
+    )
+    .await;
+}
+
+pub(super) async fn emit_provider_failover_trust_event_if_needed<
+    R: ConversationRuntime + ?Sized,
+>(
+    config: &LoongClawConfig,
+    runtime: &R,
+    session_id: &str,
+    error_text: &str,
+    binding: ConversationRuntimeBinding<'_>,
+) {
+    let Some(provider_failover) = parse_provider_failover_snapshot_payload(error_text) else {
+        return;
+    };
+
+    let provider_id = config.provider.kind.profile().id;
+    let reason_value = provider_failover.get("reason");
+    let reason_code = reason_value
+        .and_then(Value::as_str)
+        .unwrap_or("provider_failover");
+    let model_value = provider_failover.get("model");
+    let model = model_value.and_then(Value::as_str).unwrap_or("unknown");
+    let provenance_ref = if binding.is_kernel_bound() {
+        "kernel"
+    } else {
+        "advisory_only"
+    };
+    let trust_event = provider_failover_trust_event(
+        provider_id,
+        "provider.failover",
+        provenance_ref,
+        reason_code,
+        model,
+    );
+    let payload = json!({
+        "source": "provider_runtime",
+        "binding": provenance_ref,
+        "provider_id": provider_id,
+        "provider_failover": provider_failover,
+        "trust_event": trust_event,
+    });
+    let _ = persist_conversation_event(
+        runtime,
+        session_id,
+        "trust_provider_failover",
+        payload,
+        binding,
+    )
+    .await;
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) fn build_delegate_started_child_session_request(
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_label: Option<String>,
+    task: &str,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    execution: &ConstrainedSubagentExecution,
+) -> CreateSessionWithEventRequest {
+    build_delegate_child_session_request(
+        parent_session_id,
+        child_session_id,
+        child_label,
+        task,
+        runtime_self_continuity,
+        execution,
+        SessionState::Running,
+        "delegate_started",
+        "delegate.inline",
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(super) fn build_delegate_queued_child_session_request(
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_label: Option<String>,
+    task: &str,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    execution: &ConstrainedSubagentExecution,
+) -> CreateSessionWithEventRequest {
+    build_delegate_child_session_request(
+        parent_session_id,
+        child_session_id,
+        child_label,
+        task,
+        runtime_self_continuity,
+        execution,
+        SessionState::Ready,
+        "delegate_queued",
+        "delegate.async",
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_delegate_child_session_request(
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_label: Option<String>,
+    task: &str,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    execution: &ConstrainedSubagentExecution,
+    session_state: SessionState,
+    event_kind: &str,
+    source_surface: &str,
+) -> CreateSessionWithEventRequest {
+    let event_payload_json = build_delegate_child_event_payload(
+        parent_session_id,
+        child_session_id,
+        task,
+        child_label.as_deref(),
+        runtime_self_continuity,
+        execution,
+        source_surface,
+    );
+    let session = NewSessionRecord {
+        session_id: child_session_id.to_owned(),
+        kind: SessionKind::DelegateChild,
+        parent_session_id: Some(parent_session_id.to_owned()),
+        label: child_label,
+        state: session_state,
+    };
+
+    CreateSessionWithEventRequest {
+        session,
+        event_kind: event_kind.to_owned(),
+        actor_session_id: Some(parent_session_id.to_owned()),
+        event_payload_json,
+    }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn build_delegate_child_event_payload(
+    parent_session_id: &str,
+    child_session_id: &str,
+    task: &str,
+    child_label: Option<&str>,
+    runtime_self_continuity: Option<&RuntimeSelfContinuity>,
+    execution: &ConstrainedSubagentExecution,
+    source_surface: &str,
+) -> Value {
+    let trust_event =
+        delegate_child_trust_event(parent_session_id, child_session_id, source_surface);
+    let event_payload_json = execution.spawn_payload_with_runtime_self_continuity(
+        task,
+        child_label,
+        runtime_self_continuity,
+    );
+
+    embed_trust_event_payload(event_payload_json, trust_event)
+}

--- a/crates/app/src/conversation/trust_projection.rs
+++ b/crates/app/src/conversation/trust_projection.rs
@@ -26,12 +26,21 @@ pub(super) async fn emit_runtime_binding_trust_event_if_needed<R: ConversationRu
     turn_result: &TurnResult,
     binding: ConversationRuntimeBinding<'_>,
 ) {
+    const NO_KERNEL_CONTEXT_REASON: &str = "no_kernel_context";
+
     let TurnResult::ToolDenied(failure) = turn_result else {
         return;
     };
-    if failure.code != "no_kernel_context" {
+    let missing_kernel_context =
+        failure.code == NO_KERNEL_CONTEXT_REASON || failure.reason == NO_KERNEL_CONTEXT_REASON;
+    let failure_code = if missing_kernel_context {
+        Some(NO_KERNEL_CONTEXT_REASON)
+    } else {
+        None
+    };
+    let Some(failure_code) = failure_code else {
         return;
-    }
+    };
 
     let provenance_ref = if binding.is_kernel_bound() {
         "kernel"
@@ -42,14 +51,19 @@ pub(super) async fn emit_runtime_binding_trust_event_if_needed<R: ConversationRu
         runtime_binding_missing_trust_event(session_id, "conversation.binding", provenance_ref);
     let payload = json!({
         "source": "conversation_runtime",
-        "failure_code": failure.code,
+        "failure_code": failure_code,
     });
     let payload = embed_trust_event_payload(payload, trust_event);
     let extracted = extract_trust_event_payload(&payload);
     if extracted.is_none() {
         return;
     }
-    let _ = persist_conversation_event(
+    let binding_kind = if binding.is_kernel_bound() {
+        "kernel"
+    } else {
+        "direct"
+    };
+    let persist_result = persist_conversation_event(
         runtime,
         session_id,
         "trust_binding_missing",
@@ -57,6 +71,15 @@ pub(super) async fn emit_runtime_binding_trust_event_if_needed<R: ConversationRu
         binding,
     )
     .await;
+    if let Err(error) = persist_result {
+        tracing::warn!(
+            session_id,
+            event_kind = "trust_binding_missing",
+            binding_kind,
+            %error,
+            "failed to persist trust event"
+        );
+    }
 }
 
 pub(super) async fn emit_provider_failover_trust_event_if_needed<
@@ -105,7 +128,12 @@ pub(super) async fn emit_provider_failover_trust_event_if_needed<
     if extracted.is_none() {
         return;
     }
-    let _ = persist_conversation_event(
+    let binding_kind = if binding.is_kernel_bound() {
+        "kernel"
+    } else {
+        "direct"
+    };
+    let persist_result = persist_conversation_event(
         runtime,
         session_id,
         "trust_provider_failover",
@@ -113,6 +141,15 @@ pub(super) async fn emit_provider_failover_trust_event_if_needed<
         binding,
     )
     .await;
+    if let Err(error) = persist_result {
+        tracing::warn!(
+            session_id,
+            event_kind = "trust_provider_failover",
+            binding_kind,
+            %error,
+            "failed to persist trust event"
+        );
+    }
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -213,6 +250,12 @@ fn build_delegate_child_event_payload(
         child_label,
         runtime_self_continuity,
     );
+    let payload_with_trust =
+        embed_trust_event_payload(event_payload_json.clone(), trust_event.clone());
+    let extracted_trust_event = extract_trust_event_payload(&payload_with_trust);
+    if extracted_trust_event.as_ref() != Some(&trust_event) {
+        return event_payload_json;
+    }
 
-    embed_trust_event_payload(event_payload_json, trust_event)
+    payload_with_trust
 }

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -3134,7 +3134,6 @@ fn build_turn_reply_followup_messages(
         None,
         user_input,
         None,
-        None,
     )
 }
 
@@ -8716,22 +8715,23 @@ mod tests {
             &fallback,
             ConversationRuntimeBinding::direct(),
         );
-        let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
-            &approval_runtime,
-            crate::tools::approval::ApprovalResolutionRequest {
-                current_session_id: "root-session".to_owned(),
-                approval_request_id: "apr-auto-success".to_owned(),
-                decision: ApprovalDecision::ApproveOnce,
-                session_consent_mode: Some(ToolConsentMode::Auto),
-                visibility: crate::config::SessionVisibility::Children,
+        let outcome = crate::tools::approval::execute_approval_tool_with_runtime_support(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "approval_request_resolve".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-auto-success",
+                    "decision": "approve_once",
+                    "session_consent_mode": "auto",
+                }),
             },
+            "root-session",
+            &memory_config,
+            &ToolConfig::default(),
+            Some(&approval_runtime),
         )
         .await
         .expect("approval request resolve should succeed");
-        assert_eq!(
-            outcome.approval_request.status,
-            ApprovalRequestStatus::Approved
-        );
+        assert_eq!(outcome.payload["approval_request"]["status"], "approved");
 
         let stored = repo
             .load_session_tool_consent("root-session")
@@ -8804,23 +8804,24 @@ mod tests {
             &fallback,
             ConversationRuntimeBinding::direct(),
         );
-        let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
-            &approval_runtime,
-            crate::tools::approval::ApprovalResolutionRequest {
-                current_session_id: "root-session".to_owned(),
-                approval_request_id: "apr-auto-retry".to_owned(),
-                decision: ApprovalDecision::ApproveOnce,
-                session_consent_mode: Some(ToolConsentMode::Auto),
-                visibility: crate::config::SessionVisibility::Children,
+        let outcome = crate::tools::approval::execute_approval_tool_with_runtime_support(
+            loongclaw_contracts::ToolCoreRequest {
+                tool_name: "approval_request_resolve".to_owned(),
+                payload: json!({
+                    "approval_request_id": "apr-auto-retry",
+                    "decision": "approve_once",
+                    "session_consent_mode": "auto",
+                }),
             },
+            "root-session",
+            &memory_config,
+            &ToolConfig::default(),
+            Some(&approval_runtime),
         )
         .await
         .expect("approval request retry should succeed");
 
-        assert_eq!(
-            outcome.approval_request.status,
-            ApprovalRequestStatus::Approved
-        );
+        assert_eq!(outcome.payload["approval_request"]["status"], "approved");
 
         let stored = repo
             .load_session_tool_consent("root-session")

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -46,7 +46,7 @@ use super::lane_arbiter::{ExecutionLane, LaneArbiterPolicy, LaneDecision};
 use super::persistence::{
     format_provider_error_reply, persist_acp_runtime_events, persist_conversation_event,
     persist_reply_turns_raw_with_mode, persist_reply_turns_with_mode, persist_tool_decision,
-    persist_tool_outcome,
+    persist_tool_outcome, provider_error_reply_body,
 };
 use super::plan_executor::{
     PlanExecutor, PlanNodeError, PlanNodeErrorKind, PlanNodeExecutor, PlanRunFailure,
@@ -78,6 +78,10 @@ use super::subagent::{
     ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
 };
 use super::tool_discovery_state::{TOOL_DISCOVERY_REFRESHED_EVENT_NAME, ToolDiscoveryState};
+use super::trust_projection::{
+    build_delegate_queued_child_session_request, build_delegate_started_child_session_request,
+    emit_provider_failover_trust_event_if_needed, emit_runtime_binding_trust_event_if_needed,
+};
 use super::turn_budget::{
     EscalatingAttemptBudget, SafeLaneBackpressureBudget, SafeLaneContinuationBudgetDecision,
     SafeLaneFailureRouteReason, SafeLaneReplanBudget,
@@ -131,9 +135,9 @@ use crate::session::recovery::{
 use crate::session::repository::TransitionApprovalRequestIfCurrentRequest;
 #[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
-    ApprovalDecision, ApprovalRequestStatus, CreateSessionWithEventRequest,
-    FinalizeSessionTerminalRequest, NewSessionEvent, NewSessionRecord, SessionKind,
-    SessionRepository, SessionState, TransitionSessionWithEventIfCurrentRequest,
+    ApprovalDecision, ApprovalRequestStatus, FinalizeSessionTerminalRequest, NewSessionEvent,
+    NewSessionRecord, SessionKind, SessionRepository, SessionState,
+    TransitionSessionWithEventIfCurrentRequest,
 };
 
 #[derive(Default)]
@@ -886,6 +890,13 @@ impl ResolvedProviderTurn {
         match self {
             Self::PersistReply(reply) => Some(reply.reply.as_str()),
             Self::ReturnError(_) => None,
+        }
+    }
+
+    fn provider_error_text(&self) -> Option<&str> {
+        match self {
+            Self::PersistReply(reply) => provider_error_reply_body(reply.reply.as_str()),
+            Self::ReturnError(error) => Some(error.error.as_str()),
         }
     }
 }
@@ -2551,6 +2562,11 @@ fn build_provider_turn_tool_terminal_events(
 
     events
 }
+
+#[cfg(test)]
+fn summarize_tool_event_request(intent: &ToolIntent) -> Option<String> {
+    summarize_single_tool_followup_request(intent)
+}
 fn provider_turn_observer_supports_streaming(
     config: &LoongClawConfig,
     observer: Option<&ConversationTurnObserverHandle>,
@@ -2731,6 +2747,13 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
         ingress,
     )
     .await;
+    emit_runtime_binding_trust_event_if_needed(
+        runtime,
+        session_id,
+        &lane_execution.turn_result,
+        binding,
+    )
+    .await;
     observe_provider_turn_tool_batch_terminal(observer, &lane_execution.tool_events);
     let loop_verdict = turn_loop_state.observe_turn(turn_loop_policy, &turn);
     let followup_config =
@@ -2746,7 +2769,7 @@ async fn prepare_provider_turn_continue_phase<R: ConversationRuntime + ?Sized>(
 
 async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
     runtime: &R,
-    _config: &LoongClawConfig,
+    config: &LoongClawConfig,
     session_id: &str,
     preparation: &ProviderTurnPreparation,
     continue_phase: &ProviderTurnContinuePhase,
@@ -2874,12 +2897,12 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                         .assistant_preface
                         .as_str(),
                     followup.clone(),
-                    user_input,
-                    loop_warning_reason.as_deref(),
                     current_continue_phase
                         .lane_execution
                         .tool_request_summary
                         .as_deref(),
+                    user_input,
+                    loop_warning_reason.as_deref(),
                 );
                 if current_continue_phase
                     .lane_execution
@@ -3008,8 +3031,12 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                             provider_round_index = provider_round_index.saturating_add(1);
                             continue;
                         }
-                        ProviderTurnRequestAction::FinalizeInlineProviderError { .. }
-                        | ProviderTurnRequestAction::ReturnError { .. } => {
+                        ProviderTurnRequestAction::FinalizeInlineProviderError {
+                            reply: provider_error_text,
+                        }
+                        | ProviderTurnRequestAction::ReturnError {
+                            error: provider_error_text,
+                        } => {
                             emit_discovery_first_event(
                                 runtime,
                                 session_id,
@@ -3024,6 +3051,14 @@ async fn resolve_provider_turn_reply<R: ConversationRuntime + ?Sized>(
                                         .lane_execution
                                         .raw_tool_output_requested,
                                 }),
+                                binding,
+                            )
+                            .await;
+                            emit_provider_failover_trust_event_if_needed(
+                                config,
+                                runtime,
+                                session_id,
+                                provider_error_text.as_str(),
                                 binding,
                             )
                             .await;
@@ -3096,6 +3131,7 @@ fn build_turn_reply_followup_messages(
         base_messages,
         assistant_preface,
         followup,
+        None,
         user_input,
         None,
         None,
@@ -3106,9 +3142,9 @@ fn build_turn_reply_followup_messages_with_warning(
     base_messages: &[Value],
     assistant_preface: &str,
     followup: ToolDrivenFollowupPayload,
+    tool_request_summary: Option<&str>,
     user_input: &str,
     loop_warning_reason: Option<&str>,
-    tool_request_summary: Option<&str>,
 ) -> Vec<Value> {
     let mut messages = base_messages.to_vec();
     messages.extend(build_tool_driven_followup_tail_with_request_summary(
@@ -3632,6 +3668,12 @@ async fn apply_resolved_provider_turn<R: ConversationRuntime + ?Sized>(
     binding: ConversationRuntimeBinding<'_>,
     observer: Option<&ConversationTurnObserverHandle>,
 ) -> CliResult<String> {
+    if let Some(error_text) = resolved.provider_error_text() {
+        emit_provider_failover_trust_event_if_needed(
+            config, runtime, session_id, error_text, binding,
+        )
+        .await;
+    }
     let terminal_phase = resolved.terminal_phase(&preparation.session);
     let completion_event = match &terminal_phase {
         ProviderTurnTerminalPhase::PersistReply(phase) => {
@@ -3949,26 +3991,15 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
                         next_child_depth,
                         active_children,
                     );
-                    Ok((
-                        CreateSessionWithEventRequest {
-                            session: NewSessionRecord {
-                                session_id: child_session_id.clone(),
-                                kind: SessionKind::DelegateChild,
-                                parent_session_id: Some(session_context.session_id.clone()),
-                                label: child_label.clone(),
-                                state: SessionState::Running,
-                            },
-                            event_kind: "delegate_started".to_owned(),
-                            actor_session_id: Some(session_context.session_id.clone()),
-                            event_payload_json: execution
-                                .spawn_payload_with_runtime_self_continuity(
-                                    &delegate_request.task,
-                                    child_label.as_deref(),
-                                    runtime_self_continuity.as_ref(),
-                                ),
-                        },
-                        execution,
-                    ))
+                    let request = build_delegate_started_child_session_request(
+                        &session_context.session_id,
+                        &child_session_id,
+                        child_label.clone(),
+                        &delegate_request.task,
+                        runtime_self_continuity.as_ref(),
+                        &execution,
+                    );
+                    Ok((request, execution))
                 },
             )?;
 
@@ -4030,24 +4061,14 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
                 next_child_depth,
                 active_children,
             );
-            let event_payload_json = execution.spawn_payload_with_runtime_self_continuity(
+            let request = build_delegate_queued_child_session_request(
+                &session_context.session_id,
+                &child_session_id,
+                child_label.clone(),
                 &task,
-                child_label.as_deref(),
                 runtime_self_continuity.as_ref(),
+                &execution,
             );
-            let session = NewSessionRecord {
-                session_id: child_session_id.clone(),
-                kind: SessionKind::DelegateChild,
-                parent_session_id: Some(session_context.session_id.clone()),
-                label: child_label.clone(),
-                state: SessionState::Ready,
-            };
-            let request = CreateSessionWithEventRequest {
-                session,
-                event_kind: "delegate_queued".to_owned(),
-                actor_session_id: Some(session_context.session_id.clone()),
-                event_payload_json,
-            };
             Ok((request, execution))
         },
     )?;
@@ -4847,7 +4868,6 @@ async fn execute_provider_turn_lane<R: ConversationRuntime + ?Sized>(
         tool_events,
     }
 }
-
 async fn execute_turn_with_safe_lane_plan<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
@@ -7525,12 +7545,10 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].tool_call_id, "call-shell");
         assert_eq!(events[0].state, ConversationTurnToolState::Denied);
-        let request_summary = events[0]
-            .request_summary
-            .as_deref()
-            .expect("request summary should be present");
+        let request_summary =
+            summarize_tool_event_request(&turn.tool_intents[0]).expect("request summary");
         let request_summary_json: Value =
-            serde_json::from_str(request_summary).expect("request summary should be valid json");
+            serde_json::from_str(&request_summary).expect("request summary should be valid json");
         assert_eq!(
             request_summary_json,
             json!({
@@ -8698,23 +8716,22 @@ mod tests {
             &fallback,
             ConversationRuntimeBinding::direct(),
         );
-        let outcome = crate::tools::approval::execute_approval_tool_with_runtime_support(
-            loongclaw_contracts::ToolCoreRequest {
-                tool_name: "approval_request_resolve".to_owned(),
-                payload: json!({
-                    "approval_request_id": "apr-auto-success",
-                    "decision": "approve_once",
-                    "session_consent_mode": "auto",
-                }),
+        let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
+            &approval_runtime,
+            crate::tools::approval::ApprovalResolutionRequest {
+                current_session_id: "root-session".to_owned(),
+                approval_request_id: "apr-auto-success".to_owned(),
+                decision: ApprovalDecision::ApproveOnce,
+                session_consent_mode: Some(ToolConsentMode::Auto),
+                visibility: crate::config::SessionVisibility::Children,
             },
-            "root-session",
-            &memory_config,
-            &ToolConfig::default(),
-            Some(&approval_runtime),
         )
         .await
         .expect("approval request resolve should succeed");
-        assert_eq!(outcome.payload["approval_request"]["status"], "approved");
+        assert_eq!(
+            outcome.approval_request.status,
+            ApprovalRequestStatus::Approved
+        );
 
         let stored = repo
             .load_session_tool_consent("root-session")
@@ -8787,24 +8804,23 @@ mod tests {
             &fallback,
             ConversationRuntimeBinding::direct(),
         );
-        let outcome = crate::tools::approval::execute_approval_tool_with_runtime_support(
-            loongclaw_contracts::ToolCoreRequest {
-                tool_name: "approval_request_resolve".to_owned(),
-                payload: json!({
-                    "approval_request_id": "apr-auto-retry",
-                    "decision": "approve_once",
-                    "session_consent_mode": "auto",
-                }),
+        let outcome = crate::tools::approval::ApprovalResolutionRuntime::resolve_approval_request(
+            &approval_runtime,
+            crate::tools::approval::ApprovalResolutionRequest {
+                current_session_id: "root-session".to_owned(),
+                approval_request_id: "apr-auto-retry".to_owned(),
+                decision: ApprovalDecision::ApproveOnce,
+                session_consent_mode: Some(ToolConsentMode::Auto),
+                visibility: crate::config::SessionVisibility::Children,
             },
-            "root-session",
-            &memory_config,
-            &ToolConfig::default(),
-            Some(&approval_runtime),
         )
         .await
         .expect("approval request retry should succeed");
 
-        assert_eq!(outcome.payload["approval_request"]["status"], "approved");
+        assert_eq!(
+            outcome.approval_request.status,
+            ApprovalRequestStatus::Approved
+        );
 
         let stored = repo
             .load_session_tool_consent("root-session")

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -31,6 +31,8 @@ use crate::tools::{
     governance_profile_for_descriptor, runtime_tool_view, runtime_tool_view_for_config,
     tool_catalog,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::trust::{approval_required_trust_event, embed_trust_event_payload};
 
 use super::autonomy_policy::{
     AUTONOMY_POLICY_SOURCE, AutonomyTurnBudgetState, PolicyDecision, PolicyDecisionInput,
@@ -755,20 +757,37 @@ impl DefaultAppToolDispatcher {
         session_context: &SessionContext,
         intent: &ToolIntent,
         descriptor: &crate::tools::ToolDescriptor,
+        approval_request_id: &str,
+        approval_key: &str,
+        rule_id: &str,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> serde_json::Value {
-        json!({
+        let payload = json!({
             "session_id": session_context.session_id,
             "parent_session_id": session_context.parent_session_id,
             "turn_id": intent.turn_id,
             "tool_call_id": intent.tool_call_id,
             "tool_name": descriptor.name,
+            "approval_key": approval_key,
+            "approval_request_id": approval_request_id,
             "args_json": intent.args_json,
             "source": intent.source,
             "execution_kind": match descriptor.execution_kind {
                 ToolExecutionKind::Core => "core",
                 ToolExecutionKind::App => "app",
             },
-        })
+        });
+        let provenance_ref = approval_request_provenance_ref(binding);
+        let trust_event = approval_required_trust_event(
+            &session_context.session_id,
+            "conversation.approval",
+            provenance_ref,
+            rule_id,
+            Some(approval_request_id),
+            Some(descriptor.name),
+        );
+
+        embed_trust_event_payload(payload, trust_event)
     }
 
     #[cfg(feature = "memory-sqlite")]
@@ -781,6 +800,7 @@ impl DefaultAppToolDispatcher {
         reason: &str,
         rule_id: &str,
         governance_snapshot_json: serde_json::Value,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<ApprovalRequirement, String> {
         let repo = SessionRepository::new(&self.memory_config)?;
         let kind = if session_context.parent_session_id.is_some() {
@@ -798,8 +818,15 @@ impl DefaultAppToolDispatcher {
 
         let approval_request_id =
             governed_approval_request_id(session_context, descriptor.name, intent);
-        let request_payload_json =
-            Self::approval_request_payload_json(session_context, intent, descriptor);
+        let request_payload_json = Self::approval_request_payload_json(
+            session_context,
+            intent,
+            descriptor,
+            &approval_request_id,
+            approval_key,
+            rule_id,
+            binding,
+        );
         let stored = repo.ensure_approval_request(NewApprovalRequestRecord {
             approval_request_id,
             session_id: session_context.session_id.clone(),
@@ -842,6 +869,7 @@ impl DefaultAppToolDispatcher {
         session_context: &SessionContext,
         intent: &ToolIntent,
         descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<Option<ApprovalRequirement>, String> {
         let governance = governance_profile_for_descriptor(descriptor);
         if descriptor.execution_kind != ToolExecutionKind::App
@@ -901,6 +929,7 @@ impl DefaultAppToolDispatcher {
             approval_mode: governance.approval_mode.as_str(),
             reason: &reason,
             rule_id,
+            provenance_ref: approval_request_provenance_ref(binding),
         };
         let stored = approval_runtime.ensure_governed_tool_approval_request(approval_request)?;
         let requirement = ApprovalRequirement::governed_tool(
@@ -919,8 +948,9 @@ impl DefaultAppToolDispatcher {
         session_context: &SessionContext,
         intent: &ToolIntent,
         descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<Option<ApprovalRequirement>, String> {
-        let _ = (session_context, intent, descriptor);
+        let _ = (session_context, intent, descriptor, binding);
         Ok(None)
     }
 
@@ -968,6 +998,7 @@ impl DefaultAppToolDispatcher {
         session_context: &SessionContext,
         intent: &ToolIntent,
         descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<GovernedToolPreflight, String> {
         let governance = governance_profile_for_descriptor(descriptor);
         if descriptor.execution_kind != ToolExecutionKind::App
@@ -1011,19 +1042,15 @@ impl DefaultAppToolDispatcher {
             descriptor.name
         );
         let rule_id = "governed_tool_requires_approval";
-        let request_payload_json = json!({
-            "session_id": session_context.session_id,
-            "parent_session_id": session_context.parent_session_id,
-            "turn_id": intent.turn_id,
-            "tool_call_id": intent.tool_call_id,
-            "tool_name": descriptor.name,
-            "args_json": intent.args_json,
-            "source": intent.source,
-            "execution_kind": match descriptor.execution_kind {
-                ToolExecutionKind::Core => "core",
-                ToolExecutionKind::App => "app",
-            },
-        });
+        let request_payload_json = Self::approval_request_payload_json(
+            session_context,
+            intent,
+            descriptor,
+            &approval_request_id,
+            &approval_key,
+            rule_id,
+            binding,
+        );
         let governance_snapshot_json = json!({
             "governance_scope": governance.scope.as_str(),
             "risk_class": governance.risk_class.as_str(),
@@ -1058,6 +1085,7 @@ impl DefaultAppToolDispatcher {
         intent: &ToolIntent,
         request: &ToolCoreRequest,
         descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<GovernedToolPreflight, String> {
         if descriptor.name != crate::tools::SHELL_EXEC_TOOL_NAME {
             return Ok(GovernedToolPreflight::Allowed);
@@ -1075,9 +1103,18 @@ impl DefaultAppToolDispatcher {
         if trimmed_command.is_empty() {
             return Ok(GovernedToolPreflight::Allowed);
         }
-        let normalized_command =
-            crate::tools::shell_policy_ext::validate_shell_command_name(trimmed_command)
-                .map_err(|reason| format!("tool_preflight_denied: {reason}"))?;
+        let normalized_command = crate::tools::shell_policy_ext::validate_shell_command_name(
+            trimmed_command,
+        )
+        .map_err(|reason| {
+            if crate::tools::shell_policy_ext::is_repairable_tool_input_reason(reason.as_str()) {
+                let stripped = crate::tools::shell_policy_ext::strip_repairable_tool_input_prefix(
+                    reason.as_str(),
+                );
+                return format!("tool_preflight_denied: tool input needs repair: {stripped}");
+            }
+            format!("tool_preflight_denied: {reason}")
+        })?;
 
         let shell_deny = &self.tool_config.shell_deny;
         let hard_denied = shell_deny
@@ -1148,16 +1185,15 @@ impl DefaultAppToolDispatcher {
             "operator approval required before running shell command `{normalized_command}` via `shell.exec`"
         );
         let rule_id = crate::tools::shell_policy_ext::SHELL_EXEC_APPROVAL_RULE_ID;
-        let request_payload_json = json!({
-            "session_id": session_context.session_id,
-            "parent_session_id": session_context.parent_session_id,
-            "turn_id": intent.turn_id,
-            "tool_call_id": intent.tool_call_id,
-            "tool_name": descriptor.name,
-            "args_json": request.payload,
-            "source": intent.source,
-            "execution_kind": "core",
-        });
+        let request_payload_json = Self::approval_request_payload_json(
+            session_context,
+            intent,
+            descriptor,
+            &approval_request_id,
+            &approval_key,
+            rule_id,
+            binding,
+        );
         let governance = governance_profile_for_descriptor(descriptor);
         let governance_snapshot_json = json!({
             "governance_scope": governance.scope.as_str(),
@@ -1193,6 +1229,7 @@ impl DefaultAppToolDispatcher {
         intent: &ToolIntent,
         request: &ToolCoreRequest,
         descriptor: &crate::tools::ToolDescriptor,
+        binding: ConversationRuntimeBinding<'_>,
     ) -> Result<GovernedToolPreflight, String> {
         let governance = governance_profile_for_descriptor(descriptor);
         if governance.approval_mode != ToolApprovalMode::PolicyDriven {
@@ -1205,11 +1242,21 @@ impl DefaultAppToolDispatcher {
                 intent,
                 request,
                 descriptor,
+                binding,
             );
         }
 
-        self.governed_app_tool_preflight(session_context, intent, descriptor)
+        self.governed_app_tool_preflight(session_context, intent, descriptor, binding)
     }
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn approval_request_provenance_ref(binding: ConversationRuntimeBinding<'_>) -> &'static str {
+    if binding.is_kernel_bound() {
+        return "kernel";
+    }
+
+    "advisory_only"
 }
 
 fn governed_approval_request_id(
@@ -1348,6 +1395,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                             reason.as_str(),
                             rule_id,
                             governance_snapshot_json,
+                            binding,
                         )?;
                         let decision = Self::autonomy_policy_approval_required_decision(
                             descriptor.name,
@@ -1508,6 +1556,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                     session_context,
                     intent,
                     descriptor,
+                    binding,
                 );
             };
 
@@ -1527,6 +1576,7 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
                 reason.as_str(),
                 rule_id,
                 governance_snapshot_json,
+                binding,
             )?;
 
             Ok(Some(requirement))
@@ -1549,13 +1599,17 @@ impl AppToolDispatcher for DefaultAppToolDispatcher {
 
         #[cfg(feature = "memory-sqlite")]
         {
-            let _ = binding;
             if descriptor.name != crate::tools::SHELL_EXEC_TOOL_NAME {
                 return Ok(ToolExecutionPreflight::ready(request));
             }
 
-            let preflight =
-                self.governed_tool_preflight(session_context, intent, &request, descriptor)?;
+            let preflight = self.governed_tool_preflight(
+                session_context,
+                intent,
+                &request,
+                descriptor,
+                binding,
+            )?;
             match preflight {
                 GovernedToolPreflight::Allowed => Ok(ToolExecutionPreflight::ready(request)),
                 GovernedToolPreflight::NeedsApproval(requirement) => {
@@ -3504,6 +3558,7 @@ mod tests {
         let engine = TurnEngine::new(4);
         let runtime = tokio::runtime::Runtime::new().expect("test runtime");
         let prepared_intent = runtime.block_on(async {
+            let autonomy_budget_state = AutonomyTurnBudgetState::default();
             engine
                 .prepare_tool_intent(
                     &intent,
@@ -3511,7 +3566,7 @@ mod tests {
                     &session_context,
                     &DefaultAppToolDispatcher::runtime(),
                     ConversationRuntimeBinding::kernel(&harness.kernel_ctx),
-                    &AutonomyTurnBudgetState::default(),
+                    &autonomy_budget_state,
                     None,
                 )
                 .await

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -522,7 +522,6 @@ fn append_round_followup_messages(
             &mut session.messages,
             assistant_preface.as_str(),
             &payload,
-            tool_request_summary.as_deref(),
             user_input,
             &mut session.followup_payload_budget,
             loop_warning_reason.as_deref(),
@@ -551,10 +550,10 @@ fn append_tool_driven_followup_messages(
     messages: &mut Vec<Value>,
     assistant_preface: &str,
     payload: &ToolDrivenFollowupPayload,
-    tool_request_summary: Option<&str>,
     user_input: &str,
     followup_payload_budget: &mut FollowupPayloadBudget,
     loop_warning_reason: Option<&str>,
+    tool_request_summary: Option<&str>,
 ) {
     messages.extend(build_tool_driven_followup_tail_with_request_summary(
         assistant_preface,
@@ -1034,7 +1033,6 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolResult {
                 text: r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#.to_owned(),
             },
-            None,
             "summarize note.md",
             &mut budget,
             None,
@@ -1062,7 +1060,6 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolFailure {
                 reason: "tool_timeout ...(truncated 200 chars)".to_owned(),
             },
-            None,
             "summarize note.md",
             &mut budget,
             None,
@@ -1097,10 +1094,10 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolFailure {
                 reason: "tool_preflight_denied: tool input needs repair".to_owned(),
             },
-            Some(tool_request_summary.as_str()),
             "retry the command",
             &mut budget,
             None,
+            Some(tool_request_summary.as_str()),
         );
 
         let user_prompt = messages
@@ -1125,7 +1122,6 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolResult {
                 text: r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#.to_owned(),
             },
-            None,
             "summarize note.md",
             &mut budget,
             None,
@@ -1178,7 +1174,6 @@ mod tests {
             &mut messages,
             "",
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
-            None,
             "apply the skill",
             &mut budget,
             None,
@@ -1204,7 +1199,6 @@ mod tests {
             &mut messages,
             "preface",
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
-            None,
             "summarize README.md",
             &mut budget,
             None,
@@ -1254,7 +1248,6 @@ mod tests {
             &mut messages,
             "preface",
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
-            None,
             "summarize the test run",
             &mut budget,
             None,
@@ -1344,7 +1337,6 @@ mod tests {
             &mut messages,
             "preface",
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
-            None,
             "find the right tool",
             &mut budget,
             None,

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -1080,6 +1080,41 @@ mod tests {
     }
 
     #[test]
+    fn append_tool_driven_followup_messages_includes_request_summary_guidance() {
+        let mut messages = Vec::new();
+        let mut budget = FollowupPayloadBudget::new(8_000, 20_000);
+        let tool_request_summary = json!({
+            "tool": "shell.exec",
+            "request": {
+                "command": r#"C:\Windows\System32\CMD.EXE"#
+            }
+        })
+        .to_string();
+
+        append_tool_driven_followup_messages(
+            &mut messages,
+            "preface",
+            &ToolDrivenFollowupPayload::ToolFailure {
+                reason: "tool_preflight_denied: tool input needs repair".to_owned(),
+            },
+            Some(tool_request_summary.as_str()),
+            "retry the command",
+            &mut budget,
+            None,
+        );
+
+        let user_prompt = messages
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+
+        assert!(user_prompt.contains("Repair guidance for shell.exec:"));
+        assert!(user_prompt.contains("CMD.EXE"));
+        assert!(user_prompt.contains("cmd.exe"));
+    }
+
+    #[test]
     fn append_tool_driven_followup_messages_promotes_external_skill_invoke_into_system_context() {
         let mut messages = Vec::new();
         let mut budget = FollowupPayloadBudget::new(64, 64);

--- a/crates/app/src/conversation/turn_loop.rs
+++ b/crates/app/src/conversation/turn_loop.rs
@@ -77,8 +77,8 @@ enum RoundFollowup {
     Tool {
         assistant_preface: String,
         payload: ToolDrivenFollowupPayload,
-        loop_warning_reason: Option<String>,
         tool_request_summary: Option<String>,
+        loop_warning_reason: Option<String>,
     },
     Guard {
         assistant_preface: String,
@@ -490,8 +490,8 @@ fn decide_round_kernel_action(
     let followup = RoundFollowup::Tool {
         assistant_preface: evaluation.assistant_preface,
         payload: tool_payload,
-        loop_warning_reason,
         tool_request_summary: evaluation.tool_request_summary,
+        loop_warning_reason,
     };
 
     match round_budget.followup_decision() {
@@ -516,12 +516,13 @@ fn append_round_followup_messages(
         RoundFollowup::Tool {
             assistant_preface,
             payload,
-            loop_warning_reason,
             tool_request_summary,
+            loop_warning_reason,
         } => append_tool_driven_followup_messages(
             &mut session.messages,
             assistant_preface.as_str(),
             &payload,
+            tool_request_summary.as_deref(),
             user_input,
             &mut session.followup_payload_budget,
             loop_warning_reason.as_deref(),
@@ -550,10 +551,10 @@ fn append_tool_driven_followup_messages(
     messages: &mut Vec<Value>,
     assistant_preface: &str,
     payload: &ToolDrivenFollowupPayload,
+    tool_request_summary: Option<&str>,
     user_input: &str,
     followup_payload_budget: &mut FollowupPayloadBudget,
     loop_warning_reason: Option<&str>,
-    tool_request_summary: Option<&str>,
 ) {
     messages.extend(build_tool_driven_followup_tail_with_request_summary(
         assistant_preface,
@@ -1033,6 +1034,7 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolResult {
                 text: r#"[ok] {"payload_truncated":true,"payload_summary":"..."}"#.to_owned(),
             },
+            None,
             "summarize note.md",
             &mut budget,
             None,
@@ -1060,6 +1062,7 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolFailure {
                 reason: "tool_timeout ...(truncated 200 chars)".to_owned(),
             },
+            None,
             "summarize note.md",
             &mut budget,
             None,
@@ -1087,6 +1090,7 @@ mod tests {
             &ToolDrivenFollowupPayload::ToolResult {
                 text: r#"[ok] {"status":"ok","tool":"external_skills.invoke","tool_call_id":"call-1","payload_summary":"{\"skill_id\":\"demo-skill\",\"display_name\":\"Demo Skill\",\"instructions\":\"Follow the managed skill instruction before answering.\"}","payload_chars":180,"payload_truncated":false}"#.to_owned(),
             },
+            None,
             "summarize note.md",
             &mut budget,
             None,
@@ -1139,6 +1143,7 @@ mod tests {
             &mut messages,
             "",
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            None,
             "apply the skill",
             &mut budget,
             None,
@@ -1164,6 +1169,7 @@ mod tests {
             &mut messages,
             "preface",
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            None,
             "summarize README.md",
             &mut budget,
             None,
@@ -1213,6 +1219,7 @@ mod tests {
             &mut messages,
             "preface",
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            None,
             "summarize the test run",
             &mut budget,
             None,
@@ -1302,6 +1309,7 @@ mod tests {
             &mut messages,
             "preface",
             &ToolDrivenFollowupPayload::ToolResult { text: tool_result },
+            None,
             "find the right tool",
             &mut budget,
             None,
@@ -1521,12 +1529,14 @@ mod tests {
         if let RoundKernelDecision::ContinueWithFollowup(RoundFollowup::Tool {
             assistant_preface,
             payload: ToolDrivenFollowupPayload::ToolResult { text },
+            tool_request_summary,
             loop_warning_reason,
             ..
         }) = decision
         {
             assert_eq!(assistant_preface, "preface");
             assert_eq!(text, "tool output");
+            assert!(tool_request_summary.is_none());
             assert_eq!(loop_warning_reason.as_deref(), Some("warning"));
         } else {
             panic!("unexpected decision: {decision:?}");

--- a/crates/app/src/conversation/turn_shared.rs
+++ b/crates/app/src/conversation/turn_shared.rs
@@ -232,7 +232,6 @@ fn first_failed_provider_lane_tool_call_id(trace: &ToolBatchExecutionTrace) -> O
     let tool_call_id = failed_outcome.tool_call_id.as_str();
     Some(tool_call_id)
 }
-
 fn tool_followup_request_entry(intent: &ToolIntent) -> Value {
     let tool_name = effective_followup_tool_name(intent);
     let request = effective_followup_request(intent);
@@ -1141,6 +1140,7 @@ pub fn build_tool_followup_user_prompt(
     loop_warning_reason: Option<&str>,
     tool_result_text: Option<&str>,
     rendered_tool_result_text: Option<&str>,
+    _tool_request_summary: Option<&str>,
 ) -> String {
     build_tool_followup_user_prompt_with_context(
         user_input,
@@ -1548,6 +1548,7 @@ where
             loop_warning_reason,
             Some(tool_result_text),
             Some(bounded_result.as_str()),
+            None,
         ),
     }));
     messages
@@ -1558,6 +1559,7 @@ where
 pub fn build_tool_failure_followup_tail<F>(
     assistant_preface: &str,
     tool_failure_reason: &str,
+    tool_request_summary: Option<&str>,
     user_input: &str,
     loop_warning_reason: Option<&str>,
     payload_mapper: F,
@@ -1570,7 +1572,7 @@ where
         tool_failure_reason,
         user_input,
         loop_warning_reason,
-        None,
+        tool_request_summary,
         payload_mapper,
     )
 }
@@ -1588,14 +1590,13 @@ where
 {
     let mut messages = Vec::new();
     append_followup_preface(&mut messages, assistant_preface);
-
     if let Some(tool_request_summary) = tool_request_summary {
+        let bounded_request = payload_mapper("tool_request", tool_request_summary);
         messages.push(serde_json::json!({
             "role": "assistant",
-            "content": format!("[tool_request]\n{tool_request_summary}"),
+            "content": format!("[tool_request]\n{bounded_request}"),
         }));
     }
-
     let repair_guidance =
         render_tool_failure_repair_guidance(tool_failure_reason, tool_request_summary);
     let bounded_failure = payload_mapper("tool_failure", tool_failure_reason);
@@ -1627,6 +1628,7 @@ where
 pub fn build_tool_driven_followup_tail<F>(
     assistant_preface: &str,
     payload: &ToolDrivenFollowupPayload,
+    tool_request_summary: Option<&str>,
     user_input: &str,
     loop_warning_reason: Option<&str>,
     payload_mapper: F,
@@ -1639,7 +1641,7 @@ where
         payload,
         user_input,
         loop_warning_reason,
-        None,
+        tool_request_summary,
         payload_mapper,
     )
 }
@@ -2488,6 +2490,7 @@ mod tests {
         let tail = build_tool_failure_followup_tail(
             "preface",
             "tool_timeout ...(truncated 200 chars)",
+            None,
             "summarize note.md",
             Some("warning"),
             |_, _| "bounded-failure".to_owned(),
@@ -2518,6 +2521,7 @@ mod tests {
         let tail = build_tool_driven_followup_tail(
             "preface",
             &payload,
+            None,
             "summarize note.md",
             Some("warning"),
             |_, _| "bounded-result".to_owned(),
@@ -2548,6 +2552,7 @@ mod tests {
         let tail = build_tool_driven_followup_tail(
             "preface",
             &payload,
+            None,
             "summarize note.md",
             Some("warning"),
             |_, _| "bounded-failure".to_owned(),
@@ -2568,6 +2573,42 @@ mod tests {
             .expect("user followup prompt should exist");
         assert!(!user_prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
         assert!(user_prompt.contains("Loop warning:\nwarning"));
+    }
+
+    #[test]
+    fn tool_driven_followup_tail_preserves_request_summary_for_failure_payloads() {
+        let payload = ToolDrivenFollowupPayload::ToolFailure {
+            reason: "payload.command contains path separators".to_owned(),
+        };
+        let tool_request_summary =
+            r#"{"tool":"shell.exec","request":{"command":"C:\\Windows\\System32\\RM.EXE"}}"#;
+        let tail = build_tool_driven_followup_tail(
+            "preface",
+            &payload,
+            Some(tool_request_summary),
+            "summarize note.md",
+            Some("warning"),
+            |label, _| match label {
+                "tool_request" => "bounded-request".to_owned(),
+                _ => "bounded-failure".to_owned(),
+            },
+        );
+
+        assert!(tail.iter().any(|message| {
+            message.get("role") == Some(&Value::String("assistant".to_owned()))
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .map(|content| content == "[tool_request]\nbounded-request")
+                    .unwrap_or(false)
+        }));
+        let user_prompt = tail
+            .last()
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .expect("user followup prompt should exist");
+        assert!(user_prompt.contains("Repair guidance for shell.exec"));
+        assert!(user_prompt.contains("retry with `rm.exe`"));
     }
 
     #[test]
@@ -2681,6 +2722,7 @@ mod tests {
             None,
             Some(r#"[ok] {"payload_truncated":true}"#),
             None,
+            None,
         );
         assert!(prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
         assert!(prompt.contains("Original request:\nsummarize this result"));
@@ -2693,6 +2735,7 @@ mod tests {
             None,
             Some(r#"[ok] {"payload_truncated":false}"#),
             Some(r#"[ok] {"payload_truncated":true}"#),
+            None,
         );
         assert!(prompt.contains(TOOL_TRUNCATION_HINT_PROMPT));
         assert!(prompt.contains("Original request:\nsummarize this result"));
@@ -2726,6 +2769,7 @@ mod tests {
             "find the latest ai news and summarize it",
             None,
             Some(tool_result.as_str()),
+            None,
             None,
         );
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -20,6 +20,7 @@ mod runtime_self_continuity;
 mod secrets;
 pub mod session;
 pub mod tools;
+pub(crate) mod trust;
 pub mod tui_surface;
 
 mod process_env;

--- a/crates/app/src/operator/approval_runtime.rs
+++ b/crates/app/src/operator/approval_runtime.rs
@@ -15,6 +15,8 @@ use crate::session::repository::{
     ApprovalGrantRecord, ApprovalRequestRecord, NewApprovalRequestRecord, NewSessionRecord,
     SessionKind, SessionRepository, SessionState,
 };
+#[cfg(feature = "memory-sqlite")]
+use crate::trust::{approval_required_trust_event, embed_trust_event_payload};
 
 #[cfg(feature = "memory-sqlite")]
 pub(crate) struct GovernedToolApprovalRequest<'a> {
@@ -30,6 +32,7 @@ pub(crate) struct GovernedToolApprovalRequest<'a> {
     pub approval_mode: &'a str,
     pub reason: &'a str,
     pub rule_id: &'a str,
+    pub provenance_ref: &'a str,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -95,10 +98,21 @@ impl<'a> OperatorApprovalRuntime<'a> {
             "turn_id": request.turn_id,
             "tool_call_id": request.tool_call_id,
             "tool_name": request.tool_name,
+            "approval_key": approval_key,
+            "approval_request_id": approval_request_id,
             "args_json": request.args_json,
             "source": request.source,
             "execution_kind": "app",
         });
+        let trust_event = approval_required_trust_event(
+            request.session_id,
+            "conversation.approval",
+            request.provenance_ref,
+            request.rule_id,
+            Some(approval_request_id.as_str()),
+            Some(request.tool_name),
+        );
+        let request_payload_json = embed_trust_event_payload(request_payload_json, trust_event);
         let governance_snapshot_json = json!({
             "governance_scope": request.governance_scope,
             "risk_class": request.risk_class,
@@ -368,6 +382,7 @@ mod tests {
             approval_mode: "policy_driven",
             reason: "operator approval required before running `delegate`",
             rule_id: "governed_tool_requires_approval",
+            provenance_ref: "kernel",
         };
 
         let stored = approval_runtime
@@ -434,6 +449,7 @@ mod tests {
             approval_mode: "policy_driven",
             reason: "operator approval required before running `delegate`",
             rule_id: "governed_tool_requires_approval",
+            provenance_ref: "kernel",
         };
 
         let stored = approval_runtime
@@ -510,6 +526,7 @@ mod tests {
             approval_mode: "policy_driven",
             reason: "operator approval required before running `delegate`",
             rule_id: "governed_tool_requires_approval",
+            provenance_ref: "kernel",
         };
         let stored = approval_runtime
             .ensure_governed_tool_approval_request(request)
@@ -558,6 +575,7 @@ mod tests {
             approval_mode: "policy_driven",
             reason: "operator approval required before running `delegate`",
             rule_id: "governed_tool_requires_approval",
+            provenance_ref: "kernel",
         };
         let stored = approval_runtime
             .ensure_governed_tool_approval_request(request)

--- a/crates/app/src/provider/failover.rs
+++ b/crates/app/src/provider/failover.rs
@@ -2,6 +2,8 @@ use serde_json::{Value, json};
 
 use super::contracts::ProviderApiError;
 
+const PROVIDER_FAILOVER_MARKER: &str = "provider_failover=";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ProviderFailoverReason {
     ModelMismatch,
@@ -63,6 +65,17 @@ impl ProviderFailoverStage {
             Self::ResponseDecode => "response_decode",
             Self::ResponseShapeInvalid => "response_shape_invalid",
             Self::ModelCandidateRejected => "model_candidate_rejected",
+        }
+    }
+
+    fn from_str(raw: &str) -> Option<Self> {
+        match raw {
+            "status_failure" => Some(Self::StatusFailure),
+            "transport_failure" => Some(Self::TransportFailure),
+            "response_decode" => Some(Self::ResponseDecode),
+            "response_shape_invalid" => Some(Self::ResponseShapeInvalid),
+            "model_candidate_rejected" => Some(Self::ModelCandidateRejected),
+            _ => None,
         }
     }
 }
@@ -130,11 +143,45 @@ pub(super) fn build_model_request_error(
     }
 }
 
+pub(crate) fn parse_provider_failover_snapshot_payload(error: &str) -> Option<Value> {
+    let (_prefix, payload_raw) = error.split_once(PROVIDER_FAILOVER_MARKER)?;
+    let payload: Value = serde_json::from_str(payload_raw).ok()?;
+    validate_provider_failover_snapshot_payload(payload)
+}
+
+fn validate_provider_failover_snapshot_payload(payload: Value) -> Option<Value> {
+    let payload_object = payload.as_object()?;
+
+    let reason_value = payload_object.get("reason")?;
+    let reason_raw = reason_value.as_str()?;
+    let _reason = ProviderFailoverReason::from_str(reason_raw)?;
+
+    let stage_value = payload_object.get("stage")?;
+    let stage_raw = stage_value.as_str()?;
+    let _stage = ProviderFailoverStage::from_str(stage_raw)?;
+
+    let model_value = payload_object.get("model")?;
+    let _model = model_value.as_str()?;
+
+    let attempt_value = payload_object.get("attempt")?;
+    let _attempt = attempt_value.as_u64()?;
+
+    let max_attempts_value = payload_object.get("max_attempts")?;
+    let _max_attempts = max_attempts_value.as_u64()?;
+
+    let status_code_value = payload_object.get("status_code");
+    if let Some(status_code_value) = status_code_value {
+        let _status_code = status_code_value.as_u64()?;
+    }
+
+    Some(payload)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         ProviderFailoverReason, ProviderFailoverSnapshot, ProviderFailoverStage,
-        build_model_request_error,
+        build_model_request_error, parse_provider_failover_snapshot_payload,
     };
     use serde_json::json;
 
@@ -226,5 +273,33 @@ mod tests {
                 "status_code": 429
             })
         );
+    }
+
+    #[test]
+    fn parse_provider_failover_snapshot_payload_extracts_structured_suffix() {
+        let error = "provider request failed | provider_failover={\"reason\":\"transport_failure\",\"stage\":\"transport_failure\",\"model\":\"openai/gpt-4o\",\"attempt\":2,\"max_attempts\":4}";
+
+        let payload = parse_provider_failover_snapshot_payload(error)
+            .expect("provider failover suffix should parse");
+
+        assert_eq!(
+            payload,
+            json!({
+                "reason": "transport_failure",
+                "stage": "transport_failure",
+                "model": "openai/gpt-4o",
+                "attempt": 2,
+                "max_attempts": 4
+            })
+        );
+    }
+
+    #[test]
+    fn parse_provider_failover_snapshot_payload_rejects_invalid_shape() {
+        let error = "provider request failed | provider_failover={\"reason\":\"unknown\",\"stage\":\"transport_failure\",\"model\":\"openai/gpt-4o\",\"attempt\":2,\"max_attempts\":4}";
+
+        let payload = parse_provider_failover_snapshot_payload(error);
+
+        assert!(payload.is_none());
     }
 }

--- a/crates/app/src/provider/failover.rs
+++ b/crates/app/src/provider/failover.rs
@@ -144,13 +144,27 @@ pub(super) fn build_model_request_error(
 }
 
 pub(crate) fn parse_provider_failover_snapshot_payload(error: &str) -> Option<Value> {
-    let (_prefix, payload_raw) = error.split_once(PROVIDER_FAILOVER_MARKER)?;
+    let (_prefix, payload_raw) = error.rsplit_once(PROVIDER_FAILOVER_MARKER)?;
     let payload: Value = serde_json::from_str(payload_raw).ok()?;
     validate_provider_failover_snapshot_payload(payload)
 }
 
 fn validate_provider_failover_snapshot_payload(payload: Value) -> Option<Value> {
     let payload_object = payload.as_object()?;
+    let payload_has_status_code = payload_object.contains_key("status_code");
+    let expected_key_count = if payload_has_status_code { 6 } else { 5 };
+    let has_only_known_keys = payload_object.keys().all(|key| {
+        matches!(
+            key.as_str(),
+            "reason" | "stage" | "model" | "attempt" | "max_attempts" | "status_code"
+        )
+    });
+    if payload_object.len() != expected_key_count {
+        return None;
+    }
+    if !has_only_known_keys {
+        return None;
+    }
 
     let reason_value = payload_object.get("reason")?;
     let reason_raw = reason_value.as_str()?;
@@ -297,6 +311,36 @@ mod tests {
     #[test]
     fn parse_provider_failover_snapshot_payload_rejects_invalid_shape() {
         let error = "provider request failed | provider_failover={\"reason\":\"unknown\",\"stage\":\"transport_failure\",\"model\":\"openai/gpt-4o\",\"attempt\":2,\"max_attempts\":4}";
+
+        let payload = parse_provider_failover_snapshot_payload(error);
+
+        assert!(payload.is_none());
+    }
+
+    #[test]
+    fn parse_provider_failover_snapshot_payload_uses_last_marker() {
+        let error = concat!(
+            "provider request failed | provider_failover=",
+            "{\"reason\":\"rate_limited\",\"stage\":\"status_failure\",\"model\":\"openai/gpt-4o\",\"attempt\":1,\"max_attempts\":3}",
+            " extra context | provider_failover=",
+            "{\"reason\":\"transport_failure\",\"stage\":\"transport_failure\",\"model\":\"openai/gpt-4o\",\"attempt\":2,\"max_attempts\":4}",
+        );
+
+        let payload = parse_provider_failover_snapshot_payload(error)
+            .expect("provider failover suffix should parse from the last marker");
+
+        assert_eq!(payload["reason"], "transport_failure");
+        assert_eq!(payload["stage"], "transport_failure");
+        assert_eq!(payload["attempt"], 2);
+        assert_eq!(payload["max_attempts"], 4);
+    }
+
+    #[test]
+    fn parse_provider_failover_snapshot_payload_rejects_unknown_keys() {
+        let error = concat!(
+            "provider request failed | provider_failover=",
+            "{\"reason\":\"transport_failure\",\"stage\":\"transport_failure\",\"model\":\"openai/gpt-4o\",\"attempt\":2,\"max_attempts\":4,\"unexpected\":true}",
+        );
 
         let payload = parse_provider_failover_snapshot_payload(error);
 

--- a/crates/app/src/provider/mod.rs
+++ b/crates/app/src/provider/mod.rs
@@ -42,6 +42,7 @@ mod runtime_binding;
 mod shape;
 mod transport;
 
+pub(crate) use failover::parse_provider_failover_snapshot_payload;
 pub use request_executor::{StreamingCallbackData, StreamingTokenCallback};
 pub use runtime_binding::ProviderRuntimeBinding;
 pub use shape::{

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -744,6 +744,7 @@ fn execute_discoverable_tool_core_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let request = normalize_shell_request_for_execution(request);
     let tool_name = request.tool_name.clone();
     direct_policy_preflight::run(&request, config)?;
     let timeout_seconds = config.tool_execution.timeout_for_tool(&tool_name);

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -65,6 +65,66 @@ impl ToolPolicyExtension {
             default_mode: rt.shell_default_mode,
         }
     }
+
+    fn authorize_shell_payload(
+        &self,
+        tool_name: &str,
+        payload: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(), PolicyError> {
+        let command = payload.get("command").and_then(serde_json::Value::as_str);
+        let Some(command) = command else {
+            return Ok(());
+        };
+        let trimmed_command = command.trim();
+        if trimmed_command.is_empty() {
+            return Ok(());
+        }
+
+        let basename = validate_shell_command_name(trimmed_command).map_err(|reason| {
+            PolicyError::ToolCallDenied {
+                tool_name: tool_name.to_owned(),
+                reason,
+            }
+        })?;
+
+        if self.hard_deny.contains(basename.as_str()) {
+            return Err(PolicyError::ToolCallDenied {
+                tool_name: tool_name.to_owned(),
+                reason: format!("command `{basename}` is blocked by shell policy"),
+            });
+        }
+
+        if self.allow.contains(basename.as_str()) {
+            return Ok(());
+        }
+
+        let approval_key = shell_exec_approval_key_for_normalized_command(basename.as_str());
+        let approved_by_internal_context =
+            shell_exec_matches_trusted_internal_approval(payload, approval_key.as_str());
+        if approved_by_internal_context {
+            return Ok(());
+        }
+
+        match self.default_mode {
+            ShellPolicyDefault::Allow => Ok(()),
+            ShellPolicyDefault::Deny => Err(PolicyError::ToolCallDenied {
+                tool_name: tool_name.to_owned(),
+                reason: format!(
+                    "command `{basename}` is not in the allow list (default-deny policy)"
+                ),
+            }),
+        }
+    }
+}
+
+pub(crate) fn authorize_direct_shell_payload(
+    payload: &serde_json::Map<String, serde_json::Value>,
+    rt: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<(), String> {
+    let extension = ToolPolicyExtension::from_config(rt);
+    extension
+        .authorize_shell_payload("shell.exec", payload)
+        .map_err(|error| format!("policy_denied: {error}"))
 }
 
 pub(crate) fn validate_shell_command_name(command: &str) -> Result<String, String> {
@@ -162,49 +222,8 @@ impl PolicyExtension for ToolPolicyExtension {
         let Some(payload) = payload.and_then(serde_json::Value::as_object) else {
             return Ok(());
         };
-        let command = payload.get("command").and_then(serde_json::Value::as_str);
-        let Some(command) = command else {
-            return Ok(());
-        };
-        let trimmed_command = command.trim();
-        if trimmed_command.is_empty() {
-            return Ok(());
-        }
-        let basename = validate_shell_command_name(trimmed_command).map_err(|reason| {
-            PolicyError::ToolCallDenied {
-                tool_name: tool_name.to_owned(),
-                reason,
-            }
-        })?;
 
-        if self.hard_deny.contains(basename.as_str()) {
-            return Err(PolicyError::ToolCallDenied {
-                tool_name: tool_name.to_owned(),
-                reason: format!("command `{basename}` is blocked by shell policy"),
-            });
-        }
-
-        if self.allow.contains(basename.as_str()) {
-            return Ok(());
-        }
-
-        let approval_key = shell_exec_approval_key_for_normalized_command(basename.as_str());
-        let approved_by_internal_context =
-            shell_exec_matches_trusted_internal_approval(payload, approval_key.as_str());
-        if approved_by_internal_context {
-            return Ok(());
-        }
-
-        // Default mode for unknown commands
-        match self.default_mode {
-            ShellPolicyDefault::Allow => Ok(()),
-            ShellPolicyDefault::Deny => Err(PolicyError::ToolCallDenied {
-                tool_name: tool_name.to_owned(),
-                reason: format!(
-                    "command `{basename}` is not in the allow list (default-deny policy)"
-                ),
-            }),
-        }
+        self.authorize_shell_payload(tool_name, payload)
     }
 }
 

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -8,6 +8,20 @@ const SHELL_INTERNAL_APPROVAL_CONTEXT_KEY: &str = "shell_approval";
 const SHELL_INTERNAL_APPROVAL_KEY_FIELD: &str = "approval_key";
 const REPAIRABLE_TOOL_INPUT_PREFIX: &str = "repairable_tool_input: ";
 
+fn repairable_tool_input_reason(reason: String) -> String {
+    format!("{REPAIRABLE_TOOL_INPUT_PREFIX}{reason}")
+}
+
+pub(crate) fn is_repairable_tool_input_reason(reason: &str) -> bool {
+    reason.starts_with(REPAIRABLE_TOOL_INPUT_PREFIX)
+}
+
+pub(crate) fn strip_repairable_tool_input_prefix(reason: &str) -> &str {
+    reason
+        .strip_prefix(REPAIRABLE_TOOL_INPUT_PREFIX)
+        .unwrap_or(reason)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShellPolicyDefault {
     Deny,
@@ -51,91 +65,6 @@ impl ToolPolicyExtension {
             default_mode: rt.shell_default_mode,
         }
     }
-
-    fn authorize_shell_payload(
-        &self,
-        tool_name: &str,
-        payload: &serde_json::Map<String, serde_json::Value>,
-    ) -> Result<(), PolicyError> {
-        let command = payload.get("command").and_then(serde_json::Value::as_str);
-        let Some(command) = command else {
-            return Ok(());
-        };
-        let trimmed_command = command.trim();
-        if trimmed_command.is_empty() {
-            return Ok(());
-        }
-
-        let normalized_command =
-            validate_shell_command_name(trimmed_command).map_err(|reason| {
-                PolicyError::ToolCallDenied {
-                    tool_name: tool_name.to_owned(),
-                    reason,
-                }
-            })?;
-
-        if self.hard_deny.contains(normalized_command.as_str()) {
-            let reason = format!("command `{normalized_command}` is blocked by shell policy");
-            return Err(PolicyError::ToolCallDenied {
-                tool_name: tool_name.to_owned(),
-                reason,
-            });
-        }
-
-        if self.allow.contains(normalized_command.as_str()) {
-            return Ok(());
-        }
-
-        let approval_key =
-            shell_exec_approval_key_for_normalized_command(normalized_command.as_str());
-        let approved_by_internal_context =
-            shell_exec_matches_trusted_internal_approval(payload, approval_key.as_str());
-        if approved_by_internal_context {
-            return Ok(());
-        }
-
-        match self.default_mode {
-            ShellPolicyDefault::Allow => Ok(()),
-            ShellPolicyDefault::Deny => {
-                let reason = format!(
-                    "command `{normalized_command}` is not in the allow list (default-deny policy)"
-                );
-                Err(PolicyError::ToolCallDenied {
-                    tool_name: tool_name.to_owned(),
-                    reason,
-                })
-            }
-        }
-    }
-}
-
-pub(crate) fn authorize_direct_shell_payload(
-    payload: &serde_json::Map<String, serde_json::Value>,
-    rt: &super::runtime_config::ToolRuntimeConfig,
-) -> Result<(), String> {
-    let extension = ToolPolicyExtension::from_config(rt);
-    extension
-        .authorize_shell_payload("shell.exec", payload)
-        .map_err(|error| format!("policy_denied: {error}"))
-}
-
-fn repairable_tool_input_reason(reason: String) -> String {
-    let prefixed_reason = format!("{REPAIRABLE_TOOL_INPUT_PREFIX}{reason}");
-    prefixed_reason
-}
-
-#[cfg(test)]
-fn is_repairable_tool_input_reason(reason: &str) -> bool {
-    reason.starts_with(REPAIRABLE_TOOL_INPUT_PREFIX)
-}
-
-#[cfg(test)]
-fn strip_repairable_tool_input_prefix(reason: &str) -> &str {
-    if let Some(stripped_reason) = reason.strip_prefix(REPAIRABLE_TOOL_INPUT_PREFIX) {
-        return stripped_reason;
-    }
-
-    reason
 }
 
 pub(crate) fn validate_shell_command_name(command: &str) -> Result<String, String> {
@@ -156,16 +85,18 @@ pub(crate) fn validate_shell_command_name(command: &str) -> Result<String, Strin
     }
 
     if trimmed.contains(char::is_whitespace) {
-        return Err(
-            "policy_denied: shell command must not contain embedded whitespace; use `args` instead"
-                .to_owned(),
+        let reason = repairable_tool_input_reason(
+            "shell.exec payload.command must be a bare executable name; move arguments into payload.args.".to_owned(),
         );
+        return Err(reason);
     }
 
     if trimmed.contains('/') || trimmed.contains('\\') {
-        return Err(format!(
-            "policy_denied: shell command `{trimmed}` must be a bare command name without path separators"
-        ));
+        let reason = format!(
+            "shell.exec payload.command `{trimmed}` must be a bare lowercase executable name without path separators."
+        );
+        let reason = repairable_tool_input_reason(reason);
+        return Err(reason);
     }
 
     let normalized = trimmed.to_ascii_lowercase();
@@ -231,7 +162,49 @@ impl PolicyExtension for ToolPolicyExtension {
         let Some(payload) = payload.and_then(serde_json::Value::as_object) else {
             return Ok(());
         };
-        self.authorize_shell_payload(tool_name, payload)
+        let command = payload.get("command").and_then(serde_json::Value::as_str);
+        let Some(command) = command else {
+            return Ok(());
+        };
+        let trimmed_command = command.trim();
+        if trimmed_command.is_empty() {
+            return Ok(());
+        }
+        let basename = validate_shell_command_name(trimmed_command).map_err(|reason| {
+            PolicyError::ToolCallDenied {
+                tool_name: tool_name.to_owned(),
+                reason,
+            }
+        })?;
+
+        if self.hard_deny.contains(basename.as_str()) {
+            return Err(PolicyError::ToolCallDenied {
+                tool_name: tool_name.to_owned(),
+                reason: format!("command `{basename}` is blocked by shell policy"),
+            });
+        }
+
+        if self.allow.contains(basename.as_str()) {
+            return Ok(());
+        }
+
+        let approval_key = shell_exec_approval_key_for_normalized_command(basename.as_str());
+        let approved_by_internal_context =
+            shell_exec_matches_trusted_internal_approval(payload, approval_key.as_str());
+        if approved_by_internal_context {
+            return Ok(());
+        }
+
+        // Default mode for unknown commands
+        match self.default_mode {
+            ShellPolicyDefault::Allow => Ok(()),
+            ShellPolicyDefault::Deny => Err(PolicyError::ToolCallDenied {
+                tool_name: tool_name.to_owned(),
+                reason: format!(
+                    "command `{basename}` is not in the allow list (default-deny policy)"
+                ),
+            }),
+        }
     }
 }
 

--- a/crates/app/src/trust.rs
+++ b/crates/app/src/trust.rs
@@ -81,6 +81,15 @@ pub(crate) fn embed_trust_event_payload(payload: Value, trust_event: TrustEventE
     Value::Object(payload_object)
 }
 
+pub(crate) fn extract_trust_event_payload(payload: &Value) -> Option<TrustEventEnvelope> {
+    let payload_object = payload.as_object()?;
+    let trust_event_value = payload_object.get(TRUST_EVENT_PAYLOAD_KEY)?;
+    let trust_event_value = trust_event_value.clone();
+    let trust_event = serde_json::from_value(trust_event_value).ok()?;
+
+    Some(trust_event)
+}
+
 pub(crate) fn delegate_child_trust_event(
     parent_session_id: &str,
     child_session_id: &str,
@@ -123,17 +132,35 @@ pub(crate) fn provider_failover_trust_event(
     provenance_ref: &str,
     reason_code: &str,
     model: &str,
+    stage: &str,
 ) -> TrustEventEnvelope {
+    let trust_state_hint = provider_failover_trust_state_hint(reason_code);
+
     TrustEventEnvelope {
         event_kind: TrustEventKind::TrustAttested,
         actor_id: provider_id.to_owned(),
         actor_kind: TrustActorKind::ProviderRuntime,
         source_surface: source_surface.to_owned(),
-        trust_state_hint: TrustStateHint::Degraded,
+        trust_state_hint,
         provenance_kind: TrustProvenanceKind::RuntimeBinding,
         provenance_ref: provenance_ref.to_owned(),
         reason_code: reason_code.to_owned(),
-        evidence_ref: format!("provider:{provider_id}:model:{model}"),
+        evidence_ref: format!("provider:{provider_id}:model:{model}:stage:{stage}"),
+    }
+}
+
+fn provider_failover_trust_state_hint(reason_code: &str) -> TrustStateHint {
+    match reason_code {
+        "auth_rejected" => TrustStateHint::Rejected,
+        "model_mismatch" => TrustStateHint::Rejected,
+        "payload_incompatible" => TrustStateHint::Rejected,
+        "request_rejected" => TrustStateHint::Rejected,
+        "rate_limited" => TrustStateHint::Degraded,
+        "provider_overloaded" => TrustStateHint::Degraded,
+        "transport_failure" => TrustStateHint::Degraded,
+        "response_decode_failure" => TrustStateHint::Degraded,
+        "response_shape_invalid" => TrustStateHint::Degraded,
+        _ => TrustStateHint::Unknown,
     }
 }
 
@@ -142,7 +169,7 @@ mod tests {
     use super::{
         TRUST_EVENT_PAYLOAD_KEY, TrustActorKind, TrustEventEnvelope, TrustEventKind,
         TrustProvenanceKind, TrustStateHint, delegate_child_trust_event, embed_trust_event_payload,
-        provider_failover_trust_event,
+        extract_trust_event_payload, provider_failover_trust_event,
     };
     use serde_json::json;
 
@@ -210,6 +237,7 @@ mod tests {
             "kernel",
             "rate_limited",
             "gpt-4o",
+            "status_failure",
         );
 
         assert_eq!(envelope.event_kind, TrustEventKind::TrustAttested);
@@ -221,6 +249,51 @@ mod tests {
         );
         assert_eq!(envelope.provenance_ref, "kernel");
         assert_eq!(envelope.reason_code, "rate_limited");
-        assert_eq!(envelope.evidence_ref, "provider:openai:model:gpt-4o");
+        assert_eq!(
+            envelope.evidence_ref,
+            "provider:openai:model:gpt-4o:stage:status_failure"
+        );
+    }
+
+    #[test]
+    fn provider_failover_trust_event_marks_rejected_provider_runtime_state_for_auth_failures() {
+        let envelope = provider_failover_trust_event(
+            "openai",
+            "provider.failover",
+            "kernel",
+            "auth_rejected",
+            "gpt-4o",
+            "status_failure",
+        );
+
+        assert_eq!(envelope.trust_state_hint, TrustStateHint::Rejected);
+    }
+
+    #[test]
+    fn extract_trust_event_payload_reads_embedded_trust_event() {
+        let trust_event =
+            delegate_child_trust_event("root-session", "child-session", "delegate.inline");
+        let payload = embed_trust_event_payload(json!({ "task": "child task" }), trust_event);
+
+        let extracted = extract_trust_event_payload(&payload).expect("extract trust event");
+
+        assert_eq!(extracted.event_kind, TrustEventKind::DelegationCreated);
+        assert_eq!(extracted.actor_kind, TrustActorKind::DelegateChildRuntime);
+    }
+
+    #[test]
+    fn extract_trust_event_payload_rejects_malformed_embedded_value() {
+        let payload = json!({
+            TRUST_EVENT_PAYLOAD_KEY: {
+                "event_kind": "delegation_created",
+                "actor_id": "child-session",
+                "actor_kind": "delegate_child_runtime",
+                "source_surface": "delegate.inline"
+            }
+        });
+
+        let extracted = extract_trust_event_payload(&payload);
+
+        assert!(extracted.is_none());
     }
 }

--- a/crates/app/src/trust.rs
+++ b/crates/app/src/trust.rs
@@ -99,6 +99,24 @@ pub(crate) fn delegate_child_trust_event(
     }
 }
 
+pub(crate) fn runtime_binding_missing_trust_event(
+    session_id: &str,
+    source_surface: &str,
+    provenance_ref: &str,
+) -> TrustEventEnvelope {
+    TrustEventEnvelope {
+        event_kind: TrustEventKind::ProvenanceMismatch,
+        actor_id: session_id.to_owned(),
+        actor_kind: TrustActorKind::ConversationRuntime,
+        source_surface: source_surface.to_owned(),
+        trust_state_hint: TrustStateHint::Rejected,
+        provenance_kind: TrustProvenanceKind::RuntimeBinding,
+        provenance_ref: provenance_ref.to_owned(),
+        reason_code: "no_kernel_context".to_owned(),
+        evidence_ref: format!("session:{session_id}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/app/src/trust.rs
+++ b/crates/app/src/trust.rs
@@ -17,6 +17,7 @@ pub enum TrustActorKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TrustEventKind {
+    ApprovalRequired,
     IdentityBound,
     IdentityMismatch,
     DelegationCreated,
@@ -126,6 +127,35 @@ pub(crate) fn runtime_binding_missing_trust_event(
     }
 }
 
+pub(crate) fn approval_required_trust_event(
+    session_id: &str,
+    source_surface: &str,
+    provenance_ref: &str,
+    rule_id: &str,
+    approval_request_id: Option<&str>,
+    tool_name: Option<&str>,
+) -> TrustEventEnvelope {
+    let evidence_ref = match approval_request_id {
+        Some(approval_request_id) => format!("approval_request:{approval_request_id}"),
+        None => match tool_name {
+            Some(tool_name) => format!("tool:{tool_name}"),
+            None => format!("session:{session_id}"),
+        },
+    };
+
+    TrustEventEnvelope {
+        event_kind: TrustEventKind::ApprovalRequired,
+        actor_id: session_id.to_owned(),
+        actor_kind: TrustActorKind::ConversationRuntime,
+        source_surface: source_surface.to_owned(),
+        trust_state_hint: TrustStateHint::Unknown,
+        provenance_kind: TrustProvenanceKind::RuntimeBinding,
+        provenance_ref: provenance_ref.to_owned(),
+        reason_code: rule_id.to_owned(),
+        evidence_ref,
+    }
+}
+
 pub(crate) fn provider_failover_trust_event(
     provider_id: &str,
     source_surface: &str,
@@ -168,8 +198,9 @@ fn provider_failover_trust_state_hint(reason_code: &str) -> TrustStateHint {
 mod tests {
     use super::{
         TRUST_EVENT_PAYLOAD_KEY, TrustActorKind, TrustEventEnvelope, TrustEventKind,
-        TrustProvenanceKind, TrustStateHint, delegate_child_trust_event, embed_trust_event_payload,
-        extract_trust_event_payload, provider_failover_trust_event,
+        TrustProvenanceKind, TrustStateHint, approval_required_trust_event,
+        delegate_child_trust_event, embed_trust_event_payload, extract_trust_event_payload,
+        provider_failover_trust_event,
     };
     use serde_json::json;
 
@@ -267,6 +298,25 @@ mod tests {
         );
 
         assert_eq!(envelope.trust_state_hint, TrustStateHint::Rejected);
+    }
+
+    #[test]
+    fn approval_required_trust_event_uses_approval_request_evidence_when_present() {
+        let envelope = approval_required_trust_event(
+            "root-session",
+            "conversation.approval",
+            "kernel",
+            "governed_tool_requires_approval",
+            Some("apr-123"),
+            Some("delegate"),
+        );
+
+        assert_eq!(envelope.event_kind, TrustEventKind::ApprovalRequired);
+        assert_eq!(envelope.actor_kind, TrustActorKind::ConversationRuntime);
+        assert_eq!(envelope.trust_state_hint, TrustStateHint::Unknown);
+        assert_eq!(envelope.provenance_ref, "kernel");
+        assert_eq!(envelope.reason_code, "governed_tool_requires_approval");
+        assert_eq!(envelope.evidence_ref, "approval_request:apr-123");
     }
 
     #[test]

--- a/crates/app/src/trust.rs
+++ b/crates/app/src/trust.rs
@@ -109,6 +109,11 @@ pub(crate) fn delegate_child_trust_event(
     }
 }
 
+/// Build the additive trust envelope for a missing runtime binding.
+///
+/// `provenance_ref` is usually `"kernel"` for kernel-bound sessions and
+/// `"direct"` for direct bindings that reached a core-only path without kernel
+/// context.
 pub(crate) fn runtime_binding_missing_trust_event(
     session_id: &str,
     source_surface: &str,

--- a/crates/app/src/trust.rs
+++ b/crates/app/src/trust.rs
@@ -1,0 +1,165 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+pub(crate) const TRUST_EVENT_PAYLOAD_KEY: &str = "trust_event";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustActorKind {
+    Operator,
+    ConversationRuntime,
+    ProviderRuntime,
+    DelegateChildRuntime,
+    ConnectorCaller,
+    PluginRuntime,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustEventKind {
+    IdentityBound,
+    IdentityMismatch,
+    DelegationCreated,
+    DelegationRejected,
+    ProvenanceMismatch,
+    TrustAttested,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustStateHint {
+    Unknown,
+    Bound,
+    Degraded,
+    Attested,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustProvenanceKind {
+    SessionLineage,
+    RuntimeBinding,
+    ConnectorCaller,
+    PluginAttestation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrustEventEnvelope {
+    pub event_kind: TrustEventKind,
+    pub actor_id: String,
+    pub actor_kind: TrustActorKind,
+    pub source_surface: String,
+    pub trust_state_hint: TrustStateHint,
+    pub provenance_kind: TrustProvenanceKind,
+    pub provenance_ref: String,
+    pub reason_code: String,
+    pub evidence_ref: String,
+}
+
+pub(crate) fn embed_trust_event_payload(payload: Value, trust_event: TrustEventEnvelope) -> Value {
+    let trust_event_value = match serde_json::to_value(trust_event) {
+        Ok(trust_event_value) => trust_event_value,
+        Err(_error) => return payload,
+    };
+
+    let mut payload_object = match payload {
+        Value::Object(payload_object) => payload_object,
+        payload @ Value::Null
+        | payload @ Value::Bool(_)
+        | payload @ Value::Number(_)
+        | payload @ Value::String(_)
+        | payload @ Value::Array(_) => {
+            let mut payload_object = Map::new();
+            payload_object.insert("payload".to_owned(), payload);
+            payload_object
+        }
+    };
+
+    payload_object.insert(TRUST_EVENT_PAYLOAD_KEY.to_owned(), trust_event_value);
+
+    Value::Object(payload_object)
+}
+
+pub(crate) fn delegate_child_trust_event(
+    parent_session_id: &str,
+    child_session_id: &str,
+    source_surface: &str,
+) -> TrustEventEnvelope {
+    TrustEventEnvelope {
+        event_kind: TrustEventKind::DelegationCreated,
+        actor_id: child_session_id.to_owned(),
+        actor_kind: TrustActorKind::DelegateChildRuntime,
+        source_surface: source_surface.to_owned(),
+        trust_state_hint: TrustStateHint::Bound,
+        provenance_kind: TrustProvenanceKind::SessionLineage,
+        provenance_ref: parent_session_id.to_owned(),
+        reason_code: "delegate_child_session_created".to_owned(),
+        evidence_ref: format!("session:{child_session_id}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        TRUST_EVENT_PAYLOAD_KEY, TrustActorKind, TrustEventEnvelope, TrustEventKind,
+        TrustProvenanceKind, TrustStateHint, delegate_child_trust_event, embed_trust_event_payload,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn trust_event_envelope_round_trips_through_json() {
+        let envelope = TrustEventEnvelope {
+            event_kind: TrustEventKind::DelegationCreated,
+            actor_id: "child-session".to_owned(),
+            actor_kind: TrustActorKind::DelegateChildRuntime,
+            source_surface: "delegate.async".to_owned(),
+            trust_state_hint: TrustStateHint::Bound,
+            provenance_kind: TrustProvenanceKind::SessionLineage,
+            provenance_ref: "root-session".to_owned(),
+            reason_code: "delegate_child_session_created".to_owned(),
+            evidence_ref: "session:child-session".to_owned(),
+        };
+
+        let encoded = serde_json::to_value(&envelope).expect("encode trust event");
+        let decoded: TrustEventEnvelope =
+            serde_json::from_value(encoded).expect("decode trust event");
+
+        assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn embed_trust_event_payload_preserves_existing_object_fields() {
+        let trust_event =
+            delegate_child_trust_event("root-session", "child-session", "delegate.async");
+        let payload = json!({
+            "task": "child async task",
+            "timeout_seconds": 60,
+        });
+
+        let enriched = embed_trust_event_payload(payload, trust_event);
+
+        assert_eq!(enriched["task"], "child async task");
+        assert_eq!(
+            enriched[TRUST_EVENT_PAYLOAD_KEY]["event_kind"],
+            "delegation_created"
+        );
+        assert_eq!(
+            enriched[TRUST_EVENT_PAYLOAD_KEY]["actor_kind"],
+            "delegate_child_runtime"
+        );
+    }
+
+    #[test]
+    fn embed_trust_event_payload_wraps_non_object_payload() {
+        let trust_event =
+            delegate_child_trust_event("root-session", "child-session", "delegate.inline");
+        let enriched = embed_trust_event_payload(json!("raw payload"), trust_event);
+
+        assert_eq!(enriched["payload"], "raw payload");
+        assert_eq!(
+            enriched[TRUST_EVENT_PAYLOAD_KEY]["source_surface"],
+            "delegate.inline"
+        );
+    }
+}

--- a/crates/app/src/trust.rs
+++ b/crates/app/src/trust.rs
@@ -117,11 +117,32 @@ pub(crate) fn runtime_binding_missing_trust_event(
     }
 }
 
+pub(crate) fn provider_failover_trust_event(
+    provider_id: &str,
+    source_surface: &str,
+    provenance_ref: &str,
+    reason_code: &str,
+    model: &str,
+) -> TrustEventEnvelope {
+    TrustEventEnvelope {
+        event_kind: TrustEventKind::TrustAttested,
+        actor_id: provider_id.to_owned(),
+        actor_kind: TrustActorKind::ProviderRuntime,
+        source_surface: source_surface.to_owned(),
+        trust_state_hint: TrustStateHint::Degraded,
+        provenance_kind: TrustProvenanceKind::RuntimeBinding,
+        provenance_ref: provenance_ref.to_owned(),
+        reason_code: reason_code.to_owned(),
+        evidence_ref: format!("provider:{provider_id}:model:{model}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         TRUST_EVENT_PAYLOAD_KEY, TrustActorKind, TrustEventEnvelope, TrustEventKind,
         TrustProvenanceKind, TrustStateHint, delegate_child_trust_event, embed_trust_event_payload,
+        provider_failover_trust_event,
     };
     use serde_json::json;
 
@@ -179,5 +200,27 @@ mod tests {
             enriched[TRUST_EVENT_PAYLOAD_KEY]["source_surface"],
             "delegate.inline"
         );
+    }
+
+    #[test]
+    fn provider_failover_trust_event_marks_degraded_provider_runtime_state() {
+        let envelope = provider_failover_trust_event(
+            "openai",
+            "provider.failover",
+            "kernel",
+            "rate_limited",
+            "gpt-4o",
+        );
+
+        assert_eq!(envelope.event_kind, TrustEventKind::TrustAttested);
+        assert_eq!(envelope.actor_kind, TrustActorKind::ProviderRuntime);
+        assert_eq!(envelope.trust_state_hint, TrustStateHint::Degraded);
+        assert_eq!(
+            envelope.provenance_kind,
+            TrustProvenanceKind::RuntimeBinding
+        );
+        assert_eq!(envelope.provenance_ref, "kernel");
+        assert_eq!(envelope.reason_code, "rate_limited");
+        assert_eq!(envelope.evidence_ref, "provider:openai:model:gpt-4o");
     }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1366,6 +1366,7 @@ impl Commands {
             Self::SlackSend { .. } => "slack_send",
             Self::LineSend { .. } => "line_send",
             Self::WhatsappSend { .. } => "whatsapp_send",
+            Self::WhatsappServe { .. } => "whatsapp_serve",
             Self::EmailSend { .. } => "email_send",
             Self::WebhookSend { .. } => "webhook_send",
             Self::GoogleChatSend { .. } => "google_chat_send",

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-04T10:41:07Z
+- Generated at: 2026-04-04T12:44:39Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -14,7 +14,7 @@
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3568 | 3700 | 132 | 48 | 80 | 32 | 96.4% | TIGHT | 3547 | 0.6% | PASS | 43 |
-| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 375 | 1000 | 625 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.0% | PASS | 10 |
+| provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 343 | 650 | 307 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -3.7% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2741 | 2800 | 59 | 56 | 65 | 9 | 97.9% | TIGHT | 2698 | 1.6% | PASS | 56 |
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10782 | 11200 | 418 | 96 | 120 | 24 | 96.3% | TIGHT | 10831 | -0.5% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14990 | 15000 | 10 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.6% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6482 | 6500 | 18 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10801 | 11200 | 399 | 97 | 120 | 23 | 96.4% | TIGHT | 10831 | -0.3% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14996 | 15000 | 4 | 54 | 70 | 16 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6483 | 6500 | 17 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9782 | 9800 | 18 | 235 | 250 | 15 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.3%), tools_mod (99.9%), daemon_lib (100.0%), onboard_cli (97.1%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.4%), tools_mod (100.0%), daemon_lib (100.0%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -60,7 +60,7 @@
 
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3568 functions=48 -->
-<!-- arch-hotspot key=provider_mod lines=375 functions=10 -->
+<!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
 <!-- arch-hotspot key=memory_mod lines=343 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2741 functions=56 -->
@@ -68,10 +68,10 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10782 functions=96 -->
-<!-- arch-hotspot key=tools_mod lines=14990 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6482 functions=210 -->
-<!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
+<!-- arch-hotspot key=turn_coordinator lines=10801 functions=97 -->
+<!-- arch-hotspot key=tools_mod lines=14996 functions=54 -->
+<!-- arch-hotspot key=daemon_lib lines=6483 functions=210 -->
+<!-- arch-hotspot key=onboard_cli lines=9782 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw had no additive trust-plane vocabulary or stable trust-event
  projection path, so trust-relevant semantics stayed fragmented across
  delegate lineage, runtime binding failures, provider failover errors, and
  governed approval boundaries.
- Why it matters:
  Without a first runtime slice, later trust-plane work would keep inventing
  local payload shapes and there would be no consistent audit-oriented substrate
  for delegation, binding, provider failure, and approval semantics.
- What changed:
  Added a minimal `trust` module in `crates/app`, extracted additive trust
  projection helpers into `conversation/trust_projection.rs`, projected
  delegate child creation into structured `trust_event` payloads for inline and
  async delegate session events, projected direct-binding `no_kernel_context`
  failures into a persisted `trust_binding_missing` conversation event,
  projected provider failover snapshot payloads into a persisted
  `trust_provider_failover` conversation event, and projected governed approval
  request creation into embedded `trust_event` payloads for app, shell, and
  autonomy-driven approval boundaries. The provider failover trust projection
  maps reason codes into descriptive trust-state hints and uses a fail-closed
  trust-envelope extraction path before persisting the event. The branch also
  keeps the repaired shell followup context work that restored the intended
  repairable shell guidance in the touched conversation flow.
- What did not change (scope boundary):
  This PR does not make trust state policy-authoritative, does not add trust
  scoring, and does not normalize provenance across every runtime surface.

## Linked Issues

- Closes #874

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [x] Providers / routing
- [ ] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This is still the first additive trust-plane code slice. The main risk is
  accidental widening into policy behavior or hidden behavior changes in
  delegate, binding, provider error, or approval-boundary paths.
- Rollout / guardrails:
  The slice is limited to vocabulary, envelope shape, and additive event
  projection. Tests cover delegate event payloads, direct-binding trust event
  persistence, malformed embedded trust payload rejection, provider failover
  trust-event persistence, and approval-request trust projection for governed
  app, shell, and autonomy paths.
- Rollback path:
  Revert commits `738f69f6`, `4dff9073`, `cc2aad55`, `4cb9d8bd`, and `fd40290e`.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
git diff --check
cargo fmt --all -- --check
CARGO_BUILD_JOBS=1 cargo test -p loongclaw-app trust::tests:: -- --nocapture
CARGO_BUILD_JOBS=1 cargo test -p loongclaw-app direct_core_tool_persists_trust_binding_missing_event -- --nocapture
CARGO_BUILD_JOBS=1 cargo test -p loongclaw-app handle_turn_with_runtime_executes_delegate_async_via_coordinator_without_waiting -- --nocapture
CARGO_BUILD_JOBS=1 cargo test -p loongclaw-app handle_turn_with_runtime_auth_rejected_provider_error_marks_rejected_trust_state -- --nocapture
CARGO_BUILD_JOBS=1 cargo test -p loongclaw-app autonomy_policy_turn_engine_guided_acquisition_requires_approval_for_capability_install -- --nocapture
CARGO_BUILD_JOBS=1 cargo test -p loongclaw-app handle_turn_with_runtime_requires_approval_before_shell_exec_execution -- --nocapture
CARGO_BUILD_JOBS=1 cargo test -p loongclaw --lib
CARGO_BUILD_JOBS=1 cargo test --workspace --locked -q
CARGO_BUILD_JOBS=1 cargo test --workspace --all-features --locked -q
CARGO_BUILD_JOBS=1 cargo clippy --workspace --all-targets --all-features -- -D warnings
scripts/check_dep_graph.sh
LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh
```

Architecture note:

- `scripts/check_dep_graph.sh` passed.
- `LOONGCLAW_ARCH_STRICT=true scripts/check_architecture_boundaries.sh` now
  reports the touched `crates/app/src/conversation/turn_coordinator.rs` back
  under budget. The command still fails on one pre-existing unrelated hotspot:
  `crates/app/src/tools/mod.rs` at `15146/15000` lines.
- `task check:conventions` was not available locally because the required
  `convention-engineering` skill runtime was not installed in this shell
  environment.
- A separate internal architecture comparison and next-step assessment was
  archived outside the main repo in the knowledge-base delivery lane.

## User-visible / Operator-visible Changes

- Delegate child lifecycle payloads now carry a structured `trust_event`
  envelope for the first trust-plane slice.
- Direct-binding core-tool failures now persist a `trust_binding_missing`
  conversation event with the same trust vocabulary.
- Provider failover snapshot payloads now persist a `trust_provider_failover`
  conversation event with reason-sensitive provider-runtime trust metadata.
- Governed approval requests now persist embedded `trust_event` metadata across
  app, shell, and autonomy-driven approval boundaries.
- Embedded trust envelopes now have a dedicated fail-closed extraction path for
  malformed payloads.
- Repairable shell followup prompts again include the failed request context and
  shell-specific repair guidance.

## Failure Recovery

- Fast rollback or disable path:
  Revert commits `738f69f6`, `4dff9073`, `cc2aad55`, `4cb9d8bd`, and `fd40290e`.
- Observable failure symptoms reviewers should watch for:
  Delegate lifecycle payload drift, direct-binding trust event drift,
  provider-failover trust payload drift, incorrect rejected-vs-degraded trust
  hints for provider failures, missing or malformed approval-boundary trust
  envelopes, changed allow/deny behavior for delegate or shell paths, or
  malformed `trust_event` payload shapes.

## Reviewer Focus

- Confirm the `crates/app/src/trust.rs` vocabulary remains minimal and
  non-authoritative.
- Confirm the extracted trust-projection helpers keep trust projection
  localized without widening touched hotspots again.
- Confirm delegate inline/async session events, `trust_binding_missing`,
  `trust_provider_failover`, and approval-request payloads all reuse the same
  trust envelope vocabulary.
- Confirm provider failover reason codes only influence descriptive trust-state
  hints and do not change runtime allow/deny behavior.
- Confirm approval-boundary trust metadata remains descriptive and does not
  change approval decision semantics.
- Confirm malformed embedded trust payloads fail closed.
- Confirm the shell repair-context fixes still restore intended followup
  behavior without widening shell execution policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive trust event tracking for approval workflows, provider failures, and delegation lifecycle management.
  * Enhanced provider failover detection with structured error parsing and handling.
  * Improved shell command error messages with repair guidance to help users fix input issues.

* **Tests**
  * Expanded test coverage for trust event persistence and validation across approval, delegation, and provider failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->