### PR TITLE
Fix direct-path shell and file policy denial classification

### DIFF
--- a/crates/app/src/tools/direct_policy_preflight.rs
+++ b/crates/app/src/tools/direct_policy_preflight.rs
@@ -1,0 +1,104 @@
+use loongclaw_contracts::ToolCoreRequest;
+
+use super::file_policy_ext;
+use super::runtime_config;
+use super::shell_policy_ext;
+
+pub(super) fn run(
+    request: &ToolCoreRequest,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<(), String> {
+    let payload = request.payload.as_object();
+    let Some(payload) = payload else {
+        return Ok(());
+    };
+
+    let tool_name = request.tool_name.as_str();
+
+    if tool_name == "shell.exec" {
+        return shell_policy_ext::authorize_direct_shell_payload(payload, config);
+    }
+
+    let is_file_tool = matches!(tool_name, "file.read" | "file.write" | "file.edit");
+    if is_file_tool {
+        return file_policy_ext::authorize_direct_file_payload(tool_name, payload, config);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use loongclaw_contracts::ToolCoreRequest;
+    use serde_json::json;
+
+    use super::run;
+    use super::runtime_config;
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp_root = std::env::temp_dir();
+        let dirname = format!("loongclaw-{prefix}-{sequence}");
+        let path = temp_root.join(dirname);
+        std::fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    #[test]
+    fn run_reuses_shared_shell_policy_default_deny() {
+        let config = runtime_config::ToolRuntimeConfig {
+            shell_allow: BTreeSet::new(),
+            ..runtime_config::ToolRuntimeConfig::default()
+        };
+
+        let request = ToolCoreRequest {
+            tool_name: "shell.exec".to_owned(),
+            payload: json!({"command": "git"}),
+        };
+
+        let error = run(&request, &config).expect_err("unknown shell command should be denied");
+
+        assert_eq!(
+            error,
+            "policy_denied: tool call denied by policy for `shell.exec`: command `git` is not in the allow list (default-deny policy)"
+        );
+    }
+
+    #[test]
+    fn run_reuses_shared_file_policy_escape_guard() {
+        let root = unique_temp_dir("direct-policy-preflight");
+        let config = runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            ..runtime_config::ToolRuntimeConfig::default()
+        };
+
+        let request = ToolCoreRequest {
+            tool_name: "file.write".to_owned(),
+            payload: json!({
+                "path": "../outside.txt",
+                "content": "blocked"
+            }),
+        };
+
+        let error = run(&request, &config).expect_err("escaped file path should be denied");
+
+        assert!(
+            error.starts_with("policy_denied: "),
+            "expected policy_denied prefix, got: {error}"
+        );
+        assert!(
+            error.contains("policy extension file-policy denied request"),
+            "expected shared file policy prefix, got: {error}"
+        );
+        assert!(
+            error.contains("escapes file root"),
+            "expected shared file policy denial, got: {error}"
+        );
+    }
+}

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -111,6 +111,53 @@ impl FilePolicyExtension {
         let normalized = super::normalize_without_fs(&combined);
         !normalized.starts_with(effective_root)
     }
+
+    fn authorize_file_payload(
+        &self,
+        tool_name: &str,
+        payload: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(), PolicyError> {
+        let Some(root) = self.file_root.as_deref() else {
+            return Ok(());
+        };
+
+        let path_key = if tool_name == "claw.migrate" {
+            "input_path"
+        } else {
+            "path"
+        };
+        let raw_path = payload
+            .get(path_key)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+
+        let has_path = !raw_path.is_empty();
+        if !has_path {
+            return Ok(());
+        }
+
+        let escapes_root = self.path_escapes_root(raw_path);
+        if !escapes_root {
+            return Ok(());
+        }
+
+        let reason = format!("path `{raw_path}` escapes file root `{}`", root.display());
+        Err(PolicyError::ExtensionDenied {
+            extension: self.name().to_owned(),
+            reason,
+        })
+    }
+}
+
+pub(crate) fn authorize_direct_file_payload(
+    tool_name: &str,
+    payload: &serde_json::Map<String, serde_json::Value>,
+    rt: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<(), String> {
+    let extension = FilePolicyExtension::new(rt.file_root.clone());
+    extension
+        .authorize_file_payload(tool_name, payload)
+        .map_err(|error| format!("policy_denied: {error}"))
 }
 
 impl PolicyExtension for FilePolicyExtension {
@@ -143,26 +190,12 @@ impl PolicyExtension for FilePolicyExtension {
             });
         }
 
-        if let Some(ref root) = self.file_root {
-            // claw.migrate uses `input_path`; all other file tools use `path`.
-            let path_key = if tool_name == "claw.migrate" {
-                "input_path"
-            } else {
-                "path"
-            };
-            let raw_path = params
-                .get("payload")
-                .and_then(|p| p.get(path_key))
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+        let payload = params.get("payload").and_then(serde_json::Value::as_object);
+        let Some(payload) = payload else {
+            return Ok(());
+        };
 
-            if !raw_path.is_empty() && self.path_escapes_root(raw_path) {
-                return Err(PolicyError::ExtensionDenied {
-                    extension: self.name().to_owned(),
-                    reason: format!("path `{raw_path}` escapes file root `{}`", root.display()),
-                });
-            }
-        }
+        self.authorize_file_payload(tool_name, payload)?;
 
         Ok(())
     }

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -4697,10 +4697,12 @@ mod tests {
 
     #[test]
     fn tool_search_hides_tools_exceeding_granted_capabilities() {
-        let root = std::env::temp_dir().join(format!(
-            "loongclaw-tool-search-cap-filter-{}",
-            std::process::id()
-        ));
+        let created_at = std::time::SystemTime::now();
+        let duration = created_at
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock should be after epoch");
+        let nanos = duration.as_nanos();
+        let root = std::env::temp_dir().join(format!("loongclaw-tool-search-cap-filter-{nanos}"));
         std::fs::create_dir_all(&root).expect("create fixture root");
 
         let config = test_tool_runtime_config(root.clone());
@@ -4734,10 +4736,13 @@ mod tests {
     #[cfg(feature = "tool-shell")]
     #[test]
     fn tool_search_hides_bash_exec_without_side_effect_capabilities() {
-        let root = std::env::temp_dir().join(format!(
-            "loongclaw-tool-search-bash-cap-filter-{}",
-            std::process::id()
-        ));
+        let created_at = std::time::SystemTime::now();
+        let duration = created_at
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock should be after epoch");
+        let nanos = duration.as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("loongclaw-tool-search-bash-cap-filter-{nanos}"));
         std::fs::create_dir_all(&root).expect("create fixture root");
 
         let mut config = test_tool_runtime_config(root.clone());

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -739,6 +739,7 @@ fn execute_discoverable_tool_core_with_config(
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let tool_name = request.tool_name.clone();
+    run_direct_tool_policy_preflight(&request, config)?;
     let timeout_seconds = config.tool_execution.timeout_for_tool(&tool_name);
 
     let inner = {
@@ -752,6 +753,30 @@ fn execute_discoverable_tool_core_with_config(
         }
         _ => inner(),
     }
+}
+
+fn run_direct_tool_policy_preflight(
+    request: &ToolCoreRequest,
+    config: &runtime_config::ToolRuntimeConfig,
+) -> Result<(), String> {
+    let payload = request.payload.as_object();
+    let Some(payload) = payload else {
+        return Ok(());
+    };
+
+    let tool_name = request.tool_name.as_str();
+    let is_shell_tool = tool_name == "shell.exec";
+    if is_shell_tool {
+        shell_policy_ext::authorize_direct_shell_payload(payload, config)?;
+        return Ok(());
+    }
+
+    let is_file_tool = matches!(tool_name, "file.read" | "file.write" | "file.edit");
+    if is_file_tool {
+        file_policy_ext::authorize_direct_file_payload(tool_name, payload, config)?;
+    }
+
+    Ok(())
 }
 
 fn tool_uses_dedicated_timeout(tool_name: &str) -> bool {
@@ -3431,6 +3456,27 @@ mod tests {
 
     #[cfg(feature = "tool-shell")]
     #[test]
+    fn direct_shell_exec_preflight_reuses_shared_shell_policy_default_deny() {
+        let mut config = test_tool_runtime_config(std::env::temp_dir());
+        config.shell_allow = BTreeSet::new();
+
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "shell.exec".to_owned(),
+                payload: json!({"command": "git"}),
+            },
+            &config,
+        )
+        .expect_err("unknown shell command should be denied by shared direct-path preflight");
+
+        assert_eq!(
+            error,
+            "policy_denied: tool call denied by policy for `shell.exec`: command `git` is not in the allow list (default-deny policy)"
+        );
+    }
+
+    #[cfg(feature = "tool-shell")]
+    #[test]
     fn shell_exec_times_out_when_timeout_ms_is_small() {
         let mut config = test_tool_runtime_config(std::env::temp_dir());
         #[cfg(unix)]
@@ -3497,6 +3543,38 @@ mod tests {
         assert!(
             elapsed < std::time::Duration::from_millis(2_500),
             "timeout path should not wait for descendant pipe holders; elapsed={elapsed:?}"
+        );
+    }
+
+    #[cfg(feature = "tool-file")]
+    #[test]
+    fn direct_file_write_preflight_reuses_shared_file_policy_escape_guard() {
+        let root = unique_temp_dir("loongclaw-direct-file-write-preflight");
+        let config = test_tool_runtime_config(root);
+
+        let error = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "file.write".to_owned(),
+                payload: json!({
+                    "path": "../outside.txt",
+                    "content": "blocked"
+                }),
+            },
+            &config,
+        )
+        .expect_err("escaped file path should be denied by direct-path preflight");
+
+        assert!(
+            error.starts_with("policy_denied: "),
+            "expected policy_denied prefix, got: {error}"
+        );
+        assert!(
+            error.contains("policy extension file-policy denied request"),
+            "expected shared file policy prefix, got: {error}"
+        );
+        assert!(
+            error.contains("escapes file root"),
+            "expected shared file policy denial, got: {error}"
         );
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -39,6 +39,7 @@ mod bundled_skills;
 mod catalog;
 mod claw_migrate;
 pub(crate) mod delegate;
+mod direct_policy_preflight;
 mod external_skills;
 mod external_skills_scan;
 mod external_skills_sources;
@@ -739,7 +740,7 @@ fn execute_discoverable_tool_core_with_config(
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let tool_name = request.tool_name.clone();
-    run_direct_tool_policy_preflight(&request, config)?;
+    direct_policy_preflight::run(&request, config)?;
     let timeout_seconds = config.tool_execution.timeout_for_tool(&tool_name);
 
     let inner = {
@@ -753,30 +754,6 @@ fn execute_discoverable_tool_core_with_config(
         }
         _ => inner(),
     }
-}
-
-fn run_direct_tool_policy_preflight(
-    request: &ToolCoreRequest,
-    config: &runtime_config::ToolRuntimeConfig,
-) -> Result<(), String> {
-    let payload = request.payload.as_object();
-    let Some(payload) = payload else {
-        return Ok(());
-    };
-
-    let tool_name = request.tool_name.as_str();
-    let is_shell_tool = tool_name == "shell.exec";
-    if is_shell_tool {
-        shell_policy_ext::authorize_direct_shell_payload(payload, config)?;
-        return Ok(());
-    }
-
-    let is_file_tool = matches!(tool_name, "file.read" | "file.write" | "file.edit");
-    if is_file_tool {
-        file_policy_ext::authorize_direct_file_payload(tool_name, payload, config)?;
-    }
-
-    Ok(())
 }
 
 fn tool_uses_dedicated_timeout(tool_name: &str) -> bool {
@@ -3456,27 +3433,6 @@ mod tests {
 
     #[cfg(feature = "tool-shell")]
     #[test]
-    fn direct_shell_exec_preflight_reuses_shared_shell_policy_default_deny() {
-        let mut config = test_tool_runtime_config(std::env::temp_dir());
-        config.shell_allow = BTreeSet::new();
-
-        let error = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "shell.exec".to_owned(),
-                payload: json!({"command": "git"}),
-            },
-            &config,
-        )
-        .expect_err("unknown shell command should be denied by shared direct-path preflight");
-
-        assert_eq!(
-            error,
-            "policy_denied: tool call denied by policy for `shell.exec`: command `git` is not in the allow list (default-deny policy)"
-        );
-    }
-
-    #[cfg(feature = "tool-shell")]
-    #[test]
     fn shell_exec_times_out_when_timeout_ms_is_small() {
         let mut config = test_tool_runtime_config(std::env::temp_dir());
         #[cfg(unix)]
@@ -3543,38 +3499,6 @@ mod tests {
         assert!(
             elapsed < std::time::Duration::from_millis(2_500),
             "timeout path should not wait for descendant pipe holders; elapsed={elapsed:?}"
-        );
-    }
-
-    #[cfg(feature = "tool-file")]
-    #[test]
-    fn direct_file_write_preflight_reuses_shared_file_policy_escape_guard() {
-        let root = unique_temp_dir("loongclaw-direct-file-write-preflight");
-        let config = test_tool_runtime_config(root);
-
-        let error = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "file.write".to_owned(),
-                payload: json!({
-                    "path": "../outside.txt",
-                    "content": "blocked"
-                }),
-            },
-            &config,
-        )
-        .expect_err("escaped file path should be denied by direct-path preflight");
-
-        assert!(
-            error.starts_with("policy_denied: "),
-            "expected policy_denied prefix, got: {error}"
-        );
-        assert!(
-            error.contains("policy extension file-policy denied request"),
-            "expected shared file policy prefix, got: {error}"
-        );
-        assert!(
-            error.contains("escapes file root"),
-            "expected shared file policy denial, got: {error}"
         );
     }
 

--- a/crates/app/src/tools/shell_policy_ext.rs
+++ b/crates/app/src/tools/shell_policy_ext.rs
@@ -51,6 +51,72 @@ impl ToolPolicyExtension {
             default_mode: rt.shell_default_mode,
         }
     }
+
+    fn authorize_shell_payload(
+        &self,
+        tool_name: &str,
+        payload: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<(), PolicyError> {
+        let command = payload.get("command").and_then(serde_json::Value::as_str);
+        let Some(command) = command else {
+            return Ok(());
+        };
+        let trimmed_command = command.trim();
+        if trimmed_command.is_empty() {
+            return Ok(());
+        }
+
+        let normalized_command =
+            validate_shell_command_name(trimmed_command).map_err(|reason| {
+                PolicyError::ToolCallDenied {
+                    tool_name: tool_name.to_owned(),
+                    reason,
+                }
+            })?;
+
+        if self.hard_deny.contains(normalized_command.as_str()) {
+            let reason = format!("command `{normalized_command}` is blocked by shell policy");
+            return Err(PolicyError::ToolCallDenied {
+                tool_name: tool_name.to_owned(),
+                reason,
+            });
+        }
+
+        if self.allow.contains(normalized_command.as_str()) {
+            return Ok(());
+        }
+
+        let approval_key =
+            shell_exec_approval_key_for_normalized_command(normalized_command.as_str());
+        let approved_by_internal_context =
+            shell_exec_matches_trusted_internal_approval(payload, approval_key.as_str());
+        if approved_by_internal_context {
+            return Ok(());
+        }
+
+        match self.default_mode {
+            ShellPolicyDefault::Allow => Ok(()),
+            ShellPolicyDefault::Deny => {
+                let reason = format!(
+                    "command `{normalized_command}` is not in the allow list (default-deny policy)"
+                );
+                Err(PolicyError::ToolCallDenied {
+                    tool_name: tool_name.to_owned(),
+                    reason,
+                })
+            }
+        }
+    }
+}
+
+pub(crate) fn authorize_direct_shell_payload(
+    payload: &serde_json::Map<String, serde_json::Value>,
+    rt: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<(), String> {
+    let extension = ToolPolicyExtension::from_config(rt);
+    extension
+        .authorize_shell_payload("shell.exec", payload)
+        .map_err(|error| format!("policy_denied: {error}"))
 }
 
 fn repairable_tool_input_reason(reason: String) -> String {
@@ -165,49 +231,7 @@ impl PolicyExtension for ToolPolicyExtension {
         let Some(payload) = payload.and_then(serde_json::Value::as_object) else {
             return Ok(());
         };
-        let command = payload.get("command").and_then(serde_json::Value::as_str);
-        let Some(command) = command else {
-            return Ok(());
-        };
-        let trimmed_command = command.trim();
-        if trimmed_command.is_empty() {
-            return Ok(());
-        }
-        let basename = validate_shell_command_name(trimmed_command).map_err(|reason| {
-            PolicyError::ToolCallDenied {
-                tool_name: tool_name.to_owned(),
-                reason,
-            }
-        })?;
-
-        if self.hard_deny.contains(basename.as_str()) {
-            return Err(PolicyError::ToolCallDenied {
-                tool_name: tool_name.to_owned(),
-                reason: format!("command `{basename}` is blocked by shell policy"),
-            });
-        }
-
-        if self.allow.contains(basename.as_str()) {
-            return Ok(());
-        }
-
-        let approval_key = shell_exec_approval_key_for_normalized_command(basename.as_str());
-        let approved_by_internal_context =
-            shell_exec_matches_trusted_internal_approval(payload, approval_key.as_str());
-        if approved_by_internal_context {
-            return Ok(());
-        }
-
-        // Default mode for unknown commands
-        match self.default_mode {
-            ShellPolicyDefault::Allow => Ok(()),
-            ShellPolicyDefault::Deny => Err(PolicyError::ToolCallDenied {
-                tool_name: tool_name.to_owned(),
-                reason: format!(
-                    "command `{basename}` is not in the allow list (default-deny policy)"
-                ),
-            }),
-        }
+        self.authorize_shell_payload(tool_name, payload)
     }
 }
 

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T17:26:21Z
+- Generated at: 2026-04-03T17:52:04Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,7 +23,7 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10782 | 11200 | 418 | 96 | 120 | 24 | 96.3% | TIGHT | 10831 | -0.5% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14985 | 15000 | 15 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14990 | 15000 | 10 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.6% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10782 functions=96 -->
-<!-- arch-hotspot key=tools_mod lines=14985 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14990 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-03T14:36:28Z
+- Generated at: 2026-04-03T17:26:21Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,7 +23,7 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10782 | 11200 | 418 | 96 | 120 | 24 | 96.3% | TIGHT | 10831 | -0.5% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14983 | 15000 | 17 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14985 | 15000 | 15 | 54 | 70 | 16 | 99.9% | TIGHT | 14472 | 3.5% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9519 | 9800 | 281 | 228 | 250 | 22 | 97.1% | TIGHT | 9519 | 0.0% | PASS | 228 |
 
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10782 functions=96 -->
-<!-- arch-hotspot key=tools_mod lines=14983 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14985 functions=54 -->
 <!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9519 functions=228 -->
 <!-- arch-boundary key=memory_literals status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  Direct `shell.exec` and `file.*` execution did not reuse the shared shell/file policy extension checks before tool dispatch, so the direct path drifted from the kernel-governed path.
- Why it matters:
  Policy denials could surface as generic execution failures instead of policy denials, which weakens governance consistency and breaks the expected conversation-level failure contract.
- What changed:
  Added a direct-path policy preflight for `shell.exec`, `file.read`, `file.write`, and `file.edit`; refactored shell/file policy extensions to reuse shared authorization helpers; normalized direct-path policy failures back to `policy_denied:` so the existing kernel and conversation classifiers produce `ToolDenied`; moved the direct preflight dispatcher and its regression coverage into a dedicated tools submodule to keep `tools/mod.rs` within the architecture budget; refreshed `docs/releases/architecture-drift-2026-04.md` with the new measured line count; stabilized tool-search temp fixture names so parallel Windows runs do not collide on PID-only directory names.
- What did not change (scope boundary):
  No broader tool execution architecture changes, no removal of execution-layer shell/file guards, and no behavior changes for unrelated tools.

## Linked Issues

- Closes #860
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [ ] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [x] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes how direct-path shell/file policy denials are classified and surfaced to the conversation layer.
- Rollout / guardrails:
  The change is intentionally narrow to `shell.exec` and `file.read` / `file.write` / `file.edit`, execution-layer checks remain in place as defense in depth, and the direct preflight dispatcher now lives outside `tools/mod.rs` so the change does not push that hotspot over its tracked size budget.
- Rollback path:
  Revert PR #882, or revert commits `a1de915b` and `62270968`.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [ ] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-issue-860 cargo clippy --workspace --all-targets --all-features -- -D warnings
CARGO_TARGET_DIR=/tmp/loongclaw-issue-860 cargo test --workspace --locked --quiet
CARGO_TARGET_DIR=/tmp/loongclaw-issue-860 cargo test --workspace --all-features --locked --quiet
CARGO_TARGET_DIR=/tmp/loongclaw-issue-860 cargo test -p loongclaw-app integ_file_read_sandbox_rejects_path_escape --test conversation_integration -- --exact
CARGO_TARGET_DIR=/tmp/loongclaw-issue-860 cargo test -p loongclaw-app tool_search_hides_tools_exceeding_granted_capabilities
CARGO_TARGET_DIR=/tmp/loongclaw-issue-860 cargo test -p loongclaw-app tool_search_hides_bash_exec_without_side_effect_capabilities
bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-$(date -u +%Y-%m).md
scripts/bootstrap_release_local_artifacts.sh
LOONGCLAW_RELEASE_DOCS_STRICT=1 scripts/check-docs.sh
./scripts/check_dep_graph.sh
LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh

All commands passed. The targeted integration regression now returns ToolDenied again, full workspace plus all-features test suites stayed green after the final cleanup pass, and the updated architecture drift report confirms `tools/mod.rs` remains within its tracked size budget.
```

## User-visible / Operator-visible Changes

- Direct policy denials for `shell.exec` and `file.*` now surface consistently as policy denials instead of retryable execution failures.

## Failure Recovery

- Fast rollback or disable path:
  Revert PR #882, or revert commits `a1de915b` and `62270968`.
- Observable failure symptoms reviewers should watch for:
  Direct shell/file calls unexpectedly surfacing as `ToolError`, or policy-denied cases bypassing the shared preflight and reaching execution.

## Reviewer Focus

- Review `crates/app/src/tools/mod.rs` for the new direct-path preflight boundary.
- Review `crates/app/src/tools/direct_policy_preflight.rs` for the extracted direct-path dispatcher and regression coverage.
- Review `crates/app/src/tools/shell_policy_ext.rs` and `crates/app/src/tools/file_policy_ext.rs` to confirm the shared helpers preserve existing policy semantics while restoring direct-path classification.
- Review `crates/app/src/tools/mod.rs` around the tool-search capability-filter fixtures to confirm the temp-path change removes PID-only collisions without changing search semantics.
- Review `docs/releases/architecture-drift-2026-04.md` to confirm the refreshed hotspot metric matches the post-refactor file size.
