### PR TITLE
refactor(channel): refine capability traits and Feishu delivery paths

### DIFF
--- a/docs/plans/2026-04-04-channel-trait-capability-refinement-design.md
+++ b/docs/plans/2026-04-04-channel-trait-capability-refinement-design.md
@@ -1,0 +1,447 @@
+# Channel Trait Capability Refinement Design
+
+Date: 2026-04-04
+Issue: `#404`
+Status: follow-up refinement proposal
+
+> This document is a follow-up refinement proposal for the merged adapter-level
+> trait direction. It does not replace or reopen the original Option A
+> direction.
+
+## Current State
+
+Issue `#404` no longer needs a design for establishing the initial trait-based
+channel abstraction. That work has already landed incrementally:
+
+- traits layer established in `channel/traits/`
+- Feishu API module moved under `channel/feishu/api/`
+- `MessagingApi` implemented on `FeishuAdapter`
+- `DocumentsApi` implemented on `FeishuAdapter`
+
+## Goal
+
+The current merged trait layer solved the primary `#404` problem: tools and
+adapters now have a platform-agnostic API surface. However, `MessagingApi` and
+`DocumentsApi` are still relatively wide interfaces. Platforms that support
+only a subset of methods may still need to expose `ApiError::NotSupported`
+branches.
+
+This document evaluates a narrower question:
+
+**Should the merged `MessagingApi` and `DocumentsApi` be decomposed into
+smaller capability traits so partial platform support is modeled more directly
+at the type boundary?**
+
+## Background
+
+The current channel trait layer already establishes several important constraints:
+
+- traits are implemented at the adapter layer, not directly on low-level HTTP clients
+- messaging traits reuse normalized routing and session types already used by the channel system
+- the abstraction is additive and compatible with incremental migration
+
+### Adapter boundary remains correct
+
+The old #404 abstraction work established an important boundary that should not be reopened in this
+follow-up:
+
+- low-level clients remain focused on transport, auth, and retry
+- adapters own channel-facing context such as token refresh, normalized routing, and compatibility
+  with existing `ChannelAdapter` flows
+- the trait layer is therefore implemented on adapters, not directly on low-level clients
+
+That boundary is still the right one for capability refinement. Narrower traits should continue to
+be adapter-level capabilities.
+
+### Relationship with `ChannelAdapter`
+
+The current trait layer coexists with `ChannelAdapter` rather than replacing it in a single cutover.
+
+That coexistence remains intentional:
+
+- `ChannelAdapter` still owns the legacy protocol-oriented receive/send boundary
+- the trait layer provides a more focused capability surface for newer code
+- capability refinement should preserve this staged migration model rather than forcing a second
+  big-bang transition
+
+Relevant current sources:
+
+- `crates/app/src/channel/traits/mod.rs`
+- `crates/app/src/channel/traits/messaging.rs`
+- `crates/app/src/channel/traits/documents.rs`
+- `crates/app/src/channel/feishu/adapter.rs`
+
+## Problem
+
+The remaining pain is narrower than the original #404 problem.
+
+### 1. Wide traits still blur real platform support
+
+`MessagingApi` and `DocumentsApi` expose a broad set of methods. Some platforms implement most of
+the trait but still have to reject individual methods at runtime.
+
+This keeps part of the platform capability matrix implicit in implementation details instead of
+making it visible at the type boundary.
+
+### 2. Callers cannot express minimal dependency precisely
+
+A caller that only needs "append document content" or "send message" still depends on a wider
+trait surface than it actually uses.
+
+That is not catastrophic, but it weakens one of the expected benefits of the abstraction layer:
+small, focused interfaces that are easy to inject and easy to mock.
+
+### 3. `NotSupported` remains necessary in places where the type system could help
+
+`ApiError::NotSupported` is still the right fallback for compatibility surfaces and genuinely
+dynamic paths, but it should not be the dominant way to model stable capability gaps between
+platforms.
+
+## Non-Goals
+
+This proposal is intentionally narrow. It does **not** do the following:
+
+- redesign `ApiError`
+- redesign `Pagination`
+- redesign `ChannelOutboundTarget`
+- redesign `ChannelSession`
+- redesign `MessageContent` or `DocumentContent`
+- introduce a second routing vocabulary alongside the existing channel routing model
+- introduce a new kernel capability, policy, or audit model
+- revisit the Option A vs Option B decision from #404
+- move trait implementations from adapters back down into low-level clients
+- define the full future trait model for wiki, file, drive, or chat APIs
+
+## Design Constraints
+
+Any refinement in this area must respect repository architecture and the already merged #404 work.
+
+### 1. Additive first
+
+The existing trait layer is already merged and in use. Refinement must be additive by default.
+New traits are acceptable. Breaking replacement of the current trait layer is not.
+
+### 2. Reuse existing channel vocabulary
+
+The current trait layer intentionally reuses normalized routing and session types. Refinement must
+continue to use:
+
+- existing `ApiError`
+- existing `Pagination`
+- existing `ChannelOutboundTarget`
+- existing `ChannelSession`
+- existing `MessageContent`
+- existing `DocumentContent`
+
+This proposal must not create a second normalized surface for the same domain.
+
+### 3. No shadow capability system
+
+Channel capability modeling is not kernel capability authorization.
+
+Kernel capability, policy, and audit boundaries remain authoritative for security-sensitive
+execution paths. Channel trait decomposition is only an API-shape decision inside the app/channel
+layer.
+
+### 4. Single source of truth
+
+If capability metadata is added later, it must not create two independent truth sources such as:
+
+- one path saying a capability is supported
+- another path returning `None` or `NotSupported` for the same capability
+
+Refinement should prefer simple, mechanically consistent designs.
+
+## Current Baseline
+
+### Current messaging trait
+
+`MessagingApi` currently includes:
+
+- `send_message`
+- `reply`
+- `get_message`
+- `list_messages`
+- `search_messages`
+- `edit_message`
+- `delete_message`
+
+`RichMessagingApi` extends it for card-oriented behavior.
+
+### Current documents trait
+
+`DocumentsApi` currently includes:
+
+- `create_document`
+- `get_document`
+- `get_document_content`
+- `update_document`
+- `append_to_document`
+- `list_documents`
+- `search_documents`
+- `delete_document`
+- `move_document`
+
+### Current Feishu reality
+
+Feishu now implements the traits at the adapter layer, which is the correct merged abstraction
+boundary. But support is not uniform across all methods.
+
+For example, the current implementation still uses `ApiError::NotSupported` for several document
+operations such as:
+
+- full document update
+- document list
+- document search
+- document delete
+- document move
+
+That makes Feishu a good initial case study for whether smaller traits would improve the API
+boundary.
+
+## Proposal
+
+### Recommendation
+
+Keep the current `MessagingApi` and `DocumentsApi` as compatibility surfaces, and introduce a
+small number of narrower capability traits on top of them.
+
+This is an additive decomposition, not a rewrite.
+
+### Proposed document capability traits
+
+First-pass split:
+
+- `DocumentCreateApi`
+- `DocumentReadApi`
+- `DocumentAppendApi`
+- `DocumentSearchApi`
+- `DocumentMutateApi`
+
+Suggested ownership of methods:
+
+- `DocumentCreateApi`
+  - `create_document`
+- `DocumentReadApi`
+  - `get_document`
+  - `get_document_content`
+- `DocumentAppendApi`
+  - `append_to_document`
+- `DocumentSearchApi`
+  - `list_documents`
+  - `search_documents`
+- `DocumentMutateApi`
+  - `update_document`
+  - `delete_document`
+  - `move_document`
+
+Reasoning:
+
+- `append_to_document` is common enough in current Feishu usage to deserve its own small trait.
+- `list` and `search` are often paired as discovery-style operations and can remain together.
+- `update/delete/move` are administrative mutations and can be grouped conservatively instead of
+  splitting into excessively fine traits on day one.
+
+### Proposed messaging capability traits
+
+First-pass split:
+
+- `MessageSendApi`
+- `MessageQueryApi`
+- `MessageEditApi`
+- `MessageDeleteApi`
+
+Suggested ownership of methods:
+
+- `MessageSendApi`
+  - `send_message`
+  - `reply`
+- `MessageQueryApi`
+  - `get_message`
+  - `list_messages`
+  - `search_messages`
+- `MessageEditApi`
+  - `edit_message`
+- `MessageDeleteApi`
+  - `delete_message`
+
+Reasoning:
+
+- send/reply are both write-path message creation flows and belong together
+- read/query methods form a coherent read capability surface
+- edit and delete are often the most platform-variable operations and benefit from separation
+
+### Why this split is intentionally conservative
+
+This proposal does not attempt to model every micro-capability in the first pass.
+
+It is deliberately optimized for:
+
+- reducing the most obvious `NotSupported` mismatches
+- giving callers smaller traits to depend on
+- avoiding a combinatorial explosion of tiny traits
+- staying close to the current merged `MessagingApi` and `DocumentsApi`
+
+## Explicit Non-Recommendation: Second Vocabulary Rewrite
+
+The following direction is explicitly out of scope and not recommended for this phase:
+
+- defining a new `SendDestination` abstraction in parallel with `ChannelOutboundTarget`
+- defining a new `ChannelSession` abstraction in parallel with the current normalized session type
+- defining a new `Pagination` type in parallel with the existing validated pagination model
+- defining a new `ApiError` hierarchy in parallel with the current channel trait errors
+- defining a new `MessagePayload` hierarchy in parallel with `MessageContent`
+
+That direction would reopen already merged #404 decisions and create a second trait-surface
+vocabulary inside the same subsystem.
+
+## Capability Discovery
+
+Runtime capability discovery is not the primary recommendation for this phase.
+
+The preferred calling model remains:
+
+- inject the smallest trait the caller needs
+- let adapter implementation availability determine what can be wired
+
+If runtime capability metadata becomes necessary later, it should be introduced as a lightweight
+descriptor generated from the same implementation boundary, not as a second independently maintained
+discovery system.
+
+This proposal therefore does **not** recommend:
+
+- a `supports_*` matrix plus access/downcast traits
+- dual truth sources for capability support
+- an AI-agent-oriented runtime probing protocol as the main API surface
+
+## Error Semantics
+
+The current `ApiError` remains unchanged.
+
+Refinement only changes where `NotSupported` is expected to appear.
+
+### Preferred semantics after refinement
+
+- callers using narrow capability traits should rarely see `ApiError::NotSupported`
+- `NotSupported` remains acceptable on wide compatibility traits
+- `NotSupported` remains acceptable in dynamic or platform-bridging code paths where the exact
+  capability surface is not statically selected
+
+This means trait decomposition should **reduce** the visible `NotSupported` surface, not attempt to
+abolish the error entirely.
+
+## Feishu Case Study
+
+Feishu is the best immediate test bed because it already sits on the merged #404 adapter-centered
+architecture and still exhibits uneven method support.
+
+### Current likely mapping
+
+Feishu is a natural fit for:
+
+- `DocumentCreateApi`
+- `DocumentReadApi`
+- `DocumentAppendApi`
+- `MessageSendApi`
+- `MessageQueryApi`
+
+Feishu is currently a poor fit, or at least an incomplete fit, for:
+
+- `DocumentSearchApi`
+- parts of `DocumentMutateApi`
+- message edit depending on content and endpoint restrictions
+
+### Expected benefit
+
+Under a narrower trait model:
+
+- Feishu would implement fewer "present but unsupported" methods
+- new callers could request only the write or read surfaces they actually need
+- capability boundaries would be visible from injected trait types instead of hidden in method
+  bodies
+
+## Migration Plan
+
+### Phase 1: Add narrow traits
+
+Add the new capability traits alongside the existing wide traits.
+
+No caller breakage. No DTO churn. No routing-model changes.
+
+### Phase 2: Adapter adoption
+
+Implement the new narrow traits for Feishu first, reusing the existing adapter implementation
+logic.
+
+This phase should be mostly extraction and signature shaping, not behavioral redesign.
+
+### Phase 3: Caller trials
+
+Update a small number of new or isolated callers to depend on narrow traits such as:
+
+- `MessageSendApi`
+- `DocumentReadApi`
+- `DocumentAppendApi`
+
+This phase is where the proposal must prove that it actually improves ergonomics.
+
+### Phase 4: Re-evaluate wide traits
+
+Only after real caller adoption should the project decide whether:
+
+- the wide traits remain as stable compatibility surfaces
+- the wide traits become secondary convenience traits composed from the narrow traits
+
+This document does **not** recommend planning removal of the wide traits yet.
+
+## Acceptance Criteria
+
+This proposal is only worthwhile if all of the following are true:
+
+- the new design is additive on top of the merged #404 trait layer
+- no second channel routing/session/error/content vocabulary is introduced
+- at least one real platform can implement a narrower, more truthful capability surface
+- at least one real caller can depend on a smaller trait than `MessagingApi` or `DocumentsApi`
+- the amount of platform-specific `ApiError::NotSupported` exposed through normal typed usage
+  decreases
+- the design keeps adapter layer ownership and does not blur adapter/client boundaries
+- all Rust examples introduced by follow-up docs compile on stable Rust
+
+## Trade-offs
+
+| Pros | Cons |
+|------|------|
+| smaller traits express dependencies more clearly | more traits to name, document, and wire |
+| platforms can expose a more truthful capability surface | some duplication between wide and narrow traits may remain |
+| callers can mock narrower interfaces more easily | migration has to be staged carefully to avoid churn |
+| reduces avoidable `NotSupported` branches in typed paths | over-splitting would make the API harder to learn |
+
+## Decision
+
+Recommended direction:
+
+- keep the merged #404 trait layer
+- do not redesign its core DTO vocabulary
+- introduce a conservative set of narrower capability traits
+- validate the value on Feishu and a small number of callers before expanding the model further
+
+## Future Work
+
+Not part of this phase, but reasonable follow-up topics later:
+
+- richer capability descriptors if a real runtime selection use case emerges
+- optional decomposition for calendar traits if uneven support appears there too
+- wiki/file/chat trait families after the current messaging/documents surfaces stabilize
+- tool-layer migration patterns once narrower traits prove useful in production code
+
+## References
+
+- `crates/app/src/channel/traits/mod.rs`
+- `crates/app/src/channel/traits/messaging.rs`
+- `crates/app/src/channel/traits/documents.rs`
+- `crates/app/src/channel/traits/error.rs`
+- `crates/app/src/channel/types.rs`
+- `crates/app/src/channel/feishu/adapter.rs`
+- `crates/app/src/channel/feishu/api/messaging_api.rs`
+- `docs/plans/2026-04-04-channel-trait-capability-refinement-implementation-plan.md`
+- Issue #404 comments and merged follow-up steps

