### PR TITLE
fix(daemon): stabilize browser companion version probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,6 +2622,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "wait-timeout",
  "wat",
 ]
 

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -85,6 +85,7 @@ dunce = "1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+wait-timeout = "0.2"
 
 [[bin]]
 name = "loong"

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -11,6 +11,10 @@ pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser comp
 const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
 const BROWSER_COMPANION_PROBE_ATTEMPTS: usize = 3;
 
+fn browser_companion_probe_timeout_seconds(timeout_seconds: u64) -> u64 {
+    timeout_seconds.max(1)
+}
+
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BrowserCompanionDiagnostics {
@@ -39,6 +43,7 @@ impl BrowserCompanionDiagnostics {
                 command,
                 timeout_seconds,
             } => {
+                let timeout_seconds = browser_companion_probe_timeout_seconds(*timeout_seconds);
                 format!(
                     "command `{command} {BROWSER_COMPANION_VERSION_ARG}` timed out after {}s",
                     timeout_seconds
@@ -143,7 +148,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
 
     let runtime_ready = runtime.is_runtime_ready();
     let expected_version = runtime.expected_version;
-    let probe_timeout_seconds = runtime.timeout_seconds;
+    let probe_timeout_seconds = browser_companion_probe_timeout_seconds(runtime.timeout_seconds);
     let Some(command) = runtime.command else {
         return Some(BrowserCompanionDiagnostics {
             command: None,
@@ -284,7 +289,8 @@ fn wait_for_browser_companion_probe_output(
     mut child: std::process::Child,
     timeout_seconds: u64,
 ) -> Result<Output, BrowserCompanionProbeError> {
-    let timeout_duration = Duration::from_secs(timeout_seconds.max(1));
+    let timeout_seconds = browser_companion_probe_timeout_seconds(timeout_seconds);
+    let timeout_duration = Duration::from_secs(timeout_seconds);
     let wait_result = child.wait_timeout(timeout_duration);
     let status_option = wait_result.map_err(|error| {
         let error_message = error.to_string();
@@ -343,15 +349,11 @@ fn observed_version_matches_expected(observed_version: &str, expected_version: &
 mod tests {
     use super::*;
     #[cfg(unix)]
-    use std::ffi::OsString;
-    #[cfg(unix)]
     use std::io::Write;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     #[cfg(unix)]
     use std::path::{Path, PathBuf};
-    #[cfg(unix)]
-    use std::sync::MutexGuard;
     #[cfg(unix)]
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -383,55 +385,17 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn set_browser_companion_env_var(key: &str, value: &str) {
-        // SAFETY: daemon tests serialize process env mutations behind
-        // `lock_daemon_test_environment`, so no concurrent env readers/writers
-        // observe racy updates while these tests run.
-        #[allow(unsafe_code, clippy::disallowed_methods)]
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-
-    #[cfg(unix)]
-    fn remove_browser_companion_env_var(key: &str) {
-        // SAFETY: daemon tests serialize process env mutations behind
-        // `lock_daemon_test_environment`, so removing the variable here is
-        // coordinated with all other env-mutating daemon tests.
-        #[allow(unsafe_code, clippy::disallowed_methods)]
-        unsafe {
-            std::env::remove_var(key);
-        }
-    }
-
-    #[cfg(unix)]
     struct BrowserCompanionEnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        saved_ready: Option<OsString>,
+        _env: crate::test_support::ScopedEnv,
     }
 
     #[cfg(unix)]
     impl BrowserCompanionEnvGuard {
         fn runtime_gate_closed() -> Self {
-            let lock = crate::test_support::lock_daemon_test_environment();
             let key = "LOONGCLAW_BROWSER_COMPANION_READY";
-            let saved_ready = std::env::var_os(key);
-            remove_browser_companion_env_var(key);
-            Self {
-                _lock: lock,
-                saved_ready,
-            }
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for BrowserCompanionEnvGuard {
-        fn drop(&mut self) {
-            let key = "LOONGCLAW_BROWSER_COMPANION_READY";
-            match self.saved_ready.take() {
-                Some(value) => set_browser_companion_env_var(key, &value.to_string_lossy()),
-                None => remove_browser_companion_env_var(key),
-            }
+            let mut env = crate::test_support::ScopedEnv::new();
+            env.remove(key.to_owned());
+            Self { _env: env }
         }
     }
 
@@ -485,6 +449,7 @@ mod tests {
         config.tools.browser_companion.enabled = true;
         config.tools.browser_companion.command = Some(script_path.display().to_string());
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+        config.tools.browser_companion.timeout_seconds = 5;
 
         let diagnostics = collect_browser_companion_diagnostics(&config)
             .await

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -1,15 +1,14 @@
 use std::io::ErrorKind;
+use std::process::{Command as BlockingCommand, Output, Stdio};
 use std::time::Duration;
 
 use loongclaw_app as mvp;
-use tokio::process::Command;
-use tokio::time::timeout;
+use wait_timeout::ChildExt;
 
 pub(crate) const BROWSER_COMPANION_INSTALL_CHECK_NAME: &str = "browser companion install";
 pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser companion runtime gate";
 
 const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
-const BROWSER_COMPANION_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 const BROWSER_COMPANION_PROBE_ATTEMPTS: usize = 3;
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
@@ -36,10 +35,13 @@ impl BrowserCompanionDiagnostics {
             BrowserCompanionInstallStatus::MissingBinary { command } => {
                 format!("command `{command}` was not found on PATH")
             }
-            BrowserCompanionInstallStatus::ProbeTimedOut { command } => {
+            BrowserCompanionInstallStatus::ProbeTimedOut {
+                command,
+                timeout_seconds,
+            } => {
                 format!(
                     "command `{command} {BROWSER_COMPANION_VERSION_ARG}` timed out after {}s",
-                    BROWSER_COMPANION_PROBE_TIMEOUT.as_secs()
+                    timeout_seconds
                 )
             }
             BrowserCompanionInstallStatus::ProbeFailed { command, error } => {
@@ -99,6 +101,7 @@ pub(crate) enum BrowserCompanionInstallStatus {
     },
     ProbeTimedOut {
         command: String,
+        timeout_seconds: u64,
     },
     ProbeFailed {
         command: String,
@@ -140,6 +143,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
 
     let runtime_ready = runtime.is_runtime_ready();
     let expected_version = runtime.expected_version;
+    let probe_timeout_seconds = runtime.timeout_seconds;
     let Some(command) = runtime.command else {
         return Some(BrowserCompanionDiagnostics {
             command: None,
@@ -150,7 +154,7 @@ pub(crate) async fn collect_browser_companion_diagnostics(
         });
     };
 
-    match probe_browser_companion_version(&command).await {
+    match probe_browser_companion_version(&command, probe_timeout_seconds).await {
         Ok(observed_version) => {
             let install_status = match expected_version.as_deref() {
                 Some(expected_version)
@@ -179,13 +183,20 @@ pub(crate) async fn collect_browser_companion_diagnostics(
             runtime_ready,
             install_status: BrowserCompanionInstallStatus::MissingBinary { command },
         }),
-        Err(BrowserCompanionProbeError::TimedOut) => Some(BrowserCompanionDiagnostics {
-            command: Some(command.clone()),
-            expected_version,
-            observed_version: None,
-            runtime_ready,
-            install_status: BrowserCompanionInstallStatus::ProbeTimedOut { command },
-        }),
+        Err(BrowserCompanionProbeError::TimedOut) => {
+            let timed_out_command = command.clone();
+            let install_status = BrowserCompanionInstallStatus::ProbeTimedOut {
+                command,
+                timeout_seconds: probe_timeout_seconds,
+            };
+            Some(BrowserCompanionDiagnostics {
+                command: Some(timed_out_command),
+                expected_version,
+                observed_version: None,
+                runtime_ready,
+                install_status,
+            })
+        }
         Err(BrowserCompanionProbeError::SpawnFailed(error)) => Some(BrowserCompanionDiagnostics {
             command: Some(command.clone()),
             expected_version,
@@ -212,48 +223,102 @@ pub(crate) async fn collect_browser_companion_diagnostics(
 
 async fn probe_browser_companion_version(
     command: &str,
+    timeout_seconds: u64,
 ) -> Result<String, BrowserCompanionProbeError> {
-    for _attempt in 0..BROWSER_COMPANION_PROBE_ATTEMPTS {
-        let probe_result = probe_browser_companion_version_once(command).await;
-        match probe_result {
-            Err(BrowserCompanionProbeError::TimedOut) => {}
-            result => {
-                return result;
+    let command = command.to_owned();
+    let join_result = tokio::task::spawn_blocking(move || {
+        for _attempt in 0..BROWSER_COMPANION_PROBE_ATTEMPTS {
+            let probe_result =
+                probe_browser_companion_version_once(command.as_str(), timeout_seconds);
+            match probe_result {
+                Err(BrowserCompanionProbeError::TimedOut) => {}
+                result => {
+                    return result;
+                }
             }
         }
+
+        Err(BrowserCompanionProbeError::TimedOut)
+    })
+    .await;
+
+    match join_result {
+        Ok(result) => result,
+        Err(error) => Err(BrowserCompanionProbeError::SpawnFailed(error.to_string())),
+    }
+}
+
+fn probe_browser_companion_version_once(
+    command: &str,
+    timeout_seconds: u64,
+) -> Result<String, BrowserCompanionProbeError> {
+    let child = spawn_browser_companion_probe_process(command)?;
+    let output = wait_for_browser_companion_probe_output(child, timeout_seconds)?;
+    interpret_browser_companion_probe_output(output)
+}
+
+fn spawn_browser_companion_probe_process(
+    command: &str,
+) -> Result<std::process::Child, BrowserCompanionProbeError> {
+    let mut process = BlockingCommand::new(command);
+    process.arg(BROWSER_COMPANION_VERSION_ARG);
+    process.stdin(Stdio::null());
+    process.stdout(Stdio::piped());
+    process.stderr(Stdio::piped());
+
+    let spawn_result = process.spawn();
+    match spawn_result {
+        Ok(child) => Ok(child),
+        Err(error) => {
+            if error.kind() == ErrorKind::NotFound {
+                return Err(BrowserCompanionProbeError::MissingBinary);
+            }
+
+            let error_message = error.to_string();
+            Err(BrowserCompanionProbeError::SpawnFailed(error_message))
+        }
+    }
+}
+
+fn wait_for_browser_companion_probe_output(
+    mut child: std::process::Child,
+    timeout_seconds: u64,
+) -> Result<Output, BrowserCompanionProbeError> {
+    let timeout_duration = Duration::from_secs(timeout_seconds.max(1));
+    let wait_result = child.wait_timeout(timeout_duration);
+    let status_option = wait_result.map_err(|error| {
+        let error_message = error.to_string();
+        BrowserCompanionProbeError::SpawnFailed(error_message)
+    })?;
+
+    if status_option.is_some() {
+        let output_result = child.wait_with_output();
+        return output_result.map_err(|error| {
+            let error_message = error.to_string();
+            BrowserCompanionProbeError::SpawnFailed(error_message)
+        });
     }
 
+    let _ = child.kill();
+    let _ = child.wait();
     Err(BrowserCompanionProbeError::TimedOut)
 }
 
-async fn probe_browser_companion_version_once(
-    command: &str,
+fn interpret_browser_companion_probe_output(
+    output: Output,
 ) -> Result<String, BrowserCompanionProbeError> {
-    let mut probe = Command::new(command);
-    probe.arg(BROWSER_COMPANION_VERSION_ARG);
-    probe.kill_on_drop(true);
+    let observed = observed_output(&output.stdout, &output.stderr);
+    let status = output.status;
 
-    match timeout(BROWSER_COMPANION_PROBE_TIMEOUT, probe.output()).await {
-        Ok(Ok(output)) => {
-            let observed = observed_output(&output.stdout, &output.stderr);
-            if output.status.success() {
-                Ok(observed)
-            } else {
-                Err(BrowserCompanionProbeError::Exited {
-                    observed,
-                    exit_status: output.status.code(),
-                })
-            }
-        }
-        Ok(Err(error)) => {
-            if error.kind() == ErrorKind::NotFound {
-                Err(BrowserCompanionProbeError::MissingBinary)
-            } else {
-                Err(BrowserCompanionProbeError::SpawnFailed(error.to_string()))
-            }
-        }
-        Err(_) => Err(BrowserCompanionProbeError::TimedOut),
+    if status.success() {
+        return Ok(observed);
     }
+
+    let exit_status = status.code();
+    Err(BrowserCompanionProbeError::Exited {
+        observed,
+        exit_status,
+    })
 }
 
 fn observed_output(stdout: &[u8], stderr: &[u8]) -> String {
@@ -385,6 +450,7 @@ mod tests {
         config.tools.browser_companion.enabled = true;
         config.tools.browser_companion.command = Some(script_path.display().to_string());
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+        config.tools.browser_companion.timeout_seconds = 3;
 
         let diagnostics = collect_browser_companion_diagnostics(&config)
             .await
@@ -446,7 +512,7 @@ mod tests {
         let script_path = temp_dir.join("browser-companion");
         let state_path = temp_dir.join("probe-state");
         let script_body = format!(
-            "#!/bin/sh\nstate_path='{}'\nif [ ! -f \"$state_path\" ]; then\n  touch \"$state_path\"\n  sleep 11\nfi\necho 'loongclaw-browser-companion 1.5.0'\n",
+            "#!/bin/sh\nstate_path='{}'\nif [ ! -f \"$state_path\" ]; then\n  touch \"$state_path\"\n  /bin/sleep 6\nfi\necho 'loongclaw-browser-companion 1.5.0'\n",
             state_path.display()
         );
         write_browser_companion_script(&script_path, script_body.as_str());
@@ -455,6 +521,7 @@ mod tests {
         config.tools.browser_companion.enabled = true;
         config.tools.browser_companion.command = Some(script_path.display().to_string());
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+        config.tools.browser_companion.timeout_seconds = 5;
 
         let diagnostics = collect_browser_companion_diagnostics(&config)
             .await
@@ -479,7 +546,7 @@ mod tests {
         let script_path = temp_dir.join("browser-companion");
         let state_path = temp_dir.join("probe-state");
         let script_body = format!(
-            "#!/bin/sh\nstate_path='{}'\nattempt=0\nif [ -f \"$state_path\" ]; then\n  attempt=$(cat \"$state_path\")\nfi\nnext_attempt=$((attempt + 1))\nprintf '%s' \"$next_attempt\" > \"$state_path\"\nif [ \"$next_attempt\" -le 2 ]; then\n  sleep 11\nfi\necho 'loongclaw-browser-companion 1.5.0'\n",
+            "#!/bin/sh\nstate_path='{}'\nattempt=0\nif [ -f \"$state_path\" ]; then\n  attempt=$(cat \"$state_path\")\nfi\nnext_attempt=$((attempt + 1))\nprintf '%s' \"$next_attempt\" > \"$state_path\"\nif [ \"$next_attempt\" -le 2 ]; then\n  /bin/sleep 6\nfi\necho 'loongclaw-browser-companion 1.5.0'\n",
             state_path.display()
         );
         write_browser_companion_script(&script_path, script_body.as_str());
@@ -488,6 +555,7 @@ mod tests {
         config.tools.browser_companion.enabled = true;
         config.tools.browser_companion.command = Some(script_path.display().to_string());
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+        config.tools.browser_companion.timeout_seconds = 5;
 
         let diagnostics = collect_browser_companion_diagnostics(&config)
             .await
@@ -501,6 +569,39 @@ mod tests {
         assert_eq!(
             diagnostics.observed_version.as_deref(),
             Some("loongclaw-browser-companion 1.5.0")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_browser_companion_diagnostics_times_out_stalled_probe() {
+        let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
+        let temp_dir = browser_companion_temp_dir("stalled-probe");
+        let script_path = temp_dir.join("browser-companion");
+        write_browser_companion_script(
+            &script_path,
+            "#!/bin/sh\n/bin/sleep 2\necho 'loongclaw-browser-companion 1.5.0'\n",
+        );
+
+        let mut config = mvp::config::LoongClawConfig::default();
+        config.tools.browser_companion.enabled = true;
+        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
+        config.tools.browser_companion.timeout_seconds = 1;
+
+        let diagnostics = collect_browser_companion_diagnostics(&config)
+            .await
+            .expect("diagnostics should be collected");
+
+        let install_status = &diagnostics.install_status;
+        let timed_out = matches!(
+            install_status,
+            BrowserCompanionInstallStatus::ProbeTimedOut { .. }
+        );
+
+        assert!(
+            timed_out,
+            "stalled probes should time out deterministically: {diagnostics:#?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- problem:
  browser companion install diagnostics still had a scheduler-sensitive version-probe path on current `dev`, and the broader all-features validation could still fail on `collect_browser_companion_diagnostics_recovers_after_two_transient_timeouts` even after the earlier six issue-848 regressions had been rechecked.
- why it matters:
  `cargo test --workspace --all-features --locked` needs to stay green on `dev`. flaky browser companion diagnostics block unrelated work and make doctor/onboard install checks harder to trust.
- what changed:
  moved the version probe to a blocking child-process path with explicit timeout handling, kept bounded retry behavior for transient probe timeouts, aligned timeout reporting with the effective runtime timeout, and simplified the daemon-side test guard plumbing so the probe tests stay deterministic.
- what did not change:
  no browser companion protocol behavior changed. this only hardens the diagnostics and test lane around `--version` probing.

## Linked Issues

- Closes #848

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [x] Daemon / CLI / install
- [x] Browser automation
- [ ] Tools
- [ ] Docs / contributor workflow

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] targeted browser companion regressions

commands and evidence:

```text
cargo fmt --all -- --check
env CARGO_TARGET_DIR=/tmp/loongclaw-browser-review2 cargo clippy -p loongclaw --all-targets --all-features -- -D warnings
env CARGO_TARGET_DIR=/tmp/loongclaw-browser-review2 cargo test -p loongclaw collect_browser_companion_diagnostics_recovers_after_two_transient_timeouts -- --nocapture
env CARGO_TARGET_DIR=/tmp/loongclaw-browser-review2 cargo test --workspace --all-features --locked --quiet
env CARGO_TARGET_DIR=/tmp/loongclaw-browser-fix2 cargo clippy --workspace --all-targets --all-features -- -D warnings
env CARGO_TARGET_DIR=/tmp/loongclaw-browser-fix2 cargo test --workspace --locked --quiet
env CARGO_TARGET_DIR=/tmp/loongclaw-browser-fix2 cargo test --workspace --all-features --locked --quiet
```

results:
- targeted retry/timeout regressions: pass
- daemon package clippy: pass
- workspace clippy all-features: pass
- workspace tests locked: pass
- workspace tests all-features locked: pass

## User-visible / Operator-visible Changes

- browser companion install diagnostics now use the configured timeout contract when probing `--version`.
- transient probe timeouts recover deterministically in the validation lane instead of surfacing a false install warning.
- the stalled-probe path still times out cleanly and reports the active timeout value.

## Failure Recovery

- fast rollback:
  revert commits `39040d58` and `461373bb`.
- reviewer watchpoints:
  version mismatch handling should still surface mismatches quickly, and stalled probes should still return `ProbeTimedOut` instead of hanging.

## Reviewer Focus

- review the blocking version-probe path in `crates/daemon/src/browser_companion_diagnostics.rs`.
- review the timeout normalization and `ProbeTimedOut` reporting contract.
- review the transient-timeout and stalled-probe regression tests for determinism.
