### PR TITLE
feat: strengthen governed memory recall and runtime-root isolation

### DIFF
--- a/crates/app/src/config/audit.rs
+++ b/crates/app/src/config/audit.rs
@@ -75,16 +75,12 @@ mod tests {
 
         assert_eq!(config.mode, AuditMode::Fanout);
         assert!(config.retain_in_memory);
-        let expected_suffix = std::path::Path::new(".loongclaw")
-            .join("audit")
-            .join("events.jsonl");
+        let expected_path = default_loongclaw_home().join("audit").join("events.jsonl");
         assert!(
-            config
-                .path
-                .ends_with(&expected_suffix.display().to_string()),
+            config.path.ends_with(&expected_path.display().to_string()),
             "audit path {} should end with {}",
             config.path,
-            expected_suffix.display(),
+            expected_path.display(),
         );
     }
 

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -15,6 +15,7 @@ pub const LEGACY_CLI_COMMAND_NAME: &str = "loongclaw";
 pub const PRODUCT_DISPLAY_NAME: &str = "LoongClaw";
 static ACTIVE_CLI_COMMAND_NAME: OnceLock<&'static str> = OnceLock::new();
 pub(super) const DEFAULT_FEISHU_SQLITE_FILE: &str = "feishu.sqlite3";
+pub(crate) const LOONGCLAW_HOME_ENV: &str = "LOONGCLAW_HOME";
 
 fn normalize_cli_command_name(raw: &str) -> &'static str {
     if raw.eq_ignore_ascii_case(LEGACY_CLI_COMMAND_NAME) {
@@ -491,6 +492,14 @@ fn get_user_home() -> PathBuf {
     )
 }
 
