### PR TITLE
fix: honor shebang wrappers for ACPX and browser companion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2123,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
+ "tracing",
  "unicode-normalization",
  "unicode-segmentation",
  "wait-timeout",
@@ -2175,6 +2182,8 @@ dependencies = [
  "time",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "wat",
 ]
 
@@ -2251,6 +2260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3272,6 +3299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,7 +3413,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3768,6 +3803,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3902,6 +3980,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ wasmtime = { version = "43.0.0", default-features = false, features = ["std", "r
 rusqlite = { version = "0.39", features = ["bundled"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 which = "8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 [profile.release]
 lto = "thin"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -87,6 +87,7 @@ prost = { version = "0.14", optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"], optional = true }
 libc = "0.2"
+tracing.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/app/src/acp/acpx.rs
+++ b/crates/app/src/acp/acpx.rs
@@ -565,8 +565,10 @@ impl AcpRuntimeBackend for AcpxCliProbeBackend {
             }));
         }
 
-        let mut probe = Command::new(&command);
-        probe.arg("--version");
+        let (probe_command, mut probe_args) = resolve_spawn_program(&command);
+        probe_args.push("--version".to_owned());
+        let mut probe = Command::new(&probe_command);
+        probe.args(&probe_args);
         if let Some(cwd) = cwd {
             probe.current_dir(cwd);
         }
@@ -1448,9 +1450,11 @@ async fn spawn_acpx_child(
     pipe_stdin: bool,
 ) -> CliResult<tokio::process::Child> {
     retry_executable_file_busy(|| {
-        let mut process = Command::new(command);
+        let (spawn_command, mut spawn_args) = resolve_spawn_program(command);
+        spawn_args.extend(args.iter().cloned());
+        let mut process = Command::new(spawn_command);
         process
-            .args(args)
+            .args(&spawn_args)
             .current_dir(cwd)
             .stdin(if pipe_stdin {
                 Stdio::piped()
@@ -1463,6 +1467,58 @@ async fn spawn_acpx_child(
     })
     .await
     .map_err(|error| map_spawn_error(command, cwd, error))
+}
+
+fn resolve_spawn_program(command: &str) -> (String, Vec<String>) {
+    resolve_shebang_program(command).unwrap_or_else(|| (command.to_owned(), Vec::new()))
+}
+
+fn resolve_shebang_program(command: &str) -> Option<(String, Vec<String>)> {
+    let path = Path::new(command);
+    if !path.is_file() {
+        return None;
+    }
+
+    let bytes = std::fs::read(path).ok()?;
+    if !bytes.starts_with(b"#!") {
+        return None;
+    }
+
+    let line_end = bytes
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .unwrap_or(bytes.len());
+    let raw_line = std::str::from_utf8(bytes.get(2..line_end)?).ok()?.trim();
+    if raw_line.is_empty() {
+        return None;
+    }
+
+    let parts = raw_line
+        .split_whitespace()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        return None;
+    }
+
+    let first_part = parts.first()?;
+    let env_program = Path::new(first_part.as_str())
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "env");
+
+    let (spawn_command, extra_args) = if env_program {
+        let interpreter = parts.get(1)?.clone();
+        let extra_args = parts.iter().skip(2).cloned().collect::<Vec<_>>();
+        (interpreter, extra_args)
+    } else {
+        let extra_args = parts.iter().skip(1).cloned().collect::<Vec<_>>();
+        (first_part.clone(), extra_args)
+    };
+
+    let mut spawn_args = extra_args;
+    spawn_args.push(command.to_owned());
+    Some((spawn_command, spawn_args))
 }
 
 async fn retry_executable_file_busy<T, F>(mut operation: F) -> std::io::Result<T>
@@ -1846,6 +1902,44 @@ mod tests {
             .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
             .count();
         assert_eq!(staging_entries, 0, "staging files should be cleaned up");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_shebang_program_uses_declared_interpreter_for_shell_scripts() {
+        let temp_dir = unique_temp_dir("loongclaw-acpx-shebang-shell");
+        let script_path = temp_dir.join("fake-acpx");
+        write_executable_script_atomically(&script_path, "#!/bin/sh\necho ok\n")
+            .expect("write fake shell acpx script");
+
+        let (command, args) = resolve_shebang_program(script_path.to_str().expect("script path"))
+            .expect("shebang script should resolve");
+
+        assert_eq!(command, "/bin/sh");
+        assert_eq!(
+            args,
+            vec![script_path.display().to_string()],
+            "shell script should execute through the declared interpreter"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_shebang_program_uses_env_resolved_interpreter_for_python_scripts() {
+        let temp_dir = unique_temp_dir("loongclaw-acpx-shebang-python");
+        let script_path = temp_dir.join("fake-acpx");
+        write_executable_script_atomically(&script_path, "#!/usr/bin/env python3\nprint('ok')\n")
+            .expect("write fake python acpx script");
+
+        let (command, args) = resolve_shebang_program(script_path.to_str().expect("script path"))
+            .expect("env shebang script should resolve");
+
+        assert_eq!(command, "python3");
+        assert_eq!(
+            args,
+            vec![script_path.display().to_string()],
+            "env shebang should delegate to the declared interpreter"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/src/acp/manager.rs
+++ b/crates/app/src/acp/manager.rs
@@ -7,10 +7,10 @@ use crate::CliResult;
 use crate::config::LoongClawConfig;
 
 use super::backend::{
-    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, AcpAbortController, AcpConfigPatch, AcpDoctorReport,
-    AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle, AcpSessionMetadata, AcpSessionMode,
-    AcpSessionState, AcpSessionStatus, AcpTurnEventSink, AcpTurnRequest, AcpTurnResult,
-    BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
+    ACP_SESSION_METADATA_ACTIVATION_ORIGIN, ACP_TURN_METADATA_TRACE_ID, AcpAbortController,
+    AcpConfigPatch, AcpDoctorReport, AcpRoutingOrigin, AcpSessionBootstrap, AcpSessionHandle,
+    AcpSessionMetadata, AcpSessionMode, AcpSessionState, AcpSessionStatus, AcpTurnEventSink,
+    AcpTurnRequest, AcpTurnResult, BufferedAcpTurnEventSink, CompositeAcpTurnEventSink,
 };
 use super::binding::AcpSessionBindingScope;
 use super::merge_turn_events;
@@ -115,9 +115,25 @@ impl AcpSessionManager {
         self.cleanup_idle_sessions(config).await?;
 
         let selection = resolve_acp_backend_selection(config);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %selection.id,
+            conversation_id = ?bootstrap.conversation_id.as_deref(),
+            mode = ?bootstrap.mode,
+            binding = ?AcpSessionBindingScope::from_bootstrap(bootstrap),
+            "ensuring ACP session"
+        );
         if let Some(existing) =
             self.resolve_existing_session(config, selection.id.as_str(), bootstrap)?
         {
+            tracing::debug!(
+                target: "loongclaw.acp",
+                session_key = %existing.session_key,
+                backend_id = %existing.backend_id,
+                state = ?existing.state,
+                "reused ACP session"
+            );
             return Ok(existing);
         }
 
@@ -136,6 +152,13 @@ impl AcpSessionManager {
             .get(ACP_SESSION_METADATA_ACTIVATION_ORIGIN)
             .and_then(|value| AcpRoutingOrigin::parse(value));
         self.store.upsert(metadata.clone())?;
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %metadata.session_key,
+            backend_id = %metadata.backend_id,
+            activation_origin = ?metadata.activation_origin.map(AcpRoutingOrigin::as_str),
+            "created ACP session"
+        );
         Ok(metadata)
     }
 
@@ -156,11 +179,25 @@ impl AcpSessionManager {
         request: &AcpTurnRequest,
         sink: Option<&dyn AcpTurnEventSink>,
     ) -> CliResult<AcpTurnResult> {
+        let started_at = std::time::Instant::now();
         let actor_key = actor_key_for_bootstrap(bootstrap);
         let _turn_queue_guard = self.acquire_turn_queue_guard(actor_key.clone()).await?;
         self.cleanup_idle_sessions(config).await?;
 
         let mut metadata = self.ensure_session(config, bootstrap).await?;
+        let trace_id = request
+            .metadata
+            .get(ACP_TURN_METADATA_TRACE_ID)
+            .map(String::as_str);
+        tracing::debug!(
+            target: "loongclaw.acp",
+            session_key = %bootstrap.session_key,
+            backend_id = %metadata.backend_id,
+            trace_id = ?trace_id,
+            input_len = request.input.chars().count(),
+            sink_enabled = sink.is_some(),
+            "starting ACP turn"
+        );
         let backend = resolve_acp_backend(Some(metadata.backend_id.as_str()))?;
         metadata.state = AcpSessionState::Busy;
         metadata.clear_error();
@@ -209,11 +246,27 @@ impl AcpSessionManager {
             Ok(mut result) => {
                 self.record_turn_completion(turn_started_ms, true)?;
                 let streamed_events = buffered_sink.snapshot()?;
+                let duration_ms = started_at.elapsed().as_millis();
+                let reported_event_count = result.events.len();
+                let streamed_event_count = streamed_events.len();
                 result.events = merge_turn_events(&result.events, &streamed_events);
                 metadata.state = result.state;
                 metadata.clear_error();
                 metadata.touch();
                 self.store.upsert(metadata)?;
+                tracing::debug!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    state = ?result.state,
+                    stop_reason = ?result.stop_reason,
+                    reported_event_count,
+                    streamed_event_count,
+                    merged_event_count = result.events.len(),
+                    duration_ms,
+                    "ACP turn completed"
+                );
                 Ok(result)
             }
             Err(error) => {
@@ -222,6 +275,15 @@ impl AcpSessionManager {
                 metadata.state = AcpSessionState::Error;
                 metadata.set_error(error.clone());
                 self.store.upsert(metadata)?;
+                tracing::warn!(
+                    target: "loongclaw.acp",
+                    session_key = %bootstrap.session_key,
+                    backend_id = %handle.backend_id,
+                    trace_id = ?trace_id,
+                    duration_ms = started_at.elapsed().as_millis(),
+                    error = %crate::observability::summarize_error(error.as_str()),
+                    "ACP turn failed"
+                );
                 Err(error)
             }
         }

--- a/crates/app/src/channel/mod.rs
+++ b/crates/app/src/channel/mod.rs
@@ -4241,16 +4241,51 @@ pub(super) async fn process_inbound_with_provider(
     kernel_ctx: &KernelContext,
     feedback_policy: ChannelTurnFeedbackPolicy,
 ) -> CliResult<String> {
+    let started_at = std::time::Instant::now();
     let turn_config = reload_channel_turn_config(config, resolved_path)?;
     let runtime = DefaultConversationRuntime::from_config_or_env(&turn_config)?;
-    process_inbound_with_runtime_and_feedback(
+    let result = process_inbound_with_runtime_and_feedback(
         &turn_config,
         &runtime,
         message,
         ConversationRuntimeBinding::kernel(kernel_ctx),
         feedback_policy,
     )
-    .await
+    .await;
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(reply) => {
+            tracing::debug!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                reply_len = reply.chars().count(),
+                duration_ms,
+                "channel inbound processed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.channel",
+                platform = %message.session.platform.as_str(),
+                conversation_id = %message.session.conversation_id,
+                configured_account_id = ?message.session.configured_account_id.as_deref(),
+                account_id = ?message.session.account_id.as_deref(),
+                source_message_id = ?message.delivery.source_message_id.as_deref(),
+                ack_cursor = ?message.delivery.ack_cursor.as_deref(),
+                text_len = message.text.chars().count(),
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "channel inbound failed"
+            );
+        }
+    }
+    result
 }
 
 #[cfg(any(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -10,6 +10,7 @@ pub mod crypto;
 pub mod feishu;
 pub mod memory;
 pub mod migration;
+pub(crate) mod observability;
 pub mod presentation;
 pub mod prompt;
 pub mod provider;

--- a/crates/app/src/observability.rs
+++ b/crates/app/src/observability.rs
@@ -1,0 +1,102 @@
+use serde_json::Value;
+
+const MAX_LOGGED_JSON_KEYS: usize = 8;
+const MAX_ERROR_CHARS: usize = 240;
+
+pub(crate) fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+pub(crate) fn top_level_json_keys(value: &Value) -> Vec<String> {
+    let Value::Object(map) = value else {
+        return Vec::new();
+    };
+
+    let mut keys = map
+        .keys()
+        .take(MAX_LOGGED_JSON_KEYS)
+        .cloned()
+        .collect::<Vec<_>>();
+    if map.len() > MAX_LOGGED_JSON_KEYS {
+        keys.push(format!("+{}", map.len() - MAX_LOGGED_JSON_KEYS));
+    }
+    keys
+}
+
+pub(crate) fn summarize_error(error: &str) -> String {
+    let compact = error.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= MAX_ERROR_CHARS {
+        return compact;
+    }
+
+    let truncated = compact
+        .chars()
+        .take(MAX_ERROR_CHARS.saturating_sub(3))
+        .collect::<String>();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{json_value_kind, summarize_error, top_level_json_keys};
+
+    #[test]
+    fn json_value_kind_labels_common_shapes() {
+        assert_eq!(json_value_kind(&json!(null)), "null");
+        assert_eq!(json_value_kind(&json!(true)), "bool");
+        assert_eq!(json_value_kind(&json!(1)), "number");
+        assert_eq!(json_value_kind(&json!("hello")), "string");
+        assert_eq!(json_value_kind(&json!([1, 2, 3])), "array");
+        assert_eq!(json_value_kind(&json!({"command": "pwd"})), "object");
+    }
+
+    #[test]
+    fn top_level_json_keys_limits_output() {
+        let value = json!({
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+            "e": 5,
+            "f": 6,
+            "g": 7,
+            "h": 8,
+            "i": 9
+        });
+
+        assert_eq!(
+            top_level_json_keys(&value),
+            vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned(),
+                "e".to_owned(),
+                "f".to_owned(),
+                "g".to_owned(),
+                "h".to_owned(),
+                "+1".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn summarize_error_collapses_whitespace_and_truncates() {
+        let repeated = "detail ".repeat(64);
+        let summary = summarize_error(&format!("line one\nline two\t{repeated}"));
+
+        assert!(!summary.contains('\n'));
+        assert!(!summary.contains('\t'));
+        assert!(summary.ends_with("..."));
+        assert!(summary.chars().count() <= 240);
+    }
+}

--- a/crates/app/src/provider/request_failover_runtime.rs
+++ b/crates/app/src/provider/request_failover_runtime.rs
@@ -34,6 +34,15 @@ where
 
     let ordered_profiles =
         prioritize_provider_auth_profiles_by_health(auth_profiles, profile_state_policy);
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %provider.kind.profile().id,
+        binding = %binding.as_str(),
+        model_candidate_count = model_candidates.len(),
+        auth_profile_count = ordered_profiles.len(),
+        auto_model_mode,
+        "dispatching provider request across model candidates"
+    );
     let mut last_error = None;
     let mut last_error_snapshot = None;
     for (model_index, model) in model_candidates.iter().enumerate() {
@@ -44,6 +53,18 @@ where
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_success(policy, profile);
                     }
+                    tracing::debug!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %model,
+                        auth_profile_id = %profile.id,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        "provider request succeeded"
+                    );
                     return Ok(value);
                 }
                 Err(model_error) => {
@@ -54,6 +75,8 @@ where
                         snapshot,
                         ..
                     } = model_error;
+                    let exhausted = profile_index + 1 >= ordered_profiles.len()
+                        && model_index + 1 >= model_candidates.len();
                     record_provider_failover_audit_event(
                         binding,
                         provider,
@@ -62,12 +85,31 @@ where
                         auto_model_mode,
                         model_index,
                         model_candidates.len(),
-                        profile_index + 1 >= ordered_profiles.len()
-                            && model_index + 1 >= model_candidates.len(),
+                        exhausted,
                     );
                     if let Some(policy) = profile_state_policy {
                         mark_provider_profile_failure(policy, profile, reason);
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %provider.kind.profile().id,
+                        binding = %binding.as_str(),
+                        model = %snapshot.model,
+                        auth_profile_id = %profile.id,
+                        reason = %snapshot.reason.as_str(),
+                        stage = %snapshot.stage.as_str(),
+                        attempt = snapshot.attempt,
+                        max_attempts = snapshot.max_attempts,
+                        status_code = ?snapshot.status_code,
+                        try_next_model,
+                        candidate_index = model_index + 1,
+                        candidate_count = model_candidates.len(),
+                        profile_index = profile_index + 1,
+                        profile_count = ordered_profiles.len(),
+                        exhausted,
+                        error = %crate::observability::summarize_error(message.as_str()),
+                        "provider request attempt failed"
+                    );
                     last_error = Some(message);
                     last_error_snapshot = Some(snapshot);
 

--- a/crates/app/src/provider/request_session_runtime.rs
+++ b/crates/app/src/provider/request_session_runtime.rs
@@ -87,6 +87,14 @@ pub(super) async fn prepare_provider_request_session(
                             classify_profile_failure_reason_from_message(error.as_str()),
                         );
                     }
+                    tracing::warn!(
+                        target: "loongclaw.provider",
+                        provider_id = %config.provider.kind.profile().id,
+                        auth_profile_id = %profile.id,
+                        auto_model_mode,
+                        error = %crate::observability::summarize_error(error.as_str()),
+                        "provider model catalog resolution failed for auth profile"
+                    );
                     last_error = Some(error);
                 }
             }
@@ -108,7 +116,7 @@ pub(super) async fn prepare_provider_request_session(
         .await?
     };
 
-    Ok(ProviderRequestSession {
+    let session = ProviderRequestSession {
         endpoint,
         headers,
         request_policy,
@@ -119,7 +127,16 @@ pub(super) async fn prepare_provider_request_session(
         auto_model_mode,
         model_candidate_cooldown_policy,
         auth_context,
-    })
+    };
+    tracing::debug!(
+        target: "loongclaw.provider",
+        provider_id = %config.provider.kind.profile().id,
+        auth_profile_count = session.auth_profiles.len(),
+        model_candidate_count = session.model_candidates.len(),
+        auto_model_mode = session.auto_model_mode,
+        "prepared provider request session"
+    );
+    Ok(session)
 }
 
 fn build_model_candidate_cooldown_policy(

--- a/crates/app/src/provider/runtime_binding.rs
+++ b/crates/app/src/provider/runtime_binding.rs
@@ -23,7 +23,24 @@ impl<'a> ProviderRuntimeBinding<'a> {
         }
     }
 
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Kernel(_) => "kernel",
+            Self::Direct => "direct",
+        }
+    }
+
     pub const fn is_kernel_bound(self) -> bool {
         matches!(self, Self::Kernel(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProviderRuntimeBinding;
+
+    #[test]
+    fn provider_runtime_binding_labels_are_stable() {
+        assert_eq!(ProviderRuntimeBinding::direct().as_str(), "direct");
     }
 }

--- a/crates/app/src/tools/browser_companion.rs
+++ b/crates/app/src/tools/browser_companion.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::io::{ErrorKind, Write};
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -124,8 +125,10 @@ impl BrowserCompanionRunner for CommandBrowserCompanionRunner {
         let encoded = serde_json::to_vec(request)
             .map_err(|error| format!("browser_companion_request_encode_failed: {error}"))?;
         let mut child = retry_executable_file_busy(|| {
-            let mut process = Command::new(command);
+            let (spawn_command, spawn_args) = resolve_spawn_program(command);
+            let mut process = Command::new(spawn_command);
             process
+                .args(&spawn_args)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
@@ -163,6 +166,58 @@ impl BrowserCompanionRunner for CommandBrowserCompanionRunner {
                 .unwrap_or_else(|| "companion reported failure".to_owned())
         ))
     }
+}
+
+fn resolve_spawn_program(command: &str) -> (String, Vec<String>) {
+    resolve_shebang_program(command).unwrap_or_else(|| (command.to_owned(), Vec::new()))
+}
+
+fn resolve_shebang_program(command: &str) -> Option<(String, Vec<String>)> {
+    let path = Path::new(command);
+    if !path.is_file() {
+        return None;
+    }
+
+    let bytes = std::fs::read(path).ok()?;
+    if !bytes.starts_with(b"#!") {
+        return None;
+    }
+
+    let line_end = bytes
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .unwrap_or(bytes.len());
+    let raw_line = std::str::from_utf8(bytes.get(2..line_end)?).ok()?.trim();
+    if raw_line.is_empty() {
+        return None;
+    }
+
+    let parts = raw_line
+        .split_whitespace()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        return None;
+    }
+
+    let first_part = parts.first()?;
+    let env_program = Path::new(first_part.as_str())
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "env");
+
+    let (spawn_command, extra_args) = if env_program {
+        let interpreter = parts.get(1)?.clone();
+        let extra_args = parts.iter().skip(2).cloned().collect::<Vec<_>>();
+        (interpreter, extra_args)
+    } else {
+        let extra_args = parts.iter().skip(1).cloned().collect::<Vec<_>>();
+        (first_part.clone(), extra_args)
+    };
+
+    let mut spawn_args = extra_args;
+    spawn_args.push(command.to_owned());
+    Some((spawn_command, spawn_args))
 }
 
 fn retry_executable_file_busy<T, F>(mut operation: F) -> std::io::Result<T>
@@ -263,6 +318,10 @@ where
         stdin.write_all(encoded).map_err(|error| {
             cleanup();
             format!("browser_companion_stdin_write_failed: {error}")
+        })?;
+        stdin.flush().map_err(|error| {
+            cleanup();
+            format!("browser_companion_stdin_flush_failed: {error}")
         })?;
     }
 