--- a/docs/plans/2026-04-04-channel-trait-capability-refinement-implementation-plan.md
+++ b/docs/plans/2026-04-04-channel-trait-capability-refinement-implementation-plan.md
@@ -1,0 +1,262 @@
+# Channel Trait Capability Refinement Implementation Plan
+
+**Goal:** Introduce a conservative set of narrower channel capability traits on top of the merged
+#404 trait layer, validate them on the Feishu adapter, and prove value through at least one real
+caller path without redesigning the current DTO or routing vocabulary.
+
+**Architecture:** Keep `MessagingApi` and `DocumentsApi` as additive compatibility surfaces, add
+narrow traits in the existing trait modules, implement only truthful subsets on `FeishuAdapter`,
+and route one or more real Feishu send paths through helpers that depend on the smaller traits.
+
+**Tech Stack:** Rust app crate, existing `channel/traits` DTOs, `async_trait`, Feishu adapter
+tests, focused cargo test/clippy/fmt verification.
+
+---
+
+## Task 1: Persist the follow-up design and execution artifacts
+
+**Files:**
+- Existing: `docs/plans/2026-04-04-channel-trait-capability-refinement-design.md`
+- Create: `docs/plans/2026-04-04-channel-trait-capability-refinement-implementation-plan.md`
+
+**Step 1: Keep the refinement design document as the public design source**
+
+Use `docs/plans/2026-04-04-channel-trait-capability-refinement-design.md` as the design baseline
+for this slice.
+
+**Step 2: Save this implementation plan under `docs/plans/`**
+
+This plan is the execution companion for the follow-up refinement proposal.
+
+## Task 2: Add the narrow capability traits without changing the merged DTO surface
+
+**Files:**
+- Modify: `crates/app/src/channel/traits/messaging.rs`
+- Modify: `crates/app/src/channel/traits/documents.rs`
+- Modify: `crates/app/src/channel/traits/mod.rs`
+
+**Step 1: Add narrow messaging traits to the existing messaging module**
+
+Add:
+
+- `MessageSendApi`
+- `MessageQueryApi`
+- `MessageEditApi`
+- `MessageDeleteApi`
+
+Each trait should reuse the current types already exposed by `messaging.rs`:
+
+- `Message`
+- `MessageContent`
+- `Pagination`
+- `SendOptions`
+- `ChannelOutboundTarget`
+- `ChannelSession`
+
+**Step 2: Add narrow document traits to the existing documents module**
+
+Add:
+
+- `DocumentCreateApi`
+- `DocumentReadApi`
+- `DocumentAppendApi`
+- `DocumentSearchApi`
+- `DocumentMutateApi`
+
+Each trait should reuse the current document DTOs and `Pagination`.
+
+**Step 3: Re-export the new traits from `channel/traits/mod.rs`**
+
+Expose them alongside the current wide traits so new callers can adopt them without extra module
+churn.
+
+**Step 4: Preserve the current wide traits exactly**
+
+Do not:
+
+- replace `MessagingApi`
+- replace `DocumentsApi`
+- add new supertrait bounds to the existing wide traits
+- redefine `ApiError`, `Pagination`, `ChannelOutboundTarget`, `ChannelSession`, `MessageContent`,
+  or `DocumentContent`
+
+This slice is additive only.
+
+## Task 3: Implement truthful narrow-trait support on `FeishuAdapter`
+
+**Files:**
+- Modify: `crates/app/src/channel/feishu/adapter.rs`
+
+**Step 1: Implement the clearly supported messaging traits**
+
+Implement on `FeishuAdapter`:
+
+- `MessageSendApi`
+- `MessageQueryApi`
+
+Implement `MessageDeleteApi` only if the current behavior is genuinely supported across the
+existing adapter contract and does not merely preserve a compatibility-only `NotSupported` branch.
+
+Defer `MessageEditApi` if edit support is still content- or endpoint-restricted enough that the
+narrow trait would not be truthful.
+
+**Step 2: Implement the clearly supported document traits**
+
+Implement on `FeishuAdapter`:
+
+- `DocumentCreateApi`
+- `DocumentReadApi`
+- `DocumentAppendApi`
+
+Do not implement:
+
+- `DocumentSearchApi`
+- unsupported parts of `DocumentMutateApi`
+
+unless the adapter can actually satisfy those methods without simply forwarding `NotSupported`.
+
+**Step 3: Share existing adapter logic rather than forking behavior**
+
+The narrow trait impls should delegate to the same underlying helper methods and API resources used
+by the current wide trait impls.
+
+This slice should mainly be about shaping interfaces, not changing platform semantics.
+
+## Task 4: Add focused tests for the new narrow traits
+
+**Files:**
+- Modify: `crates/app/src/channel/feishu/adapter.rs`
+- Modify: `crates/app/src/channel/traits/messaging.rs`
+- Modify: `crates/app/src/channel/traits/documents.rs`
+
+**Step 1: Add compile-time trait conformance checks**
+
+Add small helper assertions in test code such as:
+
+- `assert_message_send_api::<FeishuAdapter>()`
+- `assert_message_query_api::<FeishuAdapter>()`
+- `assert_document_create_api::<FeishuAdapter>()`
+- `assert_document_read_api::<FeishuAdapter>()`
+- `assert_document_append_api::<FeishuAdapter>()`
+
+These checks ensure the expected trait ownership is explicit.
+
+**Step 2: Add behavior tests through the narrow traits**
+
+Add focused tests that call Feishu through the narrow traits rather than through the wide traits
+for operations that are already supported:
+
+- send message
+- query message
+- create document
+- read document
+- append document
+
+**Step 3: Avoid fake symmetry tests**
+
+Do not add tests that force unsupported narrow traits to exist just for API symmetry.
+
+The absence of an impl is the point.
+
+## Task 5: Route at least one real caller through a narrow trait
+
+**Files:**
+- Modify: `crates/app/src/channel/feishu/mod.rs`
+- Modify: `crates/app/src/channel/feishu/webhook.rs`
+- Modify: `crates/app/src/channel/feishu/adapter.rs` if helper extraction is needed
+
+**Step 1: Introduce a small helper using `MessageSendApi`**
+
+Extract a helper on an existing live send path that depends on `MessageSendApi` instead of the
+wide `MessagingApi` or concrete method lookup on `FeishuAdapter`.
+
+Candidate paths:
+
+- `run_feishu_send` in `crates/app/src/channel/feishu/mod.rs`
+- webhook reply send path in `crates/app/src/channel/feishu/webhook.rs`
+
+**Step 2: Keep the caller trial narrow and local**
+
+Do not wait for the full future `tools/channel/` extraction to prove value.
+
+This slice only needs one real caller path to demonstrate:
+
+- a smaller dependency surface
+- no new DTO churn
+- no routing-model rewrite
+
+**Step 3: Defer document caller migration if no natural production seam exists yet**
+
+If there is no equally natural documents caller in current production code, validate document
+traits with adapter-focused tests first and defer document caller adoption to the subsequent tool
+extraction slice.
+
+## Task 6: Decide whether compatibility helpers are necessary
+
+**Files:**
+- Modify: `crates/app/src/channel/traits/messaging.rs` if needed
+- Modify: `crates/app/src/channel/traits/documents.rs` if needed
+
+**Step 1: Evaluate whether helper wrappers improve adoption**
+
+After the narrow traits exist, decide whether small helper functions are needed for ergonomic
+bridging in tests or callers.
+
+Examples:
+
+- helper functions generic over `MessageSendApi`
+- helper functions generic over `DocumentReadApi`
+
+**Step 2: Do not add blanket impls that misrepresent support**
+
+Specifically avoid:
+
+- blanket impls that automatically make every `MessagingApi` implement all narrow messaging traits
+- blanket impls that automatically make every `DocumentsApi` implement all narrow document traits
+
+That would recreate the original problem by making unsupported capability surfaces look statically
+available.
+
+## Task 7: Run verification
+
+**Files:**
+- Modify: none
+
+**Step 1: Run focused trait and Feishu tests**
+
+Run focused tests for the changed areas, for example:
+
+- `cargo test -p loongclaw-app channel::feishu::adapter -- --nocapture`
+- `cargo test -p loongclaw-app channel::traits -- --nocapture`
+
+If the exact test filters change while implementing, keep the scope focused on the new narrow trait
+surface and Feishu adapter paths.
+
+**Step 2: Run repository verification**
+
+Run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --locked`
+- `cargo test --workspace --all-features --locked`
+
+**Step 3: Inspect the scoped diff**
+
+Run:
+
+- `git status --short`
+- `git diff -- docs/plans/2026-04-04-channel-trait-capability-refinement-design.md`
+- `git diff -- docs/plans/2026-04-04-channel-trait-capability-refinement-implementation-plan.md`
+- `git diff -- crates/app/src/channel/traits/mod.rs crates/app/src/channel/traits/messaging.rs crates/app/src/channel/traits/documents.rs crates/app/src/channel/feishu/adapter.rs crates/app/src/channel/feishu/mod.rs crates/app/src/channel/feishu/webhook.rs`
+
+## Exit Criteria
+
+This slice is complete when:
+
+- narrow traits exist and are re-exported
+- `FeishuAdapter` implements only the narrow traits it can truthfully support
+- at least one live send path depends on `MessageSendApi`
+- no new DTO or routing vocabulary has been introduced
+- the current wide traits still compile unchanged
+- focused and full verification pass


### PR DESCRIPTION
## Summary
- add narrow channel capability traits while keeping `MessagingApi` and `DocumentsApi` as compatibility surfaces
- consolidate document mutations under `DocumentWriteApi` and update Feishu adapter/tests to match the new capability split
- tighten Feishu send/reply routing, token resolution strategy, and reply chat-context handling so webhook/websocket reply paths stay truthful without silent empty-session fallback
- refresh the channel trait capability refinement design and implementation plan docs so they match the implemented trait model

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p loongclaw-app --lib channel::traits::documents::tests::narrow_trait_assertions_compile -- --exact`
- `cargo test -p loongclaw-app --lib channel::feishu::adapter::tests::feishu_adapter_document_write_api_appends_markdown_content -- --exact`
- `cargo test -p loongclaw-app --lib channel::feishu::adapter::tests::feishu_adapter_api_traits_do_not_reuse_cached_tenant_tokens -- --exact`
- `cargo test -p loongclaw-app --lib channel::feishu::tests::run_feishu_send_supports_post_receive_id_overrides_and_uuid -- --exact`
- `cargo test -p loongclaw-app --lib channel::feishu::adapter::tests::feishu_adapter_message_send_api_reply_uses_target_chat_context_when_parent_missing -- --exact`
- `cargo test -p loongclaw-app --lib channel::feishu::adapter::tests::feishu_adapter_message_send_api_reply_returns_not_found_without_chat_context -- --exact`
- `cargo test -p loongclaw-app --lib channel::feishu::payload::tests::feishu_websocket_message_event_parses_without_verification_token -- --exact`
- `cargo test -p loongclaw-app --lib channel::feishu::webhook::tests::feishu_webhook_file_event_reaches_provider_as_structured_text_and_replies -- --exact`
- `cargo test -p loongclaw-app --lib channel::feishu::websocket::tests::feishu_websocket_session_reaches_provider_and_replies -- --exact`

## Issue
- Refs #404
