### PR TITLE
Rename claw.migrate to config.import and unify import preflight

### DIFF
--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -4172,16 +4172,16 @@ mod tests {
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
-        let kernel_ctx = kernel_context("turn-engine-claw-migrate-auto");
+        let kernel_ctx = kernel_context("turn-engine-config-import-auto");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
                 &provider_tool_turn(
-                    "claw.migrate",
+                    "config.import",
                     json!({}),
                     "root-session",
-                    "turn-claw-migrate-auto",
-                    "call-claw-migrate-auto",
+                    "turn-config-import-auto",
+                    "call-config-import-auto",
                 ),
                 &session_context,
                 &dispatcher,
@@ -4193,10 +4193,10 @@ mod tests {
         let TurnResult::NeedsApproval(requirement) = result else {
             panic!("expected NeedsApproval, got {result:?}");
         };
-        assert_eq!(requirement.tool_name.as_deref(), Some("claw.migrate"));
+        assert_eq!(requirement.tool_name.as_deref(), Some("config.import"));
         assert_eq!(
             requirement.approval_key.as_deref(),
-            Some("tool:claw.migrate")
+            Some("tool:config.import")
         );
         assert_eq!(
             requirement.rule_id.as_str(),
@@ -4211,7 +4211,7 @@ mod tests {
             .expect("load approval request")
             .expect("approval request row");
         assert_eq!(stored.status, ApprovalRequestStatus::Pending);
-        assert_eq!(stored.tool_name, "claw.migrate");
+        assert_eq!(stored.tool_name, "config.import");
         assert_eq!(stored.request_payload_json["execution_kind"], "core");
     }
 
@@ -4238,16 +4238,16 @@ mod tests {
         let tool_view = runtime_tool_view_for_config(&tool_config);
         let session_context = SessionContext::root_with_tool_view("root-session", tool_view);
         let dispatcher = DefaultAppToolDispatcher::new(memory_config.clone(), tool_config);
-        let kernel_ctx = kernel_context("turn-engine-claw-migrate-full");
+        let kernel_ctx = kernel_context("turn-engine-config-import-full");
 
         let result = TurnEngine::new(4)
             .execute_turn_in_context(
                 &provider_tool_turn(
-                    "claw.migrate",
+                    "config.import",
                     json!({}),
                     "root-session",
-                    "turn-claw-migrate-full",
-                    "call-claw-migrate-full",
+                    "turn-config-import-full",
+                    "call-config-import-full",
                 ),
                 &session_context,
                 &dispatcher,
@@ -4262,7 +4262,7 @@ mod tests {
         assert!(
             failure
                 .reason
-                .contains("claw.migrate requires payload.input_path"),
+                .contains("config.import requires payload.input_path"),
             "expected execution to reach the core tool, got: {failure:?}"
         );
     }

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -467,17 +467,17 @@ fn build_tool_catalog() -> ToolCatalog {
             provider_definition_builder: tool_invoke_definition,
         },
         ToolDescriptor {
-            name: "claw.migrate",
-            provider_name: "claw_migrate",
-            aliases: &[],
-            description: "Migrate legacy Claw configs into native LoongClaw settings",
+            name: "config.import",
+            provider_name: "config_import",
+            aliases: &["claw.migrate", "claw_migrate"],
+            description: "Import legacy agent workspace config, profile, and external-skills mapping state into native LoongClaw settings",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
             visibility_gate: ToolVisibilityGate::Always,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: HIGH_RISK_TOOL_POLICY_DESCRIPTOR,
-            provider_definition_builder: claw_migrate_definition,
+            provider_definition_builder: config_import_definition,
         },
         ToolDescriptor {
             name: "external_skills.fetch",
@@ -2107,18 +2107,18 @@ fn tool_invoke_definition(descriptor: &ToolDescriptor) -> Value {
     })
 }
 
-fn claw_migrate_definition(descriptor: &ToolDescriptor) -> Value {
+fn config_import_definition(descriptor: &ToolDescriptor) -> Value {
     json!({
         "type": "function",
         "function": {
             "name": descriptor.provider_name,
-            "description": "Import, discover, plan, merge, apply, and rollback legacy Claw workspace migration into native LoongClaw config.",
+            "description": "Import, discover, plan, merge, apply, and roll back legacy agent workspace config and related external-skills state into native LoongClaw config.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "input_path": {
                         "type": "string",
-                        "description": "Path to the legacy Claw workspace, config root, or portable migration file. Required for all modes except rollback_last_apply."
+                        "description": "Path to the legacy agent workspace, config root, or portable import file. Required for all modes except rollback_last_apply."
                     },
                     "mode": {
                         "type": "string",
@@ -2138,7 +2138,7 @@ fn claw_migrate_definition(descriptor: &ToolDescriptor) -> Value {
                     "source": {
                         "type": "string",
                         "enum": ["auto", "nanobot", "openclaw", "picoclaw", "zeroclaw", "nanoclaw"],
-                        "description": "Optional source hint for plan/apply modes. Defaults to automatic detection."
+                        "description": "Optional claw-family source hint for plan/apply modes. Defaults to automatic detection."
                     },
                     "source_id": {
                         "type": "string",
@@ -3613,7 +3613,9 @@ fn tool_argument_hint(name: &str) -> &'static str {
         "feishu.whoami" => "account_id?:string,open_id?:string",
         "tool.search" => "query?:string,exact_tool_id?:string,limit?:integer",
         "tool.invoke" => "tool_id:string,lease:string,arguments:object",
-        "claw.migrate" => "input_path?:string,mode?:string,source?:string",
+        "config.import" => {
+            "input_path?:string,output_path?:string,mode?:string,source?:string,source_id?:string,primary_source_id?:string,safe_profile_merge?:boolean,apply_external_skills_plan?:boolean,force?:boolean"
+        }
         "external_skills.fetch" => {
             "reference?:string,url?:string,approval_granted?:boolean,save_as?:string,max_bytes?:integer"
         }
@@ -3984,10 +3986,16 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
             ("lease", "string"),
             ("arguments", "object"),
         ],
-        "claw.migrate" => &[
+        "config.import" => &[
             ("input_path", "string"),
+            ("output_path", "string"),
             ("mode", "string"),
             ("source", "string"),
+            ("source_id", "string"),
+            ("primary_source_id", "string"),
+            ("safe_profile_merge", "boolean"),
+            ("apply_external_skills_plan", "boolean"),
+            ("force", "boolean"),
         ],
         "external_skills.fetch" => &[
             ("reference", "string"),
@@ -4217,7 +4225,7 @@ fn tool_tags(name: &str) -> &'static [&'static str] {
         "feishu.whoami" => &["feishu", "identity", "read"],
         "tool.search" => &["core", "discover", "search"],
         "tool.invoke" => &["core", "dispatch", "invoke"],
-        "claw.migrate" => &["migration", "migrate", "config", "legacy"],
+        "config.import" => &["config", "import", "migration", "workspace", "legacy"],
         "external_skills.fetch" => &["skills", "download", "external", "fetch"],
         "external_skills.resolve" => &["skills", "resolve", "normalize", "external"],
         "external_skills.search" => &["skills", "search", "inventory", "discover"],
@@ -4789,11 +4797,25 @@ mod tests {
     }
 
     #[test]
+    fn config_import_alias_resolves_descriptor_governance() {
+        let catalog = tool_catalog();
+        let descriptor = catalog
+            .descriptor("config.import")
+            .expect("config.import descriptor");
+        let expected_policy = governance_profile_for_descriptor(descriptor);
+        let legacy_alias_policy = governance_profile_for_tool_name("claw.migrate");
+
+        assert!(descriptor.aliases.contains(&"claw.migrate"));
+        assert!(descriptor.aliases.contains(&"claw_migrate"));
+        assert_eq!(legacy_alias_policy, expected_policy);
+    }
+
+    #[test]
     fn autonomy_capability_action_is_independent_from_governance_profile() {
         let catalog = tool_catalog();
         let migrate = catalog
-            .descriptor("claw.migrate")
-            .expect("claw.migrate descriptor");
+            .descriptor("config.import")
+            .expect("config.import descriptor");
         let provider_switch = catalog
             .descriptor("provider.switch")
             .expect("provider.switch descriptor");
@@ -4825,7 +4847,7 @@ mod tests {
             ("tool.search", CapabilityActionClass::Discover),
             ("tool_search", CapabilityActionClass::Discover),
             ("tool.invoke", CapabilityActionClass::ExecuteExisting),
-            ("claw.migrate", CapabilityActionClass::ExecuteExisting),
+            ("config.import", CapabilityActionClass::ExecuteExisting),
             (
                 "external_skills.fetch",
                 CapabilityActionClass::CapabilityFetch,

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -2166,7 +2166,7 @@ fn config_import_definition(descriptor: &ToolDescriptor) -> Value {
                     },
                     "output_path": {
                         "type": "string",
-                        "description": "Target config path. Required in apply/apply_selected/rollback_last_apply modes."
+                        "description": "Optional target config path. In plan, when present, config.import reads this path to preview the merged result. Required in apply/apply_selected/rollback_last_apply modes."
                     },
                     "force": {
                         "type": "boolean",

--- a/crates/app/src/tools/config_import.rs
+++ b/crates/app/src/tools/config_import.rs
@@ -13,22 +13,44 @@ use crate::{
 };
 
 const DEFAULT_MODE: &str = "plan";
+pub(super) const CONFIG_IMPORT_TOOL_NAME: &str = "config.import";
 const SUPPORTED_SOURCES: &str = "auto, nanobot, openclaw, picoclaw, zeroclaw, nanoclaw";
 
-pub(super) fn execute_claw_migrate_tool_with_config(
+pub(super) fn config_import_mode(payload: &serde_json::Map<String, Value>) -> &str {
+    let raw_mode = payload.get("mode");
+    let raw_mode = raw_mode.and_then(Value::as_str);
+    let trimmed_mode = raw_mode.map(str::trim);
+    let mode = trimmed_mode.filter(|value| !value.is_empty());
+
+    mode.unwrap_or(DEFAULT_MODE)
+}
+
+pub(super) fn config_import_mode_requires_write_object(
+    payload: &serde_json::Map<String, Value>,
+) -> bool {
+    let mode = config_import_mode(payload);
+
+    matches!(mode, "apply" | "apply_selected" | "rollback_last_apply")
+}
+
+pub(super) fn config_import_mode_requires_write_value(payload: &Value) -> bool {
+    let payload = payload.as_object();
+    let Some(payload) = payload else {
+        return false;
+    };
+
+    config_import_mode_requires_write_object(payload)
+}
+
+pub(super) fn execute_config_import_tool_with_config(
     request: ToolCoreRequest,
     config: &super::runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     let payload = request
         .payload
         .as_object()
-        .ok_or_else(|| "claw.migrate payload must be an object".to_owned())?;
-    let mode = payload
-        .get("mode")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(DEFAULT_MODE);
+        .ok_or_else(|| format!("{CONFIG_IMPORT_TOOL_NAME} payload must be an object"))?;
+    let mode = config_import_mode(payload);
     if !matches!(
         mode,
         "plan"
@@ -42,7 +64,7 @@ pub(super) fn execute_claw_migrate_tool_with_config(
             | "rollback_last_apply"
     ) {
         return Err(format!(
-            "claw.migrate payload.mode must be `plan`, `apply`, `apply_selected`, `discover`, `plan_many`, `recommend_primary`, `merge_profiles`, `map_external_skills`, or `rollback_last_apply`, got `{mode}`"
+            "{CONFIG_IMPORT_TOOL_NAME} payload.mode must be `plan`, `apply`, `apply_selected`, `discover`, `plan_many`, `recommend_primary`, `merge_profiles`, `map_external_skills`, or `rollback_last_apply`, got `{mode}`"
         ));
     }
 
@@ -54,9 +76,10 @@ pub(super) fn execute_claw_migrate_tool_with_config(
         .map(|value| resolve_safe_path_with_config(value, config))
         .transpose()?;
 
-    if matches!(mode, "apply" | "apply_selected" | "rollback_last_apply") && output_path.is_none() {
+    let mode_requires_write = config_import_mode_requires_write_object(payload);
+    if mode_requires_write && output_path.is_none() {
         return Err(format!(
-            "claw.migrate {mode} mode requires payload.output_path"
+            "{CONFIG_IMPORT_TOOL_NAME} {mode} mode requires payload.output_path"
         ));
     }
 
@@ -69,7 +92,7 @@ pub(super) fn execute_claw_migrate_tool_with_config(
                 .and_then(Value::as_str)
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
-                .ok_or_else(|| "claw.migrate requires payload.input_path".to_owned())
+                .ok_or_else(|| format!("{CONFIG_IMPORT_TOOL_NAME} requires payload.input_path"))
                 .and_then(|value| resolve_safe_path_with_config(value, config))?,
         )
     };
@@ -88,7 +111,9 @@ pub(super) fn execute_claw_migrate_tool_with_config(
 
     if mode == "rollback_last_apply" {
         let output_path = output_path.ok_or_else(|| {
-            "claw.migrate rollback_last_apply mode requires payload.output_path".to_owned()
+            format!(
+                "{CONFIG_IMPORT_TOOL_NAME} rollback_last_apply mode requires payload.output_path"
+            )
         })?;
         let restored_path = migration::rollback_last_migration(&output_path)?;
         return Ok(ToolCoreOutcome {
@@ -103,8 +128,8 @@ pub(super) fn execute_claw_migrate_tool_with_config(
         });
     }
 
-    let input_path =
-        input_path.ok_or_else(|| "claw.migrate requires payload.input_path".to_owned())?;
+    let input_path = input_path
+        .ok_or_else(|| format!("{CONFIG_IMPORT_TOOL_NAME} requires payload.input_path"))?;
 
     if mode == "discover" {
         let report = migration::discover_import_sources(
@@ -193,7 +218,7 @@ pub(super) fn execute_claw_migrate_tool_with_config(
             .and_then(Value::as_bool)
             .unwrap_or(false);
         let selected_output_path = output_path.ok_or_else(|| {
-            "claw.migrate apply_selected mode requires payload.output_path".to_owned()
+            format!("{CONFIG_IMPORT_TOOL_NAME} apply_selected mode requires payload.output_path")
         })?;
         let result = migration::apply_import_selection(&migration::ApplyImportSelection {
             discovery: report,
@@ -227,9 +252,9 @@ pub(super) fn execute_claw_migrate_tool_with_config(
     let config_toml = config::render(&merged_config)?;
 
     let written_output_path = if mode == "apply" {
-        let output_path = output_path
-            .clone()
-            .ok_or_else(|| "claw.migrate apply mode requires payload.output_path".to_owned())?;
+        let output_path = output_path.clone().ok_or_else(|| {
+            format!("{CONFIG_IMPORT_TOOL_NAME} apply mode requires payload.output_path")
+        })?;
         let output_string = output_path.display().to_string();
         Some(config::write(Some(&output_string), &merged_config, force)?)
     } else {
@@ -395,7 +420,9 @@ fn apply_selection_result_payload(result: &migration::ApplyImportSelectionResult
 
 fn parse_source_hint(raw: &str) -> Result<Option<LegacyClawSource>, String> {
     let parsed = LegacyClawSource::from_id(raw).ok_or_else(|| {
-        format!("unsupported claw.migrate payload.source `{raw}`. supported: {SUPPORTED_SOURCES}")
+        format!(
+            "unsupported {CONFIG_IMPORT_TOOL_NAME} payload.source `{raw}`. supported: {SUPPORTED_SOURCES}"
+        )
     })?;
     if matches!(parsed, LegacyClawSource::Unknown) {
         Ok(None)
@@ -608,7 +635,7 @@ mod tests {
 
     #[test]
     fn resolve_safe_path_rejects_root_escape_with_policy_prefix() {
-        let base = unique_temp_dir("loongclaw-claw-import");
+        let base = unique_temp_dir("loongclaw-config-import");
         let root = base.join("root");
         fs::create_dir_all(&root).expect("create root");
 

--- a/crates/app/src/tools/direct_policy_preflight.rs
+++ b/crates/app/src/tools/direct_policy_preflight.rs
@@ -13,13 +13,16 @@ pub(super) fn run(
         return Ok(());
     };
 
-    let tool_name = request.tool_name.as_str();
+    let tool_name = super::canonical_tool_name(request.tool_name.as_str());
 
     if tool_name == "shell.exec" {
         return shell_policy_ext::authorize_direct_shell_payload(payload, config);
     }
 
-    let is_file_tool = matches!(tool_name, "file.read" | "file.write" | "file.edit");
+    let is_file_tool = matches!(
+        tool_name,
+        "file.read" | "file.write" | "file.edit" | "config.import"
+    );
     if is_file_tool {
         return file_policy_ext::authorize_direct_file_payload(tool_name, payload, config);
     }
@@ -38,6 +41,7 @@ mod tests {
 
     use super::run;
     use super::runtime_config;
+    use super::shell_policy_ext::ShellPolicyDefault;
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -54,6 +58,7 @@ mod tests {
     fn run_reuses_shared_shell_policy_default_deny() {
         let config = runtime_config::ToolRuntimeConfig {
             shell_allow: BTreeSet::new(),
+            shell_default_mode: ShellPolicyDefault::Deny,
             ..runtime_config::ToolRuntimeConfig::default()
         };
 
@@ -95,6 +100,39 @@ mod tests {
         assert!(
             error.contains("policy extension file-policy denied request"),
             "expected shared file policy prefix, got: {error}"
+        );
+        assert!(
+            error.contains("escapes file root"),
+            "expected shared file policy denial, got: {error}"
+        );
+    }
+
+    #[test]
+    fn run_reuses_shared_config_import_output_path_guard() {
+        let root = unique_temp_dir("direct-policy-preflight-import");
+        let config = runtime_config::ToolRuntimeConfig {
+            file_root: Some(root),
+            ..runtime_config::ToolRuntimeConfig::default()
+        };
+
+        let request = ToolCoreRequest {
+            tool_name: "config.import".to_owned(),
+            payload: json!({
+                "mode": "apply",
+                "input_path": "legacy-config.toml",
+                "output_path": "../outside.toml"
+            }),
+        };
+
+        let error = run(&request, &config).expect_err("escaped import output path should deny");
+
+        assert!(
+            error.starts_with("policy_denied: "),
+            "expected policy_denied prefix, got: {error}"
+        );
+        assert!(
+            error.contains("outside.toml"),
+            "expected escaped output path in error, got: {error}"
         );
         assert!(
             error.contains("escapes file root"),

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use loongclaw_contracts::{Capability, PolicyError};
@@ -28,14 +29,32 @@ impl FilePolicyExtension {
         }
     }
 
-    fn required_capability(tool_name: &str) -> Option<Capability> {
+    fn required_capabilities(
+        tool_name: &str,
+        payload: &serde_json::Map<String, serde_json::Value>,
+    ) -> BTreeSet<Capability> {
+        let mut required_capabilities = BTreeSet::new();
+
         match tool_name {
-            "file.read" | "memory_search" | "memory_get" | "claw.migrate" => {
-                Some(Capability::FilesystemRead)
+            "file.read" | "memory_search" | "memory_get" => {
+                required_capabilities.insert(Capability::FilesystemRead);
             }
-            "file.write" | "file.edit" => Some(Capability::FilesystemWrite),
-            _ => None,
+            "file.write" | "file.edit" => {
+                required_capabilities.insert(Capability::FilesystemWrite);
+            }
+            "config.import" => {
+                required_capabilities.insert(Capability::FilesystemRead);
+
+                let mode_requires_write =
+                    super::config_import::config_import_mode_requires_write_object(payload);
+                if mode_requires_write {
+                    required_capabilities.insert(Capability::FilesystemWrite);
+                }
+            }
+            _ => {}
         }
+
+        required_capabilities
     }
 
     /// Check whether `raw_path` escapes the configured file root.
@@ -49,9 +68,10 @@ impl FilePolicyExtension {
     /// 1. Full `canonicalize` — works when the entire path already exists.
     /// 2. Symlink detection — if the path is a symlink whose target cannot be
     ///    canonicalized (dangling), read the link target and check it directly.
-    /// 3. Parent `canonicalize` + file name — handles `file.write "new.txt"`
-    ///    where the leaf does not exist yet.
-    /// 4. Pure path normalization — neither path nor parent exists on disk.
+    /// 3. Deepest existing ancestor `canonicalize` + missing suffix re-attach —
+    ///    handles `file.write "nested/new.txt"` where one or more trailing
+    ///    components do not exist yet.
+    /// 4. Pure path normalization — no existing ancestor can be resolved.
     ///
     /// # Known limitations
     ///
@@ -68,15 +88,14 @@ impl FilePolicyExtension {
             None => return false,
         };
 
+        let effective_root = self.canon_root.as_deref().unwrap_or(root);
+
         let candidate = Path::new(raw_path);
         let combined = if candidate.is_absolute() {
             candidate.to_path_buf()
         } else {
-            root.join(candidate)
+            effective_root.join(candidate)
         };
-
-        // Effective root: prefer cached canonicalized form, fall back to raw.
-        let effective_root = self.canon_root.as_deref().unwrap_or(root);
 
         // 1. Try full canonicalize (works when the path already exists).
         if let Ok(canon) = combined.canonicalize() {
@@ -90,7 +109,7 @@ impl FilePolicyExtension {
                 let resolved = if target.is_absolute() {
                     target
                 } else {
-                    combined.parent().unwrap_or(root).join(&target)
+                    combined.parent().unwrap_or(effective_root).join(&target)
                 };
                 let normalized_target = super::normalize_without_fs(&resolved);
                 return !normalized_target.starts_with(effective_root);
@@ -99,17 +118,54 @@ impl FilePolicyExtension {
             return true;
         }
 
-        // 2. Path doesn't exist — canonicalize the parent directory instead,
-        //    then re-attach the file name.  Handles `file.write "new.txt"`.
-        if let (Some(parent), Some(file_name)) = (combined.parent(), combined.file_name())
-            && let Ok(canon_parent) = parent.canonicalize()
-        {
-            return !canon_parent.join(file_name).starts_with(effective_root);
+        // 2. Path doesn't exist — canonicalize the deepest existing ancestor,
+        //    then re-attach the missing suffix. Handles nested new paths such
+        //    as `file.write "nested/new.txt"` and keeps `/var` vs
+        //    `/private/var` aliases aligned on macOS.
+        if let Some(reconstructed_path) = reconstruct_from_existing_ancestor(&combined) {
+            return !reconstructed_path.starts_with(effective_root);
         }
 
         // 3. Neither path nor parent exists — fall back to pure normalization.
         let normalized = super::normalize_without_fs(&combined);
         !normalized.starts_with(effective_root)
+    }
+
+    fn raw_paths_for_request<'a>(
+        tool_name: &str,
+        payload: &'a serde_json::Map<String, serde_json::Value>,
+    ) -> Vec<&'a str> {
+        let mut raw_paths = Vec::new();
+
+        if tool_name == "config.import" {
+            let input_path = payload.get("input_path");
+            let input_path = input_path.and_then(serde_json::Value::as_str).unwrap_or("");
+            if !input_path.is_empty() {
+                raw_paths.push(input_path);
+            }
+
+            let mode_requires_write =
+                super::config_import::config_import_mode_requires_write_object(payload);
+            if mode_requires_write {
+                let output_path = payload.get("output_path");
+                let output_path = output_path
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                if !output_path.is_empty() {
+                    raw_paths.push(output_path);
+                }
+            }
+
+            return raw_paths;
+        }
+
+        let raw_path = payload.get("path");
+        let raw_path = raw_path.and_then(serde_json::Value::as_str).unwrap_or("");
+        if !raw_path.is_empty() {
+            raw_paths.push(raw_path);
+        }
+
+        raw_paths
     }
 
     fn authorize_file_payload(
@@ -121,32 +177,44 @@ impl FilePolicyExtension {
             return Ok(());
         };
 
-        let path_key = if tool_name == "claw.migrate" {
-            "input_path"
-        } else {
-            "path"
-        };
-        let raw_path = payload
-            .get(path_key)
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("");
-
-        let has_path = !raw_path.is_empty();
-        if !has_path {
+        let raw_paths = Self::raw_paths_for_request(tool_name, payload);
+        if raw_paths.is_empty() {
             return Ok(());
         }
 
-        let escapes_root = self.path_escapes_root(raw_path);
-        if !escapes_root {
-            return Ok(());
+        for raw_path in raw_paths {
+            let escapes_root = self.path_escapes_root(raw_path);
+            if !escapes_root {
+                continue;
+            }
+
+            let reason = format!("path `{raw_path}` escapes file root `{}`", root.display());
+            return Err(PolicyError::ExtensionDenied {
+                extension: self.name().to_owned(),
+                reason,
+            });
         }
 
-        let reason = format!("path `{raw_path}` escapes file root `{}`", root.display());
-        Err(PolicyError::ExtensionDenied {
-            extension: self.name().to_owned(),
-            reason,
-        })
+        Ok(())
     }
+}
+
+fn reconstruct_from_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut suffix_components = Vec::new();
+    let mut cursor = path;
+
+    while !cursor.exists() {
+        let component = cursor.file_name()?;
+        suffix_components.push(component.to_os_string());
+        cursor = cursor.parent()?;
+    }
+
+    let mut reconstructed = cursor.canonicalize().ok()?;
+    for component in suffix_components.iter().rev() {
+        reconstructed.push(component);
+    }
+
+    Some(reconstructed)
 }
 
 pub(crate) fn authorize_direct_file_payload(
@@ -177,23 +245,31 @@ impl PolicyExtension for FilePolicyExtension {
 
         let tool_name = super::canonical_tool_name(raw_tool_name);
 
-        let Some(required_cap) = Self::required_capability(tool_name) else {
-            return Ok(());
-        };
-
-        if !context.token.allowed_capabilities.contains(&required_cap) {
-            return Err(PolicyError::ExtensionDenied {
-                extension: self.name().to_owned(),
-                reason: format!(
-                    "tool `{tool_name}` requires capability `{required_cap:?}` not granted to token"
-                ),
-            });
-        }
-
         let payload = params.get("payload").and_then(serde_json::Value::as_object);
         let Some(payload) = payload else {
             return Ok(());
         };
+
+        let required_capabilities = Self::required_capabilities(tool_name, payload);
+        if required_capabilities.is_empty() {
+            return Ok(());
+        }
+
+        for required_capability in required_capabilities {
+            let capability_is_allowed = context
+                .token
+                .allowed_capabilities
+                .contains(&required_capability);
+            if capability_is_allowed {
+                continue;
+            }
+
+            let extension = self.name().to_owned();
+            let reason = format!(
+                "tool `{tool_name}` requires capability `{required_capability:?}` not granted to token"
+            );
+            return Err(PolicyError::ExtensionDenied { extension, reason });
+        }
 
         self.authorize_file_payload(tool_name, payload)?;
 
@@ -320,7 +396,8 @@ mod tests {
 
     #[test]
     fn denies_path_escape() {
-        let ext = FilePolicyExtension::new(Some(PathBuf::from("/home/user/project")));
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
         let pack = test_pack();
         let token = token_with_caps(BTreeSet::from([
             Capability::InvokeTool,
@@ -338,7 +415,8 @@ mod tests {
 
     #[test]
     fn allows_path_within_root() {
-        let ext = FilePolicyExtension::new(Some(PathBuf::from("/home/user/project")));
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
         let pack = test_pack();
         let token = token_with_caps(BTreeSet::from([
             Capability::InvokeTool,
@@ -351,12 +429,13 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_requires_filesystem_read() {
+    fn config_import_requires_filesystem_read() {
         let ext = FilePolicyExtension::new(None);
         let pack = test_pack();
         let token = token_with_caps(BTreeSet::from([Capability::InvokeTool]));
         let caps = BTreeSet::from([Capability::InvokeTool]);
-        let params = json!({"tool_name": "claw.migrate", "payload": {"input_path": "config.toml"}});
+        let params =
+            json!({"tool_name": "config.import", "payload": {"input_path": "config.toml"}});
         let ctx = make_context(&pack, &token, &caps, Some(&params));
         assert!(matches!(
             ext.authorize_extension(&ctx).unwrap_err(),
@@ -365,7 +444,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_allowed_with_filesystem_read() {
+    fn config_import_allowed_with_filesystem_read() {
         let ext = FilePolicyExtension::new(None);
         let pack = test_pack();
         let token = token_with_caps(BTreeSet::from([
@@ -373,17 +452,17 @@ mod tests {
             Capability::FilesystemRead,
         ]));
         let caps = BTreeSet::from([Capability::InvokeTool]);
-        let params = json!({"tool_name": "claw.migrate", "payload": {"input_path": "config.toml"}});
+        let params =
+            json!({"tool_name": "config.import", "payload": {"input_path": "config.toml"}});
         let ctx = make_context(&pack, &token, &caps, Some(&params));
         assert!(ext.authorize_extension(&ctx).is_ok());
     }
 
     #[test]
     fn memory_search_requires_filesystem_read() {
-        assert_eq!(
-            FilePolicyExtension::required_capability("memory_search"),
-            Some(Capability::FilesystemRead)
-        );
+        let payload = serde_json::Map::new();
+        let required = FilePolicyExtension::required_capabilities("memory_search", &payload);
+        assert_eq!(required, BTreeSet::from([Capability::FilesystemRead]));
 
         let ext = FilePolicyExtension::new(None);
         let pack = test_pack();
@@ -427,10 +506,9 @@ mod tests {
 
     #[test]
     fn memory_get_allowed_with_filesystem_read() {
-        assert_eq!(
-            FilePolicyExtension::required_capability("memory_get"),
-            Some(Capability::FilesystemRead)
-        );
+        let payload = serde_json::Map::new();
+        let required = FilePolicyExtension::required_capabilities("memory_get", &payload);
+        assert_eq!(required, BTreeSet::from([Capability::FilesystemRead]));
 
         let ext = FilePolicyExtension::new(None);
         let pack = test_pack();
@@ -475,15 +553,20 @@ mod tests {
 
     #[test]
     fn denies_absolute_path_outside_root() {
-        let ext = FilePolicyExtension::new(Some(PathBuf::from("/home/user/project")));
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let outside_dir = tempfile::tempdir().expect("tempdir");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
         let pack = test_pack();
         let token = token_with_caps(BTreeSet::from([
             Capability::InvokeTool,
             Capability::FilesystemRead,
         ]));
         let caps = BTreeSet::from([Capability::InvokeTool]);
-        // Absolute path to a completely different location — must be denied
-        let params = json!({"tool_name": "file.read", "payload": {"path": "/etc/passwd"}});
+        let escape_path = outside_dir.path().join("outside.txt");
+        let params = json!({
+            "tool_name": "file.read",
+            "payload": {"path": escape_path.display().to_string()}
+        });
         let ctx = make_context(&pack, &token, &caps, Some(&params));
         assert!(matches!(
             ext.authorize_extension(&ctx).unwrap_err(),
@@ -492,8 +575,9 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_sandbox_uses_input_path_key() {
-        let ext = FilePolicyExtension::new(Some(PathBuf::from("/home/user/project")));
+    fn config_import_sandbox_uses_input_path_key() {
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
         let pack = test_pack();
         let token = token_with_caps(BTreeSet::from([
             Capability::InvokeTool,
@@ -502,7 +586,7 @@ mod tests {
         let caps = BTreeSet::from([Capability::InvokeTool]);
         // input_path escapes the root — must be denied
         let params =
-            json!({"tool_name": "claw.migrate", "payload": {"input_path": "../../etc/passwd"}});
+            json!({"tool_name": "config.import", "payload": {"input_path": "../../etc/passwd"}});
         let ctx = make_context(&pack, &token, &caps, Some(&params));
         assert!(matches!(
             ext.authorize_extension(&ctx).unwrap_err(),
@@ -511,8 +595,9 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_within_root_allowed() {
-        let ext = FilePolicyExtension::new(Some(PathBuf::from("/home/user/project")));
+    fn config_import_within_root_allowed() {
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
         let pack = test_pack();
         let token = token_with_caps(BTreeSet::from([
             Capability::InvokeTool,
@@ -520,9 +605,70 @@ mod tests {
         ]));
         let caps = BTreeSet::from([Capability::InvokeTool]);
         let params =
-            json!({"tool_name": "claw.migrate", "payload": {"input_path": "subdir/config.toml"}});
+            json!({"tool_name": "config.import", "payload": {"input_path": "subdir/config.toml"}});
         let ctx = make_context(&pack, &token, &caps, Some(&params));
         assert!(ext.authorize_extension(&ctx).is_ok());
+    }
+
+    #[test]
+    fn config_import_apply_checks_output_path() {
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
+        let pack = test_pack();
+        let token = token_with_caps(BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+            Capability::FilesystemWrite,
+        ]));
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({
+            "tool_name": "config.import",
+            "payload": {
+                "mode": "apply",
+                "input_path": "subdir/config.toml",
+                "output_path": "../../etc/passwd"
+            }
+        });
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        assert!(matches!(
+            ext.authorize_extension(&ctx).unwrap_err(),
+            PolicyError::ExtensionDenied { .. }
+        ));
+    }
+
+    #[test]
+    fn config_import_apply_requires_filesystem_write() {
+        let ext = FilePolicyExtension::new(None);
+        let pack = test_pack();
+        let token = token_with_caps(BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+        ]));
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({
+            "tool_name": "config.import",
+            "payload": {
+                "mode": "apply",
+                "input_path": "config.toml",
+                "output_path": "loongclaw.toml"
+            }
+        });
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        assert!(matches!(
+            ext.authorize_extension(&ctx).unwrap_err(),
+            PolicyError::ExtensionDenied { .. }
+        ));
+    }
+
+    #[test]
+    fn nested_new_path_within_root_is_allowed() {
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
+
+        assert!(
+            !ext.path_escapes_root("nested/generated/loongclaw.toml"),
+            "nested new path under the file root should stay allowed"
+        );
     }
 
     // ── Symlink-aware filesystem tests ──────────────────────────────────

--- a/crates/app/src/tools/file_policy_ext.rs
+++ b/crates/app/src/tools/file_policy_ext.rs
@@ -89,6 +89,7 @@ impl FilePolicyExtension {
         };
 
         let effective_root = self.canon_root.as_deref().unwrap_or(root);
+        let normalized_effective_root = super::normalize_without_fs(effective_root);
 
         let candidate = Path::new(raw_path);
         let combined = if candidate.is_absolute() {
@@ -99,7 +100,7 @@ impl FilePolicyExtension {
 
         // 1. Try full canonicalize (works when the path already exists).
         if let Ok(canon) = combined.canonicalize() {
-            return !canon.starts_with(effective_root);
+            return !canon.starts_with(&normalized_effective_root);
         }
 
         // 1.5. Path is a symlink but canonicalize failed (dangling target) —
@@ -109,10 +110,15 @@ impl FilePolicyExtension {
                 let resolved = if target.is_absolute() {
                     target
                 } else {
-                    combined.parent().unwrap_or(effective_root).join(&target)
+                    let raw_parent = combined.parent().unwrap_or(effective_root);
+                    let symlink_parent = match raw_parent.canonicalize() {
+                        Ok(parent) => parent,
+                        Err(_) => return true,
+                    };
+                    symlink_parent.join(&target)
                 };
                 let normalized_target = super::normalize_without_fs(&resolved);
-                return !normalized_target.starts_with(effective_root);
+                return !normalized_target.starts_with(&normalized_effective_root);
             }
             // Cannot read the link — conservatively deny.
             return true;
@@ -123,45 +129,38 @@ impl FilePolicyExtension {
         //    as `file.write "nested/new.txt"` and keeps `/var` vs
         //    `/private/var` aliases aligned on macOS.
         if let Some(reconstructed_path) = reconstruct_from_existing_ancestor(&combined) {
-            return !reconstructed_path.starts_with(effective_root);
+            let normalized_reconstructed = super::normalize_without_fs(&reconstructed_path);
+            return !normalized_reconstructed.starts_with(&normalized_effective_root);
         }
 
         // 3. Neither path nor parent exists — fall back to pure normalization.
         let normalized = super::normalize_without_fs(&combined);
-        !normalized.starts_with(effective_root)
+        !normalized.starts_with(&normalized_effective_root)
     }
 
     fn raw_paths_for_request<'a>(
         tool_name: &str,
         payload: &'a serde_json::Map<String, serde_json::Value>,
     ) -> Vec<&'a str> {
+        let tool_name = super::canonical_tool_name(tool_name);
         let mut raw_paths = Vec::new();
 
         if tool_name == "config.import" {
-            let input_path = payload.get("input_path");
-            let input_path = input_path.and_then(serde_json::Value::as_str).unwrap_or("");
-            if !input_path.is_empty() {
+            let input_path = trimmed_non_empty_path(payload.get("input_path"));
+            if let Some(input_path) = input_path {
                 raw_paths.push(input_path);
             }
 
-            let mode_requires_write =
-                super::config_import::config_import_mode_requires_write_object(payload);
-            if mode_requires_write {
-                let output_path = payload.get("output_path");
-                let output_path = output_path
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("");
-                if !output_path.is_empty() {
-                    raw_paths.push(output_path);
-                }
+            let output_path = trimmed_non_empty_path(payload.get("output_path"));
+            if let Some(output_path) = output_path {
+                raw_paths.push(output_path);
             }
 
             return raw_paths;
         }
 
-        let raw_path = payload.get("path");
-        let raw_path = raw_path.and_then(serde_json::Value::as_str).unwrap_or("");
-        if !raw_path.is_empty() {
+        let raw_path = trimmed_non_empty_path(payload.get("path"));
+        if let Some(raw_path) = raw_path {
             raw_paths.push(raw_path);
         }
 
@@ -215,6 +214,13 @@ fn reconstruct_from_existing_ancestor(path: &Path) -> Option<PathBuf> {
     }
 
     Some(reconstructed)
+}
+
+fn trimmed_non_empty_path(value: Option<&serde_json::Value>) -> Option<&str> {
+    let raw_value = value.and_then(serde_json::Value::as_str);
+    let trimmed_value = raw_value.map(str::trim);
+
+    trimmed_value.filter(|value| !value.is_empty())
 }
 
 pub(crate) fn authorize_direct_file_payload(
@@ -637,6 +643,32 @@ mod tests {
     }
 
     #[test]
+    fn config_import_plan_checks_trimmed_output_preview_path() {
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
+        let pack = test_pack();
+        let token = token_with_caps(BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+        ]));
+        let caps = BTreeSet::from([Capability::InvokeTool]);
+        let params = json!({
+            "tool_name": "config.import",
+            "payload": {
+                "mode": "plan",
+                "input_path": "subdir/config.toml",
+                "output_path": " ../../etc/passwd "
+            }
+        });
+        let ctx = make_context(&pack, &token, &caps, Some(&params));
+        let result = ext.authorize_extension(&ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            PolicyError::ExtensionDenied { .. }
+        ));
+    }
+
+    #[test]
     fn config_import_apply_requires_filesystem_write() {
         let ext = FilePolicyExtension::new(None);
         let pack = test_pack();
@@ -669,6 +701,56 @@ mod tests {
             !ext.path_escapes_root("nested/generated/loongclaw.toml"),
             "nested new path under the file root should stay allowed"
         );
+    }
+
+    #[test]
+    fn lexical_parent_segments_after_missing_path_still_escape_root() {
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let nested_dir = root_dir.path().join("nested");
+        std::fs::create_dir_all(&nested_dir).expect("create nested dir");
+
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
+
+        assert!(
+            ext.path_escapes_root("nested/missing/../../../outside.txt"),
+            "lexical parent segments should not bypass the file root after ancestor reconstruction"
+        );
+    }
+
+    #[test]
+    fn allows_path_within_lexically_normalized_missing_root() {
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let raw_root = root_dir.path().join("missing").join("..");
+        let ext = FilePolicyExtension::new(Some(raw_root));
+
+        assert!(
+            !ext.path_escapes_root("inside.txt"),
+            "normalized missing-root paths should still allow in-root files"
+        );
+    }
+
+    #[test]
+    fn direct_file_payload_authorization_accepts_config_import_aliases() {
+        let root_dir = tempfile::tempdir().expect("tempdir");
+        let runtime_config = crate::tools::runtime_config::ToolRuntimeConfig {
+            file_root: Some(root_dir.path().to_path_buf()),
+            ..crate::tools::runtime_config::ToolRuntimeConfig::default()
+        };
+        let payload_value = json!({
+            "mode": "apply",
+            "input_path": "legacy-config.toml",
+            "output_path": "../outside.toml"
+        });
+        let payload = payload_value
+            .as_object()
+            .cloned()
+            .expect("payload should be an object");
+
+        let error = authorize_direct_file_payload("claw.migrate", &payload, &runtime_config)
+            .expect_err("alias should still reuse config.import direct file policy checks");
+
+        assert!(error.starts_with("policy_denied: "));
+        assert!(error.contains("outside.toml"));
     }
 
     // ── Symlink-aware filesystem tests ──────────────────────────────────
@@ -752,6 +834,33 @@ mod tests {
 
         let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
         assert!(!ext.path_escapes_root(link.to_str().unwrap()));
+    }
+
+    #[test]
+    fn denies_dangling_relative_symlink_via_symlinked_parent_directory() {
+        let outside = tempfile::tempdir().unwrap();
+        let outside_parent = outside.path().join("real-parent");
+        std::fs::create_dir_all(&outside_parent).unwrap();
+
+        let nested_link = outside_parent.join("dangling_relative_link");
+        let relative_target = Path::new("..").join("secret.txt");
+        if !try_symlink(&relative_target, &nested_link) {
+            return;
+        }
+
+        let root_dir = tempfile::tempdir().unwrap();
+        let linked_parent = root_dir.path().join("linked-parent");
+        if !try_symlink_dir(&outside_parent, &linked_parent) {
+            return;
+        }
+
+        let escaped_path = linked_parent.join("dangling_relative_link");
+        let ext = FilePolicyExtension::new(Some(root_dir.path().to_path_buf()));
+
+        assert!(
+            ext.path_escapes_root(escaped_path.to_str().unwrap()),
+            "relative dangling targets must resolve against the canonical symlink parent"
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -37,7 +37,7 @@ mod browser;
 mod browser_companion;
 mod bundled_skills;
 mod catalog;
-mod claw_migrate;
+mod config_import;
 pub(crate) mod delegate;
 mod direct_policy_preflight;
 pub(crate) mod download_guard;
@@ -399,7 +399,7 @@ pub async fn wait_for_session_with_config(
 /// - `..` past the filesystem root (or volume root on Windows) is silently dropped.
 /// - Relative paths preserve leading `..` components (e.g. `../../foo` stays as-is).
 ///
-/// All three path-handling modules (`file`, `claw_migrate`, `file_policy_ext`) use
+/// All three path-handling modules (`file`, `config_import`, `file_policy_ext`) use
 /// this single implementation to avoid divergence.
 pub(super) fn normalize_without_fs(path: &Path) -> PathBuf {
     use std::path::Component;
@@ -511,9 +511,11 @@ fn required_capabilities_for_tool_name_and_payload(
             caps.insert(Capability::FilesystemWrite);
             caps.insert(Capability::NetworkEgress);
         }
-        "claw.migrate" => {
+        "config.import" => {
             caps.insert(Capability::FilesystemRead);
-            if claw_migrate_mode_requires_write(payload) {
+            let mode_requires_write =
+                config_import::config_import_mode_requires_write_value(payload);
+            if mode_requires_write {
                 caps.insert(Capability::FilesystemWrite);
             }
         }
@@ -538,18 +540,6 @@ fn invoked_discoverable_tool_request(payload: &Value) -> Option<(&str, &Value)> 
         resolved.canonical_name,
         payload.get("arguments").unwrap_or(payload),
     ))
-}
-
-fn claw_migrate_mode_requires_write(payload: &Value) -> bool {
-    matches!(
-        payload
-            .get("mode")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("plan"),
-        "apply" | "apply_selected" | "rollback_last_apply"
-    )
 }
 
 fn tool_requires_network_egress(tool_name: &str) -> bool {
@@ -824,7 +814,7 @@ fn dispatch_tool_request(
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     match request.tool_name.as_str() {
-        "claw.migrate" => claw_migrate::execute_claw_migrate_tool_with_config(request, config),
+        "config.import" => config_import::execute_config_import_tool_with_config(request, config),
         "external_skills.resolve" => {
             external_skills::execute_external_skills_resolve_tool_with_config(request, config)
         }
@@ -1602,7 +1592,7 @@ fn tool_function_name(tool: &Value) -> &str {
 fn _shape_examples() -> BTreeMap<&'static str, Value> {
     let mut shapes = BTreeMap::from([
         (
-            "claw.migrate",
+            "config.import",
             json!({
                 "input_path": "/tmp/nanobot-workspace",
                 "mode": "plan",
@@ -1975,7 +1965,7 @@ mod tests {
         assert!(snapshot.contains("- tool.search: Discover non-core tools"));
         assert!(snapshot.contains("- tool.invoke: Invoke a discovered non-core tool"));
         assert!(snapshot.contains("Non-core tools are intentionally hidden"));
-        assert!(!snapshot.contains("claw.migrate"));
+        assert!(!snapshot.contains("config.import"));
         assert!(!snapshot.contains("external_skills.fetch"));
         assert!(!snapshot.contains("file.read"));
         assert!(!snapshot.contains("shell.exec"));
@@ -2007,7 +1997,7 @@ mod tests {
             "browser.click",
             "browser.extract",
             "browser.open",
-            "claw.migrate",
+            "config.import",
             "delegate",
             "delegate_async",
             "external_skills.policy",
@@ -2050,7 +2040,7 @@ mod tests {
             "browser.click",
             "browser.extract",
             "browser.open",
-            "claw.migrate",
+            "config.import",
             "delegate",
             "delegate_async",
             "external_skills.policy",
@@ -2093,19 +2083,19 @@ mod tests {
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn capability_snapshot_for_view_stays_core_only_under_restricted_view() {
-        let view = ToolView::from_tool_names(["claw.migrate", "shell.exec"]);
+        let view = ToolView::from_tool_names(["config.import", "shell.exec"]);
         let snapshot = capability_snapshot_for_view(&view);
 
         assert!(snapshot.contains("- tool.search: Discover non-core tools"));
         assert!(snapshot.contains("- tool.invoke: Invoke a discovered non-core tool"));
-        assert!(!snapshot.contains("- claw.migrate:"));
+        assert!(!snapshot.contains("- config.import:"));
         assert!(!snapshot.contains("- shell.exec:"));
     }
 
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn try_provider_tool_definitions_for_view_returns_core_only_subset() {
-        let view = ToolView::from_tool_names(["shell.exec", "claw.migrate"]);
+        let view = ToolView::from_tool_names(["shell.exec", "config.import"]);
         let defs = try_provider_tool_definitions_for_view(&view)
             .expect("restricted runtime view should still expose provider-core schemas");
         let names: Vec<&str> = defs
@@ -2475,7 +2465,9 @@ mod tests {
     fn canonical_tool_name_maps_known_aliases() {
         assert_eq!(canonical_tool_name("tool_search"), "tool.search");
         assert_eq!(canonical_tool_name("tool_invoke"), "tool.invoke");
-        assert_eq!(canonical_tool_name("claw_migrate"), "claw.migrate");
+        assert_eq!(canonical_tool_name("claw.migrate"), "config.import");
+        assert_eq!(canonical_tool_name("claw_migrate"), "config.import");
+        assert_eq!(canonical_tool_name("config_import"), "config.import");
         assert_eq!(
             canonical_tool_name("external_skills_policy"),
             "external_skills.policy"
@@ -2538,6 +2530,212 @@ mod tests {
         assert_eq!(canonical_tool_name("file.read"), "file.read");
     }
 
+    #[test]
+    fn required_capabilities_follow_effective_tool_request() {
+        let direct_file_read = ToolCoreRequest {
+            tool_name: "file.read".to_owned(),
+            payload: json!({"path": "README.md"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_file_read),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let direct_file_write = ToolCoreRequest {
+            tool_name: "file.write".to_owned(),
+            payload: json!({"path": "notes.txt", "content": "hello"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_file_write),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemWrite])
+        );
+
+        let direct_file_edit = ToolCoreRequest {
+            tool_name: "file.edit".to_owned(),
+            payload: json!({"path": "notes.txt", "old_string": "a", "new_string": "b"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_file_edit),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemWrite])
+        );
+
+        let direct_memory_search = ToolCoreRequest {
+            tool_name: "memory_search".to_owned(),
+            payload: json!({"query": "deploy freeze"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_memory_search),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let direct_memory_get = ToolCoreRequest {
+            tool_name: "memory_get".to_owned(),
+            payload: json!({"path": "MEMORY.md"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_memory_get),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let direct_web_fetch = ToolCoreRequest {
+            tool_name: "web.fetch".to_owned(),
+            payload: json!({"url": "https://example.com"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_web_fetch),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
+        let direct_web_search = ToolCoreRequest {
+            tool_name: "web.search".to_owned(),
+            payload: json!({"query": "loongclaw"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_web_search),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
+        let direct_browser_open = ToolCoreRequest {
+            tool_name: "browser.open".to_owned(),
+            payload: json!({"url": "https://example.com"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_browser_open),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
+        let direct_browser_extract = ToolCoreRequest {
+            tool_name: "browser.extract".to_owned(),
+            payload: json!({"mode": "page_text"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_browser_extract),
+            BTreeSet::from([Capability::InvokeTool])
+        );
+
+        let direct_browser_click = ToolCoreRequest {
+            tool_name: "browser.click".to_owned(),
+            payload: json!({"id": 1}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_browser_click),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
+        let direct_bash_exec = ToolCoreRequest {
+            tool_name: "bash.exec".to_owned(),
+            payload: json!({"command": "printf ok"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&direct_bash_exec),
+            BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::FilesystemRead,
+                Capability::FilesystemWrite,
+                Capability::NetworkEgress,
+            ])
+        );
+
+        let invoked_file_read = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "file.read",
+                "lease": "unused",
+                "arguments": {"path": "README.md"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_file_read),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let invoked_memory_search = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "memory_search",
+                "lease": "unused",
+                "arguments": {"query": "deploy freeze"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_memory_search),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let invoked_web_fetch = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "web.fetch",
+                "lease": "unused",
+                "arguments": {"url": "https://example.com"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_web_fetch),
+            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
+        );
+
+        let invoked_bash_exec = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "bash.exec",
+                "lease": "unused",
+                "arguments": {"command": "printf ok"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_bash_exec),
+            BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::FilesystemRead,
+                Capability::FilesystemWrite,
+                Capability::NetworkEgress,
+            ])
+        );
+
+        let invoked_claw_plan = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "config.import",
+                "lease": "unused",
+                "arguments": {"mode": "plan", "input_path": "imports/nanobot"}
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_claw_plan),
+            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
+        );
+
+        let invoked_claw_apply = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({
+                "tool_id": "config.import",
+                "lease": "unused",
+                "arguments": {
+                    "mode": "apply",
+                    "input_path": "imports/nanobot",
+                    "output_path": "loongclaw.toml"
+                }
+            }),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&invoked_claw_apply),
+            BTreeSet::from([
+                Capability::InvokeTool,
+                Capability::FilesystemRead,
+                Capability::FilesystemWrite,
+            ])
+        );
+
+        let malformed_invoke = ToolCoreRequest {
+            tool_name: "tool.invoke".to_owned(),
+            payload: json!({"lease": "unused"}),
+        };
+        assert_eq!(
+            required_capabilities_for_request(&malformed_invoke),
+            BTreeSet::from([Capability::InvokeTool])
+        );
+    }
     #[cfg(feature = "tool-file")]
     #[test]
     fn runtime_tool_view_hides_memory_tools_when_memory_corpus_is_empty() {
@@ -2955,7 +3153,7 @@ mod tests {
         assert!(
             results
                 .iter()
-                .all(|entry| entry["tool_id"] != "claw.migrate")
+                .all(|entry| entry["tool_id"] != "config.import")
         );
 
         std::fs::remove_dir_all(&root).ok();
@@ -4020,14 +4218,14 @@ mod tests {
         let mut config = test_tool_runtime_config(std::env::temp_dir());
         config.sessions_enabled = false;
 
-        let injected = ToolView::from_tool_names(["sessions_list", "claw.migrate"]);
+        let injected = ToolView::from_tool_names(["sessions_list", "config.import"]);
         let names = runtime_discoverable_tool_entries(&config, Some(&injected))
             .into_iter()
             .map(|entry| entry.canonical_name)
             .collect::<Vec<_>>();
 
         assert!(
-            names.contains(&"claw.migrate".to_owned()),
+            names.contains(&"config.import".to_owned()),
             "expected enabled injected tool to remain visible: {names:?}"
         );
         assert!(
@@ -4641,6 +4839,8 @@ mod tests {
 
     #[test]
     fn is_known_tool_name_accepts_canonical_and_alias_forms() {
+        assert!(is_known_tool_name("config.import"));
+        assert!(is_known_tool_name("config_import"));
         assert!(is_known_tool_name("claw.migrate"));
         assert!(is_known_tool_name("claw_migrate"));
         assert!(is_known_tool_name("external_skills.policy"));
@@ -13751,7 +13951,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_plan_mode_returns_nativeized_preview() {
+    fn config_import_plan_mode_returns_nativeized_preview() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -13793,7 +13993,7 @@ mod tests {
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "plan",
                     "source": "nanobot",
@@ -13802,10 +14002,10 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate plan should succeed");
+        .expect("config import plan should succeed");
 
         assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["tool_name"], "claw.migrate");
+        assert_eq!(outcome.payload["tool_name"], "config.import");
         assert_eq!(outcome.payload["mode"], "plan");
         assert_eq!(outcome.payload["source"], "nanobot");
         assert_eq!(
@@ -13834,7 +14034,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_apply_mode_writes_target_config() {
+    fn config_import_apply_mode_writes_target_config() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -13888,7 +14088,7 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate apply should succeed");
+        .expect("config import apply should succeed");
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "apply");
@@ -13920,7 +14120,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_discover_mode_returns_detected_sources() {
+    fn config_import_discover_mode_returns_detected_sources() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -13965,7 +14165,7 @@ mod tests {
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "discover",
                     "input_path": "."
@@ -13973,7 +14173,7 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate discover should succeed");
+        .expect("config import discover should succeed");
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "discover");
@@ -13983,7 +14183,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_plan_many_mode_returns_source_summaries_and_recommendation() {
+    fn config_import_plan_many_mode_returns_source_summaries_and_recommendation() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -14036,7 +14236,7 @@ mod tests {
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "plan_many",
                     "input_path": "."
@@ -14044,7 +14244,7 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate plan_many should succeed");
+        .expect("config import plan_many should succeed");
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "plan_many");
@@ -14055,7 +14255,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_merge_profiles_mode_preserves_prompt_owner() {
+    fn config_import_merge_profiles_mode_preserves_prompt_owner() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -14108,7 +14308,7 @@ mod tests {
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "merge_profiles",
                     "input_path": "."
@@ -14116,7 +14316,7 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate merge_profiles should succeed");
+        .expect("config import merge_profiles should succeed");
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "merge_profiles");
@@ -14135,7 +14335,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_map_external_skills_mode_returns_mapping_plan() {
+    fn config_import_map_external_skills_mode_returns_mapping_plan() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -14169,7 +14369,7 @@ mod tests {
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "map_external_skills",
                     "input_path": "."
@@ -14177,7 +14377,7 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate map_external_skills should succeed");
+        .expect("config import map_external_skills should succeed");
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "map_external_skills");
@@ -14201,7 +14401,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_apply_selected_mode_writes_manifest_and_backup() {
+    fn config_import_apply_selected_mode_writes_manifest_and_backup() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -14251,7 +14451,7 @@ mod tests {
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "apply_selected",
                     "input_path": ".",
@@ -14261,7 +14461,7 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate apply_selected should succeed");
+        .expect("config import apply_selected should succeed");
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(outcome.payload["mode"], "apply_selected");
@@ -14286,7 +14486,7 @@ mod tests {
     }
 
     #[test]
-    fn claw_migrate_apply_selected_mode_can_apply_external_skills_plan() {
+    fn config_import_apply_selected_mode_can_apply_external_skills_plan() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -14339,7 +14539,7 @@ mod tests {
         };
         let outcome = execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "apply_selected",
                     "input_path": ".",
@@ -14350,7 +14550,7 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate apply_selected with external skills should succeed");
+        .expect("config import apply_selected with external skills should succeed");
 
         assert_eq!(outcome.status, "ok");
         assert_eq!(
@@ -14382,14 +14582,14 @@ mod tests {
                 .join("release-guard")
                 .join("SKILL.md")
                 .exists(),
-            "claw.migrate should bridge installable local skills into the managed runtime"
+            "config.import should bridge installable local skills into the managed runtime"
         );
 
         fs::remove_dir_all(&root).ok();
     }
 
     #[test]
-    fn claw_migrate_rollback_last_apply_restores_original_config() {
+    fn config_import_rollback_last_apply_restores_original_config() {
         use std::{
             fs,
             path::{Path, PathBuf},
@@ -14439,7 +14639,7 @@ mod tests {
         };
         execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "apply_selected",
                     "input_path": ".",
@@ -14449,11 +14649,11 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate apply_selected should succeed");
+        .expect("config import apply_selected should succeed");
 
         let rollback = execute_tool_core_with_config(
             ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload: json!({
                     "mode": "rollback_last_apply",
                     "output_path": "loongclaw.toml"
@@ -14461,7 +14661,7 @@ mod tests {
             },
             &config,
         )
-        .expect("claw migrate rollback_last_apply should succeed");
+        .expect("config import rollback_last_apply should succeed");
 
         assert_eq!(rollback.status, "ok");
         assert!(

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -511,7 +511,7 @@ fn required_capabilities_for_tool_name_and_payload(
             caps.insert(Capability::FilesystemWrite);
             caps.insert(Capability::NetworkEgress);
         }
-        "config.import" => {
+        config_import::CONFIG_IMPORT_TOOL_NAME => {
             caps.insert(Capability::FilesystemRead);
             let mode_requires_write =
                 config_import::config_import_mode_requires_write_value(payload);
@@ -814,7 +814,9 @@ fn dispatch_tool_request(
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
     match request.tool_name.as_str() {
-        "config.import" => config_import::execute_config_import_tool_with_config(request, config),
+        config_import::CONFIG_IMPORT_TOOL_NAME => {
+            config_import::execute_config_import_tool_with_config(request, config)
+        }
         "external_skills.resolve" => {
             external_skills::execute_external_skills_resolve_tool_with_config(request, config)
         }
@@ -2530,212 +2532,6 @@ mod tests {
         assert_eq!(canonical_tool_name("file.read"), "file.read");
     }
 
-    #[test]
-    fn required_capabilities_follow_effective_tool_request() {
-        let direct_file_read = ToolCoreRequest {
-            tool_name: "file.read".to_owned(),
-            payload: json!({"path": "README.md"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_file_read),
-            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
-        );
-
-        let direct_file_write = ToolCoreRequest {
-            tool_name: "file.write".to_owned(),
-            payload: json!({"path": "notes.txt", "content": "hello"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_file_write),
-            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemWrite])
-        );
-
-        let direct_file_edit = ToolCoreRequest {
-            tool_name: "file.edit".to_owned(),
-            payload: json!({"path": "notes.txt", "old_string": "a", "new_string": "b"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_file_edit),
-            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemWrite])
-        );
-
-        let direct_memory_search = ToolCoreRequest {
-            tool_name: "memory_search".to_owned(),
-            payload: json!({"query": "deploy freeze"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_memory_search),
-            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
-        );
-
-        let direct_memory_get = ToolCoreRequest {
-            tool_name: "memory_get".to_owned(),
-            payload: json!({"path": "MEMORY.md"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_memory_get),
-            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
-        );
-
-        let direct_web_fetch = ToolCoreRequest {
-            tool_name: "web.fetch".to_owned(),
-            payload: json!({"url": "https://example.com"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_web_fetch),
-            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
-        );
-
-        let direct_web_search = ToolCoreRequest {
-            tool_name: "web.search".to_owned(),
-            payload: json!({"query": "loongclaw"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_web_search),
-            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
-        );
-
-        let direct_browser_open = ToolCoreRequest {
-            tool_name: "browser.open".to_owned(),
-            payload: json!({"url": "https://example.com"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_browser_open),
-            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
-        );
-
-        let direct_browser_extract = ToolCoreRequest {
-            tool_name: "browser.extract".to_owned(),
-            payload: json!({"mode": "page_text"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_browser_extract),
-            BTreeSet::from([Capability::InvokeTool])
-        );
-
-        let direct_browser_click = ToolCoreRequest {
-            tool_name: "browser.click".to_owned(),
-            payload: json!({"id": 1}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_browser_click),
-            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
-        );
-
-        let direct_bash_exec = ToolCoreRequest {
-            tool_name: "bash.exec".to_owned(),
-            payload: json!({"command": "printf ok"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&direct_bash_exec),
-            BTreeSet::from([
-                Capability::InvokeTool,
-                Capability::FilesystemRead,
-                Capability::FilesystemWrite,
-                Capability::NetworkEgress,
-            ])
-        );
-
-        let invoked_file_read = ToolCoreRequest {
-            tool_name: "tool.invoke".to_owned(),
-            payload: json!({
-                "tool_id": "file.read",
-                "lease": "unused",
-                "arguments": {"path": "README.md"}
-            }),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&invoked_file_read),
-            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
-        );
-
-        let invoked_memory_search = ToolCoreRequest {
-            tool_name: "tool.invoke".to_owned(),
-            payload: json!({
-                "tool_id": "memory_search",
-                "lease": "unused",
-                "arguments": {"query": "deploy freeze"}
-            }),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&invoked_memory_search),
-            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
-        );
-
-        let invoked_web_fetch = ToolCoreRequest {
-            tool_name: "tool.invoke".to_owned(),
-            payload: json!({
-                "tool_id": "web.fetch",
-                "lease": "unused",
-                "arguments": {"url": "https://example.com"}
-            }),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&invoked_web_fetch),
-            BTreeSet::from([Capability::InvokeTool, Capability::NetworkEgress])
-        );
-
-        let invoked_bash_exec = ToolCoreRequest {
-            tool_name: "tool.invoke".to_owned(),
-            payload: json!({
-                "tool_id": "bash.exec",
-                "lease": "unused",
-                "arguments": {"command": "printf ok"}
-            }),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&invoked_bash_exec),
-            BTreeSet::from([
-                Capability::InvokeTool,
-                Capability::FilesystemRead,
-                Capability::FilesystemWrite,
-                Capability::NetworkEgress,
-            ])
-        );
-
-        let invoked_claw_plan = ToolCoreRequest {
-            tool_name: "tool.invoke".to_owned(),
-            payload: json!({
-                "tool_id": "config.import",
-                "lease": "unused",
-                "arguments": {"mode": "plan", "input_path": "imports/nanobot"}
-            }),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&invoked_claw_plan),
-            BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
-        );
-
-        let invoked_claw_apply = ToolCoreRequest {
-            tool_name: "tool.invoke".to_owned(),
-            payload: json!({
-                "tool_id": "config.import",
-                "lease": "unused",
-                "arguments": {
-                    "mode": "apply",
-                    "input_path": "imports/nanobot",
-                    "output_path": "loongclaw.toml"
-                }
-            }),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&invoked_claw_apply),
-            BTreeSet::from([
-                Capability::InvokeTool,
-                Capability::FilesystemRead,
-                Capability::FilesystemWrite,
-            ])
-        );
-
-        let malformed_invoke = ToolCoreRequest {
-            tool_name: "tool.invoke".to_owned(),
-            payload: json!({"lease": "unused"}),
-        };
-        assert_eq!(
-            required_capabilities_for_request(&malformed_invoke),
-            BTreeSet::from([Capability::InvokeTool])
-        );
-    }
     #[cfg(feature = "tool-file")]
     #[test]
     fn runtime_tool_view_hides_memory_tools_when_memory_corpus_is_empty() {
@@ -14075,41 +13871,45 @@ mod tests {
             file_root: Some(root.clone()),
             ..runtime_config::ToolRuntimeConfig::default()
         };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "claw_migrate".to_owned(),
-                payload: json!({
-                    "mode": "apply",
-                    "source": "nanobot",
-                    "input_path": ".",
-                    "output_path": "generated/loongclaw.toml",
-                    "force": true
-                }),
-            },
-            &config,
-        )
-        .expect("config import apply should succeed");
+        let tool_names = ["claw_migrate", "claw.migrate"];
 
-        assert_eq!(outcome.status, "ok");
-        assert_eq!(outcome.payload["mode"], "apply");
-        assert_eq!(outcome.payload["config_written"], true);
-        assert_eq!(
-            outcome.payload["next_step"]
-                .as_str()
-                .expect("next_step should be present")
-                .split_whitespace()
-                .next(),
-            Some("loong")
-        );
-        assert_eq!(
-            outcome.payload["output_path"]
-                .as_str()
-                .expect("output path should exist"),
-            fs::canonicalize(&output_path)
-                .expect("output path should canonicalize")
-                .display()
-                .to_string()
-        );
+        for tool_name in tool_names {
+            let outcome = execute_tool_core_with_config(
+                ToolCoreRequest {
+                    tool_name: tool_name.to_owned(),
+                    payload: json!({
+                        "mode": "apply",
+                        "source": "nanobot",
+                        "input_path": ".",
+                        "output_path": "generated/loongclaw.toml",
+                        "force": true
+                    }),
+                },
+                &config,
+            )
+            .expect("config import apply should succeed");
+
+            assert_eq!(outcome.status, "ok");
+            assert_eq!(outcome.payload["mode"], "apply");
+            assert_eq!(outcome.payload["config_written"], true);
+            assert_eq!(
+                outcome.payload["next_step"]
+                    .as_str()
+                    .expect("next_step should be present")
+                    .split_whitespace()
+                    .next(),
+                Some("loong")
+            );
+            assert_eq!(
+                outcome.payload["output_path"]
+                    .as_str()
+                    .expect("output path should exist"),
+                fs::canonicalize(&output_path)
+                    .expect("output path should canonicalize")
+                    .display()
+                    .to_string()
+            );
+        }
 
         let raw = fs::read_to_string(&output_path).expect("output config should exist");
         assert!(raw.contains("prompt_pack_id = \"loongclaw-core-v1\""));

--- a/crates/app/src/tools/required_capabilities_tests.rs
+++ b/crates/app/src/tools/required_capabilities_tests.rs
@@ -192,23 +192,23 @@ fn required_capabilities_follow_effective_tool_request() {
         ])
     );
 
-    let invoked_claw_plan = ToolCoreRequest {
+    let invoked_config_import_plan = ToolCoreRequest {
         tool_name: "tool.invoke".to_owned(),
         payload: json!({
-            "tool_id": "claw.migrate",
+            "tool_id": "config.import",
             "lease": "unused",
             "arguments": {"mode": "plan", "input_path": "imports/nanobot"}
         }),
     };
     assert_eq!(
-        required_capabilities_for_request(&invoked_claw_plan),
+        required_capabilities_for_request(&invoked_config_import_plan),
         BTreeSet::from([Capability::InvokeTool, Capability::FilesystemRead])
     );
 
-    let invoked_claw_apply = ToolCoreRequest {
+    let invoked_config_import_apply = ToolCoreRequest {
         tool_name: "tool.invoke".to_owned(),
         payload: json!({
-            "tool_id": "claw.migrate",
+            "tool_id": "config.import",
             "lease": "unused",
             "arguments": {
                 "mode": "apply",
@@ -218,7 +218,49 @@ fn required_capabilities_follow_effective_tool_request() {
         }),
     };
     assert_eq!(
-        required_capabilities_for_request(&invoked_claw_apply),
+        required_capabilities_for_request(&invoked_config_import_apply),
+        BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+            Capability::FilesystemWrite,
+        ])
+    );
+
+    let invoked_config_import_apply_selected = ToolCoreRequest {
+        tool_name: "tool.invoke".to_owned(),
+        payload: json!({
+            "tool_id": "config.import",
+            "lease": "unused",
+            "arguments": {
+                "mode": "apply_selected",
+                "input_path": "imports/nanobot",
+                "output_path": "loongclaw.toml",
+                "source_id": "source-1"
+            }
+        }),
+    };
+    assert_eq!(
+        required_capabilities_for_request(&invoked_config_import_apply_selected),
+        BTreeSet::from([
+            Capability::InvokeTool,
+            Capability::FilesystemRead,
+            Capability::FilesystemWrite,
+        ])
+    );
+
+    let invoked_config_import_rollback = ToolCoreRequest {
+        tool_name: "tool.invoke".to_owned(),
+        payload: json!({
+            "tool_id": "config.import",
+            "lease": "unused",
+            "arguments": {
+                "mode": "rollback_last_apply",
+                "output_path": "loongclaw.toml"
+            }
+        }),
+    };
+    assert_eq!(
+        required_capabilities_for_request(&invoked_config_import_rollback),
         BTreeSet::from([
             Capability::InvokeTool,
             Capability::FilesystemRead,

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -3884,7 +3884,7 @@ pub async fn run_spec_pressure_once(
     let requires_native_tool_executor = spec_requires_native_tool_executor(spec);
     if requires_native_tool_executor && native_tool_executor.is_none() {
         return Err(
-            "spec benchmark scenario requires a native tool executor; move this claw.migrate/claw_migrate run to daemon composition root".to_owned(),
+            "spec benchmark scenario requires a native tool executor; move this config.import/claw.migrate/claw_migrate run to daemon composition root".to_owned(),
         );
     }
     let report = execute_spec_with_native_tool_executor(spec, false, native_tool_executor).await;
@@ -3895,7 +3895,7 @@ pub async fn run_spec_pressure_once(
             .is_some_and(|reason| reason.contains("native tool executor"))
     {
         return Err(
-            "spec benchmark scenario requires a native tool executor that handles the requested native tool; move this claw.migrate/claw_migrate run to daemon composition root".to_owned(),
+            "spec benchmark scenario requires a native tool executor that handles the requested native tool; move this config.import/claw.migrate/claw_migrate run to daemon composition root".to_owned(),
         );
     }
     let blocked = report.operation_kind == "blocked" || report.blocked_reason.is_some();

--- a/crates/bench/tests/bench_integration.rs
+++ b/crates/bench/tests/bench_integration.rs
@@ -33,10 +33,10 @@ fn benchmark_copy_helper_preserves_contents() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn run_spec_pressure_once_rejects_native_claw_migrate_scenarios() {
+async fn run_spec_pressure_once_rejects_native_config_import_scenarios() {
     let spec = loongclaw_spec::RunnerSpec {
         pack: VerticalPackManifest {
-            pack_id: "bench-spec-native-claw-migrate".to_owned(),
+            pack_id: "bench-spec-native-config-import".to_owned(),
             domain: "ops".to_owned(),
             version: "0.1.0".to_owned(),
             default_route: ExecutionRoute {
@@ -47,7 +47,7 @@ async fn run_spec_pressure_once_rejects_native_claw_migrate_scenarios() {
             granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
             metadata: BTreeMap::new(),
         },
-        agent_id: "bench-agent-native-claw-migrate".to_owned(),
+        agent_id: "bench-agent-native-config-import".to_owned(),
         ttl_s: 60,
         approval: None,
         defaults: None,
@@ -59,14 +59,14 @@ async fn run_spec_pressure_once_rejects_native_claw_migrate_scenarios() {
         hotfixes: Vec::new(),
         plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
-            tool_name: "claw.migrate".to_owned(),
+            tool_name: "config.import".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
             payload: json!({"mode": "plan"}),
             core: None,
         },
     };
     let scenario = ProgrammaticPressureScenario {
-        name: "native-claw-migrate".to_owned(),
+        name: "native-config-import".to_owned(),
         description: None,
         iterations: Some(1),
         warmup_iterations: Some(0),
@@ -77,7 +77,7 @@ async fn run_spec_pressure_once_rejects_native_claw_migrate_scenarios() {
 
     let error = run_spec_pressure_once(&spec, &scenario, None)
         .await
-        .expect_err("bench spec runs should reject native claw.migrate scenarios");
+        .expect_err("bench spec runs should reject native config.import scenarios");
     assert!(error.contains("native tool executor"));
 }
 
@@ -85,7 +85,7 @@ async fn run_spec_pressure_once_rejects_native_claw_migrate_scenarios() {
 async fn run_spec_pressure_once_uses_native_executor_when_present() {
     let spec = loongclaw_spec::RunnerSpec {
         pack: VerticalPackManifest {
-            pack_id: "bench-spec-native-claw-migrate-exec".to_owned(),
+            pack_id: "bench-spec-native-config-import-exec".to_owned(),
             domain: "ops".to_owned(),
             version: "0.1.0".to_owned(),
             default_route: ExecutionRoute {
@@ -96,7 +96,7 @@ async fn run_spec_pressure_once_uses_native_executor_when_present() {
             granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
             metadata: BTreeMap::new(),
         },
-        agent_id: "bench-agent-native-claw-migrate-exec".to_owned(),
+        agent_id: "bench-agent-native-config-import-exec".to_owned(),
         ttl_s: 60,
         approval: None,
         defaults: None,
@@ -108,14 +108,14 @@ async fn run_spec_pressure_once_uses_native_executor_when_present() {
         hotfixes: Vec::new(),
         plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
-            tool_name: "claw.migrate".to_owned(),
+            tool_name: "config.import".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
             payload: json!({"mode": "plan"}),
             core: None,
         },
     };
     let scenario = ProgrammaticPressureScenario {
-        name: "native-claw-migrate-exec".to_owned(),
+        name: "native-config-import-exec".to_owned(),
         description: None,
         iterations: Some(1),
         warmup_iterations: Some(0),
@@ -136,7 +136,7 @@ async fn run_spec_pressure_once_uses_native_executor_when_present() {
 async fn run_spec_pressure_once_errors_when_executor_declines_native_request() {
     let spec = loongclaw_spec::RunnerSpec {
         pack: VerticalPackManifest {
-            pack_id: "bench-spec-native-claw-migrate-declined".to_owned(),
+            pack_id: "bench-spec-native-config-import-declined".to_owned(),
             domain: "ops".to_owned(),
             version: "0.1.0".to_owned(),
             default_route: ExecutionRoute {
@@ -147,7 +147,7 @@ async fn run_spec_pressure_once_errors_when_executor_declines_native_request() {
             granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
             metadata: BTreeMap::new(),
         },
-        agent_id: "bench-agent-native-claw-migrate-declined".to_owned(),
+        agent_id: "bench-agent-native-config-import-declined".to_owned(),
         ttl_s: 60,
         approval: None,
         defaults: None,
@@ -159,14 +159,14 @@ async fn run_spec_pressure_once_errors_when_executor_declines_native_request() {
         hotfixes: Vec::new(),
         plugin_setup_readiness: None,
         operation: loongclaw_spec::OperationSpec::ToolCore {
-            tool_name: "claw.migrate".to_owned(),
+            tool_name: "config.import".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
             payload: json!({"mode": "plan"}),
             core: None,
         },
     };
     let scenario = ProgrammaticPressureScenario {
-        name: "native-claw-migrate-declined".to_owned(),
+        name: "native-config-import-declined".to_owned(),
         description: None,
         iterations: Some(1),
         warmup_iterations: Some(0),

--- a/crates/bench/tests/bench_integration.rs
+++ b/crates/bench/tests/bench_integration.rs
@@ -5,6 +5,59 @@ use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 
+fn native_config_import_spec(tool_name: &str, suffix: &str) -> loongclaw_spec::RunnerSpec {
+    let pack_id = format!("bench-spec-native-config-import-{suffix}");
+    let agent_id = format!("bench-agent-native-config-import-{suffix}");
+
+    loongclaw_spec::RunnerSpec {
+        pack: VerticalPackManifest {
+            pack_id,
+            domain: "ops".to_owned(),
+            version: "0.1.0".to_owned(),
+            default_route: ExecutionRoute {
+                harness_kind: HarnessKind::EmbeddedPi,
+                adapter: Some("pi-local".to_owned()),
+            },
+            allowed_connectors: BTreeSet::new(),
+            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            metadata: BTreeMap::new(),
+        },
+        agent_id,
+        ttl_s: 60,
+        approval: None,
+        defaults: None,
+        self_awareness: None,
+        plugin_scan: None,
+        bridge_support: None,
+        bootstrap: None,
+        auto_provision: None,
+        hotfixes: Vec::new(),
+        plugin_setup_readiness: None,
+        operation: loongclaw_spec::OperationSpec::ToolCore {
+            tool_name: tool_name.to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({"mode": "plan"}),
+            core: None,
+        },
+    }
+}
+
+fn native_config_import_scenario(
+    scenario_name: String,
+    spec: &loongclaw_spec::RunnerSpec,
+    allow_blocked: bool,
+) -> ProgrammaticPressureScenario {
+    ProgrammaticPressureScenario {
+        name: scenario_name,
+        description: None,
+        iterations: Some(1),
+        warmup_iterations: Some(0),
+        expected_operation_kind: "tool_core".to_owned(),
+        allow_blocked,
+        kind: ProgrammaticPressureScenarioKind::SpecRun { spec: spec.clone() },
+    }
+}
+
 #[test]
 fn benchmark_copy_helper_preserves_contents() {
     let tmp = std::env::temp_dir().join(format!(
@@ -34,152 +87,69 @@ fn benchmark_copy_helper_preserves_contents() {
 
 #[tokio::test]
 async fn run_spec_pressure_once_rejects_native_config_import_scenarios() {
-    let spec = loongclaw_spec::RunnerSpec {
-        pack: VerticalPackManifest {
-            pack_id: "bench-spec-native-config-import".to_owned(),
-            domain: "ops".to_owned(),
-            version: "0.1.0".to_owned(),
-            default_route: ExecutionRoute {
-                harness_kind: HarnessKind::EmbeddedPi,
-                adapter: Some("pi-local".to_owned()),
-            },
-            allowed_connectors: BTreeSet::new(),
-            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-            metadata: BTreeMap::new(),
-        },
-        agent_id: "bench-agent-native-config-import".to_owned(),
-        ttl_s: 60,
-        approval: None,
-        defaults: None,
-        self_awareness: None,
-        plugin_scan: None,
-        bridge_support: None,
-        bootstrap: None,
-        auto_provision: None,
-        hotfixes: Vec::new(),
-        plugin_setup_readiness: None,
-        operation: loongclaw_spec::OperationSpec::ToolCore {
-            tool_name: "config.import".to_owned(),
-            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
-            payload: json!({"mode": "plan"}),
-            core: None,
-        },
-    };
-    let scenario = ProgrammaticPressureScenario {
-        name: "native-config-import".to_owned(),
-        description: None,
-        iterations: Some(1),
-        warmup_iterations: Some(0),
-        expected_operation_kind: "tool_core".to_owned(),
-        allow_blocked: false,
-        kind: ProgrammaticPressureScenarioKind::SpecRun { spec: spec.clone() },
-    };
+    let cases = [
+        ("config.import", "canonical"),
+        ("claw.migrate", "legacy-alias"),
+        ("claw_migrate", "legacy-underscore-alias"),
+    ];
 
-    let error = run_spec_pressure_once(&spec, &scenario, None)
-        .await
-        .expect_err("bench spec runs should reject native config.import scenarios");
-    assert!(error.contains("native tool executor"));
+    for (tool_name, case_name) in cases {
+        let spec = native_config_import_spec(tool_name, case_name);
+        let scenario_name = format!("native-config-import-{case_name}");
+        let scenario = native_config_import_scenario(scenario_name, &spec, false);
+        let error = run_spec_pressure_once(&spec, &scenario, None)
+            .await
+            .expect_err("bench spec runs should reject native config.import scenarios");
+
+        assert!(
+            error.contains("native tool executor"),
+            "tool `{tool_name}` should require a native tool executor: {error}"
+        );
+    }
 }
 
 #[tokio::test]
 async fn run_spec_pressure_once_uses_native_executor_when_present() {
-    let spec = loongclaw_spec::RunnerSpec {
-        pack: VerticalPackManifest {
-            pack_id: "bench-spec-native-config-import-exec".to_owned(),
-            domain: "ops".to_owned(),
-            version: "0.1.0".to_owned(),
-            default_route: ExecutionRoute {
-                harness_kind: HarnessKind::EmbeddedPi,
-                adapter: Some("pi-local".to_owned()),
-            },
-            allowed_connectors: BTreeSet::new(),
-            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-            metadata: BTreeMap::new(),
-        },
-        agent_id: "bench-agent-native-config-import-exec".to_owned(),
-        ttl_s: 60,
-        approval: None,
-        defaults: None,
-        self_awareness: None,
-        plugin_scan: None,
-        bridge_support: None,
-        bootstrap: None,
-        auto_provision: None,
-        hotfixes: Vec::new(),
-        plugin_setup_readiness: None,
-        operation: loongclaw_spec::OperationSpec::ToolCore {
-            tool_name: "config.import".to_owned(),
-            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
-            payload: json!({"mode": "plan"}),
-            core: None,
-        },
-    };
-    let scenario = ProgrammaticPressureScenario {
-        name: "native-config-import-exec".to_owned(),
-        description: None,
-        iterations: Some(1),
-        warmup_iterations: Some(0),
-        expected_operation_kind: "tool_core".to_owned(),
-        allow_blocked: false,
-        kind: ProgrammaticPressureScenarioKind::SpecRun { spec: spec.clone() },
-    };
+    let cases = [
+        ("config.import", "exec-canonical"),
+        ("claw.migrate", "exec-legacy-alias"),
+        ("claw_migrate", "exec-legacy-underscore-alias"),
+    ];
 
-    let sample = run_spec_pressure_once(&spec, &scenario, Some(test_native_tool_executor))
-        .await
-        .expect("bench spec runs should execute when a native executor is injected");
+    for (tool_name, case_name) in cases {
+        let spec = native_config_import_spec(tool_name, case_name);
+        let scenario_name = format!("native-config-import-{case_name}");
+        let scenario = native_config_import_scenario(scenario_name, &spec, false);
+        let sample = run_spec_pressure_once(&spec, &scenario, Some(test_native_tool_executor))
+            .await
+            .expect("bench spec runs should execute when a native executor is injected");
 
-    assert!(sample.passed);
-    assert!(!sample.blocked);
+        assert!(sample.passed, "tool `{tool_name}` should pass");
+        assert!(!sample.blocked, "tool `{tool_name}` should not be blocked");
+    }
 }
 
 #[tokio::test]
 async fn run_spec_pressure_once_errors_when_executor_declines_native_request() {
-    let spec = loongclaw_spec::RunnerSpec {
-        pack: VerticalPackManifest {
-            pack_id: "bench-spec-native-config-import-declined".to_owned(),
-            domain: "ops".to_owned(),
-            version: "0.1.0".to_owned(),
-            default_route: ExecutionRoute {
-                harness_kind: HarnessKind::EmbeddedPi,
-                adapter: Some("pi-local".to_owned()),
-            },
-            allowed_connectors: BTreeSet::new(),
-            granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
-            metadata: BTreeMap::new(),
-        },
-        agent_id: "bench-agent-native-config-import-declined".to_owned(),
-        ttl_s: 60,
-        approval: None,
-        defaults: None,
-        self_awareness: None,
-        plugin_scan: None,
-        bridge_support: None,
-        bootstrap: None,
-        auto_provision: None,
-        hotfixes: Vec::new(),
-        plugin_setup_readiness: None,
-        operation: loongclaw_spec::OperationSpec::ToolCore {
-            tool_name: "config.import".to_owned(),
-            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
-            payload: json!({"mode": "plan"}),
-            core: None,
-        },
-    };
-    let scenario = ProgrammaticPressureScenario {
-        name: "native-config-import-declined".to_owned(),
-        description: None,
-        iterations: Some(1),
-        warmup_iterations: Some(0),
-        expected_operation_kind: "tool_core".to_owned(),
-        allow_blocked: true,
-        kind: ProgrammaticPressureScenarioKind::SpecRun { spec: spec.clone() },
-    };
+    let cases = [
+        ("config.import", "declined-canonical"),
+        ("claw.migrate", "declined-legacy-alias"),
+        ("claw_migrate", "declined-legacy-underscore-alias"),
+    ];
 
-    let error = run_spec_pressure_once(&spec, &scenario, Some(declining_native_tool_executor))
-        .await
-        .expect_err("bench spec runs should error when executor declines native requests");
+    for (tool_name, case_name) in cases {
+        let spec = native_config_import_spec(tool_name, case_name);
+        let scenario_name = format!("native-config-import-{case_name}");
+        let scenario = native_config_import_scenario(scenario_name, &spec, true);
+        let error = run_spec_pressure_once(&spec, &scenario, Some(declining_native_tool_executor))
+            .await
+            .expect_err("bench spec runs should error when executor declines native requests");
 
-    assert!(error.contains("native tool executor"));
+        assert!(
+            error.contains("native tool executor"),
+            "tool `{tool_name}` should surface the native executor failure: {error}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -180,7 +180,7 @@ fn render_import_long_about(command_name: &str) -> String {
 
 fn render_migrate_long_about(command_name: &str) -> String {
     format!(
-        "Power-user migration flow for discovering, previewing, or applying legacy claw nativeization explicitly.\n\nUse this when you want exact CLI control over migration mode selection and output handling for older claw-family workspaces. If you want the guided path, use `{command_name} onboard` instead.\n\nMode quick reference:\n- discover, plan_many, recommend_primary, merge_profiles, map_external_skills: require `--input`\n- plan: requires `--input`; `--output` is optional preview target\n- apply: requires `--input` and `--output`\n- apply_selected: requires `--input` and `--output`; use `--source-id` to pin one discovered source, and `--apply-external-skills-plan` to bridge installable local external skills into the managed runtime\n- rollback_last_apply: requires `--output`"
+        "Power-user config import flow for discovering, previewing, or applying external workspace state explicitly.\n\nUse this when you want exact CLI control over import mode selection and output handling for compatibility sources and older workspace roots. If you want the guided path, use `{command_name} onboard` instead.\n\nMode quick reference:\n- discover, plan_many, recommend_primary, merge_profiles, map_external_skills: require `--input`\n- plan: requires `--input`; `--output` is optional preview target\n- apply: requires `--input` and `--output`\n- apply_selected: requires `--input` and `--output`; use `--source-id` to pin one discovered source, and `--apply-external-skills-plan` to bridge installable local external skills into the managed runtime\n- rollback_last_apply: requires `--output`"
     )
 }
 
@@ -218,7 +218,7 @@ pub use control_plane_server::{build_control_plane_router, run_control_plane_ser
 pub fn native_spec_tool_executor(
     request: ToolCoreRequest,
 ) -> Option<Result<ToolCoreOutcome, String>> {
-    if mvp::tools::canonical_tool_name(request.tool_name.as_str()) != "claw.migrate" {
+    if mvp::tools::canonical_tool_name(request.tool_name.as_str()) != "config.import" {
         return None;
     }
     Some(mvp::tools::execute_tool_core(request))
@@ -567,17 +567,17 @@ pub enum Commands {
         exclude: Vec<String>,
     },
     #[command(
-        about = "Preview or apply legacy claw migration explicitly",
-        long_about = "Power-user migration flow for discovering, previewing, or applying legacy claw nativeization explicitly.\n\nUse this when you want exact CLI control over migration mode selection and output handling for older claw-family workspaces. If you want the guided path, use `loong onboard` instead.\n\nMode quick reference:\n- discover, plan_many, recommend_primary, merge_profiles, map_external_skills: require `--input`\n- plan: requires `--input`; `--output` is optional preview target\n- apply: requires `--input` and `--output`\n- apply_selected: requires `--input` and `--output`; use `--source-id` to pin one discovered source, and `--apply-external-skills-plan` to bridge installable local external skills into the managed runtime\n- rollback_last_apply: requires `--output`"
+        about = "Preview or apply legacy agent workspace migration explicitly",
+        long_about = "Power-user migration flow for discovering, previewing, or applying legacy agent workspace nativeization explicitly.\n\nUse this when you want exact CLI control over migration mode selection and output handling for older workspace roots and compatibility imports. If you want the guided path, use `loong onboard` instead.\n\nMode quick reference:\n- discover, plan_many, recommend_primary, merge_profiles, map_external_skills: require `--input`\n- plan: requires `--input`; `--output` is optional preview target\n- apply: requires `--input` and `--output`\n- apply_selected: requires `--input` and `--output`; use `--source-id` to pin one discovered source, and `--apply-external-skills-plan` to bridge installable local external skills into the managed runtime\n- rollback_last_apply: requires `--output`"
     )]
     Migrate {
-        /// Path to the legacy claw workspace or root to inspect
+        /// Path to the legacy agent workspace or root to inspect
         #[arg(long)]
         input: Option<String>,
         /// Target LoongClaw config path to preview, write, or roll back
         #[arg(long)]
         output: Option<String>,
-        /// Hint the legacy source kind for single-source plan/apply modes
+        /// Hint the legacy claw-family source kind for single-source plan/apply modes
         #[arg(long)]
         source: Option<String>,
         /// Migration mode to run

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -201,7 +201,9 @@ pub fn build_cli_command(command_name: &'static str) -> clap::Command {
             command.long_about(render_import_long_about(command_name))
         })
         .mut_subcommand("migrate", |command| {
-            command.long_about(render_migrate_long_about(command_name))
+            command
+                .about("Preview or apply config import modes explicitly")
+                .long_about(render_migrate_long_about(command_name))
         })
         .mut_subcommand("ask", |command| {
             command.long_about(render_ask_long_about(command_name))
@@ -567,8 +569,8 @@ pub enum Commands {
         exclude: Vec<String>,
     },
     #[command(
-        about = "Preview or apply legacy agent workspace migration explicitly",
-        long_about = "Power-user migration flow for discovering, previewing, or applying legacy agent workspace nativeization explicitly.\n\nUse this when you want exact CLI control over migration mode selection and output handling for older workspace roots and compatibility imports. If you want the guided path, use `loong onboard` instead.\n\nMode quick reference:\n- discover, plan_many, recommend_primary, merge_profiles, map_external_skills: require `--input`\n- plan: requires `--input`; `--output` is optional preview target\n- apply: requires `--input` and `--output`\n- apply_selected: requires `--input` and `--output`; use `--source-id` to pin one discovered source, and `--apply-external-skills-plan` to bridge installable local external skills into the managed runtime\n- rollback_last_apply: requires `--output`"
+        about = "Preview or apply config import modes explicitly",
+        long_about = "Power-user config import flow for discovering, previewing, or applying external workspace state explicitly.\n\nUse this when you want exact CLI control over import mode selection and output handling for compatibility sources and older workspace roots. If you want the guided path, use `loong onboard` instead.\n\nMode quick reference:\n- discover, plan_many, recommend_primary, merge_profiles, map_external_skills: require `--input`\n- plan: requires `--input`; `--output` is optional preview target\n- apply: requires `--input` and `--output`\n- apply_selected: requires `--input` and `--output`; use `--source-id` to pin one discovered source, and `--apply-external-skills-plan` to bridge installable local external skills into the managed runtime\n- rollback_last_apply: requires `--output`"
     )]
     Migrate {
         /// Path to the legacy agent workspace or root to inspect

--- a/crates/daemon/src/migrate_cli.rs
+++ b/crates/daemon/src/migrate_cli.rs
@@ -71,7 +71,7 @@ async fn run_migrate_cli_async(options: MigrateCommandOptions) -> CliResult<()> 
     )?;
     let outcome = mvp::tools::execute_tool(
         ToolCoreRequest {
-            tool_name: "claw.migrate".to_owned(),
+            tool_name: "config.import".to_owned(),
             payload: build_migrate_tool_payload(&options),
         },
         &kernel_ctx,
@@ -261,7 +261,13 @@ fn translate_migrate_cli_error(options: &MigrateCommandOptions, error: String) -
     let leaf = error
         .strip_prefix("tool execution failed: ")
         .unwrap_or(&error);
-    if leaf == "claw.migrate requires payload.input_path" {
+    if let Some((_, reason)) = leaf.split_once(" denied request: ")
+        && leaf.starts_with("policy extension ")
+    {
+        return format!("policy_denied: {reason}");
+    }
+
+    if leaf == "config.import requires payload.input_path" {
         return format!(
             "`--input` is required for `{} migrate --mode {}`",
             mvp::config::active_cli_command_name(),
@@ -271,7 +277,7 @@ fn translate_migrate_cli_error(options: &MigrateCommandOptions, error: String) -
 
     if leaf
         == format!(
-            "claw.migrate {} mode requires payload.output_path",
+            "config.import {} mode requires payload.output_path",
             options.mode.as_id()
         )
     {

--- a/crates/daemon/src/migrate_cli.rs
+++ b/crates/daemon/src/migrate_cli.rs
@@ -261,6 +261,9 @@ fn translate_migrate_cli_error(options: &MigrateCommandOptions, error: String) -
     let leaf = error
         .strip_prefix("tool execution failed: ")
         .unwrap_or(&error);
+    if leaf.starts_with("policy_denied: ") {
+        return leaf.to_owned();
+    }
     if let Some((_, reason)) = leaf.split_once(" denied request: ")
         && leaf.starts_with("policy extension ")
     {

--- a/crates/daemon/tests/integration/migrate_cli.rs
+++ b/crates/daemon/tests/integration/migrate_cli.rs
@@ -335,8 +335,8 @@ fn run_migrate_cli_apply_mode_rejects_output_path_outside_configured_file_root()
     .expect_err("policy root should deny writing outside configured file root");
 
     assert!(
-        error.contains("policy_denied"),
-        "expected policy denial, got: {error}"
+        error.starts_with("policy_denied: "),
+        "expected normalized policy denial prefix, got: {error}"
     );
 
     fs::remove_dir_all(&policy_root).ok();
@@ -388,5 +388,20 @@ fn migrate_cli_ux_help_mentions_mode_specific_required_flags() {
     assert!(
         stdout.contains("rollback_last_apply: requires `--output`"),
         "help should mention rollback requirements, got: {stdout}"
+    );
+}
+
+#[test]
+fn root_help_lists_migrate_with_config_import_wording() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_loongclaw"))
+        .arg("--help")
+        .output()
+        .expect("run loongclaw --help");
+
+    assert!(output.status.success(), "help should succeed");
+    let stdout = String::from_utf8(output.stdout).expect("help output should be utf8");
+    assert!(
+        stdout.contains("Preview or apply config import modes explicitly"),
+        "root help should expose the updated migrate summary, got: {stdout}"
     );
 }

--- a/crates/daemon/tests/integration/mod.rs
+++ b/crates/daemon/tests/integration/mod.rs
@@ -177,12 +177,12 @@ fn cli_import_help_explains_explicit_power_user_flow() {
 }
 
 #[test]
-fn cli_migrate_help_explains_explicit_migration_flow() {
+fn cli_migrate_help_explains_explicit_config_import_flow() {
     let help = render_cli_help(["migrate"]);
 
     assert!(
-        help.contains("Power-user migration flow"),
-        "migrate help should explain when to use the explicit migration command: {help}"
+        help.contains("Power-user config import flow"),
+        "migrate help should explain when to use the explicit config import command: {help}"
     );
     assert!(
         help.contains("--mode <MODE>"),

--- a/crates/daemon/tests/integration/spec_runtime.rs
+++ b/crates/daemon/tests/integration/spec_runtime.rs
@@ -6344,7 +6344,7 @@ async fn execute_spec_default_medium_policy_allows_low_risk_tool_call_without_ap
 }
 
 #[tokio::test]
-async fn execute_spec_tool_core_can_run_claw_migrate_plan_via_native_tool_runtime() {
+async fn execute_spec_tool_core_can_run_config_import_plan_via_native_tool_runtime() {
     use std::{
         fs,
         path::{Path, PathBuf},
@@ -6382,7 +6382,7 @@ async fn execute_spec_tool_core_can_run_claw_migrate_plan_via_native_tool_runtim
 
     let spec = RunnerSpec {
         pack: VerticalPackManifest {
-            pack_id: "spec-tool-core-claw-migrate".to_owned(),
+            pack_id: "spec-tool-core-config-import".to_owned(),
             domain: "ops".to_owned(),
             version: "0.1.0".to_owned(),
             default_route: ExecutionRoute {
@@ -6393,7 +6393,7 @@ async fn execute_spec_tool_core_can_run_claw_migrate_plan_via_native_tool_runtim
             granted_capabilities: BTreeSet::from([Capability::InvokeTool]),
             metadata: BTreeMap::new(),
         },
-        agent_id: "agent-tool-core-claw-migrate".to_owned(),
+        agent_id: "agent-tool-core-config-import".to_owned(),
         ttl_s: 120,
         approval: None,
         defaults: None,
@@ -6405,7 +6405,7 @@ async fn execute_spec_tool_core_can_run_claw_migrate_plan_via_native_tool_runtim
         hotfixes: Vec::new(),
         plugin_setup_readiness: None,
         operation: OperationSpec::ToolCore {
-            tool_name: "claw.migrate".to_owned(),
+            tool_name: "config.import".to_owned(),
             required_capabilities: BTreeSet::from([Capability::InvokeTool]),
             payload: json!({
                 "mode": "plan",
@@ -6436,7 +6436,7 @@ async fn execute_spec_tool_core_can_run_claw_migrate_plan_via_native_tool_runtim
 }
 
 #[tokio::test]
-async fn execute_spec_tool_extension_can_hot_handle_claw_migrate_via_core_wrapper() {
+async fn execute_spec_tool_extension_can_hot_handle_config_import_via_core_wrapper() {
     use std::{
         fs,
         path::{Path, PathBuf},

--- a/crates/spec/src/lib.rs
+++ b/crates/spec/src/lib.rs
@@ -24,7 +24,10 @@ pub const DEFAULT_AGENT_ID: &str = "agent-dev-01";
 pub type NativeToolExecutor = fn(ToolCoreRequest) -> Option<Result<ToolCoreOutcome, String>>;
 
 pub fn tool_name_requires_native_tool_executor(tool_name: &str) -> bool {
-    matches!(tool_name, "claw.migrate" | "claw_migrate")
+    matches!(
+        tool_name,
+        "config.import" | "config_import" | "claw.migrate" | "claw_migrate"
+    )
 }
 
 pub fn spec_requires_native_tool_executor(spec: &RunnerSpec) -> bool {

--- a/crates/spec/src/spec_runtime.rs
+++ b/crates/spec/src/spec_runtime.rs
@@ -3452,7 +3452,7 @@ impl ToolExtensionAdapter for ClawMigrationToolExtension {
 
         let core_outcome = core
             .execute_core_tool(ToolCoreRequest {
-                tool_name: "claw.migrate".to_owned(),
+                tool_name: "config.import".to_owned(),
                 payload,
             })
             .await?;

--- a/crates/spec/src/spec_runtime/wasm_runtime_tests.rs
+++ b/crates/spec/src/spec_runtime/wasm_runtime_tests.rs
@@ -1073,10 +1073,10 @@ fn wasm_artifact_file_identity_distinguishes_different_files() {
 }
 
 #[tokio::test]
-async fn core_tool_runtime_claw_migrate_without_native_executor_fails_closed() {
+async fn core_tool_runtime_config_import_without_native_executor_fails_closed() {
     let error = CoreToolRuntime::default()
         .execute_core_tool(ToolCoreRequest {
-            tool_name: "claw.migrate".to_owned(),
+            tool_name: "config.import".to_owned(),
             payload: json!({"mode": "plan"}),
         })
         .await
@@ -1086,7 +1086,7 @@ async fn core_tool_runtime_claw_migrate_without_native_executor_fails_closed() {
 }
 
 fn test_native_tool_executor(request: ToolCoreRequest) -> Option<Result<ToolCoreOutcome, String>> {
-    if request.tool_name != "claw.migrate" {
+    if request.tool_name != "config.import" {
         return None;
     }
     Some(Ok(ToolCoreOutcome {
@@ -1102,7 +1102,7 @@ fn test_native_tool_executor(request: ToolCoreRequest) -> Option<Result<ToolCore
 async fn core_tool_runtime_uses_explicit_native_executor_when_present() {
     let outcome = CoreToolRuntime::new(Some(test_native_tool_executor))
         .execute_core_tool(ToolCoreRequest {
-            tool_name: "claw.migrate".to_owned(),
+            tool_name: "config.import".to_owned(),
             payload: json!({"mode": "plan"}),
         })
         .await
@@ -1110,13 +1110,13 @@ async fn core_tool_runtime_uses_explicit_native_executor_when_present() {
 
     assert_eq!(outcome.status, "ok");
     assert_eq!(outcome.payload["adapter"], "native-tools");
-    assert_eq!(outcome.payload["tool"], "claw.migrate");
+    assert_eq!(outcome.payload["tool"], "config.import");
 }
 
 fn declining_native_tool_executor(
     request: ToolCoreRequest,
 ) -> Option<Result<ToolCoreOutcome, String>> {
-    if request.tool_name == "claw.migrate" {
+    if request.tool_name == "config.import" {
         return None;
     }
     Some(Ok(ToolCoreOutcome {
@@ -1129,10 +1129,10 @@ fn declining_native_tool_executor(
 }
 
 #[tokio::test]
-async fn core_tool_runtime_claw_migrate_fails_closed_when_executor_declines_request() {
+async fn core_tool_runtime_config_import_fails_closed_when_executor_declines_request() {
     let error = CoreToolRuntime::new(Some(declining_native_tool_executor))
         .execute_core_tool(ToolCoreRequest {
-            tool_name: "claw.migrate".to_owned(),
+            tool_name: "config.import".to_owned(),
             payload: json!({"mode": "plan"}),
         })
         .await

--- a/crates/spec/tests/spec_execution.rs
+++ b/crates/spec/tests/spec_execution.rs
@@ -13,6 +13,12 @@ fn spec_requires_native_tool_executor_detects_aliases_and_extension() {
         payload: json!({"mode": "plan"}),
         core: None,
     });
+    let canonical_spec = make_runner_spec(OperationSpec::ToolCore {
+        tool_name: "config.import".to_owned(),
+        required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+        payload: json!({"mode": "plan"}),
+        core: None,
+    });
     let extension_spec = make_runner_spec(OperationSpec::ToolExtension {
         extension_action: "plan".to_owned(),
         required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -28,6 +34,7 @@ fn spec_requires_native_tool_executor_detects_aliases_and_extension() {
     });
 
     assert!(spec_requires_native_tool_executor(&alias_spec));
+    assert!(spec_requires_native_tool_executor(&canonical_spec));
     assert!(spec_requires_native_tool_executor(&extension_spec));
     assert!(!spec_requires_native_tool_executor(&unrelated_spec));
 }
@@ -35,7 +42,7 @@ fn spec_requires_native_tool_executor_detects_aliases_and_extension() {
 #[tokio::test]
 async fn execute_spec_blocks_native_tool_without_executor() {
     let spec = make_runner_spec(OperationSpec::ToolCore {
-        tool_name: "claw.migrate".to_owned(),
+        tool_name: "config.import".to_owned(),
         required_capabilities: BTreeSet::from([Capability::InvokeTool]),
         payload: json!({"mode": "plan"}),
         core: None,

--- a/crates/spec/tests/spec_execution.rs
+++ b/crates/spec/tests/spec_execution.rs
@@ -7,18 +7,12 @@ use serde_json::json;
 
 #[test]
 fn spec_requires_native_tool_executor_detects_aliases_and_extension() {
-    let alias_spec = make_runner_spec(OperationSpec::ToolCore {
-        tool_name: "claw_migrate".to_owned(),
-        required_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        payload: json!({"mode": "plan"}),
-        core: None,
-    });
-    let canonical_spec = make_runner_spec(OperationSpec::ToolCore {
-        tool_name: "config.import".to_owned(),
-        required_capabilities: BTreeSet::from([Capability::InvokeTool]),
-        payload: json!({"mode": "plan"}),
-        core: None,
-    });
+    let native_tool_names = [
+        "claw.migrate",
+        "claw_migrate",
+        "config.import",
+        "config_import",
+    ];
     let extension_spec = make_runner_spec(OperationSpec::ToolExtension {
         extension_action: "plan".to_owned(),
         required_capabilities: BTreeSet::from([Capability::InvokeTool]),
@@ -33,8 +27,19 @@ fn spec_requires_native_tool_executor_detects_aliases_and_extension() {
         core: None,
     });
 
-    assert!(spec_requires_native_tool_executor(&alias_spec));
-    assert!(spec_requires_native_tool_executor(&canonical_spec));
+    for tool_name in native_tool_names {
+        let spec = make_runner_spec(OperationSpec::ToolCore {
+            tool_name: tool_name.to_owned(),
+            required_capabilities: BTreeSet::from([Capability::InvokeTool]),
+            payload: json!({"mode": "plan"}),
+            core: None,
+        });
+
+        assert!(
+            spec_requires_native_tool_executor(&spec),
+            "expected `{tool_name}` to require a native tool executor"
+        );
+    }
     assert!(spec_requires_native_tool_executor(&extension_spec));
     assert!(!spec_requires_native_tool_executor(&unrelated_spec));
 }

--- a/docs/design-docs/discovery-first-tool-runtime-contract.md
+++ b/docs/design-docs/discovery-first-tool-runtime-contract.md
@@ -31,7 +31,7 @@ This includes built-in non-core tools such as:
 - `file.read`
 - `file.write`
 - `shell.exec`
-- `claw.migrate`
+- `config.import`
 - managed external-skill lifecycle and invoke tools
 
 Discoverable tools may execute only through `tool.invoke` after discovery.


### PR DESCRIPTION
## Summary

- rename the canonical discoverable tool name from `claw.migrate` to `config.import`
- preserve `claw.migrate` and `claw_migrate` as compatibility aliases
- align tool catalog metadata, runtime routing, daemon native-tool bridging, spec/bench gates, and turn-engine approval traces around the canonical name
- unify direct-path file policy preflight for `config.import`, including writeful `output_path` checks and `FilesystemWrite` enforcement
- normalize daemon migrate CLI policy-extension denials back to `policy_denied:` for stable operator-facing error semantics
- absorb the current `dev` baseline repairs for child-session runtime narrowing, canonical FTS repair, browser companion test fixtures, and onboarding shortcut assertions so the rebased branch stays mergeable

## Why

`claw.migrate` had become too narrow for the actual surface:

- the tool already handles broader legacy workspace import flows
- the daemon and onboarding surfaces already describe this lane in broader import/migration terms
- direct-path preflight was still missing the write-path side of the import tool's file-governed behavior

Rebasing onto current `dev` also exposed live baseline regressions tracked in `#931`. Keeping those regressions unresolved would leave required verification red even though the config-import work itself was ready.

## Scope Notes

- the public daemon command remains `loong migrate`
- the legacy source hint enum still models the current claw-family source detector set
- historical dated design/plan docs are left unchanged as historical record; active runtime-facing contract text is updated
- this branch also carries the current baseline repairs from `#931` so the rebased branch remains green on current `dev`

## Validation

```text
cargo fmt --all -- --check
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-full cargo test --workspace
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-full cargo test --workspace --all-features
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-full cargo clippy --workspace --all-targets --all-features -- -D warnings
env CARGO_HOME=/tmp/loongclaw-pr-893-cargo-home cargo deny check advisories bans licenses sources
scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
scripts/check-docs.sh
diff CLAUDE.md AGENTS.md

env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-t2 cargo test -p loongclaw-app --lib required_capabilities_follow_effective_tool_request
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-t3 cargo test -p loongclaw-app --lib file_policy_ext
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-t4 cargo test -p loongclaw --test integration cli_migrate_help_explains_explicit_config_import_flow
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-t5 cargo test -p loongclaw-bench --test bench_integration
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-t6 cargo test -p loongclaw-spec --test spec_execution spec_requires_native_tool_executor_detects_aliases_and_extension
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-full cargo test -p loongclaw --test integration root_help_lists_migrate_with_config_import_wording
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-full cargo test -p loongclaw --lib browser_companion_doctor_checks_warn_when_expected_version_mismatches
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-full cargo test -p loongclaw --lib browser_companion_onboard_preflight_warns_when_runtime_gate_is_closed
env CARGO_TARGET_DIR=/tmp/loongclaw-pr-893-full cargo test -p loongclaw --test integration onboard_detected_setup_shortcut_flow_skips_detailed_edit_screens
```

## Linked Issues

Closes #888
Closes #890
Closes #931
