### PR TITLE
docs: clarify Taskfile shortcuts are optional wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,17 @@ Current tracked deviations: none.
 
 ## 3. Commands
 
+`Taskfile.yml` provides optional convenience wrappers through the `task` CLI.
+If `task` is unavailable, run the underlying `cargo` and `scripts/*` commands
+directly.
+
 - Format check: `cargo fmt --all -- --check`
 - Strict lint: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
-- Architecture check: `task check:architecture`
-- Convention check: `task check:conventions`
+- Architecture check: `./scripts/check_architecture_boundaries.sh` or `task check:architecture`
+- Convention check: `task check:conventions` (optional wrapper; requires Go + convention-engineering skill)
 - Test all features: `cargo test --workspace --all-features`
-- Canonical verify: `task verify`
-- Extended verify: `task verify:full`
+- Canonical verify: `task verify` (optional wrapper around repo verification steps)
+- Extended verify: `task verify:full` (optional wrapper around the extended local gate)
 
 ## 4. Non-Negotiable Rules
 
@@ -64,7 +68,8 @@ cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 ```
 
 Runs CI-parity cargo checks before each commit.
-Use `task verify` for the stricter local superset (architecture, conventions, docs, deny).
+Use `task verify` when the `task` CLI is installed. Otherwise run the
+underlying `cargo` and `scripts/*` verification commands directly.
 
 ## 7. Where to Look Next
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,17 @@ Current tracked deviations: none.
 
 ## 3. Commands
 
+`Taskfile.yml` provides optional convenience wrappers through the `task` CLI.
+If `task` is unavailable, run the underlying `cargo` and `scripts/*` commands
+directly.
+
 - Format check: `cargo fmt --all -- --check`
 - Strict lint: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
-- Architecture check: `task check:architecture`
-- Convention check: `task check:conventions`
+- Architecture check: `./scripts/check_architecture_boundaries.sh` or `task check:architecture`
+- Convention check: `task check:conventions` (optional wrapper; requires Go + convention-engineering skill)
 - Test all features: `cargo test --workspace --all-features`
-- Canonical verify: `task verify`
-- Extended verify: `task verify:full`
+- Canonical verify: `task verify` (optional wrapper around repo verification steps)
+- Extended verify: `task verify:full` (optional wrapper around the extended local gate)
 
 ## 4. Non-Negotiable Rules
 
@@ -64,7 +68,8 @@ cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 ```
 
 Runs CI-parity cargo checks before each commit.
-Use `task verify` for the stricter local superset (architecture, conventions, docs, deny).
+Use `task verify` when the `task` CLI is installed. Otherwise run the
+underlying `cargo` and `scripts/*` verification commands directly.
 
 ## 7. Where to Look Next
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ collaboration.
 
 - Rust stable toolchain installed.
 - `cargo` available in shell.
-- `task` CLI installed (`go-task`), required for `task verify` / `task verify:full`.
+- `task` CLI installed (`go-task`) if you want to use the convenience wrappers in
+  `Taskfile.yml` such as `task verify` / `task verify:full`.
 - Go toolchain installed (required by `task check:conventions`).
 - `cargo-deny` installed (required by `task check:deny`).
 - GitHub account with fork access.
@@ -35,14 +36,14 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features
 ```
 
-Canonical local gate:
+Optional convenience wrapper:
 
 ```bash
 task verify
 ```
 
-If `task`/`go`/convention skill dependencies are unavailable locally, run at least CI parity plus
-architecture/dep-graph checks directly:
+If `task` or its transitive dependencies are unavailable locally, run at least
+CI parity plus architecture/dep-graph checks directly:
 
 ```bash
 cargo fmt --all -- --check

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -23,10 +23,10 @@ optional `scripts/pre-commit` hook mirrors these cargo gates locally.
 
 ## Architecture Stability Guardrails
 
-1. **Complexity budgets are locally machine-checkable** — run `./scripts/check_architecture_boundaries.sh` or `task check:architecture` to inspect module line/function budgets for architecture hotspots (`spec_runtime`, `spec_execution`, `provider/mod`, `memory/mod`, `acp/manager`, `acp/acpx`, `channel/registry`, `config/channels`, `chat`, `channel/mod`, `conversation/turn_coordinator`, `tools/mod`, `daemon/lib`, `daemon/onboard_cli`). The generated drift report also classifies each hotspot by `foundation`, `structural_size`, and `operational_density` pressure so release reviews can distinguish large-surface drift from runtime-density risk.
+1. **Complexity budgets are locally machine-checkable** — run `./scripts/check_architecture_boundaries.sh` directly, or `task check:architecture` when the optional `task` CLI wrapper is installed, to inspect module line/function budgets for architecture hotspots (`spec_runtime`, `spec_execution`, `provider/mod`, `memory/mod`, `acp/manager`, `acp/acpx`, `channel/registry`, `config/channels`, `chat`, `channel/mod`, `conversation/turn_coordinator`, `tools/mod`, `daemon/lib`, `daemon/onboard_cli`). The generated drift report also classifies each hotspot by `foundation`, `structural_size`, and `operational_density` pressure so release reviews can distinguish large-surface drift from runtime-density risk.
 2. **Memory operation literals are boundary-guarded** — memory core operation strings (`append_turn`, `window`, `clear_session`) must remain centralized in `crates/app/src/memory/*` and never spread into callsites.
 3. **`spec` stays detached from `app`** — the architecture guardrails treat any direct `loongclaw-app` dependency in `crates/spec/Cargo.toml` as a boundary regression, and `./scripts/check_dep_graph.sh` must stay green.
-4. **Strict enforcement is an extended local gate** — use `task check:architecture:strict` (or set `LOONGCLAW_ARCH_STRICT=true`) to make architecture budget violations fail non-zero. This check is part of `task verify:full`, not the canonical CI-parity gate.
+4. **Strict enforcement is an extended local gate** — use `LOONGCLAW_ARCH_STRICT=true ./scripts/check_architecture_boundaries.sh` directly, or `task check:architecture:strict` when the optional `task` CLI wrapper is installed, to make architecture budget violations fail non-zero. This check is part of `task verify:full`, not the canonical CI-parity gate.
 
 ## Kernel Invariants
 

--- a/docs/design-docs/harness-engineering.md
+++ b/docs/design-docs/harness-engineering.md
@@ -76,7 +76,9 @@ The workspace clippy configuration mechanically prevents agent-generated anti-pa
 
 ### Dependency DAG as Constraint
 
-The 7-crate DAG prevents circular dependencies and implementation leakage. Enforced by `scripts/check_dep_graph.sh` and `task check:architecture`.
+The 7-crate DAG prevents circular dependencies and implementation leakage.
+Enforced by `scripts/check_dep_graph.sh` and, when the optional `task` CLI is
+installed, `task check:architecture`.
 
 ### Testing as Downstream Backpressure
 


### PR DESCRIPTION
## Summary

This PR clarifies that the checked-in `Taskfile.yml` remains supported, but the `task` CLI is an optional convenience wrapper rather than a hard requirement for normal local verification.

Changes in scope:

- clarify the active agent-guide mirrors about direct command fallbacks
- update contributor docs to describe `task` as optional convenience tooling
- update reliability and harness docs to prefer direct script commands with `task` as an optional wrapper

Closes #886

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `task` CLI is an optional convenience wrapper for running verification and architecture checks
  * Added fallback instructions to run underlying commands directly when `task` or its dependencies are unavailable
  * Updated developer documentation and contribution guidelines to reflect the optional nature of `task` CLI setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->