### PR TITLE
fix: restore dev workspace validation and drift freshness

### DIFF
--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8432,7 +8432,7 @@ async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disab
         .expect("safe lane plan should produce a reply");
 
     let persisted = runtime.persisted.lock().expect("persisted lock");
-    let event_count = persisted
+    let event_names = persisted
         .iter()
         .filter_map(|(_, role, content)| {
             if role != "assistant" {
@@ -8442,10 +8442,21 @@ async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disab
             if parsed.get("type")?.as_str()? != "conversation_event" {
                 return None;
             }
-            (parsed.get("event")?.as_str()? != "turn_checkpoint").then_some(())
+            let event_name = parsed.get("event")?.as_str()?;
+
+            match event_name {
+                "lane_selected"
+                | "plan_round_started"
+                | "plan_round_completed"
+                | "final_status" => Some(event_name.to_owned()),
+                _ => None,
+            }
         })
-        .count();
-    assert_eq!(event_count, 0, "unexpected runtime events: {persisted:?}");
+        .collect::<Vec<_>>();
+    assert!(
+        event_names.is_empty(),
+        "unexpected safe lane runtime events: {event_names:?}; persisted={persisted:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1366,7 +1366,6 @@ impl Commands {
             Self::SlackSend { .. } => "slack_send",
             Self::LineSend { .. } => "line_send",
             Self::WhatsappSend { .. } => "whatsapp_send",
-            Self::WhatsappServe { .. } => "whatsapp_serve",
             Self::EmailSend { .. } => "email_send",
             Self::WebhookSend { .. } => "webhook_send",
             Self::GoogleChatSend { .. } => "google_chat_send",

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-04T12:44:39Z
+- Generated at: 2026-04-04T13:00:10Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -23,8 +23,8 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10801 | 11200 | 399 | 97 | 120 | 23 | 96.4% | TIGHT | 10831 | -0.3% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14996 | 15000 | 4 | 54 | 70 | 16 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6483 | 6500 | 17 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14997 | 15000 | 3 | 54 | 70 | 16 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6482 | 6500 | 18 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9782 | 9800 | 18 | 235 | 250 | 15 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
@@ -69,8 +69,8 @@
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10801 functions=97 -->
-<!-- arch-hotspot key=tools_mod lines=14996 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6483 functions=210 -->
+<!-- arch-hotspot key=tools_mod lines=14997 functions=54 -->
+<!-- arch-hotspot key=daemon_lib lines=6482 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9782 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->


### PR DESCRIPTION
## Summary

- remove the duplicate `WhatsappServe` match arm in `command_kind_for_logging()`
- tighten the safe-lane runtime-events-disabled test so it only counts actual safe-lane runtime events, not unrelated trust or checkpoint records
- refresh `docs/releases/architecture-drift-2026-04.md` so the tracked report matches the current generated drift snapshot

## Why

`dev` regressed into a state where multiple CI jobs failed for the same compile error in `crates/daemon/src/lib.rs`, and governance also failed because the checked-in april architecture drift report was stale by one line in `tools_mod`.

## Validation

- `bash scripts/check_architecture_drift_freshness.sh docs/releases/architecture-drift-2026-04.md`
- `cargo fmt --all -- --check`
- `cargo doc --workspace --no-deps`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `./scripts/lint_programmatic_pressure_baseline.sh`
- `cargo test -p loongclaw-app --lib conversation::tests::handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disabled -- --exact --nocapture`
- `cargo test --workspace --locked -q`
- `cargo test --workspace --all-features --locked`

Closes #857
