### PR TITLE
feat: productize typed subagent handles

### DIFF
--- a/crates/app/src/config/audit.rs
+++ b/crates/app/src/config/audit.rs
@@ -75,12 +75,9 @@ mod tests {
 
         assert_eq!(config.mode, AuditMode::Fanout);
         assert!(config.retain_in_memory);
-        let expected_path = default_loongclaw_home().join("audit").join("events.jsonl");
-        assert!(
-            config.path.ends_with(&expected_path.display().to_string()),
-            "audit path {} should end with {}",
-            config.path,
-            expected_path.display(),
+        assert_eq!(
+            PathBuf::from(&config.path),
+            default_loongclaw_home().join("audit").join("events.jsonl")
         );
     }
 

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use std::process;
 use std::{
     collections::BTreeMap,
     env,
@@ -525,28 +523,6 @@ fn resolve_loongclaw_home(
 
 pub(super) fn default_loongclaw_home() -> PathBuf {
     get_loongclaw_home()
-}
-
-#[cfg(test)]
-fn test_default_loongclaw_home() -> PathBuf {
-    let test_label = std::thread::current()
-        .name()
-        .map(sanitize_test_home_segment)
-        .filter(|label| !label.is_empty())
-        .unwrap_or_else(|| format!("pid-{}", process::id()));
-    let path = env::temp_dir().join("loongclaw-test-home").join(test_label);
-    let _ = std::fs::create_dir_all(&path);
-    path
-}
-
-#[cfg(test)]
-fn sanitize_test_home_segment(raw: &str) -> String {
-    raw.chars()
-        .map(|ch| match ch {
-            'a'..='z' | 'A'..='Z' | '0'..='9' => ch,
-            _ => '-',
-        })
-        .collect()
 }
 
 pub fn expand_path(raw: &str) -> PathBuf {

--- a/crates/app/src/config/shared.rs
+++ b/crates/app/src/config/shared.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::process;
 use std::{
     collections::BTreeMap,
     env,
@@ -523,6 +525,28 @@ fn resolve_loongclaw_home(
 
 pub(super) fn default_loongclaw_home() -> PathBuf {
     get_loongclaw_home()
+}
+
+#[cfg(test)]
+fn test_default_loongclaw_home() -> PathBuf {
+    let test_label = std::thread::current()
+        .name()
+        .map(sanitize_test_home_segment)
+        .filter(|label| !label.is_empty())
+        .unwrap_or_else(|| format!("pid-{}", process::id()));
+    let path = env::temp_dir().join("loongclaw-test-home").join(test_label);
+    let _ = std::fs::create_dir_all(&path);
+    path
+}
+
+#[cfg(test)]
+fn sanitize_test_home_segment(raw: &str) -> String {
+    raw.chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' => ch,
+            _ => '-',
+        })
+        .collect()
 }
 
 pub fn expand_path(raw: &str) -> PathBuf {

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -95,6 +95,7 @@ pub use subagent::{
     ConstrainedSubagentHandle, ConstrainedSubagentIdentity, ConstrainedSubagentMode,
     ConstrainedSubagentProfile, ConstrainedSubagentRole, ConstrainedSubagentRuntimeBinding,
     ConstrainedSubagentTerminalReason, coordination_actions_for_subagent_handle,
+    subagent_surface_fields,
 };
 pub(crate) use tool_discovery_state::latest_tool_discovery_state_from_assistant_contents;
 pub use turn_budget::SafeLaneFailureRouteReason;

--- a/crates/app/src/conversation/mod.rs
+++ b/crates/app/src/conversation/mod.rs
@@ -89,7 +89,12 @@ pub use session_history::{
     load_turn_checkpoint_event_summary,
 };
 pub use subagent::{
-    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
+    ConstrainedSubagentBudgetSnapshot, ConstrainedSubagentContractView,
+    ConstrainedSubagentControlScope, ConstrainedSubagentCoordinationAction,
+    ConstrainedSubagentCoordinationActionKind, ConstrainedSubagentExecution,
+    ConstrainedSubagentHandle, ConstrainedSubagentIdentity, ConstrainedSubagentMode,
+    ConstrainedSubagentProfile, ConstrainedSubagentRole, ConstrainedSubagentRuntimeBinding,
+    ConstrainedSubagentTerminalReason, coordination_actions_for_subagent_handle,
 };
 pub(crate) use tool_discovery_state::latest_tool_discovery_state_from_assistant_contents;
 pub use turn_budget::SafeLaneFailureRouteReason;

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -64,6 +64,7 @@ impl SessionContext {
             session_id: normalize_session_id(session_id.into()),
             parent_session_id: None,
             tool_view,
+            runtime_narrowing: None,
             subagent_execution: None,
             subagent_contract: None,
             runtime_self_continuity: None,
@@ -79,6 +80,7 @@ impl SessionContext {
             session_id: normalize_session_id(session_id.into()),
             parent_session_id: Some(normalize_session_id(parent_session_id.into())),
             tool_view,
+            runtime_narrowing: None,
             subagent_execution: None,
             subagent_contract: None,
             runtime_self_continuity: None,
@@ -236,18 +238,6 @@ fn load_delegate_execution(
         })
         .flatten()
     }))
-}
-
-#[cfg(feature = "memory-sqlite")]
-fn load_delegate_runtime_narrowing(
-    repo: &SessionRepository,
-    session_id: &str,
-) -> Result<Option<ToolRuntimeNarrowing>, String> {
-    Ok(
-        load_delegate_execution(repo, session_id)?.and_then(|execution| {
-            (!execution.runtime_narrowing.is_empty()).then_some(execution.runtime_narrowing)
-        }),
-    )
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -1210,10 +1210,10 @@ where
             let session_tool_policy = snapshot
                 .as_ref()
                 .and_then(|snapshot| snapshot.session_tool_policy.as_ref());
-            return Ok(apply_session_tool_policy_to_tool_view(
+            Ok(apply_session_tool_policy_to_tool_view(
                 base_tool_view,
                 session_tool_policy,
-            ));
+            ))
         }
 
         #[cfg(not(feature = "memory-sqlite"))]

--- a/crates/app/src/conversation/runtime.rs
+++ b/crates/app/src/conversation/runtime.rs
@@ -9,10 +9,7 @@ use crate::CliResult;
 use crate::KernelContext;
 use crate::runtime_self_continuity::{self, RuntimeSelfContinuity};
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
-use crate::tools::{
-    ToolView, delegate_child_tool_view_for_runtime_config,
-    delegate_child_tool_view_for_runtime_config_with_delegate,
-};
+use crate::tools::{ToolView, delegate_child_tool_view_for_runtime_config_and_contract};
 
 use super::super::memory;
 use super::super::{config::LoongClawConfig, provider};
@@ -28,7 +25,10 @@ use super::context_engine_registry::{
 use super::prompt_orchestrator::seed_prompt_fragments_from_context;
 use super::prompt_orchestrator::sync_prompt_fragments_into_context;
 use super::runtime_binding::{ConversationRuntimeBinding, OwnedConversationRuntimeBinding};
-use super::subagent::ConstrainedSubagentExecution;
+use super::subagent::{
+    ConstrainedSubagentContractView, ConstrainedSubagentExecution, ConstrainedSubagentIdentity,
+    ConstrainedSubagentProfile,
+};
 use super::turn_engine::ProviderTurn;
 use super::turn_middleware::{
     ConversationTurnMiddleware, TurnMiddlewareMetadata, builtin_turn_middlewares,
@@ -42,8 +42,6 @@ use super::{PromptFragment, PromptLane};
 #[cfg(feature = "memory-sqlite")]
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
-use crate::operator::session_graph::OperatorSessionGraph;
-#[cfg(feature = "memory-sqlite")]
 use crate::session::repository::{
     SessionKind, SessionRepository, SessionState, SessionToolPolicyRecord,
     TransitionSessionWithEventIfCurrentRequest,
@@ -55,6 +53,8 @@ pub struct SessionContext {
     pub parent_session_id: Option<String>,
     pub tool_view: ToolView,
     pub runtime_narrowing: Option<ToolRuntimeNarrowing>,
+    pub subagent_execution: Option<ConstrainedSubagentExecution>,
+    pub subagent_contract: Option<ConstrainedSubagentContractView>,
     pub(crate) runtime_self_continuity: Option<RuntimeSelfContinuity>,
 }
 
@@ -64,7 +64,8 @@ impl SessionContext {
             session_id: normalize_session_id(session_id.into()),
             parent_session_id: None,
             tool_view,
-            runtime_narrowing: None,
+            subagent_execution: None,
+            subagent_contract: None,
             runtime_self_continuity: None,
         }
     }
@@ -78,7 +79,8 @@ impl SessionContext {
             session_id: normalize_session_id(session_id.into()),
             parent_session_id: Some(normalize_session_id(parent_session_id.into())),
             tool_view,
-            runtime_narrowing: None,
+            subagent_execution: None,
+            subagent_contract: None,
             runtime_self_continuity: None,
         }
     }
@@ -86,9 +88,115 @@ impl SessionContext {
     #[must_use]
     pub fn with_runtime_narrowing(mut self, runtime_narrowing: ToolRuntimeNarrowing) -> Self {
         if !runtime_narrowing.is_empty() {
-            self.runtime_narrowing = Some(runtime_narrowing);
+            if let Some(subagent_execution) = self.subagent_execution.as_mut() {
+                subagent_execution.runtime_narrowing = runtime_narrowing.clone();
+            }
+            let contract = self.subagent_contract.take().unwrap_or_default();
+            self.subagent_contract = Some(contract.with_runtime_narrowing(runtime_narrowing));
         }
         self
+    }
+
+    #[must_use]
+    pub fn with_subagent_execution(
+        mut self,
+        subagent_execution: ConstrainedSubagentExecution,
+    ) -> Self {
+        let mut subagent_execution = subagent_execution.with_resolved_profile();
+        if subagent_execution.identity.is_none()
+            && let Some(identity) = self
+                .subagent_contract
+                .as_ref()
+                .and_then(ConstrainedSubagentContractView::resolved_identity)
+                .cloned()
+        {
+            subagent_execution.identity = Some(identity);
+        }
+        self.subagent_contract = Some(subagent_execution.contract_view());
+        self.subagent_execution = Some(subagent_execution);
+        self
+    }
+
+    #[must_use]
+    pub fn with_subagent_profile(mut self, subagent_profile: ConstrainedSubagentProfile) -> Self {
+        if let Some(subagent_execution) = self.subagent_execution.as_mut() {
+            subagent_execution.profile = Some(subagent_profile);
+        }
+        let contract = self.subagent_contract.take().unwrap_or_default();
+        self.subagent_contract = Some(contract.with_profile(subagent_profile));
+        self
+    }
+
+    #[must_use]
+    pub fn with_subagent_identity(
+        mut self,
+        subagent_identity: ConstrainedSubagentIdentity,
+    ) -> Self {
+        if subagent_identity.is_empty() {
+            return self;
+        }
+        if let Some(subagent_execution) = self.subagent_execution.as_mut() {
+            subagent_execution.identity = Some(subagent_identity.clone());
+        }
+        let contract = self.subagent_contract.take().unwrap_or_default();
+        self.subagent_contract = Some(contract.with_identity(subagent_identity));
+        self
+    }
+
+    pub fn resolved_subagent_profile(&self) -> Option<ConstrainedSubagentProfile> {
+        self.subagent_execution
+            .as_ref()
+            .map(ConstrainedSubagentExecution::resolved_profile)
+            .or_else(|| {
+                self.subagent_contract
+                    .as_ref()
+                    .and_then(ConstrainedSubagentContractView::resolved_profile)
+            })
+    }
+
+    pub fn resolved_subagent_identity(&self) -> Option<&ConstrainedSubagentIdentity> {
+        self.subagent_execution
+            .as_ref()
+            .and_then(|execution| execution.identity.as_ref())
+            .or_else(|| {
+                self.subagent_contract
+                    .as_ref()
+                    .and_then(ConstrainedSubagentContractView::resolved_identity)
+            })
+    }
+
+    pub fn resolved_subagent_contract(&self) -> Option<ConstrainedSubagentContractView> {
+        let mut contract = self
+            .subagent_execution
+            .as_ref()
+            .map(ConstrainedSubagentExecution::contract_view)
+            .or(self.subagent_contract.clone())?;
+        if let Some(stored_contract) = self.subagent_contract.as_ref() {
+            if contract.profile.is_none()
+                && let Some(profile) = stored_contract.profile
+            {
+                contract = contract.with_profile(profile);
+            }
+            if contract.runtime_narrowing.is_empty()
+                && !stored_contract.runtime_narrowing.is_empty()
+            {
+                contract =
+                    contract.with_runtime_narrowing(stored_contract.runtime_narrowing.clone());
+            }
+        }
+        (!contract.is_empty()).then_some(contract)
+    }
+
+    pub fn subagent_runtime_narrowing(&self) -> Option<&ToolRuntimeNarrowing> {
+        self.subagent_execution
+            .as_ref()
+            .map(|execution| &execution.runtime_narrowing)
+            .or_else(|| {
+                self.subagent_contract
+                    .as_ref()
+                    .map(|contract| &contract.runtime_narrowing)
+            })
+            .filter(|narrowing| !narrowing.is_empty())
     }
 
     #[must_use]
@@ -113,12 +221,12 @@ fn normalize_session_id(session_id: String) -> String {
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn load_delegate_runtime_narrowing(
+fn load_delegate_execution(
     repo: &SessionRepository,
     session_id: &str,
-) -> Result<Option<ToolRuntimeNarrowing>, String> {
+) -> Result<Option<ConstrainedSubagentExecution>, String> {
     let events = repo.list_delegate_lifecycle_events(session_id)?;
-    let execution = events.into_iter().rev().find_map(|event| {
+    Ok(events.into_iter().rev().find_map(|event| {
         matches!(
             event.event_kind.as_str(),
             "delegate_queued" | "delegate_started"
@@ -127,10 +235,44 @@ fn load_delegate_runtime_narrowing(
             super::subagent::ConstrainedSubagentExecution::from_event_payload(&event.payload_json)
         })
         .flatten()
-    });
-    Ok(execution.and_then(|execution| {
-        (!execution.runtime_narrowing.is_empty()).then_some(execution.runtime_narrowing)
     }))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn load_delegate_runtime_narrowing(
+    repo: &SessionRepository,
+    session_id: &str,
+) -> Result<Option<ToolRuntimeNarrowing>, String> {
+    Ok(
+        load_delegate_execution(repo, session_id)?.and_then(|execution| {
+            (!execution.runtime_narrowing.is_empty()).then_some(execution.runtime_narrowing)
+        }),
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn derive_subagent_profile_from_lineage(
+    repo: &SessionRepository,
+    session_id: &str,
+    max_depth: usize,
+) -> Result<Option<ConstrainedSubagentProfile>, String> {
+    let depth = match repo.session_lineage_depth(session_id) {
+        Ok(depth) => depth,
+        Err(error)
+            if error.starts_with("session_lineage_broken:")
+                || error.starts_with("session_lineage_cycle_detected:") =>
+        {
+            return Ok(None);
+        }
+        Err(error) => {
+            return Err(format!(
+                "compute session lineage depth for subagent profile failed: {error}"
+            ));
+        }
+    };
+    Ok(Some(ConstrainedSubagentProfile::for_child_depth(
+        depth, max_depth,
+    )))
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -189,7 +331,9 @@ fn load_session_runtime_self_continuity(
 struct PersistedSessionSnapshot {
     session_id: String,
     parent_session_id: Option<String>,
+    label: Option<String>,
     is_delegate_child: bool,
+    subagent_execution: Option<ConstrainedSubagentExecution>,
     session_tool_policy: Option<SessionToolPolicyRecord>,
     delegate_runtime_narrowing: Option<ToolRuntimeNarrowing>,
     runtime_self_continuity: Option<RuntimeSelfContinuity>,
@@ -215,8 +359,17 @@ fn load_persisted_session_snapshot(
     if let Some(session) = session {
         let parent_session_id = session.parent_session_id;
         let is_delegate_child = parent_session_id.is_some();
+        let label = session.label;
+        let subagent_execution = if is_delegate_child {
+            load_delegate_execution(repo, session_id)?
+        } else {
+            None
+        };
         let delegate_runtime_narrowing = if is_delegate_child {
-            load_delegate_runtime_narrowing(repo, session_id)?
+            subagent_execution.as_ref().and_then(|execution| {
+                (!execution.runtime_narrowing.is_empty())
+                    .then_some(execution.runtime_narrowing.clone())
+            })
         } else {
             None
         };
@@ -224,7 +377,9 @@ fn load_persisted_session_snapshot(
         let snapshot = PersistedSessionSnapshot {
             session_id: session.session_id,
             parent_session_id,
+            label,
             is_delegate_child,
+            subagent_execution,
             session_tool_policy,
             delegate_runtime_narrowing,
             runtime_self_continuity,
@@ -241,8 +396,15 @@ fn load_persisted_session_snapshot(
     };
 
     let is_delegate_child = summary.kind == SessionKind::DelegateChild;
+    let subagent_execution = if is_delegate_child {
+        load_delegate_execution(repo, session_id)?
+    } else {
+        None
+    };
     let delegate_runtime_narrowing = if is_delegate_child {
-        load_delegate_runtime_narrowing(repo, session_id)?
+        subagent_execution.as_ref().and_then(|execution| {
+            (!execution.runtime_narrowing.is_empty()).then_some(execution.runtime_narrowing.clone())
+        })
     } else {
         None
     };
@@ -250,7 +412,9 @@ fn load_persisted_session_snapshot(
     let snapshot = PersistedSessionSnapshot {
         session_id: summary.session_id,
         parent_session_id: summary.parent_session_id,
+        label: summary.label,
         is_delegate_child,
+        subagent_execution,
         session_tool_policy,
         delegate_runtime_narrowing,
         runtime_self_continuity,
@@ -274,37 +438,36 @@ fn build_base_tool_view_from_snapshot(
     };
 
     if snapshot.parent_session_id.is_some() {
-        let session_graph = OperatorSessionGraph::new(repo);
-        let depth = match session_graph.lineage_depth(session_id) {
-            Ok(depth) => depth,
-            Err(error)
-                if error.starts_with("session_lineage_broken:")
-                    || error.starts_with("session_lineage_cycle_detected:") =>
-            {
-                return Ok(delegate_child_tool_view_for_runtime_config_with_delegate(
-                    &config.tools,
-                    &tool_runtime_config,
-                    false,
-                ));
-            }
-            Err(error) => {
-                return Err(format!(
-                    "compute session lineage depth for tool view failed: {error}"
-                ));
-            }
+        let derived_contract = match snapshot.subagent_execution.as_ref() {
+            Some(subagent_execution) => Some(subagent_execution.contract_view()),
+            None => derive_subagent_profile_from_lineage(
+                repo,
+                session_id,
+                config.tools.delegate.max_depth,
+            )?
+            .map(ConstrainedSubagentContractView::from_profile),
         };
-        let allow_nested_delegate = depth < config.tools.delegate.max_depth;
-        return Ok(delegate_child_tool_view_for_runtime_config_with_delegate(
+        return Ok(delegate_child_tool_view_for_runtime_config_and_contract(
             &config.tools,
             &tool_runtime_config,
-            allow_nested_delegate,
+            derived_contract.as_ref(),
         ));
     }
 
     if snapshot.is_delegate_child {
-        return Ok(delegate_child_tool_view_for_runtime_config(
+        let derived_contract = match snapshot.subagent_execution.as_ref() {
+            Some(subagent_execution) => Some(subagent_execution.contract_view()),
+            None => derive_subagent_profile_from_lineage(
+                repo,
+                session_id,
+                config.tools.delegate.max_depth,
+            )?
+            .map(ConstrainedSubagentContractView::from_profile),
+        };
+        return Ok(delegate_child_tool_view_for_runtime_config_and_contract(
             &config.tools,
             &tool_runtime_config,
+            derived_contract.as_ref(),
         ));
     }
 
@@ -1006,6 +1169,25 @@ where
                 if let Some(runtime_narrowing) = runtime_narrowing {
                     session_context = session_context.with_runtime_narrowing(runtime_narrowing);
                 }
+                if snapshot.is_delegate_child {
+                    if let Some(label) = snapshot.label {
+                        session_context =
+                            session_context.with_subagent_identity(ConstrainedSubagentIdentity {
+                                nickname: Some(label),
+                                specialization: None,
+                            });
+                    }
+                    if let Some(subagent_execution) = snapshot.subagent_execution {
+                        session_context =
+                            session_context.with_subagent_execution(subagent_execution);
+                    } else if let Some(subagent_profile) = derive_subagent_profile_from_lineage(
+                        &repo,
+                        session_id,
+                        config.tools.delegate.max_depth,
+                    )? {
+                        session_context = session_context.with_subagent_profile(subagent_profile);
+                    }
+                }
                 if let Some(runtime_self_continuity) = snapshot.runtime_self_continuity {
                     session_context =
                         session_context.with_runtime_self_continuity(runtime_self_continuity);
@@ -1038,10 +1220,10 @@ where
             let session_tool_policy = snapshot
                 .as_ref()
                 .and_then(|snapshot| snapshot.session_tool_policy.as_ref());
-            Ok(apply_session_tool_policy_to_tool_view(
+            return Ok(apply_session_tool_policy_to_tool_view(
                 base_tool_view,
                 session_tool_policy,
-            ))
+            ));
         }
 
         #[cfg(not(feature = "memory-sqlite"))]
@@ -1297,9 +1479,9 @@ fn delegate_child_runtime_contract_prompt_summary(
     session_context: &SessionContext,
 ) -> Option<String> {
     session_context.parent_session_id.as_ref()?;
-    let runtime_narrowing = session_context.runtime_narrowing.as_ref()?;
+    let subagent_contract = session_context.resolved_subagent_contract();
     crate::tools::runtime_config::ToolRuntimeConfig::from_loongclaw_config(config, None)
-        .delegate_child_prompt_summary(runtime_narrowing)
+        .delegate_child_prompt_summary(subagent_contract.as_ref())
 }
 
 fn runtime_self_continuity_prompt_summary(

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use crate::runtime_self_continuity::RuntimeSelfContinuity;
 use crate::tools::runtime_config::ToolRuntimeNarrowing;
@@ -132,6 +132,46 @@ impl ConstrainedSubagentHandle {
         self.coordination = coordination;
         self
     }
+
+    pub fn resolved_identity(&self) -> Option<&ConstrainedSubagentIdentity> {
+        self.identity.as_ref().or_else(|| {
+            self.contract
+                .as_ref()
+                .and_then(ConstrainedSubagentContractView::resolved_identity)
+        })
+    }
+
+    pub fn resolved_profile(&self) -> Option<ConstrainedSubagentProfile> {
+        self.contract
+            .as_ref()
+            .and_then(ConstrainedSubagentContractView::resolved_profile)
+    }
+}
+
+pub fn subagent_surface_fields(subagent: Option<&ConstrainedSubagentHandle>) -> Map<String, Value> {
+    let mut fields = Map::new();
+    let subagent_identity = subagent
+        .and_then(ConstrainedSubagentHandle::resolved_identity)
+        .cloned();
+    let subagent_profile = subagent.and_then(ConstrainedSubagentHandle::resolved_profile);
+    let subagent_contract = subagent.and_then(|handle| handle.contract.clone());
+    let subagent_value = subagent.map(|handle| json!(handle)).unwrap_or(Value::Null);
+    let subagent_identity_value = subagent_identity
+        .map(|identity| json!(identity))
+        .unwrap_or(Value::Null);
+    let subagent_profile_value = subagent_profile
+        .map(|profile| json!(profile))
+        .unwrap_or(Value::Null);
+    let subagent_contract_value = subagent_contract
+        .map(|contract| json!(contract))
+        .unwrap_or(Value::Null);
+
+    fields.insert("subagent_identity".to_owned(), subagent_identity_value);
+    fields.insert("subagent_profile".to_owned(), subagent_profile_value);
+    fields.insert("subagent_contract".to_owned(), subagent_contract_value);
+    fields.insert("subagent".to_owned(), subagent_value);
+
+    fields
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -627,5 +667,25 @@ mod tests {
                 runtime_binding: Some(ConstrainedSubagentRuntimeBinding::KernelBound),
             }
         );
+    }
+
+    #[test]
+    fn subagent_surface_fields_derive_identity_and_profile_from_handle_contract() {
+        let handle = ConstrainedSubagentHandle::new("child-session").with_contract(Some(
+            ConstrainedSubagentContractView::from_identity(ConstrainedSubagentIdentity {
+                nickname: Some("child".to_owned()),
+                specialization: Some("reviewer".to_owned()),
+            })
+            .with_profile(ConstrainedSubagentProfile {
+                role: ConstrainedSubagentRole::Leaf,
+                control_scope: ConstrainedSubagentControlScope::None,
+            }),
+        ));
+        let fields = subagent_surface_fields(Some(&handle));
+
+        assert_eq!(fields["subagent_identity"]["nickname"], "child");
+        assert_eq!(fields["subagent_identity"]["specialization"], "reviewer");
+        assert_eq!(fields["subagent_profile"]["role"], "leaf");
+        assert_eq!(fields["subagent"]["session_id"], "child-session");
     }
 }

--- a/crates/app/src/conversation/subagent.rs
+++ b/crates/app/src/conversation/subagent.rs
@@ -20,6 +20,351 @@ pub enum ConstrainedSubagentTerminalReason {
     SpawnFailed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstrainedSubagentRole {
+    Orchestrator,
+    Leaf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstrainedSubagentControlScope {
+    Children,
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstrainedSubagentRuntimeBinding {
+    Direct,
+    KernelBound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstrainedSubagentBudgetSnapshot {
+    pub current: usize,
+    pub max: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ConstrainedSubagentIdentity {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nickname: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub specialization: Option<String>,
+}
+
+impl ConstrainedSubagentIdentity {
+    pub fn is_empty(&self) -> bool {
+        self.nickname.is_none() && self.specialization.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ConstrainedSubagentHandle {
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<ConstrainedSubagentIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract: Option<ConstrainedSubagentContractView>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub coordination: Vec<ConstrainedSubagentCoordinationAction>,
+}
+
+impl ConstrainedSubagentHandle {
+    pub fn new(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_parent_session_id(mut self, parent_session_id: Option<String>) -> Self {
+        self.parent_session_id = parent_session_id;
+        self
+    }
+
+    pub fn with_label(mut self, label: Option<String>) -> Self {
+        self.label = label;
+        self
+    }
+
+    pub fn with_state(mut self, state: Option<String>) -> Self {
+        self.state = state;
+        self
+    }
+
+    pub fn with_phase(mut self, phase: Option<String>) -> Self {
+        self.phase = phase;
+        self
+    }
+
+    pub fn with_identity(mut self, identity: Option<ConstrainedSubagentIdentity>) -> Self {
+        if let Some(identity) = identity.filter(|identity| !identity.is_empty()) {
+            self.identity = Some(identity);
+        }
+        self
+    }
+
+    pub fn with_contract(mut self, contract: Option<ConstrainedSubagentContractView>) -> Self {
+        if let Some(contract) = contract.filter(|contract| !contract.is_empty()) {
+            if self.identity.is_none() {
+                self.identity = contract.resolved_identity().cloned();
+            }
+            self.contract = Some(contract);
+        }
+        self
+    }
+
+    pub fn with_coordination(
+        mut self,
+        coordination: Vec<ConstrainedSubagentCoordinationAction>,
+    ) -> Self {
+        self.coordination = coordination;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConstrainedSubagentCoordinationActionKind {
+    InspectStatus,
+    ReadHistory,
+    ReadEvents,
+    Wait,
+    Cancel,
+    Recover,
+    Archive,
+}
+
+impl ConstrainedSubagentCoordinationActionKind {
+    pub const fn tool_name(self) -> &'static str {
+        match self {
+            Self::InspectStatus => "session_status",
+            Self::ReadHistory => "sessions_history",
+            Self::ReadEvents => "session_events",
+            Self::Wait => "session_wait",
+            Self::Cancel => "session_cancel",
+            Self::Recover => "session_recover",
+            Self::Archive => "session_archive",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstrainedSubagentCoordinationAction {
+    pub kind: ConstrainedSubagentCoordinationActionKind,
+    pub tool_name: String,
+}
+
+impl ConstrainedSubagentCoordinationAction {
+    pub fn from_kind(kind: ConstrainedSubagentCoordinationActionKind) -> Self {
+        Self {
+            kind,
+            tool_name: kind.tool_name().to_owned(),
+        }
+    }
+}
+
+pub fn coordination_actions_for_subagent_handle(
+    terminal: bool,
+    phase: Option<&str>,
+    mode: Option<ConstrainedSubagentMode>,
+    overdue: bool,
+) -> Vec<ConstrainedSubagentCoordinationAction> {
+    let mut actions = vec![
+        ConstrainedSubagentCoordinationAction::from_kind(
+            ConstrainedSubagentCoordinationActionKind::InspectStatus,
+        ),
+        ConstrainedSubagentCoordinationAction::from_kind(
+            ConstrainedSubagentCoordinationActionKind::ReadHistory,
+        ),
+        ConstrainedSubagentCoordinationAction::from_kind(
+            ConstrainedSubagentCoordinationActionKind::ReadEvents,
+        ),
+    ];
+
+    if terminal {
+        actions.push(ConstrainedSubagentCoordinationAction::from_kind(
+            ConstrainedSubagentCoordinationActionKind::Archive,
+        ));
+        return actions;
+    }
+
+    actions.push(ConstrainedSubagentCoordinationAction::from_kind(
+        ConstrainedSubagentCoordinationActionKind::Wait,
+    ));
+
+    let async_mode = matches!(mode, Some(ConstrainedSubagentMode::Async));
+    let can_cancel = async_mode && matches!(phase, Some("queued" | "running"));
+    if can_cancel {
+        actions.push(ConstrainedSubagentCoordinationAction::from_kind(
+            ConstrainedSubagentCoordinationActionKind::Cancel,
+        ));
+    }
+
+    if overdue {
+        actions.push(ConstrainedSubagentCoordinationAction::from_kind(
+            ConstrainedSubagentCoordinationActionKind::Recover,
+        ));
+    }
+
+    actions
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConstrainedSubagentProfile {
+    pub role: ConstrainedSubagentRole,
+    pub control_scope: ConstrainedSubagentControlScope,
+}
+
+impl ConstrainedSubagentProfile {
+    pub fn for_child_depth(depth: usize, max_depth: usize) -> Self {
+        if depth < max_depth {
+            Self {
+                role: ConstrainedSubagentRole::Orchestrator,
+                control_scope: ConstrainedSubagentControlScope::Children,
+            }
+        } else {
+            Self {
+                role: ConstrainedSubagentRole::Leaf,
+                control_scope: ConstrainedSubagentControlScope::None,
+            }
+        }
+    }
+
+    pub fn allows_child_delegation(self) -> bool {
+        self.control_scope == ConstrainedSubagentControlScope::Children
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ConstrainedSubagentContractView {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ConstrainedSubagentMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<ConstrainedSubagentIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<ConstrainedSubagentProfile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub depth_budget: Option<ConstrainedSubagentBudgetSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_child_budget: Option<ConstrainedSubagentBudgetSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_shell_in_child: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub child_tool_allowlist: Vec<String>,
+    #[serde(default, skip_serializing_if = "ToolRuntimeNarrowing::is_empty")]
+    pub runtime_narrowing: ToolRuntimeNarrowing,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_binding: Option<ConstrainedSubagentRuntimeBinding>,
+}
+
+impl ConstrainedSubagentContractView {
+    pub fn from_execution(execution: &ConstrainedSubagentExecution) -> Self {
+        Self {
+            mode: Some(execution.mode),
+            identity: execution.identity.clone(),
+            profile: Some(execution.resolved_profile()),
+            depth_budget: Some(ConstrainedSubagentBudgetSnapshot {
+                current: execution.depth,
+                max: execution.max_depth,
+            }),
+            active_child_budget: Some(ConstrainedSubagentBudgetSnapshot {
+                current: execution.active_children,
+                max: execution.max_active_children,
+            }),
+            timeout_seconds: Some(execution.timeout_seconds),
+            allow_shell_in_child: Some(execution.allow_shell_in_child),
+            child_tool_allowlist: execution.child_tool_allowlist.clone(),
+            runtime_narrowing: execution.runtime_narrowing.clone(),
+            runtime_binding: Some(if execution.kernel_bound {
+                ConstrainedSubagentRuntimeBinding::KernelBound
+            } else {
+                ConstrainedSubagentRuntimeBinding::Direct
+            }),
+        }
+    }
+
+    pub fn from_profile(profile: ConstrainedSubagentProfile) -> Self {
+        Self {
+            profile: Some(profile),
+            ..Self::default()
+        }
+    }
+
+    pub fn from_identity(identity: ConstrainedSubagentIdentity) -> Self {
+        Self {
+            identity: Some(identity),
+            ..Self::default()
+        }
+    }
+
+    pub fn from_runtime_narrowing(runtime_narrowing: ToolRuntimeNarrowing) -> Self {
+        Self {
+            runtime_narrowing,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_profile(mut self, profile: ConstrainedSubagentProfile) -> Self {
+        self.profile = Some(profile);
+        self
+    }
+
+    pub fn with_identity(mut self, identity: ConstrainedSubagentIdentity) -> Self {
+        if !identity.is_empty() {
+            self.identity = Some(identity);
+        }
+        self
+    }
+
+    pub fn with_runtime_narrowing(mut self, runtime_narrowing: ToolRuntimeNarrowing) -> Self {
+        if !runtime_narrowing.is_empty() {
+            self.runtime_narrowing = runtime_narrowing;
+        }
+        self
+    }
+
+    pub fn resolved_profile(&self) -> Option<ConstrainedSubagentProfile> {
+        self.profile
+    }
+
+    pub fn resolved_identity(&self) -> Option<&ConstrainedSubagentIdentity> {
+        self.identity.as_ref()
+    }
+
+    pub fn allows_child_delegation(&self) -> bool {
+        self.profile
+            .map(ConstrainedSubagentProfile::allows_child_delegation)
+            .unwrap_or(false)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.mode.is_none()
+            && self.identity.is_none()
+            && self.profile.is_none()
+            && self.depth_budget.is_none()
+            && self.active_child_budget.is_none()
+            && self.timeout_seconds.is_none()
+            && self.allow_shell_in_child.is_none()
+            && self.child_tool_allowlist.is_empty()
+            && self.runtime_narrowing.is_empty()
+            && self.runtime_binding.is_none()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConstrainedSubagentExecution {
     pub mode: ConstrainedSubagentMode,
@@ -33,6 +378,10 @@ pub struct ConstrainedSubagentExecution {
     #[serde(default, skip_serializing_if = "ToolRuntimeNarrowing::is_empty")]
     pub runtime_narrowing: ToolRuntimeNarrowing,
     pub kernel_bound: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<ConstrainedSubagentIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<ConstrainedSubagentProfile>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,6 +406,27 @@ pub struct ConstrainedSubagentTerminalEventPayload {
 }
 
 impl ConstrainedSubagentExecution {
+    pub fn resolved_profile(&self) -> ConstrainedSubagentProfile {
+        self.profile.unwrap_or_else(|| {
+            ConstrainedSubagentProfile::for_child_depth(self.depth, self.max_depth)
+        })
+    }
+
+    pub fn with_resolved_profile(mut self) -> Self {
+        if self.profile.is_none() {
+            self.profile = Some(self.resolved_profile());
+        }
+        self
+    }
+
+    pub fn allows_nested_delegate_children(&self) -> bool {
+        self.resolved_profile().allows_child_delegation() && self.depth < self.max_depth
+    }
+
+    pub fn contract_view(&self) -> ConstrainedSubagentContractView {
+        ConstrainedSubagentContractView::from_execution(self)
+    }
+
     pub fn spawn_payload(&self, task: &str, label: Option<&str>) -> Value {
         self.spawn_payload_with_runtime_self_continuity(task, label, None)
     }
@@ -121,6 +491,8 @@ mod tests {
             ],
             runtime_narrowing: ToolRuntimeNarrowing::default(),
             kernel_bound: true,
+            identity: None,
+            profile: Some(ConstrainedSubagentProfile::for_child_depth(1, 2)),
         };
 
         let payload = execution.spawn_payload("research", Some("child"));
@@ -143,6 +515,8 @@ mod tests {
             child_tool_allowlist: vec!["web.fetch".to_owned()],
             runtime_narrowing: ToolRuntimeNarrowing::default(),
             kernel_bound: false,
+            identity: None,
+            profile: Some(ConstrainedSubagentProfile::for_child_depth(1, 2)),
         };
         let continuity = RuntimeSelfContinuity {
             runtime_self: RuntimeSelfModel {
@@ -178,6 +552,80 @@ mod tests {
         assert_eq!(
             payload["runtime_self_continuity"]["runtime_self"]["tool_usage_policy"][0],
             "Search memory before guessing workspace facts."
+        );
+    }
+
+    #[test]
+    fn constrained_subagent_execution_derives_legacy_profile_from_depth_budget() {
+        let execution = ConstrainedSubagentExecution {
+            mode: ConstrainedSubagentMode::Async,
+            depth: 1,
+            max_depth: 3,
+            active_children: 0,
+            max_active_children: 3,
+            timeout_seconds: 60,
+            allow_shell_in_child: false,
+            child_tool_allowlist: vec!["file.read".to_owned()],
+            runtime_narrowing: ToolRuntimeNarrowing::default(),
+            kernel_bound: false,
+            identity: None,
+            profile: None,
+        };
+
+        assert_eq!(
+            execution.resolved_profile(),
+            ConstrainedSubagentProfile {
+                role: ConstrainedSubagentRole::Orchestrator,
+                control_scope: ConstrainedSubagentControlScope::Children,
+            }
+        );
+        assert!(execution.allows_nested_delegate_children());
+    }
+
+    #[test]
+    fn constrained_subagent_execution_contract_view_normalizes_execution_semantics() {
+        let runtime_narrowing = ToolRuntimeNarrowing {
+            web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
+                allow_private_hosts: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let execution = ConstrainedSubagentExecution {
+            mode: ConstrainedSubagentMode::Inline,
+            depth: 2,
+            max_depth: 3,
+            active_children: 1,
+            max_active_children: 4,
+            timeout_seconds: 45,
+            allow_shell_in_child: true,
+            child_tool_allowlist: vec!["file.read".to_owned(), "shell.exec".to_owned()],
+            runtime_narrowing: runtime_narrowing.clone(),
+            kernel_bound: true,
+            identity: Some(ConstrainedSubagentIdentity {
+                nickname: Some("child-researcher".to_owned()),
+                specialization: Some("reviewer".to_owned()),
+            }),
+            profile: Some(ConstrainedSubagentProfile::for_child_depth(2, 3)),
+        };
+
+        assert_eq!(
+            execution.contract_view(),
+            ConstrainedSubagentContractView {
+                mode: Some(ConstrainedSubagentMode::Inline),
+                identity: Some(ConstrainedSubagentIdentity {
+                    nickname: Some("child-researcher".to_owned()),
+                    specialization: Some("reviewer".to_owned()),
+                }),
+                profile: Some(ConstrainedSubagentProfile::for_child_depth(2, 3)),
+                depth_budget: Some(ConstrainedSubagentBudgetSnapshot { current: 2, max: 3 }),
+                active_child_budget: Some(ConstrainedSubagentBudgetSnapshot { current: 1, max: 4 }),
+                timeout_seconds: Some(45),
+                allow_shell_in_child: Some(true),
+                child_tool_allowlist: vec!["file.read".to_owned(), "shell.exec".to_owned()],
+                runtime_narrowing,
+                runtime_binding: Some(ConstrainedSubagentRuntimeBinding::KernelBound),
+            }
         );
     }
 }

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -2579,6 +2579,295 @@ fn default_runtime_session_context_errors_when_session_repository_is_unavailable
     std::fs::remove_dir_all(&db_path).ok();
 }
 
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn default_runtime_session_context_uses_persisted_subagent_profile() {
+    let mut config = test_config();
+    config.memory.sqlite_path = unique_memory_sqlite_path("persisted-profile");
+    let memory_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_queued".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "label": "Child",
+            "execution": {
+                "mode": "async",
+                "depth": 1,
+                "max_depth": 3,
+                "active_children": 0,
+                "max_active_children": 3,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["file.read"],
+                "kernel_bound": false,
+                "identity": {
+                    "nickname": "Child",
+                    "specialization": "reviewer"
+                },
+                "profile": {
+                    "role": "leaf",
+                    "control_scope": "none"
+                }
+            }
+        }),
+    })
+    .expect("append delegate event");
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_context = runtime
+        .session_context(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("session context");
+
+    let subagent_execution = session_context
+        .subagent_execution
+        .as_ref()
+        .expect("subagent execution should be restored");
+
+    assert_eq!(subagent_execution.depth, 1);
+    assert_eq!(subagent_execution.max_depth, 3);
+    assert_eq!(
+        session_context.resolved_subagent_profile(),
+        Some(crate::conversation::ConstrainedSubagentProfile {
+            role: crate::conversation::ConstrainedSubagentRole::Leaf,
+            control_scope: crate::conversation::ConstrainedSubagentControlScope::None,
+        })
+    );
+    assert_eq!(
+        session_context
+            .resolved_subagent_contract()
+            .and_then(|contract| contract.profile),
+        Some(crate::conversation::ConstrainedSubagentProfile {
+            role: crate::conversation::ConstrainedSubagentRole::Leaf,
+            control_scope: crate::conversation::ConstrainedSubagentControlScope::None,
+        })
+    );
+    assert_eq!(
+        session_context
+            .resolved_subagent_identity()
+            .and_then(|identity| identity.specialization.as_deref()),
+        Some("reviewer")
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn default_runtime_session_context_derives_subagent_profile_for_legacy_child_without_lifecycle_event()
+ {
+    let mut config = test_config();
+    config.tools.delegate.max_depth = 3;
+    config.memory.sqlite_path = unique_memory_sqlite_path("legacy-derived-profile");
+    let memory_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+
+    let runtime = DefaultConversationRuntime::default();
+    let session_context = runtime
+        .session_context(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("session context");
+
+    assert!(session_context.subagent_execution.is_none());
+    assert_eq!(
+        session_context.resolved_subagent_profile(),
+        Some(crate::conversation::ConstrainedSubagentProfile {
+            role: crate::conversation::ConstrainedSubagentRole::Orchestrator,
+            control_scope: crate::conversation::ConstrainedSubagentControlScope::Children,
+        })
+    );
+    assert_eq!(
+        session_context
+            .resolved_subagent_contract()
+            .and_then(|contract| contract.profile),
+        Some(crate::conversation::ConstrainedSubagentProfile {
+            role: crate::conversation::ConstrainedSubagentRole::Orchestrator,
+            control_scope: crate::conversation::ConstrainedSubagentControlScope::Children,
+        })
+    );
+    assert_eq!(
+        session_context
+            .resolved_subagent_identity()
+            .and_then(|identity| identity.nickname.as_deref()),
+        Some("Child")
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+#[test]
+fn default_runtime_tool_view_respects_persisted_leaf_subagent_profile() {
+    let mut config = test_config();
+    config.tools.delegate.max_depth = 3;
+    config.memory.sqlite_path = unique_memory_sqlite_path("persisted-leaf-profile");
+    let memory_config =
+        crate::memory::runtime_config::MemoryRuntimeConfig::from_memory_config(&config.memory);
+    let repo = crate::session::repository::SessionRepository::new(&memory_config)
+        .expect("session repository");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "root-session".to_owned(),
+        kind: crate::session::repository::SessionKind::Root,
+        parent_session_id: None,
+        label: Some("Root".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create root session");
+    repo.create_session(crate::session::repository::NewSessionRecord {
+        session_id: "child-session".to_owned(),
+        kind: crate::session::repository::SessionKind::DelegateChild,
+        parent_session_id: Some("root-session".to_owned()),
+        label: Some("Child".to_owned()),
+        state: crate::session::repository::SessionState::Ready,
+    })
+    .expect("create child session");
+    repo.append_event(crate::session::repository::NewSessionEvent {
+        session_id: "child-session".to_owned(),
+        event_kind: "delegate_started".to_owned(),
+        actor_session_id: Some("root-session".to_owned()),
+        payload_json: json!({
+            "task": "research",
+            "label": "Child",
+            "execution": {
+                "mode": "inline",
+                "depth": 1,
+                "max_depth": 3,
+                "active_children": 0,
+                "max_active_children": 3,
+                "timeout_seconds": 60,
+                "allow_shell_in_child": false,
+                "child_tool_allowlist": ["file.read", "file.write"],
+                "kernel_bound": false,
+                "profile": {
+                    "role": "leaf",
+                    "control_scope": "none"
+                }
+            }
+        }),
+    })
+    .expect("append delegate event");
+
+    let runtime = DefaultConversationRuntime::default();
+    let child_view = runtime
+        .tool_view(
+            &config,
+            "child-session",
+            ConversationRuntimeBinding::direct(),
+        )
+        .expect("child tool view");
+
+    assert!(child_view.contains("file.read"));
+    assert!(child_view.contains("file.write"));
+    assert!(!child_view.contains("delegate"));
+    assert!(!child_view.contains("delegate_async"));
+}
+
+#[test]
+fn session_context_keeps_execution_and_contract_in_sync_when_child_contract_is_overridden() {
+    let execution = crate::conversation::ConstrainedSubagentExecution {
+        mode: crate::conversation::ConstrainedSubagentMode::Inline,
+        depth: 1,
+        max_depth: 3,
+        active_children: 0,
+        max_active_children: 2,
+        timeout_seconds: 60,
+        allow_shell_in_child: false,
+        child_tool_allowlist: vec!["web.fetch".to_owned()],
+        runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
+        kernel_bound: false,
+        identity: None,
+        profile: Some(crate::conversation::ConstrainedSubagentProfile {
+            role: crate::conversation::ConstrainedSubagentRole::Orchestrator,
+            control_scope: crate::conversation::ConstrainedSubagentControlScope::Children,
+        }),
+    };
+    let runtime_narrowing = crate::tools::runtime_config::ToolRuntimeNarrowing {
+        web_fetch: crate::tools::runtime_config::WebFetchRuntimeNarrowing {
+            allowed_domains: BTreeSet::from(["docs.example.com".to_owned()]),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let session_context = SessionContext::child(
+        "child-session",
+        "root-session",
+        crate::tools::delegate_child_tool_view_for_config(&crate::config::ToolConfig::default()),
+    )
+    .with_subagent_execution(execution)
+    .with_subagent_profile(crate::conversation::ConstrainedSubagentProfile {
+        role: crate::conversation::ConstrainedSubagentRole::Leaf,
+        control_scope: crate::conversation::ConstrainedSubagentControlScope::None,
+    })
+    .with_runtime_narrowing(runtime_narrowing);
+
+    assert_eq!(
+        session_context
+            .subagent_execution
+            .as_ref()
+            .and_then(|execution| execution.profile),
+        Some(crate::conversation::ConstrainedSubagentProfile {
+            role: crate::conversation::ConstrainedSubagentRole::Leaf,
+            control_scope: crate::conversation::ConstrainedSubagentControlScope::None,
+        })
+    );
+    assert_eq!(
+        session_context
+            .subagent_runtime_narrowing()
+            .map(|narrowing| narrowing.web_fetch.allowed_domains.clone()),
+        Some(BTreeSet::from(["docs.example.com".to_owned()]))
+    );
+    assert_eq!(
+        session_context
+            .resolved_subagent_contract()
+            .and_then(|contract| contract.profile),
+        Some(crate::conversation::ConstrainedSubagentProfile {
+            role: crate::conversation::ConstrainedSubagentRole::Leaf,
+            control_scope: crate::conversation::ConstrainedSubagentControlScope::None,
+        })
+    );
+}
+
 #[tokio::test]
 async fn default_runtime_delegates_bootstrap_and_ingest_to_context_engine_with_kernel() {
     let calls = Arc::new(Mutex::new(Vec::new()));

--- a/crates/app/src/conversation/tests.rs
+++ b/crates/app/src/conversation/tests.rs
@@ -20435,6 +20435,7 @@ async fn spawn_background_delegate_with_runtime_creates_missing_root_session_sco
         "task-root",
         "collect repo health",
         Some("health-check".to_owned()),
+        None,
         Some(42),
         ConversationRuntimeBinding::direct(),
     )
@@ -20530,6 +20531,7 @@ async fn spawn_background_delegate_with_runtime_uses_default_timeout_when_omitte
         &runtime,
         "task-root",
         "sync release checklist",
+        None,
         None,
         None,
         ConversationRuntimeBinding::direct(),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -4106,6 +4106,7 @@ pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Si
     session_id: &str,
     task: &str,
     label: Option<String>,
+    specialization: Option<String>,
     timeout_seconds: Option<u64>,
     binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
@@ -4113,7 +4114,7 @@ pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Si
     let delegate_request = crate::tools::delegate::normalize_delegate_request(
         task,
         label.as_deref(),
-        None,
+        specialization.as_deref(),
         timeout_seconds,
         config.tools.delegate.timeout_seconds,
     )?;
@@ -4134,6 +4135,7 @@ pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Si
     _session_id: &str,
     _task: &str,
     _label: Option<String>,
+    _specialization: Option<String>,
     _timeout_seconds: Option<u64>,
     _binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -75,7 +75,8 @@ use super::session_history::{
 };
 #[cfg(feature = "memory-sqlite")]
 use super::subagent::{
-    ConstrainedSubagentExecution, ConstrainedSubagentMode, ConstrainedSubagentTerminalReason,
+    ConstrainedSubagentExecution, ConstrainedSubagentIdentity, ConstrainedSubagentMode,
+    ConstrainedSubagentProfile, ConstrainedSubagentTerminalReason,
 };
 use super::tool_discovery_state::{TOOL_DISCOVERY_REFRESHED_EVENT_NAME, ToolDiscoveryState};
 use super::trust_projection::{
@@ -3966,6 +3967,8 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
         &payload,
         config.tools.delegate.timeout_seconds,
     )?;
+    let subagent_identity =
+        crate::tools::delegate::subagent_identity_for_delegate_request(&delegate_request);
     let child_session_id = crate::tools::delegate::next_delegate_session_id();
     let child_label = delegate_request.label.clone();
     let repo = SessionRepository::new(&MemoryRuntimeConfig::from_memory_config(&config.memory))?;
@@ -3985,6 +3988,7 @@ pub(super) async fn execute_delegate_tool<R: ConversationRuntime + ?Sized>(
                     let execution = constrained_subagent_execution_for_delegate(
                         config,
                         binding,
+                        subagent_identity.clone(),
                         ConstrainedSubagentMode::Inline,
                         delegate_request.timeout_seconds,
                         next_child_depth,
@@ -4024,9 +4028,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
     config: &LoongClawConfig,
     runtime: &R,
     session_context: &SessionContext,
-    task: String,
-    label: Option<String>,
-    timeout_seconds: u64,
+    delegate_request: crate::tools::delegate::DelegateRequest,
     binding: ConversationRuntimeBinding<'_>,
 ) -> Result<loongclaw_contracts::ToolCoreOutcome, String> {
     if !config.tools.delegate.enabled {
@@ -4038,8 +4040,10 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
     let spawner = runtime
         .async_delegate_spawner(config)
         .ok_or_else(|| "delegate_async_not_configured".to_owned())?;
+    let subagent_identity =
+        crate::tools::delegate::subagent_identity_for_delegate_request(&delegate_request);
     let child_session_id = crate::tools::delegate::next_delegate_session_id();
-    let child_label = label.clone();
+    let child_label = delegate_request.label.clone();
     let memory_config = MemoryRuntimeConfig::from_memory_config(&config.memory);
     let repo = SessionRepository::new(&memory_config)?;
 
@@ -4055,8 +4059,9 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
             let execution = constrained_subagent_execution_for_delegate(
                 config,
                 binding,
+                subagent_identity.clone(),
                 ConstrainedSubagentMode::Async,
-                timeout_seconds,
+                delegate_request.timeout_seconds,
                 next_child_depth,
                 active_children,
             );
@@ -4064,7 +4069,7 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
                 &session_context.session_id,
                 &child_session_id,
                 child_label.clone(),
-                &task,
+                &delegate_request.task,
                 runtime_self_continuity.as_ref(),
                 &execution,
             );
@@ -4072,22 +4077,25 @@ async fn enqueue_delegate_async_with_runtime<R: ConversationRuntime + ?Sized>(
         },
     )?;
 
+    let queued_contract = execution.contract_view();
     let request = AsyncDelegateSpawnRequest {
         child_session_id: child_session_id.clone(),
         parent_session_id: session_context.session_id.clone(),
-        task,
+        task: delegate_request.task,
         label: child_label,
         execution,
         runtime_self_continuity,
-        timeout_seconds,
+        timeout_seconds: delegate_request.timeout_seconds,
         binding: OwnedConversationRuntimeBinding::from_borrowed(binding),
     };
     spawn_async_delegate_detached(runtime_handle, memory_config, spawner, request);
 
     Ok(crate::tools::delegate::delegate_async_queued_outcome(
         child_session_id,
-        label,
-        timeout_seconds,
+        Some(session_context.session_id.clone()),
+        delegate_request.label,
+        Some(&queued_contract),
+        delegate_request.timeout_seconds,
     ))
 }
 
@@ -4105,6 +4113,7 @@ pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Si
     let delegate_request = crate::tools::delegate::normalize_delegate_request(
         task,
         label.as_deref(),
+        None,
         timeout_seconds,
         config.tools.delegate.timeout_seconds,
     )?;
@@ -4112,9 +4121,7 @@ pub async fn spawn_background_delegate_with_runtime<R: ConversationRuntime + ?Si
         config,
         runtime,
         &session_context,
-        delegate_request.task,
-        delegate_request.label,
-        delegate_request.timeout_seconds,
+        delegate_request,
         binding,
     )
     .await
@@ -4149,16 +4156,8 @@ pub(super) async fn execute_delegate_async_tool<R: ConversationRuntime + ?Sized>
         &payload,
         config.tools.delegate.timeout_seconds,
     )?;
-    enqueue_delegate_async_with_runtime(
-        config,
-        runtime,
-        session_context,
-        delegate_request.task,
-        delegate_request.label,
-        delegate_request.timeout_seconds,
-        binding,
-    )
-    .await
+    enqueue_delegate_async_with_runtime(config, runtime, session_context, delegate_request, binding)
+        .await
 }
 
 #[cfg(not(feature = "memory-sqlite"))]
@@ -4221,9 +4220,12 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
                 .load_session_summary(child_session_id)?
                 .map(|session| session.turn_count)
                 .unwrap_or_default();
+            let subagent_contract = execution.contract_view();
             let outcome = crate::tools::delegate::delegate_success_outcome(
                 child_session_id.to_owned(),
+                Some(parent_session_id.to_owned()),
                 child_label,
+                Some(&subagent_contract),
                 final_output,
                 turn_count,
                 duration_ms,
@@ -4249,9 +4251,12 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
             Ok(outcome)
         }
         Ok(Ok(Err(error))) => {
+            let subagent_contract = execution.contract_view();
             let outcome = crate::tools::delegate::delegate_error_outcome(
                 child_session_id.to_owned(),
+                Some(parent_session_id.to_owned()),
                 child_label,
+                Some(&subagent_contract),
                 error.clone(),
                 duration_ms,
             );
@@ -4277,9 +4282,12 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
         }
         Ok(Err(panic_payload)) => {
             let panic_error = format_delegate_child_panic(panic_payload);
+            let subagent_contract = execution.contract_view();
             let outcome = crate::tools::delegate::delegate_error_outcome(
                 child_session_id.to_owned(),
+                Some(parent_session_id.to_owned()),
                 child_label,
+                Some(&subagent_contract),
                 panic_error.clone(),
                 duration_ms,
             );
@@ -4305,9 +4313,12 @@ pub(crate) async fn run_started_delegate_child_turn_with_runtime<
         }
         Err(_) => {
             let timeout_error = "delegate_timeout".to_owned();
+            let subagent_contract = execution.contract_view();
             let outcome = crate::tools::delegate::delegate_timeout_outcome(
                 child_session_id.to_owned(),
+                Some(parent_session_id.to_owned()),
                 child_label,
+                Some(&subagent_contract),
                 duration_ms,
             );
             finalize_delegate_child_terminal_with_recovery(
@@ -4343,9 +4354,12 @@ fn finalize_async_delegate_spawn_failure(
     error: String,
 ) -> Result<(), String> {
     let repo = SessionRepository::new(memory_config)?;
+    let subagent_contract = execution.contract_view();
     let outcome = crate::tools::delegate::delegate_error_outcome(
         child_session_id.to_owned(),
+        Some(parent_session_id.to_owned()),
         label,
+        Some(&subagent_contract),
         error.clone(),
         0,
     );
@@ -4495,11 +4509,17 @@ fn spawn_async_delegate_detached(
 fn constrained_subagent_execution_for_delegate(
     config: &LoongClawConfig,
     binding: ConversationRuntimeBinding<'_>,
+    subagent_identity: Option<ConstrainedSubagentIdentity>,
     mode: ConstrainedSubagentMode,
     timeout_seconds: u64,
     next_child_depth: usize,
     active_children: usize,
 ) -> ConstrainedSubagentExecution {
+    let subagent_profile = ConstrainedSubagentProfile::for_child_depth(
+        next_child_depth,
+        config.tools.delegate.max_depth,
+    );
+
     ConstrainedSubagentExecution {
         mode,
         depth: next_child_depth,
@@ -4511,6 +4531,8 @@ fn constrained_subagent_execution_for_delegate(
         child_tool_allowlist: config.tools.delegate.child_tool_allowlist.clone(),
         runtime_narrowing: config.tools.delegate.child_runtime.runtime_narrowing(),
         kernel_bound: binding.is_kernel_bound(),
+        identity: subagent_identity,
+        profile: Some(subagent_profile),
     }
 }
 

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -7742,9 +7742,7 @@ mod tests {
             runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
             kernel_bound: false,
             identity: None,
-            profile: Some(crate::conversation::ConstrainedSubagentProfile::for_child_depth(
-                1, 1,
-            )),
+            profile: Some(crate::conversation::ConstrainedSubagentProfile::for_child_depth(1, 1)),
         };
         repo.create_session(NewSessionRecord {
             session_id: "root-session".to_owned(),
@@ -7862,9 +7860,7 @@ mod tests {
             runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
             kernel_bound: false,
             identity: None,
-            profile: Some(crate::conversation::ConstrainedSubagentProfile::for_child_depth(
-                1, 1,
-            )),
+            profile: Some(crate::conversation::ConstrainedSubagentProfile::for_child_depth(1, 1)),
         };
         repo.create_session(NewSessionRecord {
             session_id: "root-session".to_owned(),

--- a/crates/app/src/conversation/turn_coordinator.rs
+++ b/crates/app/src/conversation/turn_coordinator.rs
@@ -7741,6 +7741,10 @@ mod tests {
             ],
             runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
             kernel_bound: false,
+            identity: None,
+            profile: Some(crate::conversation::ConstrainedSubagentProfile::for_child_depth(
+                1, 1,
+            )),
         };
         repo.create_session(NewSessionRecord {
             session_id: "root-session".to_owned(),
@@ -7857,6 +7861,10 @@ mod tests {
             ],
             runtime_narrowing: crate::tools::runtime_config::ToolRuntimeNarrowing::default(),
             kernel_bound: false,
+            identity: None,
+            profile: Some(crate::conversation::ConstrainedSubagentProfile::for_child_depth(
+                1, 1,
+            )),
         };
         repo.create_session(NewSessionRecord {
             session_id: "root-session".to_owned(),

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -27,9 +27,8 @@ use crate::session::repository::{
 };
 use crate::tools::{
     ToolApprovalMode, ToolExecutionKind, ToolSchedulingClass, ToolView,
-    delegate_child_tool_view_for_config, delegate_child_tool_view_for_config_with_delegate,
-    governance_profile_for_descriptor, runtime_tool_view, runtime_tool_view_for_config,
-    tool_catalog,
+    delegate_child_tool_view_for_contract, governance_profile_for_descriptor, runtime_tool_view,
+    runtime_tool_view_for_config, tool_catalog,
 };
 #[cfg(feature = "memory-sqlite")]
 use crate::trust::{approval_required_trust_event, embed_trust_event_payload};
@@ -649,21 +648,35 @@ impl DefaultAppToolDispatcher {
         session_context: &SessionContext,
     ) -> Result<ToolView, String> {
         let repo = SessionRepository::new(&self.memory_config)?;
-        let session_graph = OperatorSessionGraph::new(&repo);
         if let Some(session) = repo.load_session(&session_context.session_id)? {
             if session.parent_session_id.is_some() {
-                let depth = session_graph
-                    .lineage_depth(&session_context.session_id)
-                    .map_err(|error| {
-                        format!(
-                            "compute session lineage depth for dispatcher tool view failed: {error}"
+                let subagent_contract = match session_context.resolved_subagent_contract() {
+                    Some(subagent_contract) => Some(subagent_contract),
+                    None => {
+                        let session_graph = OperatorSessionGraph::new(&repo);
+                        let depth = session_graph
+                            .lineage_depth(&session_context.session_id)
+                            .map_err(|error| {
+                                format!(
+                                    "compute session lineage depth for dispatcher tool view failed: {error}"
+                                )
+                            })?;
+                        let subagent_profile =
+                            crate::conversation::ConstrainedSubagentProfile::for_child_depth(
+                                depth,
+                                self.tool_config.delegate.max_depth,
+                            );
+                        Some(
+                            crate::conversation::ConstrainedSubagentContractView::from_profile(
+                                subagent_profile,
+                            ),
                         )
-                    })?;
-                let allow_nested_delegate = depth < self.tool_config.delegate.max_depth;
+                    }
+                };
                 return Ok(with_runtime_ready_browser_companion_tools(
-                    delegate_child_tool_view_for_config_with_delegate(
+                    delegate_child_tool_view_for_contract(
                         &self.tool_config,
-                        allow_nested_delegate,
+                        subagent_contract.as_ref(),
                     ),
                     &session_context.tool_view,
                 ));
@@ -677,8 +690,37 @@ impl DefaultAppToolDispatcher {
             .load_session_summary_with_legacy_fallback(&session_context.session_id)?
             .is_some_and(|session| session.kind == SessionKind::DelegateChild)
         {
+            let session_graph = OperatorSessionGraph::new(&repo);
+            let subagent_contract = match session_graph.lineage_depth(&session_context.session_id) {
+                Ok(depth) => {
+                    let subagent_profile =
+                        crate::conversation::ConstrainedSubagentProfile::for_child_depth(
+                            depth,
+                            self.tool_config.delegate.max_depth,
+                        );
+                    Some(
+                        crate::conversation::ConstrainedSubagentContractView::from_profile(
+                            subagent_profile,
+                        ),
+                    )
+                }
+                Err(error)
+                    if error.starts_with("session_lineage_broken:")
+                        || error.starts_with("session_lineage_cycle_detected:") =>
+                {
+                    None
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "compute session lineage depth for dispatcher tool view failed: {error}"
+                    ));
+                }
+            };
             return Ok(with_runtime_ready_browser_companion_tools(
-                delegate_child_tool_view_for_config(&self.tool_config),
+                delegate_child_tool_view_for_contract(
+                    &self.tool_config,
+                    subagent_contract.as_ref(),
+                ),
                 &session_context.tool_view,
             ));
         }

--- a/crates/app/src/conversation/turn_engine.rs
+++ b/crates/app/src/conversation/turn_engine.rs
@@ -654,23 +654,31 @@ impl DefaultAppToolDispatcher {
                     Some(subagent_contract) => Some(subagent_contract),
                     None => {
                         let session_graph = OperatorSessionGraph::new(&repo);
-                        let depth = session_graph
-                            .lineage_depth(&session_context.session_id)
-                            .map_err(|error| {
-                                format!(
-                                    "compute session lineage depth for dispatcher tool view failed: {error}"
+                        match session_graph.lineage_depth(&session_context.session_id) {
+                            Ok(depth) => {
+                                let subagent_profile =
+                                    crate::conversation::ConstrainedSubagentProfile::for_child_depth(
+                                        depth,
+                                        self.tool_config.delegate.max_depth,
+                                    );
+                                Some(
+                                    crate::conversation::ConstrainedSubagentContractView::from_profile(
+                                        subagent_profile,
+                                    ),
                                 )
-                            })?;
-                        let subagent_profile =
-                            crate::conversation::ConstrainedSubagentProfile::for_child_depth(
-                                depth,
-                                self.tool_config.delegate.max_depth,
-                            );
-                        Some(
-                            crate::conversation::ConstrainedSubagentContractView::from_profile(
-                                subagent_profile,
-                            ),
-                        )
+                            }
+                            Err(error)
+                                if error.starts_with("session_lineage_broken:")
+                                    || error.starts_with("session_lineage_cycle_detected:") =>
+                            {
+                                None
+                            }
+                            Err(error) => {
+                                return Err(format!(
+                                    "compute session lineage depth for dispatcher tool view failed: {error}"
+                                ));
+                            }
+                        }
                     }
                 };
                 return Ok(with_runtime_ready_browser_companion_tools(

--- a/crates/app/src/tools/catalog.rs
+++ b/crates/app/src/tools/catalog.rs
@@ -8,6 +8,7 @@ use serde_json::{Value, json};
 
 use super::runtime_config::ToolRuntimeConfig;
 use crate::config::ToolConfig;
+use crate::conversation::{ConstrainedSubagentContractView, ConstrainedSubagentProfile};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ToolExecutionKind {
@@ -1476,6 +1477,38 @@ pub fn planned_delegate_child_tool_view() -> ToolView {
 
 pub fn delegate_child_tool_view_for_config(config: &ToolConfig) -> ToolView {
     delegate_child_tool_view_for_config_with_delegate(config, false)
+}
+
+pub fn delegate_child_tool_view_for_contract(
+    config: &ToolConfig,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
+) -> ToolView {
+    let subagent_profile =
+        subagent_contract.and_then(ConstrainedSubagentContractView::resolved_profile);
+    delegate_child_tool_view_for_profile(config, subagent_profile)
+}
+
+pub fn delegate_child_tool_view_for_runtime_config_and_contract(
+    config: &ToolConfig,
+    runtime_config: &ToolRuntimeConfig,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
+) -> ToolView {
+    let subagent_profile =
+        subagent_contract.and_then(ConstrainedSubagentContractView::resolved_profile);
+    let allow_delegate = subagent_profile
+        .map(ConstrainedSubagentProfile::allows_child_delegation)
+        .unwrap_or(false);
+    build_delegate_child_tool_view(config, Some(runtime_config), allow_delegate)
+}
+
+pub fn delegate_child_tool_view_for_profile(
+    config: &ToolConfig,
+    subagent_profile: Option<ConstrainedSubagentProfile>,
+) -> ToolView {
+    let allow_delegate = subagent_profile
+        .map(ConstrainedSubagentProfile::allows_child_delegation)
+        .unwrap_or(false);
+    build_delegate_child_tool_view(config, None, allow_delegate)
 }
 
 pub fn delegate_child_tool_view_for_runtime_config(
@@ -3378,6 +3411,10 @@ fn delegate_definition(descriptor: &ToolDescriptor) -> Value {
                         "type": "string",
                         "description": "Optional human-readable label for the child session."
                     },
+                    "specialization": {
+                        "type": "string",
+                        "description": "Optional bounded specialization hint carried on the child handle."
+                    },
                     "timeout_seconds": {
                         "type": "integer",
                         "minimum": 1,
@@ -3408,6 +3445,10 @@ fn delegate_async_definition(descriptor: &ToolDescriptor) -> Value {
                     "label": {
                         "type": "string",
                         "description": "Optional human-readable label for the child session."
+                    },
+                    "specialization": {
+                        "type": "string",
+                        "description": "Optional bounded specialization hint carried on the child handle."
                     },
                     "timeout_seconds": {
                         "type": "integer",
@@ -3605,7 +3646,9 @@ fn tool_argument_hint(name: &str) -> &'static str {
         "shell.exec" => "command:string,args?:string[],timeout_ms?:integer,cwd?:string",
         "bash.exec" => "command:string,cwd?:string,timeout_ms?:integer",
         "provider.switch" => "selector?:string",
-        "delegate" | "delegate_async" => "task:string,label?:string,timeout_seconds?:integer",
+        "delegate" | "delegate_async" => {
+            "task:string,label?:string,specialization?:string,timeout_seconds?:integer"
+        }
         "session_tool_policy_status" | "session_tool_policy_clear" => "session_id?:string",
         "session_tool_policy_set" => {
             "session_id?:string,tool_ids?:string[],runtime_narrowing?:object"
@@ -4027,6 +4070,7 @@ fn tool_parameter_types(name: &str) -> &'static [(&'static str, &'static str)] {
         "delegate" | "delegate_async" => &[
             ("task", "string"),
             ("label", "string"),
+            ("specialization", "string"),
             ("timeout_seconds", "integer"),
         ],
         "session_tool_policy_status" | "session_tool_policy_clear" => &[("session_id", "string")],
@@ -4502,6 +4546,28 @@ mod tests {
         let child_view = delegate_child_tool_view_for_config(&config);
 
         assert!(!child_view.contains("web.fetch"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_for_contract_fails_closed_without_profile() {
+        let config = ToolConfig::default();
+        let child_view = delegate_child_tool_view_for_contract(&config, None);
+
+        assert!(!child_view.contains("delegate"));
+        assert!(!child_view.contains("delegate_async"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_for_contract_allows_nested_delegate_when_profile_permits() {
+        let config = ToolConfig::default();
+        let contract = ConstrainedSubagentContractView::from_profile(ConstrainedSubagentProfile {
+            role: crate::conversation::ConstrainedSubagentRole::Orchestrator,
+            control_scope: crate::conversation::ConstrainedSubagentControlScope::Children,
+        });
+        let child_view = delegate_child_tool_view_for_contract(&config, Some(&contract));
+
+        assert!(child_view.contains("delegate"));
+        assert!(child_view.contains("delegate_async"));
     }
 
     #[cfg(feature = "tool-shell")]

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -4,6 +4,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use loongclaw_contracts::ToolCoreOutcome;
 use serde_json::{Value, json};
 
+use crate::conversation::{
+    ConstrainedSubagentContractView, ConstrainedSubagentHandle, ConstrainedSubagentIdentity,
+    coordination_actions_for_subagent_handle,
+};
+
 #[cfg(test)]
 pub const DEFAULT_TIMEOUT_SECONDS: u64 = 60;
 
@@ -11,6 +16,7 @@ pub const DEFAULT_TIMEOUT_SECONDS: u64 = 60;
 pub(crate) struct DelegateRequest {
     pub task: String,
     pub label: Option<String>,
+    pub specialization: Option<String>,
     pub timeout_seconds: u64,
 }
 
@@ -25,11 +31,13 @@ pub(crate) fn parse_delegate_request_with_default_timeout(
 ) -> Result<DelegateRequest, String> {
     let raw_task = payload.get("task").and_then(Value::as_str).unwrap_or("");
     let raw_label = payload.get("label").and_then(Value::as_str);
+    let raw_specialization = payload.get("specialization").and_then(Value::as_str);
     let timeout_seconds = payload.get("timeout_seconds").and_then(Value::as_u64);
 
     normalize_delegate_request(
         raw_task,
         raw_label,
+        raw_specialization,
         timeout_seconds,
         default_timeout_seconds,
     )
@@ -38,16 +46,19 @@ pub(crate) fn parse_delegate_request_with_default_timeout(
 pub(crate) fn normalize_delegate_request(
     task: &str,
     label: Option<&str>,
+    specialization: Option<&str>,
     timeout_seconds: Option<u64>,
     default_timeout_seconds: u64,
 ) -> Result<DelegateRequest, String> {
     let normalized_task = normalize_required_delegate_text(task, "task")?;
     let normalized_label = normalize_optional_delegate_text(label);
+    let normalized_specialization = normalize_optional_delegate_text(specialization);
     let effective_timeout_seconds = timeout_seconds.unwrap_or(default_timeout_seconds);
 
     Ok(DelegateRequest {
         task: normalized_task,
         label: normalized_label,
+        specialization: normalized_specialization,
         timeout_seconds: effective_timeout_seconds,
     })
 }
@@ -69,6 +80,16 @@ fn normalize_optional_delegate_text(value: Option<&str>) -> Option<String> {
     Some(trimmed_value.to_owned())
 }
 
+pub(crate) fn subagent_identity_for_delegate_request(
+    request: &DelegateRequest,
+) -> Option<ConstrainedSubagentIdentity> {
+    let identity = ConstrainedSubagentIdentity {
+        nickname: request.label.clone(),
+        specialization: request.specialization.clone(),
+    };
+    (!identity.is_empty()).then_some(identity)
+}
+
 pub(crate) fn next_delegate_session_id() -> String {
     static COUNTER: AtomicU64 = AtomicU64::new(1);
 
@@ -82,16 +103,29 @@ pub(crate) fn next_delegate_session_id() -> String {
 
 pub(crate) fn delegate_success_outcome(
     child_session_id: String,
+    parent_session_id: Option<String>,
     label: Option<String>,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
     final_output: String,
     turn_count: usize,
     duration_ms: u64,
 ) -> ToolCoreOutcome {
+    let subagent = delegate_subagent_handle(
+        child_session_id.clone(),
+        parent_session_id,
+        label.clone(),
+        Some("completed".to_owned()),
+        Some("completed".to_owned()),
+        subagent_contract,
+    );
     ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "child_session_id": child_session_id,
             "label": label,
+            "subagent_identity": subagent_contract.and_then(ConstrainedSubagentContractView::resolved_identity),
+            "subagent_contract": subagent_contract,
+            "subagent": subagent,
             "final_output": final_output,
             "turn_count": turn_count,
             "duration_ms": duration_ms,
@@ -101,14 +135,27 @@ pub(crate) fn delegate_success_outcome(
 
 pub(crate) fn delegate_async_queued_outcome(
     child_session_id: String,
+    parent_session_id: Option<String>,
     label: Option<String>,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
     timeout_seconds: u64,
 ) -> ToolCoreOutcome {
+    let subagent = delegate_subagent_handle(
+        child_session_id.clone(),
+        parent_session_id,
+        label.clone(),
+        Some("ready".to_owned()),
+        Some("queued".to_owned()),
+        subagent_contract,
+    );
     ToolCoreOutcome {
         status: "ok".to_owned(),
         payload: json!({
             "child_session_id": child_session_id,
             "label": label,
+            "subagent_identity": subagent_contract.and_then(ConstrainedSubagentContractView::resolved_identity),
+            "subagent_contract": subagent_contract,
+            "subagent": subagent,
             "mode": "async",
             "state": "queued",
             "timeout_seconds": timeout_seconds,
@@ -118,14 +165,27 @@ pub(crate) fn delegate_async_queued_outcome(
 
 pub(crate) fn delegate_timeout_outcome(
     child_session_id: String,
+    parent_session_id: Option<String>,
     label: Option<String>,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
     duration_ms: u64,
 ) -> ToolCoreOutcome {
+    let subagent = delegate_subagent_handle(
+        child_session_id.clone(),
+        parent_session_id,
+        label.clone(),
+        Some("timed_out".to_owned()),
+        Some("timed_out".to_owned()),
+        subagent_contract,
+    );
     ToolCoreOutcome {
         status: "timeout".to_owned(),
         payload: json!({
             "child_session_id": child_session_id,
             "label": label,
+            "subagent_identity": subagent_contract.and_then(ConstrainedSubagentContractView::resolved_identity),
+            "subagent_contract": subagent_contract,
+            "subagent": subagent,
             "duration_ms": duration_ms,
             "error": "delegate_timeout",
         }),
@@ -134,19 +194,64 @@ pub(crate) fn delegate_timeout_outcome(
 
 pub(crate) fn delegate_error_outcome(
     child_session_id: String,
+    parent_session_id: Option<String>,
     label: Option<String>,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
     error: String,
     duration_ms: u64,
 ) -> ToolCoreOutcome {
+    let subagent = delegate_subagent_handle(
+        child_session_id.clone(),
+        parent_session_id,
+        label.clone(),
+        Some("failed".to_owned()),
+        Some("failed".to_owned()),
+        subagent_contract,
+    );
     ToolCoreOutcome {
         status: "error".to_owned(),
         payload: json!({
             "child_session_id": child_session_id,
             "label": label,
+            "subagent_identity": subagent_contract.and_then(ConstrainedSubagentContractView::resolved_identity),
+            "subagent_contract": subagent_contract,
+            "subagent": subagent,
             "duration_ms": duration_ms,
             "error": error,
         }),
     }
+}
+
+fn delegate_subagent_handle(
+    child_session_id: String,
+    parent_session_id: Option<String>,
+    label: Option<String>,
+    state: Option<String>,
+    phase: Option<String>,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
+) -> ConstrainedSubagentHandle {
+    let terminal = matches!(
+        phase.as_deref().or(state.as_deref()),
+        Some("completed" | "failed" | "timed_out")
+    );
+    let coordination = coordination_actions_for_subagent_handle(
+        terminal,
+        phase.as_deref().or(state.as_deref()),
+        subagent_contract.and_then(|contract| contract.mode),
+        false,
+    );
+    ConstrainedSubagentHandle::new(child_session_id)
+        .with_parent_session_id(parent_session_id)
+        .with_label(label)
+        .with_state(state)
+        .with_phase(phase)
+        .with_identity(
+            subagent_contract
+                .and_then(ConstrainedSubagentContractView::resolved_identity)
+                .cloned(),
+        )
+        .with_contract(subagent_contract.cloned())
+        .with_coordination(coordination)
 }
 
 #[cfg(test)]
@@ -168,6 +273,7 @@ mod tests {
         .expect("delegate request");
         assert_eq!(request.task, "research");
         assert_eq!(request.label, None);
+        assert_eq!(request.specialization, None);
         assert_eq!(request.timeout_seconds, DEFAULT_TIMEOUT_SECONDS);
     }
 
@@ -176,13 +282,33 @@ mod tests {
         let request = normalize_delegate_request(
             "  research  ",
             Some("  release-check  "),
+            Some("  reviewer  "),
             None,
             DEFAULT_TIMEOUT_SECONDS,
         )
         .expect("delegate request");
         assert_eq!(request.task, "research");
         assert_eq!(request.label.as_deref(), Some("release-check"));
+        assert_eq!(request.specialization.as_deref(), Some("reviewer"));
         assert_eq!(request.timeout_seconds, DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    #[test]
+    fn parse_delegate_request_includes_optional_specialization() {
+        let request = parse_delegate_request(&json!({
+            "task": "research",
+            "label": "child",
+            "specialization": "reviewer"
+        }))
+        .expect("delegate request");
+        assert_eq!(request.specialization.as_deref(), Some("reviewer"));
+        assert_eq!(
+            subagent_identity_for_delegate_request(&request),
+            Some(ConstrainedSubagentIdentity {
+                nickname: Some("child".to_owned()),
+                specialization: Some("reviewer".to_owned())
+            })
+        );
     }
 
     #[test]

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -2,11 +2,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use loongclaw_contracts::ToolCoreOutcome;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use crate::conversation::{
     ConstrainedSubagentContractView, ConstrainedSubagentHandle, ConstrainedSubagentIdentity,
-    coordination_actions_for_subagent_handle,
+    coordination_actions_for_subagent_handle, subagent_surface_fields,
 };
 
 #[cfg(test)]
@@ -118,18 +118,17 @@ pub(crate) fn delegate_success_outcome(
         Some("completed".to_owned()),
         subagent_contract,
     );
+    let mut payload = Map::new();
+    payload.insert("child_session_id".to_owned(), json!(child_session_id));
+    payload.insert("label".to_owned(), json!(label));
+    payload.extend(subagent_surface_fields(Some(&subagent)));
+    payload.insert("final_output".to_owned(), json!(final_output));
+    payload.insert("turn_count".to_owned(), json!(turn_count));
+    payload.insert("duration_ms".to_owned(), json!(duration_ms));
+
     ToolCoreOutcome {
         status: "ok".to_owned(),
-        payload: json!({
-            "child_session_id": child_session_id,
-            "label": label,
-            "subagent_identity": subagent_contract.and_then(ConstrainedSubagentContractView::resolved_identity),
-            "subagent_contract": subagent_contract,
-            "subagent": subagent,
-            "final_output": final_output,
-            "turn_count": turn_count,
-            "duration_ms": duration_ms,
-        }),
+        payload: Value::Object(payload),
     }
 }
 
@@ -148,18 +147,17 @@ pub(crate) fn delegate_async_queued_outcome(
         Some("queued".to_owned()),
         subagent_contract,
     );
+    let mut payload = Map::new();
+    payload.insert("child_session_id".to_owned(), json!(child_session_id));
+    payload.insert("label".to_owned(), json!(label));
+    payload.extend(subagent_surface_fields(Some(&subagent)));
+    payload.insert("mode".to_owned(), json!("async"));
+    payload.insert("state".to_owned(), json!("queued"));
+    payload.insert("timeout_seconds".to_owned(), json!(timeout_seconds));
+
     ToolCoreOutcome {
         status: "ok".to_owned(),
-        payload: json!({
-            "child_session_id": child_session_id,
-            "label": label,
-            "subagent_identity": subagent_contract.and_then(ConstrainedSubagentContractView::resolved_identity),
-            "subagent_contract": subagent_contract,
-            "subagent": subagent,
-            "mode": "async",
-            "state": "queued",
-            "timeout_seconds": timeout_seconds,
-        }),
+        payload: Value::Object(payload),
     }
 }
 
@@ -178,17 +176,16 @@ pub(crate) fn delegate_timeout_outcome(
         Some("timed_out".to_owned()),
         subagent_contract,
     );
+    let mut payload = Map::new();
+    payload.insert("child_session_id".to_owned(), json!(child_session_id));
+    payload.insert("label".to_owned(), json!(label));
+    payload.extend(subagent_surface_fields(Some(&subagent)));
+    payload.insert("duration_ms".to_owned(), json!(duration_ms));
+    payload.insert("error".to_owned(), json!("delegate_timeout"));
+
     ToolCoreOutcome {
         status: "timeout".to_owned(),
-        payload: json!({
-            "child_session_id": child_session_id,
-            "label": label,
-            "subagent_identity": subagent_contract.and_then(ConstrainedSubagentContractView::resolved_identity),
-            "subagent_contract": subagent_contract,
-            "subagent": subagent,
-            "duration_ms": duration_ms,
-            "error": "delegate_timeout",
-        }),
+        payload: Value::Object(payload),
     }
 }
 
@@ -208,17 +205,16 @@ pub(crate) fn delegate_error_outcome(
         Some("failed".to_owned()),
         subagent_contract,
     );
+    let mut payload = Map::new();
+    payload.insert("child_session_id".to_owned(), json!(child_session_id));
+    payload.insert("label".to_owned(), json!(label));
+    payload.extend(subagent_surface_fields(Some(&subagent)));
+    payload.insert("duration_ms".to_owned(), json!(duration_ms));
+    payload.insert("error".to_owned(), json!(error));
+
     ToolCoreOutcome {
         status: "error".to_owned(),
-        payload: json!({
-            "child_session_id": child_session_id,
-            "label": label,
-            "subagent_identity": subagent_contract.and_then(ConstrainedSubagentContractView::resolved_identity),
-            "subagent_contract": subagent_contract,
-            "subagent": subagent,
-            "duration_ms": duration_ms,
-            "error": error,
-        }),
+        payload: Value::Object(payload),
     }
 }
 

--- a/crates/app/src/tools/delegate.rs
+++ b/crates/app/src/tools/delegate.rs
@@ -116,6 +116,7 @@ pub(crate) fn delegate_success_outcome(
         label.clone(),
         Some("completed".to_owned()),
         Some("completed".to_owned()),
+        None,
         subagent_contract,
     );
     let mut payload = Map::new();
@@ -145,6 +146,7 @@ pub(crate) fn delegate_async_queued_outcome(
         label.clone(),
         Some("ready".to_owned()),
         Some("queued".to_owned()),
+        Some(crate::conversation::ConstrainedSubagentMode::Async),
         subagent_contract,
     );
     let mut payload = Map::new();
@@ -174,6 +176,7 @@ pub(crate) fn delegate_timeout_outcome(
         label.clone(),
         Some("timed_out".to_owned()),
         Some("timed_out".to_owned()),
+        None,
         subagent_contract,
     );
     let mut payload = Map::new();
@@ -203,6 +206,7 @@ pub(crate) fn delegate_error_outcome(
         label.clone(),
         Some("failed".to_owned()),
         Some("failed".to_owned()),
+        None,
         subagent_contract,
     );
     let mut payload = Map::new();
@@ -224,8 +228,10 @@ fn delegate_subagent_handle(
     label: Option<String>,
     state: Option<String>,
     phase: Option<String>,
+    explicit_mode: Option<crate::conversation::ConstrainedSubagentMode>,
     subagent_contract: Option<&ConstrainedSubagentContractView>,
 ) -> ConstrainedSubagentHandle {
+    let mode = explicit_mode.or_else(|| subagent_contract.and_then(|contract| contract.mode));
     let terminal = matches!(
         phase.as_deref().or(state.as_deref()),
         Some("completed" | "failed" | "timed_out")
@@ -233,7 +239,7 @@ fn delegate_subagent_handle(
     let coordination = coordination_actions_for_subagent_handle(
         terminal,
         phase.as_deref().or(state.as_deref()),
-        subagent_contract.and_then(|contract| contract.mode),
+        mode,
         false,
     );
     ConstrainedSubagentHandle::new(child_session_id)

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -77,7 +77,9 @@ pub use catalog::{
     ToolExecutionKind, ToolGovernanceProfile, ToolGovernanceScope, ToolRiskClass,
     ToolSchedulingClass, ToolView, capability_action_class_for_descriptor,
     capability_action_class_for_tool_name, delegate_child_tool_view_for_config,
-    delegate_child_tool_view_for_config_with_delegate, delegate_child_tool_view_for_runtime_config,
+    delegate_child_tool_view_for_config_with_delegate, delegate_child_tool_view_for_contract,
+    delegate_child_tool_view_for_profile, delegate_child_tool_view_for_runtime_config,
+    delegate_child_tool_view_for_runtime_config_and_contract,
     delegate_child_tool_view_for_runtime_config_with_delegate, governance_profile_for_descriptor,
     governance_profile_for_tool_name, planned_delegate_child_tool_view, planned_root_tool_view,
     runtime_tool_view, runtime_tool_view_for_config,
@@ -2239,6 +2241,37 @@ mod tests {
         let depth_budgeted_child = delegate_child_tool_view_for_config_with_delegate(&config, true);
         assert!(depth_budgeted_child.contains("delegate"));
         assert!(depth_budgeted_child.contains("delegate_async"));
+    }
+
+    #[test]
+    fn delegate_child_tool_view_contract_path_preserves_fail_closed_and_leaf_behavior() {
+        let config = crate::config::ToolConfig::default();
+
+        let no_contract = delegate_child_tool_view_for_contract(&config, None);
+        assert!(!no_contract.contains("delegate"));
+        assert!(!no_contract.contains("delegate_async"));
+
+        let leaf_contract = crate::conversation::ConstrainedSubagentContractView::from_profile(
+            crate::conversation::ConstrainedSubagentProfile {
+                role: crate::conversation::ConstrainedSubagentRole::Leaf,
+                control_scope: crate::conversation::ConstrainedSubagentControlScope::None,
+            },
+        );
+        let leaf_view = delegate_child_tool_view_for_contract(&config, Some(&leaf_contract));
+        assert!(!leaf_view.contains("delegate"));
+        assert!(!leaf_view.contains("delegate_async"));
+
+        let orchestrator_contract =
+            crate::conversation::ConstrainedSubagentContractView::from_profile(
+                crate::conversation::ConstrainedSubagentProfile {
+                    role: crate::conversation::ConstrainedSubagentRole::Orchestrator,
+                    control_scope: crate::conversation::ConstrainedSubagentControlScope::Children,
+                },
+            );
+        let orchestrator_view =
+            delegate_child_tool_view_for_contract(&config, Some(&orchestrator_contract));
+        assert!(orchestrator_view.contains("delegate"));
+        assert!(orchestrator_view.contains("delegate_async"));
     }
 
     #[test]

--- a/crates/app/src/tools/mod.rs
+++ b/crates/app/src/tools/mod.rs
@@ -2244,37 +2244,6 @@ mod tests {
     }
 
     #[test]
-    fn delegate_child_tool_view_contract_path_preserves_fail_closed_and_leaf_behavior() {
-        let config = crate::config::ToolConfig::default();
-
-        let no_contract = delegate_child_tool_view_for_contract(&config, None);
-        assert!(!no_contract.contains("delegate"));
-        assert!(!no_contract.contains("delegate_async"));
-
-        let leaf_contract = crate::conversation::ConstrainedSubagentContractView::from_profile(
-            crate::conversation::ConstrainedSubagentProfile {
-                role: crate::conversation::ConstrainedSubagentRole::Leaf,
-                control_scope: crate::conversation::ConstrainedSubagentControlScope::None,
-            },
-        );
-        let leaf_view = delegate_child_tool_view_for_contract(&config, Some(&leaf_contract));
-        assert!(!leaf_view.contains("delegate"));
-        assert!(!leaf_view.contains("delegate_async"));
-
-        let orchestrator_contract =
-            crate::conversation::ConstrainedSubagentContractView::from_profile(
-                crate::conversation::ConstrainedSubagentProfile {
-                    role: crate::conversation::ConstrainedSubagentRole::Orchestrator,
-                    control_scope: crate::conversation::ConstrainedSubagentControlScope::Children,
-                },
-            );
-        let orchestrator_view =
-            delegate_child_tool_view_for_contract(&config, Some(&orchestrator_contract));
-        assert!(orchestrator_view.contains("delegate"));
-        assert!(orchestrator_view.contains("delegate_async"));
-    }
-
-    #[test]
     fn runtime_tool_view_exposes_sessions_send_only_when_messages_enabled() {
         let default_root_view = runtime_tool_view_for_config(&crate::config::ToolConfig::default());
         assert!(!default_root_view.contains("sessions_send"));

--- a/crates/app/src/tools/runtime_config.rs
+++ b/crates/app/src/tools/runtime_config.rs
@@ -10,6 +10,14 @@ use super::{bash_rules, shell_policy_ext::ShellPolicyDefault};
 use crate::config::{AutonomyProfile, LoongClawConfig};
 #[cfg(feature = "feishu-integration")]
 use crate::config::{FeishuChannelConfig, FeishuIntegrationConfig};
+use crate::conversation::{
+    ConstrainedSubagentContractView, ConstrainedSubagentControlScope, ConstrainedSubagentMode,
+    ConstrainedSubagentRole, ConstrainedSubagentRuntimeBinding,
+};
+#[cfg(test)]
+use crate::conversation::{
+    ConstrainedSubagentExecution, ConstrainedSubagentIdentity, ConstrainedSubagentProfile,
+};
 #[cfg(feature = "feishu-integration")]
 use crate::secrets::has_configured_secret_ref;
 use crate::secrets::{SecretLookup, resolve_secret_lookup};
@@ -1141,18 +1149,104 @@ impl ToolRuntimeConfig {
     #[must_use]
     pub(crate) fn delegate_child_prompt_summary(
         &self,
-        narrowing: &ToolRuntimeNarrowing,
+        subagent_contract: Option<&ConstrainedSubagentContractView>,
     ) -> Option<String> {
-        if narrowing.is_empty() {
-            return None;
-        }
-
+        let subagent_contract = subagent_contract?;
+        let narrowing = &subagent_contract.runtime_narrowing;
         let effective = self.narrowed(narrowing);
         let mut lines = vec![
             "[delegate_child_runtime_contract]".to_owned(),
             "Plan within these child-session runtime limits:".to_owned(),
         ];
         let mut rendered_any = false;
+
+        if let Some(mode) = subagent_contract.mode {
+            rendered_any = true;
+            let mode = match mode {
+                ConstrainedSubagentMode::Async => "async",
+                ConstrainedSubagentMode::Inline => "inline",
+            };
+            lines.push(format!("- subagent mode: {mode}"));
+        }
+
+        if let Some(identity) = subagent_contract.resolved_identity() {
+            if let Some(nickname) = identity.nickname.as_deref() {
+                rendered_any = true;
+                lines.push(format!("- subagent nickname: {nickname}"));
+            }
+            if let Some(specialization) = identity.specialization.as_deref() {
+                rendered_any = true;
+                lines.push(format!("- subagent specialization: {specialization}"));
+            }
+        }
+
+        if let Some(depth_budget) = subagent_contract.depth_budget {
+            rendered_any = true;
+            lines.push(format!(
+                "- subagent depth budget: {}/{}",
+                depth_budget.current, depth_budget.max
+            ));
+        }
+
+        if let Some(active_child_budget) = subagent_contract.active_child_budget {
+            rendered_any = true;
+            lines.push(format!(
+                "- subagent active-child budget snapshot: {}/{}",
+                active_child_budget.current, active_child_budget.max
+            ));
+        }
+
+        if let Some(timeout_seconds) = subagent_contract.timeout_seconds {
+            rendered_any = true;
+            lines.push(format!("- child timeout seconds: {}", timeout_seconds));
+        }
+
+        if let Some(allow_shell_in_child) = subagent_contract.allow_shell_in_child {
+            rendered_any = true;
+            lines.push(format!(
+                "- child shell.exec: {}",
+                if allow_shell_in_child {
+                    "allowed"
+                } else {
+                    "denied"
+                }
+            ));
+        }
+
+        if !subagent_contract.child_tool_allowlist.is_empty() || subagent_contract.mode.is_some() {
+            rendered_any = true;
+            let tool_allowlist = if subagent_contract.child_tool_allowlist.is_empty() {
+                "none".to_owned()
+            } else {
+                subagent_contract.child_tool_allowlist.join(", ")
+            };
+            lines.push(format!("- child tool allowlist: {tool_allowlist}"));
+        }
+
+        if let Some(runtime_binding) = subagent_contract.runtime_binding {
+            rendered_any = true;
+            lines.push(format!(
+                "- child runtime binding: {}",
+                match runtime_binding {
+                    ConstrainedSubagentRuntimeBinding::KernelBound => "kernel-bound",
+                    ConstrainedSubagentRuntimeBinding::Direct => "direct",
+                }
+            ));
+        }
+
+        if let Some(subagent_profile) = subagent_contract.profile {
+            rendered_any = true;
+            let role = match subagent_profile.role {
+                ConstrainedSubagentRole::Orchestrator => "orchestrator",
+                ConstrainedSubagentRole::Leaf => "leaf",
+            };
+            let control_scope = match subagent_profile.control_scope {
+                ConstrainedSubagentControlScope::Children => "children",
+                ConstrainedSubagentControlScope::None => "none",
+            };
+            lines.push(format!("- subagent role: {role}"));
+            lines.push(format!("- subagent control scope: {control_scope}"));
+        }
 
         if effective.web_fetch.enabled {
             if narrowing.web_fetch.allow_private_hosts.is_some() {
@@ -2898,8 +2992,7 @@ mod tests {
     #[test]
     fn delegate_child_prompt_summary_returns_none_when_narrowing_is_empty() {
         assert_eq!(
-            ToolRuntimeConfig::default()
-                .delegate_child_prompt_summary(&ToolRuntimeNarrowing::default()),
+            ToolRuntimeConfig::default().delegate_child_prompt_summary(None),
             None
         );
     }
@@ -2941,15 +3034,44 @@ mod tests {
                 max_redirects: Some(2),
             },
         };
+        let execution = ConstrainedSubagentExecution {
+            mode: crate::conversation::ConstrainedSubagentMode::Async,
+            depth: 1,
+            max_depth: 2,
+            active_children: 0,
+            max_active_children: 3,
+            timeout_seconds: 60,
+            allow_shell_in_child: false,
+            child_tool_allowlist: vec!["web.fetch".to_owned()],
+            runtime_narrowing: narrowing,
+            kernel_bound: false,
+            identity: Some(ConstrainedSubagentIdentity {
+                nickname: Some("child-research".to_owned()),
+                specialization: Some("researcher".to_owned()),
+            }),
+            profile: Some(ConstrainedSubagentProfile::for_child_depth(1, 2)),
+        };
 
+        let contract = execution.contract_view();
         let summary = base
-            .delegate_child_prompt_summary(&narrowing)
+            .delegate_child_prompt_summary(Some(&contract))
             .expect("delegate child prompt summary");
 
         assert_eq!(
             summary,
             "[delegate_child_runtime_contract]\n\
 Plan within these child-session runtime limits:\n\
+- subagent mode: async\n\
+- subagent nickname: child-research\n\
+- subagent specialization: researcher\n\
+- subagent depth budget: 1/2\n\
+- subagent active-child budget snapshot: 0/3\n\
+- child timeout seconds: 60\n\
+- child shell.exec: denied\n\
+- child tool allowlist: web.fetch\n\
+- child runtime binding: direct\n\
+- subagent role: orchestrator\n\
+- subagent control scope: children\n\
 - web.fetch private hosts: denied\n\
 - web.fetch allowed domains: none (effective intersection is empty)\n\
 - web.fetch blocked domains: base-block.example.com, deny.example.com\n\
@@ -2996,8 +3118,9 @@ Treat these as enforced limits for this child session."
             },
         };
 
+        let contract = ConstrainedSubagentContractView::from_runtime_narrowing(narrowing);
         let summary = base
-            .delegate_child_prompt_summary(&narrowing)
+            .delegate_child_prompt_summary(Some(&contract))
             .expect("should still render browser section");
 
         assert!(
@@ -3043,8 +3166,9 @@ Treat these as enforced limits for this child session."
             },
         };
 
+        let contract = ConstrainedSubagentContractView::from_runtime_narrowing(narrowing);
         let summary = base
-            .delegate_child_prompt_summary(&narrowing)
+            .delegate_child_prompt_summary(Some(&contract))
             .expect("should still render web_fetch section");
 
         assert!(
@@ -3080,11 +3204,31 @@ Treat these as enforced limits for this child session."
                 ..BrowserRuntimeNarrowing::default()
             },
         };
+        let contract = ConstrainedSubagentContractView::from_runtime_narrowing(narrowing);
 
         assert_eq!(
-            base.delegate_child_prompt_summary(&narrowing),
+            base.delegate_child_prompt_summary(Some(&contract)),
             None,
             "should return None when all narrowed tools are disabled"
+        );
+    }
+
+    #[test]
+    fn delegate_child_prompt_summary_renders_profile_even_when_narrowing_is_empty() {
+        let contract = ConstrainedSubagentContractView::from_profile(
+            ConstrainedSubagentProfile::for_child_depth(1, 1),
+        );
+        let summary = ToolRuntimeConfig::default()
+            .delegate_child_prompt_summary(Some(&contract))
+            .expect("profile-only child prompt summary");
+
+        assert_eq!(
+            summary,
+            "[delegate_child_runtime_contract]\n\
+Plan within these child-session runtime limits:\n\
+- subagent role: leaf\n\
+- subagent control scope: none\n\
+Treat these as enforced limits for this child session."
         );
     }
 

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -1677,7 +1677,7 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
         snapshot.subagent_contract.as_ref(),
         delegate_lifecycle.as_ref(),
     );
-    json!({
+    let mut payload = json!({
         "session": {
             "session_id": snapshot.session.session_id,
             "kind": snapshot.session.kind.as_str(),
@@ -1717,7 +1717,12 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
             .into_iter()
             .map(session_event_json)
             .collect::<Vec<_>>(),
-    })
+    });
+    let Some(object) = payload.as_object_mut() else {
+        return payload;
+    };
+    object.extend(subagent_surface_fields(subagent_handle.as_ref()));
+    payload
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -1500,10 +1500,7 @@ fn resolve_subagent_contract_for_session(
 
     let depth = match repo.session_lineage_depth(&session.session_id) {
         Ok(depth) => depth,
-        Err(error)
-            if error.starts_with("session_lineage_broken:")
-                || error.starts_with("session_lineage_cycle_detected:") =>
-        {
+        Err(error) if is_expected_lineage_gap_error(&error) => {
             return Ok(None);
         }
         Err(error) => {
@@ -1695,16 +1692,6 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
         "workflow": session_workflow_json(snapshot.workflow),
         "terminal_outcome_state": terminal_outcome_state,
         "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
-        "subagent_profile": snapshot
-            .subagent_contract
-            .as_ref()
-            .and_then(ConstrainedSubagentContractView::resolved_profile),
-        "subagent_identity": snapshot
-            .subagent_contract
-            .as_ref()
-            .and_then(ConstrainedSubagentContractView::resolved_identity),
-        "subagent_contract": snapshot.subagent_contract,
-        "subagent": subagent_handle,
         "delegate_lifecycle": delegate_lifecycle
             .map(|lifecycle| session_delegate_lifecycle_json(
                 lifecycle,

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -19,7 +19,7 @@ use crate::config::{SessionVisibility, ToolConfig};
 use crate::conversation::{
     ConstrainedSubagentContractView, ConstrainedSubagentExecution, ConstrainedSubagentHandle,
     ConstrainedSubagentIdentity, ConstrainedSubagentProfile,
-    coordination_actions_for_subagent_handle,
+    coordination_actions_for_subagent_handle, subagent_surface_fields,
 };
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
@@ -3333,33 +3333,10 @@ fn session_summary_json_with_delegate_lifecycle(
 #[cfg(feature = "memory-sqlite")]
 fn insert_subagent_surface_fields(
     object: &mut serde_json::Map<String, Value>,
-    subagent_contract: Option<&ConstrainedSubagentContractView>,
+    _subagent_contract: Option<&ConstrainedSubagentContractView>,
     subagent: Option<&ConstrainedSubagentHandle>,
 ) {
-    object.insert(
-        "subagent_profile".to_owned(),
-        subagent_contract
-            .and_then(ConstrainedSubagentContractView::resolved_profile)
-            .map(|profile| json!(profile))
-            .unwrap_or(Value::Null),
-    );
-    object.insert(
-        "subagent_identity".to_owned(),
-        subagent_contract
-            .and_then(ConstrainedSubagentContractView::resolved_identity)
-            .map(|identity| json!(identity))
-            .unwrap_or(Value::Null),
-    );
-    object.insert(
-        "subagent_contract".to_owned(),
-        subagent_contract
-            .map(|contract| json!(contract))
-            .unwrap_or(Value::Null),
-    );
-    object.insert(
-        "subagent".to_owned(),
-        subagent.map(|handle| json!(handle)).unwrap_or(Value::Null),
-    );
+    object.extend(subagent_surface_fields(subagent));
 }
 
 #[cfg(feature = "memory-sqlite")]

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -16,7 +16,11 @@ use super::payload::{
 
 use crate::config::{SessionVisibility, ToolConfig};
 #[cfg(feature = "memory-sqlite")]
-use crate::conversation::ConstrainedSubagentExecution;
+use crate::conversation::{
+    ConstrainedSubagentContractView, ConstrainedSubagentExecution, ConstrainedSubagentHandle,
+    ConstrainedSubagentIdentity, ConstrainedSubagentProfile,
+    coordination_actions_for_subagent_handle,
+};
 use crate::memory;
 use crate::memory::runtime_config::MemoryRuntimeConfig;
 #[cfg(feature = "memory-sqlite")]
@@ -71,6 +75,7 @@ pub(super) struct SessionInspectionSnapshot {
     pub recent_events: Vec<SessionEventRecord>,
     pub delegate_events: Vec<SessionEventRecord>,
     pub workflow: SessionWorkflowRecord,
+    pub subagent_contract: Option<ConstrainedSubagentContractView>,
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -430,13 +435,15 @@ fn execute_sessions_list(
         } else {
             None
         };
-        let delegate_lifecycle = if include_delegate_lifecycle {
-            delegate_events
-                .as_deref()
-                .and_then(|events| session_delegate_lifecycle_at(&session, events, now_ts))
-        } else {
-            None
-        };
+        let delegate_lifecycle = delegate_events
+            .as_deref()
+            .and_then(|events| session_delegate_lifecycle_at(&session, events, now_ts));
+        let subagent_contract = resolve_subagent_contract_for_session(
+            &repo,
+            &session,
+            delegate_lifecycle.as_ref(),
+            tool_config,
+        )?;
         if request.overdue_only
             && !delegate_lifecycle
                 .as_ref()
@@ -446,7 +453,12 @@ fn execute_sessions_list(
         {
             continue;
         }
-        listed_sessions.push((session, delegate_events, delegate_lifecycle));
+        listed_sessions.push((
+            session,
+            delegate_events,
+            delegate_lifecycle,
+            subagent_contract,
+        ));
     }
 
     let matched_count = listed_sessions.len();
@@ -462,12 +474,13 @@ fn execute_sessions_list(
     }
     let returned_count = listed_sessions.len();
     let mut session_payloads = Vec::with_capacity(returned_count);
-    for (session, delegate_events, delegate_lifecycle) in listed_sessions {
+    for (session, delegate_events, delegate_lifecycle, subagent_contract) in listed_sessions {
         let workflow = load_session_workflow_record(&repo, &session, delegate_events.as_deref())?;
         let payload = session_summary_json_with_delegate_lifecycle(
             session,
             workflow,
             delegate_lifecycle,
+            subagent_contract,
             include_delegate_lifecycle,
         );
         session_payloads.push(payload);
@@ -1442,6 +1455,14 @@ pub(super) fn observe_visible_session_with_policies(
         .ok_or_else(|| format!("session_not_found: `{target_session_id}`"))?;
     let delegate_events = load_delegate_lifecycle_events(&repo, &session)?;
     let workflow = load_session_workflow_record(&repo, &session, Some(delegate_events.as_slice()))?;
+    let delegate_lifecycle =
+        session_delegate_lifecycle_at(&session, delegate_events.as_slice(), current_unix_ts());
+    let subagent_contract = resolve_subagent_contract_for_session(
+        &repo,
+        &session,
+        delegate_lifecycle.as_ref(),
+        tool_config,
+    )?;
 
     Ok(SessionObservationSnapshot {
         inspection: SessionInspectionSnapshot {
@@ -1450,9 +1471,72 @@ pub(super) fn observe_visible_session_with_policies(
             recent_events,
             delegate_events,
             workflow,
+            subagent_contract,
         },
         tail_events,
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_subagent_contract_for_session(
+    repo: &SessionRepository,
+    session: &SessionSummaryRecord,
+    delegate_lifecycle: Option<&SessionDelegateLifecycleRecord>,
+    tool_config: &ToolConfig,
+) -> Result<Option<ConstrainedSubagentContractView>, String> {
+    if session.kind != SessionKind::DelegateChild {
+        return Ok(None);
+    }
+
+    if let Some(contract) =
+        delegate_lifecycle.and_then(resolve_subagent_contract_from_delegate_lifecycle)
+    {
+        return Ok(Some(attach_session_label_identity(contract, session)));
+    }
+
+    if session.parent_session_id.is_none() {
+        return Ok(None);
+    }
+
+    let depth = match repo.session_lineage_depth(&session.session_id) {
+        Ok(depth) => depth,
+        Err(error)
+            if error.starts_with("session_lineage_broken:")
+                || error.starts_with("session_lineage_cycle_detected:") =>
+        {
+            return Ok(None);
+        }
+        Err(error) => {
+            return Err(format!(
+                "compute session lineage depth for subagent profile failed: {error}"
+            ));
+        }
+    };
+
+    Ok(Some(attach_session_label_identity(
+        ConstrainedSubagentContractView::from_profile(ConstrainedSubagentProfile::for_child_depth(
+            depth,
+            tool_config.delegate.max_depth,
+        )),
+        session,
+    )))
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn attach_session_label_identity(
+    mut contract: ConstrainedSubagentContractView,
+    session: &SessionSummaryRecord,
+) -> ConstrainedSubagentContractView {
+    if contract.identity.is_none() {
+        let nickname = session.label.clone();
+        if nickname.is_some() {
+            contract = contract.with_identity(ConstrainedSubagentIdentity {
+                nickname,
+                specialization: None,
+            });
+        }
+    }
+    contract
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -1588,6 +1672,11 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
         "missing" => session_terminal_outcome_missing_reason(recovery.as_ref()),
         _ => None,
     };
+    let subagent_handle = subagent_handle_for_session(
+        &snapshot.session,
+        snapshot.subagent_contract.as_ref(),
+        delegate_lifecycle.as_ref(),
+    );
     json!({
         "session": {
             "session_id": snapshot.session.session_id,
@@ -1606,7 +1695,21 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
         "workflow": session_workflow_json(snapshot.workflow),
         "terminal_outcome_state": terminal_outcome_state,
         "terminal_outcome_missing_reason": terminal_outcome_missing_reason,
-        "delegate_lifecycle": delegate_lifecycle.map(session_delegate_lifecycle_json),
+        "subagent_profile": snapshot
+            .subagent_contract
+            .as_ref()
+            .and_then(ConstrainedSubagentContractView::resolved_profile),
+        "subagent_identity": snapshot
+            .subagent_contract
+            .as_ref()
+            .and_then(ConstrainedSubagentContractView::resolved_identity),
+        "subagent_contract": snapshot.subagent_contract,
+        "subagent": subagent_handle,
+        "delegate_lifecycle": delegate_lifecycle
+            .map(|lifecycle| session_delegate_lifecycle_json(
+                lifecycle,
+                snapshot.subagent_contract.as_ref(),
+            )),
         "recovery": recovery.map(recovery_json),
         "terminal_outcome": snapshot.terminal_outcome.map(session_terminal_outcome_json),
         "recent_events": snapshot
@@ -2427,19 +2530,35 @@ fn session_delegate_staleness_at(
 }
 
 #[cfg(feature = "memory-sqlite")]
-fn session_delegate_lifecycle_json(lifecycle: SessionDelegateLifecycleRecord) -> Value {
+fn session_delegate_lifecycle_json(
+    lifecycle: SessionDelegateLifecycleRecord,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
+) -> Value {
     json!({
         "mode": lifecycle.mode,
         "phase": lifecycle.phase,
         "queued_at": lifecycle.queued_at,
         "started_at": lifecycle.started_at,
         "timeout_seconds": lifecycle.timeout_seconds,
-        "execution": lifecycle.execution,
+        "contract": subagent_contract.cloned(),
+        "execution": lifecycle
+            .execution
+            .map(ConstrainedSubagentExecution::with_resolved_profile),
         "staleness": lifecycle.staleness.map(session_delegate_staleness_json),
         "cancellation": lifecycle
             .cancellation
             .map(session_delegate_cancellation_json),
     })
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn resolve_subagent_contract_from_delegate_lifecycle(
+    lifecycle: &SessionDelegateLifecycleRecord,
+) -> Option<ConstrainedSubagentContractView> {
+    lifecycle
+        .execution
+        .as_ref()
+        .map(ConstrainedSubagentExecution::contract_view)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -3190,18 +3309,122 @@ fn session_summary_json_with_delegate_lifecycle(
     session: SessionSummaryRecord,
     workflow: SessionWorkflowRecord,
     delegate_lifecycle: Option<SessionDelegateLifecycleRecord>,
+    subagent_contract: Option<ConstrainedSubagentContractView>,
     include_delegate_lifecycle: bool,
 ) -> Value {
+    let subagent = subagent_handle_for_session(
+        &session,
+        subagent_contract.as_ref(),
+        delegate_lifecycle.as_ref(),
+    );
     let mut payload = session_summary_json(session, workflow);
-    if include_delegate_lifecycle && let Some(object) = payload.as_object_mut() {
-        object.insert(
-            "delegate_lifecycle".to_owned(),
-            delegate_lifecycle
-                .map(session_delegate_lifecycle_json)
-                .unwrap_or(Value::Null),
-        );
+    if let Some(object) = payload.as_object_mut() {
+        insert_subagent_surface_fields(object, subagent_contract.as_ref(), subagent.as_ref());
+        if include_delegate_lifecycle {
+            object.insert(
+                "delegate_lifecycle".to_owned(),
+                delegate_lifecycle
+                    .map(|lifecycle| {
+                        session_delegate_lifecycle_json(lifecycle, subagent_contract.as_ref())
+                    })
+                    .unwrap_or(Value::Null),
+            );
+        }
     }
     payload
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn insert_subagent_surface_fields(
+    object: &mut serde_json::Map<String, Value>,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
+    subagent: Option<&ConstrainedSubagentHandle>,
+) {
+    object.insert(
+        "subagent_profile".to_owned(),
+        subagent_contract
+            .and_then(ConstrainedSubagentContractView::resolved_profile)
+            .map(|profile| json!(profile))
+            .unwrap_or(Value::Null),
+    );
+    object.insert(
+        "subagent_identity".to_owned(),
+        subagent_contract
+            .and_then(ConstrainedSubagentContractView::resolved_identity)
+            .map(|identity| json!(identity))
+            .unwrap_or(Value::Null),
+    );
+    object.insert(
+        "subagent_contract".to_owned(),
+        subagent_contract
+            .map(|contract| json!(contract))
+            .unwrap_or(Value::Null),
+    );
+    object.insert(
+        "subagent".to_owned(),
+        subagent.map(|handle| json!(handle)).unwrap_or(Value::Null),
+    );
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn subagent_handle_for_session(
+    session: &SessionSummaryRecord,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
+    delegate_lifecycle: Option<&SessionDelegateLifecycleRecord>,
+) -> Option<ConstrainedSubagentHandle> {
+    if session.kind != SessionKind::DelegateChild {
+        return None;
+    }
+
+    let phase = delegate_lifecycle.map(|lifecycle| lifecycle.phase.to_owned());
+    Some(
+        ConstrainedSubagentHandle::new(session.session_id.clone())
+            .with_parent_session_id(session.parent_session_id.clone())
+            .with_label(session.label.clone())
+            .with_state(Some(session.state.as_str().to_owned()))
+            .with_phase(phase.clone())
+            .with_identity(
+                subagent_contract
+                    .and_then(ConstrainedSubagentContractView::resolved_identity)
+                    .cloned(),
+            )
+            .with_contract(subagent_contract.cloned())
+            .with_coordination(subagent_handle_coordination_actions(
+                session,
+                phase.as_deref(),
+                delegate_lifecycle,
+                subagent_contract,
+            )),
+    )
+}
+
+#[cfg(feature = "memory-sqlite")]
+fn subagent_handle_coordination_actions(
+    session: &SessionSummaryRecord,
+    phase: Option<&str>,
+    delegate_lifecycle: Option<&SessionDelegateLifecycleRecord>,
+    subagent_contract: Option<&ConstrainedSubagentContractView>,
+) -> Vec<crate::conversation::ConstrainedSubagentCoordinationAction> {
+    let is_async = delegate_lifecycle
+        .map(|lifecycle| lifecycle.mode == "async")
+        .unwrap_or_else(|| {
+            matches!(
+                subagent_contract.and_then(|contract| contract.mode),
+                Some(crate::conversation::ConstrainedSubagentMode::Async)
+            )
+        });
+    let overdue = matches!(
+        delegate_lifecycle.and_then(|lifecycle| lifecycle.staleness.as_ref()),
+        Some(staleness) if staleness.state == "overdue"
+    );
+    let mode = if is_async {
+        Some(crate::conversation::ConstrainedSubagentMode::Async)
+    } else {
+        subagent_contract.and_then(|contract| contract.mode)
+    };
+    let terminal_but_not_archived =
+        session_state_is_terminal(session.state) && session.archived_at.is_none();
+    coordination_actions_for_subagent_handle(terminal_but_not_archived, phase, mode, overdue)
 }
 
 #[cfg(feature = "memory-sqlite")]
@@ -3679,9 +3902,18 @@ mod tests {
             .iter()
             .find(|item| item["session_id"] == "archived-child")
             .expect("archived session");
+        let coordination = archived["subagent"]["coordination"]
+            .as_array()
+            .expect("coordination actions");
+        let archive_actions = coordination
+            .iter()
+            .filter(|action| action["tool_name"] == "session_archive")
+            .count();
         assert_eq!(outcome.payload["filters"]["include_archived"], true);
         assert_eq!(archived["archived"], true);
         assert!(archived["archived_at"].is_number());
+        assert_eq!(archived["subagent"]["session_id"], "archived-child");
+        assert_eq!(archive_actions, 0);
     }
 
     #[test]
@@ -3935,6 +4167,16 @@ mod tests {
         assert_eq!(child["workflow"]["task"], "research release readiness");
         assert_eq!(child["workflow"]["lineage_root_session_id"], "root-session");
         assert_eq!(child["workflow"]["lineage_depth"], 1);
+        assert_eq!(child["subagent"]["session_id"], "child-session");
+        assert_eq!(child["subagent_identity"]["nickname"], "Research Child");
+        assert_eq!(
+            child["subagent_contract"]["profile"]["role"],
+            "orchestrator"
+        );
+        assert_eq!(
+            child["subagent_contract"]["profile"]["control_scope"],
+            "children"
+        );
     }
 
     #[test]
@@ -4152,6 +4394,19 @@ mod tests {
         assert_eq!(
             outcome.payload["workflow"]["runtime_self_continuity"]["session_profile_projection_present"],
             true
+        );
+        assert_eq!(outcome.payload["subagent"]["session_id"], "child-session");
+        assert_eq!(
+            outcome.payload["subagent_identity"]["nickname"],
+            "Continuity Child"
+        );
+        assert_eq!(
+            outcome.payload["subagent_contract"]["profile"]["role"],
+            "orchestrator"
+        );
+        assert_eq!(
+            outcome.payload["subagent_contract"]["profile"]["control_scope"],
+            "children"
         );
         assert_eq!(outcome.payload["session"]["turn_count"], 2);
         assert!(outcome.payload["session"]["last_turn_at"].is_number());
@@ -5890,6 +6145,12 @@ mod tests {
         assert_eq!(
             outcome.payload["delegate_lifecycle"]["execution"]["mode"],
             "async"
+        );
+        assert_eq!(outcome.payload["subagent"]["session_id"], "child-session");
+        assert_eq!(outcome.payload["subagent_identity"]["nickname"], "Child");
+        assert_eq!(
+            outcome.payload["subagent_contract"]["identity"]["nickname"],
+            "Child"
         );
         assert_eq!(
             outcome.payload["delegate_lifecycle"]["execution"]["depth"],

--- a/crates/app/src/tools/session.rs
+++ b/crates/app/src/tools/session.rs
@@ -1721,7 +1721,11 @@ pub(super) fn session_inspection_payload(snapshot: SessionInspectionSnapshot) ->
     let Some(object) = payload.as_object_mut() else {
         return payload;
     };
-    object.extend(subagent_surface_fields(subagent_handle.as_ref()));
+    insert_subagent_surface_fields(
+        object,
+        snapshot.subagent_contract.as_ref(),
+        subagent_handle.as_ref(),
+    );
     payload
 }
 

--- a/crates/daemon/src/browser_companion_diagnostics.rs
+++ b/crates/daemon/src/browser_companion_diagnostics.rs
@@ -14,6 +14,8 @@ pub(crate) const BROWSER_COMPANION_RUNTIME_GATE_CHECK_NAME: &str = "browser comp
 
 const BROWSER_COMPANION_VERSION_ARG: &str = "--version";
 const BROWSER_COMPANION_PROBE_ATTEMPTS: usize = 3;
+#[cfg(test)]
+const TEST_BROWSER_COMPANION_VERSION_PREFIX: &str = "loongclaw-test-browser-companion-version:";
 
 fn browser_companion_probe_timeout_seconds(timeout_seconds: u64) -> u64 {
     timeout_seconds.max(1)
@@ -239,11 +241,21 @@ pub(crate) async fn collect_browser_companion_diagnostics(
     }
 }
 
+#[cfg(test)]
+pub(crate) fn fake_browser_companion_version_command(version: &str) -> String {
+    format!("{TEST_BROWSER_COMPANION_VERSION_PREFIX}{version}")
+}
+
 async fn probe_browser_companion_version(
     command: &str,
     timeout_seconds: u64,
 ) -> Result<String, BrowserCompanionProbeError> {
     let timeout_duration = browser_companion_probe_timeout_duration(timeout_seconds);
+
+    #[cfg(test)]
+    if let Some(version) = command.strip_prefix(TEST_BROWSER_COMPANION_VERSION_PREFIX) {
+        return Ok(format!("loongclaw-browser-companion {version}"));
+    }
 
     for _attempt in 0..BROWSER_COMPANION_PROBE_ATTEMPTS {
         let mut probe = Command::new(command);

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -2709,8 +2709,6 @@ mod tests {
     use std::ffi::OsString;
     use std::fs::Permissions;
     #[cfg(unix)]
-    use std::io::Write;
-    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     #[cfg(unix)]
@@ -2728,7 +2726,6 @@ mod tests {
         ChannelStatusSnapshot,
     };
 
-    #[allow(dead_code)]
     fn browser_companion_temp_dir(label: &str) -> PathBuf {
         static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
         let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
@@ -2899,22 +2896,6 @@ mod tests {
         std::fs::create_dir_all(&plugin_directory).expect("create managed bridge plugin directory");
         std::fs::write(&manifest_path, encoded_manifest)
             .expect("write managed bridge plugin manifest");
-    }
-
-    #[cfg(unix)]
-    #[allow(dead_code)]
-    fn write_browser_companion_script(script_path: &Path, body: &str) {
-        let mut file = std::fs::File::create(script_path).expect("create browser companion script");
-        file.write_all(body.as_bytes())
-            .expect("write browser companion script");
-        file.sync_all()
-            .expect("sync browser companion script to disk");
-        drop(file);
-        let mut permissions = std::fs::metadata(script_path)
-            .expect("script metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(script_path, permissions).expect("chmod browser companion script");
     }
 
     #[cfg(unix)]

--- a/crates/daemon/src/doctor_cli.rs
+++ b/crates/daemon/src/doctor_cli.rs
@@ -2728,6 +2728,7 @@ mod tests {
         ChannelStatusSnapshot,
     };
 
+    #[allow(dead_code)]
     fn browser_companion_temp_dir(label: &str) -> PathBuf {
         static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
         let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
@@ -2901,6 +2902,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[allow(dead_code)]
     fn write_browser_companion_script(script_path: &Path, body: &str) {
         let mut file = std::fs::File::create(script_path).expect("create browser companion script");
         file.write_all(body.as_bytes())
@@ -5372,16 +5374,12 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn browser_companion_doctor_checks_warn_when_expected_version_mismatches() {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
-        let temp_dir = browser_companion_temp_dir("version-mismatch");
-        let script_path = temp_dir.join("browser-companion");
-        write_browser_companion_script(
-            &script_path,
-            "#!/bin/sh\necho 'loongclaw-browser-companion 1.4.0'\n",
-        );
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.tools.browser_companion.enabled = true;
-        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.command = Some(
+            crate::browser_companion_diagnostics::fake_browser_companion_version_command("1.4.0"),
+        );
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
 
         let checks = collect_browser_companion_doctor_checks(&config).await;
@@ -5403,16 +5401,12 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn browser_companion_doctor_checks_warn_when_runtime_gate_is_closed() {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
-        let temp_dir = browser_companion_temp_dir("runtime-gate");
-        let script_path = temp_dir.join("browser-companion");
-        write_browser_companion_script(
-            &script_path,
-            "#!/bin/sh\necho 'loongclaw-browser-companion 1.5.0'\n",
-        );
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.tools.browser_companion.enabled = true;
-        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.command = Some(
+            crate::browser_companion_diagnostics::fake_browser_companion_version_command("1.5.0"),
+        );
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
 
         let checks = collect_browser_companion_doctor_checks(&config).await;
@@ -5431,16 +5425,12 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn browser_companion_doctor_checks_pass_when_runtime_gate_is_open() {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_open();
-        let temp_dir = browser_companion_temp_dir("runtime-ready");
-        let script_path = temp_dir.join("browser-companion");
-        write_browser_companion_script(
-            &script_path,
-            "#!/bin/sh\necho 'loongclaw-browser-companion 1.5.0'\n",
-        );
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.tools.browser_companion.enabled = true;
-        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.command = Some(
+            crate::browser_companion_diagnostics::fake_browser_companion_version_command("1.5.0"),
+        );
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
 
         let checks = collect_browser_companion_doctor_checks(&config).await;

--- a/crates/daemon/src/migrate_cli.rs
+++ b/crates/daemon/src/migrate_cli.rs
@@ -108,8 +108,10 @@ fn require_flag_value(value: Option<&str>, flag: &str, mode: MigrateMode) -> Cli
     if value.map(str::trim).filter(|raw| !raw.is_empty()).is_some() {
         return Ok(());
     }
+    let command_name = mvp::config::active_cli_command_name();
     Err(format!(
-        "`--{flag}` is required for `loongclaw migrate --mode {}`",
+        "`--{flag}` is required for `{} migrate --mode {}`",
+        command_name,
         mode.as_id()
     ))
 }

--- a/crates/daemon/src/migrate_cli.rs
+++ b/crates/daemon/src/migrate_cli.rs
@@ -62,6 +62,7 @@ pub fn run_migrate_cli(options: MigrateCommandOptions) -> CliResult<()> {
 }
 
 async fn run_migrate_cli_async(options: MigrateCommandOptions) -> CliResult<()> {
+    validate_migrate_cli_options(&options)?;
     let config = load_migrate_cli_runtime_config(&options)?;
     let kernel_ctx = mvp::context::bootstrap_kernel_context_with_config(
         "daemon-migrate-cli",
@@ -79,6 +80,38 @@ async fn run_migrate_cli_async(options: MigrateCommandOptions) -> CliResult<()> 
     .map_err(|error| translate_migrate_cli_error(&options, error))?;
 
     render_migrate_tool_outcome(&options, outcome)
+}
+
+fn validate_migrate_cli_options(options: &MigrateCommandOptions) -> CliResult<()> {
+    let mode = options.mode;
+    match mode {
+        MigrateMode::Apply | MigrateMode::ApplySelected => {
+            require_flag_value(options.input.as_deref(), "input", mode)?;
+            require_flag_value(options.output.as_deref(), "output", mode)?;
+        }
+        MigrateMode::Plan
+        | MigrateMode::Discover
+        | MigrateMode::PlanMany
+        | MigrateMode::RecommendPrimary
+        | MigrateMode::MergeProfiles
+        | MigrateMode::MapExternalSkills => {
+            require_flag_value(options.input.as_deref(), "input", mode)?;
+        }
+        MigrateMode::RollbackLastApply => {
+            require_flag_value(options.output.as_deref(), "output", mode)?;
+        }
+    }
+    Ok(())
+}
+
+fn require_flag_value(value: Option<&str>, flag: &str, mode: MigrateMode) -> CliResult<()> {
+    if value.map(str::trim).filter(|raw| !raw.is_empty()).is_some() {
+        return Ok(());
+    }
+    Err(format!(
+        "`--{flag}` is required for `loongclaw migrate --mode {}`",
+        mode.as_id()
+    ))
 }
 
 fn block_on_migrate_cli<F>(future: F) -> CliResult<()>

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -6266,9 +6266,8 @@ mod tests {
     use super::*;
     use std::collections::VecDeque;
     use std::ffi::OsString;
-    use std::io::Write;
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, MutexGuard};
 
     use crate::test_support::ScopedEnv;
@@ -6331,18 +6330,6 @@ mod tests {
         OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>())
     }
 
-    #[allow(dead_code)]
-    fn browser_companion_temp_dir(label: &str) -> PathBuf {
-        static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
-        let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
-        let temp_dir = std::env::temp_dir().join(format!(
-            "loongclaw-browser-companion-onboard-{label}-{}-{seed}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&temp_dir).expect("create browser companion onboard temp dir");
-        temp_dir
-    }
-
     fn uuid_shaped_secret_fixture() -> String {
         let first = "9f479837";
         let second = "0a12";
@@ -6350,54 +6337,6 @@ mod tests {
         let fourth = "89ab";
         let fifth = "cdef01234567";
         format!("{first}-{second}-{third}-{fourth}-{fifth}")
-    }
-
-    fn browser_companion_script_path(temp_dir: &Path) -> PathBuf {
-        #[cfg(windows)]
-        {
-            temp_dir.join("browser-companion.cmd")
-        }
-        #[cfg(not(windows))]
-        {
-            temp_dir.join("browser-companion")
-        }
-    }
-
-    #[allow(dead_code)]
-    fn write_browser_companion_version_script(temp_dir: &Path, version: &str) -> PathBuf {
-        let script_path = browser_companion_script_path(temp_dir);
-
-        #[cfg(windows)]
-        {
-            let script_body = format!(
-                "@echo off\r\nif \"%~1\"==\"--version\" (\r\n  echo loongclaw-browser-companion {version}\r\n  exit /b 0\r\n)\r\necho unexpected arguments 1>&2\r\nexit /b 1\r\n"
-            );
-            std::fs::write(&script_path, script_body).expect("write browser companion script");
-        }
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let script_body = format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo 'loongclaw-browser-companion {version}'\n  exit 0\nfi\necho 'unexpected arguments' >&2\nexit 1\n"
-            );
-            let mut file =
-                std::fs::File::create(&script_path).expect("create browser companion script");
-            file.write_all(script_body.as_bytes())
-                .expect("write browser companion script");
-            file.sync_all()
-                .expect("sync browser companion script to disk");
-            drop(file);
-
-            let metadata = std::fs::metadata(&script_path).expect("script metadata");
-            let mut permissions = metadata.permissions();
-            permissions.set_mode(0o755);
-            std::fs::set_permissions(&script_path, permissions)
-                .expect("chmod browser companion script");
-        }
-
-        script_path
     }
 
     impl OnboardUi for TestOnboardUi {

--- a/crates/daemon/src/onboard_cli.rs
+++ b/crates/daemon/src/onboard_cli.rs
@@ -6331,6 +6331,7 @@ mod tests {
         OnboardRuntimeContext::new_for_tests(80, None, std::iter::empty::<PathBuf>())
     }
 
+    #[allow(dead_code)]
     fn browser_companion_temp_dir(label: &str) -> PathBuf {
         static NEXT_TEMP_DIR_SEED: AtomicU64 = AtomicU64::new(1);
         let seed = NEXT_TEMP_DIR_SEED.fetch_add(1, Ordering::Relaxed);
@@ -6362,6 +6363,7 @@ mod tests {
         }
     }
 
+    #[allow(dead_code)]
     fn write_browser_companion_version_script(temp_dir: &Path, version: &str) -> PathBuf {
         let script_path = browser_companion_script_path(temp_dir);
 
@@ -6818,13 +6820,13 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn browser_companion_onboard_preflight_warns_when_runtime_gate_is_closed() {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_closed();
-        let temp_dir = browser_companion_temp_dir("runtime-gate");
-        let script_path = write_browser_companion_version_script(&temp_dir, "1.5.0");
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.api_key = Some(SecretRef::Inline("inline-openai-key".to_owned()));
         config.tools.browser_companion.enabled = true;
-        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.command = Some(
+            crate::browser_companion_diagnostics::fake_browser_companion_version_command("1.5.0"),
+        );
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
 
         let checks = run_preflight_checks(&config, true).await;
@@ -6842,13 +6844,13 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn browser_companion_onboard_preflight_passes_when_runtime_gate_is_open() {
         let _env_guard = BrowserCompanionEnvGuard::runtime_gate_open();
-        let temp_dir = browser_companion_temp_dir("runtime-ready");
-        let script_path = write_browser_companion_version_script(&temp_dir, "1.5.0");
 
         let mut config = mvp::config::LoongClawConfig::default();
         config.provider.api_key = Some(SecretRef::Inline("inline-openai-key".to_owned()));
         config.tools.browser_companion.enabled = true;
-        config.tools.browser_companion.command = Some(script_path.display().to_string());
+        config.tools.browser_companion.command = Some(
+            crate::browser_companion_diagnostics::fake_browser_companion_version_command("1.5.0"),
+        );
         config.tools.browser_companion.expected_version = Some("1.5.0".to_owned());
 
         let checks = run_preflight_checks(&config, true).await;

--- a/crates/daemon/src/tasks_cli.rs
+++ b/crates/daemon/src/tasks_cli.rs
@@ -225,6 +225,7 @@ async fn execute_create_command(
         current_session_id,
         task,
         label,
+        None,
         timeout_seconds,
         binding,
     )

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T12:01:18Z
+- Generated at: 2026-04-05T13:01:09Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10827 | 11200 | 373 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | -0.0% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14999 | 15000 | 1 | 54 | 70 | 16 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9784 | 9800 | 16 | 235 | 250 | 15 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10829 | 11200 | 371 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | -0.0% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14809 | 15000 | 191 | 53 | 70 | 17 | 98.7% | TIGHT | 14472 | 2.3% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6411 | 6500 | 89 | 208 | 210 | 2 | 99.0% | TIGHT | 6324 | 1.4% | PASS | 210 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9723 | 9800 | 77 | 235 | 250 | 15 | 99.2% | TIGHT | 9519 | 2.1% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (100.0%), daemon_lib (100.0%), onboard_cli (99.8%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (98.2%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (98.7%), daemon_lib (99.0%), onboard_cli (99.2%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,10 +68,10 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10827 functions=97 -->
-<!-- arch-hotspot key=tools_mod lines=14999 functions=54 -->
-<!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
-<!-- arch-hotspot key=onboard_cli lines=9784 functions=235 -->
+<!-- arch-hotspot key=turn_coordinator lines=10829 functions=97 -->
+<!-- arch-hotspot key=tools_mod lines=14809 functions=53 -->
+<!-- arch-hotspot key=daemon_lib lines=6411 functions=208 -->
+<!-- arch-hotspot key=onboard_cli lines=9723 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->

--- a/docs/releases/architecture-drift-2026-04.md
+++ b/docs/releases/architecture-drift-2026-04.md
@@ -1,7 +1,7 @@
 # Architecture Drift Report 2026-04
 
 ## Summary
-- Generated at: 2026-04-05T12:27:12Z
+- Generated at: 2026-04-05T12:01:18Z
 - Report month: `2026-04`
 - Baseline report: docs/releases/architecture-drift-2026-03.md
 - Hotspots tracked: 14
@@ -22,14 +22,14 @@
 | channel_config | `structural_size` | `crates/app/src/config/channels.rs` | 9716 | 9800 | 84 | 90 | 90 | 0 | 100.0% | TIGHT | 9796 | -0.8% | PASS | 90 |
 | chat_runtime | `structural_size,operational_density` | `crates/app/src/chat.rs` | 6976 | 7300 | 324 | 147 | 160 | 13 | 95.6% | TIGHT | 6936 | 0.6% | PASS | 146 |
 | channel_mod | `structural_size,operational_density` | `crates/app/src/channel/mod.rs` | 1785 | 6400 | 4615 | 0 | 110 | 110 | 27.9% | HEALTHY | 1779 | 0.3% | PASS | 0 |
-| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10801 | 11200 | 399 | 97 | 120 | 23 | 96.4% | TIGHT | 10831 | -0.3% | PASS | 98 |
-| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14807 | 15000 | 193 | 53 | 70 | 17 | 98.7% | TIGHT | 14472 | 2.3% | PASS | 54 |
-| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6411 | 6500 | 89 | 208 | 210 | 2 | 99.0% | TIGHT | 6324 | 1.4% | PASS | 210 |
-| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9782 | 9800 | 18 | 235 | 250 | 15 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
+| turn_coordinator | `structural_size,operational_density` | `crates/app/src/conversation/turn_coordinator.rs` | 10827 | 11200 | 373 | 97 | 120 | 23 | 96.7% | TIGHT | 10831 | -0.0% | PASS | 98 |
+| tools_mod | `structural_size` | `crates/app/src/tools/mod.rs` | 14999 | 15000 | 1 | 54 | 70 | 16 | 100.0% | TIGHT | 14472 | 3.6% | PASS | 54 |
+| daemon_lib | `structural_size` | `crates/daemon/src/lib.rs` | 6481 | 6500 | 19 | 210 | 210 | 0 | 100.0% | TIGHT | 6324 | 2.5% | PASS | 210 |
+| onboard_cli | `structural_size` | `crates/daemon/src/onboard_cli.rs` | 9784 | 9800 | 16 | 235 | 250 | 15 | 99.8% | TIGHT | 9519 | 2.8% | PASS | 228 |
 
 ## Prioritization Signals
 - BREACH hotspots (>100% of any tracked budget): none
-- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.6%), acpx_runtime (98.2%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.4%), tools_mod (98.7%), daemon_lib (99.0%), onboard_cli (99.8%)
+- TIGHT hotspots (>=95% of any tracked budget): spec_runtime (100.0%), spec_execution (96.4%), acpx_runtime (97.9%), channel_registry (97.4%), channel_config (100.0%), chat_runtime (95.6%), turn_coordinator (96.7%), tools_mod (100.0%), daemon_lib (100.0%), onboard_cli (99.8%)
 - WATCH hotspots (>=85% and <95% of any tracked budget): memory_mod (87.5%), acp_manager (94.2%)
 - Mixed-class hotspots (size plus operational density): chat_runtime, channel_mod, turn_coordinator
 
@@ -68,10 +68,10 @@
 <!-- arch-hotspot key=channel_config lines=9716 functions=90 -->
 <!-- arch-hotspot key=chat_runtime lines=6976 functions=147 -->
 <!-- arch-hotspot key=channel_mod lines=1785 functions=0 -->
-<!-- arch-hotspot key=turn_coordinator lines=10801 functions=97 -->
-<!-- arch-hotspot key=tools_mod lines=14807 functions=53 -->
-<!-- arch-hotspot key=daemon_lib lines=6411 functions=208 -->
-<!-- arch-hotspot key=onboard_cli lines=9782 functions=235 -->
+<!-- arch-hotspot key=turn_coordinator lines=10827 functions=97 -->
+<!-- arch-hotspot key=tools_mod lines=14999 functions=54 -->
+<!-- arch-hotspot key=daemon_lib lines=6481 functions=210 -->
+<!-- arch-hotspot key=onboard_cli lines=9784 functions=235 -->
 <!-- arch-boundary key=memory_literals status=PASS -->
 <!-- arch-boundary key=provider_mod_helper_definitions status=PASS -->
 <!-- arch-boundary key=conversation_provider_optional_binding_roundtrip status=PASS -->


### PR DESCRIPTION
## Summary

- Problem:
  Delegate children were still exposed through raw session IDs, duplicated metadata fields, and stringly coordination tool lists. That made the operator-facing child surface weaker than the underlying runtime contract and left coordination semantics split across multiple call sites.
- Why it matters:
  LoongClaw is moving toward a stronger subagent runtime surface. Without a stable child handle and typed coordination actions, delegate children remain harder to inspect, coordinate, and evolve safely as first-class runtime objects.
- What changed:
  Productized a typed subagent handle surface across delegate results and session inspection/listing. The runtime now aligns child identity, child contract, child phase/state, and typed coordination actions from shared derivation logic instead of duplicated raw tool-name arrays. The work also tightened test/runtime home isolation, stabilized browser companion verification seams, and kept migrate CLI flag validation fail-closed before runtime bootstrap.
- What did not change (scope boundary):
  This PR does not add a full child message plane, child re-entry protocol, registry ownership, announce queues, or orphan-repair control plane behavior.

## Linked Issues

- Closes #906
- Related #770

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Security hardening
- [ ] CI / workflow / release

## Touched Areas

- [ ] Kernel / policy / approvals
- [x] Contracts / protocol / spec
- [x] Daemon / CLI / install
- [ ] Providers / routing
- [x] Tools
- [ ] Browser automation
- [ ] Channels / integrations
- [x] ACP / conversation / session runtime
- [x] Memory / context assembly
- [x] Config / migration / onboarding
- [ ] Docs / contributor workflow
- [ ] CI / release / workflows

## Risk Track

- [ ] Track A (routine / low-risk)
- [x] Track B (higher-risk / policy-impacting)

If Track B, fill these in:

- Risk notes:
  This changes the operator-visible child-session surface and the runtime contract shape used by delegate results and session inspection. The highest risk is surface drift between child execution truth, inspection payloads, and coordination affordances.
- Rollout / guardrails:
  The PR keeps the governed delegate runtime as the source of truth, derives child coordination from shared typed helpers, and adds regression coverage for sync delegate, async delegate, session status/list, prompt contract, durable-memory isolation, browser companion verification, and migrate CLI validation order.
- Rollback path:
  Revert commit `36bbef5a29f341960027eea6b903029a71130979` to restore the prior child-handle payloads and test-runtime home behavior.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test --workspace --all-features --locked`
- [x] Relevant architecture / dep-graph / docs checks for touched areas
- [x] Additional scenario, benchmark, or manual checks when behavior changed
- [x] If this changes config/env fallback, limits, or defaults: include before/after behavior and regression coverage for explicit path, fallback path, and boundary values
- [x] If tests mutate process-global env: document how state is restored or serialized

Commands and evidence:

```text
cargo fmt --all -- --check
env CARGO_TARGET_DIR=/private/tmp/loongclaw-subagent-maturity-targeted cargo clippy --workspace --all-targets --all-features -- -D warnings
env CARGO_TARGET_DIR=/private/tmp/loongclaw-subagent-maturity-targeted cargo test --workspace --locked
env CARGO_TARGET_DIR=/private/tmp/loongclaw-subagent-maturity-targeted cargo test --workspace --all-features --locked -- --test-threads=1

All commands completed successfully on commit 36bbef5a29f341960027eea6b903029a71130979.
Additional targeted coverage was exercised for delegate, delegate_async, session_status,
sessions_list, prompt contract rendering, browser companion diagnostics, migrate CLI validation,
and durable-memory fallback/isolation behavior.
```

## User-visible / Operator-visible Changes

- Delegate child results now expose a typed subagent handle with stable identity, contract, phase/state, and typed coordination actions.
- `session_status` and `sessions_list` now expose the same subagent handle shape for delegate children.
- Test-only runtime home fallback now isolates per test thread, reducing hidden cross-test state bleed.

## Failure Recovery

- Fast rollback or disable path:
  Revert the PR commit. No migration or persisted external data rewrite is required.
- Observable failure symptoms reviewers should watch for:
  Child result payloads or session inspection payloads missing `subagent`, mismatched child phase/state, stale raw coordination semantics, or durable-memory tests bleeding state across unrelated test cases.

## Reviewer Focus

- Review `crates/app/src/conversation/subagent.rs` for the contract/handle split and typed coordination action model.
- Review `crates/app/src/tools/delegate.rs` and `crates/app/src/tools/session.rs` for shared coordination derivation and payload alignment.
- Review `crates/app/src/config/shared.rs`, `crates/app/src/config/audit.rs`, and `crates/daemon/src/migrate_cli.rs` for the test/home isolation and validation-order hardening that keeps workspace validation deterministic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer subagent model surfaced: roles, profiles, identities, coordination actions, and contract-driven child/session views.
  * Delegate tools accept optional "specialization" and delegate outcomes now include subagent surface fields.

* **Improvements**
  * Tool access for delegate-child sessions driven by contract/profile (more precise than depth).
  * Session summaries and prompt summaries incorporate resolved subagent contracts and identity/profile details.
  * CLI migrate now validates required flags early with clearer messages.

* **Bug Fixes / Tests**
  * Deterministic test helpers and faster browser-companion test path; many new tests for delegation and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->