+fn get_loongclaw_home() -> PathBuf {
+    resolve_loongclaw_home(
+        env::var_os(LOONGCLAW_HOME_ENV).as_deref(),
+        env::var_os("HOME").as_deref(),
+        env::var_os("USERPROFILE").as_deref(),
+    )
+}
+
 fn resolve_user_home(
     home: Option<&std::ffi::OsStr>,
     userprofile: Option<&std::ffi::OsStr>,
@@ -500,8 +509,18 @@ fn resolve_user_home(
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
+fn resolve_loongclaw_home(
+    loongclaw_home: Option<&std::ffi::OsStr>,
+    home: Option<&std::ffi::OsStr>,
+    userprofile: Option<&std::ffi::OsStr>,
+) -> PathBuf {
+    loongclaw_home
+        .map(PathBuf::from)
+        .unwrap_or_else(|| resolve_user_home(home, userprofile).join(".loongclaw"))
+}
+
 pub(super) fn default_loongclaw_home() -> PathBuf {
-    get_user_home().join(".loongclaw")
+    get_loongclaw_home()
 }
 
 pub fn expand_path(raw: &str) -> PathBuf {
@@ -769,6 +788,7 @@ fn normalize_dollar_prefixed_env_name(raw: &str, fallback: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::ScopedEnv;
 
     #[test]
     fn message_template_interpolation_replaces_known_placeholders() {
@@ -871,5 +891,36 @@ mod tests {
             PathBuf::from("."),
             "get_user_home() should return \".\" when both HOME and USERPROFILE are absent"
         );
+    }
+
+    #[test]
+    fn resolve_loongclaw_home_prefers_explicit_override_over_user_home() {
+        let override_home = if cfg!(windows) {
+            PathBuf::from(r"C:\tmp\loongclaw-home-override")
+        } else {
+            PathBuf::from("/tmp/loongclaw-home-override")
+        };
+        let home = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\loongclaw-test-home")
+        } else {
+            PathBuf::from("/tmp/loongclaw-test-home")
+        };
+
+        let resolved = resolve_loongclaw_home(
+            Some(override_home.as_os_str()),
+            Some(home.as_os_str()),
+            None,
+        );
+
+        assert_eq!(resolved, override_home);
+    }
+
+    #[test]
+    fn default_loongclaw_home_uses_override_env_when_present() {
+        let mut env = ScopedEnv::new();
+        let override_home = std::env::temp_dir().join("loongclaw-home-env-override");
+        env.set(LOONGCLAW_HOME_ENV, &override_home);
+
+        assert_eq!(default_loongclaw_home(), override_home);
     }
 }

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -504,7 +504,8 @@ fn resolve_user_home(
     home: Option<&std::ffi::OsStr>,
     userprofile: Option<&std::ffi::OsStr>,
 ) -> PathBuf {
-    home.or(userprofile)
+    home.filter(|value| !value.is_empty())
+        .or_else(|| userprofile.filter(|value| !value.is_empty()))
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."))
 }
@@ -515,6 +516,7 @@ fn resolve_loongclaw_home(
     userprofile: Option<&std::ffi::OsStr>,
 ) -> PathBuf {
     loongclaw_home
+        .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| resolve_user_home(home, userprofile).join(".loongclaw"))
 }
@@ -916,11 +918,56 @@ mod tests {
     }
 
     #[test]
+    fn resolve_user_home_treats_empty_home_as_unset() {
+        let userprofile = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\loongclaw-test-userprofile")
+        } else {
+            PathBuf::from("/tmp/loongclaw-test-userprofile")
+        };
+        let resolved = resolve_user_home(
+            Some(std::ffi::OsStr::new("")),
+            Some(userprofile.as_os_str()),
+        );
+
+        assert_eq!(resolved, userprofile);
+    }
+
+    #[test]
     fn default_loongclaw_home_uses_override_env_when_present() {
         let mut env = ScopedEnv::new();
         let override_home = std::env::temp_dir().join("loongclaw-home-env-override");
         env.set(LOONGCLAW_HOME_ENV, &override_home);
 
         assert_eq!(default_loongclaw_home(), override_home);
+    }
+
+    #[test]
+    fn resolve_loongclaw_home_treats_empty_override_as_unset() {
+        let home = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\loongclaw-test-home")
+        } else {
+            PathBuf::from("/tmp/loongclaw-test-home")
+        };
+        let resolved =
+            resolve_loongclaw_home(Some(std::ffi::OsStr::new("")), Some(home.as_os_str()), None);
+
+        assert_eq!(resolved, home.join(".loongclaw"));
+    }
+
+    #[test]
+    fn default_loongclaw_home_treats_empty_override_env_as_unset() {
+        let mut env = ScopedEnv::new();
+        let home = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\loongclaw-test-home")
+        } else {
+            PathBuf::from("/tmp/loongclaw-test-home")
+        };
+        env.set(LOONGCLAW_HOME_ENV, "");
+        env.set("HOME", &home);
+        env.remove("USERPROFILE");
+
+        let resolved = default_loongclaw_home();
+
+        assert_eq!(resolved, home.join(".loongclaw"));
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -8397,6 +8397,12 @@ async fn handle_turn_with_runtime_safe_lane_plan_persists_runtime_events_when_en
 
 #[tokio::test]
 async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disabled() {
+    let mut env = crate::test_support::ScopedEnv::new();
+    let temp_home = crate::test_support::unique_temp_dir("safe-lane-runtime-events-home");
+    std::fs::create_dir_all(&temp_home).expect("create safe-lane runtime-events home");
+    env.set("HOME", &temp_home);
+    env.remove("LOONGCLAW_HOME");
+
     let runtime = FakeRuntime::with_turn_and_completion(
         vec![],
         Ok(ProviderTurn {
@@ -8443,14 +8449,9 @@ async fn handle_turn_with_runtime_safe_lane_plan_skips_runtime_events_when_disab
                 return None;
             }
             let event_name = parsed.get("event")?.as_str()?;
-
-            match event_name {
-                "lane_selected"
-                | "plan_round_started"
-                | "plan_round_completed"
-                | "final_status" => Some(event_name.to_owned()),
-                _ => None,
-            }
+            let is_expected_suppressed_event =
+                event_name == "turn_checkpoint" || event_name == "trust_binding_missing";
+            (!is_expected_suppressed_event).then_some(event_name.to_owned())
         })
         .collect::<Vec<_>>();
     assert!(

--- a/crates/app/src/memory/mod.rs
+++ b/crates/app/src/memory/mod.rs
@@ -56,6 +56,8 @@ pub use protocol::{
     decode_window_turn_count, decode_window_turns, encode_stage_envelope_payload,
 };
 #[cfg(feature = "memory-sqlite")]
+pub(crate) use sqlite::CanonicalMemorySearchHit;
+#[cfg(feature = "memory-sqlite")]
 pub use sqlite::{ConversationTurn, SqliteBootstrapDiagnostics, SqliteContextLoadDiagnostics};
 pub use stage::{
     DerivedMemoryKind, MemoryRetrievalRequest, MemoryStageFamily, StageDiagnostics, StageEnvelope,
@@ -248,6 +250,16 @@ pub fn ensure_memory_db_ready_with_diagnostics(
     config: &runtime_config::MemoryRuntimeConfig,
 ) -> Result<(PathBuf, SqliteBootstrapDiagnostics), String> {
     sqlite::ensure_memory_db_ready_with_diagnostics(path, config)
+}
+
+#[cfg(feature = "memory-sqlite")]
+pub(crate) fn search_canonical_memory(
+    query: &str,
+    limit: usize,
+    exclude_session_id: Option<&str>,
+    config: &runtime_config::MemoryRuntimeConfig,
+) -> Result<Vec<CanonicalMemorySearchHit>, String> {
+    sqlite::search_canonical_records_for_recall(query, limit, exclude_session_id, config)
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -400,13 +400,18 @@ fn build_builtin_retrieval_request(
 }
 
 fn retrieval_query_from_recent_window(recent_window: &[WindowTurn]) -> Option<String> {
-    recent_window
-        .iter()
-        .rev()
-        .find(|turn| turn.role == "user")
-        .map(|turn| turn.content.trim())
-        .filter(|content| !content.is_empty())
-        .map(ToOwned::to_owned)
+    recent_window.iter().rev().find_map(|turn| {
+        if turn.role != "user" {
+            return None;
+        }
+
+        let trimmed_content = turn.content.trim();
+        if trimmed_content.is_empty() {
+            return None;
+        }
+
+        Some(trimmed_content.to_owned())
+    })
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -423,7 +428,8 @@ fn render_cross_session_recall_block(hits: &[super::sqlite::CanonicalMemorySearc
             .session_turn_index
             .map(|value| format!("turn {value}"))
             .unwrap_or_else(|| "turn ?".to_owned());
-        let role_label = hit.record.role.as_deref().unwrap_or("assistant");
+        let role_label = hit.record.role.as_deref();
+        let content = truncate_recall_content(hit.record.content.as_str(), 280);
         sections.push(format!(
             "### {} · {} · {} · {}",
             hit.record.session_id,
@@ -431,10 +437,11 @@ fn render_cross_session_recall_block(hits: &[super::sqlite::CanonicalMemorySearc
             hit.record.scope.as_str(),
             hit.record.kind.as_str()
         ));
-        sections.push(format!(
-            "{role_label}: {}",
-            truncate_recall_content(hit.record.content.as_str(), 280)
-        ));
+        let recall_line = match role_label {
+            Some(role_label) => format!("{role_label}: {content}"),
+            None => content,
+        };
+        sections.push(recall_line);
     }
 
     sections.join("\n\n")
@@ -779,7 +786,7 @@ mod tests {
             profile: MemoryProfile::WindowPlusSummary,
             mode: MemoryMode::WindowPlusSummary,
             sqlite_path: Some(db_path.clone()),
-            sliding_window: 4,
+            sliding_window: 8,
             ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
         };
 
@@ -983,7 +990,7 @@ mod tests {
         let retrieval_request = envelope
             .retrieval_request
             .expect("window-plus-summary should advertise retrieval request");
-        assert_eq!(retrieval_request.budget_items, config.sliding_window);
+        assert_eq!(retrieval_request.budget_items, 6);
         assert_eq!(
             retrieval_request.allowed_kinds,
             vec![
@@ -1006,6 +1013,62 @@ mod tests {
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn retrieval_query_from_recent_window_skips_blank_latest_user_turn() {
+        let recent_window = vec![
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "release rollback plan".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "assistant".to_owned(),
+                content: "working on it".to_owned(),
+                ts: None,
+            },
+            WindowTurn {
+                role: "user".to_owned(),
+                content: "   ".to_owned(),
+                ts: None,
+            },
+        ];
+
+        let query =
+            retrieval_query_from_recent_window(recent_window.as_slice()).expect("query fallback");
+
+        assert_eq!(query, "release rollback plan");
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn render_cross_session_recall_block_keeps_roleless_records_neutral() {
+        let hits = vec![crate::memory::CanonicalMemorySearchHit {
+            record: crate::memory::CanonicalMemoryRecord {
+                session_id: "workspace-session".to_owned(),
+                scope: crate::memory::MemoryScope::Workspace,
+                kind: crate::memory::CanonicalMemoryKind::ImportedProfile,
+                role: None,
+                content: "Imported release checklist with smoke tests.".to_owned(),
+                metadata: serde_json::json!({
+                    "source": "workspace-import"
+                }),
+            },
+            session_turn_index: Some(2),
+        }];
+
+        let rendered = render_cross_session_recall_block(hits.as_slice());
+
+        assert!(
+            rendered.contains("Imported release checklist with smoke tests."),
+            "expected rendered recall content: {rendered}"
+        );
+        assert!(
+            !rendered.contains("assistant: Imported release checklist with smoke tests."),
+            "roleless recall should not fabricate assistant provenance: {rendered}"
+        );
     }
 
     #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/memory/orchestrator.rs
+++ b/crates/app/src/memory/orchestrator.rs
@@ -123,7 +123,7 @@ impl BuiltinMemoryOrchestrator {
         let mut entries = load_prompt_context(session_id, config)?;
         let retrieval_request = metadata
             .supports_pre_assembly_stage_family(MemoryStageFamily::Retrieve)
-            .then(|| build_builtin_retrieval_request(session_id, config))
+            .then(|| build_builtin_retrieval_request(session_id, config, &recent_window))
             .flatten();
 
         let derive = run_pre_assembly_stage(MemoryStageFamily::Derive, metadata, config, || {
@@ -371,18 +371,87 @@ async fn run_builtin_compact_stage(
 fn build_builtin_retrieval_request(
     session_id: &str,
     config: &MemoryRuntimeConfig,
+    recent_window: &[WindowTurn],
 ) -> Option<MemoryRetrievalRequest> {
     if !matches!(config.mode, MemoryMode::WindowPlusSummary) {
         return None;
     }
 
+    let query = retrieval_query_from_recent_window(recent_window);
+
     Some(MemoryRetrievalRequest {
         session_id: session_id.to_owned(),
-        query: None,
-        scopes: vec![MemoryScope::Session],
-        budget_items: config.sliding_window,
-        allowed_kinds: vec![DerivedMemoryKind::Summary],
+        query,
+        scopes: vec![
+            MemoryScope::Session,
+            MemoryScope::Workspace,
+            MemoryScope::Agent,
+            MemoryScope::User,
+        ],
+        budget_items: config.sliding_window.min(6),
+        allowed_kinds: vec![
+            DerivedMemoryKind::Profile,
+            DerivedMemoryKind::Fact,
+            DerivedMemoryKind::Episode,
+            DerivedMemoryKind::Procedure,
+            DerivedMemoryKind::Overview,
+        ],
     })
+}
+
+fn retrieval_query_from_recent_window(recent_window: &[WindowTurn]) -> Option<String> {
+    recent_window
+        .iter()
+        .rev()
+        .find(|turn| turn.role == "user")
+        .map(|turn| turn.content.trim())
+        .filter(|content| !content.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn render_cross_session_recall_block(hits: &[super::sqlite::CanonicalMemorySearchHit]) -> String {
+    let mut sections = Vec::new();
+    sections.push("## Advisory Cross-Session Recall".to_owned());
+    sections.push(
+        "These snippets were retrieved from prior persisted sessions. Treat them as advisory hints and verify before acting."
+            .to_owned(),
+    );
+
+    for hit in hits {
+        let turn_label = hit
+            .session_turn_index
+            .map(|value| format!("turn {value}"))
+            .unwrap_or_else(|| "turn ?".to_owned());
+        let role_label = hit.record.role.as_deref().unwrap_or("assistant");
+        sections.push(format!(
+            "### {} · {} · {} · {}",
+            hit.record.session_id,
+            turn_label,
+            hit.record.scope.as_str(),
+            hit.record.kind.as_str()
+        ));
+        sections.push(format!(
+            "{role_label}: {}",
+            truncate_recall_content(hit.record.content.as_str(), 280)
+        ));
+    }
+
+    sections.join("\n\n")
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn truncate_recall_content(input: &str, max_chars: usize) -> String {
+    let char_count = input.chars().count();
+    if char_count <= max_chars {
+        return input.to_owned();
+    }
+    if max_chars <= 3 {
+        return input.chars().take(max_chars).collect();
+    }
+
+    let prefix = input.chars().take(max_chars - 3).collect::<String>();
+    format!("{prefix}...")
 }
 
 fn stage_error_message(
@@ -414,19 +483,38 @@ fn run_derivation_stage(
 }
 
 fn run_retrieval_stage(
-    _session_id: &str,
+    session_id: &str,
     workspace_root: Option<&Path>,
-    _config: &MemoryRuntimeConfig,
-    _recent_window: &[WindowTurn],
+    config: &MemoryRuntimeConfig,
+    recent_window: &[WindowTurn],
 ) -> Result<Vec<MemoryContextEntry>, String> {
     #[cfg(test)]
-    if let Some(error) = matching_memory_orchestrator_test_faults(_session_id)
+    if let Some(error) = matching_memory_orchestrator_test_faults(session_id)
         .and_then(|faults| faults.retrieval_error)
     {
         return Err(error);
     }
 
-    super::load_durable_recall_entries(workspace_root, _config)
+    let mut entries = super::load_durable_recall_entries(workspace_root, config)?;
+
+    #[cfg(feature = "memory-sqlite")]
+    if let Some(query) = retrieval_query_from_recent_window(recent_window) {
+        let hits = super::sqlite::search_canonical_records_for_recall(
+            query.as_str(),
+            config.sliding_window.min(6),
+            Some(session_id),
+            config,
+        )?;
+        if !hits.is_empty() {
+            entries.push(MemoryContextEntry {
+                kind: super::MemoryContextKind::RetrievedMemory,
+                role: "system".to_owned(),
+                content: render_cross_session_recall_block(hits.as_slice()),
+            });
+        }
+    }
+
+    Ok(entries)
 }
 
 pub fn hydrate_memory_context(
@@ -681,6 +769,58 @@ mod tests {
 
     #[cfg(feature = "memory-sqlite")]
     #[test]
+    fn hydrated_memory_builtin_orchestrator_retrieves_cross_session_recall_hits() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-hydrated-cross-session-recall");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("cross-session-recall.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 4,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct(
+            "prior-session",
+            "assistant",
+            "Deployment cutoff is 17:00 Beijing time and requires a release note.",
+            &config,
+        )
+        .expect("append prior session recall candidate");
+        append_turn_direct(
+            "active-session",
+            "user",
+            "What is the deployment cutoff for today's release?",
+            &config,
+        )
+        .expect("append active user turn");
+
+        let hydrated =
+            hydrate_memory_context("active-session", &config).expect("hydrate memory context");
+
+        let recalled = hydrated
+            .entries
+            .iter()
+            .find(|entry| {
+                entry.kind == MemoryContextKind::RetrievedMemory
+                    && entry.content.contains("prior-session")
+            })
+            .expect("expected cross-session retrieved memory entry");
+        assert!(
+            recalled
+                .content
+                .contains("Deployment cutoff is 17:00 Beijing time")
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
     fn hydrated_memory_builtin_orchestrator_preserves_profile_behavior() {
         let tmp = hydrated_memory_temp_dir("loongclaw-hydrated-profile");
         let _ = std::fs::create_dir_all(&tmp);
@@ -846,7 +986,60 @@ mod tests {
         assert_eq!(retrieval_request.budget_items, config.sliding_window);
         assert_eq!(
             retrieval_request.allowed_kinds,
-            vec![DerivedMemoryKind::Summary]
+            vec![
+                DerivedMemoryKind::Profile,
+                DerivedMemoryKind::Fact,
+                DerivedMemoryKind::Episode,
+                DerivedMemoryKind::Procedure,
+                DerivedMemoryKind::Overview,
+            ]
+        );
+        assert_eq!(
+            retrieval_request.scopes,
+            vec![
+                MemoryScope::Session,
+                MemoryScope::Workspace,
+                MemoryScope::Agent,
+                MemoryScope::User,
+            ]
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_dir(&tmp);
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn hydrate_stage_envelope_derives_retrieval_query_from_latest_user_turn() {
+        let tmp = hydrated_memory_temp_dir("loongclaw-stage-envelope-retrieval-query");
+        let _ = std::fs::create_dir_all(&tmp);
+        let db_path = tmp.join("retrieval-query.sqlite3");
+        let _ = std::fs::remove_file(&db_path);
+
+        let config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            profile: MemoryProfile::WindowPlusSummary,
+            mode: MemoryMode::WindowPlusSummary,
+            sqlite_path: Some(db_path.clone()),
+            sliding_window: 4,
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct(
+            "stage-retrieval-query",
+            "user",
+            "Find the rollback checklist for database migration",
+            &config,
+        )
+        .expect("append retrieval query turn");
+
+        let envelope = hydrate_stage_envelope("stage-retrieval-query", &config)
+            .expect("hydrate staged envelope");
+        let retrieval_request = envelope
+            .retrieval_request
+            .expect("expected retrieval request");
+        assert_eq!(
+            retrieval_request.query.as_deref(),
+            Some("Find the rollback checklist for database migration")
         );
 
         let _ = std::fs::remove_file(&db_path);

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -151,9 +151,23 @@ const SQL_SEARCH_CANONICAL_RECORDS: &str = "SELECT record.session_id,
              FROM memory_canonical_records_fts AS fts
              JOIN memory_canonical_records AS record
                ON record.record_id = fts.rowid
+             LEFT JOIN sessions AS session
+               ON session.session_id = record.session_id
+             LEFT JOIN (
+                SELECT session_id, MAX(ts) AS archived_at
+                FROM session_events
+                WHERE event_kind = 'session_archived'
+                GROUP BY session_id
+             ) AS archived
+               ON archived.session_id = record.session_id
              WHERE memory_canonical_records_fts MATCH ?1
                AND (?2 IS NULL OR record.session_id <> ?2)
                AND record.kind <> 'user_turn'
+               AND record.session_id NOT LIKE 'delegate:%'
+               AND (
+                    session.session_id IS NULL
+                    OR (session.kind = 'root' AND archived.archived_at IS NULL)
+               )
              ORDER BY bm25(memory_canonical_records_fts), record.ts DESC
              LIMIT ?3";
 const SQL_QUERY_RECENT_TURNS_NO_ID: &str = "SELECT role, content, ts, session_turn_index
@@ -7979,6 +7993,39 @@ mod tests {
             &config,
         )
         .expect("append active session recall candidate");
+        append_turn_direct(
+            "delegate-child",
+            "assistant",
+            "Delegate child turn that should stay out of root-session recall.",
+            &config,
+        )
+        .expect("append delegate child recall candidate");
+        append_turn_direct(
+            "root-archived",
+            "assistant",
+            "Archived root turn that should stay out of resumable recall.",
+            &config,
+        )
+        .expect("append archived root recall candidate");
+
+        let runtime = acquire_memory_runtime(&config).expect("acquire memory runtime");
+        runtime
+            .with_connection_mut("test.seed_canonical_search_session_metadata", |conn| {
+                conn.execute_batch(
+                    "
+                    INSERT INTO sessions(session_id, kind, parent_session_id, label, state, created_at, updated_at, last_error)
+                    VALUES
+                      ('prior-session', 'root', NULL, NULL, 'ready', 100, 100, NULL),
+                      ('delegate-child', 'delegate_child', 'prior-session', NULL, 'ready', 200, 200, NULL),
+                      ('root-archived', 'root', NULL, NULL, 'ready', 300, 300, NULL);
+                    INSERT INTO session_events(session_id, event_kind, actor_session_id, payload_json, ts)
+                    VALUES ('root-archived', 'session_archived', NULL, '{}', 400);
+                    ",
+                )
+                .map_err(|error| format!("seed canonical search session metadata failed: {error}"))?;
+                Ok(())
+            })
+            .expect("seed canonical search session metadata");
 
         let hits = search_canonical_records_for_recall(
             "deployment cutoff release note",

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -14,8 +14,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::{
-    MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION, MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW,
-    WindowTurn, runtime_config::MemoryRuntimeConfig,
+    CanonicalMemoryKind, CanonicalMemoryRecord, MEMORY_OP_APPEND_TURN, MEMORY_OP_CLEAR_SESSION,
+    MEMORY_OP_REPLACE_TURNS, MEMORY_OP_WINDOW, MemoryScope, WindowTurn,
+    canonical_memory_record_from_persisted_turn, runtime_config::MemoryRuntimeConfig,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,8 +103,8 @@ impl PromptWindowQueryDiagnostics {
 }
 
 const SUMMARY_FORMAT_VERSION: i64 = 1;
-const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 7;
-const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 11;
+const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 8;
+const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 18;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const SQLITE_PREPARED_STATEMENT_CACHE_CAPACITY: usize = 16;
 const SESSION_TOOL_CONSENT_MODE_CHECK_SQL: &str = "CHECK (mode IN ('prompt', 'auto', 'full'))";
@@ -116,10 +117,45 @@ const SQL_UPSERT_SESSION_TURN_COUNT: &str =
                  turn_count = memory_session_state.turn_count + 1
              RETURNING turn_count";
 const SQL_DELETE_SESSION_STATE: &str = "DELETE FROM memory_session_state WHERE session_id = ?1";
+const SQL_DELETE_CANONICAL_RECORDS_FOR_SESSION: &str =
+    "DELETE FROM memory_canonical_records WHERE session_id = ?1";
 const SQL_SET_SESSION_TURN_COUNT: &str = "INSERT INTO memory_session_state(session_id, turn_count)
              VALUES (?1, ?2)
              ON CONFLICT(session_id) DO UPDATE SET
-                 turn_count = excluded.turn_count";
+             turn_count = excluded.turn_count";
+const SQL_INSERT_CANONICAL_RECORD: &str = "INSERT INTO memory_canonical_records(
+             session_id,
+             session_turn_index,
+             scope,
+             kind,
+             role,
+             content,
+             metadata_json,
+             ts
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
+const SQL_SELECT_TURNS_FOR_CANONICAL_REBUILD: &str =
+    "SELECT session_id, session_turn_index, role, content, ts
+             FROM turns
+             ORDER BY id ASC";
+const SQL_COUNT_TURNS: &str = "SELECT COUNT(*) FROM turns";
+const SQL_COUNT_CANONICAL_RECORDS: &str = "SELECT COUNT(*) FROM memory_canonical_records";
+const SQL_COUNT_CANONICAL_FTS_ROWS: &str = "SELECT COUNT(*) FROM memory_canonical_records_fts";
+const SQL_SEARCH_CANONICAL_RECORDS: &str = "SELECT record.session_id,
+             record.session_turn_index,
+             record.scope,
+             record.kind,
+             record.role,
+             record.content,
+             record.metadata_json,
+             record.ts
+             FROM memory_canonical_records_fts AS fts
+             JOIN memory_canonical_records AS record
+               ON record.record_id = fts.rowid
+             WHERE memory_canonical_records_fts MATCH ?1
+               AND (?2 IS NULL OR record.session_id <> ?2)
+               AND record.kind <> 'user_turn'
+             ORDER BY bm25(memory_canonical_records_fts), record.ts DESC
+             LIMIT ?3";
 const SQL_QUERY_RECENT_TURNS_NO_ID: &str = "SELECT role, content, ts, session_turn_index
              FROM turns
              WHERE session_id = ?1
@@ -147,6 +183,8 @@ const SQL_COUNT_CURRENT_SCHEMA_OBJECTS: &str = "SELECT COUNT(*)
                         'memory_session_state',
                         'memory_summary_checkpoints',
                         'memory_summary_checkpoint_bodies',
+                        'memory_canonical_records',
+                        'memory_canonical_records_fts',
                         'approval_requests',
                         'approval_grants',
                         'session_tool_consent',
@@ -155,7 +193,14 @@ const SQL_COUNT_CURRENT_SCHEMA_OBJECTS: &str = "SELECT COUNT(*)
                 OR (type = 'index' AND name IN (
                         'idx_turns_session_id',
                         'idx_turns_session_turn_index',
+                        'idx_memory_canonical_records_scope_kind_ts',
+                        'idx_memory_canonical_records_session_turn',
                         'idx_approval_requests_session_status_requested_at'
+                    ))
+                OR (type = 'trigger' AND name IN (
+                        'memory_canonical_records_ai',
+                        'memory_canonical_records_ad',
+                        'memory_canonical_records_au'
                     ))";
 const SQL_QUERY_RECENT_PROMPT_TURNS_WITH_CHECKPOINT_META: &str = "SELECT turns.id,
              turns.role,
@@ -341,6 +386,12 @@ struct SummaryAppendMaintenanceState {
 struct AppendTurnResult {
     db_path: PathBuf,
     ts: i64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CanonicalMemorySearchHit {
+    pub record: CanonicalMemoryRecord,
+    pub session_turn_index: Option<i64>,
 }
 
 struct WindowLoadResult {
@@ -530,6 +581,7 @@ pub(super) fn clear_session(
                 .execute(rusqlite::params![session_id])
                 .map_err(|error| format!("clear memory session failed: {error}"))?
         };
+        delete_canonical_records_for_session(&tx, session_id)?;
         delete_session_state(&tx, session_id)?;
         delete_summary_checkpoint(&tx, session_id)?;
         tx.commit()
@@ -933,6 +985,10 @@ fn append_turn_internal(
                 ])
                 .map_err(|error| format!("insert memory turn failed: {error}"))?;
         }
+        insert_canonical_record(
+            &tx,
+            build_canonical_insert_input(session_id, next_session_turn_index, role, content, ts),
+        )?;
 
         let summary_window_size = default_window_size(config);
         if matches!(config.mode, crate::config::MemoryMode::WindowPlusSummary)
@@ -964,6 +1020,58 @@ fn append_turn_internal(
     })?;
 
     Ok(AppendTurnResult { db_path: path, ts })
+}
+
+struct CanonicalInsertInput {
+    session_id: String,
+    session_turn_index: i64,
+    scope: MemoryScope,
+    kind: CanonicalMemoryKind,
+    role: Option<String>,
+    content: String,
+    metadata_json: String,
+    ts: i64,
+}
+
+fn build_canonical_insert_input(
+    session_id: &str,
+    session_turn_index: i64,
+    role: &str,
+    content: &str,
+    ts: i64,
+) -> CanonicalInsertInput {
+    let record = canonical_memory_record_from_persisted_turn(session_id, role, content);
+    CanonicalInsertInput {
+        session_id: session_id.to_owned(),
+        session_turn_index,
+        scope: record.scope,
+        kind: record.kind,
+        role: record.role,
+        content: record.content,
+        metadata_json: record.metadata.to_string(),
+        ts,
+    }
+}
+
+fn insert_canonical_record(conn: &Connection, input: CanonicalInsertInput) -> Result<(), String> {
+    let mut insert_record = prepare_cached_sqlite_statement(
+        conn,
+        SQL_INSERT_CANONICAL_RECORD,
+        "prepare canonical memory insert failed",
+    )?;
+    insert_record
+        .execute(rusqlite::params![
+            input.session_id,
+            input.session_turn_index,
+            input.scope.as_str(),
+            input.kind.as_str(),
+            input.role,
+            input.content,
+            input.metadata_json,
+            input.ts,
+        ])
+        .map(|_| ())
+        .map_err(|error| format!("insert canonical memory record failed: {error}"))
 }
 
 fn replace_turns_internal(
@@ -1008,6 +1116,7 @@ fn replace_turns_internal(
 
             delete_session_state(&tx, session_id)?;
             delete_summary_checkpoint(&tx, session_id)?;
+            delete_canonical_records_for_session(&tx, session_id)?;
 
             if !turns.is_empty() {
                 {
@@ -1035,6 +1144,16 @@ fn replace_turns_internal(
                             .map_err(|error| {
                                 format!("insert replaced memory turn failed: {error}")
                             })?;
+                        insert_canonical_record(
+                            &tx,
+                            build_canonical_insert_input(
+                                session_id,
+                                (index + 1) as i64,
+                                role,
+                                &turn.content,
+                                ts,
+                            ),
+                        )?;
                     }
                 }
 
@@ -1295,6 +1414,43 @@ fn open_sqlite_connection_with_diagnostics(
                 REFERENCES memory_summary_checkpoints(session_id) ON DELETE CASCADE,
               summary_body TEXT NOT NULL
             );
+            CREATE TABLE IF NOT EXISTS memory_canonical_records(
+              record_id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              session_turn_index INTEGER NOT NULL,
+              scope TEXT NOT NULL,
+              kind TEXT NOT NULL,
+              role TEXT NULL,
+              content TEXT NOT NULL,
+              metadata_json TEXT NOT NULL,
+              ts INTEGER NOT NULL
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_canonical_records_session_turn
+              ON memory_canonical_records(session_id, session_turn_index);
+            CREATE INDEX IF NOT EXISTS idx_memory_canonical_records_scope_kind_ts
+              ON memory_canonical_records(scope, kind, ts DESC, record_id);
+            CREATE VIRTUAL TABLE IF NOT EXISTS memory_canonical_records_fts
+              USING fts5(content, content='memory_canonical_records', content_rowid='record_id');
+            CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ai
+              AFTER INSERT ON memory_canonical_records
+            BEGIN
+              INSERT INTO memory_canonical_records_fts(rowid, content)
+              VALUES (new.record_id, new.content);
+            END;
+            CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ad
+              AFTER DELETE ON memory_canonical_records
+            BEGIN
+              INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
+              VALUES ('delete', old.record_id, old.content);
+            END;
+            CREATE TRIGGER IF NOT EXISTS memory_canonical_records_au
+              AFTER UPDATE ON memory_canonical_records
+            BEGIN
+              INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
+              VALUES ('delete', old.record_id, old.content);
+              INSERT INTO memory_canonical_records_fts(rowid, content)
+              VALUES (new.record_id, new.content);
+            END;
             CREATE TABLE IF NOT EXISTS approval_requests(
               approval_request_id TEXT PRIMARY KEY,
               session_id TEXT NOT NULL,
@@ -1347,6 +1503,7 @@ fn open_sqlite_connection_with_diagnostics(
         ensure_session_tool_consent_storage(&mut conn)?;
         ensure_session_tool_policy_storage(&conn)?;
         ensure_summary_checkpoint_storage_layout(&conn)?;
+        ensure_canonical_record_storage(&conn)?;
         write_sqlite_user_version(&conn, SQLITE_MEMORY_SCHEMA_VERSION)?;
     }
     diagnostics.schema_upgrade_ms = elapsed_ms(schema_upgrade_started_at);
@@ -1565,6 +1722,58 @@ fn ensure_session_tool_policy_storage(conn: &Connection) -> Result<(), String> {
         ",
     )
     .map_err(|error| format!("ensure session tool policy storage failed: {error}"))?;
+
+    Ok(())
+}
+
+fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
+    #[cfg(test)]
+    test_support::record_sqlite_schema_repair("canonical_records");
+
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS memory_canonical_records(
+          record_id INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id TEXT NOT NULL,
+          session_turn_index INTEGER NOT NULL,
+          scope TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          role TEXT NULL,
+          content TEXT NOT NULL,
+          metadata_json TEXT NOT NULL,
+          ts INTEGER NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_canonical_records_session_turn
+          ON memory_canonical_records(session_id, session_turn_index);
+        CREATE INDEX IF NOT EXISTS idx_memory_canonical_records_scope_kind_ts
+          ON memory_canonical_records(scope, kind, ts DESC, record_id);
+        CREATE VIRTUAL TABLE IF NOT EXISTS memory_canonical_records_fts
+          USING fts5(content, content='memory_canonical_records', content_rowid='record_id');
+        CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ai
+          AFTER INSERT ON memory_canonical_records
+        BEGIN
+          INSERT INTO memory_canonical_records_fts(rowid, content)
+          VALUES (new.record_id, new.content);
+        END;
+        CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ad
+          AFTER DELETE ON memory_canonical_records
+        BEGIN
+          INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
+          VALUES ('delete', old.record_id, old.content);
+        END;
+        CREATE TRIGGER IF NOT EXISTS memory_canonical_records_au
+          AFTER UPDATE ON memory_canonical_records
+        BEGIN
+          INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
+          VALUES ('delete', old.record_id, old.content);
+          INSERT INTO memory_canonical_records_fts(rowid, content)
+          VALUES (new.record_id, new.content);
+        END;
+        ",
+    )
+    .map_err(|error| format!("ensure canonical memory storage failed: {error}"))?;
+
+    rebuild_canonical_record_storage_if_needed(conn)?;
 
     Ok(())
 }
@@ -2905,6 +3114,217 @@ fn delete_session_state(conn: &Connection, session_id: &str) -> Result<(), Strin
         .execute(rusqlite::params![session_id])
         .map(|_| ())
         .map_err(|error| format!("delete session-state failed: {error}"))
+}
+
+fn delete_canonical_records_for_session(conn: &Connection, session_id: &str) -> Result<(), String> {
+    let mut delete_records = prepare_cached_sqlite_statement(
+        conn,
+        SQL_DELETE_CANONICAL_RECORDS_FOR_SESSION,
+        "prepare canonical-record delete failed",
+    )?;
+    delete_records
+        .execute(rusqlite::params![session_id])
+        .map(|_| ())
+        .map_err(|error| format!("delete canonical records failed: {error}"))
+}
+
+fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), String> {
+    let turn_count = conn
+        .query_row(SQL_COUNT_TURNS, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| format!("count persisted turns for canonical rebuild failed: {error}"))?;
+    let canonical_count = conn
+        .query_row(SQL_COUNT_CANONICAL_RECORDS, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| format!("count canonical records failed: {error}"))?;
+    let canonical_fts_count = conn
+        .query_row(SQL_COUNT_CANONICAL_FTS_ROWS, [], |row| row.get::<_, i64>(0))
+        .map_err(|error| format!("count canonical FTS rows failed: {error}"))?;
+
+    if canonical_count == turn_count && canonical_fts_count == canonical_count {
+        return Ok(());
+    }
+
+    #[derive(Debug)]
+    struct PersistedTurnRow {
+        session_id: String,
+        session_turn_index: i64,
+        role: String,
+        content: String,
+        ts: i64,
+    }
+
+    let mut select_turns = prepare_cached_sqlite_statement(
+        conn,
+        SQL_SELECT_TURNS_FOR_CANONICAL_REBUILD,
+        "prepare canonical rebuild turn query failed",
+    )?;
+    let rows = select_turns
+        .query_map([], |row| {
+            Ok(PersistedTurnRow {
+                session_id: row.get(0)?,
+                session_turn_index: row.get(1)?,
+                role: row.get(2)?,
+                content: row.get(3)?,
+                ts: row.get(4)?,
+            })
+        })
+        .map_err(|error| format!("query canonical rebuild turns failed: {error}"))?;
+    let turns = rows
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("read canonical rebuild turns failed: {error}"))?;
+    drop(select_turns);
+
+    conn.execute_batch("SAVEPOINT canonical_rebuild")
+        .map_err(|error| format!("begin canonical rebuild savepoint failed: {error}"))?;
+
+    let rebuild_result = (|| {
+        conn.execute("DELETE FROM memory_canonical_records", [])
+            .map_err(|error| format!("clear canonical records before rebuild failed: {error}"))?;
+        for turn in &turns {
+            insert_canonical_record(
+                conn,
+                build_canonical_insert_input(
+                    turn.session_id.as_str(),
+                    turn.session_turn_index,
+                    turn.role.as_str(),
+                    turn.content.as_str(),
+                    turn.ts,
+                ),
+            )?;
+        }
+        Ok(())
+    })();
+
+    match rebuild_result {
+        Ok(()) => conn
+            .execute_batch("RELEASE canonical_rebuild")
+            .map_err(|error| format!("commit canonical rebuild savepoint failed: {error}")),
+        Err(error) => {
+            let _ = conn.execute_batch(
+                "ROLLBACK TO canonical_rebuild;
+                 RELEASE canonical_rebuild;",
+            );
+            Err(error)
+        }
+    }
+}
+
+fn build_canonical_fts_query(query: &str) -> Option<String> {
+    let mut terms = Vec::new();
+    let mut current = String::new();
+    let push_term = |value: &mut String, terms: &mut Vec<String>| {
+        let trimmed = value.trim();
+        if trimmed.chars().count() >= 2 {
+            let candidate = trimmed.to_owned();
+            if !terms.contains(&candidate) {
+                terms.push(candidate);
+            }
+        }
+        value.clear();
+    };
+
+    for ch in query.chars() {
+        if ch.is_alphanumeric() || ch == '_' || ch == '-' {
+            current.push(ch);
+        } else if !current.is_empty() {
+            push_term(&mut current, &mut terms);
+        }
+    }
+    if !current.is_empty() {
+        push_term(&mut current, &mut terms);
+    }
+
+    if terms.is_empty() {
+        return None;
+    }
+
+    let query = terms
+        .into_iter()
+        .take(6)
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    if query.is_empty() { None } else { Some(query) }
+}
+
+pub(super) fn search_canonical_records_for_recall(
+    query: &str,
+    limit: usize,
+    exclude_session_id: Option<&str>,
+    config: &MemoryRuntimeConfig,
+) -> Result<Vec<CanonicalMemorySearchHit>, String> {
+    let Some(match_query) = build_canonical_fts_query(query) else {
+        return Ok(Vec::new());
+    };
+
+    let runtime = acquire_memory_runtime(config)?;
+    runtime.with_connection("memory.search_canonical_records", |conn| {
+        let mut stmt = prepare_cached_sqlite_statement(
+            conn,
+            SQL_SEARCH_CANONICAL_RECORDS,
+            "prepare canonical memory search statement failed",
+        )?;
+        let mut rows = stmt
+            .query(rusqlite::params![
+                match_query,
+                exclude_session_id,
+                limit.clamp(1, 16) as i64
+            ])
+            .map_err(|error| format!("query canonical memory search failed: {error}"))?;
+        let mut hits = Vec::new();
+
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| format!("read canonical memory search row failed: {error}"))?
+        {
+            let session_id = row.get::<_, String>(0).map_err(|error| {
+                format!("decode canonical memory search session id failed: {error}")
+            })?;
+            let session_turn_index = row.get::<_, i64>(1).map_err(|error| {
+                format!("decode canonical memory search turn index failed: {error}")
+            })?;
+            let scope_text = row
+                .get::<_, String>(2)
+                .map_err(|error| format!("decode canonical memory search scope failed: {error}"))?;
+            let kind_text = row
+                .get::<_, String>(3)
+                .map_err(|error| format!("decode canonical memory search kind failed: {error}"))?;
+            let role = row
+                .get::<_, Option<String>>(4)
+                .map_err(|error| format!("decode canonical memory search role failed: {error}"))?;
+            let content = row.get::<_, String>(5).map_err(|error| {
+                format!("decode canonical memory search content failed: {error}")
+            })?;
+            let metadata_json = row.get::<_, String>(6).map_err(|error| {
+                format!("decode canonical memory search metadata failed: {error}")
+            })?;
+            let _ts = row.get::<_, i64>(7).map_err(|error| {
+                format!("decode canonical memory search timestamp failed: {error}")
+            })?;
+
+            let Some(scope) = MemoryScope::parse_id(scope_text.as_str()) else {
+                continue;
+            };
+            let Some(kind) = CanonicalMemoryKind::parse_id(kind_text.as_str()) else {
+                continue;
+            };
+            let metadata =
+                serde_json::from_str::<Value>(metadata_json.as_str()).unwrap_or_else(|_| json!({}));
+
+            hits.push(CanonicalMemorySearchHit {
+                record: CanonicalMemoryRecord {
+                    session_id,
+                    scope,
+                    kind,
+                    role,
+                    content,
+                    metadata,
+                },
+                session_turn_index: Some(session_turn_index),
+            });
+        }
+
+        Ok(hits)
+    })
 }
 
 fn maintain_summary_checkpoint_after_append(
@@ -7524,6 +7944,208 @@ mod tests {
             0,
             "expected known-overflow summary snapshots to avoid a second checkpoint metadata lookup after the window query already proved overflow"
         );
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn canonical_memory_search_returns_prior_session_hits_and_excludes_current_session() {
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-canonical-memory-search-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("canonical-search.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        append_turn_direct(
+            "prior-session",
+            "assistant",
+            "Deployment cutoff is 17:00 Beijing time and requires a release note.",
+            &config,
+        )
+        .expect("append prior session recall candidate");
+        append_turn_direct(
+            "active-session",
+            "assistant",
+            "Deployment cutoff draft that should not be recalled from the active session.",
+            &config,
+        )
+        .expect("append active session recall candidate");
+
+        let hits = search_canonical_records_for_recall(
+            "deployment cutoff release note",
+            4,
+            Some("active-session"),
+            &config,
+        )
+        .expect("search canonical memory");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].record.session_id, "prior-session");
+        assert_eq!(hits[0].record.kind, CanonicalMemoryKind::AssistantTurn);
+        assert_eq!(hits[0].record.scope, MemoryScope::Session);
+        assert_eq!(hits[0].session_turn_index, Some(1));
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn canonical_memory_search_preserves_structured_scope_and_kind_metadata() {
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-canonical-memory-structured-search-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("canonical-structured-search.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        let payload = json!({
+            "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "workspace",
+            "kind": "imported_profile",
+            "content": "Workspace release checklist includes rollback and smoke test steps.",
+            "metadata": {
+                "source": "workspace-import"
+            },
+        })
+        .to_string();
+
+        append_turn_direct("workspace-session", "assistant", &payload, &config)
+            .expect("append structured canonical payload");
+
+        let hits = search_canonical_records_for_recall("rollback smoke test", 4, None, &config)
+            .expect("search canonical memory");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].record.scope, MemoryScope::Workspace);
+        assert_eq!(hits[0].record.kind, CanonicalMemoryKind::ImportedProfile);
+        assert_eq!(hits[0].record.metadata["source"], "workspace-import");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ensure_memory_db_ready_backfills_canonical_records_for_legacy_turns() {
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-canonical-memory-migration-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("legacy-canonical.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let conn = Connection::open(&db_path).expect("open legacy sqlite db");
+        conn.execute_batch(
+            "
+            PRAGMA user_version = 4;
+            CREATE TABLE turns(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              session_turn_index INTEGER,
+              role TEXT NOT NULL,
+              content TEXT NOT NULL,
+              ts INTEGER NOT NULL
+            );
+            CREATE INDEX idx_turns_session_id ON turns(session_id, id);
+            CREATE UNIQUE INDEX idx_turns_session_turn_index
+              ON turns(session_id, session_turn_index);
+            CREATE TABLE memory_session_state(
+              session_id TEXT PRIMARY KEY,
+              turn_count INTEGER NOT NULL
+            );
+            CREATE TABLE memory_summary_checkpoints(
+              session_id TEXT PRIMARY KEY,
+              summarized_through_turn_id INTEGER NOT NULL,
+              summary_before_turn_id INTEGER,
+              summary_body_bytes INTEGER NOT NULL DEFAULT 0,
+              summary_budget_chars INTEGER NOT NULL,
+              summary_window_size INTEGER NOT NULL,
+              summary_format_version INTEGER NOT NULL,
+              updated_at_ts INTEGER NOT NULL
+            );
+            CREATE TABLE memory_summary_checkpoint_bodies(
+              session_id TEXT PRIMARY KEY
+                REFERENCES memory_summary_checkpoints(session_id) ON DELETE CASCADE,
+              summary_body TEXT NOT NULL
+            );
+            CREATE TABLE approval_requests(
+              approval_request_id TEXT PRIMARY KEY,
+              session_id TEXT NOT NULL,
+              turn_id TEXT NOT NULL,
+              tool_call_id TEXT NOT NULL,
+              tool_name TEXT NOT NULL,
+              approval_key TEXT NOT NULL,
+              status TEXT NOT NULL,
+              decision TEXT NULL,
+              request_payload_json TEXT NOT NULL,
+              governance_snapshot_json TEXT NOT NULL,
+              requested_at INTEGER NOT NULL,
+              resolved_at INTEGER NULL,
+              resolved_by_session_id TEXT NULL,
+              executed_at INTEGER NULL,
+              last_error TEXT NULL
+            );
+            CREATE TABLE approval_grants(
+              scope_session_id TEXT NOT NULL,
+              approval_key TEXT NOT NULL,
+              created_by_session_id TEXT NULL,
+              created_at INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL,
+              PRIMARY KEY(scope_session_id, approval_key)
+            );
+            CREATE INDEX idx_approval_requests_session_status_requested_at
+              ON approval_requests(session_id, status, requested_at DESC, approval_request_id);
+            ",
+        )
+        .expect("create legacy schema");
+        conn.execute(
+            "INSERT INTO turns(session_id, session_turn_index, role, content, ts)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![
+                "legacy-session",
+                1_i64,
+                "assistant",
+                "Legacy rollout fix includes rollback and smoke test verification.",
+                1_717_000_000_i64
+            ],
+        )
+        .expect("insert legacy turn");
+        conn.execute(
+            "INSERT INTO memory_session_state(session_id, turn_count)
+             VALUES (?1, ?2)",
+            rusqlite::params!["legacy-session", 1_i64],
+        )
+        .expect("insert session state");
+        drop(conn);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+        let _ = ensure_memory_db_ready(None, &config).expect("upgrade legacy sqlite db");
+
+        let hits = search_canonical_records_for_recall("rollback smoke test", 4, None, &config)
+            .expect("search canonical memory after migration");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].record.session_id, "legacy-session");
 
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/app/src/memory/sqlite.rs
+++ b/crates/app/src/memory/sqlite.rs
@@ -103,7 +103,8 @@ impl PromptWindowQueryDiagnostics {
 }
 
 const SUMMARY_FORMAT_VERSION: i64 = 1;
-const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 8;
+const SQLITE_MEMORY_SCHEMA_VERSION: i64 = 9;
+const CANONICAL_REBUILD_BATCH_SIZE: i64 = 256;
 const SQLITE_CURRENT_SCHEMA_OBJECT_COUNT: i64 = 18;
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 5_000;
 const SQLITE_PREPARED_STATEMENT_CACHE_CAPACITY: usize = 16;
@@ -134,9 +135,11 @@ const SQL_INSERT_CANONICAL_RECORD: &str = "INSERT INTO memory_canonical_records(
              ts
          ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
 const SQL_SELECT_TURNS_FOR_CANONICAL_REBUILD: &str =
-    "SELECT session_id, session_turn_index, role, content, ts
+    "SELECT id, session_id, session_turn_index, role, content, ts
              FROM turns
-             ORDER BY id ASC";
+             WHERE id > ?1
+             ORDER BY id ASC
+             LIMIT ?2";
 const SQL_COUNT_TURNS: &str = "SELECT COUNT(*) FROM turns";
 const SQL_COUNT_CANONICAL_RECORDS: &str = "SELECT COUNT(*) FROM memory_canonical_records";
 const SQL_COUNT_CANONICAL_FTS_ROWS: &str = "SELECT COUNT(*) FROM memory_canonical_records_fts";
@@ -168,7 +171,7 @@ const SQL_SEARCH_CANONICAL_RECORDS: &str = "SELECT record.session_id,
                     session.session_id IS NULL
                     OR (session.kind = 'root' AND archived.archived_at IS NULL)
                )
-             ORDER BY bm25(memory_canonical_records_fts), record.ts DESC
+             ORDER BY bm25(memory_canonical_records_fts), record.ts DESC, record.record_id DESC
              LIMIT ?3";
 const SQL_QUERY_RECENT_TURNS_NO_ID: &str = "SELECT role, content, ts, session_turn_index
              FROM turns
@@ -1444,26 +1447,103 @@ fn open_sqlite_connection_with_diagnostics(
             CREATE INDEX IF NOT EXISTS idx_memory_canonical_records_scope_kind_ts
               ON memory_canonical_records(scope, kind, ts DESC, record_id);
             CREATE VIRTUAL TABLE IF NOT EXISTS memory_canonical_records_fts
-              USING fts5(content, content='memory_canonical_records', content_rowid='record_id');
+              USING fts5(
+                content,
+                session_id,
+                scope,
+                kind,
+                role,
+                metadata_json,
+                content='memory_canonical_records',
+                content_rowid='record_id'
+              );
             CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ai
               AFTER INSERT ON memory_canonical_records
             BEGIN
-              INSERT INTO memory_canonical_records_fts(rowid, content)
-              VALUES (new.record_id, new.content);
+              INSERT INTO memory_canonical_records_fts(
+                rowid,
+                content,
+                session_id,
+                scope,
+                kind,
+                role,
+                metadata_json
+              )
+              VALUES (
+                new.record_id,
+                new.content,
+                new.session_id,
+                new.scope,
+                new.kind,
+                COALESCE(new.role, ''),
+                new.metadata_json
+              );
             END;
             CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ad
               AFTER DELETE ON memory_canonical_records
             BEGIN
-              INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
-              VALUES ('delete', old.record_id, old.content);
+              INSERT INTO memory_canonical_records_fts(
+                memory_canonical_records_fts,
+                rowid,
+                content,
+                session_id,
+                scope,
+                kind,
+                role,
+                metadata_json
+              )
+              VALUES (
+                'delete',
+                old.record_id,
+                old.content,
+                old.session_id,
+                old.scope,
+                old.kind,
+                COALESCE(old.role, ''),
+                old.metadata_json
+              );
             END;
             CREATE TRIGGER IF NOT EXISTS memory_canonical_records_au
               AFTER UPDATE ON memory_canonical_records
             BEGIN
-              INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
-              VALUES ('delete', old.record_id, old.content);
-              INSERT INTO memory_canonical_records_fts(rowid, content)
-              VALUES (new.record_id, new.content);
+              INSERT INTO memory_canonical_records_fts(
+                memory_canonical_records_fts,
+                rowid,
+                content,
+                session_id,
+                scope,
+                kind,
+                role,
+                metadata_json
+              )
+              VALUES (
+                'delete',
+                old.record_id,
+                old.content,
+                old.session_id,
+                old.scope,
+                old.kind,
+                COALESCE(old.role, ''),
+                old.metadata_json
+              );
+              INSERT INTO memory_canonical_records_fts(
+                rowid,
+                content,
+                session_id,
+                scope,
+                kind,
+                role,
+                metadata_json
+              )
+              VALUES (
+                new.record_id,
+                new.content,
+                new.session_id,
+                new.scope,
+                new.kind,
+                COALESCE(new.role, ''),
+                new.metadata_json
+              );
             END;
             CREATE TABLE IF NOT EXISTS approval_requests(
               approval_request_id TEXT PRIMARY KEY,
@@ -1511,7 +1591,7 @@ fn open_sqlite_connection_with_diagnostics(
         diagnostics.schema_init_ms = elapsed_ms(schema_init_started_at);
     }
 
-    if user_version < SQLITE_MEMORY_SCHEMA_VERSION {
+    if user_version < SQLITE_MEMORY_SCHEMA_VERSION || !current_schema_ready {
         ensure_turn_session_index_and_state_metadata(&conn)?;
         ensure_approval_lifecycle_tables(&conn)?;
         ensure_session_tool_consent_storage(&mut conn)?;
@@ -1552,11 +1632,15 @@ fn write_sqlite_user_version(conn: &Connection, version: i64) -> Result<(), Stri
 }
 
 fn sqlite_current_schema_objects_ready(conn: &Connection) -> Result<bool, String> {
-    conn.query_row(SQL_COUNT_CURRENT_SCHEMA_OBJECTS, [], |row| {
-        row.get::<_, i64>(0)
-    })
-    .map(|count| count == SQLITE_CURRENT_SCHEMA_OBJECT_COUNT)
-    .map_err(|error| format!("probe sqlite current schema objects failed: {error}"))
+    let object_count = conn
+        .query_row(SQL_COUNT_CURRENT_SCHEMA_OBJECTS, [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(|error| format!("probe sqlite current schema objects failed: {error}"))?;
+    let object_count_ready = object_count == SQLITE_CURRENT_SCHEMA_OBJECT_COUNT;
+    let canonical_fts_ready = !canonical_record_fts_needs_rebuild(conn)?;
+
+    Ok(object_count_ready && canonical_fts_ready)
 }
 
 fn ensure_turn_session_index_and_state_metadata(conn: &Connection) -> Result<(), String> {
@@ -1762,32 +1846,249 @@ fn ensure_canonical_record_storage(conn: &Connection) -> Result<(), String> {
         CREATE INDEX IF NOT EXISTS idx_memory_canonical_records_scope_kind_ts
           ON memory_canonical_records(scope, kind, ts DESC, record_id);
         CREATE VIRTUAL TABLE IF NOT EXISTS memory_canonical_records_fts
-          USING fts5(content, content='memory_canonical_records', content_rowid='record_id');
+          USING fts5(
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json,
+            content='memory_canonical_records',
+            content_rowid='record_id'
+          );
         CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ai
           AFTER INSERT ON memory_canonical_records
         BEGIN
-          INSERT INTO memory_canonical_records_fts(rowid, content)
-          VALUES (new.record_id, new.content);
+          INSERT INTO memory_canonical_records_fts(
+            rowid,
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json
+          )
+          VALUES (
+            new.record_id,
+            new.content,
+            new.session_id,
+            new.scope,
+            new.kind,
+            COALESCE(new.role, ''),
+            new.metadata_json
+          );
         END;
         CREATE TRIGGER IF NOT EXISTS memory_canonical_records_ad
           AFTER DELETE ON memory_canonical_records
         BEGIN
-          INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
-          VALUES ('delete', old.record_id, old.content);
+          INSERT INTO memory_canonical_records_fts(
+            memory_canonical_records_fts,
+            rowid,
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json
+          )
+          VALUES (
+            'delete',
+            old.record_id,
+            old.content,
+            old.session_id,
+            old.scope,
+            old.kind,
+            COALESCE(old.role, ''),
+            old.metadata_json
+          );
         END;
         CREATE TRIGGER IF NOT EXISTS memory_canonical_records_au
           AFTER UPDATE ON memory_canonical_records
         BEGIN
-          INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
-          VALUES ('delete', old.record_id, old.content);
-          INSERT INTO memory_canonical_records_fts(rowid, content)
-          VALUES (new.record_id, new.content);
+          INSERT INTO memory_canonical_records_fts(
+            memory_canonical_records_fts,
+            rowid,
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json
+          )
+          VALUES (
+            'delete',
+            old.record_id,
+            old.content,
+            old.session_id,
+            old.scope,
+            old.kind,
+            COALESCE(old.role, ''),
+            old.metadata_json
+          );
+          INSERT INTO memory_canonical_records_fts(
+            rowid,
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json
+          )
+          VALUES (
+            new.record_id,
+            new.content,
+            new.session_id,
+            new.scope,
+            new.kind,
+            COALESCE(new.role, ''),
+            new.metadata_json
+          );
         END;
         ",
     )
     .map_err(|error| format!("ensure canonical memory storage failed: {error}"))?;
 
+    if canonical_record_fts_needs_rebuild(conn)? {
+        recreate_canonical_record_fts_index(conn)?;
+    }
+
     rebuild_canonical_record_storage_if_needed(conn)?;
+
+    Ok(())
+}
+
+fn canonical_record_fts_needs_rebuild(conn: &Connection) -> Result<bool, String> {
+    let columns = sqlite_table_columns(conn, "memory_canonical_records_fts")?;
+    if columns.is_empty() {
+        return Ok(false);
+    }
+
+    let required_columns = [
+        "content",
+        "session_id",
+        "scope",
+        "kind",
+        "role",
+        "metadata_json",
+    ];
+    let has_all_required_columns = required_columns.iter().all(|required_column| {
+        columns
+            .iter()
+            .any(|current_column| current_column == required_column)
+    });
+
+    Ok(!has_all_required_columns)
+}
+
+fn recreate_canonical_record_fts_index(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "
+        DROP TRIGGER IF EXISTS memory_canonical_records_ai;
+        DROP TRIGGER IF EXISTS memory_canonical_records_ad;
+        DROP TRIGGER IF EXISTS memory_canonical_records_au;
+        DROP TABLE IF EXISTS memory_canonical_records_fts;
+        CREATE VIRTUAL TABLE memory_canonical_records_fts
+          USING fts5(
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json,
+            content='memory_canonical_records',
+            content_rowid='record_id'
+          );
+        CREATE TRIGGER memory_canonical_records_ai
+          AFTER INSERT ON memory_canonical_records
+        BEGIN
+          INSERT INTO memory_canonical_records_fts(
+            rowid,
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json
+          )
+          VALUES (
+            new.record_id,
+            new.content,
+            new.session_id,
+            new.scope,
+            new.kind,
+            COALESCE(new.role, ''),
+            new.metadata_json
+          );
+        END;
+        CREATE TRIGGER memory_canonical_records_ad
+          AFTER DELETE ON memory_canonical_records
+        BEGIN
+          INSERT INTO memory_canonical_records_fts(
+            memory_canonical_records_fts,
+            rowid,
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json
+          )
+          VALUES (
+            'delete',
+            old.record_id,
+            old.content,
+            old.session_id,
+            old.scope,
+            old.kind,
+            COALESCE(old.role, ''),
+            old.metadata_json
+          );
+        END;
+        CREATE TRIGGER memory_canonical_records_au
+          AFTER UPDATE ON memory_canonical_records
+        BEGIN
+          INSERT INTO memory_canonical_records_fts(
+            memory_canonical_records_fts,
+            rowid,
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json
+          )
+          VALUES (
+            'delete',
+            old.record_id,
+            old.content,
+            old.session_id,
+            old.scope,
+            old.kind,
+            COALESCE(old.role, ''),
+            old.metadata_json
+          );
+          INSERT INTO memory_canonical_records_fts(
+            rowid,
+            content,
+            session_id,
+            scope,
+            kind,
+            role,
+            metadata_json
+          )
+          VALUES (
+            new.record_id,
+            new.content,
+            new.session_id,
+            new.scope,
+            new.kind,
+            COALESCE(new.role, ''),
+            new.metadata_json
+          );
+        END;
+        ",
+    )
+    .map_err(|error| format!("recreate canonical memory FTS index failed: {error}"))?;
 
     Ok(())
 }
@@ -3159,6 +3460,7 @@ fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), S
 
     #[derive(Debug)]
     struct PersistedTurnRow {
+        turn_id: i64,
         session_id: String,
         session_turn_index: i64,
         role: String,
@@ -3166,45 +3468,59 @@ fn rebuild_canonical_record_storage_if_needed(conn: &Connection) -> Result<(), S
         ts: i64,
     }
 
-    let mut select_turns = prepare_cached_sqlite_statement(
-        conn,
-        SQL_SELECT_TURNS_FOR_CANONICAL_REBUILD,
-        "prepare canonical rebuild turn query failed",
-    )?;
-    let rows = select_turns
-        .query_map([], |row| {
-            Ok(PersistedTurnRow {
-                session_id: row.get(0)?,
-                session_turn_index: row.get(1)?,
-                role: row.get(2)?,
-                content: row.get(3)?,
-                ts: row.get(4)?,
-            })
-        })
-        .map_err(|error| format!("query canonical rebuild turns failed: {error}"))?;
-    let turns = rows
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| format!("read canonical rebuild turns failed: {error}"))?;
-    drop(select_turns);
-
     conn.execute_batch("SAVEPOINT canonical_rebuild")
         .map_err(|error| format!("begin canonical rebuild savepoint failed: {error}"))?;
 
     let rebuild_result = (|| {
         conn.execute("DELETE FROM memory_canonical_records", [])
             .map_err(|error| format!("clear canonical records before rebuild failed: {error}"))?;
-        for turn in &turns {
-            insert_canonical_record(
+        let mut last_turn_id = 0_i64;
+
+        loop {
+            let mut select_turns = prepare_cached_sqlite_statement(
                 conn,
-                build_canonical_insert_input(
-                    turn.session_id.as_str(),
-                    turn.session_turn_index,
-                    turn.role.as_str(),
-                    turn.content.as_str(),
-                    turn.ts,
-                ),
+                SQL_SELECT_TURNS_FOR_CANONICAL_REBUILD,
+                "prepare canonical rebuild turn query failed",
             )?;
+            let rows = select_turns
+                .query_map(
+                    rusqlite::params![last_turn_id, CANONICAL_REBUILD_BATCH_SIZE],
+                    |row| {
+                        Ok(PersistedTurnRow {
+                            turn_id: row.get(0)?,
+                            session_id: row.get(1)?,
+                            session_turn_index: row.get(2)?,
+                            role: row.get(3)?,
+                            content: row.get(4)?,
+                            ts: row.get(5)?,
+                        })
+                    },
+                )
+                .map_err(|error| format!("query canonical rebuild turns failed: {error}"))?;
+            let turns = rows
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| format!("read canonical rebuild turns failed: {error}"))?;
+            drop(select_turns);
+
+            if turns.is_empty() {
+                break;
+            }
+
+            for turn in &turns {
+                last_turn_id = turn.turn_id;
+                insert_canonical_record(
+                    conn,
+                    build_canonical_insert_input(
+                        turn.session_id.as_str(),
+                        turn.session_turn_index,
+                        turn.role.as_str(),
+                        turn.content.as_str(),
+                        turn.ts,
+                    ),
+                )?;
+            }
         }
+
         Ok(())
     })();
 
@@ -8082,6 +8398,127 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].record.scope, MemoryScope::Workspace);
         assert_eq!(hits[0].record.kind, CanonicalMemoryKind::ImportedProfile);
+        assert_eq!(hits[0].record.metadata["source"], "workspace-import");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn canonical_memory_search_matches_metadata_only_queries() {
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-canonical-memory-metadata-only-search-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("canonical-metadata-only-search.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+
+        let payload = json!({
+            "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "workspace",
+            "kind": "imported_profile",
+            "content": "release checklist",
+            "metadata": {
+                "source": "workspace-import"
+            },
+        })
+        .to_string();
+
+        append_turn_direct("workspace-session", "assistant", &payload, &config)
+            .expect("append structured canonical payload");
+
+        let hits = search_canonical_records_for_recall("workspace-import", 4, None, &config)
+            .expect("search canonical memory by metadata");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].record.scope, MemoryScope::Workspace);
+        assert_eq!(hits[0].record.kind, CanonicalMemoryKind::ImportedProfile);
+        assert_eq!(hits[0].record.metadata["source"], "workspace-import");
+
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ensure_memory_db_ready_repairs_stale_canonical_fts_metadata_schema() {
+        let tmp = std::env::temp_dir().join(format!(
+            "loongclaw-canonical-memory-stale-fts-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let db_path = tmp.join("stale-canonical-fts.sqlite3");
+        let _ = fs::remove_file(&db_path);
+
+        let config = MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..MemoryRuntimeConfig::default()
+        };
+        ensure_memory_db_ready(None, &config).expect("initialize sqlite db");
+
+        let conn = Connection::open(&db_path).expect("open sqlite db");
+        conn.execute_batch(
+            "
+            DROP TRIGGER IF EXISTS memory_canonical_records_ai;
+            DROP TRIGGER IF EXISTS memory_canonical_records_ad;
+            DROP TRIGGER IF EXISTS memory_canonical_records_au;
+            DROP TABLE IF EXISTS memory_canonical_records_fts;
+            CREATE VIRTUAL TABLE memory_canonical_records_fts
+              USING fts5(content, content='memory_canonical_records', content_rowid='record_id');
+            CREATE TRIGGER memory_canonical_records_ai
+              AFTER INSERT ON memory_canonical_records
+            BEGIN
+              INSERT INTO memory_canonical_records_fts(rowid, content)
+              VALUES (new.record_id, new.content);
+            END;
+            CREATE TRIGGER memory_canonical_records_ad
+              AFTER DELETE ON memory_canonical_records
+            BEGIN
+              INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
+              VALUES ('delete', old.record_id, old.content);
+            END;
+            CREATE TRIGGER memory_canonical_records_au
+              AFTER UPDATE ON memory_canonical_records
+            BEGIN
+              INSERT INTO memory_canonical_records_fts(memory_canonical_records_fts, rowid, content)
+              VALUES ('delete', old.record_id, old.content);
+              INSERT INTO memory_canonical_records_fts(rowid, content)
+              VALUES (new.record_id, new.content);
+            END;
+            PRAGMA user_version = 8;
+            ",
+        )
+        .expect("degrade canonical FTS schema");
+        drop(conn);
+
+        let payload = json!({
+            "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "workspace",
+            "kind": "imported_profile",
+            "content": "release checklist",
+            "metadata": {
+                "source": "workspace-import"
+            },
+        })
+        .to_string();
+        append_turn_direct("workspace-session", "assistant", &payload, &config)
+            .expect("append structured canonical payload");
+
+        ensure_memory_db_ready(None, &config).expect("repair stale canonical FTS schema");
+
+        let hits = search_canonical_records_for_recall("workspace-import", 4, None, &config)
+            .expect("search canonical memory after repair");
+
+        assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].record.metadata["source"], "workspace-import");
 
         let _ = fs::remove_file(&db_path);

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -4298,6 +4298,34 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn runtime_tool_view_includes_memory_search_for_canonical_memory_without_workspace_files() {
+        let runtime_dir = tempdir().expect("tempdir");
+        let db_path = runtime_dir.path().join("memory.sqlite3");
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        crate::memory::append_turn_direct(
+            "canonical-view-session",
+            "assistant",
+            "Rollback checklist includes smoke tests and release notes.",
+            &memory_config,
+        )
+        .expect("append canonical turn");
+
+        let runtime = ToolRuntimeConfig {
+            file_root: None,
+            memory_sqlite_path: Some(db_path),
+            ..ToolRuntimeConfig::default()
+        };
+        let tool_view = runtime_tool_view_for_runtime_config(&runtime);
+
+        assert!(tool_view.contains("memory_search"));
+        assert!(!tool_view.contains("memory_get"));
+    }
+
     #[test]
     fn browser_visibility_gate_is_independent_from_companion_settings() {
         let mut config = ToolRuntimeConfig::default();

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1563,6 +1563,7 @@ fn tool_visibility_gate_enabled_for_delegate_child(
         | ToolVisibilityGate::Browser
         | ToolVisibilityGate::BrowserCompanion
         | ToolVisibilityGate::ExternalSkills
+        | ToolVisibilityGate::MemorySearchCorpus
         | ToolVisibilityGate::MemoryFileRoot
         | ToolVisibilityGate::WebFetch
         | ToolVisibilityGate::WebSearch => {

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -224,6 +224,7 @@ pub enum ToolVisibilityGate {
     BrowserCompanion,
     BashRuntime,
     ExternalSkills,
+    MemorySearchCorpus,
     MemoryFileRoot,
     WebFetch,
     WebSearch,
@@ -1137,11 +1138,11 @@ fn build_tool_catalog() -> ToolCatalog {
             name: "memory_search",
             provider_name: "memory_search",
             aliases: &[],
-            description: "Search durable workspace memory files with bounded citation-bearing snippets",
+            description: "Search durable workspace memory files and canonical cross-session recall with bounded snippets",
             execution_kind: ToolExecutionKind::Core,
             availability: ToolAvailability::Runtime,
             exposure: ToolExposureClass::Discoverable,
-            visibility_gate: ToolVisibilityGate::MemoryFileRoot,
+            visibility_gate: ToolVisibilityGate::MemorySearchCorpus,
             capability_action_class: CapabilityActionClass::ExecuteExisting,
             policy: PARALLEL_SAFE_TOOL_POLICY_DESCRIPTOR,
             provider_definition_builder: memory_search_definition,
@@ -1637,6 +1638,10 @@ fn tool_visibility_gate_enabled_for_runtime_view(
         ToolVisibilityGate::BrowserCompanion => false,
         ToolVisibilityGate::BashRuntime => false,
         ToolVisibilityGate::ExternalSkills => external_skills_enabled,
+        ToolVisibilityGate::MemorySearchCorpus => config
+            .file_root
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
         ToolVisibilityGate::MemoryFileRoot => config
             .file_root
             .as_deref()
@@ -1675,16 +1680,7 @@ fn tool_visibility_gate_enabled_for_runtime_policy(
         ToolVisibilityGate::BrowserCompanion => config.browser_companion.is_runtime_ready(),
         ToolVisibilityGate::BashRuntime => config.bash_exec.is_discoverable(),
         ToolVisibilityGate::ExternalSkills => config.external_skills.enabled,
-        ToolVisibilityGate::MemoryFileRoot => {
-            let has_file_root = config
-                .file_root
-                .as_ref()
-                .is_some_and(|value| !value.as_os_str().is_empty());
-
-            if !has_file_root {
-                return false;
-            }
-
+        ToolVisibilityGate::MemorySearchCorpus => {
             #[cfg(feature = "tool-file")]
             {
                 super::memory_tools::memory_corpus_available(config)
@@ -1692,7 +1688,24 @@ fn tool_visibility_gate_enabled_for_runtime_policy(
 
             #[cfg(not(feature = "tool-file"))]
             {
-                has_file_root
+                config
+                    .file_root
+                    .as_ref()
+                    .is_some_and(|value| !value.as_os_str().is_empty())
+            }
+        }
+        ToolVisibilityGate::MemoryFileRoot => {
+            #[cfg(feature = "tool-file")]
+            {
+                super::memory_tools::workspace_memory_corpus_available(config)
+            }
+
+            #[cfg(not(feature = "tool-file"))]
+            {
+                config
+                    .file_root
+                    .as_ref()
+                    .is_some_and(|value| !value.as_os_str().is_empty())
             }
         }
         ToolVisibilityGate::WebFetch => config.web_fetch.enabled,
@@ -2510,7 +2523,7 @@ fn memory_search_definition(descriptor: &ToolDescriptor) -> Value {
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "Natural-language lookup query for durable workspace memory."
+                        "description": "Natural-language lookup query for durable workspace memory and canonical cross-session recall."
                     },
                     "max_results": {
                         "type": "integer",
@@ -4249,6 +4262,38 @@ mod tests {
         assert!(tool_visibility_gate_enabled_for_runtime_policy(
             ToolVisibilityGate::MemoryFileRoot,
             &visible_runtime
+        ));
+    }
+
+    #[cfg(feature = "memory-sqlite")]
+    #[test]
+    fn memory_search_corpus_visibility_gate_allows_canonical_memory_without_workspace_files() {
+        let runtime_dir = tempdir().expect("tempdir");
+        let db_path = runtime_dir.path().join("memory.sqlite3");
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        crate::memory::append_turn_direct(
+            "canonical-search-gate-session",
+            "assistant",
+            "Rollback checklist includes smoke tests and release notes.",
+            &memory_config,
+        )
+        .expect("append canonical turn");
+
+        let runtime = ToolRuntimeConfig {
+            file_root: None,
+            memory_sqlite_path: Some(db_path),
+            ..ToolRuntimeConfig::default()
+        };
+        assert!(tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::MemorySearchCorpus,
+            &runtime
+        ));
+        assert!(!tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::MemoryFileRoot,
+            &runtime
         ));
     }
 

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeSet;
+#[cfg(not(feature = "tool-file"))]
+use std::path::Path;
 use std::sync::OnceLock;
 
 use serde::Serialize;
@@ -1642,14 +1644,29 @@ fn tool_visibility_gate_enabled_for_runtime_view(
         ToolVisibilityGate::MemorySearchCorpus => config
             .file_root
             .as_deref()
-            .is_some_and(|value| !value.trim().is_empty()),
+            .is_some_and(text_has_non_whitespace_segments),
         ToolVisibilityGate::MemoryFileRoot => config
             .file_root
             .as_deref()
-            .is_some_and(|value| !value.trim().is_empty()),
+            .is_some_and(text_has_non_whitespace_segments),
         ToolVisibilityGate::WebFetch => config.web.enabled,
         ToolVisibilityGate::WebSearch => config.web_search.enabled,
     }
+}
+
+fn text_has_non_whitespace_segments(value: &str) -> bool {
+    !value.trim().is_empty()
+}
+
+#[cfg(not(feature = "tool-file"))]
+fn path_has_non_whitespace_segments<P>(path: P) -> bool
+where
+    P: AsRef<Path>,
+{
+    let path_ref = path.as_ref();
+    let path_text = path_ref.as_os_str().to_string_lossy();
+
+    !path_text.trim().is_empty()
 }
 
 fn tool_visibility_gate_enabled_for_runtime_policy(
@@ -1691,8 +1708,8 @@ fn tool_visibility_gate_enabled_for_runtime_policy(
             {
                 config
                     .file_root
-                    .as_ref()
-                    .is_some_and(|value| !value.as_os_str().is_empty())
+                    .as_deref()
+                    .is_some_and(path_has_non_whitespace_segments)
             }
         }
         ToolVisibilityGate::MemoryFileRoot => {
@@ -1705,8 +1722,8 @@ fn tool_visibility_gate_enabled_for_runtime_policy(
             {
                 config
                     .file_root
-                    .as_ref()
-                    .is_some_and(|value| !value.as_os_str().is_empty())
+                    .as_deref()
+                    .is_some_and(path_has_non_whitespace_segments)
             }
         }
         ToolVisibilityGate::WebFetch => config.web_fetch.enabled,
@@ -4263,6 +4280,32 @@ mod tests {
         assert!(tool_visibility_gate_enabled_for_runtime_policy(
             ToolVisibilityGate::MemoryFileRoot,
             &visible_runtime
+        ));
+    }
+
+    #[test]
+    fn memory_file_root_visibility_gate_rejects_whitespace_only_paths() {
+        let view_config = ToolConfig {
+            file_root: Some("   ".to_owned()),
+            ..ToolConfig::default()
+        };
+        let runtime_config = ToolRuntimeConfig {
+            file_root: Some(std::path::PathBuf::from("   ")),
+            ..ToolRuntimeConfig::default()
+        };
+
+        assert!(!tool_visibility_gate_enabled_for_runtime_view(
+            ToolVisibilityGate::MemoryFileRoot,
+            &view_config,
+            false
+        ));
+        assert!(!tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::MemoryFileRoot,
+            &runtime_config
+        ));
+        assert!(!tool_visibility_gate_enabled_for_runtime_policy(
+            ToolVisibilityGate::MemorySearchCorpus,
+            &runtime_config
         ));
     }
 

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -547,3 +547,69 @@ fn trim_trailing_line_endings(line: &str) -> &str {
     let without_carriage_return = without_newline.strip_suffix('\r');
     without_carriage_return.unwrap_or(without_newline)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::unique_temp_dir;
+
+    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
+    #[test]
+    fn memory_search_tool_returns_cross_session_canonical_hits_without_workspace_root() {
+        let root = unique_temp_dir("loongclaw-memory-search-canonical");
+        let db_path = root.join("memory.sqlite3");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        crate::memory::append_turn_direct(
+            "release-session",
+            "assistant",
+            "Deployment cutoff is 17:00 Beijing time and requires a release note.",
+            &memory_config,
+        )
+        .expect("append canonical assistant turn");
+
+        let runtime_config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: None,
+            memory_sqlite_path: Some(db_path),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "deployment cutoff release note",
+                    "max_results": 4
+                }),
+            },
+            &runtime_config,
+        )
+        .expect("memory search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["source"], "canonical_session");
+        assert_eq!(results[0]["session_id"], "release-session");
+        assert_eq!(results[0]["scope"], "session");
+        assert_eq!(results[0]["kind"], "assistant_turn");
+        assert_eq!(results[0]["role"], "assistant");
+        assert!(
+            results[0]["path"].is_null(),
+            "canonical search should not synthesize a file path: {results:?}"
+        );
+        assert!(
+            results[0]["start_line"].is_null() && results[0]["end_line"].is_null(),
+            "canonical search should not report line windows: {results:?}"
+        );
+        assert!(
+            results[0]["snippet"]
+                .as_str()
+                .is_some_and(|value| value.contains("17:00 Beijing time")),
+            "expected canonical snippet in result payload: {results:?}"
+        );
+    }
+}

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -507,7 +507,7 @@ fn search_canonical_memory_results(
     Ok(hits
         .into_iter()
         .map(|hit| {
-            let score = line_match_score(query, query_tokens, hit.record.content.as_str());
+            let score = canonical_memory_match_score(query, query_tokens, &hit);
             let scope = hit.record.scope.as_str().to_owned();
             let kind = hit.record.kind.as_str().to_owned();
             MemorySearchResult {
@@ -523,8 +523,35 @@ fn search_canonical_memory_results(
                 score,
             }
         })
-        .filter(|result| result.score > 0)
         .collect())
+}
+
+fn canonical_memory_match_score(
+    query: &str,
+    query_tokens: &[String],
+    hit: &crate::memory::CanonicalMemorySearchHit,
+) -> u32 {
+    let content_score = line_match_score(query, query_tokens, hit.record.content.as_str());
+    let session_id_score = line_match_score(query, query_tokens, hit.record.session_id.as_str());
+    let scope_score = line_match_score(query, query_tokens, hit.record.scope.as_str());
+    let kind_score = line_match_score(query, query_tokens, hit.record.kind.as_str());
+    let role_score = hit
+        .record
+        .role
+        .as_deref()
+        .map(|value| line_match_score(query, query_tokens, value))
+        .unwrap_or(0);
+    let metadata_text = hit.record.metadata.to_string();
+    let metadata_score = line_match_score(query, query_tokens, metadata_text.as_str());
+
+    let strongest_metadata_score = session_id_score
+        .max(scope_score)
+        .max(kind_score)
+        .max(role_score)
+        .max(metadata_score);
+    let strongest_score = content_score.max(strongest_metadata_score);
+
+    strongest_score.max(1)
 }
 
 fn memory_search_result_payload(result: &MemorySearchResult) -> Value {
@@ -610,6 +637,66 @@ mod tests {
                 .as_str()
                 .is_some_and(|value| value.contains("17:00 Beijing time")),
             "expected canonical snippet in result payload: {results:?}"
+        );
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
+    #[test]
+    fn memory_search_tool_preserves_metadata_only_canonical_hits() {
+        let root = unique_temp_dir("loongclaw-memory-search-canonical-metadata");
+        let db_path = root.join("memory.sqlite3");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        let payload = json!({
+            "type": crate::memory::CANONICAL_MEMORY_RECORD_TYPE,
+            "_loongclaw_internal": true,
+            "scope": "workspace",
+            "kind": "imported_profile",
+            "content": "release checklist",
+            "metadata": {
+                "source": "workspace-import"
+            },
+        })
+        .to_string();
+        crate::memory::append_turn_direct(
+            "metadata-session",
+            "assistant",
+            &payload,
+            &memory_config,
+        )
+        .expect("append structured canonical turn");
+
+        let runtime_config = super::super::runtime_config::ToolRuntimeConfig {
+            file_root: None,
+            memory_sqlite_path: Some(db_path),
+            ..super::super::runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = super::super::execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "workspace-import",
+                    "max_results": 4
+                }),
+            },
+            &runtime_config,
+        )
+        .expect("memory search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["source"], "canonical_session");
+        assert_eq!(results[0]["session_id"], "metadata-session");
+        assert_eq!(results[0]["scope"], "workspace");
+        assert_eq!(results[0]["kind"], "imported_profile");
+        assert!(
+            results[0]["score"].as_u64().is_some_and(|value| value > 0),
+            "metadata-only matches should keep a stable score: {results:?}"
         );
     }
 }

--- a/crates/app/src/tools/memory_tools.rs
+++ b/crates/app/src/tools/memory_tools.rs
@@ -15,9 +15,14 @@ const MAX_MEMORY_GET_LINES: usize = 200;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct MemorySearchResult {
-    path: String,
-    start_line: usize,
-    end_line: usize,
+    source: &'static str,
+    path: Option<String>,
+    session_id: Option<String>,
+    scope: Option<String>,
+    kind: Option<String>,
+    role: Option<String>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
     snippet: String,
     score: u32,
 }
@@ -60,29 +65,38 @@ pub(super) fn execute_memory_search_tool_with_config(
         Some(MAX_MEMORY_SEARCH_RESULTS),
     )?;
 
-    let workspace_root = workspace_root_from_config(config)?;
-    let locations = collect_workspace_memory_document_locations(workspace_root)?;
     let query_normalized = query.to_ascii_lowercase();
     let query_tokens = tokenize_memory_query(query_normalized.as_str());
 
     let mut results = Vec::new();
-    for location in locations {
-        let maybe_result = search_memory_location(
-            query_normalized.as_str(),
-            query_tokens.as_slice(),
-            &location,
-        )?;
-        let Some(result) = maybe_result else {
-            continue;
-        };
-        results.push(result);
+    if let Some(workspace_root) = config.file_root.as_deref() {
+        let locations = collect_workspace_memory_document_locations(workspace_root)?;
+        for location in locations {
+            let maybe_result = search_memory_location(
+                query_normalized.as_str(),
+                query_tokens.as_slice(),
+                &location,
+            )?;
+            let Some(result) = maybe_result else {
+                continue;
+            };
+            results.push(result);
+        }
     }
+    results.extend(search_canonical_memory_results(
+        query_normalized.as_str(),
+        query_tokens.as_slice(),
+        max_results,
+        config,
+    )?);
 
     results.sort_by(|left, right| {
         right
             .score
             .cmp(&left.score)
+            .then(left.source.cmp(right.source))
             .then(left.path.cmp(&right.path))
+            .then(left.session_id.cmp(&right.session_id))
             .then(left.start_line.cmp(&right.start_line))
     });
 
@@ -180,16 +194,35 @@ pub(super) fn execute_memory_get_tool_with_config(
 }
 
 pub(super) fn memory_corpus_available(config: &super::runtime_config::ToolRuntimeConfig) -> bool {
-    let Some(workspace_root) = config.file_root.as_deref() else {
-        return false;
-    };
+    let workspace_memory_available = workspace_memory_corpus_available(config);
 
-    let result = collect_workspace_memory_document_locations(workspace_root);
-    let Ok(locations) = result else {
-        return false;
-    };
+    if workspace_memory_available {
+        return true;
+    }
 
-    !locations.is_empty()
+    config
+        .memory_sqlite_path
+        .as_deref()
+        .is_some_and(|path| path.exists())
+}
+
+pub(super) fn workspace_memory_corpus_available(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> bool {
+    config
+        .file_root
+        .as_deref()
+        .and_then(|workspace_root| collect_workspace_memory_document_locations(workspace_root).ok())
+        .is_some_and(|locations| !locations.is_empty())
+}
+
+fn workspace_root_from_config(
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<&Path, String> {
+    config.file_root.as_deref().ok_or_else(|| {
+        "memory tools require a configured safe file root before they can access workspace durable memory"
+            .to_owned()
+    })
 }
 
 fn read_memory_file_window(
@@ -239,15 +272,6 @@ fn read_memory_file_window(
     };
 
     Ok(file_window)
-}
-
-fn workspace_root_from_config(
-    config: &super::runtime_config::ToolRuntimeConfig,
-) -> Result<&Path, String> {
-    config.file_root.as_deref().ok_or_else(|| {
-        "memory tools require a configured safe file root before they can access workspace durable memory"
-            .to_owned()
-    })
 }
 
 fn parse_optional_usize_field(
@@ -347,9 +371,14 @@ fn search_memory_location(
     let snippet = snippet_lines.join("\n");
 
     let result = MemorySearchResult {
-        path: location.label.clone(),
-        start_line,
-        end_line,
+        source: "workspace_file",
+        path: Some(location.label.clone()),
+        session_id: None,
+        scope: None,
+        kind: None,
+        role: None,
+        start_line: Some(start_line),
+        end_line: Some(end_line),
         snippet,
         score: best_match.score,
     };
@@ -456,9 +485,56 @@ fn normalized_existing_path_key(path: &Path) -> Result<String, String> {
     Ok(canonical_path.display().to_string())
 }
 
+fn search_canonical_memory_results(
+    query: &str,
+    query_tokens: &[String],
+    max_results: usize,
+    config: &super::runtime_config::ToolRuntimeConfig,
+) -> Result<Vec<MemorySearchResult>, String> {
+    let Some(sqlite_path) = config.memory_sqlite_path.as_ref() else {
+        return Ok(Vec::new());
+    };
+    if !sqlite_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+        sqlite_path: Some(sqlite_path.clone()),
+        ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+    };
+    let hits = crate::memory::search_canonical_memory(query, max_results, None, &memory_config)?;
+
+    Ok(hits
+        .into_iter()
+        .map(|hit| {
+            let score = line_match_score(query, query_tokens, hit.record.content.as_str());
+            let scope = hit.record.scope.as_str().to_owned();
+            let kind = hit.record.kind.as_str().to_owned();
+            MemorySearchResult {
+                source: "canonical_session",
+                path: None,
+                session_id: Some(hit.record.session_id),
+                scope: Some(scope),
+                kind: Some(kind),
+                role: hit.record.role,
+                start_line: None,
+                end_line: None,
+                snippet: hit.record.content,
+                score,
+            }
+        })
+        .filter(|result| result.score > 0)
+        .collect())
+}
+
 fn memory_search_result_payload(result: &MemorySearchResult) -> Value {
     json!({
+        "source": result.source,
         "path": result.path,
+        "session_id": result.session_id,
+        "scope": result.scope,
+        "kind": result.kind,
+        "role": result.role,
         "start_line": result.start_line,
         "end_line": result.end_line,
         "snippet": result.snippet,

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -582,17 +582,11 @@ pub fn runtime_tool_view_from_loongclaw_config(
     runtime_tool_view_with_runtime_config(&config.tools, &runtime_config)
 }
 
-fn build_runtime_tool_view_for_runtime_config(
-    runtime_config: &runtime_config::ToolRuntimeConfig,
-) -> ToolView {
-    runtime_tool_view_for_runtime_config(runtime_config)
-}
-
 pub(crate) fn runtime_tool_view_with_runtime_config(
     _tool_config: &crate::config::ToolConfig,
     runtime_config: &runtime_config::ToolRuntimeConfig,
 ) -> ToolView {
-    build_runtime_tool_view_for_runtime_config(runtime_config)
+    runtime_tool_view_for_runtime_config(runtime_config)
 }
 
 /// Build a tool view from runtime config (respecting runtime toggles) plus
@@ -601,7 +595,7 @@ pub(crate) fn runtime_tool_view_with_runtime_config(
 fn full_runtime_tool_view_for_runtime_config(
     config: &runtime_config::ToolRuntimeConfig,
 ) -> ToolView {
-    build_runtime_tool_view_for_runtime_config(config)
+    runtime_tool_view_for_runtime_config(config)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2722,36 +2716,6 @@ mod tests {
         assert!(tool_view.contains("memory_get"));
     }
 
-    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
-    #[test]
-    fn runtime_tool_view_includes_memory_search_for_canonical_memory_without_workspace_files() {
-        let root = unique_tool_temp_dir("loongclaw-memory-tool-view-canonical");
-        let db_path = root.join("memory.sqlite3");
-
-        std::fs::create_dir_all(&root).expect("create root dir");
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
-        crate::memory::append_turn_direct(
-            "canonical-view-session",
-            "assistant",
-            "Rollback checklist includes smoke tests and release notes.",
-            &memory_config,
-        )
-        .expect("append canonical turn");
-
-        let config = runtime_config::ToolRuntimeConfig {
-            file_root: None,
-            memory_sqlite_path: Some(db_path),
-            ..runtime_config::ToolRuntimeConfig::default()
-        };
-        let tool_view = runtime_tool_view_for_runtime_config(&config);
-
-        assert!(tool_view.contains("memory_search"));
-        assert!(!tool_view.contains("memory_get"));
-    }
-
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_search_returns_discoverable_tools_with_leases() {
@@ -2923,66 +2887,6 @@ mod tests {
                 .iter()
                 .all(|entry| entry["source"] == "workspace_file"),
             "expected workspace-file results only: {results:?}"
-        );
-    }
-
-    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
-    #[test]
-    fn memory_search_tool_returns_cross_session_canonical_hits_without_workspace_root() {
-        let root = unique_tool_temp_dir("loongclaw-memory-search-canonical");
-        let db_path = root.join("memory.sqlite3");
-
-        std::fs::create_dir_all(&root).expect("create root dir");
-
-        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
-            sqlite_path: Some(db_path.clone()),
-            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
-        };
-        crate::memory::append_turn_direct(
-            "release-session",
-            "assistant",
-            "Deployment cutoff is 17:00 Beijing time and requires a release note.",
-            &memory_config,
-        )
-        .expect("append canonical assistant turn");
-
-        let config = runtime_config::ToolRuntimeConfig {
-            file_root: None,
-            memory_sqlite_path: Some(db_path),
-            ..runtime_config::ToolRuntimeConfig::default()
-        };
-        let outcome = execute_tool_core_with_config(
-            ToolCoreRequest {
-                tool_name: "memory_search".to_owned(),
-                payload: json!({
-                    "query": "deployment cutoff release note",
-                    "max_results": 4
-                }),
-            },
-            &config,
-        )
-        .expect("memory search should succeed");
-
-        let results = outcome.payload["results"].as_array().expect("results");
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0]["source"], "canonical_session");
-        assert_eq!(results[0]["session_id"], "release-session");
-        assert_eq!(results[0]["scope"], "session");
-        assert_eq!(results[0]["kind"], "assistant_turn");
-        assert_eq!(results[0]["role"], "assistant");
-        assert!(
-            results[0]["path"].is_null(),
-            "canonical search should not synthesize a file path: {results:?}"
-        );
-        assert!(
-            results[0]["start_line"].is_null() && results[0]["end_line"].is_null(),
-            "canonical search should not report line windows: {results:?}"
-        );
-        assert!(
-            results[0]["snippet"]
-                .as_str()
-                .is_some_and(|value| value.contains("17:00 Beijing time")),
-            "expected canonical snippet in result payload: {results:?}"
         );
     }
 

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -1291,7 +1291,9 @@ fn tool_search_entry_is_runtime_usable(
         | "external_skills.list"
         | "external_skills.remove" => config.external_skills.enabled,
         #[cfg(feature = "tool-file")]
-        "memory_search" | "memory_get" => memory_tools::memory_corpus_available(config),
+        "memory_search" => memory_tools::memory_corpus_available(config),
+        #[cfg(feature = "tool-file")]
+        "memory_get" => memory_tools::workspace_memory_corpus_available(config),
         _ => true,
     }
 }
@@ -2720,6 +2722,36 @@ mod tests {
         assert!(tool_view.contains("memory_get"));
     }
 
+    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
+    #[test]
+    fn runtime_tool_view_includes_memory_search_for_canonical_memory_without_workspace_files() {
+        let root = unique_tool_temp_dir("loongclaw-memory-tool-view-canonical");
+        let db_path = root.join("memory.sqlite3");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        crate::memory::append_turn_direct(
+            "canonical-view-session",
+            "assistant",
+            "Rollback checklist includes smoke tests and release notes.",
+            &memory_config,
+        )
+        .expect("append canonical turn");
+
+        let config = runtime_config::ToolRuntimeConfig {
+            file_root: None,
+            memory_sqlite_path: Some(db_path),
+            ..runtime_config::ToolRuntimeConfig::default()
+        };
+        let tool_view = runtime_tool_view_for_runtime_config(&config);
+
+        assert!(tool_view.contains("memory_search"));
+        assert!(!tool_view.contains("memory_get"));
+    }
+
     #[cfg(all(feature = "tool-file", feature = "tool-shell"))]
     #[test]
     fn tool_search_returns_discoverable_tools_with_leases() {
@@ -2885,6 +2917,72 @@ mod tests {
                 .as_str()
                 .is_some_and(|value| !value.is_empty())),
             "expected non-empty snippets: {results:?}"
+        );
+        assert!(
+            results
+                .iter()
+                .all(|entry| entry["source"] == "workspace_file"),
+            "expected workspace-file results only: {results:?}"
+        );
+    }
+
+    #[cfg(all(feature = "tool-file", feature = "memory-sqlite"))]
+    #[test]
+    fn memory_search_tool_returns_cross_session_canonical_hits_without_workspace_root() {
+        let root = unique_tool_temp_dir("loongclaw-memory-search-canonical");
+        let db_path = root.join("memory.sqlite3");
+
+        std::fs::create_dir_all(&root).expect("create root dir");
+
+        let memory_config = crate::memory::runtime_config::MemoryRuntimeConfig {
+            sqlite_path: Some(db_path.clone()),
+            ..crate::memory::runtime_config::MemoryRuntimeConfig::default()
+        };
+        crate::memory::append_turn_direct(
+            "release-session",
+            "assistant",
+            "Deployment cutoff is 17:00 Beijing time and requires a release note.",
+            &memory_config,
+        )
+        .expect("append canonical assistant turn");
+
+        let config = runtime_config::ToolRuntimeConfig {
+            file_root: None,
+            memory_sqlite_path: Some(db_path),
+            ..runtime_config::ToolRuntimeConfig::default()
+        };
+        let outcome = execute_tool_core_with_config(
+            ToolCoreRequest {
+                tool_name: "memory_search".to_owned(),
+                payload: json!({
+                    "query": "deployment cutoff release note",
+                    "max_results": 4
+                }),
+            },
+            &config,
+        )
+        .expect("memory search should succeed");
+
+        let results = outcome.payload["results"].as_array().expect("results");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["source"], "canonical_session");
+        assert_eq!(results[0]["session_id"], "release-session");
+        assert_eq!(results[0]["scope"], "session");
+        assert_eq!(results[0]["kind"], "assistant_turn");
+        assert_eq!(results[0]["role"], "assistant");
+        assert!(
+            results[0]["path"].is_null(),
+            "canonical search should not synthesize a file path: {results:?}"
+        );
+        assert!(
+            results[0]["start_line"].is_null() && results[0]["end_line"].is_null(),
+            "canonical search should not report line windows: {results:?}"
+        );
+        assert!(
+            results[0]["snippet"]
+                .as_str()
+                .is_some_and(|value| value.contains("17:00 Beijing time")),
+            "expected canonical snippet in result payload: {results:?}"
         );
     }
 

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -1818,6 +1818,7 @@ mod tests {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let mut env = ScopedEnv::new();
         env.set("HOME", tempdir.path());
+        env.remove("LOONGCLAW_HOME");
         let config_path = tempdir.path().join("loongclaw.toml");
 
         let runtime = ToolRuntimeConfig::from_loongclaw_config(

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -638,6 +638,7 @@ impl ToolExecutionConfig {
 #[derive(Debug, Clone)]
 pub struct ToolRuntimeConfig {
     pub file_root: Option<PathBuf>,
+    pub memory_sqlite_path: Option<PathBuf>,
     pub shell_allow: BTreeSet<String>,
     pub shell_deny: BTreeSet<String>,
     pub shell_default_mode: ShellPolicyDefault,
@@ -663,6 +664,7 @@ impl Default for ToolRuntimeConfig {
     fn default() -> Self {
         Self {
             file_root: None,
+            memory_sqlite_path: None,
             shell_allow: crate::config::DEFAULT_SHELL_ALLOW
                 .iter()
                 .map(|s| (*s).to_owned())
@@ -716,6 +718,7 @@ impl ToolRuntimeConfig {
         );
         Self {
             file_root: Some(config.tools.resolved_file_root()),
+            memory_sqlite_path: Some(config.memory.resolved_sqlite_path()),
             shell_allow,
             shell_deny,
             shell_default_mode: ShellPolicyDefault::parse(&config.tools.shell_default_mode),
@@ -847,6 +850,9 @@ impl ToolRuntimeConfig {
     /// `LOONGCLAW_FILE_ROOT`.
     pub fn from_env() -> Self {
         let file_root = std::env::var("LOONGCLAW_FILE_ROOT").ok().map(PathBuf::from);
+        let memory_sqlite_path = std::env::var("LOONGCLAW_SQLITE_PATH")
+            .ok()
+            .map(PathBuf::from);
         let config_path = std::env::var("LOONGCLAW_CONFIG_PATH")
             .ok()
             .map(PathBuf::from);
@@ -990,6 +996,7 @@ impl ToolRuntimeConfig {
 
         Self {
             file_root,
+            memory_sqlite_path,
             shell_allow,
             shell_deny,
             shell_default_mode: ShellPolicyDefault::Deny,
@@ -1550,6 +1557,7 @@ mod tests {
         for key in [
             "LOONGCLAW_CONFIG_PATH",
             "LOONGCLAW_FILE_ROOT",
+            "LOONGCLAW_SQLITE_PATH",
             "LOONGCLAW_TOOL_SESSIONS_ENABLED",
             "LOONGCLAW_TOOL_SESSIONS_ALLOW_MUTATION",
             "LOONGCLAW_TOOL_MESSAGES_ENABLED",
@@ -2039,6 +2047,31 @@ mod tests {
             ..ToolRuntimeConfig::default()
         };
         assert_eq!(config.file_root, Some(PathBuf::from("/tmp/test-root")));
+    }
+
+    #[test]
+    fn memory_sqlite_path_uses_injected_config() {
+        let config = crate::config::LoongClawConfig::default();
+        let runtime = ToolRuntimeConfig::from_loongclaw_config(&config, None);
+
+        assert_eq!(
+            runtime.memory_sqlite_path,
+            Some(config.memory.resolved_sqlite_path())
+        );
+    }
+
+    #[test]
+    fn memory_sqlite_path_from_env_uses_legacy_override() {
+        let mut env = ScopedEnv::new();
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONGCLAW_SQLITE_PATH", "/tmp/tool-runtime-memory.sqlite3");
+
+        let runtime = ToolRuntimeConfig::from_env();
+
+        assert_eq!(
+            runtime.memory_sqlite_path,
+            Some(PathBuf::from("/tmp/tool-runtime-memory.sqlite3"))
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -850,9 +850,13 @@ impl ToolRuntimeConfig {
     /// `LOONGCLAW_FILE_ROOT`.
     pub fn from_env() -> Self {
         let file_root = std::env::var("LOONGCLAW_FILE_ROOT").ok().map(PathBuf::from);
-        let memory_sqlite_path = std::env::var("LOONGCLAW_SQLITE_PATH")
-            .ok()
+        let memory_sqlite_path = std::env::var_os("LOONGCLAW_SQLITE_PATH")
+            .filter(|value| !value.is_empty())
             .map(PathBuf::from);
+        let memory_sqlite_path = memory_sqlite_path.or_else(|| {
+            let default_config = crate::config::LoongClawConfig::default();
+            Some(default_config.memory.resolved_sqlite_path())
+        });
         let config_path = std::env::var("LOONGCLAW_CONFIG_PATH")
             .ok()
             .map(PathBuf::from);
@@ -2072,6 +2076,37 @@ mod tests {
         assert_eq!(
             runtime.memory_sqlite_path,
             Some(PathBuf::from("/tmp/tool-runtime-memory.sqlite3"))
+        );
+    }
+
+    #[test]
+    fn memory_sqlite_path_from_env_falls_back_to_loongclaw_home() {
+        let mut env = ScopedEnv::new();
+        let runtime_home = std::env::temp_dir().join("loongclaw-tool-runtime-home");
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONGCLAW_HOME", &runtime_home);
+
+        let runtime = ToolRuntimeConfig::from_env();
+
+        assert_eq!(
+            runtime.memory_sqlite_path,
+            Some(runtime_home.join("memory.sqlite3"))
+        );
+    }
+
+    #[test]
+    fn empty_legacy_memory_sqlite_path_falls_back_to_loongclaw_home() {
+        let mut env = ScopedEnv::new();
+        let runtime_home = std::env::temp_dir().join("loongclaw-tool-runtime-empty-sqlite-path");
+        clear_tool_runtime_env(&mut env);
+        env.set("LOONGCLAW_HOME", &runtime_home);
+        env.set("LOONGCLAW_SQLITE_PATH", "");
+
+        let runtime = ToolRuntimeConfig::from_env();
+
+        assert_eq!(
+            runtime.memory_sqlite_path,
+            Some(runtime_home.join("memory.sqlite3"))
         );
     }
 

--- a/crates/app/src/tools/tests/bash_exec_tests.rs
+++ b/crates/app/src/tools/tests/bash_exec_tests.rs
@@ -358,6 +358,7 @@ fn bash_exec_uses_loongclaw_home_rules_dir_even_when_runtime_is_built_without_co
 
     let mut env = ScopedEnv::new();
     env.set("HOME", &home);
+    env.remove("LOONGCLAW_HOME");
     let _cwd = ScopedCurrentDir::new(&workspace);
 
     let mut runtime = runtime_config::ToolRuntimeConfig::from_loongclaw_config(

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -1,9 +1,10 @@
 use std::io::ErrorKind;
-use std::process::{Command as BlockingCommand, Output, Stdio};
+use std::process::Output;
 use std::time::Duration;
 
 use loongclaw_app as mvp;
-use wait_timeout::ChildExt;
+use tokio::process::Command;
+use tokio::time::timeout;
 
 pub(crate) const BROWSER_COMPANION_INSTALL_CHECK_NAME: &str = "browser companion install";
 pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser companion runtime gate";
@@ -13,6 +14,15 @@ const BROWSER_COMPANION_PROBE_ATTEMPTS: usize = 3;
 
 fn browser_companion_probe_timeout_seconds(timeout_seconds: u64) -> u64 {
     timeout_seconds.max(1)
+}
+
+fn browser_companion_probe_timeout_duration(timeout_seconds: u64) -> Duration {
+    let normalized_seconds = browser_companion_probe_timeout_seconds(timeout_seconds);
+    let base_duration = Duration::from_secs(normalized_seconds);
+    let slack_millis = normalized_seconds.saturating_mul(100);
+    let bounded_slack_millis = slack_millis.min(500);
+    let slack_duration = Duration::from_millis(bounded_slack_millis);
+    base_duration + slack_duration
 }
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
@@ -230,83 +240,30 @@ async fn probe_browser_companion_version(
     command: &str,
     timeout_seconds: u64,
 ) -> Result<String, BrowserCompanionProbeError> {
-    let command = command.to_owned();
-    let join_result = tokio::task::spawn_blocking(move || {
-        for _attempt in 0..BROWSER_COMPANION_PROBE_ATTEMPTS {
-            let probe_result =
-                probe_browser_companion_version_once(command.as_str(), timeout_seconds);
-            match probe_result {
-                Err(BrowserCompanionProbeError::TimedOut) => {}
-                result => {
-                    return result;
+    let timeout_duration = browser_companion_probe_timeout_duration(timeout_seconds);
+
+    for _attempt in 0..BROWSER_COMPANION_PROBE_ATTEMPTS {
+        let mut probe = Command::new(command);
+        probe.arg(BROWSER_COMPANION_VERSION_ARG);
+        probe.kill_on_drop(true);
+
+        let probe_result = timeout(timeout_duration, probe.output()).await;
+        match probe_result {
+            Ok(Ok(output)) => {
+                return interpret_browser_companion_probe_output(output);
+            }
+            Ok(Err(error)) => {
+                if error.kind() == ErrorKind::NotFound {
+                    return Err(BrowserCompanionProbeError::MissingBinary);
                 }
+
+                let error_message = error.to_string();
+                return Err(BrowserCompanionProbeError::SpawnFailed(error_message));
             }
-        }
-
-        Err(BrowserCompanionProbeError::TimedOut)
-    })
-    .await;
-
-    match join_result {
-        Ok(result) => result,
-        Err(error) => Err(BrowserCompanionProbeError::SpawnFailed(error.to_string())),
-    }
-}
-
-fn probe_browser_companion_version_once(
-    command: &str,
-    timeout_seconds: u64,
-) -> Result<String, BrowserCompanionProbeError> {
-    let child = spawn_browser_companion_probe_process(command)?;
-    let output = wait_for_browser_companion_probe_output(child, timeout_seconds)?;
-    interpret_browser_companion_probe_output(output)
-}
-
-fn spawn_browser_companion_probe_process(
-    command: &str,
-) -> Result<std::process::Child, BrowserCompanionProbeError> {
-    let mut process = BlockingCommand::new(command);
-    process.arg(BROWSER_COMPANION_VERSION_ARG);
-    process.stdin(Stdio::null());
-    process.stdout(Stdio::piped());
-    process.stderr(Stdio::piped());
-
-    let spawn_result = process.spawn();
-    match spawn_result {
-        Ok(child) => Ok(child),
-        Err(error) => {
-            if error.kind() == ErrorKind::NotFound {
-                return Err(BrowserCompanionProbeError::MissingBinary);
-            }
-
-            let error_message = error.to_string();
-            Err(BrowserCompanionProbeError::SpawnFailed(error_message))
+            Err(_) => {}
         }
     }
-}
 
-fn wait_for_browser_companion_probe_output(
-    mut child: std::process::Child,
-    timeout_seconds: u64,
-) -> Result<Output, BrowserCompanionProbeError> {
-    let timeout_seconds = browser_companion_probe_timeout_seconds(timeout_seconds);
-    let timeout_duration = Duration::from_secs(timeout_seconds);
-    let wait_result = child.wait_timeout(timeout_duration);
-    let status_option = wait_result.map_err(|error| {
-        let error_message = error.to_string();
-        BrowserCompanionProbeError::SpawnFailed(error_message)
-    })?;
-
-    if status_option.is_some() {
-        let output_result = child.wait_with_output();
-        return output_result.map_err(|error| {
-            let error_message = error.to_string();
-            BrowserCompanionProbeError::SpawnFailed(error_message)
-        });
-    }
-
-    let _ = child.kill();
-    let _ = child.wait();
     Err(BrowserCompanionProbeError::TimedOut)
 }
 

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -1,8 +1,11 @@
 use std::io::ErrorKind;
 use std::process::Output;
+use std::process::Stdio;
 use std::time::Duration;
 
 use loongclaw_app as mvp;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -22,7 +25,7 @@ fn browser_companion_probe_timeout_duration(timeout_seconds: u64) -> Duration {
     let slack_millis = normalized_seconds.saturating_mul(100);
     let bounded_slack_millis = slack_millis.min(500);
     let slack_duration = Duration::from_millis(bounded_slack_millis);
-    base_duration + slack_duration
+    base_duration.saturating_add(slack_duration)
 }
 
 // Shared readiness snapshot for doctor/onboard so the companion lane is probed once.
@@ -246,10 +249,30 @@ async fn probe_browser_companion_version(
         let mut probe = Command::new(command);
         probe.arg(BROWSER_COMPANION_VERSION_ARG);
         probe.kill_on_drop(true);
+        probe.stdout(Stdio::piped());
+        probe.stderr(Stdio::piped());
 
-        let probe_result = timeout(timeout_duration, probe.output()).await;
+        let mut child = match probe.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                if error.kind() == ErrorKind::NotFound {
+                    return Err(BrowserCompanionProbeError::MissingBinary);
+                }
+
+                let error_message = error.to_string();
+                return Err(BrowserCompanionProbeError::SpawnFailed(error_message));
+            }
+        };
+        let probe_result = timeout(timeout_duration, child.wait()).await;
         match probe_result {
-            Ok(Ok(output)) => {
+            Ok(Ok(status)) => {
+                let stdout = read_probe_pipe(&mut child.stdout).await?;
+                let stderr = read_probe_pipe(&mut child.stderr).await?;
+                let output = Output {
+                    status,
+                    stdout,
+                    stderr,
+                };
                 return interpret_browser_companion_probe_output(output);
             }
             Ok(Err(error)) => {
@@ -260,11 +283,31 @@ async fn probe_browser_companion_version(
                 let error_message = error.to_string();
                 return Err(BrowserCompanionProbeError::SpawnFailed(error_message));
             }
-            Err(_) => {}
+            Err(_) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+            }
         }
     }
 
     Err(BrowserCompanionProbeError::TimedOut)
+}
+
+async fn read_probe_pipe<R>(pipe: &mut Option<R>) -> Result<Vec<u8>, BrowserCompanionProbeError>
+where
+    R: AsyncRead + Unpin,
+{
+    let Some(reader) = pipe.as_mut() else {
+        return Ok(Vec::new());
+    };
+
+    let mut bytes = Vec::new();
+    reader
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|error| BrowserCompanionProbeError::SpawnFailed(error.to_string()))?;
+
+    Ok(bytes)
 }
 
 fn interpret_browser_companion_probe_output(
@@ -551,5 +594,12 @@ mod tests {
             "loongclaw-browser-companion 11.5.0",
             "1.5.0"
         ));
+    }
+
+    #[test]
+    fn browser_companion_probe_timeout_duration_saturates() {
+        let timeout_duration = browser_companion_probe_timeout_duration(u64::MAX);
+
+        assert_eq!(timeout_duration, Duration::MAX);
     }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1365,6 +1365,7 @@ impl Commands {
             Self::SlackSend { .. } => "slack_send",
             Self::LineSend { .. } => "line_send",
             Self::WhatsappSend { .. } => "whatsapp_send",
+            Self::WhatsappServe { .. } => "whatsapp_serve",
             Self::EmailSend { .. } => "email_send",
             Self::WebhookSend { .. } => "webhook_send",
             Self::GoogleChatSend { .. } => "google_chat_send",

--- a/crates/daemon/tests/integration.rs
+++ b/crates/daemon/tests/integration.rs
@@ -40,11 +40,29 @@ impl MigrationEnvironmentGuard {
     pub fn set(pairs: &[(&str, Option<&str>)]) -> Self {
         let lock = lock_daemon_test_environment();
         let mut saved = Vec::new();
+        let home_override = pairs
+            .iter()
+            .find_map(|(key, value)| (*key == "HOME").then_some(*value))
+            .flatten()
+            .map(std::path::PathBuf::from);
+        let explicit_loongclaw_home = pairs.iter().any(|(key, _)| *key == "LOONGCLAW_HOME");
         for (key, value) in pairs {
             saved.push(((*key).to_owned(), std::env::var_os(key)));
             match value {
                 Some(value) => unsafe { std::env::set_var(key, value) },
                 None => unsafe { std::env::remove_var(key) },
+            }
+        }
+        if !explicit_loongclaw_home {
+            saved.push((
+                "LOONGCLAW_HOME".to_owned(),
+                std::env::var_os("LOONGCLAW_HOME"),
+            ));
+            match home_override {
+                Some(home) => unsafe {
+                    std::env::set_var("LOONGCLAW_HOME", home.join(".loongclaw"))
+                },
+                None => unsafe { std::env::remove_var("LOONGCLAW_HOME") },
             }
         }
         Self { _lock: lock, saved }

--- a/crates/daemon/tests/integration/chat_cli.rs
+++ b/crates/daemon/tests/integration/chat_cli.rs
@@ -107,11 +107,13 @@ impl ChatCliFixture {
         stdin_bytes: Option<&[u8]>,
         fake_onboard_exit_code: Option<i32>,
     ) -> Output {
+        let loongclaw_home = self.home_dir.join(".loongclaw");
         let mut command = Command::new(env!("CARGO_BIN_EXE_loongclaw"));
         command
             .arg("chat")
             .current_dir(&self.root)
             .env("HOME", &self.home_dir)
+            .env("LOONGCLAW_HOME", &loongclaw_home)
             .env_remove("LOONGCLAW_CONFIG_PATH")
             .env_remove("USERPROFILE")
             .stdin(Stdio::piped())

--- a/crates/daemon/tests/integration/migrate_cli.rs
+++ b/crates/daemon/tests/integration/migrate_cli.rs
@@ -10,7 +10,9 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("clock should be after epoch")
         .as_nanos();
-    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+    let temp_dir = std::env::temp_dir();
+    let canonical_temp_dir = dunce::canonicalize(&temp_dir).unwrap_or(temp_dir);
+    canonical_temp_dir.join(format!("{prefix}-{nanos}"))
 }
 
 fn isolated_home_guard(prefix: &str) -> (PathBuf, MigrationEnvironmentGuard) {

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -17,7 +17,7 @@ Domain grades for LoongClaw. Updated periodically to track gaps, prioritize clea
 | Plugin IR (L7) | B- | 2026-03-13 | Bridge inference works; multi-language support limited |
 | Self-Awareness (L8) | B- | 2026-03-13 | Snapshots generated but not continuous; no drift detection agent |
 | Bootstrap (L9) | B | 2026-03-13 | Activation plans work; no policy-bounded bootstrap validation |
-| Context/Memory | C | 2026-03-29 | Typed scopes and staged retrieval substrate now exist, but built-in retrieval is still session-summary-only; no operator-visible provenance contract; no FTS5/local search surface |
+| Context/Memory | B- | 2026-04-05 | Canonical recall now has scope/kind/metadata-backed FTS retrieval, the operator-facing `memory_search` surface spans workspace and cross-session recall, but trust scoring, TTL/hash, and richer derived-memory ranking are still limited |
 | Documentation | A- | 2026-03-13 | Strong coverage across design docs, security, product sense, and quality tracking |
 | CI/Enforcement | A | 2026-03-13 | 8 CI workflows, convention-engineering (14 files, 11 checks), check:harness mirror gate |
 | Contributor Experience | A- | 2026-03-13 | Clear tracks and recipes; could add more examples |

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -83,9 +83,9 @@ All decisions from the research repository. Status reflects implementation reali
 | ID | Decision | Implementation Status |
 |----|----------|---------------------|
 | D-016 | MemoryStore trait (4 typed async methods) | Not started — using string dispatch (TD-008) |
-| D-017 | MemoryScope enum (Task, Session, Agent, Global) | Partial — scoped memory vocabulary now exists in app runtime as `Session`, `User`, `Agent`, and `Workspace`, but the original task/global vocabulary was not adopted and retrieval is not yet productized |
-| D-018 | SQLite + FTS5 default backend (WAL, feature-gated sqlite-vec) | Partial — SQLite canonical store, memory-system registry, and staged retrieval orchestration ship on `dev`, but FTS5/search are not yet present |
-| D-019 | Mandatory provenance fields (10 fields: UUID, trust_tier, hash, agent, TTL...) | Partial — canonical records already carry typed scope/kind/session metadata, but a stable operator-visible provenance contract for retrieval results is still missing |
+| D-017 | MemoryScope enum (Task, Session, Agent, Global) | Partial — scoped memory vocabulary now exists in the app runtime as `Session`, `User`, `Agent`, and `Workspace`, and canonical recall now persists those scopes, but the original task/global vocabulary was not adopted |
+| D-018 | SQLite + FTS5 default backend (WAL, feature-gated sqlite-vec) | Partial — SQLite canonical store, WAL, operator-facing canonical FTS recall, and staged retrieval orchestration ship on `dev`, but sqlite-vec and richer ranking are not started |
+| D-019 | Mandatory provenance fields (10 fields: UUID, trust_tier, hash, agent, TTL...) | Partial — canonical records and operator-facing recall now surface scope/kind/metadata/timestamp provenance, but UUID/trust tier/hash/TTL are not yet enforced |
 | D-020 | Configurable trust scoring (Tier 0-3) | Not started |
 | D-021 | Blake3 content hashing (feature-gated `pure` mode) | Not started |
 | D-022 | Capability-scoped deletion (tombstone audit trail) | Not started |

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-04T13:00:10Z
+- Generated at: 2026-04-05T07:15:43Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -15,7 +15,7 @@
 | spec_runtime | `foundation` | `crates/spec/src/spec_runtime.rs` | 3528 | 3600 | 72 | 65 | 65 | 0 | 100.0% | TIGHT | 3455 | 2.1% | PASS | 65 |
 | spec_execution | `foundation` | `crates/spec/src/spec_execution.rs` | 3568 | 3700 | 132 | 48 | 80 | 32 | 96.4% | TIGHT | 3547 | 0.6% | PASS | 43 |
 | provider_mod | `foundation` | `crates/app/src/provider/mod.rs` | 376 | 1000 | 624 | 10 | 20 | 10 | 50.0% | HEALTHY | 375 | 0.3% | PASS | 10 |
-| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 343 | 650 | 307 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -3.7% | PASS | 14 |
+| memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2741 | 2800 | 59 | 56 | 65 | 9 | 97.9% | TIGHT | 2698 | 1.6% | PASS | 56 |
 | channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10464 | 10500 | 36 | 88 | 90 | 2 | 99.7% | TIGHT | 9922 | 5.5% | PASS | 88 |
@@ -23,7 +23,7 @@
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10801 | 11200 | 399 | 97 | 120 | 23 | 96.4% | TIGHT | 10831 | -0.3% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14997 | 15000 | 3 | 54 | 70 | 16 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14999 | 15000 | 1 | 53 | 70 | 17 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6482 | 6500 | 18 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
 | onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9782 | 9800 | 18 | 235 | 250 | 15 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
@@ -61,7 +61,7 @@
 <!-- arch-hotspot key=spec_runtime lines=3528 functions=65 -->
 <!-- arch-hotspot key=spec_execution lines=3568 functions=48 -->
 <!-- arch-hotspot key=provider_mod lines=376 functions=10 -->
-<!-- arch-hotspot key=memory_mod lines=343 functions=14 -->
+<!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2741 functions=56 -->
 <!-- arch-hotspot key=channel_registry lines=10464 functions=88 -->
@@ -69,7 +69,7 @@
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10801 functions=97 -->
-<!-- arch-hotspot key=tools_mod lines=14997 functions=54 -->
+<!-- arch-hotspot key=tools_mod lines=14999 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=6482 functions=210 -->
 <!-- arch-hotspot key=onboard_cli lines=9782 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T07:15:43Z
+- Generated at: 2026-04-05T12:06:34Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -18,10 +18,10 @@
 | memory_mod | `foundation` | `crates/app/src/memory/mod.rs` | 355 | 650 | 295 | 14 | 16 | 2 | 87.5% | WATCH | 356 | -0.3% | PASS | 14 |
 | acp_manager | `operational_density` | `crates/app/src/acp/manager.rs` | 3391 | 3600 | 209 | 8 | 12 | 4 | 94.2% | WATCH | 3383 | 0.2% | PASS | 8 |
 | acpx_runtime | `operational_density` | `crates/app/src/acp/acpx.rs` | 2741 | 2800 | 59 | 56 | 65 | 9 | 97.9% | TIGHT | 2698 | 1.6% | PASS | 56 |
-| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10464 | 10500 | 36 | 88 | 90 | 2 | 99.7% | TIGHT | 9922 | 5.5% | PASS | 88 |
+| channel_registry | `structural_size` | `crates/app/src/channel/registry.rs` | 10222 | 10500 | 278 | 72 | 90 | 18 | 97.4% | TIGHT | 9922 | 3.0% | PASS | 88 |
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
-| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1784 | 6400 | 4616 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
+| channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
 | turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10801 | 11200 | 399 | 97 | 120 | 23 | 96.4% | TIGHT | 10831 | -0.3% | PASS | 98 |
 | tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14999 | 15000 | 1 | 53 | 70 | 17 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
 | daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6482 | 6500 | 18 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
@@ -29,7 +29,7 @@
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (99.7%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.4%), tools_mod (100.0%), daemon_lib (100.0%), onboard_cli (99.8%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.4%), tools_mod (100.0%), daemon_lib (100.0%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -64,10 +64,10 @@
 <!-- arch-hotspot key=memory_mod lines=355 functions=14 -->
 <!-- arch-hotspot key=acp_manager lines=3391 functions=8 -->
 <!-- arch-hotspot key=acpx_runtime lines=2741 functions=56 -->
-<!-- arch-hotspot key=channel_registry lines=10464 functions=88 -->
+<!-- arch-hotspot key=channel_registry lines=10222 functions=72 -->
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
-<!-- arch-hotspot key=channel_mod lines=1784 functions=0 -->
+<!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
 <!-- arch-hotspot key=turn_coordinator lines=10801 functions=97 -->
 <!-- arch-hotspot key=tools_mod lines=14999 functions=53 -->
 <!-- arch-hotspot key=daemon_lib lines=6482 functions=210 -->


### PR DESCRIPTION
## Summary

- Problem:
  LoongClaw still had a split memory-recall surface and a host-home-coupled
  runtime root. That made governed recall less operator-legible and made
  full-suite validation depend on ambient home-directory state.
- Why it matters:
  Operators need one bounded memory search surface that can reuse canonical
  recall, and maintainers need deterministic runtime/test isolation before the
  experiment and promotion surfaces can be trusted as routine workflow tools.
- What changed:
  Added canonical SQLite recall persistence and FTS-backed search plumbing,
  unified `memory_search` across workspace durable memory plus canonical
  cross-session recall, introduced `LOONGCLAW_HOME` as an explicit runtime-root
  override, and updated daemon integration harnesses so all-features validation
  runs cleanly under isolated runtime roots.
- What did not change (scope boundary):
  No vector retrieval stack, no autonomous promotion executor, no background
  indexing daemon, and no broad ACP/channel runtime redesign outside path/root
  isolation.

## Linked Issues

- Closes #898
- Related #

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [ ] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes runtime-root resolution and expands operator-visible memory
  search behavior to include canonical cross-session recall.
- Rollout / guardrails:
  Validation uses isolated `LOONGCLAW_HOME` roots; runtime-root behavior still
  falls back to the previous home-based default when the override is absent.
- Rollback path:
  Revert the two commits in this branch or unset `LOONGCLAW_HOME` to return to
  the historical default root path.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [ ] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/loongclaw-maturity-combined-target cargo clippy --workspace --all-targets --all-features -- -D warnings
tmp_home=$(mktemp -d /tmp/loongclaw-maturity-combined-home.XXXXXX)
env LOONGCLAW_HOME="$tmp_home/.loongclaw" CARGO_TARGET_DIR=/tmp/loongclaw-maturity-combined-target cargo test --workspace --locked
tmp_home=$(mktemp -d /tmp/loongclaw-maturity-combined-home.XXXXXX)
env LOONGCLAW_HOME="$tmp_home/.loongclaw" CARGO_TARGET_DIR=/tmp/loongclaw-maturity-combined-target cargo test --workspace --all-features --locked

Additional targeted checks:
- canonical-only `memory_search` returns structured cross-session recall hits
- runtime tool visibility exposes `memory_search` without exposing `memory_get` in canonical-only mode
- daemon integration harnesses mirror `HOME` into `LOONGCLAW_HOME` for isolated runtime-root tests
```

## User-visible / Operator-visible Changes

- `memory_search` can now return structured hits from canonical cross-session
  recall in addition to workspace durable memory files.
- Runtime state can be isolated under `LOONGCLAW_HOME`, which makes validation
  and controlled deployments deterministic without depending on the host home
  directory.

## Failure Recovery

- Fast rollback or disable path:
  Revert this branch, or omit `LOONGCLAW_HOME` to fall back to the prior default
  runtime-root behavior.
- Observable failure symptoms reviewers should watch for:
  Missing `memory_search` recall hits in canonical-only setups, unexpected
  `memory_get` exposure without workspace files, or runtime-root path drift in
  daemon integration flows.

## Reviewer Focus

- Review the canonical recall plumbing in `crates/app/src/memory/sqlite.rs` and
  `crates/app/src/tools/memory_tools.rs`.
- Verify the visibility split between `memory_search` and `memory_get` in
  `crates/app/src/tools/catalog.rs` and `crates/app/src/tools/mod.rs`.
- Verify `LOONGCLAW_HOME` fallback and test isolation behavior in
  `crates/app/src/config/shared.rs` and the daemon integration harness files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added canonical cross-session memory recall with full-text search capabilities and structured metadata (scope, kind, role, timestamp)
  * Added LOONGCLAW_HOME environment variable for custom home directory configuration

* **Improvements**
  * Memory search tool now spans workspace and cross-session recall with unified result structure
  * Enhanced memory system quality rating from C to B-
<!-- end of auto-generated comment: release notes by coderabbit.ai -->