@@ -590,11 +649,13 @@ fn remove_browser_companion_session(scope_id: &str, session_id: &str) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        io,
-        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-        time::Duration,
-    };
+    use std::fs;
+    use std::io;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use loongclaw_contracts::ToolCoreRequest;
     use serde_json::{Value, json};
@@ -723,6 +784,88 @@ mod tests {
     fn pause_before_browser_companion_spawn_retry_succeeds_without_runtime() {
         super::pause_before_browser_companion_spawn_retry(Duration::ZERO)
             .expect("pause should work without a tokio runtime");
+    }
+
+    #[cfg(unix)]
+    fn unique_browser_companion_test_dir(prefix: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        path.push(format!("{prefix}-{nanos}"));
+        fs::create_dir_all(&path).expect("create browser companion test dir");
+        path
+    }
+
+    #[cfg(unix)]
+    fn write_shell_test_script(root: &Path, name: &str, body: &str) -> PathBuf {
+        let path = root.join(name);
+        fs::write(&path, body).expect("write browser companion test script");
+        let mut permissions = fs::metadata(&path)
+            .expect("stat browser companion test script")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).expect("chmod browser companion test script");
+        path
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_shebang_program_uses_declared_interpreter_for_shell_script() {
+        let root = unique_browser_companion_test_dir("lc-browser-shebang-shell");
+        let script = write_shell_test_script(&root, "browser-companion", "#!/bin/sh\necho ok\n");
+
+        let (command, args) = super::resolve_shebang_program(script.to_str().expect("script path"))
+            .expect("shell script should resolve through shebang");
+
+        assert_eq!(command, "/bin/sh");
+        assert_eq!(args, vec![script.display().to_string()]);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn command_runner_executes_shell_script_via_declared_interpreter() {
+        let root = unique_browser_companion_test_dir("lc-browser-runner-shell");
+        let request_path = root.join("request.json");
+        let script = write_shell_test_script(
+            &root,
+            "browser-companion",
+            &format!(
+                "#!/bin/sh\nBODY=\"$(cat)\"\nprintf '%s' \"$BODY\" > \"{}\"\nprintf '%s' '{{\"ok\":true,\"result\":{{\"page_url\":\"https://example.com\"}}}}'\n",
+                request_path.display()
+            ),
+        );
+        let request = super::BrowserCompanionProtocolRequest {
+            protocol: super::BROWSER_COMPANION_PROTOCOL,
+            tool_name: "browser.companion.session.start".to_owned(),
+            operation: "session.start",
+            action_class: "read",
+            session_scope: "scope".to_owned(),
+            session_id: "session".to_owned(),
+            arguments: json!({"url": "https://example.com"}),
+        };
+
+        let value = super::BrowserCompanionRunner::invoke(
+            &super::CommandBrowserCompanionRunner,
+            script.to_str().expect("script path"),
+            5,
+            &request,
+        )
+        .expect("shell-script browser companion should execute");
+
+        assert_eq!(value["page_url"], json!("https://example.com"));
+        let recorded: Value = serde_json::from_str(
+            &fs::read_to_string(&request_path).expect("browser companion request log"),
+        )
+        .expect("browser companion request log should be valid json");
+        assert_eq!(
+            recorded["tool_name"],
+            json!("browser.companion.session.start")
+        );
+
+        fs::remove_dir_all(root).ok();
     }
 
     struct OkRunner;

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -648,6 +648,9 @@ pub fn execute_tool_core_with_config(
     request: ToolCoreRequest,
     config: &runtime_config::ToolRuntimeConfig,
 ) -> Result<ToolCoreOutcome, String> {
+    let requested_tool_name = request.tool_name.clone();
+    let payload_kind = crate::observability::json_value_kind(&request.payload);
+    let payload_keys = crate::observability::top_level_json_keys(&request.payload);
     if !trusted_internal_tool_payload_enabled()
         && payload_uses_reserved_internal_tool_context(&request.payload)
     {
@@ -664,11 +667,40 @@ pub fn execute_tool_core_with_config(
     let effective_config = trusted_runtime_narrowing_from_payload(&request.payload)?
         .map(|narrowing| config.narrowed(&narrowing));
     let config = effective_config.as_ref().unwrap_or(config);
-    match canonical_name {
+    let started_at = std::time::Instant::now();
+    let result = match canonical_name {
         "tool.search" => execute_tool_search_tool_with_config(request, config),
         "tool.invoke" => execute_tool_invoke_tool_with_config(request, config),
         _ => execute_discoverable_tool_core_with_config(request, config),
+    };
+    let duration_ms = started_at.elapsed().as_millis();
+    match &result {
+        Ok(outcome) => {
+            tracing::debug!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                status = %outcome.status,
+                duration_ms,
+                "tool execution completed"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "loongclaw.tools",
+                requested_tool_name = %requested_tool_name,
+                canonical_tool_name = %canonical_name,
+                payload_kind,
+                payload_keys = ?payload_keys,
+                duration_ms,
+                error = %crate::observability::summarize_error(error),
+                "tool execution failed"
+            );
+        }
     }
+    result
 }
 
 fn trusted_runtime_narrowing_from_payload(

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -70,6 +70,8 @@ rand.workspace = true
 sha2.workspace = true
 ed25519-dalek.workspace = true
 dunce = "1"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [[bin]]
 name = "loongclaw"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -85,6 +85,7 @@ mod memory_context_benchmark;
 pub mod migrate_cli;
 pub mod migration;
 pub mod next_actions;
+mod observability;
 pub mod onboard_cli;
 mod onboard_finalize;
 mod onboard_preflight;
@@ -106,6 +107,7 @@ pub mod supervisor;
 pub use loongclaw_spec::programmatic::{
     acquire_programmatic_circuit_slot, record_programmatic_circuit_outcome,
 };
+pub use observability::init_tracing;
 
 #[allow(
     clippy::expect_used,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -37,7 +37,9 @@ impl Drop for StdinGuard {
 #[tokio::main]
 async fn main() {
     let _stdin_guard = StdinGuard;
+    init_tracing();
     let cli = Cli::parse();
+    tracing::debug!(target: "loongclaw.daemon", command = ?cli.command, "parsed CLI command");
     let result = match cli.command.unwrap_or_else(resolve_default_entry_command) {
         Commands::Welcome => run_welcome_cli(),
         Commands::Demo => run_demo().await,
@@ -846,6 +848,11 @@ async fn main() {
         }
     };
     if let Err(error) = result {
+        tracing::error!(
+            target: "loongclaw.daemon",
+            error = %error,
+            "CLI command failed"
+        );
         #[allow(clippy::print_stderr)]
         {
             eprintln!("error: {error}");

--- a/crates/daemon/src/observability.rs
+++ b/crates/daemon/src/observability.rs
@@ -1,0 +1,99 @@
+use std::io::{self, IsTerminal};
+
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+
+const DEFAULT_LOG_FILTER: &str = "warn";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogFormat {
+    Compact,
+    Pretty,
+    Json,
+}
+
+impl LogFormat {
+    fn parse(raw: Option<&str>) -> Self {
+        match raw
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("compact")
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "pretty" => Self::Pretty,
+            "json" => Self::Json,
+            _ => Self::Compact,
+        }
+    }
+}
+
+fn resolved_log_directive(loongclaw_log: Option<&str>, rust_log: Option<&str>) -> String {
+    loongclaw_log
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| rust_log.map(str::trim).filter(|value| !value.is_empty()))
+        .unwrap_or(DEFAULT_LOG_FILTER)
+        .to_owned()
+}
+
+fn build_env_filter(raw: &str) -> EnvFilter {
+    EnvFilter::try_new(raw).unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER))
+}
+
+pub fn init_tracing() {
+    let log_format = LogFormat::parse(std::env::var("LOONGCLAW_LOG_FORMAT").ok().as_deref());
+    let directive = resolved_log_directive(
+        std::env::var("LOONGCLAW_LOG").ok().as_deref(),
+        std::env::var("RUST_LOG").ok().as_deref(),
+    );
+    let env_filter = build_env_filter(directive.as_str());
+    let use_ansi = log_format != LogFormat::Json && io::stderr().is_terminal();
+    let base = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(io::stderr)
+        .with_target(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_ansi(use_ansi);
+
+    let _ = match log_format {
+        LogFormat::Compact => base.compact().finish().try_init(),
+        LogFormat::Pretty => base.pretty().finish().try_init(),
+        LogFormat::Json => base.json().flatten_event(true).finish().try_init(),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogFormat, build_env_filter, resolved_log_directive};
+
+    #[test]
+    fn resolved_log_directive_prefers_loongclaw_log() {
+        assert_eq!(
+            resolved_log_directive(Some("loongclaw_app=debug"), Some("warn")),
+            "loongclaw_app=debug"
+        );
+    }
+
+    #[test]
+    fn resolved_log_directive_falls_back_to_rust_log_then_default() {
+        assert_eq!(resolved_log_directive(None, Some("info")), "info");
+        assert_eq!(resolved_log_directive(None, None), "warn");
+    }
+
+    #[test]
+    fn parse_log_format_accepts_known_variants() {
+        assert_eq!(LogFormat::parse(Some("pretty")), LogFormat::Pretty);
+        assert_eq!(LogFormat::parse(Some("json")), LogFormat::Json);
+        assert_eq!(LogFormat::parse(Some("compact")), LogFormat::Compact);
+        assert_eq!(LogFormat::parse(Some("unknown")), LogFormat::Compact);
+    }
+
+    #[test]
+    fn build_env_filter_falls_back_on_invalid_directive() {
+        let filter = build_env_filter("[broken");
+        let rendered = filter.to_string();
+        assert_eq!(rendered, "warn");
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "0BSD",
     "ISC",
     "MPL-2.0",
     "Unicode-3.0",


### PR DESCRIPTION
## Summary

- Problem:
  Command-backed ACPX and browser companion flows could hang until timeout when
  the configured command path pointed to a shebang script.
- Why it matters:
  This blocked ACPX session setup, ACPX doctor version probing, browser
  companion operations, and the all-features verification gate.
- What changed:
  Added shebang-aware command spawning for ACPX and browser companion command
  paths, flushed browser companion stdin after request writes, added targeted
  regression tests, and allowed the `0BSD` transitive license required by the
  current dependency graph.
- What did not change (scope boundary):
  No product surface, protocol schema, or approval policy semantics changed.
  The fix is limited to command launch behavior and verification policy.

## Linked Issues

- Closes #897
- Related #

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [ ] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [x] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [ ] Memory / context assembly
- [ ] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [x] Track A (routine / low-risk)
- [ ] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
- Rollout / guardrails:
- Rollback path:

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [ ] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
scripts/check_architecture_boundaries.sh
scripts/check_dep_graph.sh
diff CLAUDE.md AGENTS.md
scripts/check-docs.sh
python3 scripts/sync_github_labels.py --check
bash scripts/test_sync_github_labels.sh

env HOME=/tmp/loongclaw-verify-home-20260405 \
    CARGO_HOME=/tmp/loongclaw-verify-cargo-20260405 \
    RUSTUP_HOME=<redacted-path> \
    CARGO_TARGET_DIR=/tmp/loongclaw-verify-target-20260405 \
    cargo fmt --all -- --check

env HOME=/tmp/loongclaw-verify-home-20260405 \
    CARGO_HOME=/tmp/loongclaw-verify-cargo-20260405 \
    RUSTUP_HOME=<redacted-path> \
    CARGO_TARGET_DIR=/tmp/loongclaw-verify-target-20260405 \
    cargo deny check advisories bans licenses sources

env HOME=/tmp/loongclaw-verify-home-20260405 \
    CARGO_HOME=/tmp/loongclaw-verify-cargo-20260405 \
    RUSTUP_HOME=<redacted-path> \
    CARGO_TARGET_DIR=/tmp/loongclaw-verify-target-20260405 \
    cargo clippy --workspace --all-targets --all-features -- -D warnings

env HOME=/tmp/loongclaw-verify-home-20260405 \
    CARGO_HOME=/tmp/loongclaw-verify-cargo-20260405 \
    RUSTUP_HOME=<redacted-path> \
    CARGO_TARGET_DIR=/tmp/loongclaw-verify-target-20260405 \
    cargo test --workspace --all-features -q

env HOME=/tmp/loongclaw-verify-home-20260405 \
    CARGO_HOME=/tmp/loongclaw-verify-cargo-20260405 \
    RUSTUP_HOME=<redacted-path> \
    CARGO_TARGET_DIR=/tmp/loongclaw-verify-target-20260405 \
    cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/runtime-extension.json --print-audit

env HOME=/tmp/loongclaw-verify-home-20260405 \
    CARGO_HOME=/tmp/loongclaw-verify-cargo-20260405 \
    RUSTUP_HOME=<redacted-path> \
    CARGO_TARGET_DIR=/tmp/loongclaw-verify-target-20260405 \
    cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/tool-search.json --print-audit

env HOME=/tmp/loongclaw-verify-home-20260405 \
    CARGO_HOME=/tmp/loongclaw-verify-cargo-20260405 \
    RUSTUP_HOME=<redacted-path> \
    CARGO_TARGET_DIR=/tmp/loongclaw-verify-target-20260405 \
    cargo run -p loongclaw-daemon --bin loongclaw -- run-spec --spec examples/spec/programmatic-tool-call.json --print-audit

Targeted regressions also passed for ACPX and browser companion command-backed
script execution paths.
```

## User-visible / Operator-visible Changes

- Command-backed ACPX and browser companion flows now work correctly when the
  configured command points to a shebang script wrapper instead of a native
  binary.

## Failure Recovery

- Fast rollback or disable path:
  Revert commit `a330e16e6ce752e70f4ea7ca0fac22aac0c72837`.
- Observable failure symptoms reviewers should watch for:
  Reappearance of `ACPX command timed out after 15000ms` or
  `browser_companion_timeout: command exceeded 30s` in script-backed test or
  runtime paths.

## Reviewer Focus

- `crates/app/src/acp/acpx.rs`
  Confirm the shebang-resolution path only affects script-backed commands and
  preserves existing binary command behavior.
- `crates/app/src/tools/browser_companion.rs`
  Confirm the same behavior for browser companion command invocation and the
  added stdin flush.
- `deny.toml`
  Confirm the new `0BSD` allowance is limited to the verified transitive
  dependency need and does not broaden policy beyond that requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive structured logging and observability capabilities across the application for better debugging and monitoring
  * Enhanced executable script execution with improved shebang detection and resolution

* **Improvements**
  * Added performance duration tracking for request and turn processing
  * Improved error message summarization and reporting throughout execution flows

* **Chores**
  * Added tracing framework dependencies
  * Updated license allowlist configